### PR TITLE
Add calculator template link to prefill AWG calculator

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -17,8 +17,23 @@ class ConduitFillAdmin(admin.ModelAdmin):
 
 @admin.register(CalculatorTemplate)
 class CalculatorTemplateAdmin(admin.ModelAdmin):
-    list_display = ("name", "meters", "amps", "volts", "material")
+    list_display = ("name", "meters", "amps", "volts", "material", "calculator_link")
     actions = ["run_calculator"]
+    readonly_fields = ("calculator_link",)
+    fields = (
+        "name",
+        "meters",
+        "amps",
+        "volts",
+        "material",
+        "max_awg",
+        "max_lines",
+        "phases",
+        "temperature",
+        "conduit",
+        "ground",
+        "calculator_link",
+    )
 
     def run_calculator(self, request, queryset):
         for template in queryset:
@@ -27,3 +42,12 @@ class CalculatorTemplateAdmin(admin.ModelAdmin):
             self.message_user(request, f"{template.name}: {awg}")
 
     run_calculator.short_description = "Run calculation"
+
+    def calculator_link(self, obj):
+        from django.utils.html import format_html
+
+        return format_html(
+            '<a href="{}" target="_blank">open</a>', obj.get_absolute_url()
+        )
+
+    calculator_link.short_description = "Calculator"

--- a/awg/models.py
+++ b/awg/models.py
@@ -77,3 +77,25 @@ class CalculatorTemplate(models.Model):
             conduit=self.conduit or None,
             ground=self.ground,
         )
+
+    def get_absolute_url(self):
+        from django.urls import reverse
+        from urllib.parse import urlencode
+
+        params: dict[str, object] = {
+            "meters": self.meters,
+            "amps": self.amps,
+            "volts": self.volts,
+            "material": self.material,
+            "max_lines": self.max_lines,
+            "phases": self.phases,
+            "ground": self.ground,
+        }
+        if self.max_awg:
+            params["max_awg"] = self.max_awg
+        if self.temperature is not None:
+            params["temperature"] = self.temperature
+        if self.conduit:
+            params["conduit"] = self.conduit
+
+        return f"{reverse('awg:calculator')}?{urlencode(params)}"

--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -9,29 +9,29 @@
     <div class="col-lg-3">
       <div class="mb-3">
         <label class="form-label" for="meters">Meters:</label>
-        <input id="meters" type="number" class="form-control" name="meters" required min="1" value="{{ request.POST.meters }}" />
+        <input id="meters" type="number" class="form-control" name="meters" required min="1" value="{{ form.meters }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="amps">Amps:</label>
-        <input id="amps" type="number" class="form-control" name="amps" value="{{ request.POST.amps|default:40 }}" />
+        <input id="amps" type="number" class="form-control" name="amps" value="{{ form.amps|default:40 }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="volts">Volts:</label>
-        <input id="volts" type="number" class="form-control" name="volts" value="{{ request.POST.volts|default:220 }}" />
+        <input id="volts" type="number" class="form-control" name="volts" value="{{ form.volts|default:220 }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="material">Material:</label>
         <select id="material" name="material" class="form-select">
-          <option value="cu" {% if request.POST.material == "cu" %}selected{% endif %}>Copper (cu)</option>
-          <option value="al" {% if request.POST.material == "al" %}selected{% endif %}>Aluminum (al)</option>
+          <option value="cu" {% if form.material == "cu" %}selected{% endif %}>Copper (cu)</option>
+          <option value="al" {% if form.material == "al" %}selected{% endif %}>Aluminum (al)</option>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label" for="phases">Phases:</label>
         <select id="phases" name="phases" class="form-select">
-          <option value="2" {% if request.POST.phases == "2" %}selected{% endif %}>AC Two Phases (2)</option>
-          <option value="1" {% if request.POST.phases == "1" %}selected{% endif %}>AC Single Phase (1)</option>
-          <option value="3" {% if request.POST.phases == "3" %}selected{% endif %}>AC Three Phases (3)</option>
+          <option value="2" {% if form.phases == "2" %}selected{% endif %}>AC Two Phases (2)</option>
+          <option value="1" {% if form.phases == "1" %}selected{% endif %}>AC Single Phase (1)</option>
+          <option value="3" {% if form.phases == "3" %}selected{% endif %}>AC Three Phases (3)</option>
         </select>
       </div>
     </div>
@@ -39,39 +39,39 @@
       <div class="mb-3">
         <label class="form-label" for="temperature">Temperature:</label>
         <select id="temperature" name="temperature" class="form-select">
