### PR TITLE
chore: decouple dev maintenance from launchers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,7 @@
             "program": "${workspaceFolder}/manage.py",
             "args": ["runserver"],
             "django": true,
-            "noDebug": true,
-            "preLaunchTask": "Dev: maintenance"
+            "noDebug": true
         },
         {
             "name": "Debug Server",
@@ -25,8 +24,7 @@
             },
             "program": "${workspaceFolder}/vscode_manage.py",
             "args": ["runserver"],
-            "django": true,
-            "preLaunchTask": "Dev: maintenance"
+            "django": true
         }
     ]
 }


### PR DESCRIPTION
## Summary
- stop running dev maintenance automatically when starting server from VS Code launchers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a6a6588083269e9da35dc9873c33