### PR TITLE
Display sidebar table of contents for README pages

### DIFF
--- a/website/templates/website/readme.html
+++ b/website/templates/website/readme.html
@@ -3,5 +3,16 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-{{ content|safe }}
+<div class="row">
+  <div class="col-lg-9">
+    {{ content|safe }}
+  </div>
+  {% if toc %}
+  <div class="col-lg-3">
+    <nav class="toc" style="position: sticky; top: 1rem;">
+      {{ toc|safe }}
+    </nav>
+  </div>
+  {% endif %}
+</div>
 {% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -67,3 +67,14 @@ class AdminBadgesTests(TestCase):
         self.assertContains(resp, "badge-unknown")
         self.assertContains(resp, "#6c757d")
 
+
+class ReadmeSidebarTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        Site.objects.update_or_create(id=1, defaults={"name": "website"})
+
+    def test_table_of_contents_sidebar_present(self):
+        resp = self.client.get(reverse("website:index"))
+        self.assertIn("toc", resp.context)
+        self.assertContains(resp, 'class="toc"')
+

--- a/website/views.py
+++ b/website/views.py
@@ -59,8 +59,9 @@ def index(request):
     if not readme_file.exists():
         readme_file = Path(settings.BASE_DIR) / "README.md"
     text = readme_file.read_text(encoding="utf-8")
-    html = markdown.markdown(text)
-    context = {"content": html, "title": readme_file.stem}
+    md = markdown.Markdown(extensions=["toc"])
+    html = md.convert(text)
+    context = {"content": html, "title": readme_file.stem, "toc": md.toc}
     if app_name in ("website", "readme"):
         context["nav_apps"] = get_landing_apps()
     return render(request, "website/readme.html", context)


### PR DESCRIPTION
## Summary
- generate a table of contents when rendering README files
- show README content beside a sticky sidebar TOC
- test rendering of TOC sidebar on homepage

## Testing
- `pytest`
- `python manage.py test` *(fails: Reverse for 'charger-page' not found, other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68925eaa81948326918215eb8fab7214