### PR TITLE
docs: limit README generation to releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 # Agent Guidelines
 
-- Do not edit `README.md` directly. Use `README.base.md` and each app's `README.md` under its directory. After changes, run `python manage.py build_readme` to regenerate the main README.
+- The top-level `README.md` is auto-generated. **Never edit this file directly.**
+- For documentation updates, edit `README.base.md` or the `README.md` inside the relevant app's directory (e.g., `accounts/README.md`).
+- The combined `README.md` is regenerated only when creating a release using `python manage.py build_readme`. Do not rebuild it during normal development.
 

--- a/README.base.md
+++ b/README.base.md
@@ -103,12 +103,7 @@ reinstalls dependencies.
 
 Documentation is split across multiple files. `README.base.md` provides the
 overview while each app has its own `README.md` with app-specific details.
-After updating any of these files, regenerate `README.md` with:
-
-```bash
-python manage.py build_readme
-```
-
+The combined `README.md` is generated during the release process.
 Avoid editing the combined `README.md` directly.
 
 ## Release
@@ -116,9 +111,9 @@ Avoid editing the combined `README.md` directly.
 The `release` app provides utilities for publishing the project to PyPI.
 Package metadata and optional credentials may be stored in the
 `PackageConfig` model which is managed through the Django admin. An admin
-action can invoke the full release workflow using the saved settings. Use the
-`build_pypi` management command to bump the version, build the distribution and
-upload it via Twine:
+action can invoke the full release workflow using the saved settings. The
+`build_pypi` management command regenerates the project `README.md`, bumps the
+version, builds the distribution and optionally uploads it via Twine:
 
 ```bash
 python manage.py build_pypi --all

--- a/readme/README.md
+++ b/readme/README.md
@@ -2,4 +2,5 @@
 
 Provides a view for rendering the project's generated `README.md` as HTML
 and a management command `build_readme` that rebuilds the file from
-`README.base.md` and each app's own `README.md`.
+`README.base.md` and each app's own `README.md`. The command is typically
+invoked during the release process.

--- a/release/utils.py
+++ b/release/utils.py
@@ -189,6 +189,8 @@ def build(
         if line.strip() and not line.startswith("#")
     ]
 
+    _run([sys.executable, "manage.py", "build_readme"])
+
     commit_hash = _current_commit()
     Path("BUILD").write_text(commit_hash + "\n")
     prev_build = _last_changelog_build()


### PR DESCRIPTION
## Summary
- clarify that the top-level README is only regenerated during releases
- update documentation and release tooling accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e663fdc08326a78bc10ea575137d