### PR TITLE
Fix README TOC structure and remove bullets

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -11,6 +11,10 @@
       .navbar .dropdown:hover .dropdown-menu {
         display: block;
       }
+      nav.toc ul {
+        list-style: none;
+        padding-left: 0;
+      }
     </style>
   </head>
   <body class="p-3 d-flex flex-column min-vh-100">

--- a/website/views.py
+++ b/website/views.py
@@ -59,7 +59,13 @@ def index(request):
     text = readme_file.read_text(encoding="utf-8")
     md = markdown.Markdown(extensions=["toc"])
     html = md.convert(text)
-    context = {"content": html, "title": readme_file.stem, "toc": md.toc}
+    toc_html = md.toc
+    if toc_html.strip().startswith('<div class="toc">'):
+        toc_html = toc_html.strip()[len('<div class="toc">') :]
+        if toc_html.endswith('</div>'):
+            toc_html = toc_html[: -len('</div>')]
+        toc_html = toc_html.strip()
+    context = {"content": html, "title": readme_file.stem, "toc": toc_html}
     if app_name in ("website", "readme"):
         context["nav_apps"] = get_landing_apps()
     return render(request, "website/readme.html", context)


### PR DESCRIPTION
## Summary
- Strip Markdown TOC wrapper so top entry renders as proper top-level element
- Remove bullets from TOC navigation via CSS

## Testing
- `python manage.py test website` *(fails: UNIQUE constraint failed: accounts_user.username)*
- `python manage.py test website.tests.ReadmeSidebarTests`


------
https://chatgpt.com/codex/tasks/task_e_6894c42c1fd08326a7648352bcde40af