### PR TITLE
Add timestamps to OCPP logs

### DIFF
--- a/ocpp/store.py
+++ b/ocpp/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import datetime
 import re
 
 connections = {}
@@ -41,7 +42,10 @@ def _file_path(cid: str, log_type: str = "charger") -> Path:
 
 
 def add_log(cid: str, entry: str, log_type: str = "charger") -> None:
-    """Append a log entry for the given id and log type."""
+    """Append a timestamped log entry for the given id and log type."""
+
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    entry = f"{timestamp} {entry}"
 
     store = logs[log_type]
     # Store log entries under the cid as provided but allow retrieval using

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -20,6 +20,7 @@ import websockets
 import asyncio
 from pathlib import Path
 from .simulator import SimulatorConfig, ChargePointSimulator
+import re
 
 
 class SinkConsumerTests(TransactionTestCase):
@@ -105,6 +106,8 @@ class ChargerLandingTests(TestCase):
 
     def test_log_page_renders_without_charger(self):
         store.add_log("LOG1", "hello", log_type="charger")
+        entry = store.get_logs("LOG1", log_type="charger")[0]
+        self.assertRegex(entry, r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} hello$")
         client = Client()
         resp = client.get(reverse("charger-log", args=["LOG1"]) + "?type=charger")
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- timestamp each simulator and charger log entry
- verify timestamp formatting in charger log tests

## Testing
- `pytest`
- `python manage.py test ocpp -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689b96e93234832689bbe52964c0742f