### PR TITLE
Add RFID last seen migration

### DIFF
--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -505,7 +505,6 @@ class Migration(migrations.Migration):
                 ),
                 ("released", models.BooleanField(default=False)),
                 ("added_on", models.DateTimeField(auto_now_add=True)),
-                ("last_seen_on", models.DateTimeField(blank=True, null=True)),
                 (
                     "reference",
                     models.ForeignKey(

--- a/accounts/migrations/0002_rfid_last_seen_on.py
+++ b/accounts/migrations/0002_rfid_last_seen_on.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="rfid",
+            name="last_seen_on",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- remove last_seen_on from initial migration
- add migration to add last_seen_on field to RFID model

## Testing
- `python manage.py makemigrations accounts --check`
- `python manage.py test accounts rfid`
- `python manage.py migrate accounts 0001 --noinput`
- `python manage.py migrate accounts --noinput`


------
https://chatgpt.com/codex/tasks/task_e_68ad23b1a14c8326b98ccf7f476f0e21