### PR TITLE
Add configurable badge colors for sites and nodes

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -8,6 +8,7 @@ def site_and_node(request: HttpRequest):
     Returns a dict with keys ``badge_site`` and ``badge_node``.
     ``badge_site`` is a ``Site`` instance or ``None`` if no match.
     ``badge_node`` is a ``Node`` instance or ``None`` if no match.
+    ``badge_site_color`` and ``badge_node_color`` provide the configured colors.
     """
     host = request.get_host().split(':')[0]
     site = Site.objects.filter(domain__iexact=host).first()
@@ -23,4 +24,20 @@ def site_and_node(request: HttpRequest):
     except Exception:
         node = None
 
-    return {"badge_site": site, "badge_node": node}
+    site_color = "#28a745"
+    if site:
+        try:
+            site_color = site.badge.badge_color
+        except Exception:
+            pass
+
+    node_color = "#28a745"
+    if node:
+        node_color = node.badge_color
+
+    return {
+        "badge_site": site,
+        "badge_node": node,
+        "badge_site_color": site_color,
+        "badge_node_color": node_color,
+    }

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -1,17 +1,28 @@
 from django.contrib import admin, messages
 from django.urls import path
 from django.shortcuts import redirect
+from django import forms
 import socket
 import os
 
 from .models import Node, NodeScreenshot
 
 
+class NodeAdminForm(forms.ModelForm):
+    class Meta:
+        model = Node
+        fields = "__all__"
+        widgets = {
+            "badge_color": forms.TextInput(attrs={"type": "color"})
+        }
+
+
 @admin.register(Node)
 class NodeAdmin(admin.ModelAdmin):
-    list_display = ("hostname", "address", "port", "last_seen")
+    list_display = ("hostname", "address", "port", "badge_color", "last_seen")
     search_fields = ("hostname", "address")
     change_list_template = "admin/nodes/node/change_list.html"
+    form = NodeAdminForm
 
     def get_urls(self):
         urls = super().get_urls()

--- a/nodes/migrations/0003_node_badge_color.py
+++ b/nodes/migrations/0003_node_badge_color.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0002_nodescreenshot"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="node",
+            name="badge_color",
+            field=models.CharField(default="#28a745", max_length=7),
+        ),
+    ]

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -7,6 +7,7 @@ class Node(models.Model):
     hostname = models.CharField(max_length=100)
     address = models.GenericIPAddressField()
     port = models.PositiveIntegerField(default=8000)
+    badge_color = models.CharField(max_length=7, default="#28a745")
     last_seen = models.DateTimeField(auto_now=True)
 
     def __str__(self) -> str:  # pragma: no cover - simple representation

--- a/website/admin.py
+++ b/website/admin.py
@@ -1,0 +1,24 @@
+from django.contrib import admin
+from django.contrib.sites.models import Site
+from django.contrib.sites.admin import SiteAdmin as DjangoSiteAdmin
+from django import forms
+from django.db import models
+
+from .models import SiteBadge
+
+
+class SiteBadgeInline(admin.StackedInline):
+    model = SiteBadge
+    can_delete = False
+    extra = 0
+    formfield_overrides = {
+        models.CharField: {"widget": forms.TextInput(attrs={"type": "color"})}
+    }
+
+
+class SiteAdmin(DjangoSiteAdmin):
+    inlines = [SiteBadgeInline]
+
+
+admin.site.unregister(Site)
+admin.site.register(Site, SiteAdmin)

--- a/website/migrations/0001_sitebadge.py
+++ b/website/migrations/0001_sitebadge.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ("sites", "0002_alter_domain_unique"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SiteBadge",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "badge_color",
+                    models.CharField(default="#28a745", max_length=7),
+                ),
+                (
+                    "site",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="badge",
+                        to="sites.site",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/website/models.py
+++ b/website/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+from django.contrib.sites.models import Site
+
+
+class SiteBadge(models.Model):
+    site = models.OneToOneField(Site, on_delete=models.CASCADE, related_name="badge")
+    badge_color = models.CharField(max_length=7, default="#28a745")
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"Badge for {self.site.domain}"

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -9,23 +9,23 @@
     font-size: 0.7em;
     padding: 2px 4px;
     border-radius: 4px;
+    color: white;
 }
-.badge-success {background-color:#28a745;color:white;}
-.badge-warning {background-color:#dc3545;color:white;}
+.badge-unknown {background-color:#6c757d;}
 </style>
 {% endblock %}
 {% block branding %}
 <h1 id="site-name">
   <a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a>
   {% if badge_site %}
-    <span class="badge badge-success">SITE: {{ badge_site.domain }}</span>
+    <span class="badge" style="background-color: {{ badge_site_color }};">SITE: {{ badge_site.domain }}</span>
   {% else %}
-    <span class="badge badge-warning">SITE: Unknown</span>
+    <span class="badge badge-unknown">SITE: Unknown</span>
   {% endif %}
   {% if badge_node %}
-    <span class="badge badge-success">NODE: {{ badge_node.hostname }}</span>
+    <span class="badge" style="background-color: {{ badge_node_color }};">NODE: {{ badge_node.hostname }}</span>
   {% else %}
-    <span class="badge badge-warning">NODE: Unknown</span>
+    <span class="badge badge-unknown">NODE: Unknown</span>
   {% endif %}
 </h1>
 {% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -64,4 +64,6 @@ class AdminBadgesTests(TestCase):
         Node.objects.all().delete()
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, "NODE: Unknown")
+        self.assertContains(resp, "badge-unknown")
+        self.assertContains(resp, "#6c757d")
 


### PR DESCRIPTION
## Summary
- allow setting badge colors for sites and nodes via new admin color pickers
- default unknown badges to grey instead of red
- expose badge colors in context and template for dynamic styling

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688c1e8055e4832687aeb1ba4a38d7c5