### PR TITLE
Always reinstall requirements in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,14 +36,7 @@ source .venv/bin/activate
 pip install --upgrade pip
 
 REQ_FILE="requirements.txt"
-MD5_FILE="requirements.md5"
-NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
-if [ ! -f "$MD5_FILE" ] || [ "$NEW_HASH" != "$(cat "$MD5_FILE")" ]; then
-    pip install -r "$REQ_FILE"
-    echo "$NEW_HASH" > "$MD5_FILE"
-else
-    echo "Requirements unchanged. Skipping installation."
-fi
+pip install -r "$REQ_FILE"
 
 deactivate
 

--- a/requirements.md5
+++ b/requirements.md5
@@ -1,1 +1,0 @@
-5ec5cb47ca28bacf2a544f8ba4592988


### PR DESCRIPTION
## Summary
- remove outdated MD5 hash check and always install `requirements.txt`
- delete obsolete `requirements.md5` file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5e90536083269580cc291a3e703e