### PR TITLE
Ignore requirements hash file generated by upgrade script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+ 
+# Hash file used by upgrade scripts to track dependency changes
+requirements.md5


### PR DESCRIPTION
## Summary
- ignore `requirements.md5` generated by upgrade script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d4b45c5848326b58817368c1ac35c