### PR TITLE
Use async-safe location name lookup in WebSocket handler

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -6,6 +6,7 @@ from accounts.models import Account
 
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
 from config.offline import requires_network
 
 from . import store
@@ -56,8 +57,11 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             charger_id=self.charger_id,
             defaults={"last_path": self.scope.get("path", "")},
         )
+        location_name = await sync_to_async(
+            lambda: self.charger.location.name if self.charger.location else ""
+        )()
         store.register_log_name(
-            self.charger_id, self.charger.name or self.charger_id, log_type="charger"
+            self.charger_id, location_name or self.charger_id, log_type="charger"
         )
 
     async def _get_account(self, id_tag: str) -> Account | None:


### PR DESCRIPTION
## Summary
- avoid synchronous ORM calls when registering charger log names
- fetch charger location name asynchronously in WebSocket connect handler

## Testing
- `python manage.py test ocpp`


------
https://chatgpt.com/codex/tasks/task_e_689fb3b4933483269381a647f128a8e8