### PR TITLE
Ignore port in site resolution

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,4 +1,4 @@
-from django.contrib.sites.shortcuts import get_current_site
+from utils.sites import get_site
 import socket
 
 from .active_app import set_active_app
@@ -11,7 +11,7 @@ class ActiveAppMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        site = get_current_site(request)
+        site = get_site(request)
         active = site.name or "website"
         set_active_app(active)
         request.active_app = active

--- a/utils/sites.py
+++ b/utils/sites.py
@@ -1,0 +1,19 @@
+from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
+from django.http.request import split_domain_port
+
+
+def get_site(request):
+    """Return the current Site ignoring any port in the host.
+
+    Django's default ``get_current_site`` uses the full host string, which
+    includes the port (e.g. ``"127.0.0.1:8000"``). If the ``Site`` domain is
+    stored without the port, the lookup fails and a ``RequestSite`` is returned.
+    This helper strips the port before performing the lookup so that hosts with
+    ports still resolve to the correct ``Site`` instance.
+    """
+    host, _ = split_domain_port(request.get_host())
+    try:
+        return Site.objects.get(domain=host)
+    except Site.DoesNotExist:
+        return get_current_site(request)

--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -1,10 +1,10 @@
-from django.contrib.sites.shortcuts import get_current_site
+from utils.sites import get_site
 from django.urls import Resolver404, resolve
 
 
 def nav_links(request):
     """Provide navigation links for the current site."""
-    site = get_current_site(request)
+    site = get_site(request)
     try:
         applications = site.site_applications.select_related("application").all()
     except Exception:

--- a/website/tests.py
+++ b/website/tests.py
@@ -199,6 +199,10 @@ class NavAppsTests(TestCase):
         self.assertContains(resp, "Readme")
         self.assertContains(resp, "badge rounded-pill")
 
+    def test_nav_pill_renders_with_port(self):
+        resp = self.client.get(reverse("website:index"), HTTP_HOST="127.0.0.1:8000")
+        self.assertContains(resp, "Readme")
+
     def test_app_without_root_url_excluded(self):
         site = Site.objects.get(id=1)
         app = Application.objects.create(name="accounts")

--- a/website/views.py
+++ b/website/views.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.views import LoginView
-from django.contrib.sites.shortcuts import get_current_site
+from utils.sites import get_site
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -14,7 +14,7 @@ from website.utils import landing
 
 @landing("Home")
 def index(request):
-    site = get_current_site(request)
+    site = get_site(request)
     app = (
         site.site_applications.filter(is_default=True)
         .select_related("application")
@@ -48,7 +48,7 @@ def index(request):
 
 
 def sitemap(request):
-    site = get_current_site(request)
+    site = get_site(request)
     applications = site.site_applications.all()
     base = request.build_absolute_uri("/").rstrip("/")
     lines = [


### PR DESCRIPTION
## Summary
- add helper to resolve Site without considering port
- use port-agnostic Site lookup for nav links and middleware
- ensure nav links render when host includes a port

## Testing
- `pytest`
- `python manage.py test website.tests.NavAppsTests.test_nav_pill_renders_with_port`


------
https://chatgpt.com/codex/tasks/task_e_68a4f35be2308326b30efa206f2fedc6