### PR TITLE
Add OCPP simulator fixtures and load during maintenance

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -77,6 +77,8 @@ def run_database_tasks() -> None:
         call_command("reset_migrations")
         call_command("migrate", interactive=False, fake_initial=True)
 
+    call_command("loaddata", "ocpp_simulators")
+
 
 def run_git_tasks() -> None:
     """Commit and push auto-generated migrations."""

--- a/ocpp/fixtures/ocpp_simulators.json
+++ b/ocpp/fixtures/ocpp_simulators.json
@@ -1,0 +1,18 @@
+[
+  {
+    "model": "ocpp.simulator",
+    "pk": 1,
+    "fields": {
+      "name": "CP1",
+      "cp_path": "CP1"
+    }
+  },
+  {
+    "model": "ocpp.simulator",
+    "pk": 2,
+    "fields": {
+      "name": "CP2",
+      "cp_path": "CP2"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add initial OCPP simulator fixtures for CP1 and CP2
- load simulator fixtures during database maintenance

## Testing
- `pytest -q`
- `python dev_maintenance.py database` *(fails: Migration auth.0013_userproxy dependencies reference nonexistent parent node ('accounts', '0002_initial'))*


------
https://chatgpt.com/codex/tasks/task_e_6896a2d264c88326b8e900db68d8b49e