### PR TITLE
Fix RFID CSV import requiring id column

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -223,6 +223,7 @@ class RFIDResource(resources.ModelResource):
     class Meta:
         model = RFID
         fields = ("rfid", "allowed")
+        import_id_fields = ("rfid",)
 
 
 @admin.register(RFID)


### PR DESCRIPTION
## Summary
- allow RFID admin CSV import using `rfid` as identifier instead of `id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa14906e48326bde089eb089ea56c