### PR TITLE
Improve RFID event handling responsiveness

### DIFF
--- a/rfid/always_on.py
+++ b/rfid/always_on.py
@@ -13,7 +13,9 @@ _stop = threading.Event()
 def _worker() -> None:  # pragma: no cover - background thread
     logger.debug("RFID watch thread started")
     while not _stop.is_set():
-        result = get_next_tag(timeout=0.5)
+        # Use a shorter timeout for faster responsiveness when polling for
+        # new tags from the background reader.
+        result = get_next_tag(timeout=0.1)
         if result and result.get("rfid"):
             logger.info("RFID tag detected: %s", result.get("rfid"))
             tag_scanned.send(sender=None, **result)

--- a/rfid/background_reader.py
+++ b/rfid/background_reader.py
@@ -75,8 +75,10 @@ def _worker():  # pragma: no cover - background thread
     if not _setup_hardware():
         logger.error("RFID hardware setup failed; background reader not running")
         return
-    while not _stop_event.is_set():
-        _stop_event.wait(0.5)
+    # Wait indefinitely until a stop is requested, relying solely on IRQ
+    # callbacks to populate the tag queue. This avoids periodic polling and
+    # lets the thread sleep until explicitly stopped.
+    _stop_event.wait()
     if GPIO:
         try:
             GPIO.remove_event_detect(IRQ_PIN)


### PR DESCRIPTION
## Summary
- Redesign RFID background worker to wait on stop event and rely solely on IRQ callbacks
- Poll for tags with shorter timeout to improve detection responsiveness

## Testing
- `pytest rfid/tests.py` *(fails: no such table: django_site)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2a54612c83269ae4ec7ecb67ce9d