### PR TITLE
Fix charger log view merge issue

### DIFF
--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -134,6 +134,7 @@ def charger_log_page(request, cid):
         request,
         "ocpp/charger_logs.html",
         {"charger": charger, "log": log},
+    )
 
 def charger_status(request, cid):
     """Display current transaction and charger state."""


### PR DESCRIPTION
## Summary
- fix missing parenthesis in charger log view

## Testing
- `python manage.py test` *(fails: OperationalError no such table: accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_688917f634d88326a84a349072e9b902