### PR TITLE
Enable IRQ-based background RFID reading

### DIFF
--- a/rfid/apps.py
+++ b/rfid/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class RfidConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "rfid"
+
+    def ready(self):  # pragma: no cover - startup side effects
+        from .background_reader import start
+
+        start()

--- a/rfid/background_reader.py
+++ b/rfid/background_reader.py
@@ -1,0 +1,99 @@
+"""Background RFID reader using IRQ pin events."""
+import atexit
+import logging
+import os
+import queue
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - hardware dependent
+    import RPi.GPIO as GPIO  # type: ignore
+except Exception:  # pragma: no cover - hardware dependent
+    GPIO = None  # type: ignore
+
+IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", "4"))
+_tag_queue: "queue.Queue[dict]" = queue.Queue()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_reader = None
+
+
+def _irq_callback(channel):  # pragma: no cover - hardware dependent
+    from .reader import read_rfid
+
+    result = read_rfid(mfrc=_reader, cleanup=False)
+    _tag_queue.put(result)
+
+
+def _setup_hardware():  # pragma: no cover - hardware dependent
+    global _reader
+    if GPIO is None:
+        logger.warning("GPIO library not available; RFID reader disabled")
+        return False
+    try:
+        from mfrc522 import MFRC522  # type: ignore
+    except Exception as exc:
+        logger.warning("MFRC522 library not available: %s", exc)
+        return False
+
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(IRQ_PIN, GPIO.IN)
+
+    _reader = MFRC522()
+    try:
+        # Enable interrupts for card detection (best effort)
+        _reader.dev_write(_reader.ComIEnReg, 0xA0)  # enable IdleIrq
+        _reader.dev_write(_reader.ComIrqReg, 0x7F)
+    except Exception:
+        pass
+
+    GPIO.add_event_detect(IRQ_PIN, GPIO.FALLING, callback=_irq_callback)
+    return True
+
+
+def _worker():  # pragma: no cover - background thread
+    if not _setup_hardware():
+        return
+    while not _stop_event.is_set():
+        _stop_event.wait(0.5)
+    if GPIO:
+        try:
+            GPIO.remove_event_detect(IRQ_PIN)
+            GPIO.cleanup()
+        except Exception:
+            pass
+
+
+def start():
+    """Start the background RFID reader."""
+    global _thread
+    if GPIO is None:
+        return
+    if _thread and _thread.is_alive():
+        return
+    _stop_event.clear()
+    _thread = threading.Thread(target=_worker, name="rfid-reader", daemon=True)
+    _thread.start()
+    atexit.register(stop)
+
+
+def stop():
+    """Stop the background RFID reader and cleanup GPIO."""
+    _stop_event.set()
+    if _thread:
+        _thread.join(timeout=1)
+    if GPIO:
+        try:
+            GPIO.cleanup()
+        except Exception:
+            pass
+
+
+def get_next_tag(timeout: float = 0) -> Optional[dict]:
+    """Retrieve the next tag read from the queue."""
+    try:
+        return _tag_queue.get(timeout=timeout)
+    except queue.Empty:
+        return None

--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -1,0 +1,45 @@
+import time
+from accounts.models import RFID
+
+
+def read_rfid(mfrc=None, cleanup=True) -> dict:
+    """Read a single RFID tag using the MFRC522 reader."""
+    try:
+        if mfrc is None:
+            from mfrc522 import MFRC522  # type: ignore
+            mfrc = MFRC522()
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        return {"error": str(exc)}
+
+    try:
+        import RPi.GPIO as GPIO  # pragma: no cover - hardware dependent
+    except Exception:  # pragma: no cover - hardware dependent
+        GPIO = None
+
+    try:
+        timeout = time.time() + 1
+        while time.time() < timeout:  # pragma: no cover - hardware loop
+            (status, _tag_type) = mfrc.MFRC522_Request(mfrc.PICC_REQIDL)
+            if status == mfrc.MI_OK:
+                (status, uid) = mfrc.MFRC522_Anticoll()
+                if status == mfrc.MI_OK:
+                    rfid = "".join(f"{x:02X}" for x in uid[:5])
+                    tag, created = RFID.objects.get_or_create(rfid=rfid)
+                    return {
+                        "rfid": rfid,
+                        "label_id": tag.pk,
+                        "created": created,
+                        "color": tag.color,
+                        "allowed": tag.allowed,
+                        "released": tag.released,
+                    }
+            time.sleep(0.2)
+        return {"rfid": None, "label_id": None}
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        return {"error": str(exc)}
+    finally:  # pragma: no cover - cleanup hardware
+        if cleanup and GPIO:
+            try:
+                GPIO.cleanup()
+            except Exception:
+                pass

--- a/rfid/views.py
+++ b/rfid/views.py
@@ -3,57 +3,16 @@ from django.shortcuts import render
 from website.utils import landing
 from django.urls import reverse
 
-from accounts.models import RFID
-
-
-def read_rfid() -> dict:
-    """Read a single RFID tag using the MFRC522 reader."""
-    try:
-        from mfrc522 import MFRC522  # type: ignore
-    except Exception as exc:  # pragma: no cover - hardware dependent
-        return {"error": str(exc)}
-
-    import time
-    try:
-        import RPi.GPIO as GPIO  # pragma: no cover - hardware dependent
-    except Exception:  # pragma: no cover - hardware dependent
-        GPIO = None
-
-    try:
-        mfrc = MFRC522()
-        timeout = time.time() + 1
-        while time.time() < timeout:  # pragma: no cover - hardware loop
-            (status, _tag_type) = mfrc.MFRC522_Request(mfrc.PICC_REQIDL)
-            if status == mfrc.MI_OK:
-                (status, uid) = mfrc.MFRC522_Anticoll()
-                if status == mfrc.MI_OK:
-                    rfid = "".join(f"{x:02X}" for x in uid[:5])
-                    tag, created = RFID.objects.get_or_create(rfid=rfid)
-                    return {
-                        "rfid": rfid,
-                        "label_id": tag.pk,
-                        "created": created,
-                        "color": tag.color,
-                        "allowed": tag.allowed,
-                        "released": tag.released,
-                    }
-            time.sleep(0.2)
-        return {"rfid": None, "label_id": None}
-    except Exception as exc:  # pragma: no cover - hardware dependent
-        return {"error": str(exc)}
-    finally:  # pragma: no cover - cleanup hardware
-        if GPIO:
-            try:
-                GPIO.cleanup()
-            except Exception:
-                pass
+from .background_reader import get_next_tag
 
 
 def scan_next(_request):
     """Return the next scanned RFID tag."""
-    result = read_rfid()
-    if result.get("error"):
+    result = get_next_tag()
+    if result and result.get("error"):
         return JsonResponse({"error": result["error"]}, status=500)
+    if not result:
+        result = {"rfid": None, "label_id": None}
     return JsonResponse(result)
 
 


### PR DESCRIPTION
## Summary
- add IRQ-driven background RFID reader thread
- expose queue consumer for RFID views
- start reader on app ready and ensure cleanup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a68f6164d88326bf752bef4b44393b