### PR TITLE
Refactor notifications for subject/body with independent scrolling

### DIFF
--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -15,7 +15,7 @@ def _startup_notification() -> None:
     """
 
     try:  # import here to avoid circular import during app loading
-        from .notifications import notify
+        from .notifications import notify, manager
     except Exception:  # pragma: no cover - failure shouldn't break startup
         return
 
@@ -36,13 +36,13 @@ def _startup_notification() -> None:
     revision = ""
     rev_path = Path(settings.BASE_DIR) / "REVISION"
     if rev_path.exists():
-        revision = rev_path.read_text().strip()[-4:]
+        revision = rev_path.read_text().strip()[-6:]
 
-    line2 = f"v{version}"
-    if revision:
-        line2 += f" r{revision}"
+    body = f"v{version}"
+    if manager.lcd and revision:
+        body += f" r{revision}"
 
-    notify(f"{address}:{port}", line2)
+    notify(f"{address}:{port}", body)
 
 
 class NodesConfig(AppConfig):

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -414,11 +414,12 @@ class NotificationDisplayTests(TestCase):
     def test_long_message_scrolls(self, mock_init, mock_thread):
         mock_thread.return_value.start = lambda: None
         manager = NotificationManager()
-        note_text = "a" * 40
-        manager.send(note_text)
+        subject = "a" * 20
+        body = "b" * 30
+        manager.send(subject, body)
         note = manager.queue.get_nowait()
-        self.assertEqual(note.line1, "a" * 16)
-        self.assertEqual(note.line2, "a" * 24)
+        self.assertEqual(note.subject, subject)
+        self.assertEqual(note.body, body)
         fake_time, fake_sleep = _fake_time_factory()
         with patch("nodes.notifications.time.time", fake_time), patch(
             "nodes.notifications.time.sleep", fake_sleep
@@ -426,9 +427,10 @@ class NotificationDisplayTests(TestCase):
             manager.lcd.clear.reset_mock()
             manager.lcd.write.reset_mock()
             manager._lcd_display(note, duration=1)
-        manager.lcd.write.assert_any_call(0, 0, "a" * 16)
+        top_calls = [c for c in manager.lcd.write.call_args_list if c[0][1] == 0]
         bottom_calls = [c for c in manager.lcd.write.call_args_list if c[0][1] == 1]
-        self.assertTrue(bottom_calls)
+        self.assertTrue(len(top_calls) > 1)
+        self.assertTrue(len(bottom_calls) > 1)
 
 
 

--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -52,9 +52,9 @@ def read_rfid(mfrc=None, cleanup=True, timeout: float = 1.0) -> dict:
                         status_text = "OK" if tag.allowed else "Not OK"
                         privacy = "PUB" if tag.released else "PRIV"
                         color_word = (tag.color or "").upper()
-                        line1 = f"RFID {tag.label_id} {status_text} {privacy}".strip()
-                        line2 = f"{rfid} {color_word}".strip()
-                        notify(line1, line2)
+                        subject = f"RFID {tag.label_id} {status_text} {privacy}".strip()
+                        body = f"{rfid} {color_word}".strip()
+                        notify(subject, body)
                     except Exception:
                         pass
                     return result


### PR DESCRIPTION
## Summary
- show git revision (last 6 chars) on LCD at startup when available
- switch notifications to subject/body format with independent scrolling
- send GUI fallback notifications when no LCD

## Testing
- `pytest nodes/tests.py` (fails: django.db.utils.OperationalError: no such table: django_session)

------
https://chatgpt.com/codex/tasks/task_e_68a7ac92c4ac83269f70568a083fe129