### PR TITLE
Remove RFID watch toggle from admin

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -348,11 +348,6 @@ class RFIDAdmin(ImportExportModelAdmin):
                 self.admin_site.admin_view(csrf_exempt(self.scan_next)),
                 name="accounts_rfid_scan_next",
             ),
-            path(
-                "watch/toggle/",
-                self.admin_site.admin_view(self.watch_toggle),
-                name="accounts_rfid_watch_toggle",
-            ),
         ]
         return custom + urls
 
@@ -370,15 +365,4 @@ class RFIDAdmin(ImportExportModelAdmin):
         result = scan_sources(request)
         status = 500 if result.get("error") else 200
         return JsonResponse(result, status=status)
-
-    def watch_toggle(self, request):
-        from rfid.always_on import is_running, start, stop
-
-        if is_running():
-            stop()
-            self.message_user(request, "RFID watch disabled")
-        else:
-            start()
-            self.message_user(request, "RFID watch enabled")
-        return redirect("admin:accounts_rfid_changelist")
 

--- a/accounts/templates/admin/accounts/rfid/change_list.html
+++ b/accounts/templates/admin/accounts/rfid/change_list.html
@@ -2,5 +2,4 @@
 {% block object-tools-items %}
 {{ block.super }}
 <li><a href="{% url 'admin:accounts_rfid_scan' %}">Scan RFIDs</a></li>
-<li><a href="{% url 'admin:accounts_rfid_watch_toggle' %}">Toggle RFID Watch</a></li>
 {% endblock %}

--- a/tests/test_rfid_admin_actions.py
+++ b/tests/test_rfid_admin_actions.py
@@ -55,19 +55,3 @@ class RFIDAdminActionTests(TestCase):
         self.assertEqual(black.color, RFID.WHITE)
         self.assertEqual(white.color, RFID.BLACK)
 
-
-class RFIDAdminWatchLinkTests(TestCase):
-    def setUp(self):
-        User = get_user_model()
-        self.user = User.objects.create_superuser(
-            username="rfidwatch", email="watch@example.com", password="password"
-        )
-        self.client.force_login(self.user)
-
-    def test_change_list_shows_watch_toggle(self):
-        response = self.client.get(reverse("admin:accounts_rfid_changelist"))
-        self.assertContains(response, "Toggle RFID Watch")
-        self.assertContains(
-            response, reverse("admin:accounts_rfid_watch_toggle")
-        )
-


### PR DESCRIPTION
## Summary
- remove admin endpoint to toggle RFID watch and corresponding template link
- drop related admin tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae70cbf024832694b33e98616b1141