### PR TITLE
Tie subscriptions to accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ RFID tags can be exported and imported using management commands:
 Provides a simple subscription model:
 
 - `GET /subscriptions/products/` returns available products.
-- `POST /subscriptions/subscribe/` with `user_id` and `product_id` creates a subscription.
-- `GET /subscriptions/list/?user_id=<id>` lists subscriptions for a user.
+- `POST /subscriptions/subscribe/` with `account_id` and `product_id` creates a subscription.
+- `GET /subscriptions/list/?account_id=<id>` lists subscriptions for an account.
 
 
 # OCPP App

--- a/subscriptions/README.md
+++ b/subscriptions/README.md
@@ -3,5 +3,5 @@
 Provides a simple subscription model:
 
 - `GET /subscriptions/products/` returns available products.
-- `POST /subscriptions/subscribe/` with `user_id` and `product_id` creates a subscription.
-- `GET /subscriptions/list/?user_id=<id>` lists subscriptions for a user.
+- `POST /subscriptions/subscribe/` with `account_id` and `product_id` creates a subscription.
+- `GET /subscriptions/list/?account_id=<id>` lists subscriptions for an account.

--- a/subscriptions/migrations/0002_subscription_account.py
+++ b/subscriptions/migrations/0002_subscription_account.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subscriptions', '0001_initial'),
+        ('accounts', '0011_credit_created_by'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='subscription',
+            old_name='user',
+            new_name='account',
+        ),
+        migrations.AlterField(
+            model_name='subscription',
+            name='account',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='accounts.account'),
+        ),
+    ]

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
-from django.conf import settings
 from django.db import models
+from accounts.models import Account
 
 
 class Product(models.Model):
@@ -15,9 +15,9 @@ class Product(models.Model):
 
 
 class Subscription(models.Model):
-    """A user's subscription to a product."""
+    """An account's subscription to a product."""
 
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    account = models.ForeignKey(Account, on_delete=models.CASCADE)
     product = models.ForeignKey(Product, on_delete=models.CASCADE)
     start_date = models.DateField(auto_now_add=True)
     next_renewal = models.DateField(blank=True)
@@ -28,4 +28,4 @@ class Subscription(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"{self.user} -> {self.product}"
+        return f"{self.account.user} -> {self.product}"

--- a/subscriptions/tests.py
+++ b/subscriptions/tests.py
@@ -1,7 +1,7 @@
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from accounts.models import User
+from accounts.models import User, Account
 from .models import Product, Subscription
 
 
@@ -9,19 +9,20 @@ class SubscriptionTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(username="bob", password="pwd")
+        self.account = Account.objects.create(user=self.user)
         self.product = Product.objects.create(name="Gold", renewal_period=30)
 
     def test_create_and_list_subscription(self):
         response = self.client.post(
             reverse("add-subscription"),
-            data={"user_id": self.user.id, "product_id": self.product.id},
+            data={"account_id": self.account.id, "product_id": self.product.id},
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Subscription.objects.count(), 1)
 
         list_resp = self.client.get(
-            reverse("subscription-list"), {"user_id": self.user.id}
+            reverse("subscription-list"), {"account_id": self.account.id}
         )
         self.assertEqual(list_resp.status_code, 200)
         data = list_resp.json()

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -15,7 +15,7 @@ def product_list(request):
 
 @csrf_exempt
 def add_subscription(request):
-    """Create a subscription for a user to a product from POSTed JSON."""
+    """Create a subscription for an account from POSTed JSON."""
     if request.method != "POST":
         return JsonResponse({"detail": "POST required"}, status=400)
 
@@ -24,11 +24,11 @@ def add_subscription(request):
     except json.JSONDecodeError:
         data = request.POST
 
-    user_id = data.get("user_id")
+    account_id = data.get("account_id")
     product_id = data.get("product_id")
 
-    if not user_id or not product_id:
-        return JsonResponse({"detail": "user_id and product_id required"}, status=400)
+    if not account_id or not product_id:
+        return JsonResponse({"detail": "account_id and product_id required"}, status=400)
 
     try:
         product = Product.objects.get(id=product_id)
@@ -36,7 +36,7 @@ def add_subscription(request):
         return JsonResponse({"detail": "invalid product"}, status=404)
 
     sub = Subscription.objects.create(
-        user_id=user_id,
+        account_id=account_id,
         product=product,
         next_renewal=date.today() + timedelta(days=product.renewal_period),
     )
@@ -44,13 +44,13 @@ def add_subscription(request):
 
 
 def subscription_list(request):
-    """Return subscriptions for the given user_id."""
-    user_id = request.GET.get("user_id")
-    if not user_id:
-        return JsonResponse({"detail": "user_id required"}, status=400)
+    """Return subscriptions for the given account_id."""
+    account_id = request.GET.get("account_id")
+    if not account_id:
+        return JsonResponse({"detail": "account_id required"}, status=400)
 
     subs = list(
-        Subscription.objects.filter(user_id=user_id)
+        Subscription.objects.filter(account_id=account_id)
         .select_related("product")
         .values(
             "id",


### PR DESCRIPTION
## Summary
- adjust subscription model to link to Account instead of User
- update subscription views to accept account_id
- rewrite subscription tests for account linkage
- document account-based subscriptions and regenerate README
- add migration to rename field

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688842f402b083269c27a7b57bb578c2