### PR TITLE
Align server clock and badges in admin header

### DIFF
--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -134,10 +134,14 @@ body.login .badge-unknown {background-color:#6c757d;}
 #server-clock {
     font-family: monospace;
     font-size: 0.9rem;
+    position: relative;
+    top: -2px;
 }
 
 body:not(.login) #site-badges {
     margin-left: 0.5em;
+    position: relative;
+    top: 2px;
 }
 
 body:not(.login) #site-badges .badge {


### PR DESCRIPTION
## Summary
- raise server clock to match header text baseline
- offset site badges downward for consistent alignment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe839c6388326ac3443d8324a390f