### PR TITLE
Add configurable release action in admin

### DIFF
--- a/release/admin.py
+++ b/release/admin.py
@@ -1,4 +1,7 @@
+from django import forms
 from django.contrib import admin, messages
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+from django.shortcuts import render
 
 from .models import PackageConfig
 from . import utils
@@ -9,11 +12,36 @@ class PackageConfigAdmin(admin.ModelAdmin):
     list_display = ("name", "author", "repository_url")
     actions = ["build_package"]
 
+    class BuildOptionsForm(forms.Form):
+        bump = forms.BooleanField(required=False, label="Bump version")
+        dist = forms.BooleanField(required=False, label="Build distribution")
+        twine = forms.BooleanField(required=False, label="Upload to PyPI")
+        git = forms.BooleanField(required=False, label="Commit to Git")
+        tag = forms.BooleanField(required=False, label="Tag release")
+        force = forms.BooleanField(required=False, label="Force upload")
+        all = forms.BooleanField(required=False, label="Run all steps")
+
     @admin.action(description="Build selected packages for PyPI")
     def build_package(self, request, queryset):
-        for cfg in queryset:
-            try:
-                cfg.build(all=True)
-                self.message_user(request, f"Built {cfg.name}", messages.SUCCESS)
-            except utils.ReleaseError as exc:
-                self.message_user(request, str(exc), messages.ERROR)
+        if "apply" in request.POST:
+            form = self.BuildOptionsForm(request.POST)
+            if form.is_valid():
+                opts = form.cleaned_data
+                for cfg in queryset:
+                    try:
+                        cfg.build(**opts)
+                        self.message_user(
+                            request, f"Built {cfg.name}", messages.SUCCESS
+                        )
+                    except utils.ReleaseError as exc:
+                        self.message_user(request, str(exc), messages.ERROR)
+                return None
+        else:
+            form = self.BuildOptionsForm()
+
+        context = {
+            "form": form,
+            "packages": queryset,
+            "action_checkbox_name": ACTION_CHECKBOX_NAME,
+        }
+        return render(request, "release/build_options.html", context)

--- a/release/templates/release/build_options.html
+++ b/release/templates/release/build_options.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Configure release" %}</h1>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  {% for pkg in packages %}
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ pkg.pk }}">
+  {% endfor %}
+  <input type="hidden" name="action" value="build_package">
+  <input type="submit" name="apply" value="{% trans "Build" %}">
+</form>
+{% endblock %}

--- a/release/tests.py
+++ b/release/tests.py
@@ -62,10 +62,18 @@ class PackageAdminTests(TestCase):
 
     def test_build_action_calls_utils(self):
         url = reverse("admin:release_packageconfig_changelist")
+        response = self.client.post(
+            url, {"action": "build_package", "_selected_action": [self.cfg.pk]}
+        )
+        self.assertEqual(response.status_code, 200)
         with patch("release.admin.utils.build") as mock_build:
             response = self.client.post(
                 url,
-                {"action": "build_package", "_selected_action": [self.cfg.pk]},
+                {
+                    "action": "build_package",
+                    "_selected_action": [self.cfg.pk],
+                    "apply": "1",
+                },
                 follow=True,
             )
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- add admin form to choose release steps before building
- provide template for configuring release options
- adjust tests for new two-step admin workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891408f87ec83269bb427652377c08a