### PR TITLE
chore: ignore NGINX_MODE env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ ENV/
 env.bak/
 venv.bak/
 SERVICE
+NGINX_MODE
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
## Summary
- add NGINX_MODE to root .gitignore so the env variable file isn't committed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1172a2a483269ca0b391e91cf600