### PR TITLE
Add notify management command

### DIFF
--- a/core/management/commands/notify.py
+++ b/core/management/commands/notify.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+from core.notifications import notify
+
+
+class Command(BaseCommand):
+    """Send a message to the LCD or GUI notification fallback."""
+
+    help = "Send a message to the LCD or GUI notification fallback"
+
+    def add_arguments(self, parser):
+        parser.add_argument("subject", help="First line of the message")
+        parser.add_argument(
+            "body",
+            nargs="?",
+            default="",
+            help="Optional second line of the message",
+        )
+
+    def handle(self, *args, **options):
+        subject = options["subject"]
+        body = options["body"]
+        notify(subject=subject, body=body)
+        self.stdout.write(self.style.SUCCESS("Notification sent"))

--- a/tests/test_notify_command.py
+++ b/tests/test_notify_command.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.core.management import call_command
+from unittest.mock import patch
+
+
+def test_notify_management_command_calls_core_notify():
+    with patch("core.management.commands.notify.notify") as mock_notify:
+        call_command("notify", "subject", "body")
+    mock_notify.assert_called_once_with(subject="subject", body="body")


### PR DESCRIPTION
## Summary
- add notify management command to send messages to LCD or toast fallback
- test notify management command forwards messages to core notifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12837291c8326b33c56e2770474b6