### PR TITLE
Allow admin login from local networks

### DIFF
--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -32,12 +32,18 @@ class RFIDBackend:
 
 
 class LocalhostAdminBackend(ModelBackend):
-    """Deny default admin credentials unless the request is from localhost."""
+    """Allow default admin credentials only from local networks."""
 
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username == "admin" and password == "admin" and request is not None:
-            remote = request.META.get("REMOTE_ADDR")
-            if remote not in {"127.0.0.1", "::1"}:
+            remote = request.META.get("REMOTE_ADDR", "")
+            allowed = (
+                remote == "::1"
+                or remote.startswith("127.")
+                or remote.startswith("192.168.")
+                or remote.startswith("10.42.")
+            )
+            if not allowed:
                 return None
         return super().authenticate(request, username, password, **kwargs)
 

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -26,15 +26,17 @@ from .backends import LocalhostAdminBackend
 
 
 class DefaultAdminTests(TestCase):
-    def test_admin_created_and_localhost_only(self):
+    def test_admin_created_and_local_only(self):
         self.assertTrue(User.objects.filter(username="admin").exists())
         backend = LocalhostAdminBackend()
 
-        local = HttpRequest()
-        local.META["REMOTE_ADDR"] = "127.0.0.1"
-        self.assertIsNotNone(
-            backend.authenticate(local, username="admin", password="admin")
-        )
+        for ip in ["127.0.0.1", "192.168.1.5", "10.42.0.8"]:
+            req = HttpRequest()
+            req.META["REMOTE_ADDR"] = ip
+            self.assertIsNotNone(
+                backend.authenticate(req, username="admin", password="admin"),
+                f"{ip} should allow admin login",
+            )
 
         remote = HttpRequest()
         remote.META["REMOTE_ADDR"] = "10.0.0.1"


### PR DESCRIPTION
## Summary
- allow default admin credentials from 192.168.x.x and 10.42.x.x addresses
- test admin login acceptance for local network IPs

## Testing
- `python manage.py test accounts.tests.DefaultAdminTests.test_admin_created_and_local_only -v 2 --keepdb`


------
https://chatgpt.com/codex/tasks/task_e_689a3cddc0cc8326bec475e31e9b8aba