### PR TITLE
Move custom user into auth admin section

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -3,10 +3,10 @@ from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 
-from .models import User, RFID, Account, Vehicle, Credit
+from .models import UserProxy, RFID, Account, Vehicle, Credit
 
 
-@admin.register(User)
+@admin.register(UserProxy)
 class UserAdmin(DjangoUserAdmin):
     fieldsets = DjangoUserAdmin.fieldsets + ((None, {"fields": ("phone_number",)}),)
     add_fieldsets = DjangoUserAdmin.add_fieldsets + ((None, {"fields": ("phone_number",)}),)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -3,6 +3,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
 
 class User(AbstractUser):
@@ -16,6 +17,16 @@ class User(AbstractUser):
 
     def __str__(self):
         return self.username
+
+
+class UserProxy(User):
+    """Proxy model to display users under the auth app in admin."""
+
+    class Meta:
+        proxy = True
+        app_label = "auth"
+        verbose_name = User._meta.verbose_name
+        verbose_name_plural = User._meta.verbose_name_plural
 
 
 class RFID(models.Model):

--- a/config/auth_app.py
+++ b/config/auth_app.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.apps import AuthConfig as DjangoAuthConfig
+
+
+class AuthConfig(DjangoAuthConfig):
+    """Use a shorter label for the auth section in the admin."""
+
+    verbose_name = "AUTH"
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -36,7 +36,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     "django.contrib.admin",
-    "django.contrib.auth",
+    "config.auth_app.AuthConfig",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",


### PR DESCRIPTION
## Summary
- add proxy model so users appear under auth
- rename auth app in admin to 'AUTH'

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6888f1f421a08326af8ac6eb90884f9b