### PR TITLE
feat: open navbar dropdowns on hover

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -6,6 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% trans "Arthexis Constellation" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+      /* Show dropdown menus on hover without disabling click functionality */
+      .navbar .dropdown:hover .dropdown-menu {
+        display: block;
+      }
+    </style>
   </head>
   <body class="p-3 d-flex flex-column min-vh-100">
     <div class="container flex-grow-1">


### PR DESCRIPTION
## Summary
- allow navbar dropdown menus to open on hover while retaining click behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c0a5088a083269ed394f3d63a57d0