### PR TITLE
Use dropdowns in AWG template admin

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django import forms
 
 from .models import CableSize, ConduitFill, CalculatorTemplate
 
@@ -15,8 +16,56 @@ class ConduitFillAdmin(admin.ModelAdmin):
     search_fields = ("trade_size", "conduit")
 
 
+class CalculatorTemplateForm(forms.ModelForm):
+    """Admin form mirroring the calculator's select inputs."""
+
+    material = forms.ChoiceField(
+        choices=[("cu", "Copper (cu)"), ("al", "Aluminum (al)")],
+        required=False,
+    )
+    max_lines = forms.TypedChoiceField(
+        choices=[(1, "1"), (2, "2"), (3, "3"), (4, "4")],
+        coerce=int,
+        required=False,
+    )
+    phases = forms.TypedChoiceField(
+        choices=[
+            (2, "AC Two Phases (2)"),
+            (1, "AC Single Phase (1)"),
+            (3, "AC Three Phases (3)"),
+        ],
+        coerce=int,
+        required=False,
+    )
+    temperature = forms.TypedChoiceField(
+        choices=[(60, "60C (140F)"), (75, "75C (167F)"), (90, "90C (194F)")],
+        coerce=int,
+        required=False,
+    )
+    conduit = forms.ChoiceField(
+        choices=[
+            ("emt", "EMT"),
+            ("imc", "IMC"),
+            ("rmc", "RMC"),
+            ("fmc", "FMC"),
+            ("none", "None"),
+        ],
+        required=False,
+    )
+    ground = forms.TypedChoiceField(
+        choices=[(1, "1"), (0, "0")],
+        coerce=int,
+        required=False,
+    )
+
+    class Meta:
+        model = CalculatorTemplate
+        fields = "__all__"
+
+
 @admin.register(CalculatorTemplate)
 class CalculatorTemplateAdmin(admin.ModelAdmin):
+    form = CalculatorTemplateForm
     list_display = ("name", "meters", "amps", "volts", "material", "calculator_link")
     actions = ["run_calculator"]
     readonly_fields = ("calculator_link",)

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -146,3 +146,21 @@ class CalculatorTemplateTests(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         tmpl = form.save()
         self.assertIsNone(tmpl.meters)
+
+    def test_admin_form_uses_dropdowns(self):
+        from django import forms as dj_forms
+        from awg.admin import CalculatorTemplateForm
+
+        form = CalculatorTemplateForm()
+        self.assertIsInstance(form.fields["material"], dj_forms.ChoiceField)
+        self.assertIsInstance(form.fields["material"].widget, dj_forms.Select)
+        self.assertIn(("cu", "Copper (cu)"), form.fields["material"].choices)
+
+        self.assertEqual(
+            form.fields["max_lines"].choices,
+            [(1, "1"), (2, "2"), (3, "3"), (4, "4")],
+        )
+        self.assertIsInstance(form.fields["max_lines"].widget, dj_forms.Select)
+
+        self.assertIn((2, "AC Two Phases (2)"), form.fields["phases"].choices)
+        self.assertEqual(form.fields["ground"].choices, [(1, "1"), (0, "0")])


### PR DESCRIPTION
## Summary
- Add dedicated form for CalculatorTemplate admin mirroring calculator dropdowns
- Cover admin form with tests to ensure dropdown choices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899681a2e9083269972fd32e2cb6a05