### PR TITLE
Include created timestamps in footer reference fixture

### DIFF
--- a/refs/fixtures/footer_refs.json
+++ b/refs/fixtures/footer_refs.json
@@ -6,7 +6,8 @@
       "value": "https://arthexis.com",
       "alt_text": "Arthexis",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   },
   {
@@ -16,7 +17,8 @@
       "value": "https://pypi.org/project/arthexis/",
       "alt_text": "Arthexis on PyPI",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   },
   {
@@ -26,7 +28,8 @@
       "value": "https://www.gelectriic.com",
       "alt_text": "Gelectriic Solutions",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   },
   {
@@ -36,7 +39,8 @@
       "value": "https://www.python.org/",
       "alt_text": "Python",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   },
   {
@@ -46,7 +50,8 @@
       "value": "https://www.djangoproject.com/",
       "alt_text": "Django",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   },
   {
@@ -56,7 +61,8 @@
       "value": "https://openchargealliance.org/protocols/open-charge-point-protocol/",
       "alt_text": "OCPP",
       "method": "link",
-      "include_in_footer": true
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
     }
   }
 ]


### PR DESCRIPTION
## Summary
- include created timestamps in footer reference fixtures to satisfy NOT NULL constraint

## Testing
- `python manage.py migrate --noinput`
- `python manage.py loaddata refs/fixtures/footer_refs.json`
- `python manage.py test refs -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a553e6f28c832698a19ba4743aa596