### PR TITLE
feat: remove RFID length limit

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -154,7 +154,7 @@ class AccountAdmin(admin.ModelAdmin):
         class OnboardForm(forms.Form):
             first_name = forms.CharField(label="First name")
             last_name = forms.CharField(label="Last name")
-            rfid = forms.CharField(max_length=8, required=False, label="RFID")
+            rfid = forms.CharField(required=False, label="RFID")
             allow_login = forms.BooleanField(
                 required=False, initial=False, label="Allow login"
             )

--- a/accounts/migrations/0001_initial.py
+++ b/accounts/migrations/0001_initial.py
@@ -450,12 +450,12 @@ class Migration(migrations.Migration):
                 (
                     "rfid",
                     models.CharField(
-                        max_length=8,
+                        max_length=255,
                         unique=True,
                         validators=[
                             django.core.validators.RegexValidator(
-                                "^[0-9A-Fa-f]{8}$",
-                                message="RFID must be 8 hexadecimal digits",
+                                "^[0-9A-Fa-f]+$",
+                                message="RFID must be hexadecimal digits",
                             )
                         ],
                         verbose_name="RFID",

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -170,13 +170,13 @@ class RFID(Entity):
 
     label_id = models.AutoField(primary_key=True, db_column="label_id")
     rfid = models.CharField(
-        max_length=8,
+        max_length=255,
         unique=True,
         verbose_name="RFID",
         validators=[
             RegexValidator(
-                r"^[0-9A-Fa-f]{8}$",
-                message="RFID must be 8 hexadecimal digits",
+                r"^[0-9A-Fa-f]+$",
+                message="RFID must be hexadecimal digits",
             )
         ],
     )

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -215,6 +215,10 @@ class RFIDValidationTests(TestCase):
         tag = RFID.objects.create(rfid="deadbeef")
         self.assertEqual(tag.rfid, "DEADBEEF")
 
+    def test_long_rfid_allowed(self):
+        tag = RFID.objects.create(rfid="DEADBEEF10")
+        self.assertEqual(tag.rfid, "DEADBEEF10")
+
     def test_find_user_by_rfid(self):
         user = User.objects.create_user(username="finder", password="pwd")
         acc = Account.objects.create(user=user, name="FINDER")

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -74,7 +74,7 @@ class Migration(migrations.Migration):
                 ('cp_path', models.CharField(max_length=100)),
                 ('host', models.CharField(default='127.0.0.1', max_length=100)),
                 ('ws_port', models.IntegerField(default=8000, verbose_name='WS Port')),
-                ('rfid', models.CharField(default='FFFFFFFF', max_length=8)),
+                ('rfid', models.CharField(default='FFFFFFFF', max_length=255)),
                 ('vin', models.CharField(blank=True, max_length=17)),
                 ('duration', models.IntegerField(default=600)),
                 ('interval', models.FloatField(default=5.0)),

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -210,7 +210,7 @@ class Simulator(Entity):
     cp_path = models.CharField(max_length=100)
     host = models.CharField(max_length=100, default="127.0.0.1")
     ws_port = models.IntegerField(_("WS Port"), default=8000)
-    rfid = models.CharField(max_length=8, default="FFFFFFFF")
+    rfid = models.CharField(max_length=255, default="FFFFFFFF")
     vin = models.CharField(max_length=17, blank=True)
     duration = models.IntegerField(default=600)
     interval = models.FloatField(default=5.0)


### PR DESCRIPTION
## Summary
- remove 8 character cap from RFID model and admin form
- allow longer RFID values in OCPP simulator
- add test covering extended RFID length

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adedb0125483268dfbbfb881a6850f