### PR TITLE
Refine site fixtures and enhance application metadata

### DIFF
--- a/.github/workflows/release-install.yml
+++ b/.github/workflows/release-install.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: pip install .
+      - run: pip install arthexis
       - run: |
           bash install.sh --${{ matrix.mode }} || true
+          pip install .
           python manage.py migrate --noinput

--- a/core/fixtures/package_releases.json
+++ b/core/fixtures/package_releases.json
@@ -61,47 +61,68 @@
       "password": "",
       "token": ""
     }
-  },
-  {
-    "model": "core.packagerelease",
-    "pk": 4,
-    "fields": {
-      "name": "arthexis",
-      "description": "Django-based MESH system",
-      "author": "Rafael J. Guillén-Osorio",
-      "email": "tecnologia@gelectriic.com",
-      "python_requires": ">=3.10",
-      "license": "MIT",
-      "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com",
-      "version": "0.1.1",
-      "revision": "76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d",
-      "pypi_url": "https://pypi.org/project/arthexis/0.1.1/",
-      "is_live": false,
-      "username": "",
-      "password": "",
-      "token": ""
+    },
+    {
+      "model": "core.packagerelease",
+      "pk": 4,
+      "fields": {
+        "name": "arthexis",
+        "description": "Django-based MESH system",
+        "author": "Rafael J. Guillén-Osorio",
+        "email": "tecnologia@gelectriic.com",
+        "python_requires": ">=3.10",
+        "license": "MIT",
+        "repository_url": "https://github.com/arthexis/arthexis",
+        "homepage_url": "https://arthexis.com",
+        "version": "0.1.1",
+        "revision": "76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d",
+        "pypi_url": "https://pypi.org/project/arthexis/0.1.1/",
+        "is_live": false,
+        "username": "",
+        "password": "",
+        "token": ""
+      }
+    },
+    {
+      "model": "core.packagerelease",
+      "pk": 5,
+      "fields": {
+        "name": "arthexis",
+        "description": "Django-based MESH system",
+        "author": "Rafael J. Guillén-Osorio",
+        "email": "tecnologia@gelectriic.com",
+        "python_requires": ">=3.10",
+        "license": "MIT",
+        "repository_url": "https://github.com/arthexis/arthexis",
+        "homepage_url": "https://arthexis.com",
+        "version": "0.1.2",
+        "revision": "",
+        "pypi_url": "https://pypi.org/project/arthexis/0.1.2/",
+        "is_live": false,
+        "username": "",
+        "password": "",
+        "token": ""
+      }
+    },
+    {
+      "model": "core.packagerelease",
+      "pk": 6,
+      "fields": {
+        "name": "arthexis",
+        "description": "Django-based MESH system",
+        "author": "Rafael J. Guillén-Osorio",
+        "email": "tecnologia@gelectriic.com",
+        "python_requires": ">=3.10",
+        "license": "MIT",
+        "repository_url": "https://github.com/arthexis/arthexis",
+        "homepage_url": "https://arthexis.com",
+        "version": "1.0.0",
+        "revision": "",
+        "pypi_url": "https://pypi.org/project/arthexis/1.0.0/",
+        "is_live": false,
+        "username": "",
+        "password": "",
+        "token": ""
+      }
     }
-  },
-  {
-    "model": "core.packagerelease",
-    "pk": 5,
-    "fields": {
-      "name": "arthexis",
-      "description": "Django-based MESH system",
-      "author": "Rafael J. Guillén-Osorio",
-      "email": "tecnologia@gelectriic.com",
-      "python_requires": ">=3.10",
-      "license": "MIT",
-      "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com",
-      "version": "1.0.0",
-      "revision": "",
-      "pypi_url": "https://pypi.org/project/arthexis/1.0.0/",
-      "is_live": false,
-      "username": "",
-      "password": "",
-      "token": ""
-    }
-  }
-]
+  ]

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -777,6 +777,7 @@ class Migration(migrations.Migration):
             options={
                 'verbose_name': 'Package Release',
                 'verbose_name_plural': 'Package Releases',
+                'get_latest_by': 'version',
             },
         ),
 ]

--- a/pages/admin.py
+++ b/pages/admin.py
@@ -139,9 +139,13 @@ class ApplicationModuleInline(admin.TabularInline):
 @admin.register(Application)
 class ApplicationAdmin(admin.ModelAdmin):
     form = ApplicationForm
-    list_display = ("name", "installed")
+    list_display = ("name", "app_verbose_name", "installed")
     readonly_fields = ("installed",)
     inlines = [ApplicationModuleInline]
+
+    @admin.display(description="Verbose name")
+    def app_verbose_name(self, obj):
+        return obj.verbose_name
 
     @admin.display(boolean=True)
     def installed(self, obj):

--- a/pages/fixtures/constellation.json
+++ b/pages/fixtures/constellation.json
@@ -6,25 +6,27 @@
       "description": "Multi-User Cloud & Orchestration"
     }
   },
