### PR TITLE
Rename node polling flags

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -43,8 +43,8 @@ class NodeAdmin(admin.ModelAdmin):
         "badge_color",
         "enable_public_api",
         "public_endpoint",
-        "enable_clipboard_polling",
-        "enable_screenshot_polling",
+        "clipboard_polling",
+        "screenshot_polling",
         "last_seen",
     )
     search_fields = ("hostname", "address")

--- a/nodes/migrations/0007_rename_enable_polling_fields.py
+++ b/nodes/migrations/0007_rename_enable_polling_fields.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nodes", "0006_node_enable_screenshot_polling_nodescreenshot_hash_and_more"),
+        ("nodes", "0006_textsample_node_alter_textsample_automated"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="node",
+            old_name="enable_clipboard_polling",
+            new_name="clipboard_polling",
+        ),
+        migrations.RenameField(
+            model_name="node",
+            old_name="enable_screenshot_polling",
+            new_name="screenshot_polling",
+        ),
+    ]

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -114,25 +114,25 @@ class NodeTests(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 404)
 
-    def test_enable_clipboard_polling_creates_task(self):
+    def test_clipboard_polling_creates_task(self):
         node = Node.objects.create(hostname="clip", address="127.0.0.1", port=9000)
         task_name = f"poll_clipboard_node_{node.pk}"
         self.assertFalse(PeriodicTask.objects.filter(name=task_name).exists())
-        node.enable_clipboard_polling = True
+        node.clipboard_polling = True
         node.save()
         self.assertTrue(PeriodicTask.objects.filter(name=task_name).exists())
-        node.enable_clipboard_polling = False
+        node.clipboard_polling = False
         node.save()
         self.assertFalse(PeriodicTask.objects.filter(name=task_name).exists())
 
-    def test_enable_screenshot_polling_creates_task(self):
+    def test_screenshot_polling_creates_task(self):
         node = Node.objects.create(hostname="shot", address="127.0.0.1", port=9100)
         task_name = f"capture_screenshot_node_{node.pk}"
         self.assertFalse(PeriodicTask.objects.filter(name=task_name).exists())
-        node.enable_screenshot_polling = True
+        node.screenshot_polling = True
         node.save()
         self.assertTrue(PeriodicTask.objects.filter(name=task_name).exists())
-        node.enable_screenshot_polling = False
+        node.screenshot_polling = False
         node.save()
         self.assertFalse(PeriodicTask.objects.filter(name=task_name).exists())
 


### PR DESCRIPTION
## Summary
- rename enable_clipboard_polling and enable_screenshot_polling to clipboard_polling and screenshot_polling
- adjust admin and tests
- add migration to rename fields

## Testing
- `python manage.py test nodes`
- `python manage.py makemigrations nodes --check`


------
https://chatgpt.com/codex/tasks/task_e_6899e9690ce08326854bf4529b85e650