### PR TITLE
Separate admin badge label links

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -83,16 +83,16 @@ document.addEventListener('DOMContentLoaded', function () {
   <a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a>
     {% if badge_site %}
       <span class="badge" style="background-color: {{ badge_site_color }};">
-        <a href="{% url 'admin:website_siteproxy_change' badge_site.id %}">SITE: {{ badge_site.name }}</a>
+        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE:</a> <a href="{% url 'admin:website_siteproxy_change' badge_site.id %}">{{ badge_site.name }}</a>
       </span>
     {% else %}
       <span class="badge badge-unknown">
-        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>: Unknown
+        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE:</a> Unknown
       </span>
     {% endif %}
   {% if badge_node %}
     <span class="badge" style="background-color: {{ badge_node_color }};">
-      <a href="{% url 'admin:nodes_node_change' badge_node.id %}">NODE: {{ badge_node.hostname }}</a>
+      <a href="{% url 'admin:nodes_node_changelist' %}">NODE:</a> <a href="{% url 'admin:nodes_node_change' badge_node.id %}">{{ badge_node.hostname }}</a>
     </span>
     {% for role in badge_node.roles.all %}
       <span class="badge" style="background-color: {{ badge_node_color }};">
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function () {
     {% endfor %}
   {% else %}
     <span class="badge badge-unknown">
-      <a href="{% url 'admin:nodes_node_changelist' %}">NODE: Unknown</a>
+      <a href="{% url 'admin:nodes_node_changelist' %}">NODE:</a> Unknown
     </span>
   {% endif %}
 </h1>


### PR DESCRIPTION
## Summary
- Split Site and Node badges so labels link to admin lists while names link to individual objects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa7b9a808326aa9f0239a78fcd79