### PR TITLE
Align longitude field with latitude in charger admin

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -31,6 +31,17 @@ class ChargerAdminForm(forms.ModelForm):
 @admin.register(Charger)
 class ChargerAdmin(admin.ModelAdmin):
     form = ChargerAdminForm
+    fields = (
+        "charger_id",
+        "name",
+        "config",
+        "require_rfid",
+        ("latitude", "longitude"),
+        "reference",
+        "last_heartbeat",
+        "last_meter_values",
+        "last_path",
+    )
     list_display = (
         "charger_id",
         "name",

--- a/ocpp/static/ocpp/charger_map.js
+++ b/ocpp/static/ocpp/charger_map.js
@@ -7,7 +7,8 @@
     }
 
     var mapDiv = $('<div id="charger-map" style="height: 400px;" class="mb-3"></div>');
-    $lng.parent().append(mapDiv);
+    var $row = $lng.closest('.form-row');
+    $row.after(mapDiv);
 
     var startLat = parseFloat($lat.val()) || 25.6866;
     var startLng = parseFloat($lng.val()) || -100.3161;


### PR DESCRIPTION
## Summary
- Group longitude and latitude fields together in charger admin
- Ensure longitude uses same numeric input and insert map below the field row

## Testing
- `pytest`
- `python manage.py test ocpp` *(fails: UNIQUE constraint failed: accounts_user.username)*

------
https://chatgpt.com/codex/tasks/task_e_68953a5cafc4832687f6f03e97ef62c0