### PR TITLE
Avoid hanging RFID scan and simplify success message

### DIFF
--- a/accounts/templates/admin/accounts/rfid/scan.html
+++ b/accounts/templates/admin/accounts/rfid/scan.html
@@ -10,18 +10,13 @@ async function waitScan(){
         const p = document.getElementById('status');
         if(data.error){
             p.textContent = data.error;
-            return;
-        }
-        if(data.created){
-            p.textContent = `Registered ${data.rfid}`;
-        } else {
-            p.textContent = `${data.rfid} already registered`;
+        } else if(data.rfid){
+            p.textContent = `Scanned ${data.rfid}`;
         }
     } catch(err){
         document.getElementById('status').textContent = err;
-        return;
     }
-    waitScan();
+    setTimeout(waitScan, 200);
 }
 waitScan();
 </script>


### PR DESCRIPTION
## Summary
- Avoid running the RFID hardware loop indefinitely by timing out and cleaning up
- Poll the scanner on the frontend and show a generic "Scanned" message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a846409b48326bdd266fe2f8e7ebb