### PR TITLE
Delay startup LCD notification asynchronously

### DIFF
--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -1,5 +1,7 @@
 import os
 import socket
+import threading
+import time
 from pathlib import Path
 
 from django.apps import AppConfig
@@ -8,40 +10,42 @@ from utils import revision
 
 
 def _startup_notification() -> None:
-    """Send an initial notification with host:port and version.
-
-    This function is called when the :mod:`nodes` application is ready.
-    It queues a notification that will be displayed on an attached LCD
-    screen (or desktop notification if the screen is unavailable).
-    """
+    """Queue a notification with host:port and version on a background thread."""
 
     try:  # import here to avoid circular import during app loading
         from msg.notifications import notify
     except Exception:  # pragma: no cover - failure shouldn't break startup
         return
 
-    host = socket.gethostname()
-    # Prefer IP address over hostname when available
-    try:
-        address = socket.gethostbyname(host)
-    except socket.gaierror:
-        address = host
+    def _worker() -> None:  # pragma: no cover - background thread
+        host = socket.gethostname()
+        # Prefer IP address over hostname when available
+        try:
+            address = socket.gethostbyname(host)
+        except socket.gaierror:
+            address = host
 
-    port = os.environ.get("PORT", "8000")
+        port = os.environ.get("PORT", "8000")
 
-    version = ""
-    ver_path = Path(settings.BASE_DIR) / "VERSION"
-    if ver_path.exists():
-        version = ver_path.read_text().strip()
+        version = ""
+        ver_path = Path(settings.BASE_DIR) / "VERSION"
+        if ver_path.exists():
+            version = ver_path.read_text().strip()
 
-    revision_value = revision.get_revision()
-    rev_short = revision_value[-6:] if revision_value else ""
+        revision_value = revision.get_revision()
+        rev_short = revision_value[-6:] if revision_value else ""
 
-    body = f"v{version}"
-    if rev_short:
-        body += f" r{rev_short}"
+        body = f"v{version}"
+        if rev_short:
+            body += f" r{rev_short}"
 
-    notify(f"{address}:{port}", body)
+        # Allow the LCD a moment to become ready and retry a few times
+        for _ in range(5):
+            if notify(f"{address}:{port}", body):
+                break
+            time.sleep(1)
+
+    threading.Thread(target=_worker, name="startup-notify", daemon=True).start()
 
 
 class NodesConfig(AppConfig):


### PR DESCRIPTION
## Summary
- start LCD startup notification in a background thread and retry until the display is ready

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4c2a7c2883269053bac7b439128d