### PR TITLE
Rename charger number to connector ID and tidy admin list

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -67,7 +67,7 @@ class ChargerAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "charger_id",
-                    "number",
+                    "connector_id",
                     "require_rfid",
                     "last_heartbeat",
                     "last_meter_values",
@@ -86,20 +86,17 @@ class ChargerAdmin(admin.ModelAdmin):
     readonly_fields = ("last_heartbeat", "last_meter_values")
     list_display = (
         "charger_id",
-        "number",
+        "connector_id",
         "location_name",
         "require_rfid",
-        "latitude",
-        "longitude",
         "last_heartbeat",
         "session_kw",
         "total_kw_display",
         "page_link",
-        "qr_link",
         "log_link",
         "status_link",
     )
-    search_fields = ("charger_id", "number", "location__name")
+    search_fields = ("charger_id", "connector_id", "location__name")
     actions = ["purge_data", "delete_selected"]
 
     def page_link(self, obj):

--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -145,6 +145,9 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             await database_sync_to_async(MeterReading.objects.bulk_create)(readings)
             if tx_obj and start_updated:
                 await database_sync_to_async(tx_obj.save)(update_fields=["meter_start"])
+        if connector is not None and not self.charger.connector_id:
+            self.charger.connector_id = str(connector)
+            await database_sync_to_async(self.charger.save)(update_fields=["connector_id"])
         if temperature is not None:
             self.charger.temperature = temperature
             self.charger.temperature_unit = temp_unit

--- a/ocpp/fixtures/initial_data.json
+++ b/ocpp/fixtures/initial_data.json
@@ -13,7 +13,7 @@
     "pk": 1,
     "fields": {
       "charger_id": "CP1",
-      "number": 1,
+      "connector_id": 1,
       "require_rfid": false,
       "last_heartbeat": null,
       "last_meter_values": {},
@@ -27,7 +27,7 @@
     "pk": 2,
     "fields": {
       "charger_id": "CP2",
-      "number": 2,
+      "connector_id": 2,
       "require_rfid": true,
       "last_heartbeat": null,
       "last_meter_values": {},

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('charger_id', models.CharField(max_length=100, unique=True, verbose_name='Serial Number')),
-                ('number', models.PositiveIntegerField(default=1, verbose_name='Charger Number')),
+                ('connector_id', models.CharField(blank=True, max_length=10, null=True, verbose_name='Connector ID')),
                 ('require_rfid', models.BooleanField(default=False, verbose_name='Require RFID')),
                 ('last_heartbeat', models.DateTimeField(blank=True, null=True)),
                 ('last_meter_values', models.JSONField(blank=True, default=dict)),

--- a/ocpp/migrations/0003_charger_connector_id.py
+++ b/ocpp/migrations/0003_charger_connector_id.py
@@ -1,7 +1,7 @@
 from django.db import migrations, models
 
 
-def ensure_charger_number(apps, schema_editor):
+def ensure_connector_id(apps, schema_editor):
     Charger = apps.get_model("ocpp", "Charger")
     table = Charger._meta.db_table
     with schema_editor.connection.cursor() as cursor:
@@ -11,9 +11,9 @@ def ensure_charger_number(apps, schema_editor):
                 cursor, table
             )
         ]
-    if "number" not in columns:
-        field = models.PositiveIntegerField(default=1)
-        field.set_attributes_from_name("number")
+    if "connector_id" not in columns:
+        field = models.CharField(max_length=10, null=True, blank=True)
+        field.set_attributes_from_name("connector_id")
         schema_editor.add_field(Charger, field)
 
 
@@ -23,5 +23,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(ensure_charger_number, migrations.RunPython.noop),
+        migrations.RunPython(ensure_connector_id, migrations.RunPython.noop),
     ]

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -27,7 +27,7 @@ class Charger(Entity):
     """Known charge point."""
 
     charger_id = models.CharField(_("Serial Number"), max_length=100, unique=True)
-    number = models.PositiveIntegerField(_("Charger Number"), default=1)
+    connector_id = models.CharField(_("Connector ID"), max_length=10, blank=True, null=True)
     require_rfid = models.BooleanField(_("Require RFID"), default=False)
     last_heartbeat = models.DateTimeField(null=True, blank=True)
     last_meter_values = models.JSONField(default=dict, blank=True)
@@ -68,7 +68,11 @@ class Charger(Entity):
     @property
     def name(self) -> str:
         if self.location:
-            return f"{self.location.name} #{self.number}" if self.number else self.location.name
+            return (
+                f"{self.location.name} #{self.connector_id}"
+                if self.connector_id
+                else self.location.name
+            )
         return ""
 
     @property

--- a/ocpp/test_export_import.py
+++ b/ocpp/test_export_import.py
@@ -105,7 +105,7 @@ class TransactionAdminExportImportTests(TestCase):
         url = reverse("admin:ocpp_transaction_import")
         payload = {
             "chargers": [
-                {"charger_id": "C9", "number": 1, "require_rfid": False}
+                {"charger_id": "C9", "connector_id": 1, "require_rfid": False}
             ],
             "transactions": [
                 {

--- a/ocpp/transactions_io.py
+++ b/ocpp/transactions_io.py
@@ -34,7 +34,7 @@ def export_transactions(
         data["chargers"].append(
                 {
                     "charger_id": charger.charger_id,
-                    "number": charger.number,
+                    "connector_id": charger.connector_id,
                     "require_rfid": charger.require_rfid,
                 }
         )
@@ -86,7 +86,7 @@ def import_transactions(data: dict) -> int:
         charger, _ = Charger.objects.get_or_create(
             charger_id=item["charger_id"],
             defaults={
-                "number": item.get("number", 1),
+                "connector_id": item.get("connector_id", None),
                 "require_rfid": item.get("require_rfid", False),
             },
         )


### PR DESCRIPTION
## Summary
- rename Charger number field to Connector ID and populate from MeterValues
- drop latitude, longitude, and QR code columns from Charger admin list
- update transaction import/export and fixtures for new Connector ID

## Testing
- `python manage.py migrate`
- `python manage.py makemigrations --check` *(fails: Migrations for 'core': core/migrations/0004_alter_packagerelease_options.py)*
- `python manage.py test ocpp`


------
https://chatgpt.com/codex/tasks/task_e_68b201fdf0608326a237a90259e04c30