### PR TITLE
feat(admin): expose actions on dashboard

### DIFF
--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+import re
+
+
+class AdminIndexActionLinkTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="indexadmin", email="indexadmin@example.com", password="password"
+        )
+        self.client.force_login(self.user)
+
+    def test_custom_action_links_display(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, "Rebuild README")
+        action_url = reverse("admin:release_packageconfig_changelist") + "?action=build_readme"
+        self.assertContains(response, action_url)
+        content = response.content.decode()
+        row_match = re.search(
+            r'<tr class="model-packageconfig[^>]*>(.*?)</tr>', content, re.DOTALL
+        )
+        self.assertIsNotNone(row_match)
+        row_html = row_match.group(1)
+        # Custom action links should come before the Add and Change links
+        pattern = re.compile(
+            r'(?:<td>\s*<a[^>]*class="actionlink"[^<]*</a>\s*</td>\s*)+'
+            r'<td>\s*<a[^>]*class="addlink"[^<]*</a>\s*</td>\s*'
+            r'<td>\s*<a[^>]*class="changelink"',
+            re.DOTALL,
+        )
+        self.assertRegex(row_html, pattern)

--- a/website/templates/admin/app_list.html
+++ b/website/templates/admin/app_list.html
@@ -1,0 +1,68 @@
+{% load i18n admin_extras %}
+
+{% if app_list %}
+  {% for app in app_list %}
+    <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
+      <table>
+        <caption>
+          <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
+        </caption>
+        <thead class="visually-hidden">
+          <tr>
+            <th scope="col">{% translate 'Model name' %}</th>
+            <th scope="col">{% translate 'Model actions' %}</th>
+            <th scope="col">{% translate 'Add link' %}</th>
+            <th scope="col">{% translate 'Change or view list link' %}</th>
+          </tr>
+        </thead>
+        {% for model in app.models %}
+          {% with model_name=model.object_name|lower %}
+            <tr class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
+              <th scope="row" id="{{ app.app_label }}-{{ model_name }}">
+                {% if model.admin_url %}
+                  <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a>
+                {% else %}
+                  {{ model.name }}
+                {% endif %}
+              </th>
+
+              {% if model.admin_url and show_changelinks %}
+                {% model_admin_actions app.app_label model.object_name as extra_actions %}
+                {% for action in extra_actions %}
+                  <td>
+                    <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
+                  </td>
+                {% endfor %}
+                {% if not extra_actions %}
+                  <td></td>
+                {% endif %}
+              {% else %}
+                <td></td>
+              {% endif %}
+
+              {% if model.add_url %}
+                <td><a href="{{ model.add_url }}" class="addlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Add' %}</a></td>
+              {% else %}
+                <td></td>
+              {% endif %}
+
+              {% if model.admin_url and show_changelinks %}
+                <td>
+                  {% if model.view_only %}
+                    <a href="{{ model.admin_url }}" class="viewlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'View' %}</a>
+                  {% else %}
+                    <a href="{{ model.admin_url }}" class="changelink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Change' %}</a>
+                  {% endif %}
+                </td>
+              {% elif show_changelinks %}
+                <td></td>
+              {% endif %}
+            </tr>
+          {% endwith %}
+        {% endfor %}
+      </table>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>{% translate 'You don’t have permission to view or edit anything.' %}</p>
+{% endif %}


### PR DESCRIPTION
## Summary
- show custom model admin actions as links on the main dashboard
- provide template tag to generate action URLs
- test that release actions are linked from index
- ensure custom actions appear in their own column beside Change links
- render custom actions before Add link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4a696ae483268d622484df264072