### PR TITLE
Use all-caps for navbar pills

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -57,7 +57,7 @@
                 {% for app in nav_apps %}
                 <li class="nav-item">
                   <a class="nav-link" href="{{ app.path }}">
-                    <span class="badge rounded-pill text-bg-secondary">{{ app.application.name|capfirst }}</span>
+                    <span class="badge rounded-pill text-bg-secondary">{{ app.application.name|upper }}</span>
                   </a>
                 </li>
                 {% endfor %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -196,12 +196,12 @@ class NavAppsTests(TestCase):
 
     def test_nav_pill_renders(self):
         resp = self.client.get(reverse("website:index"))
-        self.assertContains(resp, "Readme")
+        self.assertContains(resp, "README")
         self.assertContains(resp, "badge rounded-pill")
 
     def test_nav_pill_renders_with_port(self):
         resp = self.client.get(reverse("website:index"), HTTP_HOST="127.0.0.1:8000")
-        self.assertContains(resp, "Readme")
+        self.assertContains(resp, "README")
 
     def test_app_without_root_url_excluded(self):
         site = Site.objects.get(id=1)


### PR DESCRIPTION
## Summary
- render navbar application pills in uppercase for consistent styling
- adjust tests to match uppercase navigation labels

## Testing
- `python manage.py test website tests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a557e796d083269e6af73aaeecbed0