### PR TITLE
feat: tabbed charger admin with reference QR

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -31,16 +31,27 @@ class ChargerAdminForm(forms.ModelForm):
 @admin.register(Charger)
 class ChargerAdmin(admin.ModelAdmin):
     form = ChargerAdminForm
-    fields = (
-        "charger_id",
-        "name",
-        "config",
-        "require_rfid",
-        ("latitude", "longitude"),
-        "reference",
-        "last_heartbeat",
-        "last_meter_values",
-        "last_path",
+    fieldsets = (
+        (
+            "General",
+            {
+                "fields": (
+                    "charger_id",
+                    "name",
+                    "config",
+                    "require_rfid",
+                    "last_heartbeat",
+                    "last_meter_values",
+                    "last_path",
+                )
+            },
+        ),
+        (
+            "References",
+            {
+                "fields": (("latitude", "longitude"), "reference"),
+            },
+        ),
     )
     list_display = (
         "charger_id",

--- a/ocpp/static/ocpp/charger_map.js
+++ b/ocpp/static/ocpp/charger_map.js
@@ -6,9 +6,12 @@
       return;
     }
 
-    var mapDiv = $('<div id="charger-map" style="height: 400px;" class="mb-3"></div>');
-    var $row = $lng.closest('.form-row');
-    $row.after(mapDiv);
+    var $mapDiv = $('#charger-map');
+    if (!$mapDiv.length) {
+      $mapDiv = $('<div id="charger-map" style="height: 400px;" class="mb-3"></div>');
+      var $row = $lng.closest('.form-row');
+      $row.after($mapDiv);
+    }
 
     var startLat = parseFloat($lat.val()) || 25.6866;
     var startLng = parseFloat($lng.val()) || -100.3161;

--- a/ocpp/templates/admin/ocpp/charger/change_form.html
+++ b/ocpp/templates/admin/ocpp/charger/change_form.html
@@ -1,0 +1,74 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<style>
+  .nav-tabs { list-style: none; padding-left: 0; border-bottom: 1px solid #ccc; margin-bottom: 1rem; }
+  .nav-tabs li { display: inline-block; margin-right: .5rem; }
+  .nav-tabs a { text-decoration: none; padding: .5rem 1rem; display: inline-block; border: 1px solid #ccc; border-bottom: none; background: #f8f8f8; border-radius: 4px 4px 0 0; }
+  .nav-tabs a.active { background: #fff; font-weight: bold; }
+  .tab-content .tab-pane { display: none; }
+  .tab-content .tab-pane.active { display: block; }
+  .reference-wrapper { display: flex; gap: 1rem; align-items: flex-start; }
+  .reference-wrapper .qr { flex: 0 0 20%; }
+  .reference-wrapper .map { flex: 1; }
+</style>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const links = document.querySelectorAll('#charger-tabs a');
+    const panes = document.querySelectorAll('#charger-tabs-content .tab-pane');
+    links.forEach(function(link) {
+      link.addEventListener('click', function(e) {
+        e.preventDefault();
+        links.forEach(l => l.classList.remove('active'));
+        panes.forEach(p => p.classList.remove('active'));
+        link.classList.add('active');
+        document.querySelector(link.getAttribute('href')).classList.add('active');
+      });
+    });
+    if (links.length) {
+      links[0].classList.add('active');
+      panes[0].classList.add('active');
+    }
+  });
+</script>
+{% endblock %}
+
+{% block object-tools-items %}
+  {% if original.reference %}
+  <li><a href="{{ original.reference.value }}" target="_blank">Reference</a></li>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}
+
+{% block field_sets %}
+<div class="tabbed">
+  <ul class="nav-tabs" id="charger-tabs">
+    <li><a href="#tab-general" class="active">General</a></li>
+    <li><a href="#tab-references">References</a></li>
+  </ul>
+  <div class="tab-content" id="charger-tabs-content">
+    <div id="tab-general" class="tab-pane active">
+      {% with adminform.fieldsets.0 as fieldset %}
+        {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=0 %}
+      {% endwith %}
+    </div>
+    <div id="tab-references" class="tab-pane">
+      {% with adminform.fieldsets.1 as fieldset %}
+        {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=1 %}
+      {% endwith %}
+      <div class="reference-wrapper">
+        {% if original.reference and original.reference.image %}
+        <div class="qr">
+          <img src="{{ original.reference.image.url }}" alt="{{ original.reference.alt_text|default:'Reference QR' }}" style="width:100%; height:auto;" />
+        </div>
+        {% endif %}
+        <div class="map">
+          <div id="charger-map" style="height:400px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- split Charger admin form into General and References tabs
- show reference link and QR alongside map
- allow charger map script to reuse existing map container

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b88510e348326b53416975a1ea7dc