### PR TITLE
Derive revision from Git commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ __marimo__/
  
 # Hash file used by upgrade scripts to track dependency changes
 requirements.md5
+REVISION

--- a/REVISION
+++ b/REVISION
@@ -1,1 +1,0 @@
-4749e85c7f4a96d517dfbbb1caef3d0034b860eb

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -13,6 +13,7 @@ import socket
 import os
 import pyperclip
 from pyperclip import PyperclipException
+from utils import revision
 from .utils import capture_screenshot, capture_screen, save_screenshot
 from .actions import NodeAction
 
@@ -109,9 +110,9 @@ class NodeAdmin(admin.ModelAdmin):
         port = int(os.environ.get("PORT", 8000))
         base_path = str(settings.BASE_DIR)
         ver_path = Path(settings.BASE_DIR) / "VERSION"
-        rev_path = Path(settings.BASE_DIR) / "REVISION"
         installed_version = ver_path.read_text().strip() if ver_path.exists() else ""
-        installed_revision = rev_path.read_text().strip() if rev_path.exists() else ""
+        rev_value = revision.get_revision()
+        installed_revision = rev_value if rev_value else ""
 
         mac = Node.get_current_mac()
         slug = slugify(hostname)

--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from django.apps import AppConfig
 from django.conf import settings
+from utils import revision
 
 
 def _startup_notification() -> None:
@@ -33,14 +34,12 @@ def _startup_notification() -> None:
     if ver_path.exists():
         version = ver_path.read_text().strip()
 
-    revision = ""
-    rev_path = Path(settings.BASE_DIR) / "REVISION"
-    if rev_path.exists():
-        revision = rev_path.read_text().strip()[-4:]
+    revision_value = revision.get_revision()
+    rev_short = revision_value[-6:] if revision_value else ""
 
     body = f"v{version}"
-    if revision:
-        body += f" r{revision}"
+    if rev_short:
+        body += f" r{rev_short}"
 
     notify(f"{address}:{port}", body)
 

--- a/refs/templatetags/ref_tags.py
+++ b/refs/templatetags/ref_tags.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from refs.models import Reference
+from utils import revision
 
 register = template.Library()
 
@@ -64,11 +65,9 @@ def current_page_qr(context, size=200):
 @register.inclusion_tag("refs/footer.html", takes_context=True)
 def render_footer(context):
     """Render footer links for references marked to appear there."""
-    revision = ""
+    revision_value = revision.get_revision()
+    rev_short = revision_value[-6:] if revision_value else ""
     version = ""
-    rev_path = Path("REVISION")
-    if rev_path.exists():
-        revision = rev_path.read_text().strip()[-8:]
     ver_path = Path("VERSION")
     if ver_path.exists():
         version = ver_path.read_text().strip()
@@ -97,7 +96,7 @@ def render_footer(context):
 
     return {
         "footer_refs": Reference.objects.filter(include_in_footer=True),
-        "revision": revision,
+        "revision": rev_short,
         "version": version,
         "admin_links": admin_links,
         "request": request,

--- a/release/utils.py
+++ b/release/utils.py
@@ -241,7 +241,6 @@ def build(
             raise ReleaseError("Tests failed")
 
     commit_hash = _current_commit()
-    Path("REVISION").write_text(commit_hash + "\n")
     prev_revision = _last_changelog_revision()
     update_changelog(version, commit_hash, prev_revision)
 
@@ -282,7 +281,7 @@ def build(
             _run(cmd)
 
     if git:
-        files = ["VERSION", "REVISION", "pyproject.toml", "CHANGELOG.rst"]
+        files = ["VERSION", "pyproject.toml", "CHANGELOG.rst"]
         _run(["git", "add"] + files)
         msg = f"PyPI Release v{version}" if twine else f"Release v{version}"
         _run(["git", "commit", "-m", msg])

--- a/utils/revision.py
+++ b/utils/revision.py
@@ -1,0 +1,20 @@
+import subprocess
+from functools import lru_cache
+
+@lru_cache()
+def get_revision() -> str:
+    """Return the current Git commit hash.
+
+    The value is cached for the lifetime of the process to avoid repeated
+    subprocess calls, but will be refreshed on each restart.
+    """
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return ""


### PR DESCRIPTION
## Summary
- derive runtime revision from `git rev-parse` and cache in-process
- show commit-based revision in node startup notification and footer
- remove obsolete REVISION file and related release logic

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ec3f3ce48326977f023da1e76ad8