### PR TITLE
Add GELECTRIIC RFID fixture

### DIFF
--- a/accounts/fixtures/accounts.json
+++ b/accounts/fixtures/accounts.json
@@ -5,6 +5,7 @@
     "fields": {
       "name": "GELECTRIIC",
       "user": ["admin"],
+      "rfids": ["FFFFFFFF"],
       "service_account": true
     }
   }

--- a/accounts/fixtures/rfids.json
+++ b/accounts/fixtures/rfids.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "accounts.rfid",
+    "pk": "FFFFFFFF",
+    "fields": {
+      "allowed": true,
+      "added_on": "2024-01-01T00:00:00Z"
+    }
+  }
+]

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -351,3 +351,18 @@ class EVBrandFixtureTests(TestCase):
         call_command("loaddata", "accounts/fixtures/ev_brands.json", verbosity=0)
         self.assertTrue(Brand.objects.filter(name="Porsche").exists())
         self.assertTrue(Brand.objects.filter(name="Audi").exists())
+
+
+class RFIDFixtureTests(TestCase):
+    def test_fixture_assigns_gelectriic_rfid(self):
+        call_command(
+            "loaddata",
+            "accounts/fixtures/accounts.json",
+            "accounts/fixtures/rfids.json",
+            verbosity=0,
+        )
+        account = Account.objects.get(name="GELECTRIIC")
+        tag = RFID.objects.get(rfid="FFFFFFFF")
+        self.assertIn(account, tag.accounts.all())
+        self.assertEqual(tag.accounts.count(), 1)
+


### PR DESCRIPTION
## Summary
- add RFID fixture for tag `FFFFFFFF`
- link GELECTRIIC account fixture to the new RFID tag
- test fixture assignment of tag to GELECTRIIC account

## Testing
- `pytest`
- `python manage.py test accounts.tests.RFIDFixtureTests`


------
https://chatgpt.com/codex/tasks/task_e_689bd1b6a8ac83268ee39cda928a3291