### PR TITLE
Fix Celery memory backend configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -333,7 +333,7 @@ LOGGING = {
 
 # Celery configuration
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "memory://")
-CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "memory://")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "cache+memory://")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 CELERY_BEAT_SCHEDULE = {


### PR DESCRIPTION
## Summary
- default Celery result backend to `cache+memory://` to avoid ModuleNotFoundError

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4651876c83268cabcccde6076c73