-  {
-    "model": "sites.site",
-    "fields": {
-        "domain": "arrthexis.com",
-        "name": "cloud"
-    }
-  },
-  {
-    "model": "pages.application",
-    "fields": {
-      "name": "ocpp"
-    }
-  },
-  {
-    "model": "pages.application",
-    "fields": {
-      "name": "awg"
-    }
-  },
+    {
+      "model": "sites.site",
+      "fields": {
+          "domain": "arthexis.com",
+          "name": "Arthexis"
+      }
+    },
+    {
+      "model": "pages.application",
+      "fields": {
+        "name": "ocpp",
+        "description": "Provides Open Charge Point Protocol services."
+      }
+    },
+    {
+      "model": "pages.application",
+      "fields": {
+        "name": "awg",
+        "description": "Cable sizing tools using AWG standards."
+      }
+    },
   {
     "model": "pages.module",
     "fields": {

--- a/pages/fixtures/gway_box.json
+++ b/pages/fixtures/gway_box.json
@@ -3,16 +3,16 @@
     "model": "sites.site",
     "fields": {
         "domain": "192.168.129.10",
-        "name": "ethernet"
+        "name": "192.168.129.10"
     }
   },
   {
     "model": "pages.application",
-    "fields": {"name": "ocpp"}
+    "fields": {"name": "ocpp", "description": "Provides Open Charge Point Protocol services."}
   },
   {
     "model": "pages.application",
-    "fields": {"name": "awg"}
+    "fields": {"name": "awg", "description": "Cable sizing tools using AWG standards."}
   },
   {
     "model": "pages.module",

--- a/pages/fixtures/localhost.json
+++ b/pages/fixtures/localhost.json
@@ -3,16 +3,16 @@
     "model": "sites.site",
     "fields": {
         "domain": "127.0.0.1",
-        "name": "local"
+        "name": "127.0.0.1"
     }
   },
   {
     "model": "pages.application",
-    "fields": {"name": "ocpp"}
+    "fields": {"name": "ocpp", "description": "Provides Open Charge Point Protocol services."}
   },
   {
     "model": "pages.application",
-    "fields": {"name": "awg"}
+    "fields": {"name": "awg", "description": "Cable sizing tools using AWG standards."}
   },
   {
     "model": "pages.module",

--- a/pages/fixtures/sites.json
+++ b/pages/fixtures/sites.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "127.0.0.1",
-      "name": "local"
+      "name": "127.0.0.1"
     }
   },
   {
@@ -17,21 +17,21 @@
     "model": "sites.site",
     "fields": {
       "domain": "192.168.129.10",
-      "name": "ethernet"
+      "name": "192.168.129.10"
     }
   },
   {
     "model": "sites.site",
     "fields": {
       "domain": "10.42.0.1",
-      "name": "wlan-router"
+      "name": "10.42.0.1"
     }
   },
   {
     "model": "sites.site",
     "fields": {
-      "domain": "arrthexis.com",
-      "name": "cloud"
+      "domain": "arthexis.com",
+      "name": "Arthexis"
     }
   }
 ]

--- a/pages/fixtures/wlan_ap.json
+++ b/pages/fixtures/wlan_ap.json
@@ -3,7 +3,7 @@
     "model": "sites.site",
     "fields": {
       "domain": "10.42.0.1",
-      "name": "wlan-router"
+      "name": "10.42.0.1"
     }
   }
 ]

--- a/pages/migrations/0001_initial.py
+++ b/pages/migrations/0001_initial.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
                 ("is_seed_data", models.BooleanField(default=False, editable=False)),
                 ("is_deleted", models.BooleanField(default=False, editable=False)),
                 ("name", models.CharField(max_length=100, unique=True)),
+                ("description", models.TextField(blank=True)),
             ],
             options={
                 "abstract": False,

--- a/pages/models.py
+++ b/pages/models.py
@@ -16,6 +16,7 @@ class ApplicationManager(models.Manager):
 
 class Application(Entity):
     name = models.CharField(max_length=100, unique=True)
+    description = models.TextField(blank=True)
 
     objects = ApplicationManager()
 
@@ -28,6 +29,13 @@ class Application(Entity):
     @property
     def installed(self) -> bool:
         return django_apps.is_installed(self.name)
+
+    @property
+    def verbose_name(self) -> str:
+        try:
+            return django_apps.get_app_config(self.name).verbose_name
+        except LookupError:
+            return self.name
 
 
 class ModuleManager(models.Manager):

--- a/tests/test_register_site_apps_command.py
+++ b/tests/test_register_site_apps_command.py
@@ -28,7 +28,7 @@ class RegisterSiteAppsCommandTests(TestCase):
         call_command("register_site_apps")
 
         site = Site.objects.get(domain="127.0.0.1")
-        self.assertEqual(site.name, "local")
+        self.assertEqual(site.name, "127.0.0.1")
 
         node = Node.objects.get(hostname=socket.gethostname())
         self.assertFalse(node.enable_public_api)


### PR DESCRIPTION
## Summary
- clean up site fixtures to use domain names and correct `arthexis.com`
- add descriptions and verbose-name support to applications
- streamline CI database migration test workflow
- record forthcoming 0.1.2 release and align `PackageRelease` migration metadata

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b20020719883268c9aca0f10a8b1d4