### PR TITLE
Open browser on dev reload

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -38,7 +38,8 @@ that launches the server on boot.
    When the server restarts under VS Code with this variable set, it
    automatically installs any updated dependencies from
    `requirements.txt`, merges and applies migrations, and commits and
-   pushes the changes if anything was modified.
+   pushes the changes if anything was modified. It also opens the main
+   page in your default web browser each time the server reloads.
 
 The default configuration uses SQLite and is for local development only.
 To use PostgreSQL instead, set the `POSTGRES_DB` environment variable (and

--- a/readme/management/commands/runserver.py
+++ b/readme/management/commands/runserver.py
@@ -1,3 +1,6 @@
+import os
+import webbrowser
+
 from daphne.management.commands.runserver import Command as RunserverCommand
 
 class Command(RunserverCommand):
@@ -10,9 +13,16 @@ class Command(RunserverCommand):
         # Display available websocket URLs.
         websocket_paths = ['/ws/echo/', '/<path>/<cid>/']
         for path in websocket_paths:
-            self.stdout.write(f"WebSocket available at {scheme}://{host}:{server_port}{path}")
-        http_scheme = 'https' if self.ssl_options else 'http'
-        self.stdout.write(f"Admin available at {http_scheme}://{host}:{server_port}/admin/")
+            self.stdout.write(
+                f"WebSocket available at {scheme}://{host}:{server_port}{path}"
+            )
+        http_scheme = "https" if self.ssl_options else "http"
+        self.stdout.write(
+            f"Admin available at {http_scheme}://{host}:{server_port}/admin/"
+        )
+
+        if os.environ.get("DJANGO_DEV_RELOAD") and os.environ.get("RUN_MAIN") == "true":
+            webbrowser.open(f"{http_scheme}://{host}:{server_port}/")
 
 
 


### PR DESCRIPTION
## Summary
- open default web browser to the main page when the server reloads and DJANGO_DEV_RELOAD is set
- document automatic browser launch in development reload section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e6727cd883268847cdf1d61faebd