### PR TITLE
Simplify LCD notifications

### DIFF
--- a/nodes/notifications.py
+++ b/nodes/notifications.py
@@ -1,18 +1,16 @@
-"""Notification system for LCD and desktop alerts.
+"""Simple notification helper for a 16x2 LCD display.
 
-Notifications are queued and displayed sequentially on an attached
-LCD1602 display.  If the display is unavailable a desktop notification
-is attempted using :mod:`plyer`.  Each notification is shown for at
-least six seconds before the next queued item is processed.
+Messages are written directly to the LCD.  When the display is
+unavailable the message is shown using a desktop notification (via
+``plyer``) or logged.  Each line is truncated to 16 characters so that it
+fits the 16x2 hardware display.
 """
 
 from __future__ import annotations
 
+import ctypes
 import logging
-import queue
-import threading
-import time
-from dataclasses import dataclass
+import sys
 
 from .lcd import CharLCD1602, LCDUnavailableError
 
@@ -24,24 +22,13 @@ except Exception:  # pragma: no cover - plyer may not be installed
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class Notification:
-    """Information about a notification to be displayed."""
-
-    subject: str
-    body: str = ""
-    duration: float = 6.0
-
-
 class NotificationManager:
-    """Manage a queue of notifications for the LCD display."""
+    """Write notifications to the LCD or fall back to GUI/log output."""
 
     def __init__(self) -> None:
-        self.queue: queue.Queue[Notification] = queue.Queue()
         self.lcd = self._init_lcd()
-        self.thread = threading.Thread(target=self._worker, daemon=True)
-        self.thread.start()
 
+    # LCD helpers -----------------------------------------------------
     def _init_lcd(self):
         try:
             lcd = CharLCD1602()
@@ -53,81 +40,52 @@ class NotificationManager:
             logger.warning("Unexpected LCD error: %s", exc)
         return None
 
-    def send(self, subject: str, body: str = "", duration: float = 6.0) -> None:
-        """Queue a new notification."""
+    def send(self, subject: str, body: str = "") -> bool:
+        """Display *subject* and *body* and return ``True`` on success.
 
