### PR TITLE
Use monospace font for admin clock

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function () {
 }
 .badge-unknown {background-color:#6c757d;}
 #server-clock {
-    font-family: inherit;
+    font-family: monospace;
     font-size: inherit;
 }
 #nav-sidebar .module h2 {


### PR DESCRIPTION
## Summary
- use monospace font for admin nav bar clock

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d660c92483269f76fe0c52f21081