### PR TITLE
fix: adjust admin dashboard width

### DIFF
--- a/website/templates/admin/index.html
+++ b/website/templates/admin/index.html
@@ -54,7 +54,8 @@
     }
     /* Override Django's dashboard defaults so the flex layout works */
     .dashboard #content {
-        width: 100%;
+        width: auto;
+        box-sizing: border-box;
     }
     #content-main,
     #recent-boxes {


### PR DESCRIPTION
## Summary
- prevent admin dashboard content from stretching past viewport

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd70c7df08326bbb438ec687241bc