### PR TITLE
Fix migration dependency for sites app

### DIFF
--- a/website/migrations/0006_alter_application_unique_together_and_more.py
+++ b/website/migrations/0006_alter_application_unique_together_and_more.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("sites", "0003_site_is_seed_data"),
+        ("sites", "0002_alter_domain_unique"),
         ("website", "0005_alter_application_path"),
     ]
 


### PR DESCRIPTION
## Summary
- fix website migration dependency to valid `sites` migration to avoid NodeNotFoundError

## Testing
- `python dev_maintenance.py database`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990725b2bc8326bdf800d0c2d3edea