### PR TITLE
Skip blank page in onboarding wizard

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -151,28 +151,17 @@ class AccountAdmin(admin.ModelAdmin):
             obj.save()
         formset.save_m2m()
 
-    # Onboarding wizard views
+    # Onboarding wizard view
     def get_urls(self):
         urls = super().get_urls()
         custom = [
             path(
                 "onboard/",
-                self.admin_site.admin_view(self.onboard_start),
-                name="accounts_account_onboard_start",
-            ),
-            path(
-                "onboard/details/",
                 self.admin_site.admin_view(self.onboard_details),
                 name="accounts_account_onboard_details",
             ),
         ]
         return custom + urls
-
-    def onboard_start(self, request):
-        if request.method == "POST":
-            return redirect("admin:accounts_account_onboard_details")
-        context = self.admin_site.each_context(request)
-        return render(request, "accounts/onboard_start.html", context)
 
     def onboard_details(self, request):
         class OnboardForm(forms.Form):

--- a/accounts/templates/accounts/onboard_start.html
+++ b/accounts/templates/accounts/onboard_start.html
@@ -1,8 +1,0 @@
-{% extends "admin/base_site.html" %}
-{% block content %}
-<h1>Customer Onboarding</h1>
-<form method="post">
-  {% csrf_token %}
-  <input type="submit" value="Start">
-</form>
-{% endblock %}

--- a/accounts/templates/admin/accounts/account/change_list.html
+++ b/accounts/templates/admin/accounts/account/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
 {% block object-tools-items %}
 {{ block.super }}
-<li><a href="{% url 'admin:accounts_account_onboard_start' %}">Onboard customer</a></li>
+<li><a href="{% url 'admin:accounts_account_onboard_details' %}">Onboard customer</a></li>
 {% endblock %}

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -205,11 +205,9 @@ class OnboardingWizardTests(TestCase):
         self.client.force_login(User.objects.get(username="super"))
 
     def test_onboarding_flow_creates_account(self):
-        start_url = reverse("admin:accounts_account_onboard_start")
         details_url = reverse("admin:accounts_account_onboard_details")
-        response = self.client.post(start_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, details_url)
+        response = self.client.get(details_url)
+        self.assertEqual(response.status_code, 200)
         data = {
             "first_name": "John",
             "last_name": "Doe",


### PR DESCRIPTION
## Summary
- streamline customer onboarding by routing `/onboard/` directly to the details form
- link admin change list directly to onboarding form
- update onboarding test for new flow

## Testing
- `python manage.py test accounts`


------
https://chatgpt.com/codex/tasks/task_e_6894c45d39908326ada8c33828d54a36