### PR TITLE
feat: register current node during dev refresh

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -27,6 +27,7 @@ django.setup()
 
 from django.db.models.signals import post_save
 from website.models import Module, Landing, _create_landings
+from nodes.models import Node
 
 
 def _local_app_labels() -> list[str]:
@@ -156,6 +157,9 @@ def run_database_tasks() -> None:
     # Ensure Application and Module entries exist for local apps
     call_command("register_site_apps")
     Landing.objects.update(is_seed_data=True)
+
+    # Ensure current node is registered or updated
+    Node.register_current()
 
 
 TASKS = {"database": run_database_tasks}


### PR DESCRIPTION
## Summary
- ensure env refresh registers or updates the current node
- centralize node registration logic
- add tests covering node registration during env refresh

## Testing
- `python manage.py test` *(fails: test_gui_display_uses_windows_toast, test_startup_notification_uses_ip_and_revision)*

------
https://chatgpt.com/codex/tasks/task_e_68b0967063948326927ad7c869d00f14