### PR TITLE
Add generic app index view for apps without base route

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,10 +1,14 @@
 from django.urls import path
+
+from website.views import app_index
+
 from . import views
 
 urlpatterns = [
-    path('rfid-login/', views.rfid_login, name='rfid-login'),
-    path('rfids/', views.rfid_batch, name='rfid-batch'),
-    path('products/', views.product_list, name='product-list'),
-    path('subscribe/', views.add_subscription, name='add-subscription'),
-    path('list/', views.subscription_list, name='subscription-list'),
+    path("", app_index, {"module": __name__}, name="index"),
+    path("rfid-login/", views.rfid_login, name="rfid-login"),
+    path("rfids/", views.rfid_batch, name="rfid-batch"),
+    path("products/", views.product_list, name="product-list"),
+    path("subscribe/", views.add_subscription, name="add-subscription"),
+    path("list/", views.subscription_list, name="subscription-list"),
 ]

--- a/awg/urls.py
+++ b/awg/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
+
+from website.views import app_index
+
 from . import views
 
 app_name = "awg"
 
 urlpatterns = [
+    path("", app_index, {"module": __name__}, name="index"),
     path("awg-calculator/", views.calculator, name="calculator"),
 ]

--- a/integrations/urls.py
+++ b/integrations/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path
 
+from website.views import app_index
+
 from . import views
 
 app_name = "integrations"
 
 urlpatterns = [
+    path("", app_index, {"module": __name__}, name="index"),
     path("register/", views.register, name="register"),
     path("post/", views.post, name="post"),
     path("domain-post/", views.domain_post, name="domain-post"),

--- a/nodes/urls.py
+++ b/nodes/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path
 
+from website.views import app_index
+
 from . import views
 
 urlpatterns = [
-    path('list/', views.node_list, name='node-list'),
-    path('register/', views.register_node, name='register-node'),
-    path('screenshot/', views.capture, name='node-screenshot'),
-    path('<slug:endpoint>/', views.public_node_endpoint, name='node-public-endpoint'),
+    path("", app_index, {"module": __name__}, name="index"),
+    path("list/", views.node_list, name="node-list"),
+    path("register/", views.register_node, name="register-node"),
+    path("screenshot/", views.capture, name="node-screenshot"),
+    path("<slug:endpoint>/", views.public_node_endpoint, name="node-public-endpoint"),
 ]

--- a/release/urls.py
+++ b/release/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
+
+from website.views import app_index
+
 from . import views
 
 urlpatterns = [
-    path('todos/', views.todo_list, name='todo-list'),
-    path('todos/<int:pk>/toggle/', views.todo_toggle, name='todo-toggle'),
+    path("", app_index, {"module": __name__}, name="index"),
+    path("todos/", views.todo_list, name="todo-list"),
+    path("todos/<int:pk>/toggle/", views.todo_toggle, name="todo-toggle"),
 ]

--- a/website/templates/website/app_index.html
+++ b/website/templates/website/app_index.html
@@ -1,0 +1,22 @@
+{% extends "website/base.html" %}
+{% block title %}{{ app_label }}{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">{{ app_label }}</h1>
+<div class="row">
+  {% for entry in entries %}
+  <div class="col-md-4 mb-3">
+    <a href="{{ entry.url }}" class="text-decoration-none">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">{{ entry.label }}</h5>
+        </div>
+      </div>
+    </a>
+  </div>
+  {% empty %}
+  <p>No views available.</p>
+  {% endfor %}
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add reusable `app_index` view and template to list an app's URL patterns
- expose base index routes for accounts, awg, integrations, nodes, and release apps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a6011bef8832693e4bea2f88d0e6f