### PR TITLE
fix: handle missing nginx conf dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,9 @@ if [ "$SETUP_NGINX" = true ]; then
     echo "$NGINX_MODE" > NGINX_MODE
     NGINX_CONF="/etc/nginx/conf.d/arthexis-${NGINX_MODE}.conf"
 
+    # Ensure nginx config directory exists
+    sudo mkdir -p /etc/nginx/conf.d
+
     # Remove existing nginx configs for arthexis*
     sudo rm -f /etc/nginx/conf.d/arthexis-*.conf
 
@@ -122,8 +125,13 @@ NGINXCONF
     fi
 
     sudo sed -i "s/PORT_PLACEHOLDER/$PORT/" "$NGINX_CONF"
-    sudo nginx -t
-    sudo systemctl reload nginx
+
+    if command -v nginx >/dev/null 2>&1; then
+        sudo nginx -t
+        sudo systemctl reload nginx || echo "Warning: nginx reload failed"
+    else
+        echo "nginx not installed; skipping nginx test and reload"
+    fi
 fi
 
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- ensure nginx config directory exists before writing configs
- skip nginx reload when the command is unavailable

## Testing
- `shellcheck install.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ace2382da483269ce66d35309cf1ce