### PR TITLE
Restore RFID background reader

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -301,6 +301,11 @@ class RFIDAdmin(ImportExportModelAdmin):
                 name="accounts_rfid_scan_next",
             ),
             path(
+                "watch/toggle/",
+                self.admin_site.admin_view(self.watch_toggle),
+                name="accounts_rfid_watch_toggle",
+            ),
+            path(
                 "<int:pk>/write/",
                 self.admin_site.admin_view(self.write_view),
                 name="accounts_rfid_write",
@@ -324,6 +329,17 @@ class RFIDAdmin(ImportExportModelAdmin):
         result = scan_sources()
         status = 500 if result.get("error") else 200
         return JsonResponse(result, status=status)
+
+    def watch_toggle(self, request):
+        from rfid.always_on import is_running, start, stop
+
+        if is_running():
+            stop()
+            self.message_user(request, "RFID watch disabled")
+        else:
+            start()
+            self.message_user(request, "RFID watch enabled")
+        return redirect("admin:accounts_rfid_changelist")
 
     def write_link(self, obj):
         url = reverse("admin:accounts_rfid_write", args=[obj.pk])

--- a/accounts/templates/admin/accounts/rfid/change_list.html
+++ b/accounts/templates/admin/accounts/rfid/change_list.html
@@ -2,4 +2,5 @@
 {% block object-tools-items %}
 {{ block.super }}
 <li><a href="{% url 'admin:accounts_rfid_scan' %}">Scan RFIDs</a></li>
+<li><a href="{% url 'admin:accounts_rfid_watch_toggle' %}">Toggle RFID Watch</a></li>
 {% endblock %}

--- a/rfid/always_on.py
+++ b/rfid/always_on.py
@@ -1,0 +1,39 @@
+import logging
+import threading
+from typing import Optional
+
+from .background_reader import get_next_tag
+from .signals import tag_scanned
+
+logger = logging.getLogger(__name__)
+
+_thread: Optional[threading.Thread] = None
+_stop = threading.Event()
+
+def _worker() -> None:  # pragma: no cover - background thread
+    logger.debug("RFID watch thread started")
+    while not _stop.is_set():
+        result = get_next_tag(timeout=0.5)
+        if result and result.get("rfid"):
+            logger.info("RFID tag detected: %s", result.get("rfid"))
+            tag_scanned.send(sender=None, **result)
+    logger.debug("RFID watch thread exiting")
+
+def start() -> None:
+    """Start the always-on RFID watcher."""
+    global _thread
+    if _thread and _thread.is_alive():
+        return
+    _stop.clear()
+    _thread = threading.Thread(target=_worker, name="rfid-watch", daemon=True)
+    _thread.start()
+
+def stop() -> None:
+    """Stop the always-on RFID watcher."""
+    _stop.set()
+    if _thread:
+        _thread.join(timeout=1)
+
+def is_running() -> bool:
+    """Return ``True`` if the watcher thread is active."""
+    return bool(_thread and _thread.is_alive())

--- a/rfid/apps.py
+++ b/rfid/apps.py
@@ -4,3 +4,16 @@ from django.apps import AppConfig
 class RfidConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "rfid"
+
+    def ready(self):  # pragma: no cover - startup side effects
+        from .background_reader import start
+        from .signals import tag_scanned
+        from nodes.notifications import notify
+
+        def _notify(_sender, rfid=None, **_kwargs):
+            if rfid:
+                notify("RFID", str(rfid))
+
+        tag_scanned.connect(_notify, weak=False)
+
+        start()

--- a/rfid/background_reader.py
+++ b/rfid/background_reader.py
@@ -1,0 +1,133 @@
+"""Background RFID reader using IRQ pin events."""
+import atexit
+import logging
+import os
+import queue
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - hardware dependent
+    import RPi.GPIO as GPIO  # type: ignore
+except Exception:  # pragma: no cover - hardware dependent
+    GPIO = None  # type: ignore
+
+IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", "4"))
+_tag_queue: "queue.Queue[dict]" = queue.Queue()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_reader = None
+
+
+def _irq_callback(channel):  # pragma: no cover - hardware dependent
+    logger.debug("IRQ callback triggered on channel %s", channel)
+    from .reader import read_rfid
+
+    result = read_rfid(mfrc=_reader, cleanup=False)
+    if result.get("error"):
+        logger.warning("RFID read error via IRQ: %s", result["error"])
+    elif result.get("rfid"):
+        logger.info("RFID tag detected via IRQ: %s", result.get("rfid"))
+        try:
+            _reader.dev_write(_reader.ComIrqReg, 0x7F)
+        except Exception:  # pragma: no cover - hardware dependent
+            pass
+    _tag_queue.put(result)
+
+
+def _setup_hardware():  # pragma: no cover - hardware dependent
+    global _reader
+    if GPIO is None:
+        logger.warning("GPIO library not available; RFID reader disabled")
+        return False
+    try:
+        from mfrc522 import MFRC522  # type: ignore
+    except Exception as exc:
+        logger.warning("MFRC522 library not available: %s", exc)
+        return False
+
+    try:
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(IRQ_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        logger.debug("Initialized GPIO on IRQ pin %s", IRQ_PIN)
+
+        _reader = MFRC522()
+        try:
+            # Enable interrupts for card detection (best effort)
+            _reader.dev_write(_reader.ComIEnReg, 0xA0)  # enable IdleIrq
+            _reader.dev_write(_reader.ComIrqReg, 0x7F)
+        except Exception:
+            pass
+        GPIO.add_event_detect(IRQ_PIN, GPIO.FALLING, callback=_irq_callback)
+        logger.info("RFID IRQ listener active on pin %s", IRQ_PIN)
+    except Exception as exc:
+        logger.warning("Failed to initialize RFID hardware: %s", exc)
+        try:
+            GPIO.cleanup()
+        except Exception:
+            pass
+        return False
+    return True
+
+
+def _worker():  # pragma: no cover - background thread
+    if not _setup_hardware():
+        logger.error("RFID hardware setup failed; background reader not running")
+        return
+    while not _stop_event.is_set():
+        _stop_event.wait(0.5)
+    if GPIO:
+        try:
+            GPIO.remove_event_detect(IRQ_PIN)
+            GPIO.cleanup()
+        except Exception:
+            pass
+
+
+def start():
+    """Start the background RFID reader."""
+    global _thread
+    if GPIO is None:
+        return
+    if _thread and _thread.is_alive():
+        return
+    _stop_event.clear()
+    logger.debug("Starting RFID background reader thread")
+    _thread = threading.Thread(target=_worker, name="rfid-reader", daemon=True)
+    _thread.start()
+    atexit.register(stop)
+
+
+def stop():
+    """Stop the background RFID reader and cleanup GPIO."""
+    _stop_event.set()
+    if _thread:
+        _thread.join(timeout=1)
+    if GPIO:
+        try:
+            if GPIO.getmode() is not None:  # Only cleanup if GPIO was initialized
+                GPIO.cleanup()
+        except Exception:
+            pass
+
+
+def get_next_tag(timeout: float = 0) -> Optional[dict]:
+    """Retrieve the next tag read from the queue.
+
+    Falls back to direct polling if no IRQ events are queued.
+    """
+    try:
+        return _tag_queue.get(timeout=timeout)
+    except queue.Empty:
+        logger.debug("IRQ queue empty; falling back to direct read")
+        try:
+            from .reader import read_rfid
+
+            res = read_rfid(mfrc=_reader, cleanup=False)
+            if res.get("rfid") or res.get("error"):
+                logger.debug("Polling read result: %s", res)
+                return res
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            logger.debug("Polling read failed: %s", exc)
+        return None

--- a/rfid/irq_wiring_check.py
+++ b/rfid/irq_wiring_check.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, ANY
+
+from rfid.background_reader import _setup_hardware, IRQ_PIN, GPIO
+from rfid.reader import read_rfid
+
+
+class IRQPinSetupManualTest(TestCase):
+    """Manual test to ensure IRQ pin setup uses the expected GPIO pin."""
+
+    def test_irq_pin_setup(self):
+        with patch("rfid.background_reader.GPIO") as mock_gpio, \
+             patch.dict("sys.modules", {"mfrc522": MagicMock(MFRC522=MagicMock())}):
+            _setup_hardware()
+            mock_gpio.setmode.assert_called_once_with(mock_gpio.BCM)
+            mock_gpio.setup.assert_called_once_with(
+                IRQ_PIN, mock_gpio.IN, pull_up_down=mock_gpio.PUD_UP
+            )
+            mock_gpio.add_event_detect.assert_called_once_with(
+                IRQ_PIN, mock_gpio.FALLING, callback=ANY
+            )
+
+
+def check_irq_pin():
+    """Return the IRQ pin used by the reader or report if none is detected."""
+    if _setup_hardware():
+        if GPIO:
+            try:  # pragma: no cover - hardware cleanup
+                GPIO.remove_event_detect(IRQ_PIN)
+                GPIO.cleanup()
+            except Exception:
+                pass
+        return {"irq_pin": IRQ_PIN}
+
+    result = read_rfid(timeout=0.1)
+    if result.get("error"):
+        return {"error": "no scanner detected"}
+    return {"irq_pin": None}

--- a/rfid/management/commands/rfid_watch.py
+++ b/rfid/management/commands/rfid_watch.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Toggle the always-on RFID watcher"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--stop",
+            action="store_true",
+            help="Stop the always-on watcher instead of starting it",
+        )
+
+    def handle(self, *args, **options):
+        from rfid.always_on import is_running, start, stop
+
+        if options["stop"]:
+            stop()
+            self.stdout.write(self.style.SUCCESS("RFID watch disabled"))
+        else:
+            start()
+            state = "enabled" if is_running() else "disabled"
+            self.stdout.write(self.style.SUCCESS(f"RFID watch {state}"))

--- a/rfid/scanner.py
+++ b/rfid/scanner.py
@@ -1,52 +1,28 @@
-"""Helpers for reading from the local RFID scanner."""
-
-import atexit
-from typing import Optional
-
-from .reader import read_rfid
-
-
-try:  # pragma: no cover - hardware dependent
-    from mfrc522 import MFRC522  # type: ignore
-except Exception:  # pragma: no cover - hardware dependent
-    MFRC522 = None  # type: ignore
-
-try:  # pragma: no cover - hardware dependent
-    import RPi.GPIO as GPIO  # type: ignore
-except Exception:  # pragma: no cover - hardware dependent
-    GPIO = None  # type: ignore
-
-
-_reader: Optional[object] = None
-
-
-def _get_reader():  # pragma: no cover - hardware dependent
-    """Initialise and cache the hardware reader."""
-    global _reader
-    if _reader is None and MFRC522 is not None:
-        try:
-            _reader = MFRC522()
-        except Exception:
-            _reader = None
-    return _reader
-
-
-def _cleanup():  # pragma: no cover - hardware dependent
-    if GPIO is not None:
-        try:
-            GPIO.cleanup()
-        except Exception:
-            pass
-
-
-atexit.register(_cleanup)
+from .background_reader import get_next_tag, start, stop
+from .irq_wiring_check import check_irq_pin
 
 
 def scan_sources():
     """Read the next RFID tag from the local scanner."""
-    reader = _get_reader()
-    result = read_rfid(mfrc=reader, cleanup=False)
+    result = get_next_tag()
     if result and result.get("rfid"):
         return result
     return {"rfid": None, "label_id": None}
 
+
+def restart_sources():
+    """Restart the local RFID scanner."""
+    try:
+        stop()
+        start()
+        test = get_next_tag()
+        if test is not None and not test.get("error"):
+            return {"status": "restarted"}
+    except Exception:
+        pass
+    return {"error": "no scanner available"}
+
+
+def test_sources():
+    """Check the local RFID scanner for availability."""
+    return check_irq_pin()

--- a/rfid/signals.py
+++ b/rfid/signals.py
@@ -1,0 +1,5 @@
+"""Signals for the RFID app."""
+from django.dispatch import Signal
+
+# Fired when an RFID tag is detected by the always-on watcher.
+tag_scanned = Signal()

--- a/rfid/templates/rfid/reader.html
+++ b/rfid/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "website/base.html" %}
 {% block content %}
 <h1>RFID Reader</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url %}
