### PR TITLE
Log shell script output to files

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -2,6 +2,10 @@
 set -e
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 
 # Ensure virtual environment is available

--- a/configure.sh
+++ b/configure.sh
@@ -2,6 +2,10 @@
 set -e
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 
 list_envs() {

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
+
 VENV_DIR=".venv"
 PYTHON="$VENV_DIR/bin/python"
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
+
 SERVICE=""
 NGINX_MODE="internal"
 PORT=""
@@ -134,7 +140,7 @@ if [ -z "$PORT" ]; then
     fi
 fi
 
-BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$SCRIPT_DIR"
 cd "$BASE_DIR"
 DB_FILE="$BASE_DIR/db.sqlite3"
 if [ -f "$DB_FILE" ]; then

--- a/network-setup.sh
+++ b/network-setup.sh
@@ -7,6 +7,10 @@
 set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 LOCK_DIR="$BASE_DIR/locks"
 

--- a/renew-certs.sh
+++ b/renew-certs.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
+
 # Renew Let's Encrypt certificate for arthexis.com without reconfiguring services.
 DOMAIN="arthexis.com"
 LIVE_DIR="/etc/letsencrypt/live"

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,10 @@
 set -e
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 LOCK_DIR="$BASE_DIR/locks"
 

--- a/stop.sh
+++ b/stop.sh
@@ -2,6 +2,10 @@
 set -e
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 LOCK_DIR="$BASE_DIR/locks"
 LCD_LOCK="$LOCK_DIR/lcd_screen.lck"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
+
 SERVICE=""
 
 usage() {
@@ -21,7 +27,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$SCRIPT_DIR"
 cd "$BASE_DIR"
 LOCK_DIR="$BASE_DIR/locks"
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -2,6 +2,10 @@
 set -e
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
 cd "$BASE_DIR"
 
 FORCE=0


### PR DESCRIPTION
## Summary
- capture output from all shell scripts to logs/<script>.log using tee

## Testing
- `pytest -q` *(fails: no such table: core_user)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c0cf56fc8326becb11c56ca53a7f