### PR TITLE
Handle debugpy during git auto-reload restart

### DIFF
--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -1,0 +1,34 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from utils import git_sync
+
+
+def test_restart_server_plain(monkeypatch):
+    called = {}
+    monkeypatch.setattr(git_sync.os, "execv", lambda exe, args: called.update(exe=exe, args=args))
+    monkeypatch.setattr(git_sync.sys, "executable", "/usr/bin/python")
+    monkeypatch.setattr(git_sync.sys, "argv", ["manage.py", "runserver"])
+    monkeypatch.delitem(git_sync.sys.modules, "debugpy", raising=False)
+
+    git_sync._restart_server()
+
+    assert called["args"] == ["/usr/bin/python", "manage.py", "runserver"]
+
+
+def test_restart_server_strips_debugpy_launcher(monkeypatch):
+    called = {}
+    monkeypatch.setattr(git_sync.os, "execv", lambda exe, args: called.update(exe=exe, args=args))
+    monkeypatch.setattr(git_sync.sys, "executable", "/usr/bin/python")
+    monkeypatch.setattr(
+        git_sync.sys,
+        "argv",
+        ["debugpy_launcher", "5678", "--", "manage.py", "runserver", "--noreload"],
+    )
+    monkeypatch.setitem(git_sync.sys.modules, "debugpy", types.ModuleType("debugpy"))
+
+    git_sync._restart_server()
+
+    assert called["args"] == ["/usr/bin/python", "manage.py", "runserver", "--noreload"]

--- a/utils/git_sync.py
+++ b/utils/git_sync.py
@@ -6,8 +6,17 @@ import time
 
 
 def _restart_server() -> None:
-    """Restart the current process with updated code."""
-    os.execv(sys.executable, [sys.executable, *sys.argv])
+    """Restart the current process with updated code.
+
+    When run under ``debugpy`` (e.g., launched from VS Code), the original
+    command line includes the debugpy launcher and a ``--`` separator before the
+    real Django command. Re‑executing that exact command fails once the debugger
+    detaches, so strip the launcher and only run the underlying command.
+    """
+    argv = sys.argv
+    if "debugpy" in sys.modules and "--" in argv:
+        argv = argv[argv.index("--") + 1 :]
+    os.execv(sys.executable, [sys.executable, *argv])
 
 
 def _sync_loop(interval: int) -> None:


### PR DESCRIPTION
## Summary
- strip debugpy launcher args during background git sync restarts
- add tests covering restart behavior with and without debugpy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db5871d083268febcc32af99cd25