### PR TITLE
Refactor Application admin to use predefined local apps

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -35,6 +35,19 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
+LOCAL_APPS = [
+    "nodes",
+    "accounts",
+    "ocpp",
+    "references",
+    "awg",
+    "release",
+    "integrations",
+    "website",
+    "emails",
+    "app",
+]
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.admindocs",
@@ -46,19 +59,9 @@ INSTALLED_APPS = [
     "import_export",
     "django.contrib.sites",
     "channels",
-    "nodes",
-    "accounts",
-    "ocpp",
-    "references",
-    "awg",
-    "release",
-    "integrations",
     "post_office",
-    "website",
-    "emails",
-    "app",
     "django_celery_beat",
-]
+] + LOCAL_APPS
 
 SITE_ID = 1
 

--- a/website/migrations/0005_alter_application_path.py
+++ b/website/migrations/0005_alter_application_path.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("website", "0004_rename_app_to_application"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="application",
+            name="path",
+            field=models.CharField(
+                max_length=100,
+                help_text="Base path for the app, starting with /",
+                blank=True,
+            ),
+        ),
+    ]

--- a/website/models.py
+++ b/website/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 from django.contrib.sites.models import Site
+from django.apps import apps as django_apps
+from django.utils.text import slugify
 
 if not hasattr(Site, "is_seed_data"):
     Site.add_to_class("is_seed_data", models.BooleanField(default=False))
@@ -11,7 +13,9 @@ class Application(models.Model):
     )
     name = models.CharField(max_length=100)
     path = models.CharField(
-        max_length=100, help_text="Base path for the app, starting with /"
+        max_length=100,
+        help_text="Base path for the app, starting with /",
+        blank=True,
     )
     is_default = models.BooleanField(default=False)
 
@@ -20,6 +24,15 @@ class Application(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.name} ({self.path})"
+
+    @property
+    def installed(self) -> bool:
+        return django_apps.is_installed(self.name)
+
+    def save(self, *args, **kwargs):
+        if not self.path:
+            self.path = f"/{slugify(self.name)}/"
+        super().save(*args, **kwargs)
 
 
 class SiteBadge(models.Model):


### PR DESCRIPTION
## Summary
- group project apps under new `LOCAL_APPS` setting
- auto-slugify Application paths and expose install flag
- restrict Application admin to local app choices and show install status

## Testing
- `python manage.py makemigrations website --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898e6cfea3083268490817d16e33a75