### PR TITLE
Add reload flag for start scripts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
             "program": "${workspaceFolder}/manage.py",
-            "args": ["runserver"],
+            "args": ["runserver", "--noreload"],
             "django": true,
             "noDebug": true
         },
@@ -23,7 +23,7 @@
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
             "program": "${workspaceFolder}/vscode_manage.py",
-            "args": ["runserver"],
+            "args": ["runserver", "--noreload"],
             "django": true
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,9 +14,9 @@
         {
             "label": "Dev: start",
             "type": "shell",
-            "command": "${workspaceFolder}/start.sh",
+            "command": "${workspaceFolder}/start.sh --reload",
             "windows": {
-                "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe ${workspaceFolder}\\manage.py runserver 0.0.0.0:8000"
+                "command": "${workspaceFolder}\\start.bat --reload"
             },
             "problemMatcher": [],
             "detail": "Start the Django development server"

--- a/start.bat
+++ b/start.bat
@@ -4,6 +4,25 @@ if not exist %VENV%\Scripts\python.exe (
     echo Virtual environment not found. Run install.sh first.
     exit /b 1
 )
-set PORT=%1
-if "%PORT%"=="" set PORT=8000
-%VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT%
+
+set PORT=8000
+set RELOAD=
+:parse
+if "%1"=="" goto run
+if "%1"=="--port" (
+    set PORT=%2
+    shift
+    shift
+    goto parse
+)
+if "%1"=="--reload" (
+    set RELOAD=1
+    shift
+    goto parse
+)
+echo Usage: %0 [--port PORT] [--reload]
+exit /b 1
+
+:run
+if not defined RELOAD set NORELOAD=--noreload
+%VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT% %NORELOAD%

--- a/start.sh
+++ b/start.sh
@@ -22,8 +22,9 @@ if [ ! -d .venv ]; then
 fi
 source .venv/bin/activate
 
-# Default to port 8000 but allow override via --port
+# Default to port 8000 and disabled auto-reload unless --reload is provided
 PORT=8000
+RELOAD=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,12 +32,20 @@ while [[ $# -gt 0 ]]; do
       PORT="$2"
       shift 2
       ;;
+    --reload)
+      RELOAD=true
+      shift
+      ;;
     *)
-      echo "Usage: $0 [--port PORT]" >&2
+      echo "Usage: $0 [--port PORT] [--reload]" >&2
       exit 1
       ;;
   esac
 done
 
 # Start the Django development server
-python manage.py runserver 0.0.0.0:$PORT
+if [ "$RELOAD" = true ]; then
+  python manage.py runserver 0.0.0.0:$PORT
+else
+  python manage.py runserver 0.0.0.0:$PORT --noreload
+fi


### PR DESCRIPTION
## Summary
- toggle autoreload via --reload flag in start scripts
- disable autoreload by default in VS Code launch
- update VS Code tasks to pass --reload to start scripts

## Testing
- `python -m pytest tests/test_vscode_manage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac9565fc188326b227d74cd0d04c2a