### PR TITLE
Refactor dev maintenance tasks

### DIFF
--- a/README.base.md
+++ b/README.base.md
@@ -67,9 +67,15 @@ files themselves are ignored so secrets remain local.
 ### Development Maintenance
 
 Running `dev-maintenance.bat` (or `./dev-maintenance.sh`) installs updated
-dependencies when `requirements.txt` changes, removes the SQLite database
-(default `db.sqlite3` or the path from `DB_PATH`), and reruns migrations.
-This resets the database automatically for a clean development setup.
+dependencies when `requirements.txt` changes and then runs maintenance
+tasks. Database operations are grouped under the `database` task, which
+recreates the SQLite database (default `db.sqlite3` or the path from
+`DB_PATH`) and reapplies migrations. The `git` task commits and pushes any
+generated migrations. Both scripts invoke these tasks by default:
+
+```bash
+./dev-maintenance.sh database git
+```
 
 ### Resetting OCPP Migrations
 

--- a/dev-maintenance.bat
+++ b/dev-maintenance.bat
@@ -19,7 +19,4 @@ if exist requirements.txt (
         echo %REQ_HASH%>requirements.md5
     )
 )
-set "DB_FILE=%VENV%\..\db.sqlite3"
-if defined DB_PATH set "DB_FILE=%DB_PATH%"
-if exist "%DB_FILE%" del "%DB_FILE%"
-%VENV%\Scripts\python.exe dev_maintenance.py
+%VENV%\Scripts\python.exe dev_maintenance.py database git

--- a/dev-maintenance.sh
+++ b/dev-maintenance.sh
@@ -24,4 +24,4 @@ if [ -f requirements.txt ]; then
   fi
 fi
 
-"$PYTHON" dev_maintenance.py
+"$PYTHON" dev_maintenance.py database git

--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -5,42 +5,24 @@ Ensures migrations are up to date and fixes inconsistent histories.
 """
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 from pathlib import Path
 
 import django
+from django.apps import apps
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import connections
 from django.db.migrations.exceptions import InconsistentMigrationHistory
 from django.db.utils import OperationalError
-from django.db import connections
-from django.apps import apps
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 django.setup()
 
-default_db = settings.DATABASES["default"]
-using_sqlite = default_db["ENGINE"] == "django.db.backends.sqlite3"
-
-try:
-    call_command("makemigrations", interactive=False)
-except CommandError:
-    call_command("makemigrations", merge=True, interactive=False)
-
-try:
-    call_command("migrate", interactive=False)
-except InconsistentMigrationHistory:
-    call_command("reset_ocpp_migrations")
-    call_command("migrate", interactive=False)
-except OperationalError:
-    if using_sqlite:
-        connections.close_all()
-        Path(default_db["NAME"]).unlink(missing_ok=True)
-        call_command("migrate", interactive=False)
-    else:
-        raise
 
 def _has_non_initial_migrations() -> bool:
     base_dir = Path(settings.BASE_DIR)
@@ -61,19 +43,67 @@ def _has_non_initial_migrations() -> bool:
     return False
 
 
-if _has_non_initial_migrations():
-    if using_sqlite:
-        connections.close_all()
-        Path(default_db["NAME"]).unlink(missing_ok=True)
-    else:
-        call_command("migrate", "zero", interactive=False)
-    call_command("migrate", interactive=False)
-    # Squash migrations back to a single initial state after a successful migrate
-    call_command("reset_migrations")
-    call_command("migrate", interactive=False, fake_initial=True)
+def run_database_tasks() -> None:
+    """Run all database related maintenance steps."""
+    default_db = settings.DATABASES["default"]
+    using_sqlite = default_db["ENGINE"] == "django.db.backends.sqlite3"
 
-proc = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
-if proc.stdout.strip():
-    subprocess.run(["git", "add", "-A"], check=False)
-    subprocess.run(["git", "commit", "-m", "Auto migrations"], check=False)
-    subprocess.run(["git", "push"], check=False)
+    try:
+        call_command("makemigrations", interactive=False)
+    except CommandError:
+        call_command("makemigrations", merge=True, interactive=False)
+
+    try:
+        call_command("migrate", interactive=False)
+    except InconsistentMigrationHistory:
+        call_command("reset_ocpp_migrations")
+        call_command("migrate", interactive=False)
+    except OperationalError:
+        if using_sqlite:
+            connections.close_all()
+            Path(default_db["NAME"]).unlink(missing_ok=True)
+            call_command("migrate", interactive=False)
+        else:  # pragma: no cover - unreachable in sqlite
+            raise
+
+    if _has_non_initial_migrations():
+        if using_sqlite:
+            connections.close_all()
+            Path(default_db["NAME"]).unlink(missing_ok=True)
+        else:
+            call_command("migrate", "zero", interactive=False)
+        call_command("migrate", interactive=False)
+        # Squash migrations back to a single initial state
+        call_command("reset_migrations")
+        call_command("migrate", interactive=False, fake_initial=True)
+
+
+def run_git_tasks() -> None:
+    """Commit and push auto-generated migrations."""
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, text=True
+    )
+    if proc.stdout.strip():
+        subprocess.run(["git", "add", "-A"], check=False)
+        subprocess.run(["git", "commit", "-m", "Auto migrations"], check=False)
+        subprocess.run(["git", "push"], check=False)
+
+
+TASKS = {"database": run_database_tasks, "git": run_git_tasks}
+
+
+def main(selected: list[str] | None = None) -> None:
+    """Run the selected maintenance tasks."""
+    to_run = selected or list(TASKS)
+    for name in to_run:
+        TASKS[name]()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Development maintenance tasks")
+    parser.add_argument(
+        "tasks", nargs="*", choices=TASKS.keys(), help="Tasks to run"
+    )
+    args = parser.parse_args()
+    main(args.tasks)
+


### PR DESCRIPTION
## Summary
- Refactor dev_maintenance into discrete tasks
- Group database maintenance steps under a single task
- Update maintenance scripts and docs to use new task structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896a1510d2c8326bbc47ccf632efc5b