### PR TITLE
Use INT and BAD for RFID notifications

### DIFF
--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -49,8 +49,8 @@ def read_rfid(mfrc=None, cleanup=True, timeout: float = 1.0) -> dict:
                     try:
                         from nodes.notifications import notify
 
-                        status_text = "OK" if tag.allowed else "Not OK"
-                        privacy = "PUB" if tag.released else "PRIV"
+                        status_text = "OK" if tag.allowed else "BAD"
+                        privacy = "PUB" if tag.released else "INT"
                         color_word = (tag.color or "").upper()
                         subject = f"RFID {tag.label_id} {status_text} {privacy}".strip()
                         body = f"{rfid} {color_word}".strip()

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -54,7 +54,7 @@ class ReaderNotificationTests(TestCase):
         self.assertEqual(result["label_id"], 1)
         self.assertTrue(result.get("source"))
         mock_notify.assert_called_once_with(
-            "RFID 1 OK PRIV", f"{result['rfid']} BLACK"
+            "RFID 1 OK INT", f"{result['rfid']} BLACK"
         )
 
     @patch("nodes.notifications.notify")
@@ -65,7 +65,7 @@ class ReaderNotificationTests(TestCase):
 
         result = read_rfid(mfrc=self._mock_reader(), cleanup=False)
         mock_notify.assert_called_once_with(
-            "RFID 2 Not OK PRIV", f"{result['rfid']} BLACK"
+            "RFID 2 BAD INT", f"{result['rfid']} BLACK"
         )
         self.assertTrue(result.get("source"))
 


### PR DESCRIPTION
## Summary
- label private RFID notifications as INT instead of PRIV
- describe disallowed RFID scans as BAD instead of NOT OK

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d252c1008326803ad2699c876b4e