### PR TITLE
docs: clarify shell script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,27 @@ Arthexis Constellation is a Django-based suite that centralizes tools for managi
 
 ## Shell Scripts
 The project includes helper shell scripts to streamline development:
-- `install.sh` – set up a virtual environment, install dependencies, and optionally configure a systemd service with `--service NAME`.
-- `start.sh [port]` – run the development server on the specified port (default `8888`).
-- `stop.sh [port|--all]` – stop the server on a given port or all running servers.
-- `manage.sh <args>` – execute Django management commands.
-- `command.sh <command> [args...]` – run management commands using hyphenated names (e.g., `./command.sh show-migrations`).
-- `dev-maintenance.sh` – install updated dependencies when requirements change and perform database maintenance tasks.
-- `upgrade.sh` – pull the latest code and reinstall dependencies when needed.
+
+- `install.sh`  \
+  Set up a virtual environment, install dependencies, and optionally configure a systemd service with `--service NAME`.
+
+- `start.sh [port]`  \
+  Run the development server on the specified port (default `8888`).
+
+- `stop.sh [port|--all]`  \
+  Stop the server on a given port or all running servers.
+
+- `manage.sh <args>`  \
+  Execute Django management commands.
+
+- `command.sh <command> [args...]`  \
+  Run management commands using hyphenated names (e.g., `./command.sh show-migrations`).
+
+- `dev-maintenance.sh`  \
+  Install updated dependencies when requirements change and perform database maintenance tasks.
+
+- `upgrade.sh`  \
+  Pull the latest code and reinstall dependencies when needed.
 
 ## VS Code Tasks
 Two tasks are provided in `.vscode/tasks.json`:


### PR DESCRIPTION
## Summary
- improve readability of shell script docs in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a639b03aec832692a0c4c4c4c61c70