### PR TITLE
Add helper install and upgrade scripts

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -17,6 +17,11 @@ This repository contains a basic [Django](https://www.djangoproject.com/) projec
    python manage.py runserver
    ```
 
+If you prefer an automated setup, run `./install.sh` which creates a
+virtual environment and installs dependencies for you.  Adding
+`--service <name>` installs a systemd service with the specified name
+that launches the server on boot.
+
    To have the server automatically restart when files change, set
    the `DJANGO_DEV_RELOAD` environment variable:
 
@@ -52,6 +57,13 @@ languages are defined in `config/settings.py`.
 Log messages from all apps are written to `logs/arthexis.log`. The file
 rotates at midnight with the date appended to the filename. When running the
 test suite, logs are stored in `logs/tests.log` instead.
+
+## Updating
+
+Run `./upgrade.sh` to fetch the latest code from this repository. Any
+local changes are stashed automatically before pulling and restored
+afterwards.  When a virtual environment exists, the script also
+reinstalls dependencies.
 
 ## Maintaining Documentation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This repository contains a basic [Django](https://www.djangoproject.com/) projec
    python manage.py runserver
    ```
 
+If you prefer an automated setup, run `./install.sh` which creates a
+virtual environment and installs dependencies for you.  Adding
+`--service <name>` installs a systemd service with the specified name
+that launches the server on boot.
+
    To have the server automatically restart when files change, set
    the `DJANGO_DEV_RELOAD` environment variable:
 
@@ -52,6 +57,13 @@ languages are defined in `config/settings.py`.
 Log messages from all apps are written to `logs/arthexis.log`. The file
 rotates at midnight with the date appended to the filename. When running the
 test suite, logs are stored in `logs/tests.log` instead.
+
+## Updating
+
+Run `./upgrade.sh` to fetch the latest code from this repository. Any
+local changes are stashed automatically before pulling and restored
+afterwards.  When a virtual environment exists, the script also
+reinstalls dependencies.
 
 ## Maintaining Documentation
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -e
+
+SERVICE=""
+
+usage() {
+    echo "Usage: $0 [--service NAME]" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service)
+            [ -z "$2" ] && usage
+            SERVICE="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+# Create virtual environment if missing
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+deactivate
+
+if [ -n "$SERVICE" ]; then
+    SERVICE_FILE="/etc/systemd/system/${SERVICE}.service"
+    sudo bash -c "cat > '$SERVICE_FILE'" <<SERVICEEOF
+[Unit]
+Description=Arthexis Django service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$BASE_DIR
+ExecStart=$BASE_DIR/.venv/bin/python manage.py runserver 0.0.0.0:8000
+Restart=always
+User=$(id -un)
+
+[Install]
+WantedBy=multi-user.target
+SERVICEEOF
+    sudo systemctl daemon-reload
+    sudo systemctl enable "$SERVICE"
+    sudo systemctl restart "$SERVICE"
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+# Stash local changes if any
+STASHED=0
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    git stash push -u -m "auto-upgrade $(date -Is)" || true
+    STASHED=1
+fi
+
+# Pull latest changes
+git pull --rebase
+
+# Restore stashed changes
+if [ "$STASHED" -eq 1 ]; then
+    git stash pop || true
+fi
+
+# Update dependencies if virtualenv exists
+if [ -d .venv ]; then
+    source .venv/bin/activate
+    pip install -r requirements.txt
+    deactivate
+fi


### PR DESCRIPTION
## Summary
- add `install.sh` and `upgrade.sh` utilities
- document how to use the new scripts

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888cfeaa1c8832680b0efb39e211464