### PR TITLE
Make AWG calculator defaults opt-in

### DIFF
--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -22,6 +22,7 @@
       <div class="mb-3">
         <label class="form-label" for="material">Material:</label>
         <select id="material" name="material" class="form-select">
+          <option value="" {% if not form.material %}selected{% endif %}></option>
           <option value="cu" {% if form.material == "cu" %}selected{% endif %}>Copper (cu)</option>
           <option value="al" {% if form.material == "al" %}selected{% endif %}>Aluminum (al)</option>
         </select>
@@ -29,6 +30,7 @@
       <div class="mb-3">
         <label class="form-label" for="phases">Phases:</label>
         <select id="phases" name="phases" class="form-select">
+          <option value="" {% if not form.phases %}selected{% endif %}></option>
           <option value="2" {% if form.phases == "2" %}selected{% endif %}>AC Two Phases (2)</option>
           <option value="1" {% if form.phases == "1" %}selected{% endif %}>AC Single Phase (1)</option>
           <option value="3" {% if form.phases == "3" %}selected{% endif %}>AC Three Phases (3)</option>
@@ -39,6 +41,7 @@
       <div class="mb-3">
         <label class="form-label" for="temperature">Temperature:</label>
         <select id="temperature" name="temperature" class="form-select">
+          <option value="" {% if not form.temperature %}selected{% endif %}></option>
           <option value="60" {% if form.temperature == "60" %}selected{% endif %}>60C (140F)</option>
           <option value="75" {% if form.temperature == "75" %}selected{% endif %}>75C (167F)</option>
           <option value="90" {% if form.temperature == "90" %}selected{% endif %}>90C (194F)</option>
@@ -47,6 +50,7 @@
       <div class="mb-3">
         <label class="form-label" for="conduit">Conduit:</label>
         <select id="conduit" name="conduit" class="form-select">
+          <option value="" {% if not form.conduit %}selected{% endif %}></option>
           <option value="emt" {% if form.conduit == "emt" %}selected{% endif %}>EMT</option>
           <option value="imc" {% if form.conduit == "imc" %}selected{% endif %}>IMC</option>
           <option value="rmc" {% if form.conduit == "rmc" %}selected{% endif %}>RMC</option>
@@ -61,6 +65,7 @@
       <div class="mb-3">
         <label class="form-label" for="ground">Ground:</label>
         <select id="ground" name="ground" class="form-select">
+          <option value="" {% if not form.ground %}selected{% endif %}></option>
           <option value="1" {% if form.ground == "1" %}selected{% endif %}>1</option>
           <option value="0" {% if form.ground == "0" %}selected{% endif %}>0</option>
         </select>
@@ -68,6 +73,7 @@
       <div class="mb-3">
         <label class="form-label" for="max_lines">Max Lines:</label>
         <select id="max_lines" name="max_lines" class="form-select">
+          <option value="" {% if not form.max_lines %}selected{% endif %}></option>
           <option value="1" {% if form.max_lines == "1" %}selected{% endif %}>1</option>
           <option value="2" {% if form.max_lines == "2" %}selected{% endif %}>2</option>
           <option value="3" {% if form.max_lines == "3" %}selected{% endif %}>3</option>
@@ -104,7 +110,9 @@
       </div>
       {% endif %}
       <div class="mt-auto mb-3">
-        <button type="submit" class="btn btn-primary w-100">Calculate</button>
+        <button type="submit" class="btn btn-primary w-100">
+          {% if result or error or no_cable %}Calculate Again{% else %}Calculate{% endif %}
+        </button>
       </div>
     </div>
   </div>

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -28,9 +28,10 @@ class AWGCalculatorTests(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "<form")
-        self.assertIn('value="10"', resp.content.decode())
-        self.assertIn('value="40"', resp.content.decode())
-        self.assertIn('value="220"', resp.content.decode())
+        self.assertNotIn('value="10"', resp.content.decode())
+        self.assertNotIn('value="40"', resp.content.decode())
+        self.assertNotIn('value="220"', resp.content.decode())
+        self.assertIn("Calculate</button>", resp.content.decode())
 
         data = {
             "meters": "10",
@@ -50,6 +51,7 @@ class AWGCalculatorTests(TestCase):
         self.assertContains(resp, "8")
         self.assertContains(resp, "Voltage Drop")
         self.assertContains(resp, "EMT")
+        self.assertContains(resp, "Calculate Again")
 
     def test_no_cable_found(self):
         url = reverse("awg:calculator")
@@ -68,10 +70,10 @@ class AWGCalculatorTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "No Suitable Cable Found")
 
-    def test_none_query_params_use_defaults(self):
+    def test_query_params_prefill_form(self):
         url = (
             reverse("awg:calculator")
-            + "?meters=None&amps=None&volts=None&material=&max_lines=None&phases=None&ground=None"
+            + "?meters=10&amps=40&volts=220&material=cu&max_lines=1&phases=2&temperature=60&conduit=emt&ground=1"
         )
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)

--- a/awg/views.py
+++ b/awg/views.py
@@ -229,37 +229,23 @@ def calculator(request):
     """Display the AWG calculator form and results using a template."""
     form_data = request.POST or request.GET
     form = {k: v for k, v in form_data.items() if v not in (None, "", "None")}
-    default = CalculatorTemplate.objects.filter(name="EV Charger").first()
-    if not form and default:
-        form = {
-            "meters": str(default.meters) if default.meters is not None else "",
-            "amps": str(default.amps),
-            "volts": str(default.volts),
-            "material": default.material,
-            "max_awg": default.max_awg or "",
-            "max_lines": str(default.max_lines),
-            "phases": str(default.phases),
-            "temperature": str(default.temperature) if default.temperature is not None else "",
-            "conduit": default.conduit or "",
-            "ground": str(default.ground),
-        }
     context: dict[str, object] = {"form": form}
     if request.method == "POST" and request.POST.get("meters"):
         max_awg = request.POST.get("max_awg") or None
-        conduit_field = request.POST.get("conduit") or (default.conduit if default else None)
+        conduit_field = request.POST.get("conduit")
         conduit_arg = None if conduit_field in (None, "", "none", "None") else conduit_field
         try:
             result = find_awg(
                 meters=request.POST.get("meters"),
-                amps=request.POST.get("amps") or (str(default.amps) if default else None),
-                volts=request.POST.get("volts") or (str(default.volts) if default else None),
-                material=request.POST.get("material") or (default.material if default else None),
-                max_lines=request.POST.get("max_lines") or (str(default.max_lines) if default else None),
-                phases=request.POST.get("phases") or (str(default.phases) if default else None),
+                amps=request.POST.get("amps"),
+                volts=request.POST.get("volts"),
+                material=request.POST.get("material"),
+                max_lines=request.POST.get("max_lines"),
+                phases=request.POST.get("phases"),
                 max_awg=max_awg,
-                temperature=request.POST.get("temperature") or (str(default.temperature) if default and default.temperature is not None else None),
+                temperature=request.POST.get("temperature") or None,
                 conduit=conduit_arg,
-                ground=request.POST.get("ground") or (str(default.ground) if default else None),
+                ground=request.POST.get("ground"),
             )
         except Exception as exc:  # pragma: no cover - defensive
             context["error"] = str(exc)


### PR DESCRIPTION
## Summary
- Display blank AWG calculator fields by default and only prefill when values are supplied via query params
- Swap calculator button to "Calculate Again" after showing a result
- Add tests for query param defaults and button behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f20979d08326a797ad85fab686db