### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,4 +203,6 @@ label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
 
 Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
-the README content has simple default styling.
+the README content has simple default styling. A button in the upper-right
+corner toggles between light and dark themes and remembers the preference using
+`localStorage`.

--- a/website/README.md
+++ b/website/README.md
@@ -6,4 +6,6 @@ label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
 
 Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
-the README content has simple default styling.
+the README content has simple default styling. A button in the upper-right
+corner toggles between light and dark themes and remembers the preference using
+`localStorage`.

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,7 +8,31 @@
   </head>
   <body class="p-3">
     <div class="container">
+      <div class="text-end mb-3">
+        <button id="theme-toggle" class="btn btn-sm btn-outline-secondary" onclick="toggleTheme()">Dark Mode</button>
+      </div>
       {% block content %}{% endblock %}
     </div>
+    <script>
+      function setTheme(theme) {
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        localStorage.setItem('theme', theme);
+        document.getElementById('theme-toggle').innerText = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+      }
+
+      function toggleTheme() {
+        const current = document.documentElement.getAttribute('data-bs-theme') || 'light';
+        setTheme(current === 'light' ? 'dark' : 'light');
+      }
+
+      (function() {
+        const saved = localStorage.getItem('theme');
+        if (saved) {
+          setTheme(saved);
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          setTheme('dark');
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- switch website template to allow dark mode
- add button and JS to remember theme preference
- document the new feature in website README
- rebuild the combined README

## Testing
- `python -m pip install -q -r requirements.txt`
- `python manage.py build_readme`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68882cc5f1588326831ddc1ddedc1afe