### PR TITLE
Hide apps without URLs from navbar

### DIFF
--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -1,4 +1,5 @@
 from django.contrib.sites.shortcuts import get_current_site
+from django.urls import Resolver404, resolve
 
 
 def nav_links(request):
@@ -8,4 +9,13 @@ def nav_links(request):
         applications = site.site_applications.select_related("application").all()
     except Exception:
         applications = []
-    return {"nav_apps": applications}
+
+    valid_apps = []
+    for app in applications:
+        try:
+            resolve(app.path)
+        except Resolver404:
+            continue
+        valid_apps.append(app)
+
+    return {"nav_apps": valid_apps}

--- a/website/tests.py
+++ b/website/tests.py
@@ -182,6 +182,13 @@ class NavAppsTests(TestCase):
         self.assertContains(resp, "Readme")
         self.assertContains(resp, "badge rounded-pill")
 
+    def test_app_without_root_url_excluded(self):
+        site = Site.objects.get(id=1)
+        app = Application.objects.create(name="accounts")
+        SiteApplication.objects.create(site=site, application=app, path="/accounts/")
+        resp = self.client.get(reverse("website:index"))
+        self.assertNotContains(resp, 'href="/accounts/"')
+
 
 class ApplicationModelTests(TestCase):
     def test_path_defaults_to_slugified_name(self):


### PR DESCRIPTION
## Summary
- Skip apps whose paths don't resolve to existing views when building the navbar
- Add test ensuring unresolved apps are excluded from navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5cbb36188326a8f35e3eefe88b77