### PR TITLE
Avoid clobbering site relations during dev maintenance

### DIFF
--- a/website/migrations/0002_site_is_seed_data.py
+++ b/website/migrations/0002_site_is_seed_data.py
@@ -5,7 +5,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("website", "0001_initial"),
-        ("sites", "0002_alter_domain_unique"),
+        ("sites", "0001_initial"),
     ]
 
     operations = [

--- a/website/migrations/0003_siteproxy.py
+++ b/website/migrations/0003_siteproxy.py
@@ -7,7 +7,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("sites", "0002_alter_domain_unique"),
+        ("sites", "0001_initial"),
         ("website", "0002_site_is_seed_data"),
     ]
 

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -55,22 +55,20 @@ document.addEventListener('DOMContentLoaded', function () {
   <a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a>
     {% if badge_site %}
       <span class="badge" style="background-color: {{ badge_site_color }};">
-        <a href="{% url 'admin:sites_site_changelist' %}">SITE</a>:
-        <a href="{% url 'admin:sites_site_change' badge_site.id %}">{{ badge_site.name }}</a>
+        <a href="{% url 'admin:website_siteproxy_change' badge_site.id %}">SITE: {{ badge_site.name }}</a>
       </span>
     {% else %}
       <span class="badge badge-unknown">
-        <a href="{% url 'admin:sites_site_changelist' %}">SITE</a>: Unknown
+        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>: Unknown
       </span>
     {% endif %}
   {% if badge_node %}
     <span class="badge" style="background-color: {{ badge_node_color }};">
-      <a href="{% url 'admin:nodes_node_changelist' %}">NODE</a>:
-      <a href="{% url 'admin:nodes_node_change' badge_node.id %}">{{ badge_node.hostname }}</a>
+      <a href="{% url 'admin:nodes_node_change' badge_node.id %}">NODE: {{ badge_node.hostname }}</a>
     </span>
   {% else %}
     <span class="badge badge-unknown">
-      <a href="{% url 'admin:nodes_node_changelist' %}">NODE</a>: Unknown
+      <a href="{% url 'admin:nodes_node_changelist' %}">NODE: Unknown</a>
     </span>
   {% endif %}
 </h1>


### PR DESCRIPTION
## Summary
- Make website migrations depend only on the initial `sites` migration
- Limit `dev_maintenance` to local apps and stop resetting migrations
- Render SITE and NODE badges with contiguous text so tests pass

## Testing
- `python dev_maintenance.py database`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6897fcd922f483269d69c30ba93f2cd8