### PR TITLE
Show systemd service status on start

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,8 @@ if [ -f SERVICE ]; then
   SERVICE_NAME="$(cat SERVICE)"
   if systemctl list-unit-files | grep -Fq "${SERVICE_NAME}.service"; then
     sudo systemctl restart "$SERVICE_NAME"
+    # Show status information so the user can verify the service state
+    sudo systemctl status "$SERVICE_NAME" --no-pager
     exit 0
   fi
 fi


### PR DESCRIPTION
## Summary
- display systemd unit status after restarting service in start script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7daa57544832683c9b5104c96548b