### PR TITLE
Require RFID for CP2 charger fixtures

### DIFF
--- a/ocpp/fixtures/initial_data.json
+++ b/ocpp/fixtures/initial_data.json
@@ -28,7 +28,7 @@
     "fields": {
       "charger_id": "CP2",
       "config": {},
-      "require_rfid": false,
+      "require_rfid": true,
       "last_heartbeat": null,
       "last_meter_values": {},
       "reference": null,

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -27,6 +27,18 @@ from .tasks import purge_meter_readings
 
 
 
+class ChargerFixtureTests(TestCase):
+    fixtures = ["initial_data.json"]
+
+    def test_cp2_requires_rfid(self):
+        cp2 = Charger.objects.get(charger_id="CP2")
+        self.assertTrue(cp2.require_rfid)
+
+    def test_cp1_does_not_require_rfid(self):
+        cp1 = Charger.objects.get(charger_id="CP1")
+        self.assertFalse(cp1.require_rfid)
+
+
 class SinkConsumerTests(TransactionTestCase):
     async def test_sink_replies(self):
         communicator = WebsocketCommunicator(application, "/ws/sink/")


### PR DESCRIPTION
## Summary
- make CP2 charger require RFID by default while CP1 remains open
- add tests covering default RFID requirement for CP1 and CP2

## Testing
- `./manage.sh test ocpp`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf0bb868832682364e9872faa608