### PR TITLE
Add Spanish translation

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -40,6 +40,13 @@ Launch configurations are provided in `.vscode/launch.json`:
 
 Open the *Run and Debug* pane in VS Code and choose the desired configuration.
 
+## Internationalization
+
+English is the primary language for this project.  A Spanish translation is
+available under `locale/es`.  You can activate it by setting the `LANGUAGE_CODE`
+setting or selecting the language via Django's i18n mechanisms.  The supported
+languages are defined in `config/settings.py`.
+
 ## Maintaining Documentation
 
 Documentation is split across multiple files. `README.base.md` provides the

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Launch configurations are provided in `.vscode/launch.json`:
 
 Open the *Run and Debug* pane in VS Code and choose the desired configuration.
 
+## Internationalization
+
+English is the primary language for this project.  A Spanish translation is
+available under `locale/es`.  You can activate it by setting the `LANGUAGE_CODE`
+setting or selecting the language via Django's i18n mechanisms.  The supported
+languages are defined in `config/settings.py`.
+
 ## Maintaining Documentation
 
 Documentation is split across multiple files. `README.base.md` provides the

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
+from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -57,6 +58,7 @@ SITE_ID = 1
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -75,6 +77,7 @@ TEMPLATES = [
             "context_processors": [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.i18n",
                 "django.contrib.messages.context_processors.messages",
             ],
         },
@@ -143,6 +146,13 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
+
+LANGUAGES = [
+    ("en", _("English")),
+    ("es", _("Spanish")),
+]
+
+LOCALE_PATHS = [BASE_DIR / "locale"]
 
 TIME_ZONE = "UTC"
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-29 03:19+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+#: config/settings.py:151
+msgid "English"
+msgstr ""
+
+#: config/settings.py:152
+msgid "Spanish"
+msgstr ""
+
+#: nodes/templates/admin/nodes/node/change_list.html:7
+msgid "Register current host"
+msgstr "Registrar anfitri\xC3\xB3n actual"
+
+#: website/templates/website/base.html:7
+msgid "Arthexis"
+msgstr "Arthexis"
+
+#: website/templates/website/base.html:13
+#: website/templates/website/base.html:21
+msgid "Dark Mode"
+msgstr "Modo Oscuro"
+
+#: website/templates/website/base.html:21
+msgid "Light Mode"
+msgstr "Modo Claro"

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -1,15 +1,16 @@
+{% load i18n %}
 <!doctype html>
-<html lang="en" data-bs-theme="light">
+<html lang="{{ LANGUAGE_CODE }}" data-bs-theme="light">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Arthexis{% endblock %}</title>
+    <title>{% block title %}{% trans "Arthexis" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
   <body class="p-3">
     <div class="container">
       <div class="text-end mb-3">
-        <button id="theme-toggle" class="btn btn-sm btn-outline-secondary" onclick="toggleTheme()">Dark Mode</button>
+        <button id="theme-toggle" class="btn btn-sm btn-outline-secondary" onclick="toggleTheme()">{% trans "Dark Mode" %}</button>
       </div>
       {% block content %}{% endblock %}
     </div>
@@ -17,7 +18,7 @@
       function setTheme(theme) {
         document.documentElement.setAttribute('data-bs-theme', theme);
         localStorage.setItem('theme', theme);
-        document.getElementById('theme-toggle').innerText = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+        document.getElementById('theme-toggle').innerText = theme === 'dark' ? '{% trans "Light Mode" %}' : '{% trans "Dark Mode" %}';
       }
 
       function toggleTheme() {


### PR DESCRIPTION
## Summary
- support i18n in settings
- translate template strings
- add Spanish locale with translations
- document available language support

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68883d25c070832699a6d21fd15cc2b2