### PR TITLE
Make Charger admin heartbeat and meter values read-only

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -61,6 +61,7 @@ class ChargerAdmin(admin.ModelAdmin):
             },
         ),
     )
+    readonly_fields = ("last_heartbeat", "last_meter_values")
     list_display = (
         "charger_id",
         "location_name",

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -287,6 +287,20 @@ class ChargerAdminTests(TestCase):
         resp = self.client.get(url)
         self.assertContains(resp, "AdminLoc")
 
+    def test_last_fields_are_read_only(self):
+        now = timezone.now()
+        charger = Charger.objects.create(
+            charger_id="ADMINRO",
+            last_heartbeat=now,
+            last_meter_values={"a": 1},
+        )
+        url = reverse("admin:ocpp_charger_change", args=[charger.pk])
+        resp = self.client.get(url)
+        self.assertContains(resp, "Last heartbeat")
+        self.assertContains(resp, "Last meter values")
+        self.assertNotContains(resp, 'name="last_heartbeat"')
+        self.assertNotContains(resp, 'name="last_meter_values"')
+
     def test_purge_action_removes_data(self):
         charger = Charger.objects.create(charger_id="PURGE1")
         Transaction.objects.create(


### PR DESCRIPTION
## Summary
- mark `last_heartbeat` and `last_meter_values` as readonly in Charger admin
- add test ensuring these fields are not editable in admin

## Testing
- `python manage.py test ocpp.tests.ChargerAdminTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a092f9b7e08326827b7f7d304fd87d