### PR TITLE
Persist simulator logs to disk

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -121,6 +121,7 @@ class SimulatorAdmin(admin.ModelAdmin):
         for obj in queryset:
             if obj.pk in store.simulators:
                 continue
+            store.register_log_name(obj.cp_path, obj.name)
             sim = ChargePointSimulator(obj.as_config())
             sim.start()
             store.simulators[obj.pk] = sim

--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -94,7 +94,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data=None, bytes_data=None):
         if text_data is None:
             return
-        store.logs.setdefault(self.charger_id, []).append(f"> {text_data}")
+        store.add_log(self.charger_id, f"> {text_data}")
         try:
             msg = json.loads(text_data)
         except json.JSONDecodeError:
@@ -167,4 +167,4 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                 reply_payload = {"idTagInfo": {"status": "Accepted"}}
             response = [3, msg_id, reply_payload]
             await self.send(json.dumps(response))
-            store.logs.setdefault(self.charger_id, []).append(f"< {json.dumps(response)}")
+            store.add_log(self.charger_id, f"< {json.dumps(response)}")

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -61,7 +61,7 @@ class Charger(models.Model):
 
         Transaction.objects.filter(charger_id=self.charger_id).delete()
         self.meter_readings.all().delete()
-        store.logs.pop(self.charger_id, None)
+        store.clear_log(self.charger_id)
         store.transactions.pop(self.charger_id, None)
         store.history.pop(self.charger_id, None)
 
@@ -72,7 +72,7 @@ class Charger(models.Model):
         if (
             Transaction.objects.filter(charger_id=self.charger_id).exists()
             or self.meter_readings.exists()
-            or store.logs.get(self.charger_id)
+            or store.get_logs(self.charger_id)
             or store.transactions.get(self.charger_id)
             or store.history.get(self.charger_id)
         ):

--- a/ocpp/store.py
+++ b/ocpp/store.py
@@ -1,7 +1,69 @@
-"""In-memory store for OCPP data."""
+"""In-memory store for OCPP data with file backed logs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
 
 connections = {}
 transactions = {}
 logs = {}
 history = {}
 simulators = {}
+
+# mapping of charger id / cp_path to simulator name used for log files
+log_names: dict[str, str] = {}
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def register_log_name(cid: str, name: str) -> None:
+    """Register a friendly name for the charger id used in log files."""
+
+    log_names[cid] = name
+
+
+def _safe_name(name: str) -> str:
+    return re.sub(r"[^\w.-]", "_", name)
+
+
+def _file_path(cid: str) -> Path:
+    name = log_names.get(cid, cid)
+    return LOG_DIR / f"{_safe_name(name)}.log"
+
+
+def add_log(cid: str, entry: str) -> None:
+    """Append a log entry for the given charger id."""
+
+    logs.setdefault(cid, []).append(entry)
+    path = _file_path(cid)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(entry + "\n")
+
+
+def get_logs(cid: str) -> list[str]:
+    """Return all log entries for the given charger id."""
+
+    if cid not in log_names:
+        try:
+            from .models import Simulator
+
+            sim = Simulator.objects.filter(cp_path=cid).first()
+            if sim:
+                log_names[cid] = sim.name
+        except Exception:  # pragma: no cover - best effort lookup
+            pass
+    path = _file_path(cid)
+    if path.exists():
+        return path.read_text(encoding="utf-8").splitlines()
+    return logs.get(cid, [])
+
+
+def clear_log(cid: str) -> None:
+    """Remove any stored logs for the charger id."""
+
+    logs.pop(cid, None)
+    path = _file_path(cid)
+    if path.exists():
+        path.unlink()

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -102,12 +102,12 @@ class ChargerLandingTests(TestCase):
         self.assertContains(resp, "Offline")
 
     def test_log_page_renders_without_charger(self):
-        store.logs["LOG1"] = ["hello"]
+        store.add_log("LOG1", "hello")
         client = Client()
         resp = client.get(reverse("charger-log", args=["LOG1"]))
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "hello")
-        store.logs.pop("LOG1", None)
+        store.clear_log("LOG1")
 
 
 class SimulatorLandingTests(TestCase):
@@ -157,7 +157,7 @@ class ChargerAdminTests(TestCase):
             timestamp=timezone.now(),
             value=1,
         )
-        store.logs["PURGE1"] = ["entry"]
+        store.add_log("PURGE1", "entry")
         url = reverse("admin:ocpp_charger_changelist")
         self.client.post(url, {"action": "purge_data", "_selected_action": [charger.pk]})
         self.assertFalse(Transaction.objects.filter(charger_id="PURGE1").exists())

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -93,7 +93,7 @@ def charger_detail(request, cid):
         if tx_obj.stop_time is not None:
             tx_data["stopTime"] = tx_obj.stop_time.isoformat()
 
-    log = store.logs.get(cid, [])
+    log = store.get_logs(cid)
     return JsonResponse(
         {
             "charger_id": cid,
@@ -221,7 +221,7 @@ def charger_log_page(request, cid):
         charger = Charger.objects.get(charger_id=cid)
     except Charger.DoesNotExist:
         charger = Charger(charger_id=cid)
-    log = store.logs.get(cid, [])
+    log = store.get_logs(cid)
     return render(
         request,
         "ocpp/charger_logs.html",
@@ -266,5 +266,5 @@ def dispatch_action(request, cid):
         asyncio.get_event_loop().create_task(ws.send(msg))
     else:
         return JsonResponse({"detail": "unknown action"}, status=400)
-    store.logs.setdefault(cid, []).append(f"< {msg}")
+    store.add_log(cid, f"< {msg}")
     return JsonResponse({"sent": msg})


### PR DESCRIPTION
## Summary
- write OCPP logs to per-simulator files for persistence
- wire admin simulator start to register log filenames
- read persisted log files in detail and admin views

## Testing
- `python manage.py test ocpp.tests.ChargerLandingTests.test_log_page_renders_without_charger -v2`
- `python manage.py test ocpp.tests.ChargerAdminTests.test_purge_action_removes_data ocpp.tests.SimulatorAdminTests.test_admin_lists_log_link -v2`


------
https://chatgpt.com/codex/tasks/task_e_6898d25725d88326b519630b7bcf655c