### PR TITLE
Add navigation bar for website app

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,7 @@ Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
 the README content has simple default styling. A button in the upper-right
 corner toggles between light and dark themes and remembers the preference using
 `localStorage`.
+
+When visiting the default *website* domain, a navigation bar shows links to all
+enabled apps that expose public URLs, plus a link to an automatically generated
+sitemap.

--- a/website/README.md
+++ b/website/README.md
@@ -9,3 +9,7 @@ Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
 the README content has simple default styling. A button in the upper-right
 corner toggles between light and dark themes and remembers the preference using
 `localStorage`.
+
+When visiting the default *website* domain, a navigation bar shows links to all
+enabled apps that expose public URLs, plus a link to an automatically generated
+sitemap.

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -9,6 +9,24 @@
   </head>
   <body class="p-3">
     <div class="container">
+      {% if nav_apps %}
+      <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+        <div class="container-fluid">
+          <a class="navbar-brand" href="/">Arthexis</a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              {% for item in nav_apps %}
+              <li class="nav-item"><a class="nav-link" href="{{ item.path }}">{{ item.name }}</a></li>
+              {% endfor %}
+              <li class="nav-item"><a class="nav-link" href="{% url 'website:website-sitemap' %}">Sitemap</a></li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+      {% endif %}
       <div class="text-end mb-3">
         <button id="theme-toggle" class="btn btn-sm btn-outline-secondary" onclick="toggleTheme()">{% trans "Dark Mode" %}</button>
       </div>

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 from . import views
 
+
+app_name = "website"
+
 urlpatterns = [
     path("", views.index, name="index"),
+    path("sitemap.xml", views.sitemap, name="website-sitemap"),
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -2,7 +2,28 @@ from pathlib import Path
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import render
+from django.http import HttpResponse
+from django.urls import reverse
+import inspect
 import markdown
+from config import urls as project_urls
+from django.urls.resolvers import URLResolver
+
+
+def get_public_apps():
+    apps = []
+    for p in project_urls.urlpatterns:
+        if isinstance(p, URLResolver):
+            prefix = p.pattern._route
+            if prefix and not prefix.startswith("admin"):
+                module = p.urlconf_module
+                name = (
+                    module.__package__.split(".")[0]
+                    if inspect.ismodule(module)
+                    else str(module).split(".")[0]
+                )
+                apps.append({"name": name.capitalize(), "path": "/" + prefix})
+    return apps
 
 
 def index(request):
@@ -15,8 +36,21 @@ def index(request):
         readme_file = Path(settings.BASE_DIR) / "README.md"
     text = readme_file.read_text(encoding="utf-8")
     html = markdown.markdown(text)
-    return render(
-        request,
-        "website/readme.html",
-        {"content": html, "title": readme_file.stem},
-    )
+    context = {"content": html, "title": readme_file.stem}
+    if app_name in ("website", "readme"):
+        context["nav_apps"] = get_public_apps()
+    return render(request, "website/readme.html", context)
+
+
+def sitemap(request):
+    apps = get_public_apps()
+    base = request.build_absolute_uri("/").rstrip("/")
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        f"  <url><loc>{base}/</loc></url>",
+    ]
+    for app in apps:
+        lines.append(f"  <url><loc>{base}{app['path']}</loc></url>")
+    lines.append("</urlset>")
+    return HttpResponse("\n".join(lines), content_type="application/xml")


### PR DESCRIPTION
## Summary
- show a Bootstrap navigation bar with links to all enabled apps and a sitemap
- generate sitemap listing app paths
- document navbar usage

## Testing
- `python manage.py build_readme`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888fd8e59f88326bc5876f62ef96431