### PR TITLE
Use active site name for titles and rename default sites

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -12,7 +12,7 @@ class ActiveAppMiddleware:
 
     def __call__(self, request):
         site = get_site(request)
-        active = site.name or "website"
+        active = site.name or "Terminal"
         set_active_app(active)
         request.active_app = active
         try:

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -518,12 +518,6 @@ msgstr ""
 msgid "Register Current"
 msgstr "Registrar anfitrión actual"
 
-#: website/templates/website/base.html:7
-#, fuzzy
-#| msgid "Constellation"
-msgid "Arthexis Constellation"
-msgstr "Constellation"
-
 #: website/templates/website/base.html:67
 #: website/templates/website/login.html:4
 #: website/templates/website/login.html:9

--- a/tests/test_register_site_apps_command.py
+++ b/tests/test_register_site_apps_command.py
@@ -28,7 +28,7 @@ class RegisterSiteAppsCommandTests(TestCase):
         call_command("register_site_apps")
 
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "website")
+        self.assertEqual(site.name, "Terminal")
 
         node = Node.objects.get(hostname=socket.gethostname())
         self.assertFalse(node.enable_public_api)

--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "192.168.129.10",
-      "name": "GWAY-BOX"
+      "name": "Gateway"
     }
   },
   {

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "127.0.0.1",
-      "name": "website"
+      "name": "Terminal"
     }
   }
 ]

--- a/website/management/commands/register_site_apps.py
+++ b/website/management/commands/register_site_apps.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         site, _ = Site.objects.get_or_create(
-            domain="127.0.0.1", defaults={"name": "website"}
+            domain="127.0.0.1", defaults={"name": "Terminal"}
         )
 
         hostname = socket.gethostname()

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{% trans "Arthexis Constellation" %}{% endblock %}</title>
+    <title>{% block title %}{{ badge_site.name|default:"Arthexis" }} {% trans "Constellation" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
       html[data-bs-theme='light'] {

--- a/website/tests.py
+++ b/website/tests.py
@@ -17,7 +17,7 @@ class LoginViewTests(TestCase):
             username="staff", password="pwd", is_staff=True
         )
         self.user = User.objects.create_user(username="user", password="pwd")
-        Site.objects.update_or_create(id=1, defaults={"name": "website"})
+        Site.objects.update_or_create(id=1, defaults={"name": "Terminal"})
 
     def test_login_link_in_navbar(self):
         resp = self.client.get(reverse("website:index"))
@@ -118,7 +118,7 @@ class AdminSidebarTests(TestCase):
 class ReadmeSidebarTests(TestCase):
     def setUp(self):
         self.client = Client()
-        Site.objects.update_or_create(id=1, defaults={"name": "website"})
+        Site.objects.update_or_create(id=1, defaults={"name": "Terminal"})
 
     def test_table_of_contents_sidebar_present(self):
         resp = self.client.get(reverse("website:index"))
@@ -142,7 +142,7 @@ class SiteAdminRegisterCurrentTests(TestCase):
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
-            id=1, defaults={"name": "example", "domain": "example.com"}
+            id=1, defaults={"name": "Constellation", "domain": "arthexis.com"}
         )
 
     def test_register_current_creates_site(self):
@@ -162,7 +162,7 @@ class SiteAdminRegisterCurrentTests(TestCase):
         )
         self.assertRedirects(resp, reverse("admin:website_siteproxy_changelist"))
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "website")
+        self.assertEqual(site.name, "Terminal")
 
 
 class AdminBadgesWebsiteTests(TestCase):
@@ -174,20 +174,20 @@ class AdminBadgesWebsiteTests(TestCase):
         )
         self.client.force_login(self.admin)
         Site.objects.update_or_create(
-            id=1, defaults={"name": "website", "domain": "127.0.0.1"}
+            id=1, defaults={"name": "Terminal", "domain": "127.0.0.1"}
         )
 
     @override_settings(ALLOWED_HOSTS=["127.0.0.1", "testserver"])
     def test_badge_shows_website_for_ip_domain(self):
         resp = self.client.get(reverse("admin:index"), HTTP_HOST="127.0.0.1")
-        self.assertContains(resp, "SITE: website")
+        self.assertContains(resp, "SITE: Terminal")
 
 
 class NavAppsTests(TestCase):
     def setUp(self):
         self.client = Client()
         site, _ = Site.objects.update_or_create(
-            id=1, defaults={"domain": "127.0.0.1", "name": "website"}
+            id=1, defaults={"domain": "127.0.0.1", "name": "Terminal"}
         )
         app = Application.objects.create(name="Readme")
         SiteApplication.objects.create(


### PR DESCRIPTION
## Summary
- display active Site name in page title
- rename default Site fixtures and related tests to Gateway, Terminal, and Constellation
- adjust site registration command and middleware for updated defaults

## Testing
- `django-admin compilemessages`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55818d2e08326a11a22fd912c6e4e