### PR TITLE
Fix cross-platform path and notification issues in tests

### DIFF
--- a/core/notifications.py
+++ b/core/notifications.py
@@ -92,12 +92,11 @@ class NotificationManager:
                     # Disable further toast attempts; the log fallback will be used
                     # instead to avoid repeated errors in headless environments.
                     self._toaster = None
-            elif plyer_notification:
+            if plyer_notification:
                 try:  # pragma: no cover - depends on platform
                     plyer_notification.notify(
                         title="Arthexis", message=f"{subject}\n{body}", timeout=6
                     )
-                    return
                 except Exception as exc:  # pragma: no cover - depends on platform
                     logger.warning("Windows notification failed: %s", exc)
         logger.info("%s %s", subject, body)

--- a/nodes/actions.py
+++ b/nodes/actions.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, Optional, Type
 from django.apps import apps
 from django.conf import settings
 from django.core.management import call_command
-from django.http import FileResponse
+from django.http import HttpResponse
 from django.utils import timezone
 from pathlib import Path
 from django.db import connection
@@ -107,9 +107,7 @@ class GenerateBackupAction(NodeAction):
         Backup.objects.create(
             location=str(file_path.relative_to(base_path)), size=size, report=report
         )
-        return FileResponse(
-            file_path.open("rb"),
-            as_attachment=True,
-            filename=filename,
-            content_type="application/json",
-        )
+        data = file_path.read_bytes()
+        response = HttpResponse(data, content_type="application/json")
+        response["Content-Disposition"] = f"attachment; filename={filename}"
+        return response

--- a/nodes/utils.py
+++ b/nodes/utils.py
@@ -45,7 +45,7 @@ def save_screenshot(path: Path, node=None, method: str = ""):
     if ContentSample.objects.filter(hash=digest).exists():
         logger.info("Duplicate screenshot content; record not created")
         return None
-    stored_path = str(original if not original.is_absolute() else path)
+    stored_path = (original if not original.is_absolute() else path).as_posix()
     return ContentSample.objects.create(
         node=node,
         path=stored_path,


### PR DESCRIPTION
## Summary
- Normalize screenshot paths to POSIX format when saving
- Ensure backup files are closed before returning response
- Always log notifications when Windows toast is unavailable

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b224ee350083268611709994e149ec