### PR TITLE
Improve SecurityGroup admin permissions selector

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -6,7 +6,10 @@ from django.shortcuts import redirect, render
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
-from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.admin import (
+    GroupAdmin as DjangoGroupAdmin,
+    UserAdmin as DjangoUserAdmin,
+)
 from import_export import resources, fields
 from import_export.admin import ImportExportModelAdmin
 from import_export.widgets import ForeignKeyWidget
@@ -69,8 +72,8 @@ class ReferenceAdmin(admin.ModelAdmin):
 
 
 @admin.register(SecurityGroup)
-class SecurityGroupAdmin(admin.ModelAdmin):
-    pass
+class SecurityGroupAdmin(DjangoGroupAdmin):
+    filter_horizontal = ("permissions",)
 
 
 class AccountRFIDForm(forms.ModelForm):


### PR DESCRIPTION
## Summary
- Use Django's GroupAdmin for SecurityGroup
- Enable horizontal filter for easier permission selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b12c12ad3883269aa4d18e23484792