### PR TITLE
Restrict default admin login to localhost

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -6,3 +6,14 @@ class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "accounts"
     verbose_name = _("Accounts and Products")
+
+    def ready(self):  # pragma: no cover - called by Django
+        from django.contrib.auth import get_user_model
+        from django.db.models.signals import post_migrate
+
+        def create_default_admin(**kwargs):
+            User = get_user_model()
+            if not User.objects.exists():
+                User.objects.create_superuser("admin", password="admin")
+
+        post_migrate.connect(create_default_admin, sender=self)

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -1,4 +1,8 @@
+"""Custom authentication backends for the accounts app."""
+
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+
 from .models import Account
 
 
@@ -25,3 +29,15 @@ class RFIDBackend:
             return User.objects.get(pk=user_id)
         except User.DoesNotExist:
             return None
+
+
+class LocalhostAdminBackend(ModelBackend):
+    """Deny default admin credentials unless the request is from localhost."""
+
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        if username == "admin" and password == "admin" and request is not None:
+            remote = request.META.get("REMOTE_ADDR")
+            if remote not in {"127.0.0.1", "::1"}:
+                return None
+        return super().authenticate(request, username, password, **kwargs)
+

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,5 +1,6 @@
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.http import HttpRequest
 
 from django.utils import timezone
 from .models import User, RFID, Account, Vehicle, Credit, Address, Product, Subscription
@@ -7,6 +8,25 @@ from ocpp.models import Transaction
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
+from .backends import LocalhostAdminBackend
+
+
+class DefaultAdminTests(TestCase):
+    def test_admin_created_and_localhost_only(self):
+        self.assertTrue(User.objects.filter(username="admin").exists())
+        backend = LocalhostAdminBackend()
+
+        local = HttpRequest()
+        local.META["REMOTE_ADDR"] = "127.0.0.1"
+        self.assertIsNotNone(
+            backend.authenticate(local, username="admin", password="admin")
+        )
+
+        remote = HttpRequest()
+        remote.META["REMOTE_ADDR"] = "10.0.0.1"
+        self.assertIsNone(
+            backend.authenticate(remote, username="admin", password="admin")
+        )
 
 
 class RFIDLoginTests(TestCase):

--- a/config/settings.py
+++ b/config/settings.py
@@ -107,9 +107,9 @@ CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
 # Custom user model
 AUTH_USER_MODEL = "accounts.User"
 
-# Enable RFID authentication backend in addition to Django's default
+# Enable RFID authentication backend and restrict default admin login to localhost
 AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",
+    "accounts.backends.LocalhostAdminBackend",
     "accounts.backends.RFIDBackend",
 ]
 


### PR DESCRIPTION
## Summary
- create default admin user automatically when no users exist
- add authentication backend that blocks admin/admin login from non-local addresses
- add tests for default admin authentication

## Testing
- `python manage.py test` (fails: failures=4, errors=24)
- `python manage.py test accounts.tests`

------
https://chatgpt.com/codex/tasks/task_e_68925e6e3c5c83269edd71f06b85d510