### PR TITLE
Consolidate admin action links into single column

### DIFF
--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -35,7 +35,7 @@ class AdminIndexActionLinkTests(TestCase):
         row_html = row_match.group(1)
         # Custom action links should come before the Add and Change links
         pattern = re.compile(
-            r'(?:<td>\s*<a[^>]*class="actionlink"[^<]*</a>\s*</td>\s*)+'
+            r'<td class="actions">\s*(?:<a[^>]*class="actionlink"[^<]*</a>\s*)+</td>\s*'
             r'<td>\s*<a[^>]*class="addlink"[^<]*</a>\s*</td>\s*'
             r'<td>\s*<a[^>]*class="changelink"',
             re.DOTALL,

--- a/website/templates/admin/app_list.html
+++ b/website/templates/admin/app_list.html
@@ -28,16 +28,13 @@
 
               {% if model.admin_url and show_changelinks %}
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
-                {% for action in extra_actions %}
-                  <td>
+                <td class="actions">
+                  {% for action in extra_actions %}
                     <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
-                  </td>
-                {% endfor %}
-                {% if not extra_actions %}
-                  <td></td>
-                {% endif %}
+                  {% endfor %}
+                </td>
               {% else %}
-                <td></td>
+                <td class="actions"></td>
               {% endif %}
 
               {% if model.add_url %}

--- a/website/templates/admin/index.html
+++ b/website/templates/admin/index.html
@@ -94,6 +94,16 @@
     @keyframes blink {
         50% { opacity: 0; }
     }
+    .dashboard-main td.actions {
+        text-align: right;
+        white-space: nowrap;
+    }
+    .dashboard-main td.actions .actionlink {
+        margin-left: 16px;
+    }
+    .dashboard-main td.actions .actionlink:first-child {
+        margin-left: 0;
+    }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Consolidate multiple admin action links into a single right-aligned column
- Style action links with spacing to keep dashboard rows uniform
- Update tests for consolidated action column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de2bee7808326919b68289b563969