### PR TITLE
Fix website migration dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,4 +3,5 @@
 - The top-level `README.md` is auto-generated. **Never edit this file directly.**
 - For documentation updates, edit `README.base.md` or the `README.md` inside the relevant app's directory (e.g., `accounts/README.md`).
 - The combined `README.md` is regenerated only when creating a release using `python manage.py build_readme`. Do not rebuild it during normal development.
+- If migrations fail with `NodeNotFoundError` for `sites.0002_alter_domain_unique`, update any `website` app migration dependencies to use `('sites', '0001_initial')`.
 

--- a/website/migrations/0002_app.py
+++ b/website/migrations/0002_app.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("sites", "0002_alter_domain_unique"),
+        ("sites", "0001_initial"),
         ("website", "0001_initial"),
     ]
 


### PR DESCRIPTION
## Summary
- avoid missing migration node by depending on the initial Sites migration
- document how to handle missing `sites.0002_alter_domain_unique` errors in agent guidelines

## Testing
- `python manage.py migrate`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6897872b49448326be75937a8761fb9c