### PR TITLE
Customize site branding and rename default hosts

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -324,7 +324,7 @@ class SubscriptionTests(TestCase):
 class OnboardingWizardTests(TestCase):
     def setUp(self):
         self.client = Client()
-        User.objects.create_superuser("super", "super@example.com", "pwd")
+        User.objects.create_superuser("super", "super@arthexis.com", "pwd")
         self.client.force_login(User.objects.get(username="super"))
 
     def test_onboarding_flow_creates_account(self):

--- a/integrator/test_bsky.py
+++ b/integrator/test_bsky.py
@@ -79,7 +79,7 @@ class BskyAdminActionTests(TestCase):
         self.admin = User.objects.create_superuser(
             username="bsky-admin",
             password="secret",
-            email="admin@example.com",
+            email="admin@arthexis.com",
         )
         self.client.force_login(self.admin)
         self.account = BskyAccount.objects.create(

--- a/integrator/test_odoo.py
+++ b/integrator/test_odoo.py
@@ -77,7 +77,7 @@ class OdooAdminTests(TestCase):
         self.admin = User.objects.create_superuser(
             username="odoo-admin",
             password="secret",
-            email="admin@example.com",
+            email="admin@arthexis.com",
         )
         self.client.force_login(self.admin)
         os.environ.update(

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -17,12 +17,12 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(help_text="Identifier for this configuration (e.g., 'myapp')", max_length=100, unique=True)),
-                ('server_name', models.CharField(help_text='Host name(s) for the server block (e.g., example.com)', max_length=255)),
+                ('server_name', models.CharField(help_text='Host name(s) for the server block (e.g., arthexis.com)', max_length=255)),
                 ('primary_upstream', models.CharField(help_text='Primary upstream in host:port form (e.g., 10.0.0.1:8000)', max_length=255)),
                 ('backup_upstream', models.CharField(blank=True, help_text='Backup upstream in host:port form (e.g., 127.0.0.1:9000)', max_length=255)),
                 ('listen_port', models.PositiveIntegerField(default=80, help_text='Port nginx listens on (e.g., 80 or 443)')),
-                ('ssl_certificate', models.CharField(blank=True, help_text='Path to SSL certificate (e.g., /etc/ssl/certs/example.crt)', max_length=255)),
-                ('ssl_certificate_key', models.CharField(blank=True, help_text='Path to SSL certificate key (e.g., /etc/ssl/private/example.key)', max_length=255)),
+                ('ssl_certificate', models.CharField(blank=True, help_text='Path to SSL certificate (e.g., /etc/ssl/certs/arthexis.crt)', max_length=255)),
+                ('ssl_certificate_key', models.CharField(blank=True, help_text='Path to SSL certificate key (e.g., /etc/ssl/private/arthexis.key)', max_length=255)),
                 ('config_text', models.TextField(blank=True)),
             ],
             options={

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -160,7 +160,7 @@ class NodeAdminTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="nodes-admin", password="adminpass", email="admin@example.com"
+            username="nodes-admin", password="adminpass", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
 
@@ -228,7 +228,7 @@ class NodeActionTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="action-admin", password="adminpass", email="admin@example.com"
+            username="action-admin", password="adminpass", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
 
@@ -330,7 +330,7 @@ class TextPatternAdminActionTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.user = User.objects.create_superuser(
-            "pattern_admin", "admin@example.com", "pass"
+            "pattern_admin", "admin@arthexis.com", "pass"
         )
         self.client.login(username="pattern_admin", password="pass")
 
@@ -352,7 +352,7 @@ class TextSampleAdminTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.user = User.objects.create_superuser(
-            "clipboard_admin", "admin@example.com", "pass"
+            "clipboard_admin", "admin@arthexis.com", "pass"
         )
         self.client.login(username="clipboard_admin", password="pass")
 
@@ -412,7 +412,7 @@ class ClipboardTaskTests(TestCase):
         file_path = screenshot_dir / "test.png"
         file_path.write_bytes(b"task")
         mock_capture.return_value = Path("screenshots/test.png")
-        capture_node_screenshot("http://example.com")
+        capture_node_screenshot("http://arthexis.com")
         self.assertEqual(NodeScreenshot.objects.count(), 1)
         screenshot = NodeScreenshot.objects.first()
         self.assertEqual(screenshot.node, node)

--- a/ocpp/fixtures/ocpp_simulators.json
+++ b/ocpp/fixtures/ocpp_simulators.json
@@ -25,7 +25,7 @@
     "fields": {
       "name": "Ethernet CP1",
       "cp_path": "CP1",
-      "host": "192.168.129.10",
+      "host": "Gateway",
       "ws_port": 8888,
       "vin": "WP0ZZZ00000000000",
       "kw_max": 60.0
@@ -37,7 +37,7 @@
     "fields": {
       "name": "Ethernet CP2",
       "cp_path": "CP2",
-      "host": "192.168.129.10",
+      "host": "Gateway",
       "ws_port": 8888,
       "vin": "WAUZZZ00000000000",
       "kw_max": 120.0

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -387,7 +387,7 @@ class ChargerAdminTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="ocpp-admin", password="secret", email="admin@example.com"
+            username="ocpp-admin", password="secret", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
 
@@ -466,7 +466,7 @@ class TransactionAdminTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="tx-admin", password="secret", email="tx@example.com"
+            username="tx-admin", password="secret", email="tx@arthexis.com"
         )
         self.client.force_login(self.admin)
 
@@ -490,7 +490,7 @@ class SimulatorAdminTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="admin2", password="secret", email="admin2@example.com"
+            username="admin2", password="secret", email="admin2@arthexis.com"
         )
         self.client.force_login(self.admin)
 

--- a/references/tests.py
+++ b/references/tests.py
@@ -10,15 +10,15 @@ from .models import Reference
 
 class ReferenceTests(TestCase):
     def test_template_tag_creates_reference(self):
-        html = Template("{% load ref_tags %}{% ref_img 'https://example.com' alt='Example' %}").render(Context())
-        ref = Reference.objects.get(value='https://example.com')
+        html = Template("{% load ref_tags %}{% ref_img 'https://arthexis.com' alt='Constellation' %}").render(Context())
+        ref = Reference.objects.get(value='https://arthexis.com')
         self.assertIn(ref.image.url, html)
-        self.assertEqual(ref.alt_text, 'Example')
+        self.assertEqual(ref.alt_text, 'Constellation')
         self.assertTrue(ref.image.path.endswith('.png'))
         self.assertEqual(ref.uses, 1)
         # calling again should not create another record but increment uses
-        Template("{% load ref_tags %}{% ref_img 'https://example.com' %}").render(Context())
-        self.assertEqual(Reference.objects.filter(value='https://example.com').count(), 1)
+        Template("{% load ref_tags %}{% ref_img 'https://arthexis.com' %}").render(Context())
+        self.assertEqual(Reference.objects.filter(value='https://arthexis.com').count(), 1)
         ref.refresh_from_db()
         self.assertEqual(ref.uses, 2)
 
@@ -42,15 +42,15 @@ class FooterTemplateTagTests(TestCase):
 
     def test_footer_renders_selected_references(self):
         Reference.objects.create(
-            value="https://example.com", alt_text="Example", include_in_footer=True
+            value="https://arthexis.com", alt_text="Constellation", include_in_footer=True
         )
         Reference.objects.create(value="https://ignored.com", alt_text="Ignore")
         request = self.factory.get("/")
         html = Template("{% load ref_tags %}{% render_footer %}").render(
             Context({"request": request})
         )
-        self.assertIn("https://example.com", html)
-        self.assertIn("Example", html)
+        self.assertIn("https://arthexis.com", html)
+        self.assertIn("Constellation", html)
         self.assertNotIn("https://ignored.com", html)
         self.assertIn("data:image/png;base64", html)
         rev = Path("REVISION").read_text().strip()[-8:]
@@ -59,9 +59,9 @@ class FooterTemplateTagTests(TestCase):
         self.assertIn(f"rev {rev}", html)
 
     def test_footer_shows_admin_links_for_staff(self):
-        Reference.objects.create(value="https://example.com", include_in_footer=True)
+        Reference.objects.create(value="https://arthexis.com", include_in_footer=True)
         user = get_user_model().objects.create_user(
-            "staff", "staff@example.com", "pass", is_staff=True
+            "staff", "staff@arthexis.com", "pass", is_staff=True
         )
         request = self.factory.get("/ref/")
         request.user = user
@@ -93,12 +93,12 @@ class ReferenceAdminDisplayTests(TestCase):
     def setUp(self):
         self.client = Client()
         user = get_user_model().objects.create_superuser(
-            "refadmin", "admin@example.com", "pass"
+            "refadmin", "admin@arthexis.com", "pass"
         )
         self.client.force_login(user)
 
     def test_change_form_displays_qr_code(self):
-        ref = Reference.objects.create(value="https://example.com")
+        ref = Reference.objects.create(value="https://arthexis.com")
         resp = self.client.get(
             reverse("admin:references_reference_change", args=[ref.pk])
         )

--- a/release/tests.py
+++ b/release/tests.py
@@ -40,7 +40,7 @@ class PackageConfigTests(TestCase):
             name="pkg",
             description="desc",
             author="me",
-            email="me@example.com",
+            email="me@arthexis.com",
             python_requires=">=3.10",
             license="MIT",
         )
