### PR TITLE
Add admin URL display on server start

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -17,8 +17,11 @@ This repository contains a basic [Django](https://www.djangoproject.com/) projec
    python manage.py runserver
    ```
 
-   The included `runserver` command comes from Daphne via Django Channels,
-   so it serves the ASGI application and supports WebSocket endpoints.
+    The included `runserver` command comes from Daphne via Django Channels,
+    so it serves the ASGI application and supports WebSocket endpoints.
+
+   When it starts you will see the server URL along with direct WebSocket
+   and admin links printed to the console.
 
 If you prefer an automated setup, run `./install.sh` which creates a
 virtual environment and installs dependencies for you.  Adding

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ This repository contains a basic [Django](https://www.djangoproject.com/) projec
    python manage.py runserver
    ```
 
-   The included `runserver` command comes from Daphne via Django Channels,
-   so it serves the ASGI application and supports WebSocket endpoints.
+    The included `runserver` command comes from Daphne via Django Channels,
+    so it serves the ASGI application and supports WebSocket endpoints.
+
+   When it starts you will see the server URL along with direct WebSocket
+   and admin links printed to the console.
 
 If you prefer an automated setup, run `./install.sh` which creates a
 virtual environment and installs dependencies for you.  Adding

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,8 @@ def main():
 
         core_runserver.Command = DaphneRunserver
 
-        # Patch the runserver command to display WebSocket URLs when it binds
+        # Patch the runserver command to display WebSocket URLs and admin link
+        # when it binds
         def patched_on_bind(self, server_port):
             original_on_bind(self, server_port)
             host = self.addr or (
@@ -30,6 +31,10 @@ def main():
                 self.stdout.write(
                     f"WebSocket available at {scheme}://{host}:{server_port}{path}"
                 )
+            http_scheme = "https" if getattr(self, "ssl_options", None) else "http"
+            self.stdout.write(
+                f"Admin available at {http_scheme}://{host}:{server_port}/admin/"
+            )
 
         original_on_bind = core_runserver.Command.on_bind
         core_runserver.Command.on_bind = patched_on_bind

--- a/readme/management/commands/runserver.py
+++ b/readme/management/commands/runserver.py
@@ -1,7 +1,7 @@
 from daphne.management.commands.runserver import Command as RunserverCommand
 
 class Command(RunserverCommand):
-    """Extended runserver command that also prints WebSocket URLs."""
+    """Extended runserver command that also prints WebSocket URLs and admin link."""
 
     def on_bind(self, server_port):
         super().on_bind(server_port)
@@ -11,6 +11,8 @@ class Command(RunserverCommand):
         websocket_paths = ['/ws/echo/', '/<path>/<cid>/']
         for path in websocket_paths:
             self.stdout.write(f"WebSocket available at {scheme}://{host}:{server_port}{path}")
+        http_scheme = 'https' if self.ssl_options else 'http'
+        self.stdout.write(f"Admin available at {http_scheme}://{host}:{server_port}/admin/")
 
 
 


### PR DESCRIPTION
## Summary
- print admin link when starting runserver
- mention the console output in README

## Testing
- `python manage.py test`
- `python manage.py build_readme`


------
https://chatgpt.com/codex/tasks/task_e_6888e80d2b4083268f43e8448dbaf573