### PR TITLE
Add Celery tasks for clipboard samples and node screenshots

### DIFF
--- a/clipboard/tasks.py
+++ b/clipboard/tasks.py
@@ -1,0 +1,37 @@
+import logging
+import socket
+from pathlib import Path
+
+import pyperclip
+from pyperclip import PyperclipException
+from celery import shared_task
+
+from .models import Sample
+from nodes.models import Node, NodeScreenshot
+from nodes.utils import capture_screenshot
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def sample_clipboard() -> None:
+    """Save current clipboard contents to a :class:`Sample` entry."""
+    try:
+        content = pyperclip.paste()
+    except PyperclipException as exc:  # pragma: no cover - depends on OS clipboard
+        logger.error("Clipboard error: %s", exc)
+        return
+    if not content:
+        logger.info("Clipboard is empty")
+        return
+    Sample.objects.create(content=content)
+
+
+@shared_task
+def capture_node_screenshot(url: str, port: int = 8000) -> str:
+    """Capture a screenshot of ``url`` and record it as a :class:`NodeScreenshot`."""
+    path: Path = capture_screenshot(url)
+    hostname = socket.gethostname()
+    node = Node.objects.filter(hostname=hostname, port=port).first()
+    screenshot = NodeScreenshot.objects.create(node=node, path=str(path))
+    return screenshot.path


### PR DESCRIPTION
## Summary
- add clipboard Celery task for saving current clipboard text
- add Celery task to capture a node screenshot and store it
- exercise new tasks in unit tests

## Testing
- `pytest`
- `python manage.py test` *(fails: NoReverseMatch: 'sites_site_changelist' not found)*
- `python manage.py test clipboard.tests.ClipboardTaskTests`


------
https://chatgpt.com/codex/tasks/task_e_6897fc5ef8c083269f21407af226534b