### PR TITLE
Handle charger reconnects and simulator termination

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -43,6 +43,11 @@ class CSMSConsumer(AsyncWebsocketConsumer):
         offered = self.scope.get("subprotocols", [])
         if "ocpp1.6" in offered:
             subprotocol = "ocpp1.6"
+        # If a connection for this charger already exists, close it so a new
+        # simulator session can start immediately.
+        existing = store.connections.get(self.charger_id)
+        if existing is not None:
+            await existing.close()
         await self.accept(subprotocol=subprotocol)
         store.add_log(
             self.charger_id,


### PR DESCRIPTION
## Summary
- Terminate existing CSMS charger sessions when a new simulator connects to the same charger
- Mark charge point simulators as stopped when a charger closes the connection
- Add regression tests for reconnect handling and remote termination

## Testing
- `python manage.py test ocpp.tests.CSMSConsumerTests ocpp.tests.ChargePointSimulatorTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae0253eaa88326b576ea24315ce401