### PR TITLE
Use name for RFIDSource string repr and unique local fixture UUID

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -309,6 +309,9 @@ class RFIDSource(Entity):
         resp.raise_for_status()
         return resp.json()
 
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.name
+
 
 class Account(Entity):
     """Track kW credits for a user."""

--- a/rfid/fixtures/rfid_sources.json
+++ b/rfid/fixtures/rfid_sources.json
@@ -7,7 +7,7 @@
       "endpoint": "scanner",
       "default_order": 0,
       "proxy_url": null,
-      "uuid": "00000000-0000-0000-0000-000000000001"
+      "uuid": null
     }
   },
   {


### PR DESCRIPTION
## Summary
- Return the `name` in `RFIDSource.__str__` for clearer admin displays
- Leave the Local Scanner fixture UUID empty so each node generates its own UUID

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d82f4658832689cdd875ec43c00d