### PR TITLE
Load localhost site fixture during dev maintenance

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -78,6 +78,7 @@ def run_database_tasks() -> None:
         call_command("migrate", interactive=False, fake_initial=True)
 
     call_command("loaddata", "ocpp_simulators")
+    call_command("loaddata", "localhost")
 
 
 def run_git_tasks() -> None:


### PR DESCRIPTION
## Summary
- Ensure dev maintenance loads the `localhost` fixture so a Site object exists for local development

## Testing
- `python manage.py test website -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6897cb4815b483268f2b05267edab9ea