### PR TITLE
Support remote RFID scanner fallback

### DIFF
--- a/rfid/fixtures/rfid_sources.json
+++ b/rfid/fixtures/rfid_sources.json
@@ -9,5 +9,16 @@
       "proxy_url": null,
       "uuid": "00000000-0000-0000-0000-000000000001"
     }
+  },
+  {
+    "model": "accounts.rfidsource",
+    "pk": 2,
+    "fields": {
+      "name": "gway-001",
+      "endpoint": "scanner",
+      "default_order": 1,
+      "proxy_url": "http://192.168.129.10:8888",
+      "uuid": null
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- preload both local and gway-001 RFID sources via fixtures
- build web-service URLs with `_build_url` and fall back to remote scanner when local fails
- add tests covering scanner selection and API view behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7cdf43ca08326b26e57f582162870