### PR TITLE
Improve OCPP log view scrolling

### DIFF
--- a/ocpp/templates/ocpp/charger_logs.html
+++ b/ocpp/templates/ocpp/charger_logs.html
@@ -5,8 +5,9 @@
 {% block extra_head %}
 <style>
   #log {
-    max-height: 60vh;
+    max-height: calc(1em * 40);
     overflow-y: auto;
+    overflow-x: auto;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- limit charger log view to ~40 lines and allow horizontal scrolling

## Testing
- `python manage.py test` *(fails: failures=10)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2de76708326bc1d4adbafe906c2