### PR TITLE
Rename Nginx configurations to NGINX templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ Links can be grouped into columns by providing a column name to the decorator.
 
 # Nginx App
 
-Provides management of nginx configurations with support for HTTP, WebSockets, optional SSL
-certificates and fallback upstream servers. Configurations can be applied to the host using a
+Provides management of NGINX templates with support for HTTP, WebSockets, optional SSL
+certificates and fallback upstream servers. Templates can be applied to the host using a
 management command:
 
 ```bash
@@ -371,7 +371,7 @@ python manage.py apply_nginx_config <id>
 ```
 
 The Django admin includes an action to test connectivity to the configured upstream servers.
-It also shows the rendered configuration so it can be reviewed or copied.
+It also shows the rendered template so it can be reviewed or copied.
 
 
 # Website App

--- a/nginx_app/README.md
+++ b/nginx_app/README.md
@@ -1,7 +1,7 @@
 # Nginx App
 
-Provides management of nginx configurations with support for HTTP, WebSockets, optional SSL
-certificates and fallback upstream servers. Configurations can be applied to the host using a
+Provides management of NGINX templates with support for HTTP, WebSockets, optional SSL
+certificates and fallback upstream servers. Templates can be applied to the host using a
 management command:
 
 ```bash
@@ -9,4 +9,4 @@ python manage.py apply_nginx_config <id>
 ```
 
 The Django admin includes an action to test connectivity to the configured upstream servers.
-It also shows the rendered configuration so it can be reviewed or copied.
+It also shows the rendered template so it can be reviewed or copied.

--- a/nginx_app/admin.py
+++ b/nginx_app/admin.py
@@ -20,7 +20,7 @@ class NginxConfigAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("rendered_config",)
 
-    @admin.action(description="Test selected nginx configurations")
+    @admin.action(description="Test selected NGINX templates")
     def test_configuration(self, request, queryset):
         for cfg in queryset:
             if cfg.test_connection():

--- a/nginx_app/apps.py
+++ b/nginx_app/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 class NginxAppConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'nginx_app'
-    verbose_name = 'Nginx Configurations'
+    verbose_name = 'NGINX Templates'

--- a/nginx_app/management/commands/apply_nginx_config.py
+++ b/nginx_app/management/commands/apply_nginx_config.py
@@ -6,7 +6,7 @@ from nginx_app.models import NginxConfig
 
 
 class Command(BaseCommand):
-    help = "Apply an nginx configuration by writing it to the nginx directory and reloading nginx"
+    help = "Apply an NGINX template by writing it to the NGINX directory and reloading NGINX"
 
     def add_arguments(self, parser):
         parser.add_argument('config_id', type=int, help='ID of the NginxConfig to apply')
@@ -26,4 +26,4 @@ class Command(BaseCommand):
 
         subprocess.run(['nginx', '-t'], check=True)
         subprocess.run(['nginx', '-s', 'reload'], check=True)
-        self.stdout.write(self.style.SUCCESS(f"Applied configuration {cfg.name} to {path}"))
+        self.stdout.write(self.style.SUCCESS(f"Applied template {cfg.name} to {path}"))

--- a/nginx_app/migrations/0001_initial.py
+++ b/nginx_app/migrations/0001_initial.py
@@ -44,8 +44,8 @@ class Migration(migrations.Migration):
                 ("config_text", models.TextField(blank=True)),
             ],
             options={
-                "verbose_name": "Nginx configuration",
-                "verbose_name_plural": "Nginx configurations",
+                "verbose_name": "NGINX Template",
+                "verbose_name_plural": "NGINX Templates",
             },
         ),
     ]

--- a/nginx_app/models.py
+++ b/nginx_app/models.py
@@ -45,14 +45,14 @@ class NginxConfig(models.Model):
     config_text = models.TextField(blank=True)
 
     class Meta:
-        verbose_name = 'Nginx configuration'
-        verbose_name_plural = 'Nginx configurations'
+        verbose_name = 'NGINX Template'
+        verbose_name_plural = 'NGINX Templates'
 
     def __str__(self):
         return self.name
 
     def render_config(self):
-        """Generate an nginx configuration with websocket support and optional SSL."""
+        """Generate an NGINX template with websocket support and optional SSL."""
         upstream_name = f"{self.name}_upstream"
         lines = [
             f"upstream {upstream_name} {{",


### PR DESCRIPTION
## Summary
- use "NGINX Templates" for app and model labels
- update management command and admin text to match new naming
- document NGINX templates in app and root README

## Testing
- `python manage.py test nginx_app`


------
https://chatgpt.com/codex/tasks/task_e_688aec56249c8326a965029de6d77144