### PR TITLE
Fix webshell admin redirect

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -64,7 +64,9 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path(
         "webshell/",
-        RedirectView.as_view(pattern_name="execute-script", permanent=False),
+        RedirectView.as_view(
+            pattern_name="admin:webshell_script_add", permanent=False
+        ),
     ),
     path("webshell/", include("webshell.urls")),
     path("i18n/", include("django.conf.urls.i18n")),


### PR DESCRIPTION
## Summary
- redirect /webshell/ to the admin shell page instead of execute endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a54502affc8326b4d4923a5bbbcc9f