### PR TITLE
Add packaging dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ selenium
 requests
 toml
 
+packaging
 pyperclip


### PR DESCRIPTION
## Summary
- include packaging library in requirements to avoid missing-module errors during development tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d8da65efc832686490113fdad3af6