### PR TITLE
fix: handle suffixed cert directories

### DIFF
--- a/renew-certs.sh
+++ b/renew-certs.sh
@@ -6,23 +6,34 @@ DOMAIN="arthexis.com"
 LIVE_DIR="/etc/letsencrypt/live"
 CERT_DIR="$LIVE_DIR/$DOMAIN"
 
-# If a certificate already exists, show its details and determine the
-# expiration date. Skip renewal when the certificate is more than 30 days
-# away from expiry.
-if [ -f "$CERT_DIR/fullchain.pem" ]; then
+# Determine where the current certificate files live. Certbot may store
+# them in a suffixed directory (e.g. "$DOMAIN-0001") on renewal.
+EXISTING_DIR=$(sudo ls -1d "$LIVE_DIR/${DOMAIN}"* 2>/dev/null | sort | tail -n 1)
+
+if [ -n "$EXISTING_DIR" ]; then
+    # Ensure the expected directory exists and contains the certificate.
+    if [ "$EXISTING_DIR" != "$CERT_DIR" ]; then
+        echo "Existing certificate found for $DOMAIN in $EXISTING_DIR"
+        echo "Copying certificates to $CERT_DIR"
+        sudo mkdir -p "$CERT_DIR"
+        sudo cp "$EXISTING_DIR/fullchain.pem" "$CERT_DIR/fullchain.pem"
+        sudo cp "$EXISTING_DIR/privkey.pem" "$CERT_DIR/privkey.pem"
+    fi
+
     echo "Current certificate details:"
     sudo openssl x509 -subject -issuer -enddate -noout -in "$CERT_DIR/fullchain.pem"
     EXPIRATION=$(sudo openssl x509 -enddate -noout -in "$CERT_DIR/fullchain.pem" | cut -d= -f2)
     EXP_EPOCH=$(date -d "$EXPIRATION" +%s)
     NOW_EPOCH=$(date +%s)
     DAYS_LEFT=$(( (EXP_EPOCH - NOW_EPOCH) / 86400 ))
+    echo "Days until renewal: $DAYS_LEFT"
 
     if [ "$DAYS_LEFT" -gt 30 ]; then
         echo "Renewal skipped: certificate for $DOMAIN valid until $EXPIRATION"
         exit 0
     fi
 else
-    echo "No existing certificate found for $DOMAIN in $CERT_DIR"
+    echo "No existing certificate found for $DOMAIN in $LIVE_DIR"
 fi
 
 echo "Stopping nginx if running…"
@@ -46,20 +57,26 @@ LATEST_DIR=$(sudo ls -1d "$LIVE_DIR/${DOMAIN}"* 2>/dev/null | sort | tail -n 1)
 # failure.
 if [ -z "$LATEST_DIR" ]; then
     echo "No certificate directory found for $DOMAIN after running certbot." >&2
-fi
+else
+    # If Certbot placed the renewed certificate in a different directory, copy
+    # the relevant files back to the expected location.
+    if [ "$LATEST_DIR" != "$CERT_DIR" ]; then
+        echo "Copying certificates from $LATEST_DIR to $CERT_DIR"
+        sudo mkdir -p "$CERT_DIR"
+        sudo cp "$LATEST_DIR/fullchain.pem" "$CERT_DIR/fullchain.pem"
+        sudo cp "$LATEST_DIR/privkey.pem" "$CERT_DIR/privkey.pem"
+    fi
 
-# If Certbot placed the renewed certificate in a different directory (e.g. arthexis.com-0001),
-# copy the relevant files back to the expected location.
-if [ -n "$LATEST_DIR" ] && [ "$LATEST_DIR" != "$CERT_DIR" ]; then
-    echo "Copying certificates from $LATEST_DIR to $CERT_DIR"
-    sudo cp "$LATEST_DIR/fullchain.pem" "$CERT_DIR/fullchain.pem"
-    sudo cp "$LATEST_DIR/privkey.pem" "$CERT_DIR/privkey.pem"
-fi
-
-# Display the new certificate's details if a file is present.
-if [ -f "$CERT_DIR/fullchain.pem" ]; then
-    echo "New certificate details:"
-    sudo openssl x509 -subject -issuer -enddate -noout -in "$CERT_DIR/fullchain.pem"
+    # Display the new certificate's details and days until renewal if a file is present.
+    if [ -f "$CERT_DIR/fullchain.pem" ]; then
+        echo "New certificate details:"
+        sudo openssl x509 -subject -issuer -enddate -noout -in "$CERT_DIR/fullchain.pem"
+        EXPIRATION=$(sudo openssl x509 -enddate -noout -in "$CERT_DIR/fullchain.pem" | cut -d= -f2)
+        EXP_EPOCH=$(date -d "$EXPIRATION" +%s)
+        NOW_EPOCH=$(date +%s)
+        DAYS_LEFT=$(( (EXP_EPOCH - NOW_EPOCH) / 86400 ))
+        echo "Days until renewal: $DAYS_LEFT"
+    fi
 fi
 
 # Restart nginx if it was previously running.


### PR DESCRIPTION
## Summary
- handle certificates stored in suffixed LetsEncrypt live directories
- show days until a certificate must be renewed

## Testing
- `bash -n renew-certs.sh`
- `shellcheck renew-certs.sh`
- `pytest tests/test_readme_language.py` *(fails: django.db.utils.OperationalError: no such table: django_site)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e707e758832680fedf6bb9fdb3c3