+{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url %}
 {% endblock %}

--- a/rfid/templates/rfid/scanner.html
+++ b/rfid/templates/rfid/scanner.html
@@ -1,6 +1,9 @@
 {% with prefix=prefix|default:"rfid" %}
   <div id="{{ prefix }}-scanner">
   <p id="{{ prefix }}-status">Scanner ready</p>
+  <p>
+    <button id="{{ prefix }}-restart-test">Restart &amp; Test Scanner</button>
+  </p>
   <div class="field"><span class="label">Label:</span><span class="value" id="{{ prefix }}-label"></span></div>
   <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
   <div class="field"><span class="label">Color:</span><span class="value" id="{{ prefix }}-color"></span></div>
@@ -35,10 +38,11 @@
   const allowedEl = document.getElementById('{{ prefix }}-allowed');
   const releasedEl = document.getElementById('{{ prefix }}-released');
   const referenceEl = document.getElementById('{{ prefix }}-reference');
+  const restartTestBtn = document.getElementById('{{ prefix }}-restart-test');
 
   function showError(message){
     console.error(message);
-    statusEl.textContent = 'RFID reader not detected.';
+    statusEl.textContent = 'RFID reader not detected. Please connect the reader and press Restart & Test Scanner.';
   }
 
   async function poll(){
@@ -55,7 +59,7 @@
         allowedEl.textContent = data.allowed === undefined ? '' : (data.allowed ? 'Yes' : 'No');
         releasedEl.textContent = data.released === undefined ? '' : (data.released ? 'Yes' : 'No');
         referenceEl.textContent = data.reference || '';
-        if(data.reference && /^https?:\\/\\//i.test(data.reference)){
+        if(data.reference && /^https?:\/\//i.test(data.reference)){
           const w = window.open(data.reference, '_blank');
           if(w){ w.focus(); }
         }
@@ -69,8 +73,24 @@
     }
     setTimeout(poll, 200);
   }
