### PR TITLE
Use requirements.md5 in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,16 @@ source .venv/bin/activate
 pip install --upgrade pip
 
 REQ_FILE="requirements.txt"
-pip install -r "$REQ_FILE"
+MD5_FILE="requirements.md5"
+NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
+STORED_HASH=""
+[ -f "$MD5_FILE" ] && STORED_HASH=$(cat "$MD5_FILE")
+if [ "$NEW_HASH" != "$STORED_HASH" ]; then
+    pip install -r "$REQ_FILE"
+    echo "$NEW_HASH" > "$MD5_FILE"
+else
+    echo "Requirements unchanged. Skipping installation."
+fi
 
 deactivate
 


### PR DESCRIPTION
## Summary
- Only install dependencies when `requirements.txt` changes and maintain its hash

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'vscode_manage')*

------
https://chatgpt.com/codex/tasks/task_e_68ab63aa8f088326a92f05758438dfe2