### PR TITLE
Move rotated logs into old directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,11 @@ cover/
 *.log.*
 *.logs.*
 # Log directories
-logs/
+logs/*
+!logs/.gitkeep
+!logs/old/
+logs/old/*
+!logs/old/.gitkeep
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/config/logging.py
+++ b/config/logging.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import glob
 import logging
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -23,3 +25,19 @@ class ActiveAppFileHandler(TimedRotatingFileHandler):
                 self.stream.close()
             self.stream = self._open()
         super().emit(record)
+
+    def rotation_filename(self, default_name: str) -> str:
+        """Place rotated logs inside the old log directory."""
+        default_path = Path(default_name)
+        return str(Path(settings.OLD_LOG_DIR) / default_path.name)
+
+    def getFilesToDelete(self):
+        """Return files to delete in the old log directory respecting backupCount."""
+        if self.backupCount <= 0:
+            return []
+        _, base_name = os.path.split(self.baseFilename)
+        files = glob.glob(os.path.join(settings.OLD_LOG_DIR, base_name + ".*"))
+        files.sort()
+        if len(files) <= self.backupCount:
+            return []
+        return files[: len(files) - self.backupCount]

--- a/config/settings.py
+++ b/config/settings.py
@@ -299,6 +299,8 @@ BSKY_APP_PASSWORD = os.environ.get("BSKY_APP_PASSWORD")
 # Logging configuration
 LOG_DIR = BASE_DIR / "logs"
 LOG_DIR.mkdir(exist_ok=True)
+OLD_LOG_DIR = LOG_DIR / "old"
+OLD_LOG_DIR.mkdir(exist_ok=True)
 LOG_FILE_NAME = "tests.log" if "test" in sys.argv else f"{socket.gethostname()}.log"
 
 LOGGING = {


### PR DESCRIPTION
## Summary
- add `logs/old` folder and adjust ignore rules
- ensure old logs stored under `logs/old`
- redirect log rotation to `logs/old` and prune backups

## Testing
- `pytest` *(fails: django.db.utils.OperationalError: no such table: core_account)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c0f8755c83268fc25969afc37d2c