### PR TITLE
Improve logging per active app

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -57,9 +57,10 @@ languages are defined in `config/settings.py`.
 
 ## Logging
 
-Log messages from all apps are written to `logs/arthexis.log`. The file
-rotates at midnight with the date appended to the filename. When running the
-test suite, logs are stored in `logs/tests.log` instead.
+Log messages are written to `logs/<active_app>.log` where `<active_app>` is the
+application handling the current request. By default this is `website.log`. The
+file rotates at midnight with the date appended to the filename. When running
+the test suite, logs are stored in `logs/tests.log` instead.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ languages are defined in `config/settings.py`.
 
 ## Logging
 
-Log messages from all apps are written to `logs/arthexis.log`. The file
-rotates at midnight with the date appended to the filename. When running the
-test suite, logs are stored in `logs/tests.log` instead.
+Log messages are written to `logs/<active_app>.log` where `<active_app>` is the
+application handling the current request. By default this is `website.log`. The
+file rotates at midnight with the date appended to the filename. When running
+the test suite, logs are stored in `logs/tests.log` instead.
 
 ## Updating
 

--- a/config/active_app.py
+++ b/config/active_app.py
@@ -1,0 +1,14 @@
+import threading
+
+_active = threading.local()
+_active.name = "website"
+
+
+def get_active_app():
+    """Return the currently active app name."""
+    return getattr(_active, "name", "website")
+
+
+def set_active_app(name: str) -> None:
+    """Set the active app name for the current thread."""
+    _active.name = name or "website"

--- a/config/logging.py
+++ b/config/logging.py
@@ -1,0 +1,25 @@
+import sys
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from django.conf import settings
+
+from .active_app import get_active_app
+
+
+class ActiveAppFileHandler(TimedRotatingFileHandler):
+    """File handler that writes to a file named after the active app."""
+
+    def _current_file(self) -> Path:
+        if "test" in sys.argv:
+            return Path(settings.LOG_DIR) / "tests.log"
+        return Path(settings.LOG_DIR) / f"{get_active_app()}.log"
+
+    def emit(self, record: logging.LogRecord) -> None:
+        current = str(self._current_file())
+        if self.baseFilename != current:
+            self.baseFilename = current
+            if self.stream:
+                self.stream.close()
+            self.stream = self._open()
+        super().emit(record)

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,0 +1,17 @@
+from django.contrib.sites.shortcuts import get_current_site
+
+from .active_app import set_active_app
+
+
+class ActiveAppMiddleware:
+    """Store the current app based on the request's site."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        site = get_current_site(request)
+        active = site.name or "website"
+        set_active_app(active)
+        request.active_app = active
+        return self.get_response(request)

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import os
 import sys
 from django.utils.translation import gettext_lazy as _
+from .active_app import get_active_app
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -59,6 +60,7 @@ SITE_ID = 1
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "config.middleware.ActiveAppMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -177,7 +179,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Logging configuration
 LOG_DIR = BASE_DIR / "logs"
 LOG_DIR.mkdir(exist_ok=True)
-LOG_FILE_NAME = "tests.log" if "test" in sys.argv else "arthexis.log"
+LOG_FILE_NAME = "tests.log" if "test" in sys.argv else "website.log"
 
 LOGGING = {
     "version": 1,
@@ -189,7 +191,7 @@ LOGGING = {
     },
     "handlers": {
         "file": {
-            "class": "logging.handlers.TimedRotatingFileHandler",
+            "class": "config.logging.ActiveAppFileHandler",
             "filename": str(LOG_DIR / LOG_FILE_NAME),
             "when": "midnight",
             "backupCount": 7,


### PR DESCRIPTION
## Summary
- track active app in thread-local storage
- add middleware to set request.active_app
- log to a file named after the active app using a custom handler
- default log becomes `website.log`
- document new logging behaviour

## Testing
- `pip install -r requirements.txt`
- `python manage.py build_readme`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888e694ebdc8326b1779a4870ea2bde