### PR TITLE
Add EV brand fixtures for Porsche and Audi

### DIFF
--- a/accounts/fixtures/ev_brands.json
+++ b/accounts/fixtures/ev_brands.json
@@ -1,0 +1,18 @@
+[
+  {
+    "model": "accounts.brand",
+    "pk": 1,
+    "fields": {
+      "name": "Porsche",
+      "is_seed_data": true
+    }
+  },
+  {
+    "model": "accounts.brand",
+    "pk": 2,
+    "fields": {
+      "name": "Audi",
+      "is_seed_data": true
+    }
+  }
+]

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -20,6 +20,7 @@ from accounts.models import RFID, RFIDSource
 from ocpp.models import Transaction
 
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.db import IntegrityError
 from .backends import LocalhostAdminBackend
 
@@ -306,3 +307,10 @@ class OnboardingWizardTests(TestCase):
         account = Account.objects.get(user=user)
         self.assertTrue(account.rfids.filter(rfid="ABCD1234").exists())
         self.assertTrue(account.vehicles.filter(vin="VIN12345678901234").exists())
+
+
+class EVBrandFixtureTests(TestCase):
+    def test_ev_brand_fixture_loads(self):
+        call_command("loaddata", "accounts/fixtures/ev_brands.json", verbosity=0)
+        self.assertTrue(Brand.objects.filter(name="Porsche").exists())
+        self.assertTrue(Brand.objects.filter(name="Audi").exists())


### PR DESCRIPTION
## Summary
- seed Porsche and Audi as EV brands
- test that EV brand fixture loads correctly

## Testing
- `pytest`
- `python manage.py test accounts`


------
https://chatgpt.com/codex/tasks/task_e_6898fdfacdf88326bdc99c7c51880a87