### PR TITLE
Add VS Code shortcut for running tasks

### DIFF
--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -1,0 +1,8 @@
+[
+    {
+        "key": "ctrl+alt+r",
+        "command": "workbench.action.tasks.runTask",
+        "mac": "cmd+alt+r",
+        "description": "Run Task"
+    }
+]


### PR DESCRIPTION
## Summary
- add keybinding to run configured VS Code tasks via `ctrl+alt+r`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a486cc447c832680fec929be1d7b08