### PR TITLE
feat(admin): show detailed date and timezone on clock hover

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 - Add --satellite flag to install script
 - Add msg app for LCD/Windows notifications
 - Remove environment sigils integration
+- Show full date and timezone in admin clock tooltip
 
 0.1.1 [revision 76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d]
 ---------------------------------------------------------

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -2,6 +2,7 @@ import socket
 
 from django.contrib.sites.models import Site
 from django.http import HttpRequest
+from django.conf import settings
 
 
 def site_and_node(request: HttpRequest):
@@ -57,4 +58,5 @@ def site_and_node(request: HttpRequest):
         "badge_node": node,
         "badge_site_color": site_color,
         "badge_node_color": node_color,
+        "TIME_ZONE": settings.TIME_ZONE,
     }

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -83,6 +83,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     const serverStart = Date.parse("{{ current_time|escapejs }}");
     const clientStart = Date.now();
+    const tz = "{{ TIME_ZONE|escapejs }}";
     function pad(n) {
         return String(n).padStart(2, '0');
     }
@@ -90,6 +91,12 @@ document.addEventListener('DOMContentLoaded', function () {
         const now = new Date(serverStart + (Date.now() - clientStart));
         const formatted = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
         clock.textContent = `${formatted} {{ current_tz|escapejs }}`;
+        const dateFull = new Intl.DateTimeFormat([], { timeZone: tz, year: 'numeric', month: 'long', day: 'numeric' }).format(now);
+        const weekday = new Intl.DateTimeFormat([], { timeZone: tz, weekday: 'long' }).format(now);
+        const tzName = new Intl.DateTimeFormat([], { timeZone: tz, timeZoneName: 'long' })
+            .formatToParts(now)
+            .find(part => part.type === 'timeZoneName').value;
+        clock.title = `${dateFull}\n${weekday}\n${tzName}`;
     }
     update();
     setInterval(update, 1000);


### PR DESCRIPTION
## Summary
- expose TIME_ZONE via site_and_node context processor
- show full date and timezone when hovering admin server clock

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b071b449dc83269fb849ce5a450815