### PR TITLE
Adjust navbar styling in light mode

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -112,6 +112,24 @@
         toggle.setAttribute('aria-label', theme === 'dark' ? '{% trans "Light Mode" %}' : '{% trans "Dark Mode" %}');
         icon.setAttribute('href', theme === 'dark' ? '#icon-sun' : '#icon-moon');
         icon.setAttribute('xlink:href', theme === 'dark' ? '#icon-sun' : '#icon-moon');
+
+        const navbar = document.querySelector('nav.navbar');
+        const buttons = document.querySelectorAll('.toolbar .btn');
+        if (theme === 'light') {
+          navbar.classList.remove('navbar-dark', 'bg-dark');
+          navbar.classList.add('navbar-light', 'bg-white');
+          buttons.forEach(btn => {
+            btn.classList.remove('btn-outline-light');
+            btn.classList.add('btn-outline-dark');
+          });
+        } else {
+          navbar.classList.remove('navbar-light', 'bg-white');
+          navbar.classList.add('navbar-dark', 'bg-dark');
+          buttons.forEach(btn => {
+            btn.classList.remove('btn-outline-dark');
+            btn.classList.add('btn-outline-light');
+          });
+        }
       }
 
       function toggleTheme() {


### PR DESCRIPTION
## Summary
- Switch navbar to light styling when the site is in light mode
- Toggle buttons to dark outlines for better contrast

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76a9ec97c83268266e7c28c74c496