### PR TITLE
Replace login link with toolbar icons

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -62,15 +62,19 @@
                 </li>
                 {% endfor %}
               {% endif %}
-              <li class="nav-item">
-                <a class="nav-link" href="{% url 'website:login' %}?next={{ request.path }}">Login</a>
-              </li>
             </ul>
-            <button id="theme-toggle" class="btn btn-sm btn-outline-light ms-lg-3" onclick="toggleTheme()" aria-label="{% trans "Dark Mode" %}">
-              <svg aria-hidden="true" width="1.5rem" height="1.5rem">
-                <use href="#icon-moon"></use>
-              </svg>
-            </button>
+            <div class="toolbar ms-lg-3 d-flex align-items-center" role="toolbar">
+              <a class="btn btn-sm btn-outline-light me-2" href="{% url 'website:login' %}?next={{ request.path }}" aria-label="{% trans "Login" %}">
+                <svg aria-hidden="true" width="1.5rem" height="1.5rem">
+                  <use href="#icon-person"></use>
+                </svg>
+              </a>
+              <button id="theme-toggle" class="btn btn-sm btn-outline-light" onclick="toggleTheme()" aria-label="{% trans "Dark Mode" %}">
+                <svg aria-hidden="true" width="1.5rem" height="1.5rem">
+                  <use href="#icon-moon"></use>
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </nav>
@@ -106,6 +110,7 @@
     <svg xmlns="http://www.w3.org/2000/svg" class="base-svgs">
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-moon"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-sun"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>
+      <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-person"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></symbol>
     </svg>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Wrap login and theme toggle buttons in a new toolbar area
- Replace textual login link with user icon button
- Define SVG symbol for person icon alongside existing theme icons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ce00c3ed88326a70e2410a39f088a