### PR TITLE
Remove push step from maintenance script

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -87,14 +87,13 @@ def run_database_tasks() -> None:
 
 
 def run_git_tasks() -> None:
-    """Commit and push auto-generated migrations."""
+    """Commit auto-generated migrations without pushing."""
     proc = subprocess.run(
         ["git", "status", "--porcelain"], capture_output=True, text=True
     )
     if proc.stdout.strip():
         subprocess.run(["git", "add", "-A"], check=False)
         subprocess.run(["git", "commit", "-m", "Auto migrations"], check=False)
-        subprocess.run(["git", "push"], check=False)
 
 
 TASKS = {"database": run_database_tasks, "git": run_git_tasks}


### PR DESCRIPTION
## Summary
- avoid pushing when running git maintenance tasks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a62c023a083269f150751c3c54d97