-        self.queue.put(Notification(subject=subject, body=body, duration=duration))
+        The method truncates each line to 16 characters.  If the LCD is not
+        available or writing fails a GUI notification is attempted instead
+        and ``False`` is returned.
+        """
 
-    def _worker(self) -> None:  # pragma: no cover - background thread
-        while True:
-            note = self.queue.get()
-            try:
-                self._display(note)
-            finally:
-                self.queue.task_done()
-
-    # Display helpers -------------------------------------------------
-    def _display(self, note: Notification) -> None:
-        duration = max(note.duration, 6)
+        if not self.lcd:
+            self.lcd = self._init_lcd()
         if self.lcd:
-            self._lcd_display(note, duration)
-        else:
-            self._gui_display(note)
-            time.sleep(duration)
-
-    def _lcd_display(self, note: Notification, duration: float) -> None:
-        try:
-            subj, body = note.subject, note.body
-            if len(subj) <= 16 and len(body) <= 16:
+            try:
                 self.lcd.clear()
-                self.lcd.write(0, 0, subj.ljust(16))
-                self.lcd.write(0, 1, body.ljust(16))
-                time.sleep(duration)
-            else:
-                top_scroll = subj + " " * 4 if len(subj) > 16 else subj
-                bottom_scroll = body + " " * 4 if len(body) > 16 else body
-                end = time.time() + duration
-                idx_top = idx_bottom = 0
-                self.lcd.clear()
-                while time.time() < end:
-                    top_seg = (
-                        (top_scroll + top_scroll[:16])[idx_top: idx_top + 16]
-                        if len(subj) > 16
-                        else subj.ljust(16)
-                    )
-                    bottom_seg = (
-                        (bottom_scroll + bottom_scroll[:16])[idx_bottom: idx_bottom + 16]
-                        if len(body) > 16
-                        else body.ljust(16)
-                    )
-                    self.lcd.write(0, 0, top_seg.ljust(16))
-                    self.lcd.write(0, 1, bottom_seg.ljust(16))
-                    time.sleep(0.5)
-                    if len(subj) > 16:
-                        idx_top = (idx_top + 1) % len(top_scroll)
-                    if len(body) > 16:
-                        idx_bottom = (idx_bottom + 1) % len(bottom_scroll)
-        except Exception as exc:  # pragma: no cover - hardware dependent
-            logger.warning("LCD display failed: %s", exc)
-            self.lcd = None
-            self._gui_display(note)
-            time.sleep(duration)
+                self.lcd.write(0, 0, subject[:16].ljust(16))
+                self.lcd.write(0, 1, body[:16].ljust(16))
+                return True
+            except Exception as exc:  # pragma: no cover - hardware dependent
+                logger.warning("LCD display failed: %s", exc)
+                self.lcd = None
+        self._gui_display(subject, body)
+        return False
 
-    def _gui_display(self, note: Notification) -> None:
+    # GUI/log fallback ------------------------------------------------
+    def _gui_display(self, subject: str, body: str) -> None:
         if plyer_notify:
             try:  # pragma: no cover - depends on platform
-                plyer_notify.notify(title=note.subject, message=note.body)
+                plyer_notify.notify(title=subject, message=body)
                 return
             except Exception as exc:  # pragma: no cover - depends on platform
                 logger.warning("GUI notification failed: %s", exc)
-        logger.info("%s %s", note.subject, note.body)
+        if sys.platform.startswith("win"):
+            try:  # pragma: no cover - depends on platform
+                ctypes.windll.user32.MessageBoxW(
+                    0, f"{subject}\n{body}", "Arthexis", 0x1000
+                )
+                return
+            except Exception as exc:  # pragma: no cover - depends on platform
+                logger.warning("Windows notification failed: %s", exc)
+        logger.info("%s %s", subject, body)
 
 
 # Global manager used throughout the project
 manager = NotificationManager()
 
 
-def notify(subject: str, body: str = "", duration: float = 6.0) -> None:
-    """Queue a notification using the global manager."""
+def notify(subject: str, body: str = "") -> bool:
+    """Convenience wrapper using the global :class:`NotificationManager`."""
 
-    manager.send(subject=subject, body=body, duration=duration)
+    return manager.send(subject=subject, body=body)

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -32,7 +32,6 @@ from .models import (
     Backup,
 )
 from .tasks import capture_node_screenshot, sample_clipboard
-from nodes.notifications import NotificationManager
 
 
 class NodeTests(TestCase):
@@ -462,42 +461,62 @@ class StartupNotificationTests(TestCase):
         mock_notify.assert_called_once_with("1.2.3.4:9000", "v1.2.3 r123456")
 
 
-def _fake_time_factory():
-    current = [0]
+class NotificationManagerTests(TestCase):
+    def test_send_writes_trimmed_lines(self):
+        from .notifications import NotificationManager
 
-    def fake_time():
-        return current[0]
-
-    def fake_sleep(seconds):
-        current[0] += seconds
-
-    return fake_time, fake_sleep
-
-
-class NotificationDisplayTests(TestCase):
-    @patch("nodes.notifications.threading.Thread")
-    @patch("nodes.notifications.NotificationManager._init_lcd", return_value=MagicMock())
-    def test_long_message_scrolls(self, mock_init, mock_thread):
-        mock_thread.return_value.start = lambda: None
         manager = NotificationManager()
-        subject = "a" * 20
-        body = "b" * 30
-        manager.send(subject, body)
-        note = manager.queue.get_nowait()
-        self.assertEqual(note.subject, subject)
-        self.assertEqual(note.body, body)
-        fake_time, fake_sleep = _fake_time_factory()
-        with patch("nodes.notifications.time.time", fake_time), patch(
-            "nodes.notifications.time.sleep", fake_sleep
-        ):
-            manager.lcd.clear.reset_mock()
-            manager.lcd.write.reset_mock()
-            manager._lcd_display(note, duration=1)
-        top_calls = [c for c in manager.lcd.write.call_args_list if c[0][1] == 0]
-        bottom_calls = [c for c in manager.lcd.write.call_args_list if c[0][1] == 1]
-        self.assertTrue(len(top_calls) > 1)
-        self.assertTrue(len(bottom_calls) > 1)
+        mock_lcd = MagicMock()
+        manager.lcd = mock_lcd
+        result = manager.send("a" * 20, "b" * 20)
+        self.assertTrue(result)
+        mock_lcd.clear.assert_called_once()
+        mock_lcd.write.assert_any_call(0, 0, "a" * 16)
+        mock_lcd.write.assert_any_call(0, 1, "b" * 16)
 
+    def test_send_falls_back_to_gui(self):
+        from .notifications import NotificationManager
+
+        manager = NotificationManager()
+        manager.lcd = None
+        manager._gui_display = MagicMock()
+        result = manager.send("hi", "there")
+        self.assertFalse(result)
+        manager._gui_display.assert_called_once_with("hi", "there")
+
+    def test_send_handles_lcd_exception(self):
+        from .notifications import NotificationManager
+
+        mock_lcd = MagicMock()
+        mock_lcd.clear.side_effect = RuntimeError("boom")
+        manager = NotificationManager()
+        manager.lcd = mock_lcd
+        manager._gui_display = MagicMock()
+        result = manager.send("hi", "there")
+        self.assertFalse(result)
+        manager._gui_display.assert_called_once_with("hi", "there")
+
+    @patch("nodes.notifications.NotificationManager._init_lcd", return_value=MagicMock())
+    def test_send_reinitialises_lcd(self, mock_init):
+        from .notifications import NotificationManager
+
+        manager = NotificationManager()
+        manager.lcd = None
+        result = manager.send("subj", "body")
+        self.assertTrue(result)
+        self.assertEqual(mock_init.call_count, 2)
+
+    def test_gui_display_uses_message_box_on_windows(self):
+        from .notifications import NotificationManager
+
+        with patch("nodes.notifications.plyer_notify", None):
+            with patch("nodes.notifications.sys.platform", "win32"):
+                with patch("nodes.notifications.ctypes") as mock_ctypes:
+                    manager = NotificationManager()
+                    manager._gui_display("hi", "there")
+        mock_ctypes.windll.user32.MessageBoxW.assert_called_once_with(
+            0, "hi\nthere", "Arthexis", 0x1000
+        )
 
 
 class RecipeTests(TestCase):
@@ -648,27 +667,5 @@ class ClipboardTaskTests(TestCase):
         result = capture_node_screenshot("http://example.com")
         self.assertEqual(result, "")
         self.assertEqual(NodeScreenshot.objects.count(), 0)
-
-
-class NotificationTests(TestCase):
-    def test_gui_fallback_when_lcd_unavailable(self):
-        from .notifications import Notification, NotificationManager
-
-        manager = NotificationManager()
-        manager.lcd = None
-        with patch("nodes.notifications.plyer_notify") as mock_notify:
-            manager._display(Notification("hello", "world"))
-            mock_notify.notify.assert_called_once_with(title="hello", message="world")
-
-    def test_lcd_display_writes_lines(self):
-        from .notifications import Notification, NotificationManager
-
-        manager = NotificationManager()
-        mock_lcd = MagicMock()
-        manager.lcd = mock_lcd
-        manager._display(Notification("line1", "line2"))
-        mock_lcd.clear.assert_called_once()
-        mock_lcd.write.assert_any_call(0, 0, "line1".ljust(16))
-        mock_lcd.write.assert_any_call(0, 1, "line2".ljust(16))
 
 


### PR DESCRIPTION
## Summary
- Replace queued notifications with a direct LCD writer limited to 16x2
- Return a boolean success flag so callers can detect LCD failures
- Add tests covering LCD writes, GUI fallback, and reinitialization
- Use Windows message boxes when LCD and plyer notifications are unavailable

## Testing
- `pytest nodes/tests.py::NotificationManagerTests rfid/tests.py::ReaderNotificationTests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7133937483269f98abf3fd9b2b87