### PR TITLE
Add manual RFID wiring check with view button

### DIFF
--- a/rfid/irq_wiring_check.py
+++ b/rfid/irq_wiring_check.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, ANY
+
+from rfid.background_reader import _setup_hardware, IRQ_PIN
+
+
+class IRQPinSetupManualTest(TestCase):
+    """Manual test to ensure IRQ pin setup uses the expected GPIO pin."""
+
+    def test_irq_pin_setup(self):
+        with patch("rfid.background_reader.GPIO") as mock_gpio, \
+             patch.dict("sys.modules", {"mfrc522": MagicMock(MFRC522=MagicMock())}):
+            _setup_hardware()
+            mock_gpio.setmode.assert_called_once_with(mock_gpio.BCM)
+            mock_gpio.setup.assert_called_once_with(
+                IRQ_PIN, mock_gpio.IN, pull_up_down=mock_gpio.PUD_UP
+            )
+            mock_gpio.add_event_detect.assert_called_once_with(
+                IRQ_PIN, mock_gpio.FALLING, callback=ANY
+            )
+
+
+def check_irq_pin():
+    """Return the IRQ pin used by the reader."""
+    return {"irq_pin": IRQ_PIN}

--- a/rfid/templates/rfid/reader.html
+++ b/rfid/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "website/base.html" %}
 {% block content %}
 <h1>RFID Reader</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url %}
+{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url %}
 {% endblock %}

--- a/rfid/templates/rfid/scanner.html
+++ b/rfid/templates/rfid/scanner.html
@@ -4,6 +4,7 @@
   <p>
     <button id="{{ prefix }}-retry" style="display: none;">Try Again</button>
     <button id="{{ prefix }}-restart">Restart Scanner</button>
+    <button id="{{ prefix }}-test">Test Scanner</button>
   </p>
   <div class="field"><span class="label">Label:</span><span class="value" id="{{ prefix }}-label"></span></div>
   <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
@@ -39,6 +40,7 @@
   const releasedEl = document.getElementById('{{ prefix }}-released');
   const retryBtn = document.getElementById('{{ prefix }}-retry');
   const restartBtn = document.getElementById('{{ prefix }}-restart');
+  const testBtn = document.getElementById('{{ prefix }}-test');
 
   function showError(message){
     console.error(message);
@@ -78,6 +80,19 @@
       statusEl.textContent = 'Scanner restarted';
     } catch(err) {
       console.error(err);
+    }
+  });
+  testBtn.addEventListener('click', async () => {
+    try {
+      const resp = await fetch('{{ test_url }}');
+      const data = await resp.json();
+      if(data.error){
+        statusEl.textContent = `Error: ${data.error}`;
+      } else {
+        statusEl.textContent = `IRQ pin ${data.irq_pin}`;
+      }
+    } catch(err) {
+      statusEl.textContent = 'Test failed';
     }
   });
   poll();

--- a/rfid/urls.py
+++ b/rfid/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path("", views.reader, name="rfid-reader"),
     path("scan/next/", views.scan_next, name="rfid-scan-next"),
     path("scan/restart/", views.scan_restart, name="rfid-scan-restart"),
+    path("scan/test/", views.scan_test, name="rfid-scan-test"),
 ]

--- a/rfid/views.py
+++ b/rfid/views.py
@@ -5,6 +5,7 @@ from django.views.decorators.http import require_POST
 from website.utils import landing
 
 from .scanner import scan_sources, restart_sources
+from .irq_wiring_check import check_irq_pin
 
 
 def scan_next(_request):
@@ -22,11 +23,19 @@ def scan_restart(_request):
     return JsonResponse(result, status=status)
 
 
+def scan_test(_request):
+    """Report wiring information for the RFID scanner."""
+    result = check_irq_pin()
+    status = 500 if result.get("error") else 200
+    return JsonResponse(result, status=status)
+
+
 @landing("RFID Reader")
 def reader(request):
     """Public page to read RFID tags."""
     context = {
         "scan_url": reverse("rfid-scan-next"),
         "restart_url": reverse("rfid-scan-restart"),
+        "test_url": reverse("rfid-scan-test"),
     }
     return render(request, "rfid/reader.html", context)


### PR DESCRIPTION
## Summary
- add manual IRQ pin wiring test helper
- expose wiring info via new `/scan/test/` endpoint and button in RFID reader view

## Testing
- `pytest rfid/tests.py`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a78e5a9b9c8326a253a18923985e40