### PR TITLE
Add sigil-based environment interpolation for text fields

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -3,6 +3,8 @@ import imaplib
 import re
 from typing import Dict
 
+from utils.sigils import resolve_env_sigils
+
 from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -28,8 +30,14 @@ class EmailPattern(models.Model):
 
     @staticmethod
     def _regex_from_pattern(pattern: str) -> re.Pattern:
-        """Convert a pattern with [sigils] into a regex."""
+        """Convert a pattern with [sigils] into a regex.
 
+        ``[SIGILS]`` within ``pattern`` are first resolved using environment
+        variables via :func:`utils.sigils.resolve_env_sigils` before being
+        converted into capturing groups.
+        """
+
+        pattern = resolve_env_sigils(pattern)
         escaped = re.escape(pattern)
         regex = re.sub(r"\\\[([^\\\]]+)\\\]", r"(?P<\1>.+)", escaped)
         return re.compile(regex, re.IGNORECASE)

--- a/emails/tests.py
+++ b/emails/tests.py
@@ -1,3 +1,5 @@
+import os
+
 from django.test import TestCase
 from unittest.mock import patch
 
@@ -28,6 +30,15 @@ class EmailPatternMatchTests(TestCase):
         pattern = EmailPattern(name="greeting", subject="Hello [name]")
         message = {"subject": "No greeting"}
         self.assertEqual(pattern.matches(message), {})
+
+    def test_environment_sigils_are_resolved(self):
+        pattern = EmailPattern(
+            name="inv",
+            subject="Invoice [number] for [CLIENT]",
+        )
+        with patch.dict(os.environ, {"CLIENT": "Acme"}):
+            message = {"subject": "Invoice 42 for Acme"}
+            self.assertEqual(pattern.matches(message), {"number": "42"})
 
 
 class SendPendingEmailsTaskTests(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,3 +86,4 @@ websockets==13.1
 wsproto==1.2.0
 zope.interface==7.2
 django-webshell==0.4.0
+sigils==0.3.5

--- a/utils/sigils.py
+++ b/utils/sigils.py
@@ -1,0 +1,61 @@
+"""Utilities for resolving [SIGILS] within text using environment variables.
+
+This module provides a small wrapper around the `sigils` package to
+interpolate placeholders written as ``[NAME]`` within strings.  The
+``Sigil`` class from the third-party library expects placeholders in the
+form ``%[NAME]``.  To keep input strings tidy we allow users to write
+``[NAME]`` and transparently convert them before interpolation.
+
+Example
+-------
+>>> import os
+>>> from utils.sigils import resolve_env_sigils
+>>> os.environ['PORT'] = '8000'
+>>> resolve_env_sigils('Running on port [PORT]')
+'Running on port 8000'
+
+The function defaults to using ``os.environ`` as the context, but any
+mapping can be supplied if desired.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Mapping, Optional
+
+from sigils import Sigil
+
+# Regular expression used to detect ``[SIGIL]`` style placeholders.
+_SIGIL_PATTERN = re.compile(r"\[([^\[\]]+)\]")
+
+
+def _convert_to_sigils(template: str) -> str:
+    """Convert ``[name]`` placeholders into the ``sigils`` format ``%[name]``."""
+    # Replace each ``[something]`` with ``%[something]`` which the
+    # ``Sigil`` class recognises.
+    return _SIGIL_PATTERN.sub(r"%[\1]", template)
+
+
+def resolve_env_sigils(text: str, env: Optional[Mapping[str, str]] = None) -> str:
+    """Resolve ``[SIGILS]`` in ``text`` using values from ``env``.
+
+    Parameters
+    ----------
+    text:
+        The input string that may contain ``[NAME]`` placeholders.
+    env:
+        Optional mapping providing values for placeholders.  Defaults to
+        :data:`os.environ`.
+
+    Returns
+    -------
+    str
+        The text with all placeholders replaced.  Placeholders without a
+        matching key remain unchanged.
+    """
+    if not isinstance(text, str) or "[" not in text:
+        return text
+
+    env = dict(os.environ if env is None else env)
+    template = _convert_to_sigils(text)
+    return Sigil(template).interpolate(env, handle_errors="ignore")


### PR DESCRIPTION
## Summary
- depend on the `sigils` library
- add `resolve_env_sigils` utility for `[VAR]` placeholders
- resolve environment sigils in email pattern matching
- test environment variable interpolation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fac00e8088326a5e6395fe6a6f0d2