### PR TITLE
Print websocket URLs when running server

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ the `readme` site which renders this documentation.
 
 # Chat App
 
-This project includes basic websocket support using [Django Channels](https://channels.readthedocs.io/). After launching the development server you can connect a websocket client to `ws://localhost:8000/ws/echo/` and any text you send will be echoed back.
+This project includes basic websocket support using [Django Channels](https://channels.readthedocs.io/). After launching the development server the console now prints the available WebSocket endpoint:
+
+```
+WebSocket available at ws://localhost:8000/ws/echo/
+```
+
+You can connect a WebSocket client to this URL and any text you send will be echoed back.
 
 
 # Nodes App

--- a/chat/README.md
+++ b/chat/README.md
@@ -1,3 +1,9 @@
 # Chat App
 
-This project includes basic websocket support using [Django Channels](https://channels.readthedocs.io/). After launching the development server you can connect a websocket client to `ws://localhost:8000/ws/echo/` and any text you send will be echoed back.
+This project includes basic websocket support using [Django Channels](https://channels.readthedocs.io/). After launching the development server the console now prints the available WebSocket endpoint:
+
+```
+WebSocket available at ws://localhost:8000/ws/echo/
+```
+
+You can connect a WebSocket client to this URL and any text you send will be echoed back.

--- a/manage.py
+++ b/manage.py
@@ -11,6 +11,23 @@ def main():
         from django.core.management import execute_from_command_line
         from django.conf import settings
         from django.utils.autoreload import run_with_reloader
+        from django.contrib.staticfiles.management.commands.runserver import (
+            Command as RunserverCommand,
+        )
+        # Patch the runserver command to display WebSocket URLs
+        def patched_on_bind(self, server_port):
+            original_on_bind(self, server_port)
+            host = self.addr or (
+                self.default_addr_ipv6 if self.use_ipv6 else self.default_addr
+            )
+            scheme = "wss" if getattr(self, "ssl_options", None) else "ws"
+            for path in ["/ws/echo/", "/ws/ocpp/<cid>/"]:
+                self.stdout.write(
+                    f"WebSocket available at {scheme}://{host}:{server_port}{path}"
+                )
+
+        original_on_bind = RunserverCommand.on_bind
+        RunserverCommand.on_bind = patched_on_bind
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/readme/management/commands/runserver.py
+++ b/readme/management/commands/runserver.py
@@ -1,0 +1,16 @@
+from django.core.management.commands.runserver import Command as RunserverCommand
+
+class Command(RunserverCommand):
+    """Extended runserver command that also prints WebSocket URLs."""
+
+    def on_bind(self, server_port):
+        super().on_bind(server_port)
+        host = self.addr or (self.default_addr_ipv6 if self.use_ipv6 else self.default_addr)
+        scheme = 'wss' if self.ssl_options else 'ws'
+        # Display available websocket URLs.
+        websocket_paths = ['/ws/echo/', '/ws/ocpp/<cid>/']
+        for path in websocket_paths:
+            self.stdout.write(f"WebSocket available at {scheme}://{host}:{server_port}{path}")
+
+
+


### PR DESCRIPTION
## Summary
- show websocket URLs at server startup by patching `runserver`
- document websocket URL message in chat README

## Testing
- `python manage.py runserver --noreload & sleep 5; pkill -f runserver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688841c04fd48326acc990a205e448b8