### PR TITLE
Handle None parameters in AWG calculator links

### DIFF
--- a/awg/models.py
+++ b/awg/models.py
@@ -82,15 +82,19 @@ class CalculatorTemplate(models.Model):
         from django.urls import reverse
         from urllib.parse import urlencode
 
-        params: dict[str, object] = {
-            "meters": self.meters,
-            "amps": self.amps,
-            "volts": self.volts,
-            "material": self.material,
-            "max_lines": self.max_lines,
-            "phases": self.phases,
-            "ground": self.ground,
-        }
+        params: dict[str, object] = {}
+        for field in (
+            "meters",
+            "amps",
+            "volts",
+            "material",
+            "max_lines",
+            "phases",
+            "ground",
+        ):
+            value = getattr(self, field)
+            if value not in (None, ""):
+                params[field] = value
         if self.max_awg:
             params["max_awg"] = self.max_awg
         if self.temperature is not None:
@@ -98,4 +102,5 @@ class CalculatorTemplate(models.Model):
         if self.conduit:
             params["conduit"] = self.conduit
 
-        return f"{reverse('awg:calculator')}?{urlencode(params)}"
+        base = reverse("awg:calculator")
+        return f"{base}?{urlencode(params)}" if params else base

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -68,6 +68,17 @@ class AWGCalculatorTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "No Suitable Cable Found")
 
+    def test_none_query_params_use_defaults(self):
+        url = (
+            reverse("awg:calculator")
+            + "?meters=None&amps=None&volts=None&material=&max_lines=None&phases=None&ground=None"
+        )
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('value="10"', resp.content.decode())
+        self.assertIn('value="40"', resp.content.decode())
+        self.assertIn('value="220"', resp.content.decode())
+
 
 class CalculatorTemplateTests(TestCase):
     def setUp(self):
@@ -121,6 +132,11 @@ class CalculatorTemplateTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context["form"]["meters"], "10")
         self.assertIn("value=\"10\"", resp.content.decode())
+
+    def test_get_absolute_url_omits_none_values(self):
+        tmpl = CalculatorTemplate.objects.create(name="blank")
+        url = tmpl.get_absolute_url()
+        self.assertEqual(url, reverse("awg:calculator"))
 
     def test_all_fields_optional(self):
         from django.forms import modelform_factory

--- a/awg/views.py
+++ b/awg/views.py
@@ -227,7 +227,8 @@ def find_awg(
 @landing("AWG Calculator")
 def calculator(request):
     """Display the AWG calculator form and results using a template."""
-    form = request.POST or request.GET
+    form_data = request.POST or request.GET
+    form = {k: v for k, v in form_data.items() if v not in (None, "", "None")}
     default = CalculatorTemplate.objects.filter(name="EV Charger").first()
     if not form and default:
         form = {


### PR DESCRIPTION
## Summary
- Skip `None` and empty fields when building calculator links from templates
- Sanitize AWG calculator query params so missing fields trigger defaults
- Test that blank template URLs and `None` params behave correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899653f05e88326a05650a9e27ac5a6