### PR TITLE
feat(nodes): replace NodeCommand with NodeTask

### DIFF
--- a/app/static/app/code_editor.css
+++ b/app/static/app/code_editor.css
@@ -1,0 +1,4 @@
+.code-editor {
+    font-family: monospace;
+    width: 100%;
+}

--- a/app/static/app/code_editor.js
+++ b/app/static/app/code_editor.js
@@ -1,0 +1,14 @@
+// Simple code editor enhancements for textareas with class 'code-editor'
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('textarea.code-editor').forEach(function (el) {
+    el.addEventListener('keydown', function (e) {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        var start = this.selectionStart;
+        var end = this.selectionEnd;
+        this.value = this.value.substring(0, start) + '    ' + this.value.substring(end);
+        this.selectionStart = this.selectionEnd = start + 4;
+      }
+    });
+  });
+});

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -7,3 +7,17 @@ class CopyColorWidget(forms.TextInput):
 
     class Media:
         js = ["app/copy_color.js"]
+
+
+class CodeEditorWidget(forms.Textarea):
+    """Simple code editor widget for editing recipes."""
+
+    def __init__(self, attrs=None):
+        default_attrs = {"class": "code-editor"}
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(attrs=default_attrs)
+
+    class Media:
+        css = {"all": ["app/code_editor.css"]}
+        js = ["app/code_editor.js"]

--- a/nodes/fixtures/node_commands.json
+++ b/nodes/fixtures/node_commands.json
@@ -1,5 +1,0 @@
-[
-  {"model": "nodes.nodecommand", "pk": 1, "fields": {"command": "nmcli con show", "created": "2024-01-01T00:00:00Z"}},
-  {"model": "nodes.nodecommand", "pk": 2, "fields": {"command": "ifconfig", "created": "2024-01-01T00:00:00Z"}}
-]
-

--- a/nodes/fixtures/node_tasks.json
+++ b/nodes/fixtures/node_tasks.json
@@ -1,0 +1,5 @@
+[
+  {"model": "nodes.nodetask", "pk": 1, "fields": {"recipe": "nmcli con show", "role": null, "created": "2024-01-01T00:00:00Z"}},
+  {"model": "nodes.nodetask", "pk": 2, "fields": {"recipe": "ifconfig", "role": null, "created": "2024-01-01T00:00:00Z"}}
+]
+

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -69,12 +69,21 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='NodeCommand',
+            name='NodeTask',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('command', models.TextField()),
+                ('recipe', models.TextField()),
+                (
+                    'role',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to='nodes.noderole',
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
             ],
             options={

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -255,26 +255,27 @@ class ContentSample(Entity):
         return str(self.name)
 
 
-class NodeCommand(Entity):
-    """Shell command that can be executed on nodes."""
+class NodeTask(Entity):
+    """Recipe that can be executed on nodes."""
 
-    command = models.TextField()
+    recipe = models.TextField()
+    role = models.ForeignKey(NodeRole, on_delete=models.SET_NULL, null=True, blank=True)
     created = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         ordering = ["-created"]
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
-        return self.command
+        return self.recipe
 
     def run(self, node: Node):
-        """Execute this command on ``node`` and return its output."""
+        """Execute this recipe on ``node`` and return its output."""
         if not node.is_local:
             raise NotImplementedError("Remote node execution is not implemented")
         import subprocess
 
         result = subprocess.run(
-            self.command, shell=True, capture_output=True, text=True
+            self.recipe, shell=True, capture_output=True, text=True
         )
         return result.stdout + result.stderr
 

--- a/nodes/templates/admin/nodes/node/run_task.html
+++ b/nodes/templates/admin/nodes/node/run_task.html
@@ -1,8 +1,9 @@
 {% extends "admin/base_site.html" %}
+{% load static %}
 {% block content %}
-<h1>Run command on selected nodes</h1>
+<h1>Run task on selected nodes</h1>
 <form method="post">{% csrf_token %}
-    <input type="hidden" name="action" value="run_command">
+    <input type="hidden" name="action" value="run_task">
     {% for node in nodes %}
     <input type="hidden" name="_selected_action" value="{{ node.pk }}">
     {% endfor %}
@@ -12,8 +13,10 @@
         <li>{{ node }}</li>
         {% endfor %}
     </ul>
-    <textarea name="command" rows="4" style="width:100%"></textarea>
+    <textarea name="recipe" rows="10" class="code-editor"></textarea>
     <p><input type="submit" name="apply" value="Run"></p>
 </form>
+<link rel="stylesheet" href="{% static 'app/code_editor.css' %}">
+<script src="{% static 'app/code_editor.js' %}"></script>
 {% endblock %}
 

--- a/nodes/templates/admin/nodes/nodetask/run.html
+++ b/nodes/templates/admin/nodes/nodetask/run.html
@@ -1,10 +1,11 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
-<h1>Run saved command</h1>
-<p><strong>Command:</strong> {{ command_obj.command }}</p>
+<h1>Run saved task</h1>
+<p><strong>Recipe:</strong></p>
+<pre>{{ task_obj.recipe }}</pre>
 <form method="post">{% csrf_token %}
     <input type="hidden" name="action" value="execute">
-    <input type="hidden" name="_selected_action" value="{{ command_obj.pk }}">
+    <input type="hidden" name="_selected_action" value="{{ task_obj.pk }}">
     <p>Select nodes:</p>
     {% for node in nodes %}
     <label><input type="checkbox" name="nodes" value="{{ node.pk }}"> {{ node }}</label><br>

--- a/nodes/templates/admin/nodes/task_result.html
+++ b/nodes/templates/admin/nodes/task_result.html
@@ -1,7 +1,8 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
-<h1>Command output</h1>
-<p><strong>Command:</strong> {{ command }}</p>
+<h1>Task output</h1>
+<p><strong>Recipe:</strong></p>
+<pre>{{ recipe }}</pre>
 {% for node, output in results %}
 <h2>{{ node }}</h2>
 <pre>{{ output }}</pre>


### PR DESCRIPTION
## Summary
- refactor NodeCommand model into NodeTask with optional NodeRole and recipe field
- add simple code editor widget and update admin/task templates
- adjust tests for startup notification and GUI toast

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate --noinput`
- `python manage.py test nodes`


------
https://chatgpt.com/codex/tasks/task_e_68b1c1f61c1883269ed7c0821f682c6e