### PR TITLE
Add Register Current button to Sites admin

### DIFF
--- a/website/admin.py
+++ b/website/admin.py
@@ -1,8 +1,10 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.sites.models import Site
 from django.contrib.sites.admin import SiteAdmin as DjangoSiteAdmin
 from django import forms
 from django.db import models
+from django.shortcuts import redirect
+from django.urls import path
 
 from .models import SiteBadge
 
@@ -18,6 +20,31 @@ class SiteBadgeInline(admin.StackedInline):
 
 class SiteAdmin(DjangoSiteAdmin):
     inlines = [SiteBadgeInline]
+    change_list_template = "admin/sites/site/change_list.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "register-current/",
+                self.admin_site.admin_view(self.register_current),
+                name="sites_site_register_current",
+            )
+        ]
+        return custom + urls
+
+    def register_current(self, request):
+        domain = request.get_host().split(":")[0]
+        site, created = Site.objects.get_or_create(
+            domain=domain, defaults={"name": domain}
+        )
+        if created:
+            self.message_user(request, "Current domain registered", messages.SUCCESS)
+        else:
+            self.message_user(
+                request, "Current domain already registered", messages.INFO
+            )
+        return redirect("..")
 
 
 admin.site.unregister(Site)

--- a/website/templates/admin/sites/site/change_list.html
+++ b/website/templates/admin/sites/site/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:sites_site_register_current' %}" class="addlink">
+            {% trans 'Register Current' %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -43,7 +43,7 @@ class AdminBadgesTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="admin", password="pwd", email="admin@example.com"
+            username="badge-admin", password="pwd", email="admin@example.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
@@ -77,4 +77,27 @@ class ReadmeSidebarTests(TestCase):
         resp = self.client.get(reverse("website:index"))
         self.assertIn("toc", resp.context)
         self.assertContains(resp, 'class="toc"')
+
+
+class SiteAdminRegisterCurrentTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="site-admin", password="pwd", email="admin@example.com"
+        )
+        self.client.force_login(self.admin)
+        Site.objects.update_or_create(
+            id=1, defaults={"name": "example", "domain": "example.com"}
+        )
+
+    def test_register_current_creates_site(self):
+        resp = self.client.get(reverse("admin:sites_site_changelist"))
+        self.assertContains(resp, "Register Current")
+
+        resp = self.client.get(reverse("admin:sites_site_register_current"))
+        self.assertRedirects(resp, reverse("admin:sites_site_changelist"))
+        self.assertTrue(Site.objects.filter(domain="testserver").exists())
+        site = Site.objects.get(domain="testserver")
+        self.assertEqual(site.name, "testserver")
 


### PR DESCRIPTION
## Summary
- add custom Sites admin view and button to register current request domain
- include template and tests for the new Register Current feature

## Testing
- `pytest`
- `python manage.py test website`


------
https://chatgpt.com/codex/tasks/task_e_6894fc4e78c083268b4823705cff351b