@@ -61,7 +61,7 @@ class PackageAdminTests(TestCase):
             name="pkg",
             description="desc",
             author="me",
-            email="me@example.com",
+            email="me@arthexis.com",
             python_requires=">=3.10",
             license="MIT",
             token="tok",

--- a/tests/test_admin_history.py
+++ b/tests/test_admin_history.py
@@ -18,7 +18,7 @@ class AdminHistoryTests(TestCase):
     def test_admin_history_records_filters(self):
         User = get_user_model()
         user = User.objects.create_superuser(
-            username="histadmin", email="histadmin@example.com", password="password"
+            username="histadmin", email="histadmin@arthexis.com", password="password"
         )
         self.client.force_login(user)
         url = reverse("admin:accounts_account_changelist") + "?q=test"

--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -18,7 +18,7 @@ class AdminIndexActionLinkTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.user = User.objects.create_superuser(
-            username="indexadmin", email="indexadmin@example.com", password="password"
+            username="indexadmin", email="indexadmin@arthexis.com", password="password"
         )
         self.client.force_login(self.user)
 

--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -2,8 +2,8 @@
   {
     "model": "sites.site",
     "fields": {
-      "domain": "192.168.129.10",
-      "name": "GWAY-BOX"
+      "domain": "Gateway",
+      "name": "Gateway"
     }
   },
   {
@@ -17,7 +17,7 @@
   {
     "model": "website.siteapplication",
     "fields": {
-      "site": ["192.168.129.10"],
+      "site": ["Gateway"],
       "application": ["ocpp"],
       "path": "/ocpp/",
       "is_default": false
@@ -26,7 +26,7 @@
   {
     "model": "website.siteapplication",
     "fields": {
-      "site": ["192.168.129.10"],
+      "site": ["Gateway"],
       "application": ["rfid"],
       "path": "/rfid/",
       "is_default": false

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "127.0.0.1",
-      "name": "website"
+      "name": "Terminal"
     }
   }
 ]

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{% trans "Arthexis Constellation" %}{% endblock %}</title>
+    <title>{% block title %}{{ badge_site.name|default:_("Arthexis") }} {% trans "Constellation" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
       html[data-bs-theme='light'] {
@@ -47,7 +47,7 @@
     <div class="container flex-grow-1">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
         <div class="container-fluid">
-          <a class="navbar-brand" href="/">Arthexis</a>
+          <a class="navbar-brand" href="/">{{ badge_site.name|default:_("Arthexis") }}</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>

--- a/website/tests.py
+++ b/website/tests.py
@@ -55,7 +55,7 @@ class AdminBadgesTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="badge-admin", password="pwd", email="admin@example.com"
+            username="badge-admin", password="pwd", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
@@ -99,7 +99,7 @@ class AdminSidebarTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="sidebar_admin", password="pwd", email="admin@example.com"
+            username="sidebar_admin", password="pwd", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
@@ -138,11 +138,11 @@ class SiteAdminRegisterCurrentTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="site-admin", password="pwd", email="admin@example.com"
+            username="site-admin", password="pwd", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
-            id=1, defaults={"name": "example", "domain": "example.com"}
+            id=1, defaults={"name": "Constellation", "domain": "arthexis.com"}
         )
 
     def test_register_current_creates_site(self):
@@ -156,13 +156,13 @@ class SiteAdminRegisterCurrentTests(TestCase):
         self.assertEqual(site.name, "testserver")
 
     @override_settings(ALLOWED_HOSTS=["127.0.0.1", "testserver"])
-    def test_register_current_ip_sets_website_name(self):
+    def test_register_current_ip_sets_terminal_name(self):
         resp = self.client.get(
             reverse("admin:website_siteproxy_register_current"), HTTP_HOST="127.0.0.1"
         )
         self.assertRedirects(resp, reverse("admin:website_siteproxy_changelist"))
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "website")
+        self.assertEqual(site.name, "Terminal")
 
 
 class AdminBadgesWebsiteTests(TestCase):
@@ -170,24 +170,24 @@ class AdminBadgesWebsiteTests(TestCase):
         self.client = Client()
         User = get_user_model()
         self.admin = User.objects.create_superuser(
-            username="badge-admin2", password="pwd", email="admin@example.com"
+            username="badge-admin2", password="pwd", email="admin@arthexis.com"
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
-            id=1, defaults={"name": "website", "domain": "127.0.0.1"}
+            id=1, defaults={"name": "Terminal", "domain": "127.0.0.1"}
         )
 
     @override_settings(ALLOWED_HOSTS=["127.0.0.1", "testserver"])
     def test_badge_shows_website_for_ip_domain(self):
         resp = self.client.get(reverse("admin:index"), HTTP_HOST="127.0.0.1")
-        self.assertContains(resp, "SITE: website")
+        self.assertContains(resp, "SITE: Terminal")
 
 
 class NavAppsTests(TestCase):
     def setUp(self):
         self.client = Client()
         site, _ = Site.objects.update_or_create(
-            id=1, defaults={"domain": "127.0.0.1", "name": "website"}
+            id=1, defaults={"domain": "127.0.0.1", "name": "Terminal"}
         )
         app = Application.objects.create(name="Readme")
         SiteApplication.objects.create(


### PR DESCRIPTION
## Summary
- Use the active Site name for the page title and navbar brand
- Rename default host fixtures to Gateway and Terminal
- Replace example.com with arthexis.com and Constellation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5429a36c08326a2955622ff8401c4