### PR TITLE
Enable clickable URLs in recent references view

### DIFF
--- a/refs/templates/refs/recent.html
+++ b/refs/templates/refs/recent.html
@@ -1,5 +1,5 @@
 {% extends "website/base.html" %}
-{% load i18n %}
+{% load i18n ref_tags %}
 
 {% block title %}{% trans "Recent References" %}{% endblock %}
 
@@ -15,7 +15,11 @@
           <small class="text-muted">{{ ref.created|date:"Y-m-d H:i" }}</small>
         </div>
         {% if ref.content_type == 'text' %}
+        {% if ref.value|is_url %}
+        <p class="mb-1"><a href="{{ ref.value }}" target="_blank" rel="noopener noreferrer">{{ ref.value|truncatechars:100 }}</a></p>
+        {% else %}
         <p class="mb-1">{{ ref.value|truncatechars:100 }}</p>
+        {% endif %}
         {% else %}
           {% if ref.file %}
           <img src="{{ ref.file.url }}" alt="{{ ref.alt_text }}" class="img-thumbnail" style="max-width:100px;">

--- a/refs/templatetags/ref_tags.py
+++ b/refs/templatetags/ref_tags.py
@@ -1,6 +1,7 @@
 import base64
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import urlparse
 
 import qrcode
 from django import template
@@ -12,6 +13,16 @@ from django.utils.safestring import mark_safe
 from refs.models import Reference
 
 register = template.Library()
+
+
+@register.filter
+def is_url(value):
+    """Return True if the given value looks like an HTTP/HTTPS URL."""
+    try:
+        result = urlparse(value)
+    except Exception:
+        return False
+    return result.scheme in {"http", "https"} and bool(result.netloc)
 
 
 @register.simple_tag

--- a/refs/tests.py
+++ b/refs/tests.py
@@ -80,6 +80,12 @@ class RecentReferencesTests(TestCase):
         resp = self.client.get(reverse("refs:recent"))
         self.assertContains(resp, "<img", html=False)
 
+    def test_url_value_rendered_as_link(self):
+        Reference.objects.create(value="https://click.com", alt_text="Click")
+        resp = self.client.get(reverse("refs:recent"))
+        self.assertContains(resp, '<a href="https://click.com"', html=False)
+        self.assertContains(resp, 'target="_blank"', html=False)
+
 
 class FooterTemplateTagTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- detect URL text values in recent references
- render URL references as links opening in a new tab
- test URL rendering in recent references page

## Testing
- `python manage.py test` (fails: `ocpp.tests.ChargerSessionPaginationTests.test_session_search_by_date`)
- `python manage.py test refs`


------
https://chatgpt.com/codex/tasks/task_e_68a663bcfc8c832694c16458d2c47bf8