### PR TITLE
Add command to reset OCPP migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ python manage.py apply_nginx_config <id>
 The Django admin includes an action to test connectivity to the configured
 upstream servers and shows the rendered template for review.
 
+## Recipes
+
+`Recipe` objects allow storing scripts as ordered `Step` entries. In the Django
+admin the recipe can be edited either as a list of steps or as a single text
+block representing the full script.
+
 
 # Accounts and Products App
 
@@ -232,6 +238,14 @@ RFID tags can be exported and imported using management commands:
 
 This app implements a lightweight Charge Point management system using
 [OCPP 1.6](https://github.com/OCA/ocpp) over WebSockets.
+
+### Resetting Migrations
+
+If OCPP migrations become inconsistent, clear and reapply them for the OCPP app only:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
 
 ### Sink Endpoint
 

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -3,6 +3,14 @@
 This app implements a lightweight Charge Point management system using
 [OCPP 1.6](https://github.com/OCA/ocpp) over WebSockets.
 
+### Resetting Migrations
+
+If OCPP migrations become inconsistent, clear and reapply them for the OCPP app only:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
+
 ### Sink Endpoint
 
 A permissive WebSocket sink is exposed at `ws://127.0.0.1:8000/ws/sink/` which

--- a/ocpp/management/commands/reset_ocpp_migrations.py
+++ b/ocpp/management/commands/reset_ocpp_migrations.py
@@ -1,0 +1,13 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.migrations.recorder import MigrationRecorder
+
+
+class Command(BaseCommand):
+    help = "Clear recorded OCPP migrations and apply them again."
+
+    def handle(self, *args, **options):
+        MigrationRecorder(connection).migration_qs.filter(app="ocpp").delete()
+        call_command("migrate", "ocpp", fake_initial=True)
+


### PR DESCRIPTION
## Summary
- add management command to clear recorded OCPP migrations and re-run migrations for only the OCPP app
- document how to reset OCPP migrations in the README

## Testing
- `python manage.py build_readme`
- `python manage.py test` *(fails: failures=3, errors=16)*


------
https://chatgpt.com/codex/tasks/task_e_688f9b9d5c9c83268b17076fc64766ab