### PR TITLE
Tune simulator energy levels

### DIFF
--- a/ocpp/fixtures/ocpp_simulators.json
+++ b/ocpp/fixtures/ocpp_simulators.json
@@ -5,7 +5,8 @@
     "fields": {
       "name": "Local CP1",
       "cp_path": "CP1",
-      "vin": "WP0ZZZ00000000000"
+      "vin": "WP0ZZZ00000000000",
+      "kw_max": 60.0
     }
   },
   {
@@ -14,7 +15,8 @@
     "fields": {
       "name": "Local CP2",
       "cp_path": "CP2",
-      "vin": "WAUZZZ00000000000"
+      "vin": "WAUZZZ00000000000",
+      "kw_max": 120.0
     }
   },
   {
@@ -25,7 +27,8 @@
       "cp_path": "CP1",
       "host": "192.168.129.10",
       "ws_port": 8888,
-      "vin": "WP0ZZZ00000000000"
+      "vin": "WP0ZZZ00000000000",
+      "kw_max": 60.0
     }
   },
   {
@@ -36,7 +39,8 @@
       "cp_path": "CP2",
       "host": "192.168.129.10",
       "ws_port": 8888,
-      "vin": "WAUZZZ00000000000"
+      "vin": "WAUZZZ00000000000",
+      "kw_max": 120.0
     }
   }
 ]

--- a/ocpp/simulator.py
+++ b/ocpp/simulator.py
@@ -167,14 +167,15 @@ class ChargePointSimulator:
 
             meter = meter_start
             steps = max(1, int(cfg.duration / cfg.interval))
-            step_min = max(1, int((cfg.kw_min * 1000) / steps))
-            step_max = max(1, int((cfg.kw_max * 1000) / steps))
+            target_kwh = cfg.kw_max * random.uniform(0.9, 1.1)
+            step_avg = (target_kwh * 1000) / steps
 
             start_time = time.monotonic()
             while time.monotonic() - start_time < cfg.duration:
                 if self._stop_event.is_set():
                     break
-                meter += random.randint(step_min, step_max)
+                inc = random.gauss(step_avg, step_avg * 0.05)
+                meter += max(1, int(inc))
                 meter_kw = meter / 1000.0
                 await send(
                     json.dumps(


### PR DESCRIPTION
## Summary
- set CP1 simulator fixtures to 60 kWh and CP2 to 120 kWh
- randomize simulator energy increments around configured capacity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb2b39988326873b3e5119ac9aab