### PR TITLE
Add charger numbers for OCPP chargers

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -45,6 +45,7 @@ class ChargerAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "charger_id",
+                    "number",
                     "config",
                     "require_rfid",
                     "last_heartbeat",
@@ -64,6 +65,7 @@ class ChargerAdmin(admin.ModelAdmin):
     readonly_fields = ("last_heartbeat", "last_meter_values")
     list_display = (
         "charger_id",
+        "number",
         "location_name",
         "require_rfid",
         "latitude",
@@ -76,7 +78,7 @@ class ChargerAdmin(admin.ModelAdmin):
         "log_link",
         "status_link",
     )
-    search_fields = ("charger_id", "location__name")
+    search_fields = ("charger_id", "number", "location__name")
     actions = ["purge_data", "delete_selected"]
 
     def test_link(self, obj):

--- a/ocpp/fixtures/initial_data.json
+++ b/ocpp/fixtures/initial_data.json
@@ -13,6 +13,7 @@
     "pk": 1,
     "fields": {
       "charger_id": "CP1",
+      "number": 1,
       "config": {},
       "require_rfid": false,
       "last_heartbeat": null,
@@ -27,6 +28,7 @@
     "pk": 2,
     "fields": {
       "charger_id": "CP2",
+      "number": 2,
       "config": {},
       "require_rfid": true,
       "last_heartbeat": null,

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('charger_id', models.CharField(max_length=100, unique=True, verbose_name='Serial Number')),
+                ('number', models.PositiveIntegerField(default=1, verbose_name='Charger Number')),
                 ('config', models.JSONField(blank=True, default=dict)),
                 ('require_rfid', models.BooleanField(default=False, verbose_name='Require RFID')),
                 ('last_heartbeat', models.DateTimeField(blank=True, null=True)),

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -28,6 +28,7 @@ class Charger(Entity):
     """Known charge point with optional configuration."""
 
     charger_id = models.CharField(_("Serial Number"), max_length=100, unique=True)
+    number = models.PositiveIntegerField(_("Charger Number"), default=1)
     config = models.JSONField(default=dict, blank=True)
     require_rfid = models.BooleanField(_("Require RFID"), default=False)
     last_heartbeat = models.DateTimeField(null=True, blank=True)
@@ -68,7 +69,9 @@ class Charger(Entity):
 
     @property
     def name(self) -> str:
-        return self.location.name if self.location else ""
+        if self.location:
+            return f"{self.location.name} #{self.number}" if self.number else self.location.name
+        return ""
 
     @property
     def latitude(self):

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -38,6 +38,14 @@ class ChargerFixtureTests(TestCase):
         cp1 = Charger.objects.get(charger_id="CP1")
         self.assertFalse(cp1.require_rfid)
 
+    def test_charger_numbers(self):
+        cp1 = Charger.objects.get(charger_id="CP1")
+        cp2 = Charger.objects.get(charger_id="CP2")
+        self.assertEqual(cp1.number, 1)
+        self.assertEqual(cp2.number, 2)
+        self.assertEqual(cp1.name, "Simulator #1")
+        self.assertEqual(cp2.name, "Simulator #2")
+
 
 class SinkConsumerTests(TransactionTestCase):
     async def test_sink_replies(self):
@@ -643,7 +651,7 @@ class ChargerLocationTests(TestCase):
         charger = Charger.objects.create(charger_id="LOC1", location=loc)
         self.assertAlmostEqual(float(charger.latitude), 10.123456)
         self.assertAlmostEqual(float(charger.longitude), -20.654321)
-        self.assertEqual(charger.name, "Loc1")
+        self.assertEqual(charger.name, "Loc1 #1")
 
 
 class MeterReadingTests(TransactionTestCase):


### PR DESCRIPTION
## Summary
- add `number` field to OCPP Charger model with display logic
- show charger numbers in admin and seed data
- extend tests and fixtures for numbered chargers

## Testing
- `python manage.py test ocpp -v 2`
- `python manage.py makemigrations ocpp --check --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68abc6613554832699245c253382d7d7