### PR TITLE
Reset database automatically in dev maintenance script

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -52,6 +52,13 @@ Any `*.env` file found there is automatically loaded when running management
 commands or the server. The directory is included in the repository but `.env`
 files themselves are ignored so secrets remain local.
 
+### Development Maintenance
+
+Running `dev-maintenance.bat` (or `./dev-maintenance.sh`) installs dependencies,
+removes the SQLite database (default `db.sqlite3` or the path from `DB_PATH`),
+and reruns migrations. This resets the database automatically for a clean
+development setup.
+
 ### Resetting OCPP Migrations
 
 If OCPP migrations become inconsistent during development, clear their recorded

--- a/dev-maintenance.bat
+++ b/dev-maintenance.bat
@@ -10,4 +10,7 @@ if not exist %VENV%\Scripts\python.exe (
 if exist requirements.txt (
     %VENV%\Scripts\python.exe -m pip install -r requirements.txt
 )
+set "DB_FILE=%VENV%\..\db.sqlite3"
+if defined DB_PATH set "DB_FILE=%DB_PATH%"
+if exist "%DB_FILE%" del "%DB_FILE%"
 %VENV%\Scripts\python.exe dev_maintenance.py


### PR DESCRIPTION
## Summary
- Delete SQLite database before running `dev_maintenance.py` in `dev-maintenance.bat`
- Document the automatic database reset behavior in `README.base.md`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689241d456988326a13590ce978f687b