### PR TITLE
fix: relax Site migration dependency

### DIFF
--- a/app/migrations/0001_add_is_seed_data_to_site.py
+++ b/app/migrations/0001_add_is_seed_data_to_site.py
@@ -3,7 +3,8 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("sites", "0002_alter_domain_unique"),
+        # Depend on the initial sites migration so this runs on any Django version
+        ("sites", "0001_initial"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- depend on the initial django.contrib.sites migration so custom setups without the later migration still work

## Testing
- `python manage.py test` *(fails: OperationalError no such column django_site.is_seed_data; 89 tests, 53 errors, 1 failure)*

------
https://chatgpt.com/codex/tasks/task_e_6897efdba38883268e14bd6e278b4673