### PR TITLE
Add Bootstrap styling to README site

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,6 @@ Displays the README for a particular app depending on the subdomain.
 The mapping uses Django's `Site` model: set a site's *name* to the
 label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
+
+Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
+the README content has simple default styling.

--- a/website/README.md
+++ b/website/README.md
@@ -4,3 +4,6 @@ Displays the README for a particular app depending on the subdomain.
 The mapping uses Django's `Site` model: set a site's *name* to the
 label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
+
+Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
+the README content has simple default styling.

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Arthexis{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body class="p-3">
+    <div class="container">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/website/templates/website/readme.html
+++ b/website/templates/website/readme.html
@@ -1,0 +1,7 @@
+{% extends "website/base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+{{ content|safe }}
+{% endblock %}

--- a/website/views.py
+++ b/website/views.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.http import HttpResponse
+from django.shortcuts import render
 import markdown
 
 
@@ -15,4 +15,8 @@ def index(request):
         readme_file = Path(settings.BASE_DIR) / "README.md"
     text = readme_file.read_text(encoding="utf-8")
     html = markdown.markdown(text)
-    return HttpResponse(html)
+    return render(
+        request,
+        "website/readme.html",
+        {"content": html, "title": readme_file.stem},
+    )


### PR DESCRIPTION
## Summary
- create base and README templates for the website app
- render README through templates with Bootstrap
- mention Bootstrap usage in website documentation

## Testing
- `python manage.py build_readme`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888203cf5988326867a7c7db223b305