-          <option value="60" {% if request.POST.temperature == "60" %}selected{% endif %}>60C (140F)</option>
-          <option value="75" {% if request.POST.temperature == "75" %}selected{% endif %}>75C (167F)</option>
-          <option value="90" {% if request.POST.temperature == "90" %}selected{% endif %}>90C (194F)</option>
+          <option value="60" {% if form.temperature == "60" %}selected{% endif %}>60C (140F)</option>
+          <option value="75" {% if form.temperature == "75" %}selected{% endif %}>75C (167F)</option>
+          <option value="90" {% if form.temperature == "90" %}selected{% endif %}>90C (194F)</option>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label" for="conduit">Conduit:</label>
         <select id="conduit" name="conduit" class="form-select">
-          <option value="emt" {% if request.POST.conduit == "emt" %}selected{% endif %}>EMT</option>
-          <option value="imc" {% if request.POST.conduit == "imc" %}selected{% endif %}>IMC</option>
-          <option value="rmc" {% if request.POST.conduit == "rmc" %}selected{% endif %}>RMC</option>
-          <option value="fmc" {% if request.POST.conduit == "fmc" %}selected{% endif %}>FMC</option>
-          <option value="none" {% if request.POST.conduit == "none" %}selected{% endif %}>None</option>
+          <option value="emt" {% if form.conduit == "emt" %}selected{% endif %}>EMT</option>
+          <option value="imc" {% if form.conduit == "imc" %}selected{% endif %}>IMC</option>
+          <option value="rmc" {% if form.conduit == "rmc" %}selected{% endif %}>RMC</option>
+          <option value="fmc" {% if form.conduit == "fmc" %}selected{% endif %}>FMC</option>
+          <option value="none" {% if form.conduit == "none" %}selected{% endif %}>None</option>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label" for="max_awg">Max AWG:</label>
-        <input id="max_awg" type="text" class="form-control" name="max_awg" value="{{ request.POST.max_awg }}" />
+        <input id="max_awg" type="text" class="form-control" name="max_awg" value="{{ form.max_awg }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="ground">Ground:</label>
         <select id="ground" name="ground" class="form-select">
-          <option value="1" {% if request.POST.ground == "1" or request.POST.ground == None %}selected{% endif %}>1</option>
-          <option value="0" {% if request.POST.ground == "0" %}selected{% endif %}>0</option>
+          <option value="1" {% if form.ground == "1" or form.ground == None %}selected{% endif %}>1</option>
+          <option value="0" {% if form.ground == "0" %}selected{% endif %}>0</option>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label" for="max_lines">Max Lines:</label>
         <select id="max_lines" name="max_lines" class="form-select">
-          <option value="1" {% if request.POST.max_lines == "1" or request.POST.max_lines == None %}selected{% endif %}>1</option>
-          <option value="2" {% if request.POST.max_lines == "2" %}selected{% endif %}>2</option>
-          <option value="3" {% if request.POST.max_lines == "3" %}selected{% endif %}>3</option>
-          <option value="4" {% if request.POST.max_lines == "4" %}selected{% endif %}>4</option>
+          <option value="1" {% if form.max_lines == "1" or form.max_lines == None %}selected{% endif %}>1</option>
+          <option value="2" {% if form.max_lines == "2" %}selected{% endif %}>2</option>
+          <option value="3" {% if form.max_lines == "3" %}selected{% endif %}>3</option>
+          <option value="4" {% if form.max_lines == "4" %}selected{% endif %}>4</option>
         </select>
       </div>
     </div>

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -98,3 +98,22 @@ class CalculatorTemplateTests(TestCase):
         )
         result = tmpl.run()
         self.assertEqual(result["awg"], "8")
+
+    def test_get_absolute_url_prefills_form(self):
+        tmpl = CalculatorTemplate.objects.create(
+            name="test",
+            meters=10,
+            amps=40,
+            volts=220,
+            material="cu",
+            max_lines=1,
+            phases=2,
+            temperature=60,
+            conduit="emt",
+            ground=1,
+        )
+        url = tmpl.get_absolute_url()
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context["form"]["meters"], "10")
+        self.assertIn("value=\"10\"", resp.content.decode())

--- a/awg/views.py
+++ b/awg/views.py
@@ -227,7 +227,8 @@ def find_awg(
 @landing("AWG Calculator")
 def calculator(request):
     """Display the AWG calculator form and results using a template."""
-    context: dict[str, object] = {}
+    form = request.POST or request.GET
+    context: dict[str, object] = {"form": form}
     if request.method == "POST" and request.POST.get("meters"):
         max_awg = request.POST.get("max_awg") or None
         conduit_field = request.POST.get("conduit")


### PR DESCRIPTION
## Summary
- link calculator templates to the public calculator with query parameters
- allow calculator view/template to pre-fill fields from GET parameters
- test calculator template link

## Testing
- `python manage.py test awg`

------
https://chatgpt.com/codex/tasks/task_e_6898fb651e488326be1c49a72cf7e258