### PR TITLE
Fix RFID scan view import

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -270,11 +270,11 @@ class RFIDAdmin(ImportExportModelAdmin):
 
     def scan_next(self, request):
         try:
-            from gpiozero import MFRC522
+            import MFRC522
         except Exception as exc:  # pragma: no cover - hardware dependent
             return JsonResponse({"error": str(exc)}, status=500)
 
-        mfrc = MFRC522()
+        mfrc = MFRC522.MFRC522()
         while True:  # pragma: no cover - hardware loop
             (status, _TagType) = mfrc.MFRC522_Request(mfrc.PICC_REQIDL)
             if status == mfrc.MI_OK:


### PR DESCRIPTION
## Summary
- fix admin RFID scan view to import MFRC522 module directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5f0807cc832699ae9c837801c93d