### PR TITLE
feat: allow custom port in scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,10 @@ set -e
 
 SERVICE=""
 SETUP_NGINX=false
+PORT=8888
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--nginx]" >&2
+    echo "Usage: $0 [--service NAME] [--nginx] [--port PORT]" >&2
     exit 1
 }
 
@@ -19,6 +20,11 @@ while [[ $# -gt 0 ]]; do
         --nginx)
             SETUP_NGINX=true
             shift
+            ;;
+        --port)
+            [ -z "$2" ] && usage
+            PORT="$2"
+            shift 2
             ;;
         *)
             usage
@@ -67,7 +73,7 @@ server {
 
     # Default proxy to web app
     location / {
-        proxy_pass http://127.0.0.1:8888;
+        proxy_pass http://127.0.0.1:PORT_PLACEHOLDER;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -78,6 +84,7 @@ server {
     }
 }
 NGINXCONF
+    sudo sed -i "s/PORT_PLACEHOLDER/$PORT/" "$NGINX_CONF"
     sudo nginx -t
     sudo systemctl reload nginx
 fi
@@ -111,7 +118,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=$BASE_DIR
-ExecStart=$BASE_DIR/.venv/bin/python manage.py runserver 0.0.0.0:8888
+ExecStart=$BASE_DIR/.venv/bin/python manage.py runserver 0.0.0.0:$PORT
 Restart=always
 User=$(id -un)
 

--- a/start.sh
+++ b/start.sh
@@ -22,8 +22,21 @@ if [ ! -d .venv ]; then
 fi
 source .venv/bin/activate
 
-# Default to port 8000 but allow override via first argument
-PORT=${1:-8000}
+# Default to port 8000 but allow override via --port
+PORT=8000
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--port PORT]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Start the Django development server
 python manage.py runserver 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- add --port option to start.sh for selecting server port
- make install.sh accept --port to wire nginx and systemd to custom port

## Testing
- `bash -n install.sh start.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abc31c86a883269544e28edcf860fe