### PR TITLE
Ignore more log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ cover/
 
 # Django stuff:
 *.log
+# Additional log files
+*.logs
+*.log.*
+*.logs.*
+# Log directories
+logs/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal


### PR DESCRIPTION
## Summary
- add patterns for `.logs` and variants to `.gitignore`

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'daphne')*

------
https://chatgpt.com/codex/tasks/task_e_6888ccb2c8848326a41f3533084a8c82