### PR TITLE
Refactor RFID scanning to drop duration tracking

### DIFF
--- a/rfid/background_reader.py
+++ b/rfid/background_reader.py
@@ -4,7 +4,6 @@ import logging
 import os
 import queue
 import threading
-import time
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -19,14 +18,12 @@ _tag_queue: "queue.Queue[dict]" = queue.Queue()
 _thread: Optional[threading.Thread] = None
 _stop_event = threading.Event()
 _reader = None
-_current: Optional[dict] = None
 
 
 def _irq_callback(channel):  # pragma: no cover - hardware dependent
     logger.debug("IRQ callback triggered on channel %s", channel)
     from .reader import read_rfid
 
-    global _current
     result = read_rfid(mfrc=_reader, cleanup=False)
     if result.get("error"):
         logger.warning("RFID read error via IRQ: %s", result["error"])
@@ -35,20 +32,6 @@ def _irq_callback(channel):  # pragma: no cover - hardware dependent
         try:
             _reader.dev_write(_reader.ComIrqReg, 0x7F)
         except Exception:  # pragma: no cover - hardware dependent
-            pass
-        result["start"] = time.time()
-        result["duration"] = 0
-        result["last_notified"] = 0
-        _current = result
-        try:
-            from nodes.notifications import notify
-
-            status_text = "OK" if result.get("allowed") else "Not OK"
-            color_char = (result.get("color") or "")[:1].upper()
-            line1 = f"RFID {result['label_id']} {status_text} {color_char}".strip()
-            line2 = f"{result['rfid']} 0s"
-            notify(line1, line2)
-        except Exception:  # pragma: no cover - notifications best effort
             pass
     _tag_queue.put(result)
 
@@ -118,11 +101,9 @@ def start():
 
 def stop():
     """Stop the background RFID reader and cleanup GPIO."""
-    global _current
     _stop_event.set()
     if _thread:
         _thread.join(timeout=1)
-    _current = None
     if GPIO:
         try:
             if GPIO.getmode() is not None:  # Only cleanup if GPIO was initialized
@@ -136,57 +117,17 @@ def get_next_tag(timeout: float = 0) -> Optional[dict]:
 
     Falls back to direct polling if no IRQ events are queued.
     """
-    global _current
     try:
-        tag = _tag_queue.get(timeout=timeout)
-        if tag and tag.get("rfid"):
-            _current = tag
-        return tag
+        return _tag_queue.get(timeout=timeout)
     except queue.Empty:
         logger.debug("IRQ queue empty; falling back to direct read")
         try:
             from .reader import read_rfid
 
-            if _current:
-                res = read_rfid(mfrc=_reader, cleanup=False, timeout=0.1)
-                if res.get("rfid") == _current.get("rfid"):
-                    duration = int(time.time() - _current["start"])
-                    if duration > _current.get("last_notified", 0):
-                        try:
-                            from nodes.notifications import notify
-
-                            status_text = "OK" if _current.get("allowed") else "Not OK"
-                            color_char = (_current.get("color") or "")[:1].upper()
-                            line1 = f"RFID {_current['label_id']} {status_text} {color_char}".strip()
-                            line2 = f"{_current['rfid']} {duration}s"
-                            notify(line1, line2)
-                        except Exception:  # pragma: no cover
-                            pass
-                        _current["last_notified"] = duration
-                    _current["duration"] = duration
-                    return _current
-                else:
-                    duration = int(time.time() - _current["start"])
-                    if duration >= 0 and duration > _current.get("last_notified", 0):
-                        try:
-                            from nodes.notifications import notify
-
-                            status_text = "OK" if _current.get("allowed") else "Not OK"
-                            color_char = (_current.get("color") or "")[:1].upper()
-                            line1 = f"RFID {_current['label_id']} {status_text} {color_char}".strip()
-                            line2 = f"{_current['rfid']} {duration}s"
-                            notify(line1, line2)
-                        except Exception:  # pragma: no cover
-                            pass
-                    _current["duration"] = duration
-                    result = _current
-                    _current = None
-                    return result
-            else:
-                res = read_rfid(mfrc=_reader, cleanup=False)
-                if res.get("rfid") or res.get("error"):
-                    logger.debug("Polling read result: %s", res)
-                    return res
+            res = read_rfid(mfrc=_reader, cleanup=False)
+            if res.get("rfid") or res.get("error"):
+                logger.debug("Polling read result: %s", res)
+                return res
         except Exception as exc:  # pragma: no cover - hardware dependent
             logger.debug("Polling read failed: %s", exc)
         return None

--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -50,9 +50,10 @@ def read_rfid(mfrc=None, cleanup=True, timeout: float = 1.0) -> dict:
                         from nodes.notifications import notify
 
                         status_text = "OK" if tag.allowed else "Not OK"
-                        color_char = (tag.color or "")[:1].upper()
-                        line1 = f"RFID {tag.label_id} {status_text} {color_char}".strip()
-                        line2 = f"{rfid} 0s"
+                        privacy = "PUB" if tag.released else "PRIV"
+                        color_word = (tag.color or "").upper()
+                        line1 = f"RFID {tag.label_id} {status_text} {privacy}".strip()
+                        line2 = f"{rfid} {color_word}".strip()
                         notify(line1, line2)
                     except Exception:
                         pass

--- a/rfid/templates/rfid/scanner.html
+++ b/rfid/templates/rfid/scanner.html
@@ -55,7 +55,7 @@
         return;
       } else if(data.rfid){
         labelEl.textContent = data.label_id;
-        rfidEl.textContent = data.rfid ? `${data.rfid} ${data.duration || 0}s` : '';
+        rfidEl.textContent = data.rfid || '';
         colorEl.textContent = data.color || '';
         allowedEl.textContent = data.allowed === undefined ? '' : (data.allowed ? 'Yes' : 'No');
         releasedEl.textContent = data.released === undefined ? '' : (data.released ? 'Yes' : 'No');

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -54,7 +54,7 @@ class ReaderNotificationTests(TestCase):
         self.assertEqual(result["label_id"], 1)
         self.assertTrue(result.get("source"))
         mock_notify.assert_called_once_with(
-            "RFID 1 OK B", f"{result['rfid']} 0s"
+            "RFID 1 OK PRIV", f"{result['rfid']} BLACK"
         )
 
     @patch("nodes.notifications.notify")
@@ -65,7 +65,7 @@ class ReaderNotificationTests(TestCase):
 
         result = read_rfid(mfrc=self._mock_reader(), cleanup=False)
         mock_notify.assert_called_once_with(
-            "RFID 2 Not OK B", f"{result['rfid']} 0s"
+            "RFID 2 Not OK PRIV", f"{result['rfid']} BLACK"
         )
         self.assertTrue(result.get("source"))
 


### PR DESCRIPTION
## Summary
- simplify background RFID reader by removing duration tracking and returning tags immediately
- show PUB/PRIV and card color in LCD notifications instead of Black/White with timers
- drop duration from web scanner display and update tests

## Testing
- `python manage.py test rfid -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a78ea162e48326bdd2c596bd4f993e