### PR TITLE
Add command wrapper script for Django commands

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+# Activate virtual environment if present
+if [ -d .venv ]; then
+  source .venv/bin/activate
+fi
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <command> [args...]" >&2
+  exit 1
+fi
+
+COMMAND="${1//-/_}"
+shift
+
+python manage.py "$COMMAND" "$@"


### PR DESCRIPTION
## Summary
- add command.sh to wrap manage.py with automatic .venv activation
- convert hyphenated command names to underscores for Django compatibility

## Testing
- `./command.sh check`
- `./command.sh test awg.tests.AWGCalculatorTests.test_no_cable_found --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_689aa36d71ec832692874fbfc2be4163