### PR TITLE
Fix charger page QR code rendering

### DIFF
--- a/qrcodes/templatetags/qr_tags.py
+++ b/qrcodes/templatetags/qr_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.safestring import mark_safe
 
 from qrcodes.models import QRLink
 
@@ -9,4 +10,7 @@ register = template.Library()
 def qr_img(value, size=200):
     """Return an <img> tag with the QR code for the given value."""
     qr, _ = QRLink.objects.get_or_create(value=value)
-    return f'<img src="{qr.image.url}" width="{size}" height="{size}" alt="QR code" />'
+    return mark_safe(
+        f'<img src="{qr.image.url}" width="{size}" height="{size}" alt="QR code" />'
+    )
+


### PR DESCRIPTION
## Summary
- return HTML `img` tag marked safe in `qr_img`

## Testing
- `python3 manage.py test`
- `python3 manage.py build_readme`

------
https://chatgpt.com/codex/tasks/task_e_6888f82da31c83269289eccf64fa6d1b