+  restartTestBtn.addEventListener('click', async () => {
+    try {
+      await fetch('{{ restart_url }}', {method: 'POST'});
+      const resp = await fetch('{{ test_url }}');
+      const data = await resp.json();
+      let msg = '';
+      if(data.error){
+        msg = 'No local scanner detected.';
+      } else if(data.irq_pin !== undefined){
+        msg = `IRQ pin ${data.irq_pin}.`;
+      }
+      statusEl.textContent = msg || 'Test completed';
+      poll();
+    } catch(err) {
+      statusEl.textContent = 'Test failed';
+    }
+  });
   poll();
 })();
 </script>
 {% endwith %}
-

--- a/rfid/urls.py
+++ b/rfid/urls.py
@@ -4,4 +4,6 @@ from . import views
 urlpatterns = [
     path("", views.reader, name="rfid-reader"),
     path("scan/next/", views.scan_next, name="rfid-scan-next"),
+    path("scan/restart/", views.scan_restart, name="rfid-scan-restart"),
+    path("scan/test/", views.scan_test, name="rfid-scan-test"),
 ]

--- a/rfid/views.py
+++ b/rfid/views.py
@@ -1,9 +1,10 @@
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
+from django.views.decorators.http import require_POST
 from website.utils import landing
 
-from .scanner import scan_sources
+from .scanner import scan_sources, restart_sources, test_sources
 
 
 def scan_next(_request):
