### PR TITLE
docs: document helper scripts and VS Code tasks

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -14,6 +14,21 @@ Arthexis Constellation es una suite basada en Django que centraliza herramientas
 2. `python manage.py runserver`
 3. Ejecutar comandos de administración con `python manage.py <command>`
 
+## Scripts de Shell
+El proyecto incluye scripts de ayuda para agilizar el desarrollo:
+- `install.sh` – crea un entorno virtual, instala dependencias y opcionalmente configura un servicio systemd con `--service NOMBRE`.
+- `start.sh [puerto]` – inicia el servidor de desarrollo en el puerto indicado (por defecto `8888`).
+- `stop.sh [puerto|--all]` – detiene el servidor en el puerto dado o todos los servidores en ejecución.
+- `manage.sh <args>` – ejecuta comandos de administración de Django.
+- `command.sh <comando> [args...]` – ejecuta comandos de administración usando nombres con guiones (por ejemplo, `./command.sh show-migrations`).
+- `dev-maintenance.sh` – instala dependencias actualizadas cuando cambian los requisitos y realiza tareas de mantenimiento de la base de datos.
+- `upgrade.sh` – obtiene el último código y reinstala dependencias cuando es necesario.
+
+## Tareas de VS Code
+`.vscode/tasks.json` provee dos tareas:
+- **Dev: maintenance** – ejecuta `dev-maintenance.sh` (o el `.bat` equivalente en Windows).
+- **Update requirements** – instala dependencias actualizadas mediante `install.sh` y regenera `requirements.txt`.
+
 ## Aplicaciones Incluidas
 | Aplicación | Propósito |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ Arthexis Constellation is a Django-based suite that centralizes tools for managi
 2. `python manage.py runserver`
 3. Run management commands with `python manage.py <command>`
 
+## Shell Scripts
+The project includes helper shell scripts to streamline development:
+- `install.sh` – set up a virtual environment, install dependencies, and optionally configure a systemd service with `--service NAME`.
+- `start.sh [port]` – run the development server on the specified port (default `8888`).
+- `stop.sh [port|--all]` – stop the server on a given port or all running servers.
+- `manage.sh <args>` – execute Django management commands.
+- `command.sh <command> [args...]` – run management commands using hyphenated names (e.g., `./command.sh show-migrations`).
+- `dev-maintenance.sh` – install updated dependencies when requirements change and perform database maintenance tasks.
+- `upgrade.sh` – pull the latest code and reinstall dependencies when needed.
+
+## VS Code Tasks
+Two tasks are provided in `.vscode/tasks.json`:
+- **Dev: maintenance** – runs `dev-maintenance.sh` (or the Windows `.bat` equivalent).
+- **Update requirements** – installs updated dependencies via `install.sh` and regenerates `requirements.txt`.
+
 ## Included Apps
 | App | Purpose |
 | --- | --- |


### PR DESCRIPTION
## Summary
- document helper shell scripts for setup and maintenance
- outline available VS Code tasks

## Testing
- `./install.sh` *(fails: Operation cancelled by user)*
- `python -m pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a505f003a0832693f5c0f290899f08