### PR TITLE
Add admin connection testing for Odoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,9 @@ Provides a small `QRLink` model that stores a value and generates a QR image for
 
 Provides a simple integration with an Odoo server. The `Instance` model stores
 connection credentials and a `/odoo/test/<id>/` endpoint checks whether the
-specified instance can be authenticated.
+specified instance can be authenticated. Instances can be managed through the
+Django admin where a **Test connection** action attempts to authenticate with
+the selected servers.
 
 
 # Readme App

--- a/odoo/README.md
+++ b/odoo/README.md
@@ -2,4 +2,6 @@
 
 Provides a simple integration with an Odoo server. The `Instance` model stores
 connection credentials and a `/odoo/test/<id>/` endpoint checks whether the
-specified instance can be authenticated.
+specified instance can be authenticated. Instances can be managed through the
+Django admin where a **Test connection** action attempts to authenticate with
+the selected servers.

--- a/odoo/admin.py
+++ b/odoo/admin.py
@@ -1,0 +1,43 @@
+from django.contrib import admin, messages
+
+from .models import Instance
+
+import xmlrpc.client
+from urllib.parse import urljoin
+
+
+@admin.register(Instance)
+class InstanceAdmin(admin.ModelAdmin):
+    list_display = ("name", "url", "database", "username")
+    actions = ["test_connection"]
+
+    def test_connection(self, request, queryset):
+        for instance in queryset:
+            server = xmlrpc.client.ServerProxy(
+                urljoin(instance.url, "/xmlrpc/2/common")
+            )
+            try:
+                uid = server.authenticate(
+                    instance.database,
+                    instance.username,
+                    instance.password,
+                    {},
+                )
+            except Exception as exc:
+                self.message_user(
+                    request,
+                    f"{instance.name}: {exc}",
+                    level=messages.ERROR,
+                )
+                continue
+
+            if uid:
+                self.message_user(request, f"{instance.name}: success")
+            else:
+                self.message_user(
+                    request,
+                    f"{instance.name}: invalid credentials",
+                    level=messages.ERROR,
+                )
+
+    test_connection.short_description = "Test connection"

--- a/odoo/tests.py
+++ b/odoo/tests.py
@@ -1,5 +1,6 @@
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.contrib.auth import get_user_model
 from unittest.mock import patch
 
 from .models import Instance
@@ -30,3 +31,43 @@ class OdooTests(TestCase):
         mock_srv.authenticate.return_value = False
         response = self.client.post(reverse("odoo-test", args=[self.instance.pk]))
         self.assertEqual(response.status_code, 401)
+
+class OdooAdminTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="admin",
+            password="secret",
+            email="admin@example.com",
+        )
+        self.client.force_login(self.admin)
+        self.instance = Instance.objects.create(
+            name="Local",
+            url="http://odoo.local",
+            database="db",
+            username="user",
+            password="pwd",
+        )
+
+    @patch("xmlrpc.client.ServerProxy")
+    def test_admin_action(self, mock_proxy):
+        mock_srv = mock_proxy.return_value
+        mock_srv.authenticate.return_value = 1
+        url = reverse("admin:odoo_instance_changelist")
+        resp = self.client.post(
+            url,
+            {
+                "action": "test_connection",
+                "_selected_action": [self.instance.pk],
+            },
+        )
+        self.assertEqual(resp.status_code, 302)
+        mock_proxy.assert_called()
+        mock_srv.authenticate.assert_called_with(
+            self.instance.database,
+            self.instance.username,
+            self.instance.password,
+            {},
+        )
+


### PR DESCRIPTION
## Summary
- add an admin interface for `odoo.Instance` with a test connection action
- document the new admin action
- include tests for the admin functionality
- rebuild README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888cf23796883268453379017571f1b