### PR TITLE
Restore sidebar styling for admin dashboard history boxes

### DIFF
--- a/website/templates/admin/index.html
+++ b/website/templates/admin/index.html
@@ -5,17 +5,47 @@
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'admin/css/dashboard.css' %}">
   <style>
-    .app-grid {
+    .dashboard {
         display: flex;
         flex-wrap: wrap;
         gap: 1rem;
     }
-    .app-grid .module {
+    .dashboard-main {
         flex: 1 1 300px;
-        min-width: 250px;
+        min-width: 300px;
     }
-    .app-grid table {
-        width: 100%;
+    .dashboard-side {
+        flex: 1 1 300px;
+        min-width: 300px;
+        background: var(--darkened-bg);
+    }
+    .dashboard-side .module {
+        background: none;
+    }
+    .dashboard-side .module h2 {
+        background: none;
+        padding: 16px;
+        margin-bottom: 16px;
+        border-bottom: 1px solid var(--hairline-color);
+        font-size: 1.125rem;
+        color: var(--body-fg);
+    }
+    .dashboard-side h3 {
+        color: var(--body-quiet-color);
+        padding: 0 16px;
+        margin: 0 0 16px;
+    }
+    .dashboard-side p {
+        padding: 0 16px;
+    }
+    .dashboard-side .actionlist {
+        padding: 0;
+        margin: 16px;
+    }
+    .dashboard-side .actionlist li {
+        line-height: 1.2;
+        margin-bottom: 10px;
+        padding-left: 18px;
     }
   </style>
 {% endblock %}
@@ -28,49 +58,53 @@
 {% block nav-sidebar %}{% endblock %}
 
 {% block content %}
-<div id="content-main" class="app-grid">
-  {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
-  <div class="module" id="recent-actions-module">
-      <h2>{% translate 'Recent actions' %}</h2>
-      <h3>{% translate 'My actions' %}</h3>
-          {% load log %}
-          {% get_admin_log 10 as admin_log for_user user %}
-          {% if not admin_log %}
-          <p>{% translate 'None available' %}</p>
-          {% else %}
-          <ul class="actionlist">
-          {% for entry in admin_log %}
-          <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %} changelink{% endif %}{% if entry.is_deletion %} deletelink{% endif %}">
-              <span class="visually-hidden">{% if entry.is_addition %}{% translate 'Added:' %}{% elif entry.is_change %}{% translate 'Changed:' %}{% elif entry.is_deletion %}{% translate 'Deleted:' %}{% endif %}</span>
-              {% if entry.is_deletion or not entry.get_admin_url %}
-                  {{ entry.object_repr }}
-              {% else %}
-                  <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
-              {% endif %}
-              <br>
-              {% if entry.content_type %}
-                  <span class="mini quiet">{% filter capfirst %}{{ entry.content_type.name }}{% endfilter %}</span>
-              {% else %}
-                  <span class="mini quiet">{% translate 'Unknown content' %}</span>
-              {% endif %}
-          </li>
-          {% endfor %}
-          </ul>
-          {% endif %}
+<div class="dashboard">
+  <div id="content-main" class="dashboard-main">
+    {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
   </div>
-  <div class="module" id="recent-history-module">
-      <h2>{% translate 'Recent admin lists' %}</h2>
-      {% with history=user.admin_history.all|slice:":10" %}
-          {% if history %}
-          <ul class="actionlist">
-              {% for item in history %}
-              <li class="changelink"><a href="{{ item.url }}">{{ item.admin_label }}</a></li>
-              {% endfor %}
-          </ul>
-          {% else %}
-          <p>{% translate 'None available' %}</p>
-          {% endif %}
-      {% endwith %}
+  <div class="dashboard-side" id="recent-boxes">
+    <div class="module" id="recent-history-module">
+        <h2>{% translate 'Recent admin lists' %}</h2>
+        {% with history=user.admin_history.all|slice:":10" %}
+            {% if history %}
+            <ul class="actionlist">
+                {% for item in history %}
+                <li class="changelink"><a href="{{ item.url }}">{{ item.admin_label }}</a></li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p>{% translate 'None available' %}</p>
+            {% endif %}
+        {% endwith %}
+    </div>
+    <div class="module" id="recent-actions-module">
+        <h2>{% translate 'Recent actions' %}</h2>
+        <h3>{% translate 'My actions' %}</h3>
+            {% load log %}
+            {% get_admin_log 10 as admin_log for_user user %}
+            {% if not admin_log %}
+            <p>{% translate 'None available' %}</p>
+            {% else %}
+            <ul class="actionlist">
+            {% for entry in admin_log %}
+            <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %} changelink{% endif %}{% if entry.is_deletion %} deletelink{% endif %}">
+                <span class="visually-hidden">{% if entry.is_addition %}{% translate 'Added:' %}{% elif entry.is_change %}{% translate 'Changed:' %}{% elif entry.is_deletion %}{% translate 'Deleted:' %}{% endif %}</span>
+                {% if entry.is_deletion or not entry.get_admin_url %}
+                    {{ entry.object_repr }}
+                {% else %}
+                    <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                {% endif %}
+                <br>
+                {% if entry.content_type %}
+                    <span class="mini quiet">{% filter capfirst %}{{ entry.content_type.name }}{% endfilter %}</span>
+                {% else %}
+                    <span class="mini quiet">{% translate 'Unknown content' %}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Stack recent admin lists and recent actions in a single sidebar container with inverted background
- Rebalance dashboard flex layout so app list and sidebar each take half the width

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba49571388326be9a09ad11dd799b