### PR TITLE
Handle debugpy during git auto-reload restart

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
             "windows": {
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
-            "program": "${workspaceFolder}/manage.py",
+            "program": "${workspaceFolder}/vscode_manage.py",
             "args": ["runserver"],
             "django": true,
             "preLaunchTask": "Dev: maintenance"

--- a/tests/test_vscode_manage.py
+++ b/tests/test_vscode_manage.py
@@ -1,0 +1,33 @@
+import os
+import runpy
+import sys
+
+import pytest
+
+import utils.git_sync as git_sync
+import vscode_manage
+
+
+def test_wrapper_strips_debugpy(monkeypatch):
+    monkeypatch.setenv("DEBUGPY_LAUNCHER_PORT", "1234")
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(["/a", "/debugpy", "/b"]))
+
+    called = {}
+    monkeypatch.setattr(runpy, "run_path", lambda path, run_name: called.setdefault("path", path))
+
+    exec_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(os, "execv", lambda exe, argv: exec_calls.append((exe, argv)))
+
+    vscode_manage.main(["runserver"])
+
+    assert called["path"] == "manage.py"
+    assert "DEBUGPY_LAUNCHER_PORT" not in os.environ
+    assert "/debugpy" not in os.environ["PYTHONPATH"]
+
+    monkeypatch.setenv("DEBUGPY_LAUNCHER_PORT", "5678")
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(["/x", "/debugpy", "/y"]))
+    git_sync._restart_server()
+
+    assert "DEBUGPY_LAUNCHER_PORT" not in os.environ
+    assert "/debugpy" not in os.environ["PYTHONPATH"]
+    assert exec_calls

--- a/vscode_manage.py
+++ b/vscode_manage.py
@@ -1,0 +1,41 @@
+import os
+import runpy
+import sys
+
+from utils import git_sync as _git_sync
+
+
+def _strip_debugpy() -> None:
+    os.environ.pop("DEBUGPY_LAUNCHER_PORT", None)
+    if "PYTHONPATH" in os.environ:
+        os.environ["PYTHONPATH"] = os.pathsep.join(
+            p for p in os.environ["PYTHONPATH"].split(os.pathsep) if "debugpy" not in p
+        )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for VS Code debugger.
+
+    Removes debugpy hooks and proxies execution to ``manage.py`` while
+    patching ``utils.git_sync._restart_server`` so subsequent restarts run
+    without the debugger attached.
+    """
+
+    _strip_debugpy()
+
+    orig_restart = _git_sync._restart_server
+
+    def restart() -> None:
+        _strip_debugpy()
+        orig_restart()
+
+    _git_sync._restart_server = restart
+
+    if argv is None:
+        argv = sys.argv[1:]
+    sys.argv = ["manage.py", *argv]
+    runpy.run_path("manage.py", run_name="__main__")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    main()


### PR DESCRIPTION
## Summary
- add `vscode_manage.py` wrapper for VS Code that strips debugpy hooks and patches `git_sync` restarts
- restore default `_restart_server` logic and update VS Code debug configuration to use the wrapper
- cover wrapper behavior with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db5871d083268febcc32af99cd25