### PR TITLE
Handle Windows toast errors gracefully

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import django
+from django.apps import apps
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+_original_setup = django.setup
+
+def safe_setup():
+    if not apps.ready:
+        _original_setup()
+
+django.setup = safe_setup
+safe_setup()

--- a/tests/test_notifications_fallback.py
+++ b/tests/test_notifications_fallback.py
@@ -41,3 +41,19 @@ def test_gui_display_uses_plyer_when_toast_unavailable(monkeypatch):
 
     assert fake.calls[0]["title"] == "Arthexis"
     assert fake.calls[0]["timeout"] == 6
+
+
+def test_send_returns_true_and_disables_toaster_on_failure(monkeypatch):
+    class BadToaster:
+        def show_toast(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(notifications, "ToastNotifier", lambda: BadToaster())
+    monkeypatch.setattr(notifications, "plyer_notification", None)
+    monkeypatch.setattr(notifications.sys, "platform", "win32")
+
+    nm = notifications.NotificationManager()
+    nm.lcd = None
+
+    assert nm.send("subject", "body") is True
+    assert nm._toaster is None


### PR DESCRIPTION
## Summary
- prevent repeated LCD init attempts and treat log/GUI fallback as success
- disable Windows toast notifications after a failure to avoid noisy loops
- test notification fallback when toast notifier fails
- initialize Django once during test collection to avoid reentrant setup errors

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_notifications_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae798d7d6c8326b616061b54742e57