### PR TITLE
Add OCPP websocket simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ Active connections and logs remain in-memory via `ocpp.store`, but
 completed charging sessions are saved in the `Transaction` model for
 later inspection.
 
+### Simulator
+
+The app includes a small WebSocket charge point simulator located in
+`ocpp/simulator.py`.  It can be used to exercise the CSMS during
+development.  Example usage:
+
+```python
+import asyncio
+from ocpp.simulator import SimulatorConfig, ChargePointSimulator
+
+config = SimulatorConfig(host="localhost", ws_port=8000, cp_path="SIM1")
+sim = ChargePointSimulator(config)
+asyncio.run(sim._run_session())
+```
+
+The simulator establishes an OCPP 1.6 connection, starts a transaction and
+sends periodic meter values.  See the module for additional options such as
+RFID authentication or repeat mode.
+
 
 # Readme App
 

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -36,3 +36,22 @@ payload of the most recent `MeterValues` message received from the charger.
 Active connections and logs remain in-memory via `ocpp.store`, but
 completed charging sessions are saved in the `Transaction` model for
 later inspection.
+
+### Simulator
+
+The app includes a small WebSocket charge point simulator located in
+`ocpp/simulator.py`.  It can be used to exercise the CSMS during
+development.  Example usage:
+
+```python
+import asyncio
+from ocpp.simulator import SimulatorConfig, ChargePointSimulator
+
+config = SimulatorConfig(host="localhost", ws_port=8000, cp_path="SIM1")
+sim = ChargePointSimulator(config)
+asyncio.run(sim._run_session())
+```
+
+The simulator establishes an OCPP 1.6 connection, starts a transaction and
+sends periodic meter values.  See the module for additional options such as
+RFID authentication or repeat mode.

--- a/ocpp/simulator.py
+++ b/ocpp/simulator.py
@@ -1,0 +1,169 @@
+import asyncio
+import base64
+import json
+import random
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import websockets
+
+
+@dataclass
+class SimulatorConfig:
+    """Configuration for a simulated charge point."""
+
+    host: str = "127.0.0.1"
+    ws_port: int = 9000
+    rfid: str = "FFFFFFFF"
+    cp_path: str = "CPX"
+    duration: int = 600
+    kwh_min: float = 30.0
+    kwh_max: float = 60.0
+    interval: float = 5.0
+    pre_charge_delay: float = 0.0
+    repeat: bool = False
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+
+class ChargePointSimulator:
+    """Lightweight simulator for a single OCPP 1.6 charge point."""
+
+    def __init__(self, config: SimulatorConfig) -> None:
+        self.config = config
+        self._task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+
+    async def _run_session(self) -> None:
+        cfg = self.config
+        uri = f"ws://{cfg.host}:{cfg.ws_port}/{cfg.cp_path}"
+        headers = {}
+        if cfg.username and cfg.password:
+            userpass = f"{cfg.username}:{cfg.password}"
+            b64 = base64.b64encode(userpass.encode()).decode()
+            headers["Authorization"] = f"Basic {b64}"
+
+        async with websockets.connect(
+            uri, subprotocols=["ocpp1.6"], additional_headers=headers
+        ) as ws:
+            # handshake
+            await ws.send(
+                json.dumps(
+                    [
+                        2,
+                        "boot",
+                        "BootNotification",
+                        {
+                            "chargePointModel": "Simulator",
+                            "chargePointVendor": "SimVendor",
+                        },
+                    ]
+                )
+            )
+            await ws.recv()
+            await ws.send(json.dumps([2, "auth", "Authorize", {"idTag": cfg.rfid}]))
+            await ws.recv()
+
+            meter_start = random.randint(1000, 2000)
+            await ws.send(
+                json.dumps(
+                    [
+                        2,
+                        "start",
+                        "StartTransaction",
+                        {
+                            "connectorId": 1,
+                            "idTag": cfg.rfid,
+                            "meterStart": meter_start,
+                        },
+                    ]
+                )
+            )
+            resp = await ws.recv()
+            tx_id = json.loads(resp)[2].get("transactionId")
+
+            meter = meter_start
+            steps = max(1, int(cfg.duration / cfg.interval))
+            step_min = max(1, int((cfg.kwh_min * 1000) / steps))
+            step_max = max(1, int((cfg.kwh_max * 1000) / steps))
+
+            start_time = time.monotonic()
+            while time.monotonic() - start_time < cfg.duration:
+                if self._stop_event.is_set():
+                    break
+                meter += random.randint(step_min, step_max)
+                meter_kwh = meter / 1000.0
+                await ws.send(
+                    json.dumps(
+                        [
+                            2,
+                            "meter",
+                            "MeterValues",
+                            {
+                                "connectorId": 1,
+                                "transactionId": tx_id,
+                                "meterValue": [
+                                    {
+                                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                                        "sampledValue": [
+                                            {
+                                                "value": f"{meter_kwh:.3f}",
+                                                "measurand": "Energy.Active.Import.Register",
+                                                "unit": "kWh",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ]
+                    )
+                )
+                await asyncio.sleep(cfg.interval)
+
+            await ws.send(
+                json.dumps(
+                    [
+                        2,
+                        "stop",
+                        "StopTransaction",
+                        {
+                            "transactionId": tx_id,
+                            "idTag": cfg.rfid,
+                            "meterStop": meter,
+                        },
+                    ]
+                )
+            )
+            await ws.recv()
+
+    async def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self._run_session()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                # wait briefly then retry
+                await asyncio.sleep(1)
+                continue
+            if not self.config.repeat:
+                break
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._stop_event.set()
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+            self._stop_event = asyncio.Event()
+
+
+__all__ = ["SimulatorConfig", "ChargePointSimulator"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg[binary]>=3
 markdown
 qrcode
 Pillow
+websockets>=12


### PR DESCRIPTION
## Summary
- implement a simple charge point simulator in `ocpp/simulator.py`
- document simulator usage
- add `websockets` to requirements
- rebuild project README

## Testing
- `pip install -r requirements.txt`
- `python manage.py build_readme`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881ee6127483269e20bac333fe1cac