### PR TITLE
feat: add Odoo profile model

### DIFF
--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -752,7 +752,7 @@ class Migration(migrations.Migration):
             ],
             options={"ordering": ["-created"]},
         ),
-            migrations.CreateModel(
+        migrations.CreateModel(
             name='PackageRelease',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
@@ -777,6 +777,24 @@ class Migration(migrations.Migration):
             options={
                 'verbose_name': 'Package Release',
                 'verbose_name_plural': 'Package Releases',
+                'get_latest_by': 'version',
             },
         ),
-]
+        migrations.CreateModel(
+            name='OdooProfile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('host', models.CharField(max_length=255)),
+                ('database', models.CharField(max_length=255)),
+                ('username', models.CharField(max_length=255)),
+                ('password', models.CharField(max_length=255)),
+                ('verified_on', models.DateTimeField(blank=True, null=True)),
+                ('odoo_uid', models.PositiveIntegerField(blank=True, editable=False, null=True)),
+                ('name', models.CharField(blank=True, editable=False, max_length=255)),
+                ('email', models.EmailField(blank=True, editable=False, max_length=254)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='odoo_profile', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/tests/test_odoo_profile.py
+++ b/tests/test_odoo_profile.py
@@ -1,0 +1,88 @@
+import xmlrpc.client
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+from core.models import User, OdooProfile
+
+
+class FakeCommon:
+    def __init__(self, uid):
+        self.uid = uid
+
+    def authenticate(self, db, username, password, _):
+        return self.uid
+
+
+class FakeModels:
+    def __init__(self, info=None, raise_error=False):
+        self.info = info or {"name": "Odoo User", "email": "user@example.com"}
+        self.raise_error = raise_error
+
+    def execute_kw(self, db, uid, password, model, method, args, kwargs):
+        if self.raise_error:
+            raise Exception("fail")
+        return [self.info]
+
+
+def test_verify_success(monkeypatch):
+    def fake_proxy(url):
+        if url.endswith("/common"):
+            return FakeCommon(uid=42)
+        return FakeModels()
+
+    monkeypatch.setattr(xmlrpc.client, "ServerProxy", fake_proxy)
+    user = User.objects.create(username="u")
+    profile = OdooProfile.objects.create(
+        user=user,
+        host="http://test",
+        database="db",
+        username="u",
+        password="p",
+    )
+    assert profile.verify() is True
+    profile.refresh_from_db()
+    assert profile.odoo_uid == 42
+    assert profile.name == "Odoo User"
+    assert profile.email == "user@example.com"
+    assert profile.verified_on is not None
+
+
+def test_credentials_change_resets_verification(monkeypatch):
+    user = User.objects.create(username="u")
+    profile = OdooProfile.objects.create(
+        user=user,
+        host="http://test",
+        database="db",
+        username="u",
+        password="p",
+    )
+    profile.verified_on = timezone.now()
+    profile.save()
+    profile.password = "new"
+    profile.save()
+    profile.refresh_from_db()
+    assert profile.verified_on is None
+
+
+def test_execute_failure_marks_unverified(monkeypatch):
+    user = User.objects.create(username="u")
+    profile = OdooProfile.objects.create(
+        user=user,
+        host="http://test",
+        database="db",
+        username="u",
+        password="p",
+    )
+    profile.odoo_uid = 42
+    profile.verified_on = timezone.now()
+    profile.save()
+
+    def fake_proxy(url):
+        return FakeModels(raise_error=True)
+
+    monkeypatch.setattr(xmlrpc.client, "ServerProxy", fake_proxy)
+    try:
+        profile.execute("res.users", "read", [42])
+    except Exception:
+        pass
+    profile.refresh_from_db()
+    assert profile.verified_on is None


### PR DESCRIPTION
## Summary
- add OdooProfile model to store and verify user Odoo API credentials
- expose Odoo profile management and verification in admin
- test Odoo profile verification and credential invalidation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b203b419288326b1b120a08fe2b72e