### PR TITLE
Handle scanners missing IRQ support in test endpoint

### DIFF
--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -92,8 +92,17 @@ class ScanTestViewTests(SimpleTestCase):
         self.assertEqual(resp.json(), {"irq_pin": 7})
 
     @patch("config.middleware.get_site")
+    @patch("rfid.irq_wiring_check.read_rfid", return_value={"rfid": None, "label_id": None})
     @patch("rfid.irq_wiring_check._setup_hardware", return_value=False)
-    def test_scan_test_error(self, mock_setup, mock_site):
+    def test_scan_test_success_without_irq(self, mock_setup, mock_read, mock_site):
+        resp = self.client.get(reverse("rfid-scan-test"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"irq_pin": None})
+
+    @patch("config.middleware.get_site")
+    @patch("rfid.irq_wiring_check.read_rfid", return_value={"error": "boom"})
+    @patch("rfid.irq_wiring_check._setup_hardware", return_value=False)
+    def test_scan_test_error(self, mock_setup, mock_read, mock_site):
         resp = self.client.get(reverse("rfid-scan-test"))
         self.assertEqual(resp.status_code, 500)
         self.assertEqual(resp.json(), {"error": "no scanner detected"})


### PR DESCRIPTION
## Summary
- Allow `scan/test` endpoint to fallback to a direct read when IRQ wiring fails
- Expand tests for IRQ check to cover polling fallback and error cases

## Testing
- `python -m pytest rfid/tests.py::ScanTestViewTests::test_scan_test_success rfid/tests.py::ScanTestViewTests::test_scan_test_success_without_irq rfid/tests.py::ScanTestViewTests::test_scan_test_error`


------
https://chatgpt.com/codex/tasks/task_e_68a7e12676948326913616ea681be9f7