### PR TITLE
Add QR-based charger landing page and admin links

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -72,6 +72,7 @@ class ChargerAdmin(admin.ModelAdmin):
         "session_kw",
         "total_kw_display",
         "test_link",
+        "qr_link",
         "log_link",
         "status_link",
     )
@@ -82,10 +83,22 @@ class ChargerAdmin(admin.ModelAdmin):
         from django.utils.html import format_html
 
         return format_html(
-            '<a href="{}" target="_blank">open</a>', obj.get_absolute_url()
+            '<a href="{}" onclick="window.open(this.href,\'landing\',\'width=400,height=600\');return false;">open</a>',
+            obj.get_absolute_url(),
         )
 
     test_link.short_description = "Landing Page"
+
+    def qr_link(self, obj):
+        from django.utils.html import format_html
+
+        if obj.reference and obj.reference.image:
+            return format_html(
+                '<a href="{}" target="_blank">qr</a>', obj.reference.image.url
+            )
+        return ""
+
+    qr_link.short_description = "QR Code"
 
     def log_link(self, obj):
         from django.utils.html import format_html

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -60,7 +60,9 @@ class Charger(Entity):
         super().save(*args, **kwargs)
         ref_value = self._full_url()
         if not self.reference or self.reference.value != ref_value:
-            ref, _ = Reference.objects.get_or_create(value=ref_value)
+            ref, _ = Reference.objects.get_or_create(
+                value=ref_value, defaults={"alt_text": self.charger_id}
+            )
             self.reference = ref
             super().save(update_fields=["reference"])
 

--- a/ocpp/templates/ocpp/charger_page.html
+++ b/ocpp/templates/ocpp/charger_page.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ charger.name|default:charger.charger_id }}</title>
+  <script>
+    setInterval(function(){ location.reload(); }, 5000);
+  </script>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; padding: 1em; }
+    .progress { width: 100%; background: #eee; height: 20px; border-radius: 10px; overflow: hidden; margin-top: 1em; }
+    .progress-bar { height: 100%; background: #4caf50; transition: width 0.5s; }
+  </style>
+</head>
+<body>
+{% load i18n %}
+{% if tx %}
+  <h1>{% trans "Charging" %}</h1>
+  <div class="progress"><div class="progress-bar" style="width: {{ tx.kw|floatformat:0 }}%;"></div></div>
+  <p>{% trans "Energy" %}: {{ tx.kw|floatformat:2 }} kW</p>
+  <p>{% trans "Started" %}: {{ tx.start_time }}</p>
+{% else %}
+  <h1>{{ charger.name|default:charger.charger_id }}</h1>
+  <p>{% trans "Plug in your vehicle and slide your RFID card over the reader to begin charging." %}</p>
+{% endif %}
+</body>
+</html>

--- a/ocpp/templates/ocpp/charger_session_search.html
+++ b/ocpp/templates/ocpp/charger_session_search.html
@@ -36,5 +36,5 @@
   <p>{% trans "No sessions found." %}</p>
   {% endif %}
 {% endif %}
-<a href="{% url 'charger-page' charger.charger_id %}">{% trans "Back" %}</a>
+<a href="{% url 'charger-status' charger.charger_id %}">{% trans "Back" %}</a>
 {% endblock %}

--- a/ocpp/templates/ocpp/dashboard.html
+++ b/ocpp/templates/ocpp/dashboard.html
@@ -16,7 +16,7 @@
   <tbody>
     {% for item in chargers %}
     <tr>
-      <td><a href="{% url 'charger-page' item.charger.charger_id %}">{{ item.charger.name|default:item.charger.charger_id }}</a></td>
+      <td><a href="{% url 'charger-status' item.charger.charger_id %}">{{ item.charger.name|default:item.charger.charger_id }}</a></td>
       <td>{{ item.charger.charger_id }}</td>
       <td><span class="badge" style="background-color: {{ item.color }};">{{ item.state }}</span></td>
     </tr>

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -210,8 +210,15 @@ def cp_simulator(request):
     return render(request, "ocpp/cp_simulator.html", context)
 
 
-@login_required
 def charger_page(request, cid):
+    """Public landing page for a charger displaying usage guidance or progress."""
+    charger = get_object_or_404(Charger, charger_id=cid)
+    tx = store.transactions.get(cid)
+    return render(request, "ocpp/charger_page.html", {"charger": charger, "tx": tx})
+
+
+@login_required
+def charger_status(request, cid):
     charger = get_object_or_404(Charger, charger_id=cid)
     session_id = request.GET.get("session")
     live_tx = store.transactions.get(cid)
@@ -297,12 +304,6 @@ def charger_log_page(request, cid):
         "ocpp/charger_logs.html",
         {"charger": charger, "log": log},
     )
-
-@login_required
-def charger_status(request, cid):
-    """Display current transaction and charger state."""
-    return charger_page(request, cid)
-
 
 @csrf_exempt
 @api_login_required


### PR DESCRIPTION
## Summary
- Add lightweight public charger page with auto-refresh instructions and charging progress
- Ensure each charger stores a QR reference to this page and expose it in admin
- Update admin and dashboard links to use new landing and status pages

## Testing
- `python manage.py test ocpp`
- `python manage.py test refs`


------
https://chatgpt.com/codex/tasks/task_e_68a87dc0bd1c8326af51c7612ead5690