### PR TITLE
Avoid GPIO cleanup when uninitialized

### DIFF
--- a/rfid/background_reader.py
+++ b/rfid/background_reader.py
@@ -94,7 +94,8 @@ def stop():
         _thread.join(timeout=1)
     if GPIO:
         try:
-            GPIO.cleanup()
+            if GPIO.getmode() is not None:  # Only cleanup if GPIO was initialized
+                GPIO.cleanup()
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- guard `GPIO.cleanup` with a mode check to avoid warnings when no pins were configured

## Testing
- `./env-refresh.sh`
- `./manage.sh test` *(fails: AttributeError: <module 'rfid.views' ...> does not have the attribute 'read_rfid')*


------
https://chatgpt.com/codex/tasks/task_e_68a74904b4c88326a3a513008ba94bc8