### PR TITLE
Link modules to node roles and allow optional site names

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -53,9 +53,12 @@ def site_and_node(request: HttpRequest):
     if node:
         node_color = node.badge_color
 
+    site_name = site.name if site else ""
+    node_role_name = node.role.name if node and node.role else ""
     return {
         "badge_site": site,
         "badge_node": node,
+        "badge_site_name": site_name or node_role_name,
         "badge_site_color": site_color,
         "badge_node_color": node_color,
         "TIME_ZONE": settings.TIME_ZONE,

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,5 +1,6 @@
 from utils.sites import get_site
 import socket
+from nodes.models import Node
 
 from .active_app import set_active_app
 
@@ -12,7 +13,9 @@ class ActiveAppMiddleware:
 
     def __call__(self, request):
         site = get_site(request)
-        active = site.name or "Terminal"
+        node = Node.get_local()
+        role_name = node.role.name if node and node.role else "Terminal"
+        active = site.name or role_name
         set_active_app(active)
         request.active_app = active
         try:

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -8,6 +8,12 @@ import os
 import socket
 from pathlib import Path
 from utils import revision
+from django.db import models
+
+
+class NodeRoleManager(models.Manager):
+    def get_by_natural_key(self, name: str):
+        return self.get(name=name)
 
 
 class NodeRole(Entity):
@@ -16,8 +22,13 @@ class NodeRole(Entity):
     name = models.CharField(max_length=50, unique=True)
     description = models.CharField(max_length=200, blank=True)
 
+    objects = NodeRoleManager()
+
     class Meta:
         ordering = ["name"]
+
+    def natural_key(self):  # pragma: no cover - simple representation
+        return (self.name,)
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.contrib.sites.models import Site
 from website.models import Application, Module
+from nodes.models import Node, NodeRole
 
 from config.asgi import application
 
@@ -393,11 +394,16 @@ class ChargerLandingTests(TestCase):
 
 class SimulatorLandingTests(TestCase):
     def setUp(self):
-        site, _ = Site.objects.update_or_create(
-            id=1, defaults={"domain": "testserver", "name": "website"}
+        role, _ = NodeRole.objects.get_or_create(name="Terminal")
+        Node.objects.update_or_create(
+            mac_address=Node.get_current_mac(),
+            defaults={"hostname": "localhost", "address": "127.0.0.1", "role": role},
+        )
+        Site.objects.update_or_create(
+            id=1, defaults={"domain": "testserver", "name": ""}
         )
         app = Application.objects.create(name="Ocpp")
-        module = Module.objects.create(site=site, application=app, path="/ocpp/")
+        module = Module.objects.create(node_role=role, application=app, path="/ocpp/")
         module.create_landings()
         User = get_user_model()
         self.user = User.objects.create_user(username="nav", password="pwd")

--- a/tests/test_register_site_apps_command.py
+++ b/tests/test_register_site_apps_command.py
@@ -16,7 +16,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from website.models import Application, Module
-from nodes.models import Node
+from nodes.models import Node, NodeRole
 
 
 class RegisterSiteAppsCommandTests(TestCase):
@@ -28,12 +28,13 @@ class RegisterSiteAppsCommandTests(TestCase):
         call_command("register_site_apps")
 
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "Terminal")
+        self.assertEqual(site.name, "")
 
         node = Node.objects.get(hostname=socket.gethostname())
         self.assertFalse(node.enable_public_api)
         self.assertFalse(node.clipboard_polling)
         self.assertFalse(node.screenshot_polling)
+        role = NodeRole.objects.get(name="Terminal")
 
         for label in settings.LOCAL_APPS:
             try:
@@ -42,4 +43,6 @@ class RegisterSiteAppsCommandTests(TestCase):
                 continue
             self.assertTrue(Application.objects.filter(name=config.label).exists())
             app = Application.objects.get(name=config.label)
-            self.assertTrue(site.modules.filter(application=app).exists())
+            self.assertTrue(
+                Module.objects.filter(node_role=role, application=app).exists()
+            )

--- a/website/admin.py
+++ b/website/admin.py
@@ -36,14 +36,17 @@ class SiteBadgeInline(admin.StackedInline):
     fields = ("badge_color", "favicon")
 
 
-class ModuleInline(admin.TabularInline):
-    model = Module
-    extra = 0
-    fields = ("application", "path", "menu", "is_default", "favicon")
+class SiteForm(forms.ModelForm):
+    name = forms.CharField(required=False)
+
+    class Meta:
+        model = Site
+        fields = "__all__"
 
 
 class SiteAdmin(DjangoSiteAdmin):
-    inlines = [SiteBadgeInline, ModuleInline]
+    form = SiteForm
+    inlines = [SiteBadgeInline]
     change_list_template = "admin/sites/site/change_list.html"
     fields = ("domain", "name")
     list_display = ("domain", "name")
@@ -98,7 +101,7 @@ class SiteAdmin(DjangoSiteAdmin):
         except ValueError:
             name = domain
         else:
-            name = "Terminal"
+            name = ""
         site, created = Site.objects.get_or_create(
             domain=domain, defaults={"name": name}
         )
@@ -153,7 +156,7 @@ class LandingInline(admin.TabularInline):
 
 @admin.register(Module)
 class ModuleAdmin(admin.ModelAdmin):
-    list_display = ("application", "site", "path", "menu", "is_default")
-    list_filter = ("site", "application")
-    fields = ("site", "application", "path", "menu", "is_default", "favicon")
+    list_display = ("application", "node_role", "path", "menu", "is_default")
+    list_filter = ("node_role", "application")
+    fields = ("node_role", "application", "path", "menu", "is_default", "favicon")
     inlines = [LandingInline]

--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -2,6 +2,8 @@ from utils.sites import get_site
 from django.urls import Resolver404, resolve
 from django.conf import settings
 from pathlib import Path
+from nodes.models import Node
+from .models import Module
 
 _favicon_path = (
     Path(settings.BASE_DIR) / "website" / "fixtures" / "data" / "favicon.txt"
@@ -15,9 +17,15 @@ except OSError:
 def nav_links(request):
     """Provide navigation links for the current site."""
     site = get_site(request)
-    try:
-        modules = site.modules.select_related("application").prefetch_related("landings").all()
-    except Exception:
+    node = Node.get_local()
+    role = node.role if node else None
+    if role:
+        modules = (
+            Module.objects.filter(node_role=role)
+            .select_related("application")
+            .prefetch_related("landings")
+        )
+    else:
         modules = []
 
     valid_modules = []

--- a/website/fixtures/constellation.json
+++ b/website/fixtures/constellation.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "arthexis.com",
-      "name": "Constellation"
+      "name": ""
     }
   },
   {
@@ -21,8 +21,8 @@
   {
     "model": "website.module",
     "fields": {
-      "site": [
-        "arthexis.com"
+      "node_role": [
+        "Constellation"
       ],
       "application": [
         "ocpp"
@@ -34,7 +34,7 @@
   {
     "model": "website.landing",
     "fields": {
-      "module": ["arthexis.com", "/ocpp/"],
+      "module": ["Constellation", "/ocpp/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner"
     }
@@ -42,8 +42,8 @@
   {
     "model": "website.module",
     "fields": {
-      "site": [
-        "arthexis.com"
+      "node_role": [
+        "Constellation"
       ],
       "application": [
         "awg"

--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "192.168.129.10",
-      "name": "Gateway"
+      "name": ""
     }
   },
   {
@@ -17,7 +17,7 @@
   {
     "model": "website.module",
     "fields": {
-      "site": ["192.168.129.10"],
+      "node_role": ["Gateway"],
       "application": ["ocpp"],
       "path": "/ocpp/",
       "is_default": true
@@ -26,7 +26,7 @@
   {
     "model": "website.landing",
     "fields": {
-      "module": ["192.168.129.10", "/ocpp/"],
+      "module": ["Gateway", "/ocpp/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner"
     }
@@ -34,7 +34,7 @@
   {
     "model": "website.module",
     "fields": {
-      "site": ["192.168.129.10"],
+      "node_role": ["Gateway"],
       "application": ["awg"],
       "path": "/awg/",
       "is_default": false

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "127.0.0.1",
-      "name": "Terminal"
+      "name": ""
     }
   },
   {
@@ -17,7 +17,7 @@
   {
     "model": "website.module",
     "fields": {
-      "site": ["127.0.0.1"],
+      "node_role": ["Terminal"],
       "application": ["ocpp"],
       "path": "/ocpp/",
       "is_default": true
@@ -26,7 +26,7 @@
   {
     "model": "website.landing",
     "fields": {
-      "module": ["127.0.0.1", "/ocpp/"],
+      "module": ["Terminal", "/ocpp/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner"
     }
@@ -34,7 +34,7 @@
   {
     "model": "website.module",
     "fields": {
-      "site": ["127.0.0.1"],
+      "node_role": ["Terminal"],
       "application": ["awg"],
       "path": "/awg/",
       "is_default": false

--- a/website/management/commands/register_site_apps.py
+++ b/website/management/commands/register_site_apps.py
@@ -6,19 +6,20 @@ from django.utils.text import slugify
 import socket
 
 from website.models import Application, Module
-from nodes.models import Node
+from nodes.models import Node, NodeRole
 
 
 class Command(BaseCommand):
     help = (
         "Create Application entries for installed local apps and attach them to"
-        " the default 127.0.0.1 site."
+        " the Terminal node role."
     )
 
     def handle(self, *args, **options):
         site, _ = Site.objects.get_or_create(
-            domain="127.0.0.1", defaults={"name": "Terminal"}
+            domain="127.0.0.1", defaults={"name": ""}
         )
+        role, _ = NodeRole.objects.get_or_create(name="Terminal")
 
         hostname = socket.gethostname()
         Node.objects.get_or_create(
@@ -29,6 +30,7 @@ class Command(BaseCommand):
                 "enable_public_api": False,
                 "clipboard_polling": False,
                 "screenshot_polling": False,
+                "role": role,
             },
         )
 
@@ -40,7 +42,7 @@ class Command(BaseCommand):
             app, _ = Application.objects.get_or_create(name=config.label)
             path = f"/{slugify(app.name)}/"
             module, created = Module.objects.update_or_create(
-                site=site, path=path, defaults={"application": app}
+                node_role=role, path=path, defaults={"application": app}
             )
             if created:
                 module.create_landings()

--- a/website/migrations/0001_initial.py
+++ b/website/migrations/0001_initial.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("sites", "0002_alter_domain_unique"),
+        ("nodes", "0001_initial"),
     ]
 
     operations = [
@@ -119,18 +120,18 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "site",
+                    "node_role",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="modules",
-                        to="sites.site",
+                        to="nodes.noderole",
                     ),
                 ),
             ],
             options={
                 "verbose_name": "Module",
                 "verbose_name_plural": "Modules",
-                "unique_together": {("site", "path")},
+                "unique_together": {("node_role", "path")},
             },
         ),
         migrations.CreateModel(

--- a/website/models.py
+++ b/website/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from integrate.models import Entity
 from django.contrib.sites.models import Site
+from nodes.models import NodeRole
 from django.apps import apps as django_apps
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -30,13 +31,13 @@ class Application(Entity):
 
 
 class ModuleManager(models.Manager):
-    def get_by_natural_key(self, domain: str, path: str):
-        return self.get(site__domain=domain, path=path)
+    def get_by_natural_key(self, role: str, path: str):
+        return self.get(node_role__name=role, path=path)
 
 
 class Module(Entity):
-    site = models.ForeignKey(
-        Site, on_delete=models.CASCADE, related_name="modules",
+    node_role = models.ForeignKey(
+        NodeRole, on_delete=models.CASCADE, related_name="modules",
     )
     application = models.ForeignKey(
         Application, on_delete=models.CASCADE, related_name="modules",
@@ -59,12 +60,12 @@ class Module(Entity):
     class Meta:
         verbose_name = _("Module")
         verbose_name_plural = _("Modules")
-        unique_together = ("site", "path")
+        unique_together = ("node_role", "path")
 
     def natural_key(self):  # pragma: no cover - simple representation
-        return (self.site.domain, self.path)
+        return (self.node_role.name, self.path)
 
-    natural_key.dependencies = ["sites.Site"]
+    natural_key.dependencies = ["nodes.NodeRole"]
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.application.name} ({self.path})"

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -213,8 +213,8 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
   {% if badge_site %}
     <span class="badge" style="background-color: {{ badge_site_color }};">
       <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>:
-      <a href="{% url 'admin:website_siteproxy_change' badge_site.pk %}">{{ badge_site.name }}</a>
-      <span style="display:none">SITE: {{ badge_site.name }}</span>
+      <a href="{% url 'admin:website_siteproxy_change' badge_site.pk %}">{{ badge_site_name }}</a>
+      <span style="display:none">SITE: {{ badge_site_name }}</span>
     </span>
   {% else %}
     <span class="badge badge-unknown">

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{{ favicon_url }}">
-    <title>{% block title %}{{ badge_site.name|default:"Arthexis" }} {% trans "Constellation" %}{% endblock %}</title>
+    <title>{% block title %}{{ badge_site_name|default:"Arthexis" }} {% trans "Constellation" %}{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
       html[data-bs-theme='light'] {
@@ -67,7 +67,7 @@
     <div class="container flex-grow-1">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
         <div class="container-fluid">
-          <a class="navbar-brand" href="/">{{ badge_site.name|default:"Arthexis" }}</a>
+          <a class="navbar-brand" href="/">{{ badge_site_name|default:"Arthexis" }}</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>

--- a/website/views.py
+++ b/website/views.py
@@ -9,6 +9,7 @@ from django import forms
 from utils.sites import get_site
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from nodes.models import Node
 from django.urls import reverse
 from django.utils import translation
 from django.utils.encoding import force_bytes, force_str
@@ -18,6 +19,7 @@ from django.utils.translation import gettext as _
 
 import markdown
 from website.utils import landing
+from .models import Module
 
 
 logger = logging.getLogger(__name__)
@@ -26,8 +28,10 @@ logger = logging.getLogger(__name__)
 @landing("Home")
 def index(request):
     site = get_site(request)
+    node = Node.get_local()
+    role = node.role if node else None
     app = (
-        site.modules.filter(is_default=True)
+        Module.objects.filter(node_role=role, is_default=True)
         .select_related("application")
         .first()
     )
@@ -60,7 +64,9 @@ def index(request):
 
 def sitemap(request):
     site = get_site(request)
-    applications = site.modules.all()
+    node = Node.get_local()
+    role = node.role if node else None
+    applications = Module.objects.filter(node_role=role)
     base = request.build_absolute_uri("/").rstrip("/")
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
## Summary
- associate website modules with node roles instead of sites
- allow site display name to be blank and fall back to node role
- register local apps for Terminal role and load fixtures with node roles

## Testing
- `pytest`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68b101965f80832691286211176c8dfc