### PR TITLE
Move page QR code into footer

### DIFF
--- a/references/templates/references/footer.html
+++ b/references/templates/references/footer.html
@@ -1,10 +1,18 @@
+{% load rfid_tags %}
 <footer class="container mt-5 mt-auto">
   <div class="row">
-    {% for ref in footer_refs %}
-      <div class="col">
-        <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
+    <div class="col-lg-3 text-center mb-3 mb-lg-0">
+      {% current_page_qr %}
+    </div>
+    <div class="col-lg-9">
+      <div class="row justify-content-center">
+        {% for ref in footer_refs %}
+          <div class="col-auto">
+            <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
+          </div>
+        {% endfor %}
       </div>
-    {% endfor %}
+    </div>
   </div>
   {% if revision %}
   <div class="row">

--- a/references/templatetags/ref_tags.py
+++ b/references/templatetags/ref_tags.py
@@ -22,8 +22,8 @@ def ref_img(value, size=200, alt=None):
     )
 
 
-@register.inclusion_tag("references/footer.html")
-def render_footer():
+@register.inclusion_tag("references/footer.html", takes_context=True)
+def render_footer(context):
     """Render footer links for references marked to appear there."""
     revision = ""
     path = Path("REVISION")
@@ -32,5 +32,6 @@ def render_footer():
     return {
         "footer_refs": Reference.objects.filter(include_in_footer=True),
         "revision": revision,
+        "request": context.get("request"),
     }
 

--- a/website/templates/website/readme.html
+++ b/website/templates/website/readme.html
@@ -1,6 +1,4 @@
 {% extends "website/base.html" %}
-{% load rfid_tags %}
-
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
@@ -42,9 +40,6 @@
         }
       })();
     </script>
-    <div class="mt-3 text-center">
-      {% current_page_qr %}
-    </div>
   </div>
   {% endif %}
   <div class="{% if toc %}col-lg-9{% else %}col-12{% endif %}">


### PR DESCRIPTION
## Summary
- relocate page QR code from sidebar to footer and center footer links
- pass request context through render_footer to support QR rendering
- adjust tests for new footer layout

## Testing
- `pytest`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6897cf2a75788326a71bc9eb1e111cef