### PR TITLE
Align admin date and time inputs

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -129,9 +129,14 @@ document.addEventListener('DOMContentLoaded', function () {
 #nav-sidebar .module.collapsed table {
     display: none;
 }
-.form-row > div:only-child input[type="text"],
+.form-row > div:only-child input[type="text"]:not(.vDateField):not(.vTimeField),
 .form-row > div:only-child textarea {
     width: 150% !important;
+}
+
+.form-row .datetime {
+    display: flex;
+    gap: 0.5em;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure admin date and time inputs appear side by side by excluding them from wide input rule and using flex layout

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f4134df48326909cbd7840227723