### PR TITLE
Preserve requirement markers when updating requirements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,9 +13,9 @@
         {
             "label": "Update requirements",
             "type": "shell",
-            "command": "${workspaceFolder}/install.sh && ${workspaceFolder}/.venv/bin/python -m pip freeze > requirements.txt",
+            "command": "${workspaceFolder}/install.sh && ${workspaceFolder}/.venv/bin/python ${workspaceFolder}/freeze_requirements.py",
             "windows": {
-                "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe -m pip install -U -r requirements.txt; if ($?) { ${workspaceFolder}\\.venv\\Scripts\\python.exe -m pip freeze | Out-File -Encoding ascii requirements.txt }"
+                "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe -m pip install -U -r requirements.txt; if ($?) { ${workspaceFolder}\\.venv\\Scripts\\python.exe ${workspaceFolder}\\freeze_requirements.py }"
             },
             "problemMatcher": [],
             "detail": "Install updated dependencies and regenerate requirements.txt"

--- a/freeze_requirements.py
+++ b/freeze_requirements.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Freeze dependencies without dropping environment markers."""
+from __future__ import annotations
+
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def freeze(req_file: Path) -> None:
+    lines = req_file.read_text().splitlines()
+    frozen: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            frozen.append(line)
+            continue
+        if ";" in stripped:
+            req_part, marker = stripped.split(";", 1)
+            marker = ";" + marker  # preserve original marker spacing
+        else:
+            req_part, marker = stripped, ""
+        name = req_part.split("==")[0].strip()
+        try:
+            pkg_version = version(name)
+            req_part = f"{name}=={pkg_version}"
+        except PackageNotFoundError:
+            req_part = req_part.strip()
+        frozen.append(req_part + marker)
+    req_file.write_text("\n".join(frozen) + "\n")
+
+
+def main(argv: list[str] | None = None) -> None:
+    path = Path(argv[0]) if argv else Path("requirements.txt")
+    freeze(path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add freeze_requirements script to keep environment markers while freezing deps
- update VS Code task to use new script instead of plain `pip freeze`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f10d37d083268f17ab04b718088f