### PR TITLE
Add logging and connection check to OCPP simulator

### DIFF
--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -159,12 +159,11 @@ def cp_simulator(request):
                 password=request.POST.get("password") or None,
             )
             try:
-                started = _start_simulator(sim_params, cp=cp_idx)
-                message = (
-                    f"CP{cp_idx} started."
-                    if started
-                    else f"CP{cp_idx} already running."
-                )
+                started, status, log_file = _start_simulator(sim_params, cp=cp_idx)
+                if started:
+                    message = f"CP{cp_idx} started: {status}. Logs: {log_file}"
+                else:
+                    message = f"CP{cp_idx} {status}. Logs: {log_file}"
             except Exception as exc:  # pragma: no cover - unexpected
                 message = f"Failed to start CP{cp_idx}: {exc}"
         elif action == "stop":


### PR DESCRIPTION
## Summary
- log every simulator message and response to file using `store.add_log`
- wait for initial connection result when starting a simulator and return status with log file path
- expose connection status and log location in simulator control view

## Testing
- `python manage.py test ocpp -v 2`

------
https://chatgpt.com/codex/tasks/task_e_689b6a916a08832695db475c837fe954