### PR TITLE
Add generic RFID model for user auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The `nodes` app exposes a simple JSON interface for keeping track of other insta
 
 # Accounts App
 
-Users may authenticate using the UID of an RFID card. POST the UID as JSON to `/accounts/rfid-login/` and the server will return the user's details if the UID matches an existing account.
+Users may authenticate using any RFID tag assigned to their account. POST the UID as JSON to `/accounts/rfid-login/` and the server will return the user's details if the tag matches one stored in the `RFID` model.
+
+The `RFID` model stores card identifiers. A tag may belong to a user or be marked as `blacklisted` to disable it.
 
 ## Account Credits
 
@@ -101,12 +103,14 @@ in the database while keeping active connections in memory. Every charger
 known to the system is stored in the `Charger` model. When a device
 connects with an unknown ID it will be created automatically. The model
 includes a JSON `config` field for storing charger-specific settings.
+
 Each charger also has a `require_rfid` flag that can be enabled to
 enforce RFID authentication. When set, the server validates the `idTag`
-against known users before allowing a transaction to start.
+against entries in the `RFID` table before allowing a transaction to start.
 
 It also records the timestamp of the last `Heartbeat` message and the
 payload of the most recent `MeterValues` message received from the charger.
+
 
 
 ### REST Endpoints

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -1,6 +1,8 @@
 # Accounts App
 
-Users may authenticate using the UID of an RFID card. POST the UID as JSON to `/accounts/rfid-login/` and the server will return the user's details if the UID matches an existing account.
+Users may authenticate using any RFID tag assigned to their account. POST the UID as JSON to `/accounts/rfid-login/` and the server will return the user's details if the tag matches one stored in the `RFID` model.
+
+The `RFID` model stores card identifiers. A tag may belong to a user or be marked as `blacklisted` to disable it.
 
 ## Account Credits
 

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,22 +1,18 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 
-from .models import User, BlacklistedRFID, Account
+from .models import User, RFID, Account
 
 
 @admin.register(User)
 class UserAdmin(DjangoUserAdmin):
-    fieldsets = DjangoUserAdmin.fieldsets + (
-        ("RFID", {"fields": ("rfid_uid",)}),
-    )
-    add_fieldsets = DjangoUserAdmin.add_fieldsets + (
-        ("RFID", {"fields": ("rfid_uid",)}),
-    )
+    pass
 
 
-@admin.register(BlacklistedRFID)
-class BlacklistedRFIDAdmin(admin.ModelAdmin):
-    list_display = ("uid", "added_on")
+
+@admin.register(RFID)
+class RFIDAdmin(admin.ModelAdmin):
+    list_display = ("uid", "user", "blacklisted", "added_on")
 
 
 @admin.register(Account)

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from .models import RFID
 
 
 class RFIDBackend:
@@ -7,11 +8,12 @@ class RFIDBackend:
     def authenticate(self, request, rfid_uid=None, **kwargs):
         if not rfid_uid:
             return None
-        User = get_user_model()
-        try:
-            return User.objects.get(rfid_uid=rfid_uid)
-        except User.DoesNotExist:
-            return None
+        tag = RFID.objects.filter(
+            uid=rfid_uid, blacklisted=False, user__isnull=False
+        ).select_related("user").first()
+        if tag:
+            return tag.user
+        return None
 
     def get_user(self, user_id):
         User = get_user_model()

--- a/accounts/migrations/0004_rfid_model.py
+++ b/accounts/migrations/0004_rfid_model.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_account"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RFID",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uid", models.CharField(max_length=64, unique=True)),
+                ("blacklisted", models.BooleanField(default=False)),
+                ("added_on", models.DateTimeField(auto_now_add=True)),
+                (
+                    "user",
+                    models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="rfids", to=settings.AUTH_USER_MODEL),
+                ),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name="user",
+            name="rfid_uid",
+        ),
+        migrations.DeleteModel(
+            name="BlacklistedRFID",
+        ),
+    ]
+

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,48 +1,34 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 
 
 class User(AbstractUser):
-    """Custom user with optional RFID UID for card-based login."""
-
-    rfid_uid = models.CharField(
-        max_length=64,
-        unique=True,
-        blank=True,
-        null=True,
-        help_text="RFID card identifier",
-    )
+    """Custom user model."""
 
     def __str__(self):
         return self.username
 
