### PR TITLE
Center footer links and shrink QR code

### DIFF
--- a/references/templates/references/footer.html
+++ b/references/templates/references/footer.html
@@ -1,8 +1,8 @@
 {% load rfid_tags %}
 <footer class="container mt-5 mt-auto">
-  <div class="row">
+  <div class="row align-items-center">
     <div class="col-lg-3 text-center mb-3 mb-lg-0">
-      {% current_page_qr %}
+      {% current_page_qr 100 %}
     </div>
     <div class="col-lg-9">
       <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- Center footer links vertically alongside QR code
- Display a smaller QR code image in footer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3fd476708326ba9b9e81e2b1084e