### PR TITLE
Add NGINX template fixture

### DIFF
--- a/nodes/fixtures/arthexis_nginx.json
+++ b/nodes/fixtures/arthexis_nginx.json
@@ -1,0 +1,16 @@
+[
+  {
+    "model": "nodes.nginxconfig",
+    "pk": 1,
+    "fields": {
+      "name": "arthexis",
+      "server_name": "arthexis.com *.arthexis.com",
+      "primary_upstream": "127.0.0.1:8888",
+      "backup_upstream": "",
+      "listen_port": 443,
+      "ssl_certificate": "/etc/letsencrypt/live/arthexis.com/fullchain.pem",
+      "ssl_certificate_key": "/etc/letsencrypt/live/arthexis.com/privkey.pem",
+      "config_text": "# Redirect all HTTP traffic to HTTPS\nserver {\nlisten 80;\nserver_name arthexis.com *.arthexis.com;\nreturn 301 https://$host$request_uri;\n}\n\n# HTTPS Server\nserver {\nlisten 443 ssl;\nserver_name arthexis.com *.arthexis.com;\n\nssl_certificate /etc/letsencrypt/live/arthexis.com/fullchain.pem;\nssl_certificate_key /etc/letsencrypt/live/arthexis.com/privkey.pem;\ninclude /etc/letsencrypt/options-ssl-nginx.conf;\nssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;\n\n    # WebSocket for OCPP CSMS\nlocation /ocpp/csms {\nproxy_pass http://127.0.0.1:9999;\nproxy_http_version 1.1;\nproxy_set_header Upgrade $http_upgrade;\nproxy_set_header Connection \"Upgrade\";\nproxy_set_header Host $host;\nproxy_set_header X-Real-IP $remote_addr;\nproxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\nproxy_set_header X-Forwarded-Proto $scheme;\n}\n\n    # Default proxy to web app\nlocation / {\nproxy_pass http://127.0.0.1:8888;\nproxy_set_header Host $host;\nproxy_set_header X-Real-IP $remote_addr;\nproxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\nproxy_set_header X-Forwarded-Proto $scheme;\n}\n}\n"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add NGINX configuration fixture for arthexis.com with HTTPS redirect and proxy settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f4b94e648326b0eb06fac7d4d9f8