### PR TITLE
Improve new reference form layout

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -414,6 +414,14 @@ msgstr "Número de serie"
 msgid "No chargers found."
 msgstr ""
 
+#: refs/forms.py:14
+msgid "Value / URL"
+msgstr "Valor / URL"
+
+#: refs/forms.py:15
+msgid "Alt text"
+msgstr "Texto alternativo"
+
 #: refs/templates/refs/landing.html:4
 #: refs/templates/refs/landing.html:7
 msgid "Reference Generator"

--- a/refs/forms.py
+++ b/refs/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import Reference
 
@@ -9,3 +10,11 @@ class ReferenceForm(forms.ModelForm):
     class Meta:
         model = Reference
         fields = ["value", "alt_text"]
+        labels = {
+            "value": _("Value / URL"),
+            "alt_text": _("Alt text"),
+        }
+        widgets = {
+            "value": forms.TextInput(attrs={"class": "form-control"}),
+            "alt_text": forms.TextInput(attrs={"class": "form-control"}),
+        }

--- a/refs/templates/refs/recent.html
+++ b/refs/templates/refs/recent.html
@@ -22,8 +22,15 @@
     <h2>{% trans "New Reference" %}</h2>
     <form method="post" class="card card-body">
       {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit" class="btn btn-primary">{% trans "Create" %}</button>
+      <div class="mb-3">
+        <label for="{{ form.value.id_for_label }}" class="form-label">{{ form.value.label }}</label>
+        {{ form.value }}
+      </div>
+      <div class="mb-3">
+        <label for="{{ form.alt_text.id_for_label }}" class="form-label">{{ form.alt_text.label }}</label>
+        {{ form.alt_text }}
+      </div>
+      <button type="submit" class="btn btn-primary w-100">{% trans "Create" %}</button>
     </form>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Align "New Reference" form inputs vertically with full-width Bootstrap styling
- Rename "Value" field to "Value / URL"
- Add Spanish translations for new labels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61a8f9b088326be30fa01edcbf27e