### PR TITLE
Ensure tests run migrations before execution

### DIFF
--- a/.github/workflows/release-install.yml
+++ b/.github/workflows/release-install.yml
@@ -2,7 +2,13 @@ name: Install latest release
 
 on:
   pull_request:
+    paths:
+      - '**/migrations/**'
+      - '.github/workflows/release-install.yml'
   push:
+    paths:
+      - '**/migrations/**'
+      - '.github/workflows/release-install.yml'
 
 jobs:
   install:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,47 @@ sys.path.insert(0, str(ROOT))
 
 import django
 from django.apps import apps
+from django.core.management import call_command
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
+# Keep a reference to the original setup function so we can call it lazily
 _original_setup = django.setup
 
+
 def safe_setup():
+    """Initialize Django and ensure the test database is migrated.
+
+    Pytest does not use ``pytest-django`` for these tests, so simply calling
+    :func:`django.setup` leaves the SQLite database without any tables.  Many
+    tests exercise ORM behaviour and expect the schema to exist.  Run
+    ``migrate`` the first time Django is configured so the database file and
+    tables are created automatically.
+    """
+
     if not apps.ready:
+        # Start from a clean SQLite database for every test run.
+        db_path = ROOT / "db.sqlite3"
+        if db_path.exists():
+            db_path.unlink()
+
+        # Perform the regular Django setup after cleaning up the database
         _original_setup()
+        from django.conf import settings
+
+        # Speed up tests by using a lightweight password hasher and disabling
+        # password validation checks. The default PBKDF2 hasher uses one
+        # million iterations which is unnecessarily slow for unit tests and
+        # would make the migration phase (which creates a default superuser)
+        # take several seconds.
+        settings.PASSWORD_HASHERS = [
+            "django.contrib.auth.hashers.MD5PasswordHasher"
+        ]
+        settings.AUTH_PASSWORD_VALIDATORS = []
+
+        # Apply migrations to create the database schema
+        call_command("migrate", run_syncdb=True, verbosity=0)
+
 
 django.setup = safe_setup
 safe_setup()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -63,3 +63,19 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
 else
     pkill -f "manage.py runserver" || true
 fi
+
+# Ensure any Celery workers or beats are also stopped
+pkill -f "celery -A config" || true
+
+# Remove the local SQLite database if it exists
+DB_FILE="$BASE_DIR/db.sqlite3"
+if [ -f "$DB_FILE" ]; then
+    rm -f "$DB_FILE"
+fi
+
+# Clear lock directory and other cached configuration
+rm -rf "$LOCK_DIR"
+rm -f "$BASE_DIR/AUTO_UPGRADE"
+rm -f "$BASE_DIR/requirements.md5"
+
+echo "Uninstall complete."


### PR DESCRIPTION
## Summary
- auto-migrate SQLite test database for clean schema setup
- kill lingering Celery tasks and purge database/config during uninstall
- run release-install workflow only when migration files change

## Testing
- `bash -n uninstall.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2011c36c48326947cc9acd5dd7155