### PR TITLE
Fix dark mode coloring for toolbar icons

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -19,6 +19,9 @@
           max-width: 90%;
         }
       }
+      .toolbar svg {
+        fill: currentColor;
+      }
       nav.toc {
         position: sticky;
         top: 1rem;


### PR DESCRIPTION
## Summary
- ensure navbar toolbar SVG icons inherit current text color so admin and theme icons appear white in dark mode

## Testing
- `python manage.py test website`


------
https://chatgpt.com/codex/tasks/task_e_68a773a34d64832697512f8cf785b4fe