### PR TITLE
Increase SQLite timeout to reduce install database locks

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -239,6 +239,7 @@ else:
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": BASE_DIR / "db.sqlite3",
+            "OPTIONS": {"timeout": 30},
         }
     }
 


### PR DESCRIPTION
## Summary
- increase SQLite connection timeout to wait for file locks during installation

## Testing
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af61196d848326a698aeefc1d2252d