### PR TITLE
Add default site fixtures and update site names

### DIFF
--- a/tests/test_register_site_apps_command.py
+++ b/tests/test_register_site_apps_command.py
@@ -28,7 +28,7 @@ class RegisterSiteAppsCommandTests(TestCase):
         call_command("register_site_apps")
 
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "")
+        self.assertEqual(site.name, "local")
 
         node = Node.objects.get(hostname=socket.gethostname())
         self.assertFalse(node.enable_public_api)

--- a/website/fixtures/constellation.json
+++ b/website/fixtures/constellation.json
@@ -2,8 +2,8 @@
   {
     "model": "sites.site",
     "fields": {
-      "domain": "arthexis.com",
-      "name": ""
+        "domain": "arthexis.com",
+        "name": "cloud-main"
     }
   },
   {

--- a/website/fixtures/gway_box.json
+++ b/website/fixtures/gway_box.json
@@ -2,8 +2,8 @@
   {
     "model": "sites.site",
     "fields": {
-      "domain": "192.168.129.10",
-      "name": ""
+        "domain": "192.168.129.10",
+        "name": "ethernet"
     }
   },
   {

--- a/website/fixtures/localhost.json
+++ b/website/fixtures/localhost.json
@@ -2,8 +2,8 @@
   {
     "model": "sites.site",
     "fields": {
-      "domain": "127.0.0.1",
-      "name": ""
+        "domain": "127.0.0.1",
+        "name": "local"
     }
   },
   {

--- a/website/fixtures/localhost_site.json
+++ b/website/fixtures/localhost_site.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "localhost",
+      "name": "localhost"
+    }
+  }
+]

--- a/website/fixtures/wlan_ap.json
+++ b/website/fixtures/wlan_ap.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model": "sites.site",
+    "fields": {
+      "domain": "10.42.0.1",
+      "name": "wlan-ap"
+    }
+  }
+]

--- a/website/management/commands/register_site_apps.py
+++ b/website/management/commands/register_site_apps.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         site, _ = Site.objects.get_or_create(
-            domain="127.0.0.1", defaults={"name": ""}
+            domain="127.0.0.1", defaults={"name": "local"}
         )
         role, _ = NodeRole.objects.get_or_create(name="Terminal")
 


### PR DESCRIPTION
## Summary
- add fixtures for localhost, wlan-ap, and other site domains
- set default site name to `local`
- adjust tests for updated site naming

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b12bdbfe8c832680443560b534c004