### PR TITLE
Fix RFID inline admin field

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -14,7 +14,7 @@ class AccountRFIDForm(forms.ModelForm):
 
     class Meta:
         model = Account.rfids.through
-        fields = ["rfid"]
+        fields = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- ensure RFID inline form stores string input on RFID model before assigning to through model

## Testing
- `python manage.py test` *(fails: AdminBadgesTests.test_badges_show_site_and_node, AdminBadgesTests.test_badges_warn_when_node_missing)*

------
https://chatgpt.com/codex/tasks/task_e_688aed131a348326be550ff7231242eb