### PR TITLE
Track nodes by MAC address to allow duplicate IPs

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -19,23 +19,25 @@ def site_and_node(request: HttpRequest):
     try:
         from nodes.models import Node
 
-        hostname = socket.gethostname()
-        try:
-            addresses = socket.gethostbyname_ex(hostname)[2]
-        except socket.gaierror:
-            addresses = []
+        node = Node.get_local()
+        if not node:
+            hostname = socket.gethostname()
+            try:
+                addresses = socket.gethostbyname_ex(hostname)[2]
+            except socket.gaierror:
+                addresses = []
 
-        node = Node.objects.filter(hostname__iexact=hostname).first()
-        if not node:
-            for addr in addresses:
-                node = Node.objects.filter(address=addr).first()
-                if node:
-                    break
-        if not node:
-            node = (
-                Node.objects.filter(hostname__iexact=host).first()
-                or Node.objects.filter(address=host).first()
-            )
+            node = Node.objects.filter(hostname__iexact=hostname).first()
+            if not node:
+                for addr in addresses:
+                    node = Node.objects.filter(address=addr).first()
+                    if node:
+                        break
+            if not node:
+                node = (
+                    Node.objects.filter(hostname__iexact=host).first()
+                    or Node.objects.filter(address=host).first()
+                )
     except Exception:
         node = None
 

--- a/nodes/management/commands/sample_clipboard.py
+++ b/nodes/management/commands/sample_clipboard.py
@@ -1,7 +1,5 @@
 from django.core.management.base import BaseCommand
 
-import os
-import socket
 import pyperclip
 from pyperclip import PyperclipException
 
@@ -23,8 +21,6 @@ class Command(BaseCommand):
         if TextSample.objects.filter(content=content).exists():
             self.stdout.write("Duplicate sample not created")
             return
-        hostname = socket.gethostname()
-        port = int(os.environ.get("PORT", 8000))
-        node = Node.objects.filter(hostname=hostname, port=port).first()
+        node = Node.get_local()
         sample = TextSample.objects.create(content=content, node=node)
         self.stdout.write(self.style.SUCCESS(f"Saved sample at {sample.created_at}"))

--- a/nodes/migrations/0018_node_mac_address.py
+++ b/nodes/migrations/0018_node_mac_address.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("nodes", "0017_node_base_path_node_installed_revision_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="node",
+            name="mac_address",
+            field=models.CharField(max_length=17, unique=True, null=True, blank=True),
+        ),
+    ]

--- a/nodes/tasks.py
+++ b/nodes/tasks.py
@@ -1,6 +1,4 @@
 import logging
-import socket
-import os
 from pathlib import Path
 
 import pyperclip
@@ -27,9 +25,7 @@ def sample_clipboard() -> None:
     if TextSample.objects.filter(content=content).exists():
         logger.info("Duplicate clipboard content; sample not created")
         return
-    hostname = socket.gethostname()
-    port = int(os.environ.get("PORT", 8000))
-    node = Node.objects.filter(hostname=hostname, port=port).first()
+    node = Node.get_local()
     TextSample.objects.create(content=content, node=node, automated=True)
 
 
@@ -41,8 +37,7 @@ def capture_node_screenshot(
     if url is None:
         url = f"http://localhost:{port}"
     path: Path = capture_screenshot(url)
-    hostname = socket.gethostname()
-    node = Node.objects.filter(hostname=hostname, port=port).first()
+    node = Node.get_local()
     save_screenshot(path, node=node, method=method)
     return str(path)
 


### PR DESCRIPTION
## Summary
- add `mac_address` to Node model and utilities to detect the local node
- register nodes by MAC address and warn on duplicates
- update admin, tasks and tests to use the new MAC-based lookup

## Testing
- `python manage.py makemigrations nodes --check`
- `python manage.py migrate`
- `python manage.py test nodes`

------
https://chatgpt.com/codex/tasks/task_e_68a553b0f62c8326bd201a00594d289d