### PR TITLE
Add copy button for badge color fields in admin

### DIFF
--- a/app/static/app/copy_color.js
+++ b/app/static/app/copy_color.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.copy-color-button').forEach(function (btn) {
+    btn.addEventListener('click', function (e) {
+      e.preventDefault();
+      var target = document.getElementById(btn.dataset.target);
+      if (target) {
+        navigator.clipboard.writeText(target.value);
+      }
+    });
+  });
+});

--- a/app/templates/widgets/copy_color.html
+++ b/app/templates/widgets/copy_color.html
@@ -1,0 +1,7 @@
+<input
+  type="{{ widget.type }}"
+  name="{{ widget.name }}"
+  {% if widget.value != None %}value="{{ widget.value }}"{% endif %}
+  {% include "django/forms/widgets/attrs.html" %}
+/>
+<a href="#" class="button copy-color-button" data-target="{{ widget.attrs.id }}">Copy</a>

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -1,0 +1,9 @@
+from django import forms
+
+
+class CopyColorWidget(forms.TextInput):
+    input_type = "color"
+    template_name = "widgets/copy_color.html"
+
+    class Media:
+        js = ["app/copy_color.js"]

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -3,6 +3,7 @@ from django.urls import path
 from django.shortcuts import redirect
 from django.utils.html import format_html
 from django import forms
+from app.widgets import CopyColorWidget
 from django.db import models
 from django.conf import settings
 from pathlib import Path
@@ -30,9 +31,7 @@ class NodeAdminForm(forms.ModelForm):
     class Meta:
         model = Node
         fields = "__all__"
-        widgets = {
-            "badge_color": forms.TextInput(attrs={"type": "color"})
-        }
+        widgets = {"badge_color": CopyColorWidget()}
 
 
 @admin.register(Node)

--- a/website/admin.py
+++ b/website/admin.py
@@ -3,6 +3,7 @@ from django.contrib.sites.admin import SiteAdmin as DjangoSiteAdmin
 from django.contrib.sites.models import Site
 from django import forms
 from django.db import models
+from app.widgets import CopyColorWidget
 from django.shortcuts import redirect
 from django.urls import path
 import ipaddress
@@ -27,9 +28,7 @@ class SiteBadgeInline(admin.StackedInline):
     model = SiteBadge
     can_delete = False
     extra = 0
-    formfield_overrides = {
-        models.CharField: {"widget": forms.TextInput(attrs={"type": "color"})}
-    }
+    formfield_overrides = {models.CharField: {"widget": CopyColorWidget}}
 
 
 class SiteApplicationInline(admin.TabularInline):


### PR DESCRIPTION
## Summary
- add reusable CopyColorWidget with template and script to copy color values
- integrate color copy widget into Node and Site admin forms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa1ff494c83269153ea7d943d2bc7