### PR TITLE
Add sticky footer to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,5 +362,5 @@ the preference using `localStorage`.
 When visiting the default *website* domain, a navigation bar shows links to all
 enabled apps that expose public URLs. Views decorated with `footer_link` are
 collected into a footer where links can be grouped into columns. The
-automatically generated sitemap now appears there.
-
+automatically generated sitemap now appears there. The footer stays at the
+bottom of short pages but scrolls into view on longer ones.

--- a/website/README.md
+++ b/website/README.md
@@ -14,4 +14,5 @@ the preference using `localStorage`.
 When visiting the default *website* domain, a navigation bar shows links to all
 enabled apps that expose public URLs. Views decorated with `footer_link` are
 collected into a footer where links can be grouped into columns. The
-automatically generated sitemap now appears there.
+automatically generated sitemap now appears there. The footer stays at the
+bottom of short pages but scrolls into view on longer ones.

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -7,8 +7,8 @@
     <title>{% block title %}{% trans "Arthexis Constellation" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
-  <body class="p-3">
-    <div class="container">
+  <body class="p-3 d-flex flex-column min-vh-100">
+    <div class="container flex-grow-1">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
         <div class="container-fluid">
           <a class="navbar-brand" href="/">Arthexis</a>
@@ -39,7 +39,7 @@
       </div>
       {% block content %}{% endblock %}
     </div>
-    <footer class="container mt-5">
+    <footer class="container mt-5 mt-auto">
       <div class="row">
         {% for col in footer_columns %}
         <div class="col">


### PR DESCRIPTION
## Summary
- keep footer at the bottom of short pages with flexbox helpers
- document sticky footer behavior

## Testing
- `python manage.py test` *(fails: OperationalError: table "accounts_rfid" already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6889423cf7488326ba3ea835dea317eb