### PR TITLE
Move README TOC sidebar to left

### DIFF
--- a/website/templates/website/readme.html
+++ b/website/templates/website/readme.html
@@ -4,9 +4,6 @@
 
 {% block content %}
 <div class="row">
-  <div class="col-lg-9">
-    {{ content|safe }}
-  </div>
   {% if toc %}
   <div class="col-lg-3">
     <nav class="toc" style="position: sticky; top: 1rem;">
@@ -46,5 +43,8 @@
     </script>
   </div>
   {% endif %}
+  <div class="{% if toc %}col-lg-9{% else %}col-12{% endif %}">
+    {{ content|safe }}
+  </div>
 </div>
 {% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -103,6 +103,8 @@ class ReadmeSidebarTests(TestCase):
         resp = self.client.get(reverse("website:index"))
         self.assertIn("toc", resp.context)
         self.assertContains(resp, 'class="toc"')
+        html = resp.content.decode()
+        self.assertLess(html.index('nav class="toc"'), html.index('class="col-lg-9"'))
 
 
 class SiteAdminRegisterCurrentTests(TestCase):


### PR DESCRIPTION
## Summary
- show README table of contents on the left side of the page
- expand ReadmeSidebarTests to assert the sidebar precedes the main content

## Testing
- `python manage.py test website.tests.ReadmeSidebarTests`
- `python manage.py test` *(fails: UNIQUE constraint failed: accounts_user.username)*

------
https://chatgpt.com/codex/tasks/task_e_6896b4e2938483269556fba342f1ceeb