### PR TITLE
Include AWG calculator on all sites

### DIFF
--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -11,6 +11,10 @@
     "fields": {"name": "ocpp"}
   },
   {
+    "model": "website.application",
+    "fields": {"name": "awg"}
+  },
+  {
     "model": "website.module",
     "fields": {
       "site": ["192.168.129.10"],
@@ -25,6 +29,15 @@
       "module": ["192.168.129.10", "/ocpp/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner"
+    }
+  },
+  {
+    "model": "website.module",
+    "fields": {
+      "site": ["192.168.129.10"],
+      "application": ["awg"],
+      "path": "/awg/",
+      "is_default": false
     }
   }
 ]

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -11,6 +11,10 @@
     "fields": {"name": "ocpp"}
   },
   {
+    "model": "website.application",
+    "fields": {"name": "awg"}
+  },
+  {
     "model": "website.module",
     "fields": {
       "site": ["127.0.0.1"],
@@ -25,6 +29,15 @@
       "module": ["127.0.0.1", "/ocpp/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner"
+    }
+  },
+  {
+    "model": "website.module",
+    "fields": {
+      "site": ["127.0.0.1"],
+      "application": ["awg"],
+      "path": "/awg/",
+      "is_default": false
     }
   }
 ]


### PR DESCRIPTION
## Summary
- add AWG application to gway_box and localhost fixtures
- register AWG module for every site so calculator link is always displayed

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b067744f1c8326a852aad291f32c57