### PR TITLE
Default nodes to Terminal role

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ ENABLE_LCD_SCREEN=false
 DISABLE_LCD_SCREEN=false
 CLEAN=false
 ENABLE_CONTROL=false
-NODE_ROLE="Unknown"
+NODE_ROLE="Terminal"
 
 usage() {
     echo "Usage: $0 [--service NAME] [--public|--internal] [--port PORT] [--upgrade] [--auto-upgrade] [--latest] [--satellite] [--terminal] [--control] [--constellation] [--celery] [--lcd-screen|--no-lcd-screen] [--clean]" >&2

--- a/nodes/fixtures/node_roles.json
+++ b/nodes/fixtures/node_roles.json
@@ -2,6 +2,5 @@
   {"model": "nodes.noderole", "pk": 1, "fields": {"name": "Terminal", "description": "Single-User Research & Development"}},
   {"model": "nodes.noderole", "pk": 2, "fields": {"name": "Control", "description": "Single-Device Testing & Special Task Appliances"}},
   {"model": "nodes.noderole", "pk": 3, "fields": {"name": "Gateway", "description": "Multi-Device Edge, Network & Data Acquisition"}},
-  {"model": "nodes.noderole", "pk": 4, "fields": {"name": "Constellation", "description": "Multi-User Cloud & Orchestration"}},
-  {"model": "nodes.noderole", "pk": 5, "fields": {"name": "Unknown", "description": "Unknown or unspecified"}}
+  {"model": "nodes.noderole", "pk": 4, "fields": {"name": "Constellation", "description": "Multi-User Cloud & Orchestration"}}
 ]

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -99,16 +99,16 @@ class Node(Entity):
             # assign role from installation lock file
             role_lock = Path(settings.BASE_DIR) / "locks" / "role.lck"
             role_name = (
-                role_lock.read_text().strip() if role_lock.exists() else "Unknown"
+                role_lock.read_text().strip() if role_lock.exists() else "Terminal"
             )
             role = NodeRole.objects.filter(name=role_name).first()
             if role:
                 node.role = role
                 node.save(update_fields=["role"])
         if created and node.role is None:
-            unknown = NodeRole.objects.filter(name="Unknown").first()
-            if unknown:
-                node.role = unknown
+            terminal = NodeRole.objects.filter(name="Terminal").first()
+            if terminal:
+                node.role = terminal
                 node.save(update_fields=["role"])
         return node, created
 


### PR DESCRIPTION
## Summary
- remove `Unknown` node role
- default node role to `Terminal` when registering
- set installer default role to `Terminal`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1089afbd483268a1a5498e9e1a735