### PR TITLE
chore: run release workflow on pull requests only

### DIFF
--- a/.github/workflows/release-install.yml
+++ b/.github/workflows/release-install.yml
@@ -2,7 +2,6 @@ name: Install latest release
 
 on:
   pull_request:
-  push:
 
 jobs:
   install:


### PR DESCRIPTION
## Summary
- run release install workflow for pull request events only

## Testing
- `python -m pytest` *(fails: django.db.utils.OperationalError: no such table: auth_user)*

------
https://chatgpt.com/codex/tasks/task_e_68b21847a7308326b6408ed394a02cd6