### PR TITLE
Refine RFID scan display

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.urls import path, reverse
 from django.shortcuts import redirect, render
 from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.html import format_html
@@ -291,12 +292,12 @@ class RFIDAdmin(ImportExportModelAdmin):
         custom = [
             path(
                 "scan/",
-                self.admin_site.admin_view(self.scan_view),
+                self.admin_site.admin_view(csrf_exempt(self.scan_view)),
                 name="accounts_rfid_scan",
             ),
             path(
                 "scan/next/",
-                self.admin_site.admin_view(self.scan_next),
+                self.admin_site.admin_view(csrf_exempt(self.scan_next)),
                 name="accounts_rfid_scan_next",
             ),
             path(

--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -38,9 +38,11 @@ def read_rfid(mfrc=None, cleanup=True, timeout: float = 1.0) -> dict:
                         from nodes.notifications import notify
 
                         status_text = "OK" if tag.allowed else "BAD"
-                        privacy = "PUB" if tag.released else "INT"
                         color_word = (tag.color or "").upper()
-                        subject = f"RFID {tag.label_id} {status_text} {privacy}".strip()
+                        # Display scan results on the LCD in the format:
+                        #   Row 1: "RFID <label> <OK/BAD>"
+                        #   Row 2: "<rfid> <COLOR>"
+                        subject = f"RFID {tag.label_id} {status_text}".strip()
                         body = f"{rfid} {color_word}".strip()
                         notify(subject, body)
                     except Exception:

--- a/rfid/templates/rfid/scanner.html
+++ b/rfid/templates/rfid/scanner.html
@@ -59,7 +59,9 @@
           const w = window.open(data.reference, '_blank');
           if(w){ w.focus(); }
         }
-        statusEl.textContent = data.created ? `Created label ${data.label_id}` : `Detected label ${data.label_id}`;
+        const okText = data.allowed === undefined ? '' : (data.allowed ? 'OK' : 'BAD');
+        const statusMsg = okText ? `RFID ${data.label_id} ${okText}` : `RFID ${data.label_id}`;
+        statusEl.textContent = data.created ? `Created ${statusMsg}` : statusMsg;
       }
     } catch(err){
       showError(err);

--- a/tests/test_rfid_admin_scan_csrf.py
+++ b/tests/test_rfid_admin_scan_csrf.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+
+class AdminRfidScanCsrfTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="rfidadmin",
+            email="rfidadmin@example.com",
+            password="password",
+        )
+        self.client = Client(enforce_csrf_checks=True)
+        self.client.force_login(self.user)
+
+    def test_scan_view_allows_post_without_csrf(self):
+        response = self.client.post(reverse("admin:accounts_rfid_scan"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- Show RFID label and status in the scanner view
- Simplify LCD notification format to `RFID <label> <OK/BAD>`
- Allow admin RFID scan endpoint without CSRF token and test it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad00b15b908326afba6d25a7829c72