-    def clean(self):
-        super().clean()
-        if self.rfid_uid and BlacklistedRFID.objects.filter(uid=self.rfid_uid).exists():
-            raise ValidationError({"rfid_uid": "This RFID has been blacklisted."})
 
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        super().save(*args, **kwargs)
-
-
-class BlacklistedRFID(models.Model):
-    """RFID identifiers that are permanently blocked."""
+class RFID(models.Model):
+    """RFID tag assigned to a user or blacklisted."""
 
     uid = models.CharField(max_length=64, unique=True)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        related_name="rfids",
+        on_delete=models.SET_NULL,
+    )
+    blacklisted = models.BooleanField(default=False)
     added_on = models.DateTimeField(auto_now_add=True)
 
     def save(self, *args, **kwargs):
+        if self.blacklisted:
+            self.user = None
         super().save(*args, **kwargs)
-        User = get_user_model()
-        try:
-            user = User.objects.get(rfid_uid=self.uid)
-            user.rfid_uid = None
-            user.save(update_fields=["rfid_uid"])
-        except User.DoesNotExist:
-            pass
 
     def __str__(self):  # pragma: no cover - simple representation
         return self.uid

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,16 +1,18 @@
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from .models import User, BlacklistedRFID, Account
+from .models import User, RFID, Account
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 
 
 class RFIDLoginTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="secret", rfid_uid="CARD123"
+            username="alice", password="secret"
         )
+        RFID.objects.create(uid="CARD123", user=self.user)
 
     def test_rfid_login_success(self):
         response = self.client.post(
@@ -33,18 +35,18 @@ class RFIDLoginTests(TestCase):
 class BlacklistRFIDTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            username="eve", password="secret", rfid_uid="BAD123"
+            username="eve", password="secret"
         )
+        self.rfid = RFID.objects.create(uid="BAD123", user=self.user)
 
     def test_blacklist_removes_and_blocks(self):
-        BlacklistedRFID.objects.create(uid="BAD123")
+        self.rfid.blacklisted = True
+        self.rfid.save()
         self.user.refresh_from_db()
-        self.assertIsNone(self.user.rfid_uid)
+        self.assertFalse(self.user.rfids.exists())
 
-        with self.assertRaises(ValidationError):
-            User.objects.create_user(
-                username="bob", password="pwd", rfid_uid="BAD123"
-            )
+        with self.assertRaises(IntegrityError):
+            RFID.objects.create(uid="BAD123", user=self.user)
 
 
 class AccountTests(TestCase):

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -19,7 +19,7 @@ includes a JSON `config` field for storing charger-specific settings.
 
 Each charger also has a `require_rfid` flag that can be enabled to
 enforce RFID authentication. When set, the server validates the `idTag`
-against known users before allowing a transaction to start.
+against entries in the `RFID` table before allowing a transaction to start.
 
 It also records the timestamp of the last `Heartbeat` message and the
 payload of the most recent `MeterValues` message received from the charger.

--- a/ocpp/migrations/0004_merge.py
+++ b/ocpp/migrations/0004_merge.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ocpp", "0003_add_charger_status_fields"),
+        ("ocpp", "0003_charger_require_rfid"),
+    ]
+
+    operations = []
+

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 
 from config.asgi import application
 from .models import Transaction, Charger
+from accounts.models import RFID
 
 
 class CSMSConsumerTests(TransactionTestCase):
@@ -75,7 +76,8 @@ class CSMSConsumerTests(TransactionTestCase):
 
     async def test_rfid_required_accepts_known_tag(self):
         User = get_user_model()
-        await database_sync_to_async(User.objects.create_user)(username="bob", password="pwd", rfid_uid="CARDX")
+        user = await database_sync_to_async(User.objects.create_user)(username="bob", password="pwd")
+        await database_sync_to_async(RFID.objects.create)(uid="CARDX", user=user)
         await database_sync_to_async(Charger.objects.create)(charger_id="RFIDOK", require_rfid=True)
         communicator = WebsocketCommunicator(application, "/ws/ocpp/RFIDOK/")
         connected, _ = await communicator.connect()


### PR DESCRIPTION
## Summary
- replace `rfid_uid` and `BlacklistedRFID` with a general `RFID` model
- update RFID auth backend to use the new model
- allow chargers to validate `idTag` via RFID table
- adjust tests and docs

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68881840a0448326b78493456e271441