### PR TITLE
feat: show real-time server clock in admin header

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -72,6 +72,27 @@ document.addEventListener('DOMContentLoaded', function () {
     toggleEmptyGroups();
 });
 </script>
+{% now "c" as current_time %}
+<script id="admin-server-clock">
+document.addEventListener('DOMContentLoaded', function () {
+    const clock = document.getElementById('server-clock');
+    if (!clock) {
+        return;
+    }
+    const serverStart = Date.parse("{{ current_time|escapejs }}");
+    const clientStart = Date.now();
+    function pad(n) {
+        return String(n).padStart(2, '0');
+    }
+    function update() {
+        const now = new Date(serverStart + (Date.now() - clientStart));
+        const formatted = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+        clock.textContent = formatted;
+    }
+    update();
+    setInterval(update, 1000);
+});
+</script>
 {% endblock %}
 {% block extrastyle %}
 {{ block.super }}
@@ -111,7 +132,7 @@ document.addEventListener('DOMContentLoaded', function () {
 {% endblock %}
 {% block branding %}
 <h1 id="site-name">
-  <a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a>
+  <a href="{% url 'admin:index' %}"><span id="server-clock"></span></a>
     {% if badge_site %}
       <span class="badge" style="background-color: {{ badge_site_color }};">
         <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE:</a> <a href="{% url 'admin:website_siteproxy_change' badge_site.id %}">{{ badge_site.name }}</a>


### PR DESCRIPTION
## Summary
- replace Constellation header text with live server clock
- add JavaScript to update clock every second

## Testing
- `python manage.py test` *(fails: test_environment_sigils_are_resolved, test_matches_extracts_variables, test_session_search_by_date, test_badges_show_site_and_node, test_badges_warn_when_node_missing, test_badge_shows_website_for_ip_domain, test_nav_pill_renders_with_port)*

------
https://chatgpt.com/codex/tasks/task_e_68a5478030fc8326b9e61606675a4376