### PR TITLE
Add rotating log file config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+media/
 
 # Flask stuff:
 instance/

--- a/README.base.md
+++ b/README.base.md
@@ -47,6 +47,12 @@ available under `locale/es`.  You can activate it by setting the `LANGUAGE_CODE`
 setting or selecting the language via Django's i18n mechanisms.  The supported
 languages are defined in `config/settings.py`.
 
+## Logging
+
+Log messages from all apps are written to `logs/arthexis.log`. The file
+rotates at midnight with the date appended to the filename. When running the
+test suite, logs are stored in `logs/tests.log` instead.
+
 ## Maintaining Documentation
 
 Documentation is split across multiple files. `README.base.md` provides the

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ available under `locale/es`.  You can activate it by setting the `LANGUAGE_CODE`
 setting or selecting the language via Django's i18n mechanisms.  The supported
 languages are defined in `config/settings.py`.
 
+## Logging
+
+Log messages from all apps are written to `logs/arthexis.log`. The file
+rotates at midnight with the date appended to the filename. When running the
+test suite, logs are stored in `logs/tests.log` instead.
+
 ## Maintaining Documentation
 
 Documentation is split across multiple files. `README.base.md` provides the
@@ -186,9 +192,9 @@ Each `Charger` instance automatically gets a public landing page at
 charger is saved and can be embedded in templates via the `qr_img` tag from the
 `qrcodes` app. The admin list displays a "Landing Page" link for quick testing.
 
-Active connections and logs remain in-memory via `ocpp.store`, but
-completed charging sessions are saved in the `Transaction` model for
-later inspection.
+Active connections remain in-memory via `ocpp.store`. OCPP messages are
+also written to the project's log file. Completed charging sessions are
+saved in the `Transaction` model for later inspection.
 
 ### Simulator
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
+import sys
 from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -172,3 +173,32 @@ MEDIA_ROOT = BASE_DIR / "media"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Logging configuration
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+LOG_FILE_NAME = "tests.log" if "test" in sys.argv else "arthexis.log"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        }
+    },
+    "handlers": {
+        "file": {
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": str(LOG_DIR / LOG_FILE_NAME),
+            "when": "midnight",
+            "backupCount": 7,
+            "encoding": "utf-8",
+            "formatter": "standard",
+        }
+    },
+    "root": {
+        "handlers": ["file"],
+        "level": "DEBUG",
+    },
+}

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -45,9 +45,9 @@ Each `Charger` instance automatically gets a public landing page at
 charger is saved and can be embedded in templates via the `qr_img` tag from the
 `qrcodes` app. The admin list displays a "Landing Page" link for quick testing.
 
-Active connections and logs remain in-memory via `ocpp.store`, but
-completed charging sessions are saved in the `Transaction` model for
-later inspection.
+Active connections remain in-memory via `ocpp.store`. OCPP messages are
+also written to the project's log file. Completed charging sessions are
+saved in the `Transaction` model for later inspection.
 
 ### Simulator
 


### PR DESCRIPTION
## Summary
- set up rotating file logger to logs/arthexis.log
- use tests.log when running the test suite
- document logging in README.base and ocpp README
- ignore media directory

## Testing
- `python manage.py build_readme`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688848a5b8c08326850a12814120c101