### PR TITLE
Add login page and staff redirect

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -29,6 +29,7 @@
               </li>
               {% endfor %}
               <li class="nav-item"><a class="nav-link" href="{% url 'website:website-sitemap' %}">Sitemap</a></li>
+              <li class="nav-item"><a class="nav-link" href="{% url 'website:login' %}?next={{ request.path }}">Login</a></li>
             </ul>
           </div>
         </div>

--- a/website/templates/website/login.html
+++ b/website/templates/website/login.html
@@ -1,0 +1,22 @@
+{% extends "website/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Login" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Login" %}</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.non_field_errors }}
+  <div class="mb-3">
+    <label for="id_username" class="form-label">{% trans "Username" %}</label>
+    <input type="text" name="username" class="form-control" id="id_username" required>
+  </div>
+  <div class="mb-3">
+    <label for="id_password" class="form-label">{% trans "Password" %}</label>
+    <input type="password" name="password" class="form-control" id="id_password" required>
+  </div>
+  {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
+  <button type="submit" class="btn btn-primary">{% trans "Log in" %}</button>
+</form>
+{% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -1,0 +1,39 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+
+
+class LoginViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            username="staff", password="pwd", is_staff=True
+        )
+        self.user = User.objects.create_user(username="user", password="pwd")
+        Site.objects.update_or_create(id=1, defaults={"name": "website"})
+
+    def test_login_link_in_navbar(self):
+        resp = self.client.get(reverse("website:index"))
+        self.assertContains(resp, "href=\"/login/?next=/\"")
+
+    def test_staff_login_redirects_admin(self):
+        resp = self.client.post(
+            reverse("website:login"),
+            {"username": "staff", "password": "pwd"},
+        )
+        self.assertRedirects(resp, reverse("admin:index"))
+
+    def test_already_logged_in_staff_redirects(self):
+        self.client.force_login(self.staff)
+        resp = self.client.get(reverse("website:login"))
+        self.assertRedirects(resp, reverse("admin:index"))
+
+    def test_regular_user_redirects_next(self):
+        resp = self.client.post(
+            reverse("website:login") + "?next=/nodes/list/",
+            {"username": "user", "password": "pwd"},
+        )
+        self.assertRedirects(resp, "/nodes/list/")
+

--- a/website/urls.py
+++ b/website/urls.py
@@ -7,4 +7,5 @@ app_name = "website"
 urlpatterns = [
     path("", views.index, name="index"),
     path("sitemap.xml", views.sitemap, name="website-sitemap"),
+    path("login/", views.login_view, name="login"),
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.urls import reverse
+from django.contrib.auth.views import LoginView
 
 import inspect
 import markdown
@@ -75,3 +76,24 @@ def sitemap(request):
             lines.append(f"  <url><loc>{base}{page['path']}</loc></url>")
     lines.append("</urlset>")
     return HttpResponse("\n".join(lines), content_type="application/xml")
+
+
+class CustomLoginView(LoginView):
+    """Login view that redirects staff to the admin."""
+
+    template_name = "website/login.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            if request.user.is_staff:
+                return redirect("admin:index")
+            return redirect(self.get_success_url())
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_success_url(self):
+        if self.request.user.is_staff:
+            return reverse("admin:index")
+        return self.get_redirect_url() or "/"
+
+
+login_view = CustomLoginView.as_view()


### PR DESCRIPTION
## Summary
- add login link to navbar
- implement login view with staff redirect
- create login page template
- test login flow

## Testing
- `python manage.py test website.tests.LoginViewTests.test_regular_user_redirects_next`
- `python manage.py test` *(fails: OperationalError: no such table: accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_68890c57f8988326bc561d66b1405d20