### PR TITLE
Handle inconsistent history during dev maintenance

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -52,6 +52,13 @@ def run_database_tasks() -> None:
         call_command("makemigrations", interactive=False)
     except CommandError:
         call_command("makemigrations", merge=True, interactive=False)
+    except InconsistentMigrationHistory:
+        if using_sqlite:
+            connections.close_all()
+            Path(default_db["NAME"]).unlink(missing_ok=True)
+            call_command("makemigrations", interactive=False)
+        else:  # pragma: no cover - unreachable in sqlite
+            raise
 
     try:
         call_command("migrate", interactive=False)


### PR DESCRIPTION
## Summary
- handle `InconsistentMigrationHistory` from `makemigrations` in `dev_maintenance.py`
- recreate SQLite database when migrations are out-of-order and retry

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cb05b72c832693cc4dfaa84b6dfa