### PR TITLE
Add LCD reset and timing safeguards

### DIFF
--- a/msg/notifications.py
+++ b/msg/notifications.py
@@ -63,7 +63,15 @@ class NotificationManager:
                 return True
             except Exception as exc:  # pragma: no cover - hardware dependent
                 logger.warning("LCD display failed: %s", exc)
-                self.lcd = None
+                try:
+                    self.lcd.reset()
+                    self.lcd.clear()
+                    self.lcd.write(0, 0, subject[:16].ljust(16))
+                    self.lcd.write(0, 1, body[:16].ljust(16))
+                    return True
+                except Exception as exc2:  # pragma: no cover - hardware dependent
+                    logger.warning("LCD reset failed: %s", exc2)
+                    self.lcd = None
         self._gui_display(subject, body)
         return False
 
@@ -73,7 +81,7 @@ class NotificationManager:
             if self._toaster:
                 try:  # pragma: no cover - depends on platform
                     self._toaster.show_toast(
-                        "Arthexis", f"{subject}\n{body}", duration=10, threaded=True
+                        "Arthexis", f"{subject}\n{body}", duration=6, threaded=True
                     )
                     return
                 except Exception as exc:  # pragma: no cover - depends on platform
@@ -81,7 +89,7 @@ class NotificationManager:
             elif plyer_notification:
                 try:  # pragma: no cover - depends on platform
                     plyer_notification.notify(
-                        title="Arthexis", message=f"{subject}\n{body}", timeout=10
+                        title="Arthexis", message=f"{subject}\n{body}", timeout=6
                     )
                     return
                 except Exception as exc:  # pragma: no cover - depends on platform

--- a/nodes/lcd.py
+++ b/nodes/lcd.py
@@ -72,6 +72,8 @@ class CharLCD1602:
         self._pulse_enable(high)
         self._write_word(self.LCD_ADDR, low)
         self._pulse_enable(low)
+        # Give the LCD time to process the command to avoid garbled output.
+        time.sleep(0.001)
 
     def send_data(self, data: int) -> None:
         high = (data & 0xF0) | 0x01
@@ -80,6 +82,8 @@ class CharLCD1602:
         self._pulse_enable(high)
         self._write_word(self.LCD_ADDR, low)
         self._pulse_enable(low)
+        # Allow the LCD controller to catch up between data writes.
+        time.sleep(0.001)
 
     def i2c_scan(self) -> List[str]:  # pragma: no cover - requires hardware
         cmd = "i2cdetect -y 1 | awk 'NR>1 {$1=\"\"; print}'"
@@ -112,6 +116,10 @@ class CharLCD1602:
     def clear(self) -> None:
         self.send_command(0x01)
         time.sleep(0.002)
+
+    def reset(self) -> None:
+        """Re-run the initialisation sequence to recover the display."""
+        self.init_lcd(addr=self.LCD_ADDR, bl=self.BLEN)
 
     def set_backlight(self, on: bool = True) -> None:  # pragma: no cover - hardware dependent
         self.BLEN = 1 if on else 0

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -494,6 +494,7 @@ class NotificationManagerTests(TestCase):
         manager._gui_display = MagicMock()
         result = manager.send("hi", "there")
         self.assertFalse(result)
+        mock_lcd.reset.assert_called_once()
         manager._gui_display.assert_called_once_with("hi", "there")
 
     @patch("msg.notifications.NotificationManager._init_lcd", return_value=MagicMock())
@@ -515,7 +516,7 @@ class NotificationManagerTests(TestCase):
                 manager = NotificationManager()
                 manager._gui_display("hi", "there")
         mock_toast.show_toast.assert_called_once_with(
-            "Arthexis", "hi\nthere", duration=10, threaded=True
+            "Arthexis", "hi\nthere", duration=6, threaded=True
         )
 
     def test_gui_display_logs_when_toast_unavailable(self):


### PR DESCRIPTION
## Summary
- add per-command and per-data delays so LCD can process writes
- expose a reset routine and retry LCD writes before falling back
- align Windows notification durations to six seconds

## Testing
- `pytest tests/test_notifications_fallback.py tests/test_lcd_smbus2.py nodes/tests.py::NotificationManagerTests::test_send_writes_trimmed_lines nodes/tests.py::NotificationManagerTests::test_send_falls_back_to_gui nodes/tests.py::NotificationManagerTests::test_send_handles_lcd_exception nodes/tests.py::NotificationManagerTests::test_send_reinitialises_lcd nodes/tests.py::NotificationManagerTests::test_gui_display_uses_windows_toast -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e8b93d483269b02232b7d891b5d