### PR TITLE
Run migrations during install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+- Run migrations during install to avoid missing tables after database removal
 - Add --satellite flag to install script
 - Add --control flag to install script to create Control site
 - Add msg app for LCD/Windows notifications

--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,8 @@ else
     echo "Requirements unchanged. Skipping installation."
 fi
 
+python manage.py migrate --noinput
+
 deactivate
 
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+def test_install_script_runs_migrate():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    assert "python manage.py migrate" in content
+


### PR DESCRIPTION
## Summary
- run `python manage.py migrate` during install to rebuild the database
- document migration step for fresh installs
- test that the install script runs migrations

## Testing
- `python manage.py migrate --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a07e734c83269c8e43fba44cbe37