### PR TITLE
Align Calculate button with final input row in AWG calculator

### DIFF
--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -75,10 +75,7 @@
         </select>
       </div>
     </div>
-    <div class="col-lg-6">
-      <div class="mb-3">
-        <button type="submit" class="btn btn-primary w-100">Calculate</button>
-      </div>
+    <div class="col-lg-6 d-flex flex-column">
       {% if error %}
       <p class="text-danger">Error: {{ error }}</p>
       {% elif no_cable %}
@@ -106,6 +103,9 @@
         {% endif %}
       </div>
       {% endif %}
+      <div class="mt-auto mb-3">
+        <button type="submit" class="btn btn-primary w-100">Calculate</button>
+      </div>
     </div>
   </div>
 </form>


### PR DESCRIPTION
## Summary
- place Calculate button at bottom of third column in AWG calculator
- ensure button aligns with final row of input fields using flexbox

## Testing
- `python -m django test awg --settings=config.settings -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688d8ce9b2fc83269f6bdd6f802bd456