@@ -13,10 +14,27 @@ def scan_next(_request):
     return JsonResponse(result, status=status)
 
 
+@require_POST
+def scan_restart(_request):
+    """Restart the RFID scanner."""
+    result = restart_sources()
+    status = 500 if result.get("error") else 200
+    return JsonResponse(result, status=status)
+
+
+def scan_test(_request):
+    """Report wiring information for the local RFID scanner."""
+    result = test_sources()
+    status = 500 if result.get("error") else 200
+    return JsonResponse(result, status=status)
+
+
 @landing("RFID Reader")
 def reader(request):
     """Public page to read RFID tags."""
     context = {
         "scan_url": reverse("rfid-scan-next"),
+        "restart_url": reverse("rfid-scan-restart"),
+        "test_url": reverse("rfid-scan-test"),
     }
     return render(request, "rfid/reader.html", context)

--- a/tests/test_rfid_admin_actions.py
+++ b/tests/test_rfid_admin_actions.py
@@ -9,8 +9,11 @@ import django
 django.setup()
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory, TestCase
-from unittest.mock import MagicMock
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.urls import reverse
 
 from accounts.admin import RFIDAdmin
 from accounts.models import RFID
@@ -21,19 +24,18 @@ class RFIDAdminActionTests(TestCase):
         self.site = AdminSite()
         self.admin = RFIDAdmin(RFID, self.site)
         self.factory = RequestFactory()
-
-        class DummyUser:
-            is_active = True
-
-            def has_perm(self, _perm):
-                return True
-
-        self.user = DummyUser()
-        self.admin.message_user = MagicMock()
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="rfidadmin", email="rfid@example.com", password="password"
+        )
 
     def _request_with_messages(self):
         request = self.factory.post("/admin/accounts/rfid/")
         request.user = self.user
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        setattr(request, "_messages", FallbackStorage(request))
         return request
 
     def test_swap_color_action_registered(self):
@@ -43,12 +45,29 @@ class RFIDAdminActionTests(TestCase):
         self.assertIn("swap_color", actions)
 
     def test_swap_color_action_swaps_colors(self):
-        black = MagicMock(color=RFID.BLACK)
-        white = MagicMock(color=RFID.WHITE)
+        black = RFID.objects.create(rfid="00112233", color=RFID.BLACK)
+        white = RFID.objects.create(rfid="44556677", color=RFID.WHITE)
         request = self._request_with_messages()
-        queryset = [black, white]
+        queryset = RFID.objects.filter(pk__in=[black.pk, white.pk])
         self.admin.swap_color(request, queryset)
+        black.refresh_from_db()
+        white.refresh_from_db()
         self.assertEqual(black.color, RFID.WHITE)
         self.assertEqual(white.color, RFID.BLACK)
-        black.save.assert_called_once()
-        white.save.assert_called_once()
+
+
+class RFIDAdminWatchLinkTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="rfidwatch", email="watch@example.com", password="password"
+        )
+        self.client.force_login(self.user)
+
+    def test_change_list_shows_watch_toggle(self):
+        response = self.client.get(reverse("admin:accounts_rfid_changelist"))
+        self.assertContains(response, "Toggle RFID Watch")
+        self.assertContains(
+            response, reverse("admin:accounts_rfid_watch_toggle")
+        )
+


### PR DESCRIPTION
## Summary
- Reintroduce IRQ-based background RFID reader and watcher infrastructure
- Expose restart and wiring test endpoints for RFID scanner
- Align RFID notification tests with current message format

## Testing
- `python manage.py test rfid.tests tests.test_rfid_admin_actions -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68ad095daa0c83269c3102e76e882aa8