### PR TITLE
Add Spanish translations for AWG and OCPP models

### DIFF
--- a/awg/models.py
+++ b/awg/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class CableSize(models.Model):
@@ -19,6 +20,10 @@ class CableSize(models.Model):
 
     def __str__(self):  # pragma: no cover - simple representation
         return f"{self.awg_size} {self.material}"
+
+    class Meta:
+        verbose_name = _("Cable Size")
+        verbose_name_plural = _("Cable Sizes")
 
 
 class ConduitFill(models.Model):
@@ -43,6 +48,10 @@ class ConduitFill(models.Model):
     def __str__(self):  # pragma: no cover - simple representation
         return f"{self.trade_size} {self.conduit}"
 
+    class Meta:
+        verbose_name = _("Conduit Fill")
+        verbose_name_plural = _("Conduit Fills")
+
 
 class CalculatorTemplate(models.Model):
     """Template containing parameters for an AWG calculation."""
@@ -63,6 +72,10 @@ class CalculatorTemplate(models.Model):
 
     def __str__(self):  # pragma: no cover - simple representation
         return self.name
+
+    class Meta:
+        verbose_name = _("Calculator Template")
+        verbose_name_plural = _("Calculator Templates")
 
     def run(self):
         from .views import find_awg

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -398,9 +398,9 @@ msgstr ""
 msgid "Next 10"
 msgstr ""
 
-#: ocpp/templates/ocpp/dashboard.html:4 ocpp/templates/ocpp/dashboard.html:7
+#: ocpp/templates/ocpp/dashboard.html:4 ocpp/templates/ocpp/dashboard.html:7 ocpp/models.py:45
 msgid "Chargers"
-msgstr ""
+msgstr "Cargadores"
 
 #: ocpp/templates/ocpp/dashboard.html:11
 msgid "Name"
@@ -408,7 +408,7 @@ msgstr ""
 
 #: ocpp/templates/ocpp/dashboard.html:12
 msgid "Serial Number"
-msgstr ""
+msgstr "Número de serie"
 
 #: ocpp/templates/ocpp/dashboard.html:24
 msgid "No chargers found."
@@ -541,3 +541,75 @@ msgstr ""
 #: website/templates/website/login.html:22
 msgid "Log in"
 msgstr ""
+
+#: awg/models.py:24
+msgid "Cable Size"
+msgstr "Tamaño de cable"
+
+#: awg/models.py:25
+msgid "Cable Sizes"
+msgstr "Tamaños de cable"
+
+#: awg/models.py:52
+msgid "Conduit Fill"
+msgstr "Llenado de conducto"
+
+#: awg/models.py:53
+msgid "Conduit Fills"
+msgstr "Llenados de conducto"
+
+#: awg/models.py:77
+msgid "Calculator Template"
+msgstr "Plantilla de calculadora"
+
+#: awg/models.py:78
+msgid "Calculator Templates"
+msgstr "Plantillas de calculadora"
+
+#: ocpp/models.py:22
+msgid "Location"
+msgstr "Ubicación"
+
+#: ocpp/models.py:23
+msgid "Locations"
+msgstr "Ubicaciones"
+
+#: ocpp/models.py:44
+msgid "Charger"
+msgstr "Cargador"
+
+#: ocpp/models.py:31
+msgid "Require RFID"
+msgstr "Requiere RFID"
+
+#: ocpp/models.py:140
+msgid "Transaction"
+msgstr "Transacción"
+
+#: ocpp/models.py:141
+msgid "Transactions"
+msgstr "Transacciones"
+
+#: ocpp/models.py:194
+msgid "Meter Reading"
+msgstr "Lectura de medidor"
+
+#: ocpp/models.py:195
+msgid "Meter Readings"
+msgstr "Lecturas de medidor"
+
+#: ocpp/models.py:204
+msgid "WS Port"
+msgstr "Puerto WS"
+
+#: ocpp/models.py:209
+msgid "Delay"
+msgstr "Retardo"
+
+#: ocpp/models.py:219
+msgid "Simulator"
+msgstr "Simulador"
+
+#: ocpp/models.py:220
+msgid "Simulators"
+msgstr "Simuladores"

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.urls import reverse
 from django.contrib.sites.models import Site
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from references.models import Reference
 from accounts.models import Account
@@ -17,13 +18,17 @@ class Location(models.Model):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
 
+    class Meta:
+        verbose_name = _("Location")
+        verbose_name_plural = _("Locations")
+
 
 class Charger(models.Model):
     """Known charge point with optional configuration."""
 
-    charger_id = models.CharField("Serial Number", max_length=100, unique=True)
+    charger_id = models.CharField(_("Serial Number"), max_length=100, unique=True)
     config = models.JSONField(default=dict, blank=True)
-    require_rfid = models.BooleanField("Require RFID", default=False)
+    require_rfid = models.BooleanField(_("Require RFID"), default=False)
     last_heartbeat = models.DateTimeField(null=True, blank=True)
     last_meter_values = models.JSONField(default=dict, blank=True)
     reference = models.OneToOneField(Reference, null=True, blank=True, on_delete=models.SET_NULL)
@@ -34,6 +39,10 @@ class Charger(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.charger_id
+
+    class Meta:
+        verbose_name = _("Charger")
+        verbose_name_plural = _("Chargers")
 
     def get_absolute_url(self):
         return reverse("charger-page", args=[self.charger_id])
@@ -127,6 +136,10 @@ class Transaction(models.Model):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.charger}:{self.pk}"
 
+    class Meta:
+        verbose_name = _("Transaction")
+        verbose_name_plural = _("Transactions")
+
     @property
     def kw(self) -> float:
         """Return consumed energy in kW for this session."""
@@ -177,6 +190,10 @@ class MeterReading(models.Model):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.charger} {self.measurand} {self.value}{self.unit}".strip()
 
+    class Meta:
+        verbose_name = _("Meter Reading")
+        verbose_name_plural = _("Meter Readings")
+
 
 class Simulator(models.Model):
     """Preconfigured simulator that can be started from the admin."""
@@ -184,12 +201,12 @@ class Simulator(models.Model):
     name = models.CharField(max_length=100, unique=True)
     cp_path = models.CharField(max_length=100)
     host = models.CharField(max_length=100, default="127.0.0.1")
-    ws_port = models.IntegerField("WS Port", default=8000)
+    ws_port = models.IntegerField(_("WS Port"), default=8000)
     rfid = models.CharField(max_length=8, default="FFFFFFFF")
     vin = models.CharField(max_length=17, blank=True)
     duration = models.IntegerField(default=600)
     interval = models.FloatField(default=5.0)
-    pre_charge_delay = models.FloatField("Delay", default=10.0)
+    pre_charge_delay = models.FloatField(_("Delay"), default=10.0)
     kw_max = models.FloatField(default=60.0)
     repeat = models.BooleanField(default=False)
     username = models.CharField(max_length=100, blank=True)
@@ -197,6 +214,10 @@ class Simulator(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
+
+    class Meta:
+        verbose_name = _("Simulator")
+        verbose_name_plural = _("Simulators")
 
     def as_config(self):
         from .simulator import SimulatorConfig


### PR DESCRIPTION
## Summary
- Localize AWG models with Spanish verbose names.
- Provide Spanish verbose names and field labels for OCPP models.
- Extend es locale with translations for AWG and OCPP model strings.

## Testing
- `pytest -q`
- `python manage.py compilemessages`


------
https://chatgpt.com/codex/tasks/task_e_68a483611db4832691e51c3c36555597