### PR TITLE
Handle missing chargers on log page

### DIFF
--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -96,6 +96,14 @@ class ChargerLandingTests(TestCase):
         self.assertContains(resp, "2.00")
         self.assertContains(resp, "Offline")
 
+    def test_log_page_renders_without_charger(self):
+        store.logs["LOG1"] = ["hello"]
+        client = Client()
+        resp = client.get(reverse("charger-log", args=["LOG1"]))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "hello")
+        store.logs.pop("LOG1", None)
+
 
 class SimulatorLandingTests(TestCase):
     def test_simulator_page_in_nav(self):

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -217,7 +217,10 @@ def charger_page(request, cid):
 
 def charger_log_page(request, cid):
     """Render a simple page with the log for the charger."""
-    charger = get_object_or_404(Charger, charger_id=cid)
+    try:
+        charger = Charger.objects.get(charger_id=cid)
+    except Charger.DoesNotExist:
+        charger = Charger(charger_id=cid)
     log = store.logs.get(cid, [])
     return render(
         request,


### PR DESCRIPTION
## Summary
- avoid 404 on /ocpp/log/<id>/ by showing logs even if the charger isn't registered
- add test covering log view without a Charger entry

## Testing
- `python manage.py test ocpp.tests.ChargerLandingTests -v 2`
- `python manage.py test ocpp -v 2` *(fails: IntegrityError: UNIQUE constraint failed: accounts_user.username)*

------
https://chatgpt.com/codex/tasks/task_e_6893e203c740832688c20d15c92f64f5