### PR TITLE
Use plyer for cross-platform notifications

### DIFF
--- a/msg/notifications.py
+++ b/msg/notifications.py
@@ -1,22 +1,17 @@
 """Simple notification helper for a 16x2 LCD display.
 
-Messages are written directly to the LCD. When the display is unavailable
- the message is shown using a Windows notification that auto-dismisses after
- six seconds or logged. Each line is truncated to 16 characters so that it
- fits the 16x2 hardware display.
+Messages are written directly to the LCD. When the display is unavailable,
+the message is shown using a desktop notification that auto-dismisses after
+six seconds or logged. Each line is truncated to 16 characters so that it
+fits the 16x2 hardware display.
 """
 from __future__ import annotations
 
 import logging
-import sys
 import threading
 
 from nodes.lcd import CharLCD1602, LCDUnavailableError
 
-try:  # pragma: no cover - optional dependency
-    from win10toast import ToastNotifier
-except Exception:  # pragma: no cover - win10toast may not be installed
-    ToastNotifier = None
 try:  # pragma: no cover - optional dependency
     from plyer import notification as plyer_notification
 except Exception:  # pragma: no cover - plyer may not be installed
@@ -35,13 +30,6 @@ class NotificationManager:
         self.lcd = self._init_lcd()
         self._lcd_attempted = True
 
-        # ``win10toast`` is only available on Windows and can fail when used in
-        # a non-interactive environment (e.g. service or CI). Any failure will
-        # disable further toast attempts so the application falls back to
-        # logging quietly.
-        self._toaster = (
-            ToastNotifier() if sys.platform.startswith("win") and ToastNotifier else None
-        )
 
     # LCD helpers -----------------------------------------------------
     def _init_lcd(self):
@@ -104,26 +92,14 @@ class NotificationManager:
 
     # GUI/log fallback ------------------------------------------------
     def _gui_display(self, subject: str, body: str) -> None:
-        if sys.platform.startswith("win"):
-            if self._toaster:
-                try:  # pragma: no cover - depends on platform
-                    self._toaster.show_toast(
-                        "Arthexis", f"{subject}\n{body}", duration=6
-                    )
-                    return
-                except Exception as exc:  # pragma: no cover - depends on platform
-                    logger.warning("Windows toast notification failed: %s", exc)
-                    # Disable further toast attempts; the log fallback will be used
-                    # instead to avoid repeated errors in headless environments.
-                    self._toaster = None
-            elif plyer_notification:
-                try:  # pragma: no cover - depends on platform
-                    plyer_notification.notify(
-                        title="Arthexis", message=f"{subject}\n{body}", timeout=6
-                    )
-                    return
-                except Exception as exc:  # pragma: no cover - depends on platform
-                    logger.warning("Windows notification failed: %s", exc)
+        if plyer_notification:
+            try:  # pragma: no cover - depends on platform
+                plyer_notification.notify(
+                    title="Arthexis", message=f"{subject}\n{body}", timeout=6
+                )
+                return
+            except Exception as exc:  # pragma: no cover - depends on platform
+                logger.warning("Desktop notification failed: %s", exc)
         logger.info("%s %s", subject, body)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ mfrc522==0.0.7; sys_platform == "linux"
 outcome==1.3.0.post0
 packaging==25.0
 pillow==11.3.0
-plyer==2.1.0; sys_platform == "win32"
+plyer==2.1.0
 prompt_toolkit==3.0.51
 psycopg==3.2.9
 psycopg-binary==3.2.9
@@ -87,7 +87,6 @@ wcwidth==0.2.13
 webencodings==0.5.1
 websocket-client==1.8.0
 websockets==13.1
-win10toast==0.9; sys_platform == "win32"
 wsproto==1.2.0
 zope.interface==7.2
 sigils==0.3.5


### PR DESCRIPTION
## Summary
- remove Windows-only win10toast dependency
- send desktop notifications via plyer when available
- update tests for new notification fallback logic

## Testing
- `pip install django-grappelli==4.0.2`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8383808483268023b3615f521b44