### PR TITLE
Move runtime flags to dedicated locks directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,8 +155,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-SERVICE
-NGINX_MODE
+locks/
 
 # Spyder project settings
 .spyderproject

--- a/install.sh
+++ b/install.sh
@@ -81,11 +81,13 @@ fi
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
+LOCK_DIR="$BASE_DIR/locks"
+mkdir -p "$LOCK_DIR"
 
 if [ "$ENABLE_CELERY" = true ]; then
-    touch CELERY
+    touch "$LOCK_DIR/celery.lck"
 else
-    rm -f CELERY
+    rm -f "$LOCK_DIR/celery.lck"
 fi
 
 # Create virtual environment if missing
@@ -95,7 +97,7 @@ fi
 
 # If requested, install nginx configuration and reload
 if [ "$SETUP_NGINX" = true ]; then
-    echo "$NGINX_MODE" > NGINX_MODE
+    echo "$NGINX_MODE" > "$LOCK_DIR/nginx_mode.lck"
     NGINX_CONF="/etc/nginx/conf.d/arthexis-${NGINX_MODE}.conf"
 
     # Ensure nginx config directory exists
@@ -186,7 +188,7 @@ deactivate
 # If a service name was provided, install a systemd unit and persist its name
 if [ -n "$SERVICE" ]; then
     SERVICE_FILE="/etc/systemd/system/${SERVICE}.service"
-    echo "$SERVICE" > SERVICE
+    echo "$SERVICE" > "$LOCK_DIR/service.lck"
     if [ "$ENABLE_CELERY" = true ]; then
         EXEC_CMD="/bin/sh -c 'cd $BASE_DIR && .venv/bin/celery -A config worker -l info & .venv/bin/celery -A config beat -l info & exec .venv/bin/python manage.py runserver 0.0.0.0:$PORT'"
     else

--- a/network-setup.sh
+++ b/network-setup.sh
@@ -6,6 +6,10 @@
 
 set -euo pipefail
 
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+LOCK_DIR="$BASE_DIR/locks"
+
 usage() {
     cat <<USAGE
 Usage: $0 [--password] [--no-firewall]
@@ -50,8 +54,8 @@ command -v nmcli >/dev/null 2>&1 || {
 if [[ $SKIP_FIREWALL == false ]]; then
     PORTS=(22 5900 21114)
     MODE="internal"
-    if [ -f NGINX_MODE ]; then
-        MODE="$(cat NGINX_MODE)"
+    if [ -f "$LOCK_DIR/nginx_mode.lck" ]; then
+        MODE="$(cat "$LOCK_DIR/nginx_mode.lck")"
     fi
     if [ "$MODE" = "public" ]; then
         PORTS+=(80 443 8000)

--- a/release/tasks.py
+++ b/release/tasks.py
@@ -54,7 +54,7 @@ def check_github_updates() -> None:
 
     subprocess.run(args, cwd=base_dir, check=True)
 
-    service_file = base_dir / "SERVICE"
+    service_file = base_dir / "locks/service.lck"
     if service_file.exists():
         service = service_file.read_text().strip()
         subprocess.run([

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,12 +23,13 @@ done
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$BASE_DIR"
+LOCK_DIR="$BASE_DIR/locks"
 
-if [ -z "$SERVICE" ] && [ -f SERVICE ]; then
-    SERVICE="$(cat SERVICE)"
+if [ -z "$SERVICE" ] && [ -f "$LOCK_DIR/service.lck" ]; then
+    SERVICE="$(cat "$LOCK_DIR/service.lck")"
 fi
 
-read -p "This will stop the Arthexis server. Continue? [y/N] " CONFIRM
+read -r -p "This will stop the Arthexis server. Continue? [y/N] " CONFIRM
 if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
     echo "Aborted."
     exit 0
@@ -42,7 +43,7 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
         sudo rm "$SERVICE_FILE"
         sudo systemctl daemon-reload
     fi
-    rm -f SERVICE
+    rm -f "$LOCK_DIR/service.lck"
 else
     pkill -f "manage.py runserver" || true
 fi

--- a/vscode_manage.py
+++ b/vscode_manage.py
@@ -8,7 +8,7 @@ from pathlib import Path
 def main(argv=None):
     argv = list(argv or [])
     base_dir = Path(__file__).resolve().parent
-    celery_enabled = (base_dir / "CELERY").exists()
+    celery_enabled = (base_dir / "locks/celery.lck").exists()
     if "--celery" in argv:
         celery_enabled = True
         argv.remove("--celery")


### PR DESCRIPTION
## Summary
- store runtime flag files in `locks/` with `.lck` extension
- update scripts and tooling to use new lock file paths
- ignore `locks/` directory in git

## Testing
- `shellcheck install.sh start.sh uninstall.sh network-setup.sh`
- `python -m pytest` *(fails: assert 10 == 6)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1170e5cc83269de3a18c7b18775a