### PR TITLE
Fix seed data admin template access to private model meta

### DIFF
--- a/integrator/admin.py
+++ b/integrator/admin.py
@@ -128,7 +128,14 @@ def seed_data_view(request):
     for model in apps.get_models():
         if issubclass(model, Entity):
             for obj in model.all_objects.filter(is_seed_data=True):
-                seed_items.append((model, obj))
+                seed_items.append(
+                    {
+                        "model_verbose_name": model._meta.verbose_name,
+                        "model_app_label": model._meta.app_label,
+                        "model_name": model._meta.model_name,
+                        "obj": obj,
+                    }
+                )
     if request.method == "POST":
         app_label = request.POST["app"]
         model_name = request.POST["model"]

--- a/integrator/templates/admin/seed_data.html
+++ b/integrator/templates/admin/seed_data.html
@@ -13,17 +13,17 @@
     </tr>
   </thead>
   <tbody>
-  {% for model, obj in seed_items %}
+  {% for item in seed_items %}
     <tr>
-      <td>{{ model._meta.verbose_name }}</td>
-      <td>{{ obj }}</td>
-      <td>{% if obj.is_deleted %}Deleted{% else %}Active{% endif %}</td>
+      <td>{{ item.model_verbose_name }}</td>
+      <td>{{ item.obj }}</td>
+      <td>{% if item.obj.is_deleted %}Deleted{% else %}Active{% endif %}</td>
       <td>
-        {% if obj.is_deleted %}
+        {% if item.obj.is_deleted %}
         <form method="post" style="display:inline">{% csrf_token %}
-          <input type="hidden" name="app" value="{{ model._meta.app_label }}">
-          <input type="hidden" name="model" value="{{ model._meta.model_name }}">
-          <input type="hidden" name="pk" value="{{ obj.pk }}">
+          <input type="hidden" name="app" value="{{ item.model_app_label }}">
+          <input type="hidden" name="model" value="{{ item.model_name }}">
+          <input type="hidden" name="pk" value="{{ item.obj.pk }}">
           <button type="submit" class="button">Reinstall</button>
         </form>
         {% endif %}


### PR DESCRIPTION
## Summary
- Avoid direct `_meta` access in seed data admin page by passing model metadata from view
- Update template to use provided metadata

## Testing
- `python manage.py test integrator`
- `python manage.py makemigrations integrator --check --dry-run`
- `python manage.py test` *(fails: test_session_search_by_date)*

------
https://chatgpt.com/codex/tasks/task_e_68a663cdc0108326a64c15f65bc1f35e