### PR TITLE
Report missing scanner in RFID IRQ pin test

### DIFF
--- a/rfid/irq_wiring_check.py
+++ b/rfid/irq_wiring_check.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, ANY
 
-from rfid.background_reader import _setup_hardware, IRQ_PIN
+from rfid.background_reader import _setup_hardware, IRQ_PIN, GPIO
 
 
 class IRQPinSetupManualTest(TestCase):
@@ -21,5 +21,15 @@ class IRQPinSetupManualTest(TestCase):
 
 
 def check_irq_pin():
-    """Return the IRQ pin used by the reader."""
+    """Return the IRQ pin used by the reader or report if none is detected."""
+    if not _setup_hardware():
+        return {"error": "no scanner detected"}
+
+    if GPIO:
+        try:  # pragma: no cover - hardware cleanup
+            GPIO.remove_event_detect(IRQ_PIN)
+            GPIO.cleanup()
+        except Exception:
+            pass
+
     return {"irq_pin": IRQ_PIN}

--- a/rfid/templates/rfid/scanner.html
+++ b/rfid/templates/rfid/scanner.html
@@ -2,9 +2,7 @@
   <div id="{{ prefix }}-scanner">
   <p id="{{ prefix }}-status">Scanner ready</p>
   <p>
-    <button id="{{ prefix }}-retry" style="display: none;">Try Again</button>
-    <button id="{{ prefix }}-restart">Restart Scanner</button>
-    <button id="{{ prefix }}-test">Test Scanner</button>
+    <button id="{{ prefix }}-restart-test">Restart &amp; Test Scanner</button>
   </p>
   <div class="field"><span class="label">Label:</span><span class="value" id="{{ prefix }}-label"></span></div>
   <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
@@ -38,14 +36,11 @@
   const colorEl = document.getElementById('{{ prefix }}-color');
   const allowedEl = document.getElementById('{{ prefix }}-allowed');
   const releasedEl = document.getElementById('{{ prefix }}-released');
-  const retryBtn = document.getElementById('{{ prefix }}-retry');
-  const restartBtn = document.getElementById('{{ prefix }}-restart');
-  const testBtn = document.getElementById('{{ prefix }}-test');
+  const restartTestBtn = document.getElementById('{{ prefix }}-restart-test');
 
   function showError(message){
     console.error(message);
-    statusEl.textContent = 'RFID reader not detected. Please connect the reader and press Try Again.';
-    retryBtn.style.display = 'inline-block';
+    statusEl.textContent = 'RFID reader not detected. Please connect the reader and press Restart & Test Scanner.';
   }
 
   async function poll(){
@@ -69,27 +64,16 @@
     }
     setTimeout(poll, 200);
   }
-  retryBtn.addEventListener('click', () => {
-    retryBtn.style.display = 'none';
-    statusEl.textContent = 'Scanner ready';
-    poll();
-  });
-  restartBtn.addEventListener('click', async () => {
+  restartTestBtn.addEventListener('click', async () => {
     try {
       await fetch('{{ restart_url }}', {method: 'POST'});
-      statusEl.textContent = 'Scanner restarted';
-    } catch(err) {
-      console.error(err);
-    }
-  });
-  testBtn.addEventListener('click', async () => {
-    try {
       const resp = await fetch('{{ test_url }}');
       const data = await resp.json();
       if(data.error){
         statusEl.textContent = `Error: ${data.error}`;
       } else {
         statusEl.textContent = `IRQ pin ${data.irq_pin}`;
+        poll();
       }
     } catch(err) {
       statusEl.textContent = 'Test failed';

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -78,3 +78,21 @@ class RestartViewTests(SimpleTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"status": "restarted"})
         mock_restart.assert_called_once()
+
+
+class ScanTestViewTests(SimpleTestCase):
+    @patch("config.middleware.get_site")
+    @patch("rfid.irq_wiring_check.GPIO")
+    @patch("rfid.irq_wiring_check.IRQ_PIN", new=7)
+    @patch("rfid.irq_wiring_check._setup_hardware", return_value=True)
+    def test_scan_test_success(self, mock_setup, mock_gpio, mock_site):
+        resp = self.client.get(reverse("rfid-scan-test"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"irq_pin": 7})
+
+    @patch("config.middleware.get_site")
+    @patch("rfid.irq_wiring_check._setup_hardware", return_value=False)
+    def test_scan_test_error(self, mock_setup, mock_site):
+        resp = self.client.get(reverse("rfid-scan-test"))
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"error": "no scanner detected"})


### PR DESCRIPTION
## Summary
- Detect absence of RFID scanner in IRQ pin test endpoint and report an error instead of always showing pin 4
- Clean up GPIO resources after test run
- Add tests for success and missing-scanner scenarios
- Simplify RFID scanner UI by replacing multiple control buttons with a single **Restart & Test Scanner** button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7acf7053483268a02294077759a42