### PR TITLE
feat: auto sync git during dev reload

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,14 +1,61 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 import os
+import subprocess
 import sys
+from pathlib import Path
 
 from config.loadenv import loadenv
+
+
+def _notify_and_exit(message: str) -> None:
+    """Display a Windows notification, open latest log, and exit."""
+    if os.name == "nt":  # pragma: no cover - Windows only behaviour
+        try:
+            import ctypes
+
+            ctypes.windll.user32.MessageBoxW(0, message, "ArtHexis", 0)
+        except Exception:
+            pass
+        logs_dir = Path(__file__).resolve().parent / "logs"
+        log_files = list(logs_dir.glob("*.log"))
+        if log_files:
+            latest = max(log_files, key=lambda p: p.stat().st_mtime)
+            try:
+                subprocess.Popen(["notepad.exe", str(latest)])
+            except Exception:
+                pass
+    raise SystemExit(message)
+
+
+def _maybe_sync_git() -> None:
+    """Check for pending git updates and sync if possible."""
+    if os.environ.get("RUN_MAIN") != "true":
+        return
+    try:
+        from django.conf import settings
+
+        if not settings.DEBUG:
+            return
+    except Exception:
+        return
+
+    subprocess.run(["git", "fetch"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    dirty = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True).stdout.strip()
+    status = subprocess.run(["git", "status", "-uno"], capture_output=True, text=True).stdout
+    if "behind" in status:
+        if not dirty:
+            result = subprocess.run(["git", "pull"], capture_output=True, text=True)
+            if result.returncode != 0:
+                _notify_and_exit("Git pull failed. Check logs for details.")
+        else:
+            _notify_and_exit("Uncommitted changes prevent auto-sync.")
 
 def main() -> None:
     """Run administrative tasks."""
     loadenv()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    _maybe_sync_git()
     try:
         from django.core.management import execute_from_command_line
         from daphne.management.commands.runserver import (


### PR DESCRIPTION
## Summary
- auto-sync repository when debugging if working tree clean
- stop server with Windows notification and log if sync not possible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d16acc3c8326be7cfd2d0990a3f7