### PR TITLE
docs: relocate README note and update agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Agent Guidelines
-
-- The top-level `README.md` and `README.base.md` must not be edited unless explicitly instructed.
+- Note: do not modify README files unless directed. Use Django's admindocs for app documentation.
 - Application documentation lives in Django's admindocs. Do not create or modify per-app README files.
+- Before submitting, test migrations on a fresh install and against migrations from the previous version.
 

--- a/README.base.md
+++ b/README.base.md
@@ -36,7 +36,3 @@ Arthexis Constellation is a Django-based suite that centralizes tools for managi
 - [Channels](https://channels.readthedocs.io/)
 - [Celery](https://docs.celeryq.dev/)
 - [Bootstrap](https://getbootstrap.com/)
-
----
-
-*Note: do not modify this README unless directed. Use Django's admindocs for app documentation.*

--- a/README.es.md
+++ b/README.es.md
@@ -36,8 +36,3 @@ Arthexis Constellation es una suite basada en Django que centraliza herramientas
 - [Channels](https://channels.readthedocs.io/)
 - [Celery](https://docs.celeryq.dev/)
 - [Bootstrap](https://getbootstrap.com/)
-
----
-
-*Nota: no modifiques este README salvo que se indique. Usa los admindocs de Django para la documentación de las aplicaciones.*
-

--- a/README.md
+++ b/README.md
@@ -36,7 +36,3 @@ Arthexis Constellation is a Django-based suite that centralizes tools for managi
 - [Channels](https://channels.readthedocs.io/)
 - [Celery](https://docs.celeryq.dev/)
 - [Bootstrap](https://getbootstrap.com/)
-
----
-
-*Note: do not modify this README unless directed. Use Django's admindocs for app documentation.*

--- a/release/fixtures/legacy/readme_sections.json
+++ b/release/fixtures/legacy/readme_sections.json
@@ -38,13 +38,5 @@
       "order": 5,
       "content": "## External Links\n- [Python 3.12](https://www.python.org/downloads/release/python-31210/)\n- [MIT License](LICENSE)\n- [Django](https://www.djangoproject.com/)\n- [Channels](https://channels.readthedocs.io/)\n- [Celery](https://docs.celeryq.dev/)\n- [Bootstrap](https://getbootstrap.com/)"
     }
-  },
-  {
-    "model": "release.readmesection",
-    "pk": 6,
-    "fields": {
-      "order": 6,
-      "content": "---\n\n*Note: do not modify this README unless directed. Use Django's admindocs for app documentation.*"
-    }
   }
 ]


### PR DESCRIPTION
## Summary
- remove "do not modify this README" note from English, Spanish, and base READMEs
- keep the notice in AGENTS.md and advise testing migrations on fresh and upgraded installs
- drop obsolete note from legacy README fixture

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b521a8b483269077007d612a1a24