### PR TITLE
Track RFID last seen and allow new tag colors

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -245,7 +245,15 @@ class RFIDResource(resources.ModelResource):
 
     class Meta:
         model = RFID
-        fields = ("label_id", "rfid", "reference", "allowed", "color", "released")
+        fields = (
+            "label_id",
+            "rfid",
+            "reference",
+            "allowed",
+            "color",
+            "released",
+            "last_seen_on",
+        )
         import_id_fields = ("label_id",)
 
 
@@ -262,12 +270,14 @@ class RFIDAdmin(ImportExportModelAdmin):
         "accounts_display",
         "allowed",
         "added_on",
+        "last_seen_on",
         "write_link",
     )
     list_filter = ("color", "released", "allowed")
     search_fields = ("label_id", "rfid")
     autocomplete_fields = ["accounts"]
     actions = ["scan_rfids", "swap_color"]
+    readonly_fields = ("added_on", "last_seen_on")
 
     def accounts_display(self, obj):
         return ", ".join(str(a) for a in obj.accounts.all())

--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -493,13 +493,19 @@ class Migration(migrations.Migration):
                 (
                     "color",
                     models.CharField(
-                        choices=[("black", "Black"), ("white", "White")],
+                        choices=[
+                            ("black", "Black"),
+                            ("white", "White"),
+                            ("blue", "Blue"),
+                            ("trans", "Trans"),
+                        ],
                         default="black",
                         max_length=5,
                     ),
                 ),
                 ("released", models.BooleanField(default=False)),
                 ("added_on", models.DateTimeField(auto_now_add=True)),
+                ("last_seen_on", models.DateTimeField(blank=True, null=True)),
                 (
                     "reference",
                     models.ForeignKey(

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -204,7 +204,14 @@ class RFID(Entity):
     allowed = models.BooleanField(default=True)
     BLACK = "black"
     WHITE = "white"
-    COLOR_CHOICES = [(BLACK, "Black"), (WHITE, "White")]
+    BLUE = "blue"
+    TRANS = "trans"
+    COLOR_CHOICES = [
+        (BLACK, "Black"),
+        (WHITE, "White"),
+        (BLUE, "Blue"),
+        (TRANS, "Trans"),
+    ]
     color = models.CharField(
         max_length=5,
         choices=COLOR_CHOICES,
@@ -220,6 +227,7 @@ class RFID(Entity):
     )
     released = models.BooleanField(default=False)
     added_on = models.DateTimeField(auto_now_add=True)
+    last_seen_on = models.DateTimeField(null=True, blank=True)
 
     def save(self, *args, **kwargs):
         if self.rfid:

--- a/rfid/reader.py
+++ b/rfid/reader.py
@@ -1,4 +1,5 @@
 import time
+from django.utils import timezone
 from accounts.models import RFID
 
 
@@ -25,6 +26,8 @@ def read_rfid(mfrc=None, cleanup=True, timeout: float = 1.0) -> dict:
                 if status == mfrc.MI_OK:
                     rfid = "".join(f"{x:02X}" for x in uid[:5])
                     tag, created = RFID.objects.get_or_create(rfid=rfid)
+                    tag.last_seen_on = timezone.now()
+                    tag.save(update_fields=["last_seen_on"])
                     result = {
                         "rfid": rfid,
                         "label_id": tag.pk,

--- a/rfid/tests.py
+++ b/rfid/tests.py
@@ -9,6 +9,7 @@ django.setup()
 from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 from rfid.reader import read_rfid
+from accounts.models import RFID
 
 
 class ScanNextViewTests(SimpleTestCase):
@@ -79,6 +80,28 @@ class ReaderNotificationTests(TestCase):
         mock_notify.assert_called_once_with(
             "RFID 2 BAD", f"{result['rfid']} BLACK"
         )
+
+
+class RFIDLastSeenTests(TestCase):
+    def _mock_reader(self):
+        class MockReader:
+            MI_OK = 1
+            PICC_REQIDL = 0
+
+            def MFRC522_Request(self, _):
+                return (self.MI_OK, None)
+
+            def MFRC522_Anticoll(self):
+                return (self.MI_OK, [0xAB, 0xCD, 0x12, 0x34])
+
+        return MockReader()
+
+    @patch("nodes.notifications.notify")
+    def test_last_seen_updated_on_read(self, _mock_notify):
+        tag = RFID.objects.create(rfid="ABCD1234")
+        read_rfid(mfrc=self._mock_reader(), cleanup=False)
+        tag.refresh_from_db()
+        self.assertIsNotNone(tag.last_seen_on)
 
 
 class RestartViewTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- record when an RFID was last scanned
- add Blue and Trans to available RFID colors
- expose last-seen timestamp in admin

## Testing
- `python manage.py makemigrations accounts rfid --check --dry-run`
- `python manage.py test nodes.tests.NodeActionTests.test_generate_backup_action_creates_backup --verbosity 2` *(fails: 302 != 200)*
- `python manage.py test nodes.tests.NotificationManagerTests.test_gui_display_uses_windows_toast --verbosity 2` *(fails: expected toast duration 10, got 6)*
- `python manage.py test website.tests.ReadmeSidebarTests.test_included_apps_table_renders --verbosity 2` *(fails: expected '<td>accounts</td>' in response)*

------
https://chatgpt.com/codex/tasks/task_e_68ad181c5e1883269b1f41ea8dbd8d29