### PR TITLE
Ensure abbreviations consistently uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ quickly verify whether an account would be accepted by a charger.
 ## Vehicles
 
 An account may be associated with multiple **Vehicle** records. Each vehicle
-stores the `brand`, `model` and `vin` (Vehicle Identification Number) so that a
+stores the `brand`, `model` and `VIN` (Vehicle Identification Number) so that a
 user's cars can be identified when using OCPP chargers.
 
 ## RFID CSV Utilities

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -29,7 +29,7 @@ quickly verify whether an account would be accepted by a charger.
 ## Vehicles
 
 An account may be associated with multiple **Vehicle** records. Each vehicle
-stores the `brand`, `model` and `vin` (Vehicle Identification Number) so that a
+stores the `brand`, `model` and `VIN` (Vehicle Identification Number) so that a
 user's cars can be identified when using OCPP chargers.
 
 ## RFID CSV Utilities

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -159,7 +159,7 @@ class Vehicle(models.Model):
     )
     brand = models.CharField(max_length=100, blank=True)
     model = models.CharField(max_length=100, blank=True)
-    vin = models.CharField(max_length=17, unique=True)
+    vin = models.CharField(max_length=17, unique=True, verbose_name="VIN")
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         parts = " ".join(p for p in [self.brand, self.model] if p)

--- a/ocpp/apps.py
+++ b/ocpp/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class OcppConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "ocpp"
+    verbose_name = "OCPP"


### PR DESCRIPTION
## Summary
- enforce uppercase label for Vehicle VIN field
- set verbose_name for OCPP app
- adjust documentation to use VIN in caps
- rebuild README

## Testing
- `python manage.py build_readme`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f74c1bb48326845e85f6482d6994