### PR TITLE
Remove migration hash artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,8 +221,8 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
  
-# Hash file used by upgrade scripts to track dependency changes
-requirements.md5
+# Hash files used by upgrade scripts to track dependency changes
+*.md5
 REVISION
 
 # Auto-upgrade control file

--- a/migrations.md5
+++ b/migrations.md5
@@ -1,1 +1,0 @@
-e34f2ea8e8bcee1c757074dbf9cddacf


### PR DESCRIPTION
## Summary
- remove mistakenly committed `migrations.md5`
- ignore all generated `*.md5` hash files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b110e021988326848f09d3088a8700