### PR TITLE
Fix migrations so RFID table exists for tests

### DIFF
--- a/accounts/migrations/0015_alter_address_municipality_alter_address_state_and_more.py
+++ b/accounts/migrations/0015_alter_address_municipality_alter_address_state_and_more.py
@@ -25,7 +25,4 @@ class Migration(migrations.Migration):
             name='vin',
             field=models.CharField(max_length=17, unique=True, verbose_name='VIN'),
         ),
-        migrations.DeleteModel(
-            name='RFID',
-        ),
     ]


### PR DESCRIPTION
## Summary
- keep the RFID table by removing the DeleteModel operation from migration 0015

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688921aae04483268ec38323cb9ad5ee