### PR TITLE
Restart LCD service with systemd

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,13 @@ if [ -f "$LOCK_DIR/service.lck" ]; then
     sudo systemctl restart "$SERVICE_NAME"
     # Show status information so the user can verify the service state
     sudo systemctl status "$SERVICE_NAME" --no-pager
+    if [ -f "$LOCK_DIR/lcd_screen.lck" ]; then
+      LCD_SERVICE="lcd-$SERVICE_NAME"
+      if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+        sudo systemctl restart "$LCD_SERVICE"
+        sudo systemctl status "$LCD_SERVICE" --no-pager || true
+      fi
+    fi
     exit 0
   fi
 fi

--- a/stop.sh
+++ b/stop.sh
@@ -20,17 +20,17 @@ if [ -f "$LOCK_DIR/service.lck" ]; then
   if systemctl list-unit-files | grep -Fq "${SERVICE_NAME}.service"; then
     sudo systemctl stop "$SERVICE_NAME"
     sudo systemctl status "$SERVICE_NAME" --no-pager || true
-    LCD_SERVICE="lcd-$SERVICE_NAME"
     if [ -f "$LCD_LOCK" ]; then
+      LCD_SERVICE="lcd-$SERVICE_NAME"
       "$PYTHON" - <<'PY'
 from core.notifications import notify
 notify("Goodbye!")
 PY
       sleep 1
-    fi
-    if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
-      sudo systemctl stop "$LCD_SERVICE"
-      sudo systemctl status "$LCD_SERVICE" --no-pager || true
+      if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+        sudo systemctl stop "$LCD_SERVICE"
+        sudo systemctl status "$LCD_SERVICE" --no-pager || true
+      fi
     fi
     exit 0
   fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -49,17 +49,19 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
         sudo rm "$SERVICE_FILE"
         sudo systemctl daemon-reload
     fi
-    LCD_SERVICE="lcd-$SERVICE"
-    if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
-        sudo systemctl stop "$LCD_SERVICE" || true
-        sudo systemctl disable "$LCD_SERVICE" || true
-        LCD_SERVICE_FILE="/etc/systemd/system/${LCD_SERVICE}.service"
-        if [ -f "$LCD_SERVICE_FILE" ]; then
-            sudo rm "$LCD_SERVICE_FILE"
+    if [ -f "$LOCK_DIR/lcd_screen.lck" ]; then
+        LCD_SERVICE="lcd-$SERVICE"
+        if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+            sudo systemctl stop "$LCD_SERVICE" || true
+            sudo systemctl disable "$LCD_SERVICE" || true
+            LCD_SERVICE_FILE="/etc/systemd/system/${LCD_SERVICE}.service"
+            if [ -f "$LCD_SERVICE_FILE" ]; then
+                sudo rm "$LCD_SERVICE_FILE"
+            fi
         fi
+        rm -f "$LOCK_DIR/lcd_screen.lck"
     fi
     rm -f "$LOCK_DIR/service.lck"
-    rm -f "$LOCK_DIR/lcd_screen.lck"
 else
     pkill -f "manage.py runserver" || true
 fi


### PR DESCRIPTION
## Summary
- ensure start.sh restarts lcd service alongside main service
- stop LCD systemd service and send Goodbye message on stop
- remove LCD service during uninstall when screen lock is present

## Testing
- `pytest` *(fails: django.db.utils.OperationalError: no such table)*
- `pytest tests/test_notifications_fallback.py tests/test_lcd_smbus2.py`

------
https://chatgpt.com/codex/tasks/task_e_68b21977435483268a74eac6ba7b6060