### PR TITLE
Compact CP simulator layout

### DIFF
--- a/ocpp/static/ocpp/evcs/cp_simulator.css
+++ b/ocpp/static/ocpp/evcs/cp_simulator.css
@@ -1,4 +1,4 @@
-.simulator-card { max-width: 420px; }
+.simulator-card { max-width: 800px; margin: 0 auto; }
 .simulator-status { display: flex; align-items: center; gap: 4px; }
 .state-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; }
 .state-dot.online { background: #4caf50; }

--- a/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/ocpp/templates/ocpp/cp_simulator_block.html
@@ -1,88 +1,88 @@
-<div class="card simulator-card mb-4">
+<div class="card simulator-card mb-3">
   <div class="card-body">
     <form method="post" class="simulator-form">
       {% csrf_token %}
       <input type="hidden" name="cp" value="{{ idx }}">
-      <div class="row g-3">
-        <div class="col-md-6">
-          <div class="mb-3">
+      <div class="row g-2">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="host{{ idx }}">Host</label>
-            <input id="host{{ idx }}" name="host" value="{{ cp.params.host|default:default_host }}" class="form-control">
+            <input id="host{{ idx }}" name="host" value="{{ cp.params.host|default:default_host }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="ws_port{{ idx }}">Port</label>
-            <input id="ws_port{{ idx }}" name="ws_port" value="{{ cp.params.ws_port|default:default_ws_port }}" class="form-control">
+            <input id="ws_port{{ idx }}" name="ws_port" value="{{ cp.params.ws_port|default:default_ws_port }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="cp_path{{ idx }}">ChargePoint Path</label>
-            <input id="cp_path{{ idx }}" name="cp_path" value="{{ cp.params.cp_path|default:default_cp_path }}" class="form-control">
+            <input id="cp_path{{ idx }}" name="cp_path" value="{{ cp.params.cp_path|default:default_cp_path }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="rfid{{ idx }}">RFID</label>
-            <input id="rfid{{ idx }}" name="rfid" value="{{ cp.params.rfid|default:default_rfid }}" class="form-control">
+            <input id="rfid{{ idx }}" name="rfid" value="{{ cp.params.rfid|default:default_rfid }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="vin{{ idx }}">VIN</label>
-            <input id="vin{{ idx }}" name="vin" value="{{ cp.params.vin|default:default_vin }}" class="form-control">
+            <input id="vin{{ idx }}" name="vin" value="{{ cp.params.vin|default:default_vin }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="duration{{ idx }}">Duration (s)</label>
-            <input id="duration{{ idx }}" name="duration" value="{{ cp.params.duration|default:600 }}" class="form-control">
+            <input id="duration{{ idx }}" name="duration" value="{{ cp.params.duration|default:600 }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="interval{{ idx }}">Interval (s)</label>
-            <input id="interval{{ idx }}" name="interval" value="{{ cp.params.interval|default:5 }}" class="form-control">
+            <input id="interval{{ idx }}" name="interval" value="{{ cp.params.interval|default:5 }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="pre_charge_delay{{ idx }}">Pre-charge Delay (s)</label>
-            <input id="pre_charge_delay{{ idx }}" name="pre_charge_delay" value="{{ cp.params.pre_charge_delay|default:0 }}" class="form-control">
+            <input id="pre_charge_delay{{ idx }}" name="pre_charge_delay" value="{{ cp.params.pre_charge_delay|default:0 }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="kw_min{{ idx }}">Energy Min (kW)</label>
-            <input id="kw_min{{ idx }}" name="kw_min" value="{{ cp.params.kw_min|default:30 }}" class="form-control">
+            <input id="kw_min{{ idx }}" name="kw_min" value="{{ cp.params.kw_min|default:30 }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="kw_max{{ idx }}">Energy Max (kW)</label>
-            <input id="kw_max{{ idx }}" name="kw_max" value="{{ cp.params.kw_max|default:60 }}" class="form-control">
+            <input id="kw_max{{ idx }}" name="kw_max" value="{{ cp.params.kw_max|default:60 }}" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="repeat{{ idx }}">Repeat</label>
-            <select id="repeat{{ idx }}" name="repeat" class="form-select">
+            <select id="repeat{{ idx }}" name="repeat" class="form-select form-select-sm">
               <option value="False" {% if not cp.params.repeat %}selected{% endif %}>No</option>
               <option value="True" {% if cp.params.repeat %}selected{% endif %}>Yes</option>
             </select>
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="username{{ idx }}">User</label>
-            <input id="username{{ idx }}" name="username" value="" class="form-control">
+            <input id="username{{ idx }}" name="username" value="" class="form-control form-control-sm">
           </div>
         </div>
-        <div class="col-md-6">
-          <div class="mb-3">
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="password{{ idx }}">Pass</label>
-            <input id="password{{ idx }}" name="password" type="password" value="" class="form-control">
+            <input id="password{{ idx }}" name="password" type="password" value="" class="form-control form-control-sm">
           </div>
         </div>
       </div>
@@ -91,7 +91,7 @@
         <button type="submit" name="action" value="stop" class="btn btn-secondary" {% if not cp.running %}disabled{% endif %}>Stop</button>
       </div>
     </form>
-    <div class="simulator-status mt-3"><span class="state-dot {% if cp.running %}online{% else %}stopped{% endif %}"></span><span>{% if cp.running %}Running{% else %}Stopped{% endif %}</span></div>
+    <div class="simulator-status mt-2"><span class="state-dot {% if cp.running %}online{% else %}stopped{% endif %}"></span><span>{% if cp.running %}Running{% else %}Stopped{% endif %}</span></div>
     <div class="simulator-details">
       <label>Last Status:</label> <span class="stat">{{ cp.last_status|default:"-" }}</span>
       <label>Phase:</label> <span class="stat">{{ cp.phase|default:"-" }}</span>


### PR DESCRIPTION
## Summary
- Reduce spacing and use smaller inputs in CP simulator form
- Widen and center simulator card for more horizontal room

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afec9396ac8326957dfe7cebda867d