### PR TITLE
Restore admin badge links and normalize clock font

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -109,6 +109,10 @@ document.addEventListener('DOMContentLoaded', function () {
     text-decoration: none;
 }
 .badge-unknown {background-color:#6c757d;}
+#server-clock {
+    font-family: inherit;
+    font-size: inherit;
+}
 #nav-sidebar .module h2 {
     cursor: pointer;
 }
@@ -134,17 +138,27 @@ document.addEventListener('DOMContentLoaded', function () {
 <h1 id="site-name">
   <a href="{% url 'admin:index' %}"><span id="server-clock"></span></a>
     {% if badge_site %}
-      <span class="badge" style="background-color: {{ badge_site_color }};">SITE: {{ badge_site.name }}</span>
+      <span class="badge" style="background-color: {{ badge_site_color }};">
+        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>:
+        <a href="{% url 'admin:website_siteproxy_change' badge_site.pk %}">{{ badge_site.name }}</a>
+      </span>
     {% else %}
-      <span class="badge badge-unknown">SITE: Unknown</span>
+      <span class="badge badge-unknown">
+        <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>: Unknown
+      </span>
     {% endif %}
   {% if badge_node %}
-    <span class="badge" style="background-color: {{ badge_node_color }};">NODE: {{ badge_node.hostname }}</span>
+    <span class="badge" style="background-color: {{ badge_node_color }};">
+      <a href="{% url 'admin:nodes_node_changelist' %}">NODE</a>:
+      <a href="{% url 'admin:nodes_node_change' badge_node.pk %}">{{ badge_node.hostname }}</a>
+    </span>
     {% for role in badge_node.roles.all %}
       <span class="badge" style="background-color: {{ badge_node_color }};">ROLE: {{ role.name }}</span>
     {% endfor %}
   {% else %}
-    <span class="badge badge-unknown">NODE: Unknown</span>
+    <span class="badge badge-unknown">
+      <a href="{% url 'admin:nodes_node_changelist' %}">NODE</a>: Unknown
+    </span>
   {% endif %}
 </h1>
 {% endblock %}

--- a/website/tests.py
+++ b/website/tests.py
@@ -93,6 +93,17 @@ class AdminBadgesTests(TestCase):
         self.assertContains(resp, "badge-unknown")
         self.assertContains(resp, "#6c757d")
 
+    def test_badges_link_to_admin(self):
+        resp = self.client.get(reverse("admin:index"))
+        site_list = reverse("admin:website_siteproxy_changelist")
+        site_change = reverse("admin:website_siteproxy_change", args=[1])
+        node_list = reverse("admin:nodes_node_changelist")
+        node_change = reverse("admin:nodes_node_change", args=[self.node.pk])
+        self.assertContains(resp, f'href="{site_list}"')
+        self.assertContains(resp, f'href="{site_change}"')
+        self.assertContains(resp, f'href="{node_list}"')
+        self.assertContains(resp, f'href="{node_change}"')
+
 
 class AdminSidebarTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- ensure admin header clock uses default font
- restore site and node badge links to changelist and change pages
- test badge links in admin interface

## Testing
- `python manage.py makemigrations --check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a558cbb1f88326b3573d5cc4ad5105