### PR TITLE
Handle existing is_seed_data column

### DIFF
--- a/website/migrations/0002_site_is_seed_data.py
+++ b/website/migrations/0002_site_is_seed_data.py
@@ -1,4 +1,36 @@
-from django.db import migrations
+from django.db import connection, migrations
+
+
+def add_is_seed_data(apps, schema_editor):
+    with connection.cursor() as cursor:
+        existing = {
+            col.name
+            for col in connection.introspection.get_table_description(
+                cursor, "django_site"
+            )
+        }
+    if "is_seed_data" not in existing:
+        schema_editor.execute(
+            "ALTER TABLE django_site ADD COLUMN is_seed_data BOOLEAN NOT NULL DEFAULT 0"
+        )
+
+
+def drop_is_seed_data(apps, schema_editor):
+    with connection.cursor() as cursor:
+        existing = {
+            col.name
+            for col in connection.introspection.get_table_description(
+                cursor, "django_site"
+            )
+        }
+    if "is_seed_data" in existing:
+        try:
+            schema_editor.execute(
+                "ALTER TABLE django_site DROP COLUMN is_seed_data"
+            )
+        except Exception:
+            # Some SQLite versions don't support dropping columns; ignore.
+            pass
 
 
 class Migration(migrations.Migration):
@@ -8,10 +40,5 @@ class Migration(migrations.Migration):
         ("sites", "0001_initial"),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            sql="ALTER TABLE django_site ADD COLUMN is_seed_data BOOLEAN NOT NULL DEFAULT 0",
-            reverse_sql="ALTER TABLE django_site DROP COLUMN is_seed_data",
-        )
-    ]
+    operations = [migrations.RunPython(add_is_seed_data, drop_is_seed_data)]
 


### PR DESCRIPTION
## Summary
- avoid duplicate-column errors by adding `django_site.is_seed_data` only when missing

## Testing
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898029552c48326a969bbca93560adf