### PR TITLE
Reduce server clock font size

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -133,7 +133,7 @@ body.login #site-badges .badge a {
 body.login .badge-unknown {background-color:#6c757d;}
 #server-clock {
     font-family: monospace;
-    font-size: 0.9em;
+    font-size: 0.9rem;
 }
 
 body:not(.login) #site-badges {


### PR DESCRIPTION
## Summary
- shrink server clock font so it better matches badge size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe4905f248326bdb835096789b008