### PR TITLE
Skip landing auto creation during fixture loading

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -161,6 +161,8 @@ from django.dispatch import receiver
 
 
 @receiver(post_save, sender=Module)
-def _create_landings(sender, instance, created, **kwargs):  # pragma: no cover - simple handler
-    if created:
+def _create_landings(
+    sender, instance, created, raw, **kwargs
+):  # pragma: no cover - simple handler
+    if created and not raw:
         instance.create_landings()

--- a/website/tests.py
+++ b/website/tests.py
@@ -396,6 +396,14 @@ class LandingCreationTests(TestCase):
         self.assertTrue(module.landings.filter(path="/").exists())
 
 
+class LandingFixtureTests(TestCase):
+    def test_constellation_fixture_loads_without_duplicates(self):
+        fixture = Path(settings.BASE_DIR, "website", "fixtures", "constellation.json")
+        call_command("loaddata", str(fixture))
+        module = Module.objects.get(path="/ocpp/", site__domain="arthexis.com")
+        self.assertEqual(module.landings.filter(path="/ocpp/rfid/").count(), 1)
+
+
 class AllowedHostSubnetTests(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
## Summary
- avoid auto-generating landings when loading fixtures by ignoring post-save signal with `raw`
- add regression test ensuring constellation fixture loads without duplicate landings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f4b958108326bcc8a3606df7c9c3