### PR TITLE
Add command to reset OCPP migrations

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -52,6 +52,16 @@ Any `*.env` file found there is automatically loaded when running management
 commands or the server. The directory is included in the repository but `.env`
 files themselves are ignored so secrets remain local.
 
+### Resetting OCPP Migrations
+
+If OCPP migrations become inconsistent during development, remove all OCPP tables and rerun their migrations:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
+
+This command deletes all OCPP data before reapplying migrations only for the OCPP app.
+
 ### Offline Mode
 
 Set the environment variable `ARTHEXIS_OFFLINE=1` to prevent code paths that

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Any `*.env` file found there is automatically loaded when running management
 commands or the server. The directory is included in the repository but `.env`
 files themselves are ignored so secrets remain local.
 
+### Resetting OCPP Migrations
+
+If OCPP migrations become inconsistent during development, remove all OCPP tables and rerun their migrations:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
+
+This command deletes all OCPP data before reapplying migrations only for the OCPP app.
+
 ### Offline Mode
 
 Set the environment variable `ARTHEXIS_OFFLINE=1` to prevent code paths that
@@ -171,6 +181,12 @@ python manage.py apply_nginx_config <id>
 The Django admin includes an action to test connectivity to the configured
 upstream servers and shows the rendered template for review.
 
+## Recipes
+
+`Recipe` objects allow storing scripts as ordered `Step` entries. In the Django
+admin the recipe can be edited either as a list of steps or as a single text
+block representing the full script.
+
 
 # Accounts and Products App
 
@@ -232,6 +248,16 @@ RFID tags can be exported and imported using management commands:
 
 This app implements a lightweight Charge Point management system using
 [OCPP 1.6](https://github.com/OCA/ocpp) over WebSockets.
+
+### Resetting Migrations
+
+If OCPP migrations become inconsistent, drop all OCPP tables and reapply them:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
+
+This removes all OCPP data before running migrations again.
 
 ### Sink Endpoint
 

--- a/ocpp/README.md
+++ b/ocpp/README.md
@@ -3,6 +3,16 @@
 This app implements a lightweight Charge Point management system using
 [OCPP 1.6](https://github.com/OCA/ocpp) over WebSockets.
 
+### Resetting Migrations
+
+If OCPP migrations become inconsistent, drop all OCPP tables and reapply them:
+
+```bash
+python manage.py reset_ocpp_migrations
+```
+
+This removes all OCPP data before running migrations again.
+
 ### Sink Endpoint
 
 A permissive WebSocket sink is exposed at `ws://127.0.0.1:8000/ws/sink/` which

--- a/ocpp/management/commands/reset_ocpp_migrations.py
+++ b/ocpp/management/commands/reset_ocpp_migrations.py
@@ -1,0 +1,23 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.migrations.recorder import MigrationRecorder
+
+
+class Command(BaseCommand):
+    help = "Clear recorded OCPP migrations and apply them again."
+
+    def handle(self, *args, **options):
+        recorder = MigrationRecorder(connection)
+        if recorder.has_table():
+            recorder.migration_qs.filter(app="ocpp").delete()
+
+        with connection.cursor() as cursor:
+            tables = [
+                t for t in connection.introspection.table_names() if t.startswith("ocpp_")
+            ]
+            for table in tables:
+                cursor.execute(f"DROP TABLE {connection.ops.quote_name(table)}")
+
+        call_command("migrate", "ocpp", fake_initial=True)
+


### PR DESCRIPTION
## Summary
- drop all `ocpp_*` tables before replaying migrations in `reset_ocpp_migrations`
- document that the reset command wipes OCPP data before reapplying migrations

## Testing
- `python manage.py build_readme`
- `python manage.py reset_ocpp_migrations`
- `python manage.py test` *(fails: failures=3, errors=16)*

------
https://chatgpt.com/codex/tasks/task_e_688f9b9d5c9c83268b17076fc64766ab