### PR TITLE
style: improve cp simulator layout

### DIFF
--- a/ocpp/static/ocpp/evcs/cp_simulator.css
+++ b/ocpp/static/ocpp/evcs/cp_simulator.css
@@ -1,9 +1,6 @@
-.simulator-form { margin-bottom: 1em; }
-.simulator-form div { margin: 0.25em 0; }
-.simulator-form label { display: inline-block; width: 160px; }
-.simulator-form input, .simulator-form select { width: 200px; }
-.form-btns { margin-top: 0.5em; }
-.state-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; }
+.simulator-card { max-width: 420px; }
+.simulator-status { display: flex; align-items: center; gap: 4px; }
+.state-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; }
 .state-dot.online { background: #4caf50; }
 .state-dot.stopped { background: #f44336; }
 .simulator-details { display: grid; grid-template-columns: auto 1fr; gap: 4px 8px; margin-top: 0.5em; }

--- a/ocpp/templates/ocpp/cp_simulator.html
+++ b/ocpp/templates/ocpp/cp_simulator.html
@@ -5,23 +5,25 @@
 
 {% block extra_head %}
 <link rel="stylesheet" href="{% static 'ocpp/evcs/cp_simulator.css' %}">
-<link rel="stylesheet" href="{% static 'tabs.css' %}">
-<script src="{% static 'tabs.js' %}"></script>
 {% endblock %}
 
 {% block content %}
 <h1>OCPP Charge Point Simulator</h1>
 {% if message %}<div class="sim-msg">{{ message }}</div>{% endif %}
-<div class="gw-tabs">
-  <div class="gw-tabs-bar">
-    <div class="gw-tab">Primary CP</div>
-    <div class="gw-tab">Secondary CP</div>
+<ul class="nav nav-tabs mb-3" id="cpSimTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="cp1-tab" data-bs-toggle="tab" data-bs-target="#cp1" type="button" role="tab" aria-controls="cp1" aria-selected="true">Primary CP</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="cp2-tab" data-bs-toggle="tab" data-bs-target="#cp2" type="button" role="tab" aria-controls="cp2" aria-selected="false">Secondary CP</button>
+  </li>
+</ul>
+<div class="tab-content" id="cpSimContent">
+  <div class="tab-pane fade show active" id="cp1" role="tabpanel" aria-labelledby="cp1-tab">
+      {% include "ocpp/cp_simulator_block.html" with cp=states.0 idx=1 params_json=params_jsons.0 state_json=state_jsons.0 default_cp_path=default_cp_paths.0 default_vin=default_vins.0 next_tab='cp2' %}
   </div>
-  <div class="gw-tab-block">
-      {% include "ocpp/cp_simulator_block.html" with cp=states.0 idx=1 params_json=params_jsons.0 state_json=state_jsons.0 default_cp_path=default_cp_paths.0 default_vin=default_vins.0 %}
-    </div>
-    <div class="gw-tab-block">
-      {% include "ocpp/cp_simulator_block.html" with cp=states.1 idx=2 params_json=params_jsons.1 state_json=state_jsons.1 default_cp_path=default_cp_paths.1 default_vin=default_vins.1 %}
-    </div>
+  <div class="tab-pane fade" id="cp2" role="tabpanel" aria-labelledby="cp2-tab">
+      {% include "ocpp/cp_simulator_block.html" with cp=states.1 idx=2 params_json=params_jsons.1 state_json=state_jsons.1 default_cp_path=default_cp_paths.1 default_vin=default_vins.1 prev_tab='cp1' %}
   </div>
+</div>
 {% endblock %}

--- a/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/ocpp/templates/ocpp/cp_simulator_block.html
@@ -1,40 +1,115 @@
-<form method="post" class="simulator-form">
-  {% csrf_token %}
-  <input type="hidden" name="cp" value="{{ idx }}">
-  <div><label>Host:</label><input name="host" value="{{ cp.params.host|default:default_host }}"></div>
-  <div><label>Port:</label><input name="ws_port" value="{{ cp.params.ws_port|default:default_ws_port }}"></div>
-  <div><label>ChargePoint Path:</label><input name="cp_path" value="{{ cp.params.cp_path|default:default_cp_path }}"></div>
-    <div><label>RFID:</label><input name="rfid" value="{{ cp.params.rfid|default:default_rfid }}"></div>
-    <div><label>VIN:</label><input name="vin" value="{{ cp.params.vin|default:default_vin }}"></div>
-    <div><label>Duration (s):</label><input name="duration" value="{{ cp.params.duration|default:600 }}"></div>
-  <div><label>Interval (s):</label><input name="interval" value="{{ cp.params.interval|default:5 }}"></div>
-  <div><label>Pre-charge Delay (s):</label><input name="pre_charge_delay" value="{{ cp.params.pre_charge_delay|default:0 }}"></div>
-  <div><label>Energy Min (kW):</label><input name="kw_min" value="{{ cp.params.kw_min|default:30 }}"></div>
-  <div><label>Energy Max (kW):</label><input name="kw_max" value="{{ cp.params.kw_max|default:60 }}"></div>
-  <div><label>Repeat:</label>
-    <select name="repeat">
-      <option value="False" {% if not cp.params.repeat %}selected{% endif %}>No</option>
-      <option value="True" {% if cp.params.repeat %}selected{% endif %}>Yes</option>
-    </select>
+<div class="card simulator-card mb-4">
+  <div class="card-body">
+    <form method="post" class="simulator-form">
+      {% csrf_token %}
+      <input type="hidden" name="cp" value="{{ idx }}">
+      <div class="row g-3">
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="host{{ idx }}">Host</label>
+            <input id="host{{ idx }}" name="host" value="{{ cp.params.host|default:default_host }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="ws_port{{ idx }}">Port</label>
+            <input id="ws_port{{ idx }}" name="ws_port" value="{{ cp.params.ws_port|default:default_ws_port }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="cp_path{{ idx }}">ChargePoint Path</label>
+            <input id="cp_path{{ idx }}" name="cp_path" value="{{ cp.params.cp_path|default:default_cp_path }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="rfid{{ idx }}">RFID</label>
+            <input id="rfid{{ idx }}" name="rfid" value="{{ cp.params.rfid|default:default_rfid }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="vin{{ idx }}">VIN</label>
+            <input id="vin{{ idx }}" name="vin" value="{{ cp.params.vin|default:default_vin }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="duration{{ idx }}">Duration (s)</label>
+            <input id="duration{{ idx }}" name="duration" value="{{ cp.params.duration|default:600 }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="interval{{ idx }}">Interval (s)</label>
+            <input id="interval{{ idx }}" name="interval" value="{{ cp.params.interval|default:5 }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="pre_charge_delay{{ idx }}">Pre-charge Delay (s)</label>
+            <input id="pre_charge_delay{{ idx }}" name="pre_charge_delay" value="{{ cp.params.pre_charge_delay|default:0 }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="kw_min{{ idx }}">Energy Min (kW)</label>
+            <input id="kw_min{{ idx }}" name="kw_min" value="{{ cp.params.kw_min|default:30 }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="kw_max{{ idx }}">Energy Max (kW)</label>
+            <input id="kw_max{{ idx }}" name="kw_max" value="{{ cp.params.kw_max|default:60 }}" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="repeat{{ idx }}">Repeat</label>
+            <select id="repeat{{ idx }}" name="repeat" class="form-select">
+              <option value="False" {% if not cp.params.repeat %}selected{% endif %}>No</option>
+              <option value="True" {% if cp.params.repeat %}selected{% endif %}>Yes</option>
+            </select>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="username{{ idx }}">User</label>
+            <input id="username{{ idx }}" name="username" value="" class="form-control">
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="mb-3">
+            <label class="form-label" for="password{{ idx }}">Pass</label>
+            <input id="password{{ idx }}" name="password" type="password" value="" class="form-control">
+          </div>
+        </div>
+      </div>
+      <div class="d-flex gap-2">
+        <button type="submit" name="action" value="start" class="btn btn-primary" {% if cp.running %}disabled{% endif %}>Start</button>
+        <button type="submit" name="action" value="stop" class="btn btn-secondary" {% if not cp.running %}disabled{% endif %}>Stop</button>
+      </div>
+    </form>
+    <div class="simulator-status mt-3"><span class="state-dot {% if cp.running %}online{% else %}stopped{% endif %}"></span><span>{% if cp.running %}Running{% else %}Stopped{% endif %}</span></div>
+    <div class="simulator-details">
+      <label>Last Status:</label> <span class="stat">{{ cp.last_status|default:"-" }}</span>
+      <label>Phase:</label> <span class="stat">{{ cp.phase|default:"-" }}</span>
+      <label>Last Message:</label> <span class="stat">{{ cp.last_message|default:"-" }}</span>
+      <label>Last Command:</label> <span class="stat">{{ cp.last_command|default:"-" }}</span>
+      <label>Started:</label> <span class="stat">{{ cp.start_time|default:"-" }}</span>
+      <label>Stopped:</label> <span class="stat">{{ cp.stop_time|default:"-" }}</span>
+    </div>
+    {% if cp.last_error %}
+    <div class="error mt-2"><b>Error:</b><pre>{{ cp.last_error }}</pre></div>
+    {% endif %}
+    <details class="simulator-panel"><summary>Show Simulator Params</summary><pre>{{ params_json|safe }}</pre></details>
+    <details class="simulator-panel"><summary>Show Simulator State JSON</summary><pre>{{ state_json|safe }}</pre></details>
+    {% if prev_tab or next_tab %}
+    <div class="d-flex justify-content-between mt-3">
+      {% if prev_tab %}<a class="btn btn-outline-secondary" data-bs-toggle="tab" href="#{{ prev_tab }}">Prev</a>{% endif %}
+      {% if next_tab %}<a class="btn btn-outline-secondary ms-auto" data-bs-toggle="tab" href="#{{ next_tab }}">Next</a>{% endif %}
+    </div>
+    {% endif %}
   </div>
-  <div><label>User:</label><input name="username" value=""></div>
-  <div><label>Pass:</label><input name="password" type="password" value=""></div>
-  <div class="form-btns">
-    <button type="submit" name="action" value="start" {% if cp.running %}disabled{% endif %}>Start</button>
-    <button type="submit" name="action" value="stop" {% if not cp.running %}disabled{% endif %}>Stop</button>
-  </div>
-</form>
-<div class="simulator-status"><span class="state-dot {% if cp.running %}online{% else %}stopped{% endif %}"></span><span>{% if cp.running %}Running{% else %}Stopped{% endif %}</span></div>
-<div class="simulator-details">
-  <label>Last Status:</label> <span class="stat">{{ cp.last_status|default:"-" }}</span>
-  <label>Phase:</label> <span class="stat">{{ cp.phase|default:"-" }}</span>
-  <label>Last Message:</label> <span class="stat">{{ cp.last_message|default:"-" }}</span>
-  <label>Last Command:</label> <span class="stat">{{ cp.last_command|default:"-" }}</span>
-  <label>Started:</label> <span class="stat">{{ cp.start_time|default:"-" }}</span>
-  <label>Stopped:</label> <span class="stat">{{ cp.stop_time|default:"-" }}</span>
 </div>
-{% if cp.last_error %}
-<div class="error"><b>Error:</b><pre>{{ cp.last_error }}</pre></div>
-{% endif %}
-<details class="simulator-panel"><summary>Show Simulator Params</summary><pre>{{ params_json|safe }}</pre></details>
-<details class="simulator-panel"><summary>Show Simulator State JSON</summary><pre>{{ state_json|safe }}</pre></details>


### PR DESCRIPTION
## Summary
- switch CP simulator to Bootstrap tab layout with one simulator per tab
- place simulator fields in a card with consistent form controls
- add simple tab navigation links and clean up simulator styling

## Testing
- `python manage.py test ocpp`


------
https://chatgpt.com/codex/tasks/task_e_68afe8f0b6a08326a15726038197b2c4