### PR TITLE
feat(admin): make sidebar app groups collapsible

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -1,6 +1,23 @@
 {% extends "admin/base.html" %}
 {% load i18n %}
 {% block title %}{% if title %}{{ title }} | {% endif %}{{ site_title|default:_('Django site admin') }}{% endblock %}
+{% block extrahead %}
+{{ block.super }}
+<script id="admin-collapsible-apps">
+document.addEventListener('DOMContentLoaded', function () {
+    const modules = document.querySelectorAll('#nav-sidebar .module');
+    modules.forEach(function (module) {
+        const header = module.querySelector('h2');
+        const content = module.querySelector('ul, table');
+        if (header && content) {
+            header.addEventListener('click', function () {
+                module.classList.toggle('collapsed');
+            });
+        }
+    });
+});
+</script>
+{% endblock %}
 {% block extrastyle %}
 {{ block.super }}
 <style>
@@ -12,6 +29,21 @@
     color: white;
 }
 .badge-unknown {background-color:#6c757d;}
+#nav-sidebar .module h2 {
+    cursor: pointer;
+}
+#nav-sidebar .module h2::after {
+    content: '\25BC';
+    float: right;
+    transition: transform 0.2s;
+}
+#nav-sidebar .module.collapsed h2::after {
+    transform: rotate(-90deg);
+}
+#nav-sidebar .module.collapsed ul,
+#nav-sidebar .module.collapsed table {
+    display: none;
+}
 </style>
 {% endblock %}
 {% block branding %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -43,7 +43,7 @@ class AdminBadgesTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="admin", password="pwd", email="admin@example.com"
+            username="badge_admin", password="pwd", email="admin@example.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
@@ -66,6 +66,27 @@ class AdminBadgesTests(TestCase):
         self.assertContains(resp, "NODE: Unknown")
         self.assertContains(resp, "badge-unknown")
         self.assertContains(resp, "#6c757d")
+
+
+class AdminSidebarTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="sidebar_admin", password="pwd", email="admin@example.com"
+        )
+        self.client.force_login(self.admin)
+        Site.objects.update_or_create(
+            id=1, defaults={"name": "test", "domain": "testserver"}
+        )
+        from nodes.models import Node
+
+        Node.objects.create(hostname="testserver", address="127.0.0.1")
+
+    def test_sidebar_app_groups_collapsible_script_present(self):
+        url = reverse("admin:nodes_node_changelist")
+        resp = self.client.get(url)
+        self.assertContains(resp, 'id="admin-collapsible-apps"')
 
 
 class ReadmeSidebarTests(TestCase):


### PR DESCRIPTION
## Summary
- add JavaScript and styles to collapse/expand app modules in admin sidebar
- cover collapsible sidebar behavior with test

## Testing
- `pytest`
- `python manage.py test` *(fails: UNIQUE constraint failed: accounts_user.username; FAIL: test_page_renders_and_calculates)*
- `python manage.py test website`

------
https://chatgpt.com/codex/tasks/task_e_6894fe9277b08326b99dcb9fb42bc10d