### PR TITLE
Improve RFID IRQ handling

### DIFF
--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -1,18 +1,25 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+import os
+import django
+from django.test import SimpleTestCase
 from django.urls import reverse
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
 
-class ScanNextViewTests(TestCase):
-    @patch("rfid.views.read_rfid", return_value={"rfid": "ABCD1234", "label_id": 1, "created": False})
-    def test_scan_next_success(self, mock_read):
+
+class ScanNextViewTests(SimpleTestCase):
+    @patch("utils.sites.get_site")
+    @patch("rfid.views.get_next_tag", return_value={"rfid": "ABCD1234", "label_id": 1, "created": False})
+    def test_scan_next_success(self, mock_get, mock_site):
         resp = self.client.get(reverse("rfid-scan-next"))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"rfid": "ABCD1234", "label_id": 1, "created": False})
 
-    @patch("rfid.views.read_rfid", return_value={"error": "boom"})
-    def test_scan_next_error(self, mock_read):
+    @patch("utils.sites.get_site")
+    @patch("rfid.views.get_next_tag", return_value={"error": "boom"})
+    def test_scan_next_error(self, mock_get, mock_site):
         resp = self.client.get(reverse("rfid-scan-next"))
         self.assertEqual(resp.status_code, 500)
         self.assertEqual(resp.json(), {"error": "boom"})


### PR DESCRIPTION
## Summary
- add logging and IRQ pin pull-up for RFID reader
- add polling fallback when no IRQ events are queued
- update tests for new background reader API

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings pytest rfid/tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a75443e3ac83269722a39db875a813