### PR TITLE
Display area and 60C amps in AWG cable admin

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -6,7 +6,13 @@ from .models import CableSize, ConduitFill, CalculatorTemplate
 
 @admin.register(CableSize)
 class CableSizeAdmin(admin.ModelAdmin):
-    list_display = ("awg_size", "material", "line_num")
+    list_display = (
+        "awg_size",
+        "material",
+        "area_kcmil",
+        "amps_60c",
+        "line_num",
+    )
     search_fields = ("awg_size", "material")
 
 

--- a/tests/test_awg_admin.py
+++ b/tests/test_awg_admin.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.contrib.admin.sites import AdminSite
+from django.test import SimpleTestCase
+
+from awg.admin import CableSizeAdmin
+from awg.models import CableSize
+
+
+class CableSizeAdminListDisplayTests(SimpleTestCase):
+    def test_list_display_shows_area_and_amps(self):
+        admin = CableSizeAdmin(CableSize, AdminSite())
+        assert "area_kcmil" in admin.list_display
+        assert "amps_60c" in admin.list_display


### PR DESCRIPTION
## Summary
- show Area kcmil and Amps 60C in the AWG Cable Size admin list
- test CableSize admin list for Area kcmil and Amps 60C columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3f721774832686163e0af82b1050