### PR TITLE
Handle Windows toast notifications synchronously

### DIFF
--- a/msg/notifications.py
+++ b/msg/notifications.py
@@ -108,7 +108,7 @@ class NotificationManager:
             if self._toaster:
                 try:  # pragma: no cover - depends on platform
                     self._toaster.show_toast(
-                        "Arthexis", f"{subject}\n{body}", duration=6, threaded=True
+                        "Arthexis", f"{subject}\n{body}", duration=6
                     )
                     return
                 except Exception as exc:  # pragma: no cover - depends on platform

--- a/tests/test_notifications_fallback.py
+++ b/tests/test_notifications_fallback.py
@@ -6,8 +6,8 @@ def test_gui_display_uses_toast_when_available(monkeypatch):
         def __init__(self):
             self.calls = []
 
-        def show_toast(self, title, message, duration, threaded):
-            self.calls.append((title, message, duration, threaded))
+        def show_toast(self, title, message, duration=5, **kwargs):
+            self.calls.append((title, message, duration, kwargs))
 
     fake = FakeToaster()
     monkeypatch.setattr(notifications, "ToastNotifier", lambda: fake)


### PR DESCRIPTION
## Summary
- avoid repeated Windows toasts by removing extra threaded display
- update toast fallback test for new call signature

## Testing
- `pip install django-grappelli`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d479b508326899f71f366272ead