### PR TITLE
Add feedback and timeout for RFID scan

### DIFF
--- a/rfid/templates/rfid/reader.html
+++ b/rfid/templates/rfid/reader.html
@@ -2,23 +2,35 @@
 {% block content %}
 <h1>RFID Reader</h1>
 <button id="start-scan" class="btn btn-primary mb-3">Start Scan</button>
+<p id="scan-status" class="text-muted"></p>
 <p>Scanned RFID: <span id="rfid-value"></span></p>
 <a href="#" id="clear-rfid" class="btn btn-link">Clear</a>
 <script>
 let socket;
 const valueEl = document.getElementById('rfid-value');
+const statusEl = document.getElementById('scan-status');
 const clearEl = document.getElementById('clear-rfid');
 
 document.getElementById('start-scan').addEventListener('click', () => {
+    statusEl.textContent = 'Starting…';
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
     socket = new WebSocket(`${proto}://${window.location.host}/ws/rfid/`);
+    const timeoutId = setTimeout(() => {
+        statusEl.textContent = 'Error: reader not responding';
+        socket.close();
+    }, 10000);
     socket.onopen = () => socket.send(JSON.stringify({action: 'start'}));
     socket.onmessage = (event) => {
         const data = JSON.parse(event.data);
-        if (data.rfid) {
+        if (data.status === 'started') {
+            statusEl.textContent = 'Reader started';
+            clearTimeout(timeoutId);
+        } else if (data.rfid) {
             valueEl.textContent = data.rfid;
         } else if (data.error) {
-            valueEl.textContent = data.error;
+            statusEl.textContent = data.error;
+            clearTimeout(timeoutId);
+            socket.close();
         }
     };
 });

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -1,3 +1,7 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
 from django.test import TransactionTestCase
 from channels.testing import WebsocketCommunicator
 from config.asgi import application
@@ -9,3 +13,36 @@ class RFIDConsumerTests(TransactionTestCase):
         connected, _ = await communicator.connect()
         self.assertTrue(connected)
         await communicator.disconnect()
+
+    async def test_start_returns_status(self):
+        with patch("rfid.consumers.read_rfid", return_value={"rfid": None}):
+            communicator = WebsocketCommunicator(application, "/ws/rfid/")
+            connected, _ = await communicator.connect()
+            self.assertTrue(connected)
+            await communicator.send_json_to({"action": "start"})
+            resp = await communicator.receive_json_from()
+            self.assertEqual(resp, {"status": "started"})
+            await communicator.disconnect()
+
+    async def test_start_handles_error(self):
+        with patch("rfid.consumers.read_rfid", return_value={"error": "boom"}):
+            communicator = WebsocketCommunicator(application, "/ws/rfid/")
+            connected, _ = await communicator.connect()
+            self.assertTrue(connected)
+            await communicator.send_json_to({"action": "start"})
+            resp = await communicator.receive_json_from()
+            self.assertEqual(resp, {"error": "boom"})
+            await communicator.disconnect()
+
+    async def test_start_timeout(self):
+        with patch(
+            "rfid.consumers.asyncio.wait_for",
+            new=AsyncMock(side_effect=asyncio.TimeoutError),
+        ):
+            communicator = WebsocketCommunicator(application, "/ws/rfid/")
+            connected, _ = await communicator.connect()
+            self.assertTrue(connected)
+            await communicator.send_json_to({"action": "start"})
+            resp = await communicator.receive_json_from()
+            self.assertEqual(resp, {"error": "RFID reader timeout"})
+            await communicator.disconnect()


### PR DESCRIPTION
## Summary
- add WebSocket startup response with 10s timeout in RFID consumer
- show reader status and timeout/error messages in RFID scan template
- extend RFID consumer tests for start ack, error and timeout cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc00b3b3c8326aaa7fc33b9fa133d