### PR TITLE
Rename node pattern model and add clipboard testing action

### DIFF
--- a/nodes/migrations/0005_rename_pattern_textpattern.py
+++ b/nodes/migrations/0005_rename_pattern_textpattern.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nodes", "0004_node_enable_clipboard_polling_and_textsample"),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="Pattern",
+            new_name="TextPattern",
+        ),
+    ]


### PR DESCRIPTION
## Summary
- rename Pattern model to TextPattern and support substituting multiple sigils
- add admin action to test patterns against clipboard text
- cover TextPattern matching and clipboard testing with new tests

## Testing
- `python manage.py test nodes.tests --verbosity=2`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68995f44a04c8326ba8580cb3fcce657