### PR TITLE
Register sites on node creation and update site fixtures

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -3,6 +3,7 @@ from integrate.models import Entity
 import re
 from django.utils.text import slugify
 from django.conf import settings
+from django.contrib.sites.models import Site
 import uuid
 import os
 import socket
@@ -123,6 +124,7 @@ class Node(Entity):
             if terminal:
                 node.role = terminal
                 node.save(update_fields=["role"])
+        Site.objects.get_or_create(domain=hostname, defaults={"name": "host"})
         node.ensure_keys()
         return node, created
 

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -16,6 +16,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib import admin
+from django.contrib.sites.models import Site
 from django_celery_beat.models import PeriodicTask
 from django.conf import settings
 from .admin import RecipeAdmin
@@ -247,6 +248,7 @@ class NodeAdminTests(TestCase):
 
     def test_register_current_host(self):
         url = reverse("admin:nodes_node_register_current")
+        hostname = socket.gethostname()
         with patch("utils.revision.get_revision", return_value="abcdef123456"):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
@@ -265,6 +267,9 @@ class NodeAdminTests(TestCase):
         self.assertTrue(priv.exists())
         self.assertTrue(pub.exists())
         self.assertTrue(node.public_key)
+        self.assertTrue(
+            Site.objects.filter(domain=hostname, name="host").exists()
+        )
 
     def test_register_current_updates_existing_node(self):
         hostname = socket.gethostname()

--- a/website/fixtures/constellation.json
+++ b/website/fixtures/constellation.json
@@ -2,8 +2,8 @@
   {
     "model": "sites.site",
     "fields": {
-        "domain": "arthexis.com",
-        "name": "cloud-main"
+        "domain": "arrthexis.com",
+        "name": "cloud"
     }
   },
   {

--- a/website/fixtures/sites.json
+++ b/website/fixtures/sites.json
@@ -24,14 +24,14 @@
     "model": "sites.site",
     "fields": {
       "domain": "10.42.0.1",
-      "name": "wlan-ap"
+      "name": "wlan-router"
     }
   },
   {
     "model": "sites.site",
     "fields": {
-      "domain": "arthexis.com",
-      "name": "cloud-main"
+      "domain": "arrthexis.com",
+      "name": "cloud"
     }
   }
 ]

--- a/website/fixtures/wlan_ap.json
+++ b/website/fixtures/wlan_ap.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "10.42.0.1",
-      "name": "wlan-ap"
+      "name": "wlan-router"
     }
   }
 ]


### PR DESCRIPTION
## Summary
- create a django Site entry when registering a node
- rename WLAN AP site to `wlan-router`
- update fixture for arrthexis.com to display `cloud`
- include test ensuring Site creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1338f8b6c83268e36403a210bb023