### PR TITLE
fix: support python3 in env-refresh.sh

### DIFF
--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -2,8 +2,19 @@
 set -e
 
 VENV_DIR=".venv"
+
+# Determine which Python executable is available
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_CMD="python"
+else
+  echo "Python interpreter not found" >&2
+  exit 1
+fi
+
 if [ ! -d "$VENV_DIR" ]; then
-  python -m venv "$VENV_DIR"
+  "$PYTHON_CMD" -m venv "$VENV_DIR"
 fi
 
 PYTHON="$VENV_DIR/bin/python"


### PR DESCRIPTION
## Summary
- ensure `env-refresh.sh` uses `python3` when `python` command is missing

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6878212648326b5faf5602198f1b5