### PR TITLE
Improve certificate renewal script diagnostics

### DIFF
--- a/renew-certs.sh
+++ b/renew-certs.sh
@@ -6,9 +6,12 @@ DOMAIN="arthexis.com"
 LIVE_DIR="/etc/letsencrypt/live"
 CERT_DIR="$LIVE_DIR/$DOMAIN"
 
-# If a certificate already exists, determine the expiration date and skip
-# renewal when it is more than 30 days away.
+# If a certificate already exists, show its details and determine the
+# expiration date. Skip renewal when the certificate is more than 30 days
+# away from expiry.
 if [ -f "$CERT_DIR/fullchain.pem" ]; then
+    echo "Current certificate details:"
+    sudo openssl x509 -subject -issuer -enddate -noout -in "$CERT_DIR/fullchain.pem"
     EXPIRATION=$(sudo openssl x509 -enddate -noout -in "$CERT_DIR/fullchain.pem" | cut -d= -f2)
     EXP_EPOCH=$(date -d "$EXPIRATION" +%s)
     NOW_EPOCH=$(date +%s)
@@ -18,6 +21,8 @@ if [ -f "$CERT_DIR/fullchain.pem" ]; then
         echo "Renewal skipped: certificate for $DOMAIN valid until $EXPIRATION"
         exit 0
     fi
+else
+    echo "No existing certificate found for $DOMAIN in $CERT_DIR"
 fi
 
 echo "Stopping nginx if running…"
@@ -29,11 +34,19 @@ fi
 
 echo "Requesting certificate renewal…"
 # Using certonly to avoid modifying existing web server configuration.
-sudo certbot certonly --keep-until-expiring --quiet --standalone -d "$DOMAIN" --non-interactive || true
+if ! sudo certbot certonly --keep-until-expiring --standalone -d "$DOMAIN" --non-interactive; then
+    echo "Certbot failed to obtain or renew the certificate. Check the output above or /var/log/letsencrypt/ for details." >&2
+fi
 
 echo "Checking for renewed certificate files…"
 # After renewal, determine the latest certificate directory for the domain.
 LATEST_DIR=$(sudo ls -1d "$LIVE_DIR/${DOMAIN}"* 2>/dev/null | sort | tail -n 1)
+
+# Warn when no directory was produced, which usually indicates a certbot
+# failure.
+if [ -z "$LATEST_DIR" ]; then
+    echo "No certificate directory found for $DOMAIN after running certbot." >&2
+fi
 
 # If Certbot placed the renewed certificate in a different directory (e.g. arthexis.com-0001),
 # copy the relevant files back to the expected location.
@@ -43,10 +56,10 @@ if [ -n "$LATEST_DIR" ] && [ "$LATEST_DIR" != "$CERT_DIR" ]; then
     sudo cp "$LATEST_DIR/privkey.pem" "$CERT_DIR/privkey.pem"
 fi
 
-# Display the new certificate's expiration date.
+# Display the new certificate's details if a file is present.
 if [ -f "$CERT_DIR/fullchain.pem" ]; then
-    EXPIRATION=$(sudo openssl x509 -enddate -noout -in "$CERT_DIR/fullchain.pem" | cut -d= -f2)
-    echo "Certificate for $DOMAIN expires on: $EXPIRATION"
+    echo "New certificate details:"
+    sudo openssl x509 -subject -issuer -enddate -noout -in "$CERT_DIR/fullchain.pem"
 fi
 
 # Restart nginx if it was previously running.


### PR DESCRIPTION
## Summary
- add certificate detail output and early-skip logic
- surface certbot errors and warn when no new cert directory is created
- display new certificate details after renewal

## Testing
- `bash -n renew-certs.sh`
- `shellcheck renew-certs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a7df946d60832684b650735bd1d699