### PR TITLE
Fix EmailPattern admin link

### DIFF
--- a/emails/admin.py
+++ b/emails/admin.py
@@ -6,11 +6,31 @@ from django.utils.html import format_html
 from .models import EmailPattern
 
 
-@admin.register(EmailPattern)
 class EmailPatternAdmin(admin.ModelAdmin):
     list_display = ("name", "subject", "test_button")
     actions = ["test_patterns"]
     change_form_template = "admin/emails/emailpattern/change_form.html"
+
+    permission_app_labels = ("post_office", "emails")
+
+    def _user_has_perm(self, request, perm):
+        model = self.model._meta.model_name
+        return any(
+            request.user.has_perm(f"{label}.{perm}_{model}")
+            for label in self.permission_app_labels
+        )
+
+    def has_view_permission(self, request, obj=None):
+        return self._user_has_perm(request, "view")
+
+    def has_change_permission(self, request, obj=None):
+        return self._user_has_perm(request, "change")
+
+    def has_delete_permission(self, request, obj=None):
+        return self._user_has_perm(request, "delete")
+
+    def has_add_permission(self, request):
+        return self._user_has_perm(request, "add")
 
     def get_urls(self):
         urls = super().get_urls()

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -21,3 +21,15 @@ class EmailsConfig(AppConfig):
         emails_config.models.pop(EmailPattern.__name__.lower(), None)
         EmailPattern._meta.app_label = "post_office"
         post_office_config.models[EmailPattern.__name__.lower()] = EmailPattern
+
+        from django.contrib import admin
+        from .admin import EmailPatternAdmin
+
+        admin.site.register(EmailPattern, EmailPatternAdmin)
+
+        from django.conf import settings
+        from django.urls import clear_url_caches
+        from importlib import import_module, reload
+
+        clear_url_caches()
+        reload(import_module(settings.ROOT_URLCONF))

--- a/tests/test_emailpattern_admin.py
+++ b/tests/test_emailpattern_admin.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class EmailPatternAdminUrlTests(TestCase):
+    def test_changelist_url_is_reversible(self):
+        self.assertEqual(
+            reverse("admin:post_office_emailpattern_changelist"),
+            "/admin/post_office/emailpattern/",
+        )


### PR DESCRIPTION
## Summary
- ensure EmailPattern admin perms fallback to both post_office and emails labels
- re-register EmailPattern in admin after moving app label
- test EmailPattern admin URL reverses correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e7eccff88326a61c8b819c86433d