### PR TITLE
fix(rfid): initialize scanner on first poll

### DIFF
--- a/rfid/scanner.py
+++ b/rfid/scanner.py
@@ -1,9 +1,51 @@
+"""Helpers for reading from the local RFID scanner."""
+
+import atexit
+from typing import Optional
+
 from .reader import read_rfid
+
+
+try:  # pragma: no cover - hardware dependent
+    from mfrc522 import MFRC522  # type: ignore
+except Exception:  # pragma: no cover - hardware dependent
+    MFRC522 = None  # type: ignore
+
+try:  # pragma: no cover - hardware dependent
+    import RPi.GPIO as GPIO  # type: ignore
+except Exception:  # pragma: no cover - hardware dependent
+    GPIO = None  # type: ignore
+
+
+_reader: Optional[object] = None
+
+
+def _get_reader():  # pragma: no cover - hardware dependent
+    """Initialise and cache the hardware reader."""
+    global _reader
+    if _reader is None and MFRC522 is not None:
+        try:
+            _reader = MFRC522()
+        except Exception:
+            _reader = None
+    return _reader
+
+
+def _cleanup():  # pragma: no cover - hardware dependent
+    if GPIO is not None:
+        try:
+            GPIO.cleanup()
+        except Exception:
+            pass
+
+
+atexit.register(_cleanup)
 
 
 def scan_sources():
     """Read the next RFID tag from the local scanner."""
-    result = read_rfid()
+    reader = _get_reader()
+    result = read_rfid(mfrc=reader, cleanup=False)
     if result and result.get("rfid"):
         return result
     return {"rfid": None, "label_id": None}

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -1,4 +1,5 @@
 import os
+import importlib
 from unittest.mock import patch, MagicMock
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
@@ -79,5 +80,18 @@ class ReaderNotificationTests(TestCase):
         mock_notify.assert_called_once_with(
             "RFID 2 BAD INT", f"{result['rfid']} BLACK"
         )
+
+
+class PersistentScannerTests(SimpleTestCase):
+    @patch("rfid.scanner.read_rfid", return_value={"rfid": None, "label_id": None})
+    @patch("rfid.scanner.MFRC522")
+    def test_reader_initialized_once(self, mock_mfrc, mock_read):
+        import rfid.scanner as scanner
+
+        scanner._reader = None
+        scanner.scan_sources()
+        scanner.scan_sources()
+        self.assertEqual(mock_mfrc.call_count, 1)
+        mock_read.assert_called_with(mfrc=mock_mfrc.return_value, cleanup=False)
 
 


### PR DESCRIPTION
## Summary
- keep RFID hardware initialized and reuse reader on scans
- add regression test to ensure reader initializes only once

## Testing
- `pytest rfid/tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace685feb88326a7caa0b11b60cf38