### PR TITLE
Add offline mode decorator

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -52,6 +52,13 @@ Any `*.env` file found there is automatically loaded when running management
 commands or the server. The directory is included in the repository but `.env`
 files themselves are ignored so secrets remain local.
 
+### Offline Mode
+
+Set the environment variable `ARTHEXIS_OFFLINE=1` to prevent code paths that
+require network access from running. Functions marked with a special decorator
+will raise an error if they execute while this flag is set, allowing tests or
+other strict operations to ensure no external services are contacted.
+
 ## VS Code
 
 Launch configurations are provided in `.vscode/launch.json`:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Any `*.env` file found there is automatically loaded when running management
 commands or the server. The directory is included in the repository but `.env`
 files themselves are ignored so secrets remain local.
 
+### Offline Mode
+
+Set the environment variable `ARTHEXIS_OFFLINE=1` to prevent code paths that
+require network access from running. Functions marked with a special decorator
+will raise an error if they execute while this flag is set, allowing tests or
+other strict operations to ensure no external services are contacted.
+
 ## VS Code
 
 Launch configurations are provided in `.vscode/launch.json`:

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -1,7 +1,9 @@
 from channels.generic.websocket import AsyncWebsocketConsumer
 import json
+from config.offline import requires_network
 
 class EchoConsumer(AsyncWebsocketConsumer):
+    @requires_network
     async def connect(self):
         await self.accept()
 

--- a/config/offline.py
+++ b/config/offline.py
@@ -1,0 +1,41 @@
+import os
+import functools
+import asyncio
+
+class OfflineError(RuntimeError):
+    """Raised when a network operation is attempted in offline mode."""
+
+
+def _is_offline() -> bool:
+    flag = os.environ.get("ARTHEXIS_OFFLINE", "").lower()
+    return flag not in ("", "0", "false", "no")
+
+
+def requires_network(func):
+    """Decorator that blocks execution when offline mode is enabled.
+
+    When the environment variable ``ARTHEXIS_OFFLINE`` is set to a truthy value,
+    any function decorated with ``@requires_network`` will raise
+    :class:`OfflineError` before executing. Works with both synchronous and
+    asynchronous callables.
+    """
+
+    if asyncio.iscoroutinefunction(func):
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            if _is_offline():
+                raise OfflineError(f"{func.__name__} requires network access")
+            return await func(*args, **kwargs)
+
+        return async_wrapper
+
+    @functools.wraps(func)
+    def sync_wrapper(*args, **kwargs):
+        if _is_offline():
+            raise OfflineError(f"{func.__name__} requires network access")
+        return func(*args, **kwargs)
+
+    return sync_wrapper
+
+
+__all__ = ["OfflineError", "requires_network"]

--- a/mailer/views.py
+++ b/mailer/views.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from .models import EmailTemplate, QueuedEmail
+from config.offline import requires_network
 
 
 @csrf_exempt
@@ -60,6 +61,7 @@ def purge(request):
     return JsonResponse({"purged": count})
 
 
+@requires_network
 def send_queued():
     """Send all unsent queued emails."""
     for email in QueuedEmail.objects.filter(sent=False).select_related("template"):

--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -6,6 +6,7 @@ from accounts.models import RFID, Account
 
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
+from config.offline import requires_network
 
 from . import store
 from decimal import Decimal
@@ -16,6 +17,7 @@ from .models import Transaction, Charger, MeterReading
 class CSMSConsumer(AsyncWebsocketConsumer):
     """Very small subset of OCPP 1.6 CSMS behaviour."""
 
+    @requires_network
     async def connect(self):
         self.charger_id = self.scope["url_route"]["kwargs"].get("cid", "")
         subprotocol = None

--- a/ocpp/simulator.py
+++ b/ocpp/simulator.py
@@ -8,6 +8,7 @@ from typing import Optional
 import threading
 
 import websockets
+from config.offline import requires_network
 
 
 @dataclass
@@ -37,6 +38,7 @@ class ChargePointSimulator:
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
 
+    @requires_network
     async def _run_session(self) -> None:
         cfg = self.config
         uri = f"ws://{cfg.host}:{cfg.ws_port}/{cfg.cp_path}"

--- a/odoo/admin.py
+++ b/odoo/admin.py
@@ -4,6 +4,7 @@ from .models import Instance
 
 import xmlrpc.client
 from urllib.parse import urljoin
+from config.offline import requires_network
 
 
 @admin.register(Instance)
@@ -11,6 +12,7 @@ class InstanceAdmin(admin.ModelAdmin):
     list_display = ("name", "url", "database", "username")
     actions = ["test_connection"]
 
+    @requires_network
     def test_connection(self, request, queryset):
         for instance in queryset:
             server = xmlrpc.client.ServerProxy(

--- a/odoo/views.py
+++ b/odoo/views.py
@@ -5,8 +5,10 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
 from .models import Instance
+from config.offline import requires_network
 
 
+@requires_network
 def test_connection(request, pk):
     instance = get_object_or_404(Instance, pk=pk)
     server = xmlrpc.client.ServerProxy(urljoin(instance.url, "/xmlrpc/2/common"))

--- a/release/utils.py
+++ b/release/utils.py
@@ -10,6 +10,7 @@ import requests
 import toml
 
 from . import Credentials, Package, DEFAULT_PACKAGE
+from config.offline import requires_network
 
 
 class ReleaseError(Exception):
@@ -137,6 +138,7 @@ def update_changelog(version: str, build_hash: str, prev_build: Optional[str] = 
     Path("CHANGELOG.rst").write_text(new_text, encoding="utf-8")
 
 
+@requires_network
 def build(
     *,
     bump: bool = False,

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+import asyncio
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config.offline import requires_network, OfflineError
+
+@requires_network
+def sync_func():
+    return 'ok'
+
+@requires_network
+async def async_func():
+    return 'ok'
+
+def test_sync_function_offline(monkeypatch):
+    monkeypatch.setenv('ARTHEXIS_OFFLINE', '1')
+    with pytest.raises(OfflineError):
+        sync_func()
+
+def test_async_function_offline(monkeypatch):
+    monkeypatch.setenv('ARTHEXIS_OFFLINE', '1')
+    with pytest.raises(OfflineError):
+        asyncio.run(async_func())
+
+def test_release_build_offline(monkeypatch):
+    from release.utils import build
+    monkeypatch.setenv('ARTHEXIS_OFFLINE', '1')
+    with pytest.raises(OfflineError):
+        build()


### PR DESCRIPTION
## Summary
- add `requires_network` decorator to gate network access when `ARTHEXIS_OFFLINE` is set
- apply decorator to network-heavy helpers in release, Odoo, OCPP, chat and mailer apps
- document offline mode and cover behavior with unit tests

## Testing
- `python manage.py build_readme`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688adbf883fc83268a5fd813e2d19f1d