### PR TITLE
Add charger log views and admin links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,8 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# local media generated during tests
+media/
 # Pyre type checker
 .pyre/
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ payload of the most recent `MeterValues` message received from the charger.
 - `GET /ocpp/chargers/<cid>/` – retrieve details and message log for a charger.
 - `POST /ocpp/chargers/<cid>/action/` – send actions such as `remote_stop` or
   `reset` to the charger.
+- `GET /ocpp/log/<cid>/` – HTML page showing the message log for a charger.
 
 ### Charger Landing Pages
 
@@ -161,6 +162,8 @@ Each `Charger` instance automatically gets a public landing page at
 `/ocpp/c/<charger_id>/`. A QR code pointing to this URL is created when the
 charger is saved and can be embedded in templates via the `qr_img` tag from the
 `qrcodes` app. The admin list displays a "Landing Page" link for quick testing.
+Another "Log" link opens `/ocpp/log/<charger_id>/` which renders the stored
+message exchange as HTML.
 
 Active connections and logs remain in-memory via `ocpp.store`, but
 completed charging sessions are saved in the `Transaction` model for

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -32,6 +32,7 @@ payload of the most recent `MeterValues` message received from the charger.
 - `GET /ocpp/chargers/<cid>/` – retrieve details and message log for a charger.
 - `POST /ocpp/chargers/<cid>/action/` – send actions such as `remote_stop` or
   `reset` to the charger.
+- `GET /ocpp/log/<cid>/` – HTML page showing the message log for a charger.
 
 ### Charger Landing Pages
 
@@ -39,6 +40,8 @@ Each `Charger` instance automatically gets a public landing page at
 `/ocpp/c/<charger_id>/`. A QR code pointing to this URL is created when the
 charger is saved and can be embedded in templates via the `qr_img` tag from the
 `qrcodes` app. The admin list displays a "Landing Page" link for quick testing.
+Another "Log" link opens `/ocpp/log/<charger_id>/` which renders the stored
+message exchange as HTML.
 
 Active connections and logs remain in-memory via `ocpp.store`, but
 completed charging sessions are saved in the `Transaction` model for

--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -15,6 +15,7 @@ class ChargerAdmin(admin.ModelAdmin):
         "require_rfid",
         "last_heartbeat",
         "test_link",
+        "log_link",
     )
     search_fields = ("charger_id", "name")
 
@@ -27,10 +28,19 @@ class ChargerAdmin(admin.ModelAdmin):
 
     test_link.short_description = "Landing Page"
 
+    def log_link(self, obj):
+        from django.utils.html import format_html
+        from django.urls import reverse
+
+        url = reverse("charger-log", args=[obj.charger_id])
+        return format_html('<a href="{}" target="_blank">view</a>', url)
+
+    log_link.short_description = "Log"
+
 
 @admin.register(Simulator)
 class SimulatorAdmin(admin.ModelAdmin):
-    list_display = ("name", "cp_path", "host", "ws_port", "running")
+    list_display = ("name", "cp_path", "host", "ws_port", "running", "log_link")
     actions = ("start_simulator", "stop_simulator")
 
     def running(self, obj):
@@ -60,3 +70,12 @@ class SimulatorAdmin(admin.ModelAdmin):
         self.message_user(request, "Stopping simulators")
 
     stop_simulator.short_description = "Stop selected simulators"
+
+    def log_link(self, obj):
+        from django.utils.html import format_html
+        from django.urls import reverse
+
+        url = reverse("charger-log", args=[obj.cp_path])
+        return format_html('<a href="{}" target="_blank">view</a>', url)
+
+    log_link.short_description = "Log"

--- a/ocpp/templates/ocpp/charger_logs.html
+++ b/ocpp/templates/ocpp/charger_logs.html
@@ -1,0 +1,11 @@
+{% extends "website/base.html" %}
+
+{% block title %}Log for {{ charger.name|default:charger.charger_id }}{% endblock %}
+
+{% block content %}
+<h1>Log for {{ charger.name|default:charger.charger_id }}</h1>
+<pre class="bg-light p-3">
+{% for entry in log %}{{ entry }}
+{% endfor %}
+</pre>
+{% endblock %}

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from config.asgi import application
-from .models import Transaction, Charger
+from .models import Transaction, Charger, Simulator
 from accounts.models import RFID, Account
 
 
@@ -71,6 +71,30 @@ class ChargerAdminTests(TestCase):
         url = reverse("admin:ocpp_charger_changelist")
         resp = self.client.get(url)
         self.assertContains(resp, charger.get_absolute_url())
+
+    def test_admin_lists_log_link(self):
+        charger = Charger.objects.create(charger_id="LOG1")
+        url = reverse("admin:ocpp_charger_changelist")
+        resp = self.client.get(url)
+        log_url = reverse("charger-log", args=["LOG1"])
+        self.assertContains(resp, log_url)
+
+
+class SimulatorAdminTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="admin2", password="secret", email="admin2@example.com"
+        )
+        self.client.force_login(self.admin)
+
+    def test_admin_lists_log_link(self):
+        sim = Simulator.objects.create(name="SIM", cp_path="SIMX")
+        url = reverse("admin:ocpp_simulator_changelist")
+        resp = self.client.get(url)
+        log_url = reverse("charger-log", args=["SIMX"])
+        self.assertContains(resp, log_url)
 
     async def test_unknown_charger_auto_registered(self):
         communicator = WebsocketCommunicator(application, "/ws/ocpp/NEWCHG/")

--- a/ocpp/urls.py
+++ b/ocpp/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("chargers/<str:cid>/", views.charger_detail, name="charger-detail"),
     path("chargers/<str:cid>/action/", views.dispatch_action, name="charger-action"),
     path("c/<str:cid>/", views.charger_page, name="charger-page"),
+    path("log/<str:cid>/", views.charger_log_page, name="charger-log"),
 ]

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -95,6 +95,17 @@ def charger_page(request, cid):
     return render(request, "ocpp/charger_page.html", {"charger": charger})
 
 
+def charger_log_page(request, cid):
+    """Render a simple page with the log for the charger."""
+    charger = get_object_or_404(Charger, charger_id=cid)
+    log = store.logs.get(cid, [])
+    return render(
+        request,
+        "ocpp/charger_logs.html",
+        {"charger": charger, "log": log},
+    )
+
+
 @csrf_exempt
 def dispatch_action(request, cid):
     ws = store.connections.get(cid)


### PR DESCRIPTION
## Summary
- add `charger_log_page` view with template and URL
- expose log links in Charger and Simulator admin lists
- document log view in `ocpp/README.md` and rebuild main README
- add tests for new admin links
- ignore generated media files

## Testing
- `python manage.py build_readme`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68883c2a9044832694b02567ee822c5f