### PR TITLE
Add address model linked to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ Users may authenticate using any RFID tag assigned to their account. POST the RF
 The `RFID` model stores card identifiers (8 hexadecimal digits). A tag may belong to a user and is `allowed` by default. Set `allowed` to `false` to disable it.
 
 The `User` model has a **Contact** section containing optional `phone_number` and
-`address` fields. It also includes a `has_charger` flag indicating whether the
-user has a charger at that location.
+`address` fields. The `address` field is a foreign key to the `Address` model
+which stores `street`, `number`, `municipality`, `state` and `postal_code`.
+Only municipalities from the Mexican states of Coahuila and Nuevo León are
+accepted. The user model also includes a `has_charger` flag indicating whether
+the user has a charger at that location.
 
 The `RFID` model stores card identifiers (8 hexadecimal digits). A tag may belong to a user or be marked as `blacklisted` to disable it.
 

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -5,8 +5,11 @@ Users may authenticate using any RFID tag assigned to their account. POST the RF
 The `RFID` model stores card identifiers (8 hexadecimal digits). A tag may belong to a user and is `allowed` by default. Set `allowed` to `false` to disable it.
 
 The `User` model has a **Contact** section containing optional `phone_number` and
-`address` fields. It also includes a `has_charger` flag indicating whether the
-user has a charger at that location.
+`address` fields. The `address` field is a foreign key to the `Address` model
+which stores `street`, `number`, `municipality`, `state` and `postal_code`.
+Only municipalities from the Mexican states of Coahuila and Nuevo León are
+accepted. The user model also includes a `has_charger` flag indicating whether
+the user has a charger at that location.
 
 The `RFID` model stores card identifiers (8 hexadecimal digits). A tag may belong to a user or be marked as `blacklisted` to disable it.
 

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -3,7 +3,7 @@ from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 
-from .models import UserProxy, RFID, Account, Vehicle, Credit
+from .models import UserProxy, RFID, Account, Vehicle, Credit, Address
 
 
 @admin.register(UserProxy)
@@ -14,6 +14,12 @@ class UserAdmin(DjangoUserAdmin):
     add_fieldsets = DjangoUserAdmin.add_fieldsets + (
         ("Contact", {"fields": ("phone_number", "address", "has_charger")}),
     )
+
+
+@admin.register(Address)
+class AddressAdmin(admin.ModelAdmin):
+    list_display = ("street", "number", "municipality", "state", "postal_code")
+    search_fields = ("street", "municipality", "postal_code")
 
 
 

--- a/accounts/migrations/0014_address_model.py
+++ b/accounts/migrations/0014_address_model.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0013_user_address_user_has_charger"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Address",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("street", models.CharField(max_length=255)),
+                ("number", models.CharField(max_length=20)),
+                ("municipality", models.CharField(max_length=100)),
+                ("state", models.CharField(max_length=2)),
+                ("postal_code", models.CharField(max_length=10)),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name="user",
+            name="address",
+        ),
+        migrations.AddField(
+            model_name="user",
+            name="address",
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="accounts.address"),
+        ),
+    ]

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -2,7 +2,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from django.utils import timezone
-from .models import User, RFID, Account, Vehicle, Credit
+from .models import User, RFID, Account, Vehicle, Credit, Address
 from ocpp.models import Transaction
 
 from django.core.exceptions import ValidationError
@@ -107,3 +107,27 @@ class VehicleTests(TestCase):
         Vehicle.objects.create(account=acc, brand="Tesla", model="Model S", vin="VIN12345678901234")
         Vehicle.objects.create(account=acc, brand="Nissan", model="Leaf", vin="VIN23456789012345")
         self.assertEqual(acc.vehicles.count(), 2)
+
+
+class AddressTests(TestCase):
+    def test_invalid_municipality_state(self):
+        addr = Address(
+            street="Main",
+            number="1",
+            municipality="Monterrey",
+            state=Address.State.COAHUILA,
+            postal_code="00000",
+        )
+        with self.assertRaises(ValidationError):
+            addr.full_clean()
+
+    def test_user_link(self):
+        addr = Address.objects.create(
+            street="Main",
+            number="2",
+            municipality="Monterrey",
+            state=Address.State.NUEVO_LEON,
+            postal_code="64000",
+        )
+        user = User.objects.create_user(username="addr", password="pwd", address=addr)
+        self.assertEqual(user.address, addr)


### PR DESCRIPTION
## Summary
- add `Address` model with municipalities in Coahuila and Nuevo León
- link `User.address` to the new model
- expose address administration
- update documentation and tests

## Testing
- `python manage.py build_readme`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888faca2d308326b6c2ea81c03d8525