### PR TITLE
Enhance footer links and metadata

### DIFF
--- a/references/fixtures/footer_references.json
+++ b/references/fixtures/footer_references.json
@@ -24,7 +24,7 @@
     "pk": 3,
     "fields": {
       "value": "https://www.gelectriic.com",
-      "alt_text": "Gelectriic",
+      "alt_text": "Gelectriic Solutions",
       "method": "link",
       "include_in_footer": true
     }

--- a/references/templates/references/footer.html
+++ b/references/templates/references/footer.html
@@ -1,7 +1,7 @@
 {% load rfid_tags %}
 <footer class="container mt-4 pt-4">
   <div class="row align-items-center">
-    <div class="col-lg-3 text-center mb-3 mb-lg-0">
+    <div class="col-lg-3 text-center text-lg-start mb-3 mb-lg-0">
       {% current_page_qr 100 %}
     </div>
     <div class="col-lg-9">
@@ -14,9 +14,18 @@
       </div>
     </div>
   </div>
-  {% if revision %}
+  {% if request.user.is_staff and admin_links %}
+  <div class="row justify-content-center text-secondary small mt-2">
+    {% for name, url in admin_links %}
+    <div class="col-auto"><a class="link-secondary" href="{{ url }}">{{ name }}</a></div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% if version or revision %}
   <div class="row">
-    <div class="col text-end text-muted small">rev {{ revision }}</div>
+    <div class="col text-end text-muted small">
+      {% if version %}ver {{ version }}{% endif %}{% if revision %} rev {{ revision }}{% endif %}
+    </div>
   </div>
   {% endif %}
 </footer>


### PR DESCRIPTION
## Summary
- align QR code in footer to the left for balance
- show app VERSION alongside revision in footer
- add staff-only admin model links row in footer
- rename Gelectriic reference to Gelectriic Solutions

## Testing
- `python3 manage.py test references.tests`
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_689cc2035b2483268895cce89780e7ec