### PR TITLE
Allow string RFID primary keys in admin write URLs

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -270,12 +270,12 @@ class RFIDAdmin(ImportExportModelAdmin):
                 name="accounts_rfid_scan_next",
             ),
             path(
-                "<int:pk>/write/",
+                "<slug:pk>/write/",
                 self.admin_site.admin_view(self.write_view),
                 name="accounts_rfid_write",
             ),
             path(
-                "<int:pk>/write/next/",
+                "<slug:pk>/write/next/",
                 self.admin_site.admin_view(self.write_next),
                 name="accounts_rfid_write_next",
             ),

--- a/tests/test_rfid_admin_urls.py
+++ b/tests/test_rfid_admin_urls.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+
+class RFIDAdminURLTests(SimpleTestCase):
+    def test_reverse_write_accepts_hex_pk(self):
+        url = reverse("admin:accounts_rfid_write", args=["ABCDEF12"])
+        self.assertEqual(url, "/admin/accounts/rfid/ABCDEF12/write/")


### PR DESCRIPTION
## Summary
- handle string primary keys in RFID admin write URLs
- add regression test covering hex RFID key reversal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c05ff6f348326b3029a25b6bd02a7