### PR TITLE
Add default site fixtures

### DIFF
--- a/website/fixtures/constellation.json
+++ b/website/fixtures/constellation.json
@@ -1,12 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "fields": {
-      "domain": "arthexis.com",
-      "name": ""
-    }
-  },
-  {
     "model": "website.application",
     "fields": {
       "name": "ocpp"

--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -1,12 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "fields": {
-      "domain": "192.168.129.10",
-      "name": ""
-    }
-  },
-  {
     "model": "website.application",
     "fields": {"name": "ocpp"}
   },

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -1,12 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "fields": {
-      "domain": "127.0.0.1",
-      "name": ""
-    }
-  },
-  {
     "model": "website.application",
     "fields": {"name": "ocpp"}
   },

--- a/website/fixtures/sites.json
+++ b/website/fixtures/sites.json
@@ -1,0 +1,37 @@
+[
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "127.0.0.1",
+      "name": "local"
+    }
+  },
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "localhost",
+      "name": "localhost"
+    }
+  },
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "192.168.129.10",
+      "name": "ethernet"
+    }
+  },
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "10.42.0.1",
+      "name": "wlan-ap"
+    }
+  },
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "arthexis.com",
+      "name": "cloud-main"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- define default `Site` fixtures mapping common addresses to names
- remove inline `Site` entries from existing website fixtures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b12bac381483269dd406cb99301b35