### PR TITLE
Add public RFID reader view with WebSocket stream

### DIFF
--- a/accounts/consumers.py
+++ b/accounts/consumers.py
@@ -1,0 +1,75 @@
+import asyncio
+import contextlib
+import json
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+
+def read_rfid() -> dict:
+    """Read a single RFID tag using the MFRC522 reader."""
+    try:
+        from mfrc522 import MFRC522  # type: ignore
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        return {"error": str(exc)}
+
+    import time
+    try:
+        import RPi.GPIO as GPIO  # pragma: no cover - hardware dependent
+    except Exception:  # pragma: no cover - hardware dependent
+        GPIO = None
+
+    mfrc = MFRC522()
+    timeout = time.time() + 1
+    try:
+        while time.time() < timeout:  # pragma: no cover - hardware loop
+            (status, _tag_type) = mfrc.MFRC522_Request(mfrc.PICC_REQIDL)
+            if status == mfrc.MI_OK:
+                (status, uid) = mfrc.MFRC522_Anticoll()
+                if status == mfrc.MI_OK:
+                    rfid = "".join(f"{x:02X}" for x in uid[:5])
+                    return {"rfid": rfid}
+            time.sleep(0.2)
+        return {"rfid": None}
+    finally:  # pragma: no cover - cleanup hardware
+        if GPIO:
+            try:
+                GPIO.cleanup()
+            except Exception:
+                pass
+
+
+class RFIDConsumer(AsyncWebsocketConsumer):
+    """Stream RFID scans over a websocket."""
+
+    async def connect(self):  # pragma: no cover - trivial
+        await self.accept()
+        self.scanning = False
+        self.scan_task = None
+
+    async def disconnect(self, code):  # pragma: no cover - trivial
+        self.scanning = False
+        if self.scan_task:
+            self.scan_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.scan_task
+
+    async def receive(self, text_data=None, bytes_data=None):
+        if not text_data:
+            return
+        try:
+            data = json.loads(text_data)
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("action") == "start" and not self.scanning:
+            self.scanning = True
+            self.scan_task = asyncio.create_task(self._scan_loop())
+
+    async def _scan_loop(self):
+        while self.scanning:
+            result = await asyncio.to_thread(read_rfid)
+            if result.get("rfid"):
+                await self.send(json.dumps({"rfid": result["rfid"]}))
+            elif result.get("error"):
+                await self.send(json.dumps({"error": result["error"]}))
+                self.scanning = False
+            await asyncio.sleep(0.1)

--- a/accounts/routing.py
+++ b/accounts/routing.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    path("ws/rfid/", consumers.RFIDConsumer.as_asgi()),
+]

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,4 +1,4 @@
-from django.test import Client, TestCase
+from django.test import Client, TestCase, TransactionTestCase
 from django.urls import reverse
 from django.http import HttpRequest
 import json
@@ -23,6 +23,8 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.db import IntegrityError
 from .backends import LocalhostAdminBackend
+from channels.testing import WebsocketCommunicator
+from config.asgi import application
 
 
 class DefaultAdminTests(TestCase):
@@ -380,4 +382,12 @@ class RFIDFixtureTests(TestCase):
         tag = RFID.objects.get(rfid="FFFFFFFF")
         self.assertIn(account, tag.accounts.all())
         self.assertEqual(tag.accounts.count(), 1)
+
+
+class RFIDConsumerTests(TransactionTestCase):
+    async def test_websocket_connects(self):
+        communicator = WebsocketCommunicator(application, "/ws/rfid/")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        await communicator.disconnect()
 

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -13,17 +13,21 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 import ocpp.routing
+import accounts.routing
 
 loadenv()
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 django_asgi_app = get_asgi_application()
 
+websocket_patterns = (
+    ocpp.routing.websocket_urlpatterns
+    + accounts.routing.websocket_urlpatterns
+)
+
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
-        "websocket": AuthMiddlewareStack(
-            URLRouter(ocpp.routing.websocket_urlpatterns)
-        ),
+        "websocket": AuthMiddlewareStack(URLRouter(websocket_patterns)),
     }
 )

--- a/website/templates/website/rfid.html
+++ b/website/templates/website/rfid.html
@@ -1,0 +1,31 @@
+{% extends "website/base.html" %}
+{% block content %}
+<h1>RFID Reader</h1>
+<button id="start-scan" class="btn btn-primary mb-3">Start Scan</button>
+<p>Scanned RFID: <span id="rfid-value"></span></p>
+<a href="#" id="clear-rfid" class="btn btn-link">Clear</a>
+<script>
+let socket;
+const valueEl = document.getElementById('rfid-value');
+const clearEl = document.getElementById('clear-rfid');
+
+document.getElementById('start-scan').addEventListener('click', () => {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    socket = new WebSocket(`${proto}://${window.location.host}/ws/rfid/`);
+    socket.onopen = () => socket.send(JSON.stringify({action: 'start'}));
+    socket.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        if (data.rfid) {
+            valueEl.textContent = data.rfid;
+        } else if (data.error) {
+            valueEl.textContent = data.error;
+        }
+    };
+});
+
+clearEl.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    valueEl.textContent = '';
+});
+</script>
+{% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -246,3 +246,15 @@ class AllowedHostSubnetTests(TestCase):
             reverse("website:index"), HTTP_HOST="11.0.0.1"
         )
         self.assertEqual(resp.status_code, 400)
+
+
+class RFIDPageTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        Site.objects.update_or_create(
+            id=1, defaults={"domain": "testserver", "name": "website"}
+        )
+
+    def test_page_renders(self):
+        resp = self.client.get(reverse("website:rfid-reader"))
+        self.assertContains(resp, "Start Scan")

--- a/website/urls.py
+++ b/website/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("sitemap.xml", views.sitemap, name="website-sitemap"),
     path("login/", views.login_view, name="login"),
+    path("rfid/", views.rfid_reader, name="rfid-reader"),
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -58,6 +58,12 @@ def sitemap(request):
     return HttpResponse("\n".join(lines), content_type="application/xml")
 
 
+@landing("RFID Reader")
+def rfid_reader(request):
+    """Public page to read RFID tags."""
+    return render(request, "website/rfid.html")
+
+
 class CustomLoginView(LoginView):
     """Login view that redirects staff to the admin."""
 


### PR DESCRIPTION
## Summary
- expose RFID scans over a new WebSocket consumer
- add public RFID reader page and URL
- wire new consumer into ASGI routing

## Testing
- `pytest`
- `python manage.py test accounts website`


------
https://chatgpt.com/codex/tasks/task_e_689ca443235083268643598f7554d4c2