### PR TITLE
Render Markdown tables on site index

### DIFF
--- a/readme/views.py
+++ b/readme/views.py
@@ -7,5 +7,5 @@ import markdown
 def readme(request):
     readme_path = Path(settings.BASE_DIR) / "README.md"
     text = readme_path.read_text(encoding="utf-8")
-    html = markdown.markdown(text)
+    html = markdown.markdown(text, extensions=["tables"])
     return HttpResponse(html)

--- a/website/tests.py
+++ b/website/tests.py
@@ -18,7 +18,7 @@ class LoginViewTests(TestCase):
 
     def test_login_link_in_navbar(self):
         resp = self.client.get(reverse("website:index"))
-        self.assertContains(resp, "href=\"/login/?next=/\"")
+        self.assertContains(resp, 'href="/login/?next=/"')
 
     def test_staff_login_redirects_admin(self):
         resp = self.client.post(
@@ -107,6 +107,11 @@ class ReadmeSidebarTests(TestCase):
         html = resp.content.decode()
         self.assertLess(html.index('nav class="toc"'), html.index('class="col-lg-9"'))
 
+    def test_included_apps_table_renders(self):
+        resp = self.client.get(reverse("website:index"))
+        self.assertContains(resp, "<table")
+        self.assertContains(resp, "<td>accounts</td>")
+
 
 class SiteAdminRegisterCurrentTests(TestCase):
     def setUp(self):
@@ -125,9 +130,7 @@ class SiteAdminRegisterCurrentTests(TestCase):
         self.assertContains(resp, "Register Current")
 
         resp = self.client.get(reverse("admin:website_siteproxy_register_current"))
-        self.assertRedirects(
-            resp, reverse("admin:website_siteproxy_changelist")
-        )
+        self.assertRedirects(resp, reverse("admin:website_siteproxy_changelist"))
         self.assertTrue(Site.objects.filter(domain="testserver").exists())
         site = Site.objects.get(domain="testserver")
         self.assertEqual(site.name, "testserver")
@@ -137,9 +140,7 @@ class SiteAdminRegisterCurrentTests(TestCase):
         resp = self.client.get(
             reverse("admin:website_siteproxy_register_current"), HTTP_HOST="127.0.0.1"
         )
-        self.assertRedirects(
-            resp, reverse("admin:website_siteproxy_changelist")
-        )
+        self.assertRedirects(resp, reverse("admin:website_siteproxy_changelist"))
         site = Site.objects.get(domain="127.0.0.1")
         self.assertEqual(site.name, "localhost")
 
@@ -173,5 +174,4 @@ class NavAppsTests(TestCase):
     def test_nav_pill_renders(self):
         resp = self.client.get(reverse("website:index"))
         self.assertContains(resp, "Readme")
-        self.assertContains(resp, 'badge rounded-pill')
-
+        self.assertContains(resp, "badge rounded-pill")

--- a/website/views.py
+++ b/website/views.py
@@ -23,13 +23,13 @@ def index(request):
     if not readme_file.exists():
         readme_file = Path(settings.BASE_DIR) / "README.md"
     text = readme_file.read_text(encoding="utf-8")
-    md = markdown.Markdown(extensions=["toc"])
+    md = markdown.Markdown(extensions=["toc", "tables"])
     html = md.convert(text)
     toc_html = md.toc
     if toc_html.strip().startswith('<div class="toc">'):
         toc_html = toc_html.strip()[len('<div class="toc">') :]
-        if toc_html.endswith('</div>'):
-            toc_html = toc_html[: -len('</div>')]
+        if toc_html.endswith("</div>"):
+            toc_html = toc_html[: -len("</div>")]
         toc_html = toc_html.strip()
     context = {"content": html, "title": readme_file.stem, "toc": toc_html}
     return render(request, "website/readme.html", context)


### PR DESCRIPTION
## Summary
- Render README using Markdown tables extension
- Ensure readme view handles tables
- Test included apps table renders correctly

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68989b3102848326a13d3f9c9b400afd