### PR TITLE
Display goodbye message on LCD during uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -35,6 +35,15 @@ if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
     exit 0
 fi
 
+LCD_LOCK="$LOCK_DIR/lcd_screen.lck"
+if [ -f "$LCD_LOCK" ]; then
+    python3 - <<'PY'
+from core.notifications import notify
+notify("Goodbye!")
+PY
+    sleep 2
+fi
+
 if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service"; then
     sudo systemctl stop "$SERVICE" || true
     sudo systemctl disable "$SERVICE" || true


### PR DESCRIPTION
## Summary
- notify LCD screen with a "Goodbye!" message when uninstalling a setup that enabled the LCD screen

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b109111ee083269247139f940eed9f