### PR TITLE
Add date filters for meter readings admin

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -2,6 +2,9 @@ from django.contrib import admin
 from django import forms
 
 import asyncio
+from datetime import timedelta
+
+from django.utils import timezone
 
 from .models import Charger, Simulator, MeterReading
 from .simulator import ChargePointSimulator
@@ -174,16 +177,47 @@ class SimulatorAdmin(admin.ModelAdmin):
     log_link.short_description = "Log"
 
 
+class MeterReadingDateFilter(admin.SimpleListFilter):
+    title = "Timestamp"
+    parameter_name = "timestamp_range"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("today", "Today"),
+            ("7days", "Last 7 days"),
+            ("30days", "Last 30 days"),
+            ("older", "Older than 30 days"),
+        ]
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        now = timezone.now()
+        if value == "today":
+            start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            end = start + timedelta(days=1)
+            return queryset.filter(timestamp__gte=start, timestamp__lt=end)
+        if value == "7days":
+            start = now - timedelta(days=7)
+            return queryset.filter(timestamp__gte=start)
+        if value == "30days":
+            start = now - timedelta(days=30)
+            return queryset.filter(timestamp__gte=start)
+        if value == "older":
+            cutoff = now - timedelta(days=30)
+            return queryset.filter(timestamp__lt=cutoff)
+        return queryset
+
+
 @admin.register(MeterReading)
 class MeterReadingAdmin(admin.ModelAdmin):
     list_display = (
         "charger",
         "timestamp",
         "value",
-        "measurand",
         "unit",
         "connector_id",
         "transaction_id",
     )
-    list_filter = ("charger", "measurand")
+    date_hierarchy = "timestamp"
+    list_filter = ("charger", MeterReadingDateFilter)
 


### PR DESCRIPTION
## Summary
- Hide measurand field in meter reading admin list
- Add date hierarchy and custom filters for recent meter readings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bac1d3ca08326ac80b172db221b43