### PR TITLE
Add GWAY-BOX site fixture

### DIFF
--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -1,0 +1,30 @@
+[
+  {
+    "model": "sites.site",
+    "pk": 1,
+    "fields": {
+      "domain": "192.168.129.10",
+      "name": "GWAY-BOX"
+    }
+  },
+  {
+    "model": "website.application",
+    "pk": 1,
+    "fields": {"name": "ocpp"}
+  },
+  {
+    "model": "website.application",
+    "pk": 2,
+    "fields": {"name": "rfid"}
+  },
+  {
+    "model": "website.siteapplication",
+    "pk": 1,
+    "fields": {"site": 1, "application": 1, "path": "/ocpp/", "is_default": false}
+  },
+  {
+    "model": "website.siteapplication",
+    "pk": 2,
+    "fields": {"site": 1, "application": 2, "path": "/rfid/", "is_default": false}
+  }
+]


### PR DESCRIPTION
## Summary
- add site fixture for GWAY-BOX at 192.168.129.10
- include OCPP and RFID applications for the site

## Testing
- `python manage.py test` *(fails: ChargerSessionPaginationTests.test_session_search_by_date)*
- `python manage.py test website`


------
https://chatgpt.com/codex/tasks/task_e_689e84ebd0608326aeb28832eda00831