### PR TITLE
feat: split package release models

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -34,7 +34,9 @@ from .models import (
     Reference,
     Message,
     OdooProfile,
+    PackageHub,
     PackageRelease,
+    PackagerProfile,
 )
 from .notifications import notify
 from . import release
@@ -76,6 +78,16 @@ class ReferenceAdmin(admin.ModelAdmin):
         return ""
 
     qr_code.short_description = "QR Code"
+
+
+@admin.register(PackagerProfile)
+class PackagerProfileAdmin(admin.ModelAdmin):
+    list_display = ("name",)
+
+
+@admin.register(PackageHub)
+class PackageHubAdmin(admin.ModelAdmin):
+    list_display = ("name",)
 
 
 @admin.register(SecurityGroup)
@@ -457,7 +469,7 @@ class BuildReleaseForm(forms.Form):
 
 @admin.register(PackageRelease)
 class PackageReleaseAdmin(admin.ModelAdmin):
-    list_display = ("name", "version", "pypi_url", "is_live")
+    list_display = ("hub", "version", "pypi_url", "is_live")
     actions = ["build_release", "create_next_release"]
 
     @admin.action(description="Build selected packages")
@@ -482,7 +494,7 @@ class PackageReleaseAdmin(admin.ModelAdmin):
                             stash=stash_opt,
                         )
                         self.message_user(
-                            request, f"Built {cfg.name}", messages.SUCCESS
+                            request, f"Built {cfg.hub.name}", messages.SUCCESS
                         )
                     except ValidationError as exc:
                         self.message_user(

--- a/core/fixtures/package_releases.json
+++ b/core/fixtures/package_releases.json
@@ -1,6 +1,14 @@
 [
   {
-    "model": "core.packagerelease",
+    "model": "core.packagerprofile",
+    "pk": 1,
+    "fields": {
+      "name": "default",
+      "token": ""
+    }
+  },
+  {
+    "model": "core.packagehub",
     "pk": 1,
     "fields": {
       "name": "arthexis",
@@ -10,119 +18,79 @@
       "python_requires": ">=3.10",
       "license": "MIT",
       "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com",
+      "homepage_url": "https://arthexis.com"
+    }
+  },
+  {
+    "model": "core.packagerelease",
+    "pk": 1,
+    "fields": {
+      "hub": 1,
+      "profile": 1,
       "version": "0.0.0",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.0.0/",
-      "is_live": false,
-      "username": "",
-      "password": "",
-      "token": ""
+      "is_live": false
     }
   },
   {
     "model": "core.packagerelease",
     "pk": 2,
     "fields": {
-      "name": "arthexis",
-      "description": "Django-based MESH system",
-      "author": "Rafael J. Guillén-Osorio",
-      "email": "tecnologia@gelectriic.com",
-      "python_requires": ">=3.10",
-      "license": "MIT",
-      "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com",
+      "hub": 1,
+      "profile": 1,
       "version": "0.0.1",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.0.1/",
-      "is_live": false,
-      "username": "",
-      "password": "",
-      "token": ""
+      "is_live": false
     }
   },
   {
     "model": "core.packagerelease",
     "pk": 3,
     "fields": {
-      "name": "arthexis",
-      "description": "Django-based MESH system",
-      "author": "Rafael J. Guillén-Osorio",
-      "email": "tecnologia@gelectriic.com",
-      "python_requires": ">=3.10",
-      "license": "MIT",
-      "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com",
+      "hub": 1,
+      "profile": 1,
       "version": "0.1.0",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.0/",
-      "is_live": false,
-      "username": "",
-      "password": "",
-      "token": ""
+      "is_live": false
     }
-    },
-    {
-      "model": "core.packagerelease",
-      "pk": 4,
-      "fields": {
-        "name": "arthexis",
-        "description": "Django-based MESH system",
-        "author": "Rafael J. Guillén-Osorio",
-        "email": "tecnologia@gelectriic.com",
-        "python_requires": ">=3.10",
-        "license": "MIT",
-        "repository_url": "https://github.com/arthexis/arthexis",
-        "homepage_url": "https://arthexis.com",
-        "version": "0.1.1",
-        "revision": "76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d",
-        "pypi_url": "https://pypi.org/project/arthexis/0.1.1/",
-        "is_live": false,
-        "username": "",
-        "password": "",
-        "token": ""
-      }
-    },
-    {
-      "model": "core.packagerelease",
-      "pk": 5,
-      "fields": {
-        "name": "arthexis",
-        "description": "Django-based MESH system",
-        "author": "Rafael J. Guillén-Osorio",
-        "email": "tecnologia@gelectriic.com",
-        "python_requires": ">=3.10",
-        "license": "MIT",
-        "repository_url": "https://github.com/arthexis/arthexis",
-        "homepage_url": "https://arthexis.com",
-        "version": "0.1.2",
-        "revision": "",
-        "pypi_url": "https://pypi.org/project/arthexis/0.1.2/",
-        "is_live": false,
-        "username": "",
-        "password": "",
-        "token": ""
-      }
-    },
-    {
-      "model": "core.packagerelease",
-      "pk": 6,
-      "fields": {
-        "name": "arthexis",
-        "description": "Django-based MESH system",
-        "author": "Rafael J. Guillén-Osorio",
-        "email": "tecnologia@gelectriic.com",
-        "python_requires": ">=3.10",
-        "license": "MIT",
-        "repository_url": "https://github.com/arthexis/arthexis",
-        "homepage_url": "https://arthexis.com",
-        "version": "1.0.0",
-        "revision": "",
-        "pypi_url": "https://pypi.org/project/arthexis/1.0.0/",
-        "is_live": false,
-        "username": "",
-        "password": "",
-        "token": ""
-      }
+  },
+  {
+    "model": "core.packagerelease",
+    "pk": 4,
+    "fields": {
+      "hub": 1,
+      "profile": 1,
+      "version": "0.1.1",
+      "revision": "",
+      "pypi_url": "https://pypi.org/project/arthexis/0.1.1/",
+      "is_live": false
     }
-  ]
+  },
+  {
+    "model": "core.packagerelease",
+    "pk": 5,
+    "fields": {
+      "hub": 1,
+      "profile": 1,
+      "version": "0.1.2",
+      "revision": "",
+      "pypi_url": "https://pypi.org/project/arthexis/0.1.2/",
+      "is_live": false
+    }
+  },
+  {
+    "model": "core.packagerelease",
+    "pk": 6,
+    "fields": {
+      "hub": 1,
+      "profile": 1,
+      "version": "1.0.0",
+      "revision": "",
+      "pypi_url": "https://pypi.org/project/arthexis/1.0.0/",
+      "is_live": false
+    }
+  }
+]

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -753,7 +753,21 @@ class Migration(migrations.Migration):
             options={"ordering": ["-created"]},
         ),
         migrations.CreateModel(
-            name='PackageRelease',
+            name='PackagerProfile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('name', models.CharField(max_length=100)),
+                ('token', models.CharField(blank=True, max_length=200)),
+            ],
+            options={
+                'verbose_name': 'Packager Profile',
+                'verbose_name_plural': 'Packager Profiles',
+            },
+        ),
+        migrations.CreateModel(
+            name='PackageHub',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
@@ -766,13 +780,24 @@ class Migration(migrations.Migration):
                 ('license', models.CharField(default='MIT', max_length=100)),
                 ('repository_url', models.URLField(default='https://github.com/arthexis/arthexis')),
                 ('homepage_url', models.URLField(default='https://arthexis.com')),
+            ],
+            options={
+                'verbose_name': 'Package Hub',
+                'verbose_name_plural': 'Package Hubs',
+            },
+        ),
+        migrations.CreateModel(
+            name='PackageRelease',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('version', models.CharField(default='0.0.0', max_length=20, unique=True)),
                 ('revision', models.CharField(blank=True, max_length=40)),
                 ('pypi_url', models.URLField(blank=True)),
                 ('is_live', models.BooleanField(default=False)),
-                ('username', models.CharField(blank=True, max_length=100)),
-                ('password', models.CharField(blank=True, max_length=100)),
-                ('token', models.CharField(blank=True, max_length=200)),
+                ('hub', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.packagehub')),
+                ('profile', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
             ],
             options={
                 'verbose_name': 'Package Release',


### PR DESCRIPTION
## Summary
- split package release into hub, release, and packager profile models
- wire admin to new models
- update fixtures and migration for release split

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b22ba18b5483269be40aa53d365f06