### PR TITLE
Refine navbar with landing views

### DIFF
--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -6,6 +6,8 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404
 
+from website.utils import landing
+
 from . import store
 from .models import Transaction, Charger
 
@@ -102,11 +104,13 @@ def charger_detail(request, cid):
     )
 
 
+@landing("Charger Page")
 def charger_page(request, cid):
     charger = get_object_or_404(Charger, charger_id=cid)
     return render(request, "ocpp/charger_page.html", {"charger": charger})
 
 
+@landing("Status")
 def charger_status(request, cid):
     """Display current transaction and charger state."""
     charger = get_object_or_404(Charger, charger_id=cid)

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -18,8 +18,15 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-              {% for item in nav_apps %}
-              <li class="nav-item"><a class="nav-link" href="{{ item.path }}">{{ item.name }}</a></li>
+              {% for app in nav_apps %}
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ app.name }}</a>
+                <ul class="dropdown-menu">
+                  {% for view in app.views %}
+                  <li><a class="dropdown-item" href="{{ view.path }}">{{ view.name }}</a></li>
+                  {% endfor %}
+                </ul>
+              </li>
               {% endfor %}
               <li class="nav-item"><a class="nav-link" href="{% url 'website:website-sitemap' %}">Sitemap</a></li>
             </ul>

--- a/website/utils.py
+++ b/website/utils.py
@@ -1,0 +1,13 @@
+from django.urls import path as django_path
+
+
+def landing(label=None):
+    """Decorator to mark a view as a landing page."""
+
+    def decorator(view):
+        view.landing = True
+        view.landing_label = label or view.__name__.replace("_", " ").title()
+        return view
+
+    return decorator
+

--- a/website/views.py
+++ b/website/views.py
@@ -8,25 +8,44 @@ from django.urls import reverse
 import inspect
 import markdown
 from config import urls as project_urls
-from django.urls.resolvers import URLResolver
+from django.urls.resolvers import URLResolver, URLPattern
+from website.utils import landing
 
 
-def get_public_apps():
+def _collect_landings(resolver: URLResolver, prefix: str = ""):
+    pages = []
+    for pattern in resolver.url_patterns:
+        if isinstance(pattern, URLResolver):
+            pages.extend(_collect_landings(pattern, prefix + pattern.pattern._route))
+        elif isinstance(pattern, URLPattern):
+            view = pattern.callback
+            if getattr(view, "landing", False):
+                route = prefix + pattern.pattern._route
+                label = getattr(view, "landing_label", pattern.name or route)
+                pages.append({"name": label, "path": "/" + route})
+    return pages
+
+
+def get_landing_apps():
     apps = []
     for p in project_urls.urlpatterns:
         if isinstance(p, URLResolver):
             prefix = p.pattern._route
-            if prefix and not prefix.startswith("admin"):
-                module = p.urlconf_module
-                name = (
-                    module.__package__.split(".")[0]
-                    if inspect.ismodule(module)
-                    else str(module).split(".")[0]
-                )
-                apps.append({"name": name.capitalize(), "path": "/" + prefix})
+            if prefix.startswith("admin"):
+                continue
+            module = p.urlconf_module
+            name = (
+                module.__package__.split(".")[0]
+                if inspect.ismodule(module)
+                else str(module).split(".")[0]
+            )
+            pages = _collect_landings(p, prefix)
+            if pages:
+                apps.append({"name": name.capitalize(), "views": pages})
     return apps
 
 
+@landing("Home")
 def index(request):
     site = get_current_site(request)
     app_name = site.name or "readme"
@@ -39,12 +58,12 @@ def index(request):
     html = markdown.markdown(text)
     context = {"content": html, "title": readme_file.stem}
     if app_name in ("website", "readme"):
-        context["nav_apps"] = get_public_apps()
+        context["nav_apps"] = get_landing_apps()
     return render(request, "website/readme.html", context)
 
 
 def sitemap(request):
-    apps = get_public_apps()
+    apps = get_landing_apps()
     base = request.build_absolute_uri("/").rstrip("/")
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
@@ -52,6 +71,7 @@ def sitemap(request):
         f"  <url><loc>{base}/</loc></url>",
     ]
     for app in apps:
-        lines.append(f"  <url><loc>{base}{app['path']}</loc></url>")
+        for page in app["views"]:
+            lines.append(f"  <url><loc>{base}{page['path']}</loc></url>")
     lines.append("</urlset>")
     return HttpResponse("\n".join(lines), content_type="application/xml")


### PR DESCRIPTION
## Summary
- introduce `landing` decorator for marking views
- gather landing pages when building navbar
- render navbar items as dropdown menus
- mark charger and site views as landings

## Testing
- `python manage.py test -v 1` *(fails: OperationalError: no such table: accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_688909f85de083269e84813064abe607