### PR TITLE
Fix daphne runserver nostatic conflict

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -16,8 +16,16 @@ def main() -> None:
             Command as DaphneRunserver,
         )
         from django.core.management.commands import runserver as core_runserver
+        try:
+            from django.contrib.staticfiles.management.commands import (
+                runserver as static_runserver,
+            )
+        except Exception:  # pragma: no cover - optional app
+            static_runserver = None
 
         core_runserver.Command = DaphneRunserver
+        if static_runserver is not None:
+            static_runserver.Command = DaphneRunserver
 
         def patched_on_bind(self, server_port):
             original_on_bind(self, server_port)


### PR DESCRIPTION
## Summary
- Patch Django's runserver commands to use Daphne's implementation and avoid duplicate `--nostatic` option.

## Testing
- `python manage.py runserver --help | head -n 20`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6898d702ced883268eeac14a84ca8706