### PR TITLE
feat(admin): use domain for site badge fallback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 - Add msg app for LCD/Windows notifications
 - Remove environment sigils integration
 - Show full date and timezone in admin clock tooltip
+- Fallback to site domain in admin badge when display name missing
 
 0.1.1 [revision 76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d]
 ---------------------------------------------------------

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -58,7 +58,10 @@ def site_and_node(request: HttpRequest):
     return {
         "badge_site": site,
         "badge_node": node,
+        # Public views fall back to the node role when the site name is blank.
         "badge_site_name": site_name or node_role_name,
+        # Admin site badge uses the site display name if set, otherwise the domain.
+        "badge_admin_site_name": site_name or (site.domain if site else ""),
         "badge_site_color": site_color,
         "badge_node_color": node_color,
         "TIME_ZONE": settings.TIME_ZONE,

--- a/website/templates/admin/base_site.html
+++ b/website/templates/admin/base_site.html
@@ -213,8 +213,8 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
   {% if badge_site %}
     <span class="badge" style="background-color: {{ badge_site_color }};">
       <a href="{% url 'admin:website_siteproxy_changelist' %}">SITE</a>:
-      <a href="{% url 'admin:website_siteproxy_change' badge_site.pk %}">{{ badge_site_name }}</a>
-      <span style="display:none">SITE: {{ badge_site_name }}</span>
+      <a href="{% url 'admin:website_siteproxy_change' badge_site.pk %}">{{ badge_admin_site_name }}</a>
+      <span style="display:none">SITE: {{ badge_admin_site_name }}</span>
     </span>
   {% else %}
     <span class="badge badge-unknown">

--- a/website/tests.py
+++ b/website/tests.py
@@ -302,9 +302,9 @@ class AdminBadgesWebsiteTests(TestCase):
         )
 
     @override_settings(ALLOWED_HOSTS=["127.0.0.1", "testserver"])
-    def test_badge_shows_website_for_ip_domain(self):
+    def test_badge_shows_domain_when_site_name_blank(self):
         resp = self.client.get(reverse("admin:index"), HTTP_HOST="127.0.0.1")
-        self.assertContains(resp, "SITE: Terminal")
+        self.assertContains(resp, "SITE: 127.0.0.1")
 
 
 class NavAppsTests(TestCase):


### PR DESCRIPTION
## Summary
- show site domain in admin badge when display name missing
- keep public views using node role when site name empty
- document change in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10a455c588326b33898365bf98510