### PR TITLE
Add clean upgrade option and improve stop reliability

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -26,7 +26,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$ALL" = true ]; then
-  pkill -f "manage.py runserver" || true
+  PATTERN="manage.py runserver"
 else
-  pkill -f "manage.py runserver 0.0.0.0:$PORT" || true
+  PATTERN="manage.py runserver 0.0.0.0:$PORT"
 fi
+
+pkill -f "$PATTERN" || true
+
+while pgrep -f "$PATTERN" >/dev/null; do
+  sleep 1
+done

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -7,6 +7,7 @@ cd "$BASE_DIR"
 FORCE=0
 CLEAN_DB=0
 NO_RESTART=0
+CLEAN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --latest)
@@ -21,11 +22,20 @@ while [[ $# -gt 0 ]]; do
       NO_RESTART=1
       shift
       ;;
+    --clean)
+      CLEAN=1
+      CLEAN_DB=1
+      shift
+      ;;
     *)
       break
       ;;
   esac
 done
+
+if [ "$CLEAN" -eq 1 ]; then
+  NO_RESTART=0
+fi
 
 # Determine current and remote versions
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -77,7 +87,11 @@ if [ "$CLEAN_DB" -eq 1 ]; then
 fi
 
 # Refresh environment and restart service
-./env-refresh.sh
-if [[ $NO_RESTART -eq 0 ]]; then
-  ./start.sh
+if [ "$CLEAN" -eq 1 ]; then
+  ./install.sh --satellite
+else
+  ./env-refresh.sh
+  if [[ $NO_RESTART -eq 0 ]]; then
+    ./start.sh
+  fi
 fi


### PR DESCRIPTION
## Summary
- ensure stop.sh waits for runserver processes to exit
- add `--clean` option to upgrade.sh to wipe DB and reinstall satellite

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae286fe1f883269eaae601f09d922e