### PR TITLE
Make taskbar levels collapsible

### DIFF
--- a/website/templates/website/readme.html
+++ b/website/templates/website/readme.html
@@ -12,6 +12,38 @@
     <nav class="toc" style="position: sticky; top: 1rem;">
       {{ toc|safe }}
     </nav>
+    <script>
+      (function () {
+        function initToc() {
+          document.querySelectorAll('nav.toc ul ul').forEach(function (sub) {
+            sub.style.display = 'none';
+          });
+          document.querySelectorAll('nav.toc li').forEach(function (item) {
+            var sub = item.querySelector('ul');
+            if (!sub) {
+              return;
+            }
+            var link = item.querySelector('a');
+            var toggle = document.createElement('span');
+            toggle.textContent = '▸';
+            toggle.style.cursor = 'pointer';
+            toggle.style.marginRight = '4px';
+            toggle.addEventListener('click', function (e) {
+              e.stopPropagation();
+              var expanded = sub.style.display === 'block';
+              sub.style.display = expanded ? 'none' : 'block';
+              toggle.textContent = expanded ? '▸' : '▾';
+            });
+            link.parentNode.insertBefore(toggle, link);
+          });
+        }
+        if (document.readyState !== 'loading') {
+          initToc();
+        } else {
+          document.addEventListener('DOMContentLoaded', initToc);
+        }
+      })();
+    </script>
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- collapse nested table-of-contents levels by default
- add toggle controls to expand or collapse TOC entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940615c06c832684051ee62c792919