### PR TITLE
Improve SecurityGroup admin permissions selector

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -6,7 +6,10 @@ from django.shortcuts import redirect, render
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import get_user_model
-from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.admin import (
+    GroupAdmin as DjangoGroupAdmin,
+    UserAdmin as DjangoUserAdmin,
+)
 from import_export import resources, fields
 from import_export.admin import ImportExportModelAdmin
 from import_export.widgets import ForeignKeyWidget
@@ -69,7 +72,7 @@ class ReferenceAdmin(admin.ModelAdmin):
 
 
 @admin.register(SecurityGroup)
-class SecurityGroupAdmin(admin.ModelAdmin):
+class SecurityGroupAdmin(DjangoGroupAdmin):
     pass
 
 


### PR DESCRIPTION
## Summary
- reuse Django's built-in GroupAdmin for SecurityGroup
- enhances permissions widget with search and dual list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b12c1c85d883269e83ee83390a941d