### PR TITLE
Ignore generated security directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,8 @@ dmypy.json
 
 # local media generated during tests
 media/
+# Security keys generated for nodes
+security/
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
## Summary
- ignore security/ directory created for node key files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b13b442840832686093e1ecfea559e