### PR TITLE
Enforce nginx requirement for gateway roles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,15 @@ usage() {
     exit 1
 }
 
+require_nginx() {
+    if ! command -v nginx >/dev/null 2>&1; then
+        echo "Nginx is required for the $1 role but is not installed."
+        echo "Install nginx and re-run this script. For Debian/Ubuntu:"
+        echo "  sudo apt-get update && sudo apt-get install nginx"
+        exit 1
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --service)
@@ -70,6 +79,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --satellite)
+            require_nginx "satellite"
             AUTO_UPGRADE=true
             NGINX_MODE="internal"
             SERVICE="arthexis"
@@ -88,6 +98,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --control)
+            require_nginx "control"
             AUTO_UPGRADE=true
             NGINX_MODE="internal"
             SERVICE="arthexis"
@@ -100,6 +111,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --constellation)
+            require_nginx "constellation"
             AUTO_UPGRADE=true
             NGINX_MODE="public"
             SERVICE="arthexis"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -17,3 +17,10 @@ def test_install_script_includes_constellation_flag():
     content = script_path.read_text()
     assert "--constellation" in content
 
+
+def test_install_script_requires_nginx_for_roles():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    for role in ("satellite", "control", "constellation"):
+        assert f'require_nginx "{role}"' in content
+


### PR DESCRIPTION
## Summary
- add `require_nginx` helper to abort install when nginx is missing
- verify roles `--satellite`, `--control`, and `--constellation` enforce nginx check
- test install script for nginx checks on each role flag

## Testing
- `pytest` *(fails: No module named 'channels')*


------
https://chatgpt.com/codex/tasks/task_e_68b10425b6a48326a279f3eeefa3486b