### PR TITLE
Rename business and integrate app verbose names

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
-    verbose_name = _("Business Cores")
+    verbose_name = _("Business Models")
 
     def ready(self):  # pragma: no cover - called by Django
         from django.contrib.auth import get_user_model

--- a/integrate/__init__.py
+++ b/integrate/__init__.py
@@ -1,1 +1,1 @@
-"""Integrate app."""
+"""Integration Models app."""

--- a/integrate/apps.py
+++ b/integrate/apps.py
@@ -4,4 +4,4 @@ from django.apps import AppConfig
 class IntegrateConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "integrate"
-    verbose_name = "Integrate"
+    verbose_name = "Integration Models"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -20,8 +20,8 @@ msgstr ""
 "1 : 2;\n"
 
 #: core/apps.py:8
-msgid "Business Cores"
-msgstr "Núcleos de negocio"
+msgid "Business Models"
+msgstr "Modelos de negocio"
 
 #: core/models.py:140
 msgid "Invalid municipality for the selected state"


### PR DESCRIPTION
## Summary
- rename core app verbose name to "Business Models"
- rename integrate app verbose name to "Integration Models"
- update Spanish translation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b069951998832690fdd05747257c95