### PR TITLE
Use admin-style sun/moon icons for theme toggle

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -63,7 +63,11 @@
                 <a class="nav-link" href="{% url 'website:login' %}?next={{ request.path }}">Login</a>
               </li>
             </ul>
-            <button id="theme-toggle" class="btn btn-sm btn-outline-light ms-lg-3" onclick="toggleTheme()">{% trans "Dark Mode" %}</button>
+            <button id="theme-toggle" class="btn btn-sm btn-outline-light ms-lg-3" onclick="toggleTheme()" aria-label="{% trans "Dark Mode" %}">
+              <svg aria-hidden="true" width="1.5rem" height="1.5rem">
+                <use href="#icon-moon"></use>
+              </svg>
+            </button>
           </div>
         </div>
       </nav>
@@ -75,7 +79,11 @@
       function setTheme(theme) {
         document.documentElement.setAttribute('data-bs-theme', theme);
         localStorage.setItem('theme', theme);
-        document.getElementById('theme-toggle').innerText = theme === 'dark' ? '{% trans "Light Mode" %}' : '{% trans "Dark Mode" %}';
+        const toggle = document.getElementById('theme-toggle');
+        const icon = toggle.querySelector('use');
+        toggle.setAttribute('aria-label', theme === 'dark' ? '{% trans "Light Mode" %}' : '{% trans "Dark Mode" %}');
+        icon.setAttribute('href', theme === 'dark' ? '#icon-sun' : '#icon-moon');
+        icon.setAttribute('xlink:href', theme === 'dark' ? '#icon-sun' : '#icon-moon');
       }
 
       function toggleTheme() {
@@ -92,5 +100,9 @@
         }
       })();
     </script>
+    <svg xmlns="http://www.w3.org/2000/svg" class="base-svgs">
+      <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-moon"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
+      <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-sun"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>
+    </svg>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- swap text-based theme toggle for Django admin sun/moon icons
- update JS logic to switch icon and accessibility label

## Testing
- `python manage.py test` *(fails: test_page_renders_and_calculates, test_template_links_displayed, test_get_absolute_url_omits_none_values, test_host_outside_subnets_disallowed)*

------
https://chatgpt.com/codex/tasks/task_e_689a87f3040c83269afe970e878a993f