### PR TITLE
Add start script to launch Django server

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+# Activate virtual environment if present
+if [ -d .venv ]; then
+  source .venv/bin/activate
+fi
+
+# Default to port 8888 but allow override via first argument
+PORT=${1:-8888}
+
+# Start the Django development server
+python manage.py runserver 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- add start.sh helper to run the Django development server on Linux
- default server port to 8888 and allow override via CLI argument

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a2c89b25c83268da336bbf5738c64