### PR TITLE
Generate node key pairs on registration

### DIFF
--- a/nodes/templates/admin/nodes/node/change_form.html
+++ b/nodes/templates/admin/nodes/node/change_form.html
@@ -2,6 +2,11 @@
 {% load i18n %}
 
 {% block object-tools-items %}
+    {% if public_key_url %}
+        <li>
+            <a href="{{ public_key_url }}">{% trans "Download public key" %}</a>
+        </li>
+    {% endif %}
     {% for action in node_actions %}
         <li>
             <a href="{% url 'admin:nodes_node_action' object_id action.slug %}">


### PR DESCRIPTION
## Summary
- ensure a security directory and RSA key pair exist when registering the local Node
- allow admins to download a Node's public key from the change page
- test key generation and public key download

## Testing
- `python manage.py test nodes.tests.NodeAdminTests`


------
https://chatgpt.com/codex/tasks/task_e_68b12264a6ac832683defa903cf22baf