### PR TITLE
Allow arthexis.com domain in ALLOWED_HOSTS

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -66,6 +66,8 @@ ALLOWED_HOSTS = [
     "testserver",
     "10.42.0.0/16",
     "192.168.0.0/16",
+    "www.arthexis.com",
+    "arthexis.com",
 ]
 
 


### PR DESCRIPTION
## Summary
- add www.arthexis.com and arthexis.com to ALLOWED_HOSTS to accept requests for the production domain

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68af9f26c8326adf3c51e02eb598c