### PR TITLE
feat: add clean-db option to upgrade script

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -5,10 +5,22 @@ BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
 
 FORCE=0
-if [[ "${1:-}" == "--latest" ]]; then
-  FORCE=1
-  shift
-fi
+CLEAN_DB=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --latest)
+      FORCE=1
+      shift
+      ;;
+    --clean-db)
+      CLEAN_DB=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 # Determine current and remote versions
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -49,6 +61,12 @@ fi
 if [ ! -d .venv ]; then
   echo "Virtual environment not found. Run ./install.sh first." >&2
   exit 1
+fi
+
+# Remove existing database if requested
+if [ "$CLEAN_DB" -eq 1 ]; then
+  DB_FILE="db.sqlite3"
+  rm -f "$DB_FILE"
 fi
 
 # Refresh environment and restart service


### PR DESCRIPTION
## Summary
- add `--clean-db` flag to `upgrade.sh` to reset local SQLite database
- ensure upgrade routine can start from a fresh DB and regenerate migrations

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py migrate`


------
https://chatgpt.com/codex/tasks/task_e_68ad22e322c08326adc7407c8d720a95