### PR TITLE
Use non-blocking Windows toast notifications

### DIFF
--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -509,30 +509,24 @@ class NotificationManagerTests(TestCase):
     def test_gui_display_uses_windows_toast(self):
         from .notifications import NotificationManager
 
-        with patch("nodes.notifications.plyer_notify", None):
-            with patch("nodes.notifications.sys.platform", "win32"):
-                mock_toast = MagicMock()
-                with patch(
-                    "nodes.notifications.ToastNotifier", return_value=mock_toast
-                ):
-                    manager = NotificationManager()
-                    manager._gui_display("hi", "there")
+        with patch("nodes.notifications.sys.platform", "win32"):
+            mock_toast = MagicMock()
+            with patch("nodes.notifications.ToastNotifier", return_value=mock_toast):
+                manager = NotificationManager()
+                manager._gui_display("hi", "there")
         mock_toast.show_toast.assert_called_once_with(
-            "Arthexis", "hi\nthere", duration=6, threaded=True
+            "Arthexis", "hi\nthere", duration=10, threaded=True
         )
 
-    def test_gui_display_falls_back_to_message_box_on_windows(self):
+    def test_gui_display_logs_when_toast_unavailable(self):
         from .notifications import NotificationManager
 
-        with patch("nodes.notifications.plyer_notify", None):
-            with patch("nodes.notifications.sys.platform", "win32"):
-                with patch("nodes.notifications.ToastNotifier", None):
-                    with patch("nodes.notifications.ctypes") as mock_ctypes:
-                        manager = NotificationManager()
-                        manager._gui_display("hi", "there")
-        mock_ctypes.windll.user32.MessageBoxW.assert_called_once_with(
-            0, "hi\nthere", "Arthexis", 0x1000
-        )
+        with patch("nodes.notifications.sys.platform", "win32"):
+            with patch("nodes.notifications.ToastNotifier", None):
+                with patch("nodes.notifications.logger") as mock_logger:
+                    manager = NotificationManager()
+                    manager._gui_display("hi", "there")
+        mock_logger.info.assert_called_once_with("%s %s", "hi", "there")
 
 
 class RecipeTests(TestCase):


### PR DESCRIPTION
## Summary
- replace plyer and message box notifications with auto-dismissing Windows toasts
- log notification text when toast notifier is unavailable
- adjust tests for new toast behavior

## Testing
- `pytest nodes/tests.py::NotificationManagerTests::test_gui_display_uses_windows_toast -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ac8fa8e2908326a41c998f42c37927