### PR TITLE
Add admin search for RFIDs and enforce single account per tag

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -163,6 +163,20 @@ class RFIDValidationTests(TestCase):
         self.assertEqual(found, acc)
 
 
+class RFIDAssignmentTests(TestCase):
+    def setUp(self):
+        self.user1 = User.objects.create_user(username="user1", password="x")
+        self.user2 = User.objects.create_user(username="user2", password="x")
+        self.acc1 = Account.objects.create(user=self.user1)
+        self.acc2 = Account.objects.create(user=self.user2)
+        self.tag = RFID.objects.create(rfid="ABCDEF12")
+
+    def test_rfid_can_only_attach_to_one_account(self):
+        self.acc1.rfids.add(self.tag)
+        with self.assertRaises(ValidationError):
+            self.acc2.rfids.add(self.tag)
+
+
 class RFIDSourceTests(TestCase):
     def test_idempotent_setters(self):
         src = RFIDSource.objects.create(name="local", endpoint="rfids")


### PR DESCRIPTION
## Summary
- Allow choosing existing RFID tags via autocomplete when editing accounts
- Enable account selection in RFID admin and enforce one-account-per-tag
- Add tests to cover unique RFID assignments

## Testing
- `pytest`
- `python manage.py test accounts.tests.RFIDAssignmentTests.test_rfid_can_only_attach_to_one_account -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689a89791d74832698916bd4210ec82a