### PR TITLE
Allow empty message fields and align send form

### DIFF
--- a/msg/forms.py
+++ b/msg/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+
 from .models import Message
 
 
@@ -6,3 +7,12 @@ class MessageForm(forms.ModelForm):
     class Meta:
         model = Message
         fields = ["subject", "body"]
+        widgets = {
+            "subject": forms.TextInput(attrs={"class": "form-control font-monospace"}),
+            "body": forms.TextInput(attrs={"class": "form-control font-monospace"}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.required = False

--- a/msg/migrations/0001_initial.py
+++ b/msg/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 ("is_seed_data", models.BooleanField(default=False, editable=False)),
                 ("is_deleted", models.BooleanField(default=False, editable=False)),
                 ("subject", models.CharField(blank=True, max_length=32)),
-                ("body", models.CharField(max_length=32)),
+                ("body", models.CharField(blank=True, max_length=32)),
                 ("node", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="messages", to="nodes.node")),
                 ("created", models.DateTimeField(auto_now_add=True)),
             ],

--- a/msg/models.py
+++ b/msg/models.py
@@ -6,7 +6,7 @@ class Message(Entity):
     """System message that can be sent to LCD or GUI."""
 
     subject = models.CharField(max_length=32, blank=True)
-    body = models.CharField(max_length=32)
+    body = models.CharField(max_length=32, blank=True)
     node = models.ForeignKey(
         "nodes.Node",
         on_delete=models.SET_NULL,

--- a/msg/templates/msg/send.html
+++ b/msg/templates/msg/send.html
@@ -4,7 +4,18 @@
 <h1>Send Message</h1>
 <form method="post">
   {% csrf_token %}
-  {{ form.as_p }}
+  <div class="mb-3 row align-items-center">
+    <label for="{{ form.subject.id_for_label }}" class="col-sm-2 col-form-label text-sm-end">Subject:</label>
+    <div class="col-sm-10 col-md-6">
+      {{ form.subject }}
+    </div>
+  </div>
+  <div class="mb-3 row align-items-center">
+    <label for="{{ form.body.id_for_label }}" class="col-sm-2 col-form-label text-sm-end">Body:</label>
+    <div class="col-sm-10 col-md-6">
+      {{ form.body }}
+    </div>
+  </div>
   <button type="submit" class="btn btn-primary">Send</button>
 </form>
 {% endblock %}

--- a/msg/tests.py
+++ b/msg/tests.py
@@ -28,6 +28,13 @@ class MessageViewTests(TestCase):
         self.assertRedirects(resp, self.url)
         mock_notify.assert_called_once_with("hi", "there")
 
+    def test_can_send_empty_subject_and_body(self):
+        self.client.login(username="staff", password="pw")
+        with patch("msg.views.notify") as mock_notify:
+            resp = self.client.post(self.url, {"subject": "", "body": ""})
+        self.assertRedirects(resp, self.url)
+        mock_notify.assert_called_once_with("", "")
+
     def test_nonstaff_redirected(self):
         self.client.login(username="user", password="pw")
         resp = self.client.get(self.url)


### PR DESCRIPTION
## Summary
- Permit message body to be blank
- Style message form with aligned monospace inputs
- Test posting an empty message

## Testing
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae22df94b48326a1fad4123b486786