### PR TITLE
Add Celery startup option and auto-upgrade logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,8 @@
             "windows": {
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
-            "program": "${workspaceFolder}/manage.py",
-            "args": ["runserver", "--noreload"],
+            "program": "${workspaceFolder}/vscode_manage.py",
+            "args": ["runserver", "--noreload", "--celery"],
             "django": true,
             "noDebug": true
         },
@@ -23,7 +23,7 @@
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
             "program": "${workspaceFolder}/vscode_manage.py",
-            "args": ["runserver", "--noreload"],
+            "args": ["runserver", "--noreload", "--celery"],
             "django": true
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,9 +14,9 @@
         {
             "label": "Dev: start",
             "type": "shell",
-            "command": "${workspaceFolder}/start.sh --reload",
+            "command": "${workspaceFolder}/start.sh --reload --celery",
             "windows": {
-                "command": "${workspaceFolder}\\start.bat --reload"
+                "command": "${workspaceFolder}\\start.bat --reload --celery"
             },
             "problemMatcher": [],
             "detail": "Start the Django development server"

--- a/vscode_manage.py
+++ b/vscode_manage.py
@@ -1,17 +1,39 @@
 import os
 import runpy
+import subprocess
 import sys
+from pathlib import Path
 
 
 def main(argv=None):
-    argv = argv or []
-    os.environ.pop("DEBUGPY_LAUNCHER_PORT", None)
-    if "PYTHONPATH" in os.environ:
-        os.environ["PYTHONPATH"] = os.pathsep.join(
-            p for p in os.environ["PYTHONPATH"].split(os.pathsep) if "debugpy" not in p
-        )
-    sys.argv = ["manage.py", *argv]
-    runpy.run_path("manage.py", run_name="__main__")
+    argv = list(argv or [])
+    base_dir = Path(__file__).resolve().parent
+    celery_enabled = (base_dir / "CELERY").exists()
+    if "--celery" in argv:
+        celery_enabled = True
+        argv.remove("--celery")
+    if "--no-celery" in argv:
+        celery_enabled = False
+        argv.remove("--no-celery")
+
+    worker = beat = None
+    try:
+        if celery_enabled:
+            worker = subprocess.Popen([sys.executable, "-m", "celery", "-A", "config", "worker", "-l", "info"])
+            beat = subprocess.Popen([sys.executable, "-m", "celery", "-A", "config", "beat", "-l", "info"])
+
+        os.environ.pop("DEBUGPY_LAUNCHER_PORT", None)
+        if "PYTHONPATH" in os.environ:
+            os.environ["PYTHONPATH"] = os.pathsep.join(
+                p for p in os.environ["PYTHONPATH"].split(os.pathsep) if "debugpy" not in p
+            )
+        sys.argv = ["manage.py", *argv]
+        runpy.run_path("manage.py", run_name="__main__")
+    finally:
+        if worker:
+            worker.terminate()
+        if beat:
+            beat.terminate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--celery` flag to installer and startup scripts, implied by `--satellite`
- default VS Code configs to launch Celery alongside Django
- log auto-upgrade task runs and slugify its beat entry name

## Testing
- `bash -n start.sh install.sh`
- `python -m py_compile vscode_manage.py release/tasks.py`
- `pytest` *(fails: tests/test_notifications_fallback.py:43 and 55, assert 10 == 6)*

------
https://chatgpt.com/codex/tasks/task_e_68ae05da2f848326aa6aadb1c916c529