### PR TITLE
Require existing virtualenv for management scripts

### DIFF
--- a/command.bat
+++ b/command.bat
@@ -1,0 +1,14 @@
+@echo off
+set VENV=.venv
+if not exist %VENV%\Scripts\python.exe (
+    echo Virtual environment not found. Run install.sh first.
+    exit /b 1
+)
+if "%~1"=="" (
+    echo Usage: %0 ^<command^> [args...]
+    exit /b 1
+)
+set COMMAND=%1
+set COMMAND=%COMMAND:-=_%
+shift
+%VENV%\Scripts\python.exe manage.py %COMMAND% %*

--- a/command.sh
+++ b/command.sh
@@ -4,10 +4,12 @@ set -e
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
 
-# Activate virtual environment if present
-if [ -d .venv ]; then
-  source .venv/bin/activate
+# Ensure virtual environment is available
+if [ ! -d .venv ]; then
+  echo "Virtual environment not found. Run ./install.sh first." >&2
+  exit 1
 fi
+source .venv/bin/activate
 
 if [ $# -eq 0 ]; then
   echo "Usage: $0 <command> [args...]" >&2

--- a/env-refresh.bat
+++ b/env-refresh.bat
@@ -1,11 +1,8 @@
 @echo off
 set VENV=.venv
 if not exist %VENV%\Scripts\python.exe (
-    py -m venv %VENV%
-)
-if not exist %VENV%\Scripts\python.exe (
-    echo Virtual environment not found
-    exit /b 0
+    echo Virtual environment not found. Run install.sh first.
+    exit /b 1
 )
 if exist requirements.txt (
     for /f "skip=1 tokens=1" %%h in ('certutil -hashfile requirements.txt MD5') do (

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -2,25 +2,11 @@
 set -e
 
 VENV_DIR=".venv"
-
-# Determine which Python executable is available
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON_CMD="python3"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_CMD="python"
-else
-  echo "Python interpreter not found" >&2
-  exit 1
-fi
-
-if [ ! -d "$VENV_DIR" ]; then
-  "$PYTHON_CMD" -m venv "$VENV_DIR"
-fi
-
 PYTHON="$VENV_DIR/bin/python"
+
 if [ ! -f "$PYTHON" ]; then
-  echo "Virtual environment not found" >&2
-  exit 0
+  echo "Virtual environment not found. Run ./install.sh first." >&2
+  exit 1
 fi
 
 if [ -f requirements.txt ]; then

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,9 @@
+@echo off
+set VENV=.venv
+if not exist %VENV%\Scripts\python.exe (
+    echo Virtual environment not found. Run install.sh first.
+    exit /b 1
+)
+set PORT=%1
+if "%PORT%"=="" set PORT=8000
+%VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT%

--- a/start.sh
+++ b/start.sh
@@ -15,10 +15,12 @@ if [ -f SERVICE ]; then
   fi
 fi
 
-# Activate virtual environment if present
-if [ -d .venv ]; then
-  source .venv/bin/activate
+# Ensure virtual environment is available
+if [ ! -d .venv ]; then
+  echo "Virtual environment not found. Run ./install.sh first." >&2
+  exit 1
 fi
+source .venv/bin/activate
 
 # Default to port 8000 but allow override via first argument
 PORT=${1:-8000}

--- a/upgrade.bat
+++ b/upgrade.bat
@@ -1,0 +1,41 @@
+@echo off
+setlocal
+set BASE_DIR=%~dp0
+cd /d %BASE_DIR%
+
+set STASHED=0
+for /f %%i in ('git status --porcelain') do (
+    set STASHED=1
+    goto do_stash
+)
+:do_stash
+if %STASHED%==1 (
+    echo Warning: stashing local changes before upgrade
+    git stash push -u -m "auto-upgrade %date% %time%" >nul 2>&1
+)
+
+git pull --rebase
+
+if %STASHED%==1 (
+    git stash pop || rem ignore errors
+)
+
+if not exist .venv\Scripts\python.exe (
+    echo Virtual environment not found. Run install.sh first.
+    exit /b 1
+)
+
+set VENV=.venv
+set REQ=requirements.txt
+set MD5=requirements.md5
+for /f "skip=1 tokens=1" %%h in ('certutil -hashfile %REQ% MD5') do if not defined NEW_HASH set NEW_HASH=%%h
+if exist %MD5% (
+    set /p STORED_HASH=<%MD5%
+)
+if /I not "%NEW_HASH%"=="%STORED_HASH%" (
+    %VENV%\Scripts\python.exe -m pip install -r %REQ%
+    echo %NEW_HASH%>%MD5%
+) else (
+    echo Requirements unchanged. Skipping installation.
+)
+endlocal

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -20,19 +20,22 @@ if [ "$STASHED" -eq 1 ]; then
     git stash pop || true
 fi
 
-# Update dependencies if virtualenv exists
-if [ -d .venv ]; then
-    source .venv/bin/activate
-    REQ_FILE="requirements.txt"
-    MD5_FILE="requirements.md5"
-    NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
-    STORED_HASH=""
-    [ -f "$MD5_FILE" ] && STORED_HASH=$(cat "$MD5_FILE")
-    if [ "$NEW_HASH" != "$STORED_HASH" ]; then
-        pip install -r "$REQ_FILE"
-        echo "$NEW_HASH" > "$MD5_FILE"
-    else
-        echo "Requirements unchanged. Skipping installation."
-    fi
-    deactivate
+# Update dependencies only if the virtualenv is present
+if [ ! -d .venv ]; then
+    echo "Virtual environment not found. Run ./install.sh first." >&2
+    exit 1
 fi
+
+source .venv/bin/activate
+REQ_FILE="requirements.txt"
+MD5_FILE="requirements.md5"
+NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
+STORED_HASH=""
+[ -f "$MD5_FILE" ] && STORED_HASH=$(cat "$MD5_FILE")
+if [ "$NEW_HASH" != "$STORED_HASH" ]; then
+    pip install -r "$REQ_FILE"
+    echo "$NEW_HASH" > "$MD5_FILE"
+else
+    echo "Requirements unchanged. Skipping installation."
+fi
+deactivate

--- a/vscode_manage.py
+++ b/vscode_manage.py
@@ -1,0 +1,18 @@
+import os
+import runpy
+import sys
+
+
+def main(argv=None):
+    argv = argv or []
+    os.environ.pop("DEBUGPY_LAUNCHER_PORT", None)
+    if "PYTHONPATH" in os.environ:
+        os.environ["PYTHONPATH"] = os.pathsep.join(
+            p for p in os.environ["PYTHONPATH"].split(os.pathsep) if "debugpy" not in p
+        )
+    sys.argv = ["manage.py", *argv]
+    runpy.run_path("manage.py", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- ensure command utilities fail without an existing virtualenv and instruct to run install.sh first
- prevent env-refresh and upgrade from creating a virtualenv while still reinstalling requirements
- enforce virtualenv presence before starting the development server
- add Windows .bat counterparts for command, start, and upgrade scripts
- restore `vscode_manage` wrapper to strip VS Code debugpy settings and run `manage.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab5a7b5d5083268faeb0d6cb3eb899