### PR TITLE
Require authentication for API views

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,11 +5,14 @@ from django.contrib.auth import authenticate, login
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
+from utils.api import api_login_required
+
 from .models import Product, Subscription, Account
 from accounts.models import RFID
 
 
 @csrf_exempt
+@api_login_required
 def rfid_login(request):
     """Authenticate a user using an RFID."""
 
@@ -33,6 +36,7 @@ def rfid_login(request):
     return JsonResponse({"id": user.id, "username": user.username})
 
 
+@api_login_required
 def product_list(request):
     """Return a JSON list of products."""
 
@@ -43,6 +47,7 @@ def product_list(request):
 
 
 @csrf_exempt
+@api_login_required
 def add_subscription(request):
     """Create a subscription for an account from POSTed JSON."""
 
@@ -75,6 +80,7 @@ def add_subscription(request):
     return JsonResponse({"id": sub.id})
 
 
+@api_login_required
 def subscription_list(request):
     """Return subscriptions for the given account_id."""
 
@@ -95,6 +101,7 @@ def subscription_list(request):
 
 
 @csrf_exempt
+@api_login_required
 def rfid_batch(request):
     """Export or import RFID tags in batch."""
 

--- a/integrations/test_odoo.py
+++ b/integrations/test_odoo.py
@@ -21,6 +21,9 @@ from .models import Instance
 class OdooTests(TestCase):
     def setUp(self):
         self.client = Client()
+        User = get_user_model()
+        self.user = User.objects.create_user(username="tester", password="secret")
+        self.client.force_login(self.user)
         self.instance = Instance.objects.create(
             name="Local",
             url="http://odoo.local",

--- a/integrations/views.py
+++ b/integrations/views.py
@@ -1,13 +1,14 @@
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
+
+from utils.api import api_login_required
 
 from .services import post_from_domain, post_from_user, register_account
 
 
 @require_POST
-@login_required
+@api_login_required
 def register(request):
     handle = request.POST["handle"]
     password = request.POST["app_password"]
@@ -16,7 +17,7 @@ def register(request):
 
 
 @require_POST
-@login_required
+@api_login_required
 def post(request):
     text = request.POST["text"]
     post_from_user(request.user, text)
@@ -24,6 +25,7 @@ def post(request):
 
 
 @require_POST
+@api_login_required
 @staff_member_required
 def domain_post(request):
     text = request.POST["text"]
@@ -38,6 +40,7 @@ from config.offline import requires_network
 from .models import Instance
 
 
+@api_login_required
 @requires_network
 def test_connection(request, pk):
     instance = get_object_or_404(Instance, pk=pk)

--- a/nodes/views.py
+++ b/nodes/views.py
@@ -5,10 +5,13 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
 
+from utils.api import api_login_required
+
 from .models import Node, NodeScreenshot, NodeMessage
 from .utils import capture_screenshot, save_screenshot
 
 
+@api_login_required
 def node_list(request):
     """Return a JSON list of all known nodes."""
 
@@ -19,6 +22,7 @@ def node_list(request):
 
 
 @csrf_exempt
+@api_login_required
 def register_node(request):
     """Register or update a node from POSTed JSON data."""
 
@@ -46,6 +50,7 @@ def register_node(request):
     return JsonResponse({"id": node.id})
 
 
+@api_login_required
 def capture(request):
     """Capture a screenshot of the site's root URL and record it."""
 
@@ -65,6 +70,7 @@ def capture(request):
 
 
 @csrf_exempt
+@api_login_required
 def public_node_endpoint(request, endpoint):
     """Public API endpoint for a node.
 

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -6,6 +6,8 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404
 
+from utils.api import api_login_required
+
 from website.utils import landing
 
 from . import store
@@ -30,6 +32,7 @@ def _charger_state(charger: Charger, tx_obj: Transaction | None):
 
 
 
+@api_login_required
 def charger_list(request):
     """Return a JSON list of known chargers and state."""
     data = []
@@ -68,6 +71,7 @@ def charger_list(request):
     return JsonResponse({"chargers": data})
 
 
+@api_login_required
 def charger_detail(request, cid):
     charger = Charger.objects.filter(charger_id=cid).first()
     if charger is None:
@@ -241,6 +245,7 @@ def charger_status(request, cid):
 
 
 @csrf_exempt
+@api_login_required
 def dispatch_action(request, cid):
     ws = store.connections.get(cid)
     if ws is None:

--- a/release/views.py
+++ b/release/views.py
@@ -5,10 +5,13 @@ import json
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
+from utils.api import api_login_required
+
 from .models import Todo
 
 
 @csrf_exempt
+@api_login_required
 def todo_list(request):
     """List existing todos or create a new one."""
 
@@ -37,6 +40,7 @@ def todo_list(request):
 
 
 @csrf_exempt
+@api_login_required
 def todo_toggle(request, pk: int):
     """Toggle the completion status of a todo."""
 

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,18 @@
+from functools import wraps
+
+from django.http import JsonResponse
+
+
+def api_login_required(view_func):
+    """Require authentication for JSON API views.
+
+    Returns a 401 JSON response when the request user is not authenticated.
+    """
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse({"detail": "authentication required"}, status=401)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped


### PR DESCRIPTION
## Summary
- Add `api_login_required` decorator returning JSON 401 for unauthenticated requests
- Apply authentication to accounts, nodes, integrations, release, and OCPP API views
- Update Odoo integration tests to log in before calling authenticated endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa1a2e18c832699912604b7ee56cd