### PR TITLE
Add nginx mode flags and firewall checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,11 @@ set -e
 
 SERVICE=""
 SETUP_NGINX=false
-PORT=8888
+NGINX_MODE=""
+PORT=""
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--nginx] [--port PORT]" >&2
+    echo "Usage: $0 [--service NAME] [--nginx] [--private|--public] [--port PORT]" >&2
     exit 1
 }
 
@@ -21,6 +22,16 @@ while [[ $# -gt 0 ]]; do
             SETUP_NGINX=true
             shift
             ;;
+        --private)
+            SETUP_NGINX=true
+            NGINX_MODE="private"
+            shift
+            ;;
+        --public)
+            SETUP_NGINX=true
+            NGINX_MODE="public"
+            shift
+            ;;
         --port)
             [ -z "$2" ] && usage
             PORT="$2"
@@ -32,6 +43,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [ -z "$PORT" ]; then
+    if [ "$NGINX_MODE" = "public" ]; then
+        PORT=8000
+    else
+        PORT=8888
+    fi
+fi
+
+if [ "$SETUP_NGINX" = true ] && [ -z "$NGINX_MODE" ]; then
+    NGINX_MODE="private"
+fi
+
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
 
@@ -42,18 +65,14 @@ fi
 
 # If requested, install nginx configuration and reload
 if [ "$SETUP_NGINX" = true ]; then
-    NGINX_CONF="/etc/nginx/conf.d/arthexis.conf"
+    echo "$NGINX_MODE" > NGINX_MODE
+    NGINX_CONF="/etc/nginx/conf.d/arthexis-${NGINX_MODE}.conf"
 
-    # Remove existing nginx configs for arthexis.com to avoid conflicts
-    CONFLICTS=$(sudo grep -rlE "server_name\s+.*arthexis\.com" /etc/nginx/sites-enabled /etc/nginx/conf.d 2>/dev/null || true)
-    for f in $CONFLICTS; do
-        if [ "$f" != "$NGINX_CONF" ]; then
-            echo "Removing conflicting nginx config: $f"
-            sudo rm -f "$f"
-        fi
-    done
+    # Remove existing nginx configs for arthexis*
+    sudo rm -f /etc/nginx/conf.d/arthexis-*.conf
 
-    sudo tee "$NGINX_CONF" > /dev/null <<'NGINXCONF'
+    if [ "$NGINX_MODE" = "public" ]; then
+        sudo tee "$NGINX_CONF" > /dev/null <<'NGINXCONF'
 # Redirect all HTTP traffic to HTTPS
 server {
     listen 80;
@@ -84,6 +103,24 @@ server {
     }
 }
 NGINXCONF
+    else
+        sudo tee "$NGINX_CONF" > /dev/null <<'NGINXCONF'
+server {
+    listen 8000;
+    location / {
+        proxy_pass http://127.0.0.1:PORT_PLACEHOLDER;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+NGINXCONF
+    fi
+
     sudo sed -i "s/PORT_PLACEHOLDER/$PORT/" "$NGINX_CONF"
     sudo nginx -t
     sudo systemctl reload nginx

--- a/network-setup.sh
+++ b/network-setup.sh
@@ -8,16 +8,21 @@ set -euo pipefail
 
 usage() {
     cat <<USAGE
-Usage: $0 [--password]
-  --password  Prompt for a new WiFi password even if one is already configured.
+Usage: $0 [--password] [--no-firewall]
+  --password     Prompt for a new WiFi password even if one is already configured.
+  --no-firewall  Skip firewall port validation.
 USAGE
 }
 
 FORCE_PASSWORD=false
+SKIP_FIREWALL=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --password)
             FORCE_PASSWORD=true
+            ;;
+        --no-firewall)
+            SKIP_FIREWALL=true
             ;;
         -h|--help)
             usage
@@ -41,6 +46,34 @@ command -v nmcli >/dev/null 2>&1 || {
     echo "nmcli (NetworkManager) is required." >&2
     exit 1
 }
+
+if [[ $SKIP_FIREWALL == false ]]; then
+    PORTS=(22 5900 21114)
+    if [ -f NGINX_MODE ]; then
+        MODE="$(cat NGINX_MODE)"
+        if [ "$MODE" = "private" ]; then
+            PORTS+=(8000 8888)
+        else
+            PORTS+=(80 443 8000)
+        fi
+    else
+        PORTS+=(8000)
+    fi
+
+    if command -v ufw >/dev/null 2>&1; then
+        STATUS=$(ufw status 2>/dev/null || true)
+        if echo "$STATUS" | grep -iq "inactive"; then
+            :
+        else
+            for p in "${PORTS[@]}"; do
+                if ! echo "$STATUS" | grep -q "${p}"; then
+                    echo "Port $p is not allowed through the firewall" >&2
+                    exit 1
+                fi
+            done
+        fi
+    fi
+fi
 
 slugify() {
     local input="$1"

--- a/start.sh
+++ b/start.sh
@@ -22,9 +22,20 @@ if [ ! -d .venv ]; then
 fi
 source .venv/bin/activate
 
-# Default to port 8000 and disabled auto-reload unless --reload is provided
-PORT=8000
+# Determine default port based on nginx mode if present
+PORT=""
 RELOAD=false
+if [ -f NGINX_MODE ]; then
+  MODE="$(cat NGINX_MODE)"
+  if [ "$MODE" = "private" ]; then
+    PORT=8888
+  else
+    PORT=8000
+  fi
+fi
+if [ -z "$PORT" ]; then
+  PORT=8000
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,8 +47,16 @@ while [[ $# -gt 0 ]]; do
       RELOAD=true
       shift
       ;;
+    --private)
+      PORT=8888
+      shift
+      ;;
+    --public)
+      PORT=8000
+      shift
+      ;;
     *)
-      echo "Usage: $0 [--port PORT] [--reload]" >&2
+      echo "Usage: $0 [--port PORT] [--reload] [--private|--public]" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Summary
- add --public/--private flags to install script and write mode-specific nginx config
- default Django port based on nginx mode in start script
- validate firewall ports in network-setup script with --no-firewall override

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbfafc7c083269f9ecc84b12d239b