### PR TITLE
Fix navbar dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,10 @@ label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
 
 Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
-the README content has simple default styling. A button in the upper-right
-corner toggles between light and dark themes and remembers the preference using
-`localStorage`.
+the README content has simple default styling. The JavaScript bundle is also
+included so interactive components like the navigation dropdowns work. A button
+in the upper-right corner toggles between light and dark themes and remembers
+the preference using `localStorage`.
 
 When visiting the default *website* domain, a navigation bar shows links to all
 enabled apps that expose public URLs, plus a link to an automatically generated

--- a/website/README.md
+++ b/website/README.md
@@ -6,9 +6,10 @@ label of the app whose README should be shown. If the domain isn't
 recognized, the project README is rendered instead.
 
 Rendered pages use [Bootstrap](https://getbootstrap.com/) loaded from a CDN so
-the README content has simple default styling. A button in the upper-right
-corner toggles between light and dark themes and remembers the preference using
-`localStorage`.
+the README content has simple default styling. The JavaScript bundle is also
+included so interactive components like the navigation dropdowns work. A button
+in the upper-right corner toggles between light and dark themes and remembers
+the preference using `localStorage`.
 
 When visiting the default *website* domain, a navigation bar shows links to all
 enabled apps that expose public URLs, plus a link to an automatically generated

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -40,6 +40,7 @@
       </div>
       {% block content %}{% endblock %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       function setTheme(theme) {
         document.documentElement.setAttribute('data-bs-theme', theme);


### PR DESCRIPTION
## Summary
- load Bootstrap JS to enable dropdowns in website navbar
- document that the JavaScript bundle is included
- rebuild README

## Testing
- `python manage.py test` *(fails: OperationalError no such table accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_68892669a6e88326bc643cacc351845f