### PR TITLE
Auto-squash migrations after applying

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -39,6 +39,10 @@ except OperationalError:
     else:
         raise
 
+# Squash migrations back to a single initial state after a successful migrate
+call_command("reset_migrations")
+call_command("migrate", interactive=False, fake_initial=True)
+
 proc = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
 if proc.stdout.strip():
     subprocess.run(["git", "add", "-A"], check=False)


### PR DESCRIPTION
## Summary
- squash migrations after successful migrate in dev maintenance script

## Testing
- `python manage.py test --failfast` *(fails: AWGCalculatorTests.test_page_renders_and_calculates: Couldn't find '<table')*


------
https://chatgpt.com/codex/tasks/task_e_689404d2ed708326b92532c2103d6082