### PR TITLE
feat: autodiscover app URLs

### DIFF
--- a/tests/test_urls_autodiscover.py
+++ b/tests/test_urls_autodiscover.py
@@ -1,0 +1,19 @@
+import os
+
+import django
+from django.urls import resolve
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+
+def test_accounts_url_autodiscovered():
+    match = resolve("/accounts/rfid-login/")
+    assert match.view_name == "rfid-login"
+
+
+def test_qrcodes_custom_prefix():
+    match = resolve("/qr/")
+    assert match.view_name == "qrcodes:generator"
+


### PR DESCRIPTION
## Summary
- add function to automatically include URLs from local apps
- add tests covering automatic inclusion and prefix override

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b9c695b9c83269969fa496fa104d5