### PR TITLE
Align AWG calculator input and select field heights

### DIFF
--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -2,8 +2,14 @@
 {% load static i18n %}
 {% block title %}{% trans "AWG Calculator" %}{% endblock %}
 {% block content %}
+<style>
+  /* Ensure input fields match select field height for uniform columns */
+  #awg-calculator input.form-control {
+    height: calc(2.25rem + 2px);
+  }
+</style>
 <h1>{% trans "Cable & Conduit Calculator" %}</h1>
-<form method="post">
+<form method="post" id="awg-calculator">
   {% csrf_token %}
   <div class="row g-4 mb-3">
     <div class="col-lg-3">


### PR DESCRIPTION
## Summary
- Ensure numeric and text inputs in the AWG calculator match select field height using a scoped CSS rule

## Testing
- `python manage.py test awg`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3c37bf48326bf9383c6fa18de2a