### PR TITLE
Add NMCLI scan action in admin

### DIFF
--- a/nodes/templates/admin/nodes/nmclitemplate/change_list.html
+++ b/nodes/templates/admin/nodes/nmclitemplate/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:nodes_nmclitemplate_scan' %}" class="addlink">
+            {% trans 'Import active connections' %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add link in NMCLI template admin to scan current node for active connections
- implement scan action to import and assign new NMCLI connections to current node

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d4e18dd148326acd026a94c4251f5