### PR TITLE
Use fixture for default AWG calculator template

### DIFF
--- a/awg/fixtures/calculator_templates.json
+++ b/awg/fixtures/calculator_templates.json
@@ -1,0 +1,19 @@
+[
+  {
+    "model": "awg.calculatortemplate",
+    "pk": 1,
+    "fields": {
+      "name": "EV Charger",
+      "meters": 10,
+      "amps": 40,
+      "volts": 220,
+      "material": "cu",
+      "max_awg": "",
+      "max_lines": 1,
+      "phases": 2,
+      "temperature": 60,
+      "conduit": "emt",
+      "ground": 1
+    }
+  }
+]

--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -13,11 +13,11 @@
       </div>
       <div class="mb-3">
         <label class="form-label" for="amps">Amps:</label>
-        <input id="amps" type="number" class="form-control" name="amps" value="{{ form.amps|default:40 }}" />
+        <input id="amps" type="number" class="form-control" name="amps" value="{{ form.amps }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="volts">Volts:</label>
-        <input id="volts" type="number" class="form-control" name="volts" value="{{ form.volts|default:220 }}" />
+        <input id="volts" type="number" class="form-control" name="volts" value="{{ form.volts }}" />
       </div>
       <div class="mb-3">
         <label class="form-label" for="material">Material:</label>
@@ -61,14 +61,14 @@
       <div class="mb-3">
         <label class="form-label" for="ground">Ground:</label>
         <select id="ground" name="ground" class="form-select">
-          <option value="1" {% if form.ground == "1" or form.ground == None %}selected{% endif %}>1</option>
+          <option value="1" {% if form.ground == "1" %}selected{% endif %}>1</option>
           <option value="0" {% if form.ground == "0" %}selected{% endif %}>0</option>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label" for="max_lines">Max Lines:</label>
         <select id="max_lines" name="max_lines" class="form-select">
-          <option value="1" {% if form.max_lines == "1" or form.max_lines == None %}selected{% endif %}>1</option>
+          <option value="1" {% if form.max_lines == "1" %}selected{% endif %}>1</option>
           <option value="2" {% if form.max_lines == "2" %}selected{% endif %}>2</option>
           <option value="3" {% if form.max_lines == "3" %}selected{% endif %}>3</option>
           <option value="4" {% if form.max_lines == "4" %}selected{% endif %}>4</option>

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -5,6 +5,7 @@ from .models import CableSize, ConduitFill, CalculatorTemplate
 
 
 class AWGCalculatorTests(TestCase):
+    fixtures = ["calculator_templates.json"]
     def setUp(self):
         CableSize.objects.create(
             awg_size="8",
@@ -27,6 +28,9 @@ class AWGCalculatorTests(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "<form")
+        self.assertIn('value="10"', resp.content.decode())
+        self.assertIn('value="40"', resp.content.decode())
+        self.assertIn('value="220"', resp.content.decode())
 
         data = {
             "meters": "10",

--- a/awg/views.py
+++ b/awg/views.py
@@ -10,7 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from website.utils import landing
 
-from .models import CableSize, ConduitFill
+from .models import CableSize, ConduitFill, CalculatorTemplate
 
 
 class AWG(int):
@@ -228,23 +228,37 @@ def find_awg(
 def calculator(request):
     """Display the AWG calculator form and results using a template."""
     form = request.POST or request.GET
+    default = CalculatorTemplate.objects.filter(name="EV Charger").first()
+    if not form and default:
+        form = {
+            "meters": str(default.meters) if default.meters is not None else "",
+            "amps": str(default.amps),
+            "volts": str(default.volts),
+            "material": default.material,
+            "max_awg": default.max_awg or "",
+            "max_lines": str(default.max_lines),
+            "phases": str(default.phases),
+            "temperature": str(default.temperature) if default.temperature is not None else "",
+            "conduit": default.conduit or "",
+            "ground": str(default.ground),
+        }
     context: dict[str, object] = {"form": form}
     if request.method == "POST" and request.POST.get("meters"):
         max_awg = request.POST.get("max_awg") or None
-        conduit_field = request.POST.get("conduit")
+        conduit_field = request.POST.get("conduit") or (default.conduit if default else None)
         conduit_arg = None if conduit_field in (None, "", "none", "None") else conduit_field
         try:
             result = find_awg(
                 meters=request.POST.get("meters"),
-                amps=request.POST.get("amps", "40"),
-                volts=request.POST.get("volts", "220"),
-                material=request.POST.get("material", "cu"),
-                max_lines=request.POST.get("max_lines", "1"),
-                phases=request.POST.get("phases", "2"),
+                amps=request.POST.get("amps") or (str(default.amps) if default else None),
+                volts=request.POST.get("volts") or (str(default.volts) if default else None),
+                material=request.POST.get("material") or (default.material if default else None),
+                max_lines=request.POST.get("max_lines") or (str(default.max_lines) if default else None),
+                phases=request.POST.get("phases") or (str(default.phases) if default else None),
                 max_awg=max_awg,
-                temperature=request.POST.get("temperature"),
+                temperature=request.POST.get("temperature") or (str(default.temperature) if default and default.temperature is not None else None),
                 conduit=conduit_arg,
-                ground=request.POST.get("ground", "1"),
+                ground=request.POST.get("ground") or (str(default.ground) if default else None),
             )
         except Exception as exc:  # pragma: no cover - defensive
             context["error"] = str(exc)


### PR DESCRIPTION
## Summary
- prefill calculator using "EV Charger" template from fixture
- remove hardcoded form defaults
- cover defaults with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689961afb78c83269e390a99163c96e6