### PR TITLE
Allow admin login from docker networks

### DIFF
--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -39,6 +39,7 @@ class LocalhostAdminBackend(ModelBackend):
         ipaddress.ip_network("::1/128"),
         ipaddress.ip_network("127.0.0.0/8"),
         ipaddress.ip_network("192.168.0.0/16"),
+        ipaddress.ip_network("172.16.0.0/12"),
         ipaddress.ip_network("10.42.0.0/16"),
     ]
 

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -30,7 +30,7 @@ class DefaultAdminTests(TestCase):
         self.assertTrue(User.objects.filter(username="admin").exists())
         backend = LocalhostAdminBackend()
 
-        for ip in ["127.0.0.1", "192.168.1.5", "10.42.0.8"]:
+        for ip in ["127.0.0.1", "192.168.1.5", "10.42.0.8", "172.16.0.1"]:
             req = HttpRequest()
             req.META["REMOTE_ADDR"] = ip
             self.assertIsNotNone(

--- a/tests/test_localhost_admin_backend.py
+++ b/tests/test_localhost_admin_backend.py
@@ -1,0 +1,17 @@
+import ipaddress
+
+from django.http import HttpRequest
+from django.contrib.auth import get_user_model
+
+from accounts.backends import LocalhostAdminBackend
+
+
+def test_docker_network_allowed(tmp_path):
+    # Ensure the default admin exists
+    User = get_user_model()
+    assert User.objects.filter(username="admin").exists()
+    backend = LocalhostAdminBackend()
+    req = HttpRequest()
+    req.META["REMOTE_ADDR"] = "172.16.5.4"
+    user = backend.authenticate(req, username="admin", password="admin")
+    assert user is not None


### PR DESCRIPTION
## Summary
- allow the default admin account to authenticate from Docker private networks
- add regression test for LocalhostAdminBackend on 172.16.0.0/12 network

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbdaca3d0832690fd654001a683c1