### PR TITLE
feat: require purge before deleting charger

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -43,6 +43,7 @@ class ChargerAdmin(admin.ModelAdmin):
         "status_link",
     )
     search_fields = ("charger_id", "name")
+    actions = ["purge_data", "delete_selected"]
 
     def test_link(self, obj):
         from django.utils.html import format_html
@@ -70,6 +71,17 @@ class ChargerAdmin(admin.ModelAdmin):
         return format_html('<a href="{}" target="_blank">status</a>', url)
 
     status_link.short_description = "Status Page"
+
+    def purge_data(self, request, queryset):
+        for charger in queryset:
+            charger.purge()
+        self.message_user(request, "Data purged for selected chargers")
+
+    purge_data.short_description = "Purge data"
+
+    def delete_queryset(self, request, queryset):
+        for obj in queryset:
+            obj.delete()
 
 
 @admin.register(Simulator)


### PR DESCRIPTION
## Summary
- add purge method and deletion guard to Charger model
- expose admin action to purge charger data before removal
- test that purging clears data and deletion requires purge

## Testing
- `python manage.py test ocpp.tests.ChargerAdminTests ocpp.tests.ChargerLandingTests ocpp.tests.SimulatorAdminTests`


------
https://chatgpt.com/codex/tasks/task_e_688c0b2683048326a532d09cc8048813