### PR TITLE
Configure VS Code to use project venv

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,26 @@
             "name": "Run Server",
             "type": "python",
             "request": "launch",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "windows": {
+                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+            },
             "program": "${workspaceFolder}/manage.py",
             "args": ["runserver"],
             "django": true,
-            "noDebug": true,
+            "noDebug": true
         },
         {
             "name": "Debug Server",
             "type": "python",
             "request": "launch",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "windows": {
+                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+            },
             "program": "${workspaceFolder}/manage.py",
             "args": ["runserver"],
-            "django": true,
+            "django": true
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "python.defaultInterpreterPath": "python"
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "[windows]": {
+        "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,10 @@
         {
             "label": "Update requirements",
             "type": "shell",
-            "command": "python -m pip install -U -r requirements.txt && python -m pip freeze > requirements.txt",
+            "command": "${workspaceFolder}/.venv/bin/python -m pip install -U -r requirements.txt && ${workspaceFolder}/.venv/bin/python -m pip freeze > requirements.txt",
+            "windows": {
+                "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe -m pip install -U -r requirements.txt && ${workspaceFolder}\\.venv\\Scripts\\python.exe -m pip freeze > requirements.txt"
+            },
             "problemMatcher": []
         }
     ]


### PR DESCRIPTION
## Summary
- point VS Code to use `.venv` for the Python interpreter
- ensure run/debug configs and tasks reference the same virtual env
- add Windows-specific path so VS Code locates the virtual environment on all platforms

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7639f1988326bc6dd90b6056c666