### PR TITLE
Add footer reference fixture

### DIFF
--- a/references/fixtures/footer_references.json
+++ b/references/fixtures/footer_references.json
@@ -1,0 +1,32 @@
+[
+  {
+    "model": "references.reference",
+    "pk": 1,
+    "fields": {
+      "value": "https://arthexis.com",
+      "alt_text": "Arthexis",
+      "method": "link",
+      "include_in_footer": true
+    }
+  },
+  {
+    "model": "references.reference",
+    "pk": 2,
+    "fields": {
+      "value": "https://pypi.org/project/arthexis/",
+      "alt_text": "Arthexis on PyPI",
+      "method": "link",
+      "include_in_footer": true
+    }
+  },
+  {
+    "model": "references.reference",
+    "pk": 3,
+    "fields": {
+      "value": "https://www.gelectriic.com",
+      "alt_text": "Gelectriic",
+      "method": "link",
+      "include_in_footer": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add footer reference fixture linking to Arthexis, PyPI, and Gelectriic

## Testing
- `python manage.py test references`


------
https://chatgpt.com/codex/tasks/task_e_6897c467ed8c8326aeda4ab7270dc2c7