### PR TITLE
Handle optional OCPP subprotocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ charger ID, so `/CP1/` and `/foo/bar/CP1/` both register charger `CP1`. The full
 path used by a charger is stored in the `last_path` field of its database
 record.
 
+If a client offers the `ocpp1.6` WebSocket subprotocol, the server will
+acknowledge it during the handshake. Clients may also omit the subprotocol and
+still connect successfully.
+
 A connected charge point may send standard OCPP CALL messages
 (BootNotification, Heartbeat, Authorize, Start/StopTransaction). The
 server replies with basic CALLRESULT payloads and records transactions

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -14,6 +14,10 @@ charger ID, so `/CP1/` and `/foo/bar/CP1/` both register charger `CP1`. The full
 path used by a charger is stored in the `last_path` field of its database
 record.
 
+If a client offers the `ocpp1.6` WebSocket subprotocol, the server will
+acknowledge it during the handshake. Clients may also omit the subprotocol and
+still connect successfully.
+
 A connected charge point may send standard OCPP CALL messages
 (BootNotification, Heartbeat, Authorize, Start/StopTransaction). The
 server replies with basic CALLRESULT payloads and records transactions

--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -18,7 +18,11 @@ class CSMSConsumer(AsyncWebsocketConsumer):
 
     async def connect(self):
         self.charger_id = self.scope["url_route"]["kwargs"].get("cid", "")
-        await self.accept()
+        subprotocol = None
+        offered = self.scope.get("subprotocols", [])
+        if "ocpp1.6" in offered:
+            subprotocol = "ocpp1.6"
+        await self.accept(subprotocol=subprotocol)
         store.connections[self.charger_id] = self
         store.logs.setdefault(self.charger_id, [])
         self.charger, _ = await database_sync_to_async(


### PR DESCRIPTION
## Summary
- accept the `ocpp1.6` WebSocket subprotocol if offered
- document optional subprotocol support
- rebuild README

## Testing
- `python manage.py build_readme`
- `python manage.py test` *(fails: OperationalError table `accounts_rfid` already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68894378464883269a44273ce00b18d1