### PR TITLE
feat: link charger landing page

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -350,6 +350,10 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+#: ocpp/templates/ocpp/charger_status.html:25
+msgid "Landing page"
+msgstr ""
+
 #: ocpp/templates/ocpp/charger_status.html:27
 msgid "Viewing past session"
 msgstr ""

--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -73,7 +73,7 @@ class ChargerAdmin(admin.ModelAdmin):
         "last_heartbeat",
         "session_kw",
         "total_kw_display",
-        "test_link",
+        "page_link",
         "qr_link",
         "log_link",
         "status_link",
@@ -81,15 +81,14 @@ class ChargerAdmin(admin.ModelAdmin):
     search_fields = ("charger_id", "number", "location__name")
     actions = ["purge_data", "delete_selected"]
 
-    def test_link(self, obj):
+    def page_link(self, obj):
         from django.utils.html import format_html
 
         return format_html(
-            '<a href="{}" onclick="window.open(this.href,\'landing\',\'width=400,height=600\');return false;">open</a>',
-            obj.get_absolute_url(),
+            '<a href="{}" target="_blank">open</a>', obj.get_absolute_url()
         )
 
-    test_link.short_description = "Landing Page"
+    page_link.short_description = "Landing Page"
 
     def qr_link(self, obj):
         from django.utils.html import format_html

--- a/ocpp/templates/admin/ocpp/charger/change_form.html
+++ b/ocpp/templates/admin/ocpp/charger/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load static %}
+{% load static i18n %}
 
 {% block extrahead %}
 {{ block.super }}
@@ -36,6 +36,7 @@
 {% endblock %}
 
 {% block object-tools-items %}
+  <li><a href="{{ original.get_absolute_url }}" target="_blank">Landing page</a></li>
   {% if original.reference %}
   <li><a href="{{ original.reference.value }}" target="_blank">Reference</a></li>
   {% endif %}

--- a/ocpp/templates/ocpp/charger_status.html
+++ b/ocpp/templates/ocpp/charger_status.html
@@ -21,8 +21,9 @@
       animation: text-update-fade 1s ease-out;
     }
   </style>
-  <h1>{{ charger.name|default:charger.charger_id }}</h1>
-  {% if past_session %}
+    <h1>{{ charger.name|default:charger.charger_id }}</h1>
+    <p><a href="{% url 'charger-page' charger.charger_id %}">{% trans "Landing page" %}</a></p>
+    {% if past_session %}
   <div class="alert alert-info" role="alert">
     {% trans "Viewing past session" %} {{ tx.id }}. <a href="{% url 'charger-page' charger.charger_id %}">{% trans "Back to live" %}</a>
   </div>

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -422,6 +422,12 @@ class ChargerAdminTests(TestCase):
         log_url = reverse("charger-log", args=["LOG1"]) + "?type=charger"
         self.assertContains(resp, log_url)
 
+    def test_admin_change_links_landing_page(self):
+        charger = Charger.objects.create(charger_id="CHANGE1")
+        url = reverse("admin:ocpp_charger_change", args=[charger.pk])
+        resp = self.client.get(url)
+        self.assertContains(resp, charger.get_absolute_url())
+
     def test_admin_shows_location_name(self):
         loc = Location.objects.create(name="AdminLoc")
         Charger.objects.create(charger_id="ADMINLOC", location=loc)
@@ -959,6 +965,11 @@ class ChargerStatusViewTests(TestCase):
         tx = Transaction.objects.create(charger=charger, start_time=timezone.now())
         resp = self.client.get(reverse("charger-status", args=[charger.charger_id]))
         self.assertContains(resp, f"?session={tx.id}")
+
+    def test_status_links_landing_page(self):
+        charger = Charger.objects.create(charger_id="LAND1")
+        resp = self.client.get(reverse("charger-status", args=[charger.charger_id]))
+        self.assertContains(resp, reverse("charger-page", args=[charger.charger_id]))
 
     def test_past_session_chart(self):
         charger = Charger.objects.create(charger_id="PAST1")


### PR DESCRIPTION
## Summary
- link to charger landing page in admin list and change views
- expose landing page link from public status view
- add tests for landing page links

## Testing
- `python manage.py test ocpp`


------
https://chatgpt.com/codex/tasks/task_e_68abc7a2e03c8326900346a8d98df4c9