### PR TITLE
Add admin task to download database backup

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -183,7 +183,9 @@ class NodeAdmin(admin.ModelAdmin):
             self.message_user(request, "Unknown node action", messages.ERROR)
             return redirect("..")
         try:
-            action_cls.run(node)
+            result = action_cls.run(node)
+            if hasattr(result, "status_code"):
+                return result
             self.message_user(
                 request,
                 f"{action_cls.display_name} executed successfully",

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -354,6 +354,26 @@ class NodeActionTests(TestCase):
         finally:
             NodeAction.registry.pop("dummyaction", None)
 
+    def test_generate_backup_action_creates_backup(self):
+        hostname = socket.gethostname()
+        node = Node.objects.create(
+            hostname=hostname,
+            address="127.0.0.1",
+            port=8000,
+            mac_address=Node.get_current_mac(),
+        )
+        url = reverse(
+            "admin:nodes_node_action", args=[node.pk, "generate-db-backup"]
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(Backup.objects.count(), 1)
+        backup = Backup.objects.first()
+        path = Path(settings.BASE_DIR) / backup.location
+        if path.exists():
+            path.unlink()
+
 
 
 


### PR DESCRIPTION
## Summary
- add `GenerateBackupAction` node action for downloading database backups
- handle HTTP responses from node actions in admin
- test backup generation via admin action

## Testing
- `python manage.py test nodes`

------
https://chatgpt.com/codex/tasks/task_e_68a559237ff88326a0477c5056a9ce89