### PR TITLE
Streamline node admin list

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -43,11 +43,12 @@ class NodeAdmin(admin.ModelAdmin):
         "hostname",
         "address",
         "port",
-        "badge_color",
-        "enable_public_api",
+        "api",
         "public_endpoint",
-        "clipboard_polling",
-        "screenshot_polling",
+        "clipboard",
+        "screenshot",
+        "installed_version",
+        "roles_list",
         "last_seen",
     )
     search_fields = ("hostname", "address")
@@ -56,6 +57,29 @@ class NodeAdmin(admin.ModelAdmin):
     form = NodeAdminForm
     filter_horizontal = ("roles",)
     actions = ["run_command"]
+
+    def api(self, obj):
+        return obj.enable_public_api
+
+    api.boolean = True
+    api.short_description = "API"
+
+    def clipboard(self, obj):
+        return obj.clipboard_polling
+
+    clipboard.boolean = True
+    clipboard.short_description = "Clipboard"
+
+    def screenshot(self, obj):
+        return obj.screenshot_polling
+
+    screenshot.boolean = True
+    screenshot.short_description = "Screenshot"
+
+    def roles_list(self, obj):
+        return ", ".join(obj.roles.values_list("name", flat=True))
+
+    roles_list.short_description = "Roles"
 
     def get_urls(self):
         urls = super().get_urls()


### PR DESCRIPTION
## Summary
- simplify node admin columns and drop badge color
- add installed version and roles to node list

## Testing
- `pytest nodes -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a4bcb385588326ae4128ce1bc2a4ad