### PR TITLE
Add systemctl control command and service reload script

### DIFF
--- a/nodes/management/commands/systemctl_unit.py
+++ b/nodes/management/commands/systemctl_unit.py
@@ -1,0 +1,51 @@
+import subprocess
+from typing import Iterable
+
+from django.core.management.base import BaseCommand, CommandError
+
+from nodes.models import SystemdUnit
+
+
+class Command(BaseCommand):
+    """Send systemctl commands to installed systemd unit templates."""
+
+    help = "Run systemctl commands for SystemdUnit templates"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "action",
+            type=str,
+            help="systemctl action to execute (e.g. start, stop, restart)",
+        )
+        parser.add_argument(
+            "names",
+            nargs="*",
+            help="Names of SystemdUnits. If omitted, all installed units are used.",
+        )
+
+    def handle(self, *args, **options):
+        action: str = options["action"]
+        names: Iterable[str] = options["names"]
+
+        if names:
+            units = list(SystemdUnit.objects.filter(name__in=names))
+            missing = set(names) - {u.name for u in units}
+            if missing:
+                raise CommandError(f"Unknown SystemdUnit(s): {', '.join(sorted(missing))}")
+        else:
+            units = list(SystemdUnit.objects.all())
+
+        any_ran = False
+        for unit in units:
+            if not unit.is_installed():
+                self.stderr.write(
+                    self.style.WARNING(f"Unit {unit.name} is not installed; skipping")
+                )
+                continue
+            cmd = ["systemctl", action, f"{unit.name}.service"]
+            subprocess.run(cmd, check=True)
+            self.stdout.write(self.style.SUCCESS(f"Ran: {' '.join(cmd)}"))
+            any_ran = True
+
+        if not any_ran:
+            raise CommandError("No matching installed SystemdUnit found")

--- a/reload-services.sh
+++ b/reload-services.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+# Activate virtual environment if present
+if [ -d .venv ]; then
+  source .venv/bin/activate
+fi
+
+python manage.py systemctl_unit restart


### PR DESCRIPTION
## Summary
- add `systemctl_unit` management command to dispatch systemctl actions to installed SystemdUnit templates
- provide `reload-services.sh` helper to restart all installed services
- test command for individual and all installed units

## Testing
- `python manage.py test nodes.tests.SystemdUnitSystemctlCommandTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689f425e5d548326ad12b43720f95485