### PR TITLE
Handle missing gway dependency for OCPP views

### DIFF
--- a/ocpp/evcs.py
+++ b/ocpp/evcs.py
@@ -10,9 +10,9 @@ behaviour of the upstream implementation in a lightweight, dependency free
 fashion.
 
 Only the portions that are useful for automated tests are implemented here.
-The web based user interface present in the original file relies on internal
-``gway`` helpers and the Bottle framework.  To keep the module self contained
-and importable in the test environment those parts are intentionally omitted.
+The web based user interface present in the original file relies on additional
+helpers and the Bottle framework.  To keep the module self contained and
+importable in the test environment those parts are intentionally omitted.
 
 The simulator exposes two high level helpers:
 

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -7,7 +7,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404
 
 from website.utils import landing
-from gway import gw
 
 from . import store
 from .models import Transaction, Charger
@@ -129,11 +128,8 @@ def dashboard(request):
 @landing("Simulator")
 def cp_simulator(request):
     """Public landing page to control the OCPP charge point simulator."""
-    ws_url = gw.web.build_ws_url("ocpp", "csms")
-    default_host = ws_url.split("://")[-1].split(":")[0]
-    default_ws_port = (
-        ws_url.split(":")[-1].split("/")[0] if ":" in ws_url else "9000"
-    )
+    default_host = "127.0.0.1"
+    default_ws_port = "9000"
     default_cp_paths = ["CP1", "CP2"]
     default_rfid = "FFFFFFFF"
 


### PR DESCRIPTION
## Summary
- remove `gway` dependency from OCPP views and simulator module
- use fixed default WebSocket host and port for the simulator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c5273a448326b6bf156b1dffdf58