### PR TITLE
Add email invitation flow

### DIFF
--- a/accounts/fixtures/users.json
+++ b/accounts/fixtures/users.json
@@ -1,0 +1,14 @@
+[
+  {
+    "model": "accounts.user",
+    "pk": 2,
+    "fields": {
+      "username": "arthexis",
+      "email": "arthexis@gmail.com",
+      "is_staff": true,
+      "is_superuser": true,
+      "is_active": false,
+      "password": ""
+    }
+  }
+]

--- a/config/settings.py
+++ b/config/settings.py
@@ -248,6 +248,10 @@ STATIC_URL = "static/"
 MEDIA_URL = "media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
+# Email settings
+DEFAULT_FROM_EMAIL = "arthexis@gmail.com"
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/website/templates/website/invitation_login.html
+++ b/website/templates/website/invitation_login.html
@@ -1,0 +1,26 @@
+{% extends "website/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Email invitation" %}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 400px; width: 100%;">
+    <h1 class="text-center mb-4">{% trans "Email invitation" %}</h1>
+    <form method="post">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="mb-3">
+        <label for="id_new_password1" class="form-label">{% trans "New password" %}</label>
+        <input type="password" name="new_password1" class="form-control" id="id_new_password1">
+      </div>
+      <div class="mb-3">
+        <label for="id_new_password2" class="form-label">{% trans "Confirm password" %}</label>
+        <input type="password" name="new_password2" class="form-control" id="id_new_password2">
+      </div>
+      <button type="submit" class="btn btn-primary w-100 mb-2">{% trans "Set password" %}</button>
+      <button type="submit" name="skip" value="1" class="btn btn-secondary w-100">{% trans "Continue without password" %}</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/website/templates/website/login.html
+++ b/website/templates/website/login.html
@@ -21,6 +21,9 @@
       {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
       <button type="submit" class="btn btn-primary w-100">{% trans "Log in" %}</button>
     </form>
+    <div class="mt-3 text-center">
+      <a href="{% url 'website:request-invite' %}">{% trans "Request email invitation" %}</a>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/website/templates/website/request_invite.html
+++ b/website/templates/website/request_invite.html
@@ -1,0 +1,27 @@
+{% extends "website/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Request invitation" %}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-center">
+  <div class="card p-4" style="max-width: 400px; width: 100%;">
+    <h1 class="text-center mb-4">{% trans "Request email invitation" %}</h1>
+    {% if sent %}
+      <div class="alert alert-info" role="alert">
+        {% trans "If the email exists, an invitation has been sent." %}
+      </div>
+    {% else %}
+    <form method="post">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="mb-3">
+        <label for="id_email" class="form-label">{% trans "Email" %}</label>
+        <input type="email" name="email" class="form-control" id="id_email" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">{% trans "Send invitation" %}</button>
+    </form>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -8,4 +8,10 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("sitemap.xml", views.sitemap, name="website-sitemap"),
     path("login/", views.login_view, name="login"),
+    path("request-invite/", views.request_invite, name="request-invite"),
+    path(
+        "invitation/<uidb64>/<token>/",
+        views.invitation_login,
+        name="invitation-login",
+    ),
 ]


### PR DESCRIPTION
## Summary
- add request email invitation flow to activate accounts or reset passwords
- set default admin email and provide inactive superuser fixture

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f2a506988326b7e6a363269b44ac