### PR TITLE
Refactor node roles and add constellation install flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,10 @@ ENABLE_LCD_SCREEN=false
 DISABLE_LCD_SCREEN=false
 CLEAN=false
 ENABLE_CONTROL=false
+NODE_ROLE="Unknown"
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--public|--internal] [--port PORT] [--upgrade] [--auto-upgrade] [--latest] [--satellite] [--terminal] [--control] [--celery] [--lcd-screen|--no-lcd-screen] [--clean]" >&2
+    echo "Usage: $0 [--service NAME] [--public|--internal] [--port PORT] [--upgrade] [--auto-upgrade] [--latest] [--satellite] [--terminal] [--control] [--constellation] [--celery] [--lcd-screen|--no-lcd-screen] [--clean]" >&2
     exit 1
 }
 
@@ -74,6 +75,7 @@ while [[ $# -gt 0 ]]; do
             SERVICE="arthexis"
             LATEST=true
             ENABLE_CELERY=true
+            NODE_ROLE="Gateway"
             shift
             ;;
         --terminal)
@@ -82,6 +84,7 @@ while [[ $# -gt 0 ]]; do
             SERVICE="arthexis"
             LATEST=true
             ENABLE_CELERY=true
+            NODE_ROLE="Terminal"
             shift
             ;;
         --control)
@@ -93,6 +96,16 @@ while [[ $# -gt 0 ]]; do
             ENABLE_LCD_SCREEN=true
             DISABLE_LCD_SCREEN=false
             ENABLE_CONTROL=true
+            NODE_ROLE="Control"
+            shift
+            ;;
+        --constellation)
+            AUTO_UPGRADE=true
+            NGINX_MODE="public"
+            SERVICE="arthexis"
+            ENABLE_CELERY=true
+            LATEST=false
+            NODE_ROLE="Constellation"
             shift
             ;;
         *)
@@ -150,6 +163,7 @@ fi
 
 # Install nginx configuration and reload
 echo "$NGINX_MODE" > "$LOCK_DIR/nginx_mode.lck"
+echo "$NODE_ROLE" > "$LOCK_DIR/role.lck"
 NGINX_CONF="/etc/nginx/conf.d/arthexis-${NGINX_MODE}.conf"
 
 # Ensure nginx config directory exists

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -46,14 +46,13 @@ class NodeAdmin(admin.ModelAdmin):
         "clipboard",
         "screenshot",
         "installed_version",
-        "roles_list",
+        "role",
         "last_seen",
     )
     search_fields = ("hostname", "address", "mac_address")
     change_list_template = "admin/nodes/node/change_list.html"
     change_form_template = "admin/nodes/node/change_form.html"
     form = NodeAdminForm
-    filter_horizontal = ("roles",)
     actions = ["run_command"]
 
     def api(self, obj):
@@ -74,10 +73,6 @@ class NodeAdmin(admin.ModelAdmin):
     screenshot.boolean = True
     screenshot.short_description = "Screenshot"
 
-    def roles_list(self, obj):
-        return ", ".join(obj.roles.values_list("name", flat=True))
-
-    roles_list.short_description = "Roles"
 
     def get_urls(self):
         urls = super().get_urls()
@@ -163,7 +158,7 @@ class NodeAdmin(admin.ModelAdmin):
 
 @admin.register(NodeRole)
 class NodeRoleAdmin(admin.ModelAdmin):
-    list_display = ("name",)
+    list_display = ("name", "description")
 
 
 @admin.register(ScreenSource)

--- a/nodes/fixtures/node_roles.json
+++ b/nodes/fixtures/node_roles.json
@@ -1,9 +1,7 @@
 [
-  {"model": "nodes.noderole", "pk": 1, "fields": {"name": "Dev"}},
-  {"model": "nodes.noderole", "pk": 2, "fields": {"name": "Test"}},
-  {"model": "nodes.noderole", "pk": 3, "fields": {"name": "Prod"}},
-  {"model": "nodes.noderole", "pk": 4, "fields": {"name": "Satellite"}},
-  {"model": "nodes.noderole", "pk": 5, "fields": {"name": "Central"}},
-  {"model": "nodes.noderole", "pk": 6, "fields": {"name": "Proxy"}},
-  {"model": "nodes.noderole", "pk": 7, "fields": {"name": "Agent"}}
+  {"model": "nodes.noderole", "pk": 1, "fields": {"name": "Terminal", "description": "Single-User Research & Development"}},
+  {"model": "nodes.noderole", "pk": 2, "fields": {"name": "Control", "description": "Single-Device Testing & Special Task Appliances"}},
+  {"model": "nodes.noderole", "pk": 3, "fields": {"name": "Gateway", "description": "Multi-Device Edge, Network & Data Acquisition"}},
+  {"model": "nodes.noderole", "pk": 4, "fields": {"name": "Constellation", "description": "Multi-User Cloud & Orchestration"}},
+  {"model": "nodes.noderole", "pk": 5, "fields": {"name": "Unknown", "description": "Unknown or unspecified"}}
 ]

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -29,6 +29,19 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
+            name='NodeRole',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('name', models.CharField(max_length=50, unique=True)),
+                ('description', models.CharField(blank=True, max_length=200)),
+            ],
+            options={
+                'ordering': ['name'],
+            },
+        ),
+        migrations.CreateModel(
             name='Node',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
@@ -49,6 +62,7 @@ class Migration(migrations.Migration):
                 ('base_path', models.CharField(blank=True, max_length=255)),
                 ('installed_version', models.CharField(blank=True, max_length=20)),
                 ('installed_revision', models.CharField(blank=True, max_length=40)),
+                ('role', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='nodes.noderole')),
             ],
             options={
                 'abstract': False,
@@ -65,18 +79,6 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['-created'],
-            },
-        ),
-        migrations.CreateModel(
-            name='NodeRole',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_seed_data', models.BooleanField(default=False, editable=False)),
-                ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('name', models.CharField(max_length=50, unique=True)),
-            ],
-            options={
-                'ordering': ['name'],
             },
         ),
         migrations.CreateModel(
@@ -119,11 +121,6 @@ class Migration(migrations.Migration):
             options={
                 'ordering': ['-priority', 'id'],
             },
-        ),
-        migrations.AddField(
-            model_name='node',
-            name='roles',
-            field=models.ManyToManyField(blank=True, to='nodes.noderole'),
         ),
         migrations.CreateModel(
             name='NodeScreenshot',

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -11,3 +11,9 @@ def test_install_script_includes_terminal_flag():
     content = script_path.read_text()
     assert "--terminal" in content
 
+
+def test_install_script_includes_constellation_flag():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    assert "--constellation" in content
+

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -228,9 +228,9 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
       <a href="{% url 'admin:nodes_node_change' badge_node.pk %}">{{ badge_node.hostname }}</a>
       <span style="display:none">NODE: {{ badge_node.hostname }}</span>
     </span>
-    {% for role in badge_node.roles.all %}
-      <span class="badge" style="background-color: {{ badge_node_color }};">ROLE: {{ role.name }}</span>
-    {% endfor %}
+    {% if badge_node.role %}
+      <span class="badge" style="background-color: {{ badge_node_color }};">ROLE: {{ badge_node.role.name }}</span>
+    {% endif %}
   {% else %}
     <span class="badge badge-unknown">
       <a href="{% url 'admin:nodes_node_changelist' %}">NODE</a>: Unknown

--- a/website/tests.py
+++ b/website/tests.py
@@ -139,15 +139,14 @@ class AdminBadgesTests(TestCase):
         self.assertContains(resp, "SITE: test")
         self.assertContains(resp, f"NODE: {self.node_hostname}")
 
-    def test_badges_show_node_roles(self):
+    def test_badges_show_node_role(self):
         from nodes.models import NodeRole
 
-        role1 = NodeRole.objects.create(name="Dev")
-        role2 = NodeRole.objects.create(name="Proxy")
-        self.node.roles.add(role1, role2)
+        role = NodeRole.objects.create(name="Dev")
+        self.node.role = role
+        self.node.save()
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, "ROLE: Dev")
-        self.assertContains(resp, "ROLE: Proxy")
 
     def test_badges_warn_when_node_missing(self):
         from nodes.models import Node


### PR DESCRIPTION
## Summary
- replace multi-role nodes with single `NodeRole` including descriptions
- provide new default roles and `--constellation` install flag
- assign node role automatically from installation lock file

## Testing
- `python manage.py migrate --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fe947fc88326b83c736bf98a1acb