### PR TITLE
Fix fixture loading order

### DIFF
--- a/dev_maintenance.py
+++ b/dev_maintenance.py
@@ -78,8 +78,9 @@ def run_database_tasks() -> None:
         else:  # pragma: no cover - unreachable in sqlite
             raise
 
-    for fixture in _fixture_files():
-        call_command("loaddata", fixture)
+    fixtures = _fixture_files()
+    if fixtures:
+        call_command("loaddata", *fixtures)
 
     # Ensure Application and SiteApplication entries exist for local apps
     call_command("register_site_apps")

--- a/ocpp/fixtures/purge_meter_readings_task.json
+++ b/ocpp/fixtures/purge_meter_readings_task.json
@@ -16,7 +16,8 @@
       "interval": 1,
       "args": "[]",
       "kwargs": "{}",
-      "enabled": true
+      "enabled": true,
+      "date_changed": "2024-01-01T00:00:00Z"
     }
   }
 ]


### PR DESCRIPTION
## Summary
- load all fixtures at once in `dev_maintenance.py`
- add required `date_changed` to periodic task fixture

## Testing
- `python dev_maintenance.py database`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bdafb92108326b0159cf286f5333c