### PR TITLE
Add configurable clipboard polling and text sample deduplication

### DIFF
--- a/nodes/management/commands/sample_clipboard.py
+++ b/nodes/management/commands/sample_clipboard.py
@@ -3,11 +3,11 @@ from django.core.management.base import BaseCommand
 import pyperclip
 from pyperclip import PyperclipException
 
-from nodes.models import Sample
+from nodes.models import TextSample
 
 
 class Command(BaseCommand):
-    help = "Save current clipboard contents to a Sample entry"
+    help = "Save current clipboard contents to a TextSample entry"
 
     def handle(self, *args, **options):
         try:
@@ -18,5 +18,8 @@ class Command(BaseCommand):
         if not content:
             self.stdout.write("Clipboard is empty")
             return
-        sample = Sample.objects.create(content=content)
+        if TextSample.objects.filter(content=content).exists():
+            self.stdout.write("Duplicate sample not created")
+            return
+        sample = TextSample.objects.create(content=content)
         self.stdout.write(self.style.SUCCESS(f"Saved sample at {sample.created_at}"))

--- a/nodes/migrations/0004_node_enable_clipboard_polling_and_textsample.py
+++ b/nodes/migrations/0004_node_enable_clipboard_polling_and_textsample.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+import uuid
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0003_node_enable_public_api_node_public_endpoint_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="node",
+            name="enable_clipboard_polling",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RenameModel(
+            old_name="Sample",
+            new_name="TextSample",
+        ),
+        migrations.AddField(
+            model_name="textsample",
+            name="name",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+        migrations.AddField(
+            model_name="textsample",
+            name="automated",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterModelOptions(
+            name="textsample",
+            options={
+                "ordering": ["-created_at"],
+                "verbose_name": "Text Sample",
+                "verbose_name_plural": "Text Samples",
+            },
+        ),
+    ]

--- a/nodes/templates/admin/nodes/textsample/change_list.html
+++ b/nodes/templates/admin/nodes/textsample/change_list.html
@@ -3,7 +3,7 @@
 
 {% block object-tools-items %}
     <li>
-        <a href="{% url 'admin:nodes_sample_from_clipboard' %}" class="addlink">
+        <a href="{% url 'admin:nodes_textsample_from_clipboard' %}" class="addlink">
             {% trans 'Add from clipboard' %}
         </a>
     </li>


### PR DESCRIPTION
## Summary
- allow enabling clipboard polling per node and manage a Celery periodic task
- rename Sample to TextSample with UUID names and automated flag
- avoid duplicate clipboard captures and expose manual capture via admin

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689903a5d58c83268813d551135eea99