### PR TITLE
Adjust admin clock banner font size

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -112,7 +112,7 @@ document.addEventListener('DOMContentLoaded', function () {
 .badge-unknown {background-color:#6c757d;}
 #server-clock {
     font-family: monospace;
-    font-size: inherit;
+    font-size: 0.9em;
 }
 #nav-sidebar .module h2 {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- make the admin server-clock banner slightly smaller for a less obtrusive header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ee50f7088326b4ab3c8e4da6e687