### PR TITLE
Add landing page check and OCPP dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ map.
 - `GET /ocpp/chargers/<cid>/` – retrieve details and message log for a charger.
 - `POST /ocpp/chargers/<cid>/action/` – send actions such as `remote_stop` or
   `reset` to the charger.
+- `GET /ocpp/` – dashboard listing all chargers and their status.
 
 ### Charger Landing Pages
 

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -44,6 +44,7 @@ map.
 - `GET /ocpp/chargers/<cid>/` – retrieve details and message log for a charger.
 - `POST /ocpp/chargers/<cid>/action/` – send actions such as `remote_stop` or
   `reset` to the charger.
+- `GET /ocpp/` – dashboard listing all chargers and their status.
 
 ### Charger Landing Pages
 

--- a/ocpp/templates/ocpp/dashboard.html
+++ b/ocpp/templates/ocpp/dashboard.html
@@ -1,0 +1,28 @@
+{% extends "website/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Chargers" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Chargers" %}</h1>
+<table class="table">
+  <thead>
+    <tr>
+      <th>{% trans "Name" %}</th>
+      <th>{% trans "Serial Number" %}</th>
+      <th>{% trans "Status" %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in chargers %}
+    <tr>
+      <td><a href="{% url 'charger-page' item.charger.charger_id %}">{{ item.charger.name|default:item.charger.charger_id }}</a></td>
+      <td>{{ item.charger.charger_id }}</td>
+      <td><span class="badge" style="background-color: {{ item.color }};">{{ item.state }}</span></td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="3">{% trans "No chargers found." %}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/ocpp/urls.py
+++ b/ocpp/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("", views.dashboard, name="ocpp-dashboard"),
     path("chargers/", views.charger_list, name="charger-list"),
     path("chargers/<str:cid>/", views.charger_detail, name="charger-detail"),
     path("chargers/<str:cid>/action/", views.dispatch_action, name="charger-action"),

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -104,6 +104,23 @@ def charger_detail(request, cid):
     )
 
 
+@landing("Dashboard")
+def dashboard(request):
+    """Landing page listing all known chargers and their status."""
+    chargers = []
+    for charger in Charger.objects.all():
+        tx_obj = store.transactions.get(charger.charger_id)
+        if not tx_obj:
+            tx_obj = (
+                Transaction.objects.filter(charger_id=charger.charger_id)
+                .order_by("-start_time")
+                .first()
+            )
+        state, color = _charger_state(charger, tx_obj)
+        chargers.append({"charger": charger, "state": state, "color": color})
+    return render(request, "ocpp/dashboard.html", {"chargers": chargers})
+
+
 @landing("Charger Page")
 def charger_page(request, cid):
     charger = get_object_or_404(Charger, charger_id=cid)

--- a/website/apps.py
+++ b/website/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class WebsiteConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "website"
+
+    def ready(self):  # pragma: no cover - import for side effects
+        from . import checks  # noqa: F401

--- a/website/checks.py
+++ b/website/checks.py
@@ -1,0 +1,41 @@
+import inspect
+
+from django.core.checks import Warning, register
+from django.urls.resolvers import URLPattern, URLResolver
+
+from config import urls as project_urls
+
+
+def _collect_checks(resolver: URLResolver, errors: list, prefix: str = ""):
+    for pattern in resolver.url_patterns:
+        if isinstance(pattern, URLResolver):
+            _collect_checks(pattern, errors, prefix + pattern.pattern._route)
+        elif isinstance(pattern, URLPattern):
+            view = pattern.callback
+            if getattr(view, "landing", False):
+                sig = inspect.signature(view)
+                params = list(sig.parameters.values())
+                if params and params[0].name == "request":
+                    params = params[1:]
+                has_required = any(
+                    p.default is inspect._empty
+                    and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+                    for p in params
+                )
+                if has_required:
+                    errors.append(
+                        Warning(
+                            f'Landing view "{view.__module__}.{view.__name__}" requires URL parameters and cannot be a landing page.',
+                            id="website.W001",
+                        )
+                    )
+
+
+@register()
+def landing_views_have_no_args(app_configs, **kwargs):
+    errors: list = []
+    for p in project_urls.urlpatterns:
+        if isinstance(p, URLResolver):
+            _collect_checks(p, errors, p.pattern._route)
+    return errors
+


### PR DESCRIPTION
## Summary
- warn if landing decorator is used on views that take URL parameters
- add an OCPP dashboard landing page
- list dashboard endpoint in docs

## Testing
- `python manage.py build_readme`
- `python manage.py test --keepdb` *(fails: OperationalError: no such table: accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_68890c0e724c83268d7249ee03a805ef