### PR TITLE
Display Site name in navbar when available

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -47,7 +47,7 @@
     <div class="container flex-grow-1">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
         <div class="container-fluid">
-          <a class="navbar-brand" href="/">Arthexis</a>
+          <a class="navbar-brand" href="/">{{ badge_site.name|default:"Arthexis" }}</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>

--- a/website/tests.py
+++ b/website/tests.py
@@ -50,6 +50,27 @@ class LoginViewTests(TestCase):
         self.assertRedirects(resp, "/nodes/list/")
 
 
+class NavbarBrandTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        Site.objects.update_or_create(
+            id=1, defaults={"name": "Terminal", "domain": "testserver"}
+        )
+
+    def test_site_name_displayed_when_known(self):
+        resp = self.client.get(reverse("website:index"))
+        self.assertContains(
+            resp, '<a class="navbar-brand" href="/">Terminal</a>'
+        )
+
+    def test_default_brand_when_unknown(self):
+        Site.objects.filter(id=1).update(domain="example.com")
+        resp = self.client.get(reverse("website:index"))
+        self.assertContains(
+            resp, '<a class="navbar-brand" href="/">Arthexis</a>'
+        )
+
+
 class AdminBadgesTests(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
## Summary
- show current Site name in website navbar, falling back to "Arthexis"
- test navbar branding for known and unknown Sites

## Testing
- `python manage.py test website.tests.NavbarBrandTests`
- `python manage.py test website` *(fails: AdminBadgesTests.test_badges_show_site_and_node)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db5a3b7c8326979f0902182ddf25