### PR TITLE
Detect migration changes and rebuild schema when using --latest

### DIFF
--- a/env-refresh.bat
+++ b/env-refresh.bat
@@ -1,5 +1,7 @@
 @echo off
 set VENV=.venv
+set LATEST=0
+if "%1"=="--latest" set LATEST=1
 if not exist %VENV%\Scripts\python.exe (
     echo Virtual environment not found. Run install.sh first.
     exit /b 1
@@ -16,4 +18,8 @@ if exist requirements.txt (
         echo %REQ_HASH%>requirements.md5
     )
 )
-%VENV%\Scripts\python.exe env-refresh.py database
+if %LATEST%==1 (
+    %VENV%\Scripts\python.exe env-refresh.py --latest database
+) else (
+    %VENV%\Scripts\python.exe env-refresh.py database
+)

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -4,6 +4,19 @@ set -e
 VENV_DIR=".venv"
 PYTHON="$VENV_DIR/bin/python"
 
+LATEST=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --latest)
+      LATEST=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 if [ ! -f "$PYTHON" ]; then
   echo "Virtual environment not found. Run ./install.sh first." >&2
   exit 1
@@ -21,4 +34,8 @@ if [ -f requirements.txt ]; then
   fi
 fi
 
-"$PYTHON" env-refresh.py database
+if [ "$LATEST" -eq 1 ]; then
+  "$PYTHON" env-refresh.py --latest database
+else
+  "$PYTHON" env-refresh.py database
+fi

--- a/migrations.md5
+++ b/migrations.md5
@@ -1,0 +1,1 @@
+e34f2ea8e8bcee1c757074dbf9cddacf

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -77,7 +77,11 @@ if [ "$CLEAN_DB" -eq 1 ]; then
 fi
 
 # Refresh environment and restart service
-./env-refresh.sh
+ENV_ARGS=""
+if [[ $FORCE -eq 1 ]]; then
+  ENV_ARGS="--latest"
+fi
+./env-refresh.sh $ENV_ARGS
 if [[ $NO_RESTART -eq 0 ]]; then
   ./start.sh
 fi


### PR DESCRIPTION
## Summary
- track migration file hashes to detect schema changes
- reset database and reapply migrations when hashes change in `--latest` mode
- wire `--latest` flag through upgrade and env-refresh scripts

## Testing
- `pytest`
- `python env-refresh.py database`

------
https://chatgpt.com/codex/tasks/task_e_68b105369c9083269032c63c17adffcd