### PR TITLE
Add footer links project

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ Queued emails can be sent with the `send_queued` helper or via a management
 command. A `/purge/` endpoint deletes sent entries from the queue.
 
 
+# Footer App
+
+Collects and exposes links displayed at the bottom of the site.
+Views can be decorated with `footer_link()` to appear in the footer.
+Links can be grouped into columns by providing a column name to the decorator.
+
+
 # Website App
 
 Displays the README for a particular app depending on the subdomain.
@@ -348,5 +355,6 @@ in the upper-right corner toggles between light and dark themes and remembers
 the preference using `localStorage`.
 
 When visiting the default *website* domain, a navigation bar shows links to all
-enabled apps that expose public URLs, plus a link to an automatically generated
-sitemap.
+enabled apps that expose public URLs. Views decorated with `footer_link` are
+collected into a footer where links can be grouped into columns. The
+automatically generated sitemap now appears there.

--- a/config/settings.py
+++ b/config/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     "release",
     "odoo",
     "mailer",
+    "footer",
     "website",
 ]
 
@@ -85,6 +86,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.i18n",
                 "django.contrib.messages.context_processors.messages",
+                "footer.context_processors.footer_links",
             ],
         },
     },

--- a/footer/README.md
+++ b/footer/README.md
@@ -1,0 +1,5 @@
+# Footer App
+
+Collects and exposes links displayed at the bottom of the site.
+Views can be decorated with `footer_link()` to appear in the footer.
+Links can be grouped into columns by providing a column name to the decorator.

--- a/footer/apps.py
+++ b/footer/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FooterConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "footer"

--- a/footer/context_processors.py
+++ b/footer/context_processors.py
@@ -1,0 +1,5 @@
+from .utils import get_footer_columns
+
+
+def footer_links(request):
+    return {"footer_columns": get_footer_columns()}

--- a/footer/tests.py
+++ b/footer/tests.py
@@ -1,0 +1,18 @@
+from django.test import SimpleTestCase
+from django.urls import URLResolver, path
+
+from .utils import footer_link, get_footer_columns
+
+
+@footer_link("Sample", column="Info")
+def sample_view(request):
+    pass
+
+urlpatterns = [path("sample/", sample_view, name="sample")]
+
+
+class FooterUtilsTests(SimpleTestCase):
+    def test_collects_footer_links(self):
+        resolver = URLResolver("", urlpatterns)
+        columns = get_footer_columns(resolver)
+        self.assertEqual(columns, [{"name": "Info", "links": [{"name": "Sample", "path": "/sample/"}]}])

--- a/footer/utils.py
+++ b/footer/utils.py
@@ -1,0 +1,62 @@
+from django.urls.resolvers import URLPattern, URLResolver
+from typing import List, Dict, Optional, Iterable
+
+from config import urls as project_urls
+
+
+def footer_link(label: Optional[str] = None, column: str | None = ""):
+    """Decorator to mark a view for inclusion in the footer."""
+
+    def decorator(view):
+        view.footer_link = True
+        view.footer_label = label or view.__name__.replace("_", " ").title()
+        view.footer_column = column or ""
+        return view
+
+    return decorator
+
+
+def _get_patterns(resolver: URLResolver | Iterable) -> Iterable:
+    if isinstance(resolver, URLResolver):
+        return resolver.url_patterns
+    if hasattr(resolver, "urlpatterns"):
+        return resolver.urlpatterns
+    return resolver
+
+
+def _collect_links(resolver: URLResolver | Iterable, prefix: str = "") -> List[Dict]:
+    links: List[Dict] = []
+    for pattern in _get_patterns(resolver):
+        if isinstance(pattern, URLResolver):
+            links.extend(_collect_links(pattern, prefix + pattern.pattern._route))
+        elif isinstance(pattern, URLPattern):
+            view = pattern.callback
+            if getattr(view, "footer_link", False):
+                route = prefix + pattern.pattern._route
+                if "<" in route:
+                    continue
+                links.append(
+                    {
+                        "name": getattr(view, "footer_label", pattern.name or route),
+                        "path": "/" + route,
+                        "column": getattr(view, "footer_column", ""),
+                    }
+                )
+    return links
+
+
+def get_footer_columns(resolver: URLResolver | None = None) -> List[Dict]:
+    """Return footer links grouped by column."""
+
+    resolver = resolver or project_urls
+    links = _collect_links(resolver)
+    columns: List[Dict] = []
+    col_map: Dict[str, Dict] = {}
+    for link in links:
+        col = link["column"]
+        if col not in col_map:
+            entry = {"name": col, "links": []}
+            col_map[col] = entry
+            columns.append(entry)
+        col_map[col]["links"].append({"name": link["name"], "path": link["path"]})
+    return columns

--- a/website/README.md
+++ b/website/README.md
@@ -12,5 +12,6 @@ in the upper-right corner toggles between light and dark themes and remembers
 the preference using `localStorage`.
 
 When visiting the default *website* domain, a navigation bar shows links to all
-enabled apps that expose public URLs, plus a link to an automatically generated
-sitemap.
+enabled apps that expose public URLs. Views decorated with `footer_link` are
+collected into a footer where links can be grouped into columns. The
+automatically generated sitemap now appears there.

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -29,7 +29,6 @@
                 </li>
                 {% endfor %}
               {% endif %}
-              <li class="nav-item"><a class="nav-link" href="{% url 'website:website-sitemap' %}">Sitemap</a></li>
               <li class="nav-item"><a class="nav-link" href="{% url 'website:login' %}?next={{ request.path }}">Login</a></li>
             </ul>
           </div>
@@ -40,6 +39,20 @@
       </div>
       {% block content %}{% endblock %}
     </div>
+    <footer class="container mt-5">
+      <div class="row">
+        {% for col in footer_columns %}
+        <div class="col">
+          {% if col.name %}<h5>{{ col.name }}</h5>{% endif %}
+          <ul class="list-unstyled">
+            {% for link in col.links %}
+            <li><a href="{{ link.path }}">{{ link.name }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endfor %}
+      </div>
+    </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       function setTheme(theme) {

--- a/website/views.py
+++ b/website/views.py
@@ -11,6 +11,7 @@ import markdown
 from config import urls as project_urls
 from django.urls.resolvers import URLResolver, URLPattern
 from website.utils import landing
+from footer.utils import footer_link
 
 
 def _collect_landings(resolver: URLResolver, prefix: str = ""):
@@ -65,6 +66,7 @@ def index(request):
     return render(request, "website/readme.html", context)
 
 
+@footer_link("Sitemap")
 def sitemap(request):
     apps = get_landing_apps()
     base = request.build_absolute_uri("/").rstrip("/")


### PR DESCRIPTION
## Summary
- add new `footer` Django app
- move sitemap link to footer
- gather footer links via decorator and context processor
- update website docs

## Testing
- `python manage.py test footer`
- `python manage.py test` *(fails: OperationalError no such table: accounts_rfid)*

------
https://chatgpt.com/codex/tasks/task_e_68893aa86dfc8326a311890a2de33e76