### PR TITLE
Remove Readme application from localhost fixture

### DIFF
--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -6,15 +6,5 @@
       "domain": "127.0.0.1",
       "name": "localhost"
     }
-  },
-  {
-    "model": "website.application",
-    "pk": 1,
-    "fields": {
-      "site": 1,
-      "name": "Readme",
-      "path": "/",
-      "is_default": true
-    }
   }
 ]


### PR DESCRIPTION
## Summary
- Remove non-existent Readme app from localhost fixture to avoid system check errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d932530c832698728f70c1a91bd8