### PR TITLE
Add Celery task to send pending emails

### DIFF
--- a/emails/tasks.py
+++ b/emails/tasks.py
@@ -1,0 +1,8 @@
+from celery import shared_task
+from post_office.mail import send_queued_mail_until_done
+
+
+@shared_task
+def send_pending_emails() -> None:
+    """Send any queued emails using django-post_office."""
+    send_queued_mail_until_done()

--- a/emails/tests.py
+++ b/emails/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
+from unittest.mock import patch
 
 from .models import EmailPattern
+from .tasks import send_pending_emails
 
 
 class EmailPatternMatchTests(TestCase):
@@ -26,3 +28,10 @@ class EmailPatternMatchTests(TestCase):
         pattern = EmailPattern(name="greeting", subject="Hello [name]")
         message = {"subject": "No greeting"}
         self.assertEqual(pattern.matches(message), {})
+
+
+class SendPendingEmailsTaskTests(TestCase):
+    def test_task_calls_send_queued_mail_until_done(self):
+        with patch("emails.tasks.send_queued_mail_until_done") as mock_send:
+            send_pending_emails.run()
+            mock_send.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add a Celery shared task that sends queued emails using django-post-office
- test that the task triggers sending of queued messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f439a3a08326a61bf1fd89a2ab81