### PR TITLE
Add standalone LCD screen service and lock-file notifications

### DIFF
--- a/msg/lcd_screen.py
+++ b/msg/lcd_screen.py
@@ -1,0 +1,77 @@
+"""Standalone LCD screen updater.
+
+The script polls ``locks/lcd_screen.lck`` for up to two lines of text and
+writes them to the attached LCD1602 display. If either line exceeds 16
+characters the text scrolls horizontally. A third line in the lock file
+can define the scroll speed in milliseconds per character (default 1000
+ms).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from nodes.lcd import CharLCD1602, LCDUnavailableError
+
+logger = logging.getLogger(__name__)
+
+LOCK_FILE = Path(__file__).resolve().parents[1] / "locks" / "lcd_screen.lck"
+DEFAULT_SCROLL_MS = 1000
+
+
+def _read_lock_file() -> tuple[str, str, int]:
+    try:
+        lines = LOCK_FILE.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return "", "", DEFAULT_SCROLL_MS
+    line1 = lines[0][:64] if len(lines) > 0 else ""
+    line2 = lines[1][:64] if len(lines) > 1 else ""
+    try:
+        speed = int(lines[2]) if len(lines) > 2 else DEFAULT_SCROLL_MS
+    except ValueError:
+        speed = DEFAULT_SCROLL_MS
+    return line1, line2, speed
+
+
+def _display(lcd: CharLCD1602, line1: str, line2: str, scroll_ms: int) -> None:
+    scroll_sec = max(scroll_ms, 0) / 1000.0
+    text1 = line1[:64]
+    text2 = line2[:64]
+    pad1 = text1 + " " * 16 if len(text1) > 16 else text1.ljust(16)
+    pad2 = text2 + " " * 16 if len(text2) > 16 else text2.ljust(16)
+    steps = max(len(pad1) - 15, len(pad2) - 15)
+    for i in range(steps):
+        segment1 = pad1[i : i + 16]
+        segment2 = pad2[i : i + 16]
+        lcd.write(0, 0, segment1.ljust(16))
+        lcd.write(0, 1, segment2.ljust(16))
+        time.sleep(scroll_sec)
+
+
+def main() -> None:  # pragma: no cover - hardware dependent
+    lcd = None
+    last_mtime = 0.0
+    while True:
+        try:
+            if LOCK_FILE.exists():
+                mtime = LOCK_FILE.stat().st_mtime
+                if mtime != last_mtime or lcd is None:
+                    line1, line2, speed = _read_lock_file()
+                    if lcd is None:
+                        lcd = CharLCD1602()
+                        lcd.init_lcd()
+                    lcd.clear()
+                    _display(lcd, line1, line2, speed)
+                    last_mtime = mtime
+        except LCDUnavailableError as exc:
+            logger.warning("LCD unavailable: %s", exc)
+            lcd = None
+        except Exception as exc:
+            logger.warning("LCD update failed: %s", exc)
+            lcd = None
+        time.sleep(0.5)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/stop.sh
+++ b/stop.sh
@@ -11,6 +11,11 @@ if [ -f "$LOCK_DIR/service.lck" ]; then
   if systemctl list-unit-files | grep -Fq "${SERVICE_NAME}.service"; then
     sudo systemctl stop "$SERVICE_NAME"
     sudo systemctl status "$SERVICE_NAME" --no-pager || true
+    LCD_SERVICE="lcd-$SERVICE_NAME"
+    if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+      sudo systemctl stop "$LCD_SERVICE"
+      sudo systemctl status "$LCD_SERVICE" --no-pager || true
+    fi
     exit 0
   fi
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -43,7 +43,17 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
         sudo rm "$SERVICE_FILE"
         sudo systemctl daemon-reload
     fi
+    LCD_SERVICE="lcd-$SERVICE"
+    if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+        sudo systemctl stop "$LCD_SERVICE" || true
+        sudo systemctl disable "$LCD_SERVICE" || true
+        LCD_SERVICE_FILE="/etc/systemd/system/${LCD_SERVICE}.service"
+        if [ -f "$LCD_SERVICE_FILE" ]; then
+            sudo rm "$LCD_SERVICE_FILE"
+        fi
+    fi
     rm -f "$LOCK_DIR/service.lck"
+    rm -f "$LOCK_DIR/lcd_screen.lck"
 else
     pkill -f "manage.py runserver" || true
 fi


### PR DESCRIPTION
## Summary
- add `--no-lcd-screen` flag that removes `lcd_screen.lck` and disables the LCD service
- fall back to GUI/log notifications when the LCD lock file is absent
- clean up LCD lock file on uninstall and extend tests for the new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae80c8dde8832681f6cb730c833eb4