### PR TITLE
Ensure dev tasks use .venv for dependencies

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,76 +2,106 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
+
 from config.loadenv import loadenv
 
 
-def _dev_tasks() -> None:
-    """Perform optional maintenance tasks during auto-reload."""
+BASE_DIR = Path(__file__).resolve().parent
+VENV_DIR = BASE_DIR / ".venv"
+VENV_BIN = "Scripts" if os.name == "nt" else "bin"
+VENV_PYTHON = VENV_DIR / VENV_BIN / ("python.exe" if os.name == "nt" else "python")
+
+
+def _ensure_venv() -> None:
+    """Ensure the local virtual environment has all dependencies."""
     try:
         import subprocess
-        from pathlib import Path
+
+        if not VENV_PYTHON.exists():
+            subprocess.run([sys.executable, "-m", "venv", str(VENV_DIR)], check=False)
+        if not VENV_PYTHON.exists():
+            return
+
+        req = Path("requirements.txt")
+        if not req.exists():
+            return
+
+        freeze = subprocess.run(
+            [str(VENV_PYTHON), "-m", "pip", "freeze"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        installed = {}
+        for line in freeze.stdout.splitlines():
+            if "==" in line:
+                name, ver = line.split("==", 1)
+                installed[name.lower()] = ver
+            elif "@" in line:
+                name = line.split("@", 1)[0]
+                installed[name.strip().lower()] = None
+
+        from packaging.requirements import Requirement
+
+        req_lines = [
+            line.strip()
+            for line in req.read_text().splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+        needs_install = False
+        for line in req_lines:
+            try:
+                requirement = Requirement(line)
+            except Exception:
+                needs_install = True
+                break
+            name = requirement.name.lower()
+            version = installed.get(name)
+            if version is None:
+                if name not in installed:
+                    needs_install = True
+                    break
+            elif requirement.specifier and not requirement.specifier.contains(
+                version, prereleases=True
+            ):
+                needs_install = True
+                break
+        if needs_install:
+            subprocess.run(
+                [str(VENV_PYTHON), "-m", "pip", "install", "-r", str(req)],
+                check=False,
+            )
+    except Exception as exc:  # pragma: no cover - dev helper
+        print(f"Dev task error: {exc}")
+
+
+def _runserver_tasks() -> None:
+    """Perform optional maintenance tasks when launching the dev server."""
+    try:
+        import subprocess
 
         import django
         from django.conf import settings
         from django.core.management import call_command
         from django.core.management.base import CommandError
+        from django.db import connection
+        from django.db.migrations.exceptions import InconsistentMigrationHistory
+        from django.db.migrations.recorder import MigrationRecorder
 
         django.setup()
         if not settings.DEBUG:
             return
 
-        req = Path("requirements.txt")
-        if req.exists():
-            freeze = subprocess.run(
-                [sys.executable, "-m", "pip", "freeze"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            installed = {}
-            for line in freeze.stdout.splitlines():
-                if "==" in line:
-                    name, ver = line.split("==", 1)
-                    installed[name.lower()] = ver
-                elif "@" in line:
-                    name = line.split("@", 1)[0]
-                    installed[name.strip().lower()] = None
-            from packaging.requirements import Requirement
-
-            req_lines = [
-                line.strip()
-                for line in req.read_text().splitlines()
-                if line.strip() and not line.startswith("#")
-            ]
-            needs_install = False
-            for line in req_lines:
-                try:
-                    requirement = Requirement(line)
-                except Exception:
-                    needs_install = True
-                    break
-                name = requirement.name.lower()
-                version = installed.get(name)
-                if version is None:
-                    if name not in installed:
-                        needs_install = True
-                        break
-                elif requirement.specifier and not requirement.specifier.contains(
-                    version, prereleases=True
-                ):
-                    needs_install = True
-                    break
-            if needs_install:
-                subprocess.run(
-                    [sys.executable, "-m", "pip", "install", "-r", str(req)],
-                    check=False,
-                )
-
         try:
             call_command("makemigrations", interactive=False)
         except CommandError:
             call_command("makemigrations", merge=True, interactive=False)
-        call_command("migrate", interactive=False)
+        try:
+            call_command("migrate", interactive=False)
+        except InconsistentMigrationHistory:
+            MigrationRecorder(connection).migration_qs.filter(app="ocpp").delete()
+            call_command("migrate", interactive=False)
 
         proc = subprocess.run(
             ["git", "status", "--porcelain"], capture_output=True, text=True
@@ -130,7 +160,15 @@ def main():
         ) from exc
 
     def _execute():
-        _dev_tasks()
+        _ensure_venv()
+        if (
+            settings.DEBUG
+            and VENV_PYTHON.exists()
+            and Path(sys.executable).resolve() != VENV_PYTHON.resolve()
+        ):
+            os.execv(str(VENV_PYTHON), [str(VENV_PYTHON), *sys.argv])
+        if settings.DEBUG and len(sys.argv) > 1 and sys.argv[1] == "runserver":
+            _runserver_tasks()
         execute_from_command_line(sys.argv)
 
     if (


### PR DESCRIPTION
## Summary
- ensure `.venv` dependencies are installed before running manage.py commands
- limit dev maintenance to runserver and purge ocpp migration records when history is inconsistent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e661aa51083268194c3024ef462b7