### PR TITLE
Include ongoing transaction energy in totals

### DIFF
--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -44,9 +44,19 @@ class Charger(models.Model):
     @property
     def total_kwh(self) -> float:
         """Return total energy delivered by this charger in kWh."""
+        from . import store
+
         total = 0.0
-        for tx in self.transactions.all():
+        tx_active = store.transactions.get(self.charger_id)
+        qs = self.transactions.all()
+        if tx_active and tx_active.pk is not None:
+            qs = qs.exclude(pk=tx_active.pk)
+        for tx in qs:
             kwh = tx.kwh
+            if kwh:
+                total += kwh
+        if tx_active:
+            kwh = tx_active.kwh
             if kwh:
                 total += kwh
         return total


### PR DESCRIPTION
## Summary
- include current transaction's meter readings when computing charger totals
- test that public status page reports total energy during active sessions

## Testing
- `pytest`
- `python manage.py test ocpp.tests`


------
https://chatgpt.com/codex/tasks/task_e_689bd2175e988326bea867cebd2cf449