### PR TITLE
Remove backup, recipe, and text pattern models

### DIFF
--- a/nodes/actions.py
+++ b/nodes/actions.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Optional, Type
 
-from django.apps import apps
-from django.conf import settings
-from django.core.management import call_command
-from django.http import HttpResponse
-from django.utils import timezone
-from pathlib import Path
-from django.db import connection
-
-from .models import Backup, Node
+from .models import Node
 
 
 class NodeAction:
@@ -78,36 +70,3 @@ class CaptureScreenshotAction(NodeAction):
         return path
 
 
-class GenerateBackupAction(NodeAction):
-    display_name = "Generate DB Backup"
-    slug = "generate-db-backup"
-
-    def execute(self, node: Node, **kwargs):
-        base_path = Path(node.base_path or settings.BASE_DIR)
-        backup_dir = base_path / "backups"
-        backup_dir.mkdir(parents=True, exist_ok=True)
-        filename = f"backup-{timezone.now().strftime('%Y%m%d%H%M%S')}.json"
-        file_path = backup_dir / filename
-        with file_path.open("w", encoding="utf-8") as fh:
-            exclude = []
-            if apps.is_installed("emails"):
-                exclude.append("emails")
-            if apps.is_installed("post_office") and "emailpattern" in apps.all_models.get(
-                "post_office", {}
-            ):
-                exclude.append("post_office.emailpattern")
-            call_command("dumpdata", exclude=exclude, stdout=fh)
-        size = file_path.stat().st_size
-        tables = set(connection.introspection.table_names())
-        objects = 0
-        for model in apps.get_models():
-            if model._meta.db_table in tables:
-                objects += model.objects.count()
-        report = {"objects": objects}
-        Backup.objects.create(
-            location=str(file_path.relative_to(base_path)), size=size, report=report
-        )
-        data = file_path.read_bytes()
-        response = HttpResponse(data, content_type="application/json")
-        response["Content-Disposition"] = f"attachment; filename={filename}"
-        return response

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -14,21 +14,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='Backup',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_seed_data', models.BooleanField(default=False, editable=False)),
-                ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('location', models.CharField(help_text='Location or link to the backup file', max_length=255)),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('size', models.BigIntegerField(help_text='Size of the backup in bytes')),
-                ('report', models.JSONField(blank=True, default=dict, help_text='Report of exported objects')),
-            ],
-            options={
-                'ordering': ['-created_at'],
-            },
-        ),
-        migrations.CreateModel(
             name='NodeRole',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
@@ -88,46 +73,6 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['-created'],
-            },
-        ),
-        migrations.CreateModel(
-            name='Recipe',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_seed_data', models.BooleanField(default=False, editable=False)),
-                ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('name', models.CharField(max_length=100)),
-                ('full_script', models.TextField(blank=True)),
-            ],
-            options={
-                'abstract': False,
-            },
-        ),
-        migrations.CreateModel(
-            name='TextPattern',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_seed_data', models.BooleanField(default=False, editable=False)),
-                ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('mask', models.TextField()),
-                ('priority', models.IntegerField(default=0)),
-            ],
-            options={
-                'ordering': ['-priority', 'id'],
-            },
-        ),
-        migrations.CreateModel(
-            name='Step',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('is_seed_data', models.BooleanField(default=False, editable=False)),
-                ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('order', models.PositiveIntegerField()),
-                ('script', models.TextField()),
-                ('recipe', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='steps', to='nodes.recipe')),
-            ],
-            options={
-                'ordering': ['order'],
             },
         ),
         migrations.CreateModel(

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -256,7 +256,7 @@ class ContentSample(Entity):
 
 
 class NodeTask(Entity):
-    """Recipe that can be executed on nodes."""
+    """Script that can be executed on nodes."""
 
     recipe = models.TextField()
     role = models.ForeignKey(NodeRole, on_delete=models.SET_NULL, null=True, blank=True)
@@ -269,7 +269,7 @@ class NodeTask(Entity):
         return self.recipe
 
     def run(self, node: Node):
-        """Execute this recipe on ``node`` and return its output."""
+        """Execute this script on ``node`` and return its output."""
         if not node.is_local:
             raise NotImplementedError("Remote node execution is not implemented")
         import subprocess
@@ -280,121 +280,5 @@ class NodeTask(Entity):
         return result.stdout + result.stderr
 
 
-class Recipe(Entity):
-    """A collection of script steps that can be executed by nodes."""
-
-    name = models.CharField(max_length=100)
-    full_script = models.TextField(blank=True)
-
-    def __str__(self):  # pragma: no cover - simple representation
-        return self.name
-
-    def sync_full_script(self):
-        """Update ``full_script`` to match the joined step scripts."""
-        steps = self.steps.order_by("order").values_list("script", flat=True)
-        self.full_script = "\n".join(steps)
-        super().save(update_fields=["full_script"])
-
-
-class Step(Entity):
-    """Individual step belonging to a :class:`Recipe`."""
-
-    recipe = models.ForeignKey(
-        Recipe, related_name="steps", on_delete=models.CASCADE
-    )
-    order = models.PositiveIntegerField()
-    script = models.TextField()
-
-    class Meta:
-        ordering = ["order"]
-
-    def __str__(self):  # pragma: no cover - simple representation
-        return f"{self.order}: {self.script[:30]}"
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        self.recipe.sync_full_script()
-
-    def delete(self, *args, **kwargs):
-        super().delete(*args, **kwargs)
-        self.recipe.sync_full_script()
-
-
-
-
-class TextPattern(Entity):
-    """Text mask with optional sigils used to match against text content samples."""
-
-    mask = models.TextField()
-    priority = models.IntegerField(default=0)
-
-    class Meta:
-        ordering = ["-priority", "id"]
-
-    SIGIL_RE = re.compile(r"\[(.+?)\]")
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return self.mask
-
-    def match(self, text: str):
-        """Return the mask with sigils replaced if ``text`` matches it.
-
-        ``None`` is returned when no match is found. When a match occurs, the
-        returned string is the original mask with each ``[sigil]`` replaced by the
-        corresponding text from ``text``. Multiple sigils are supported.
-        """
-
-        regex, names = self._compile_regex()
-        match = re.search(regex, text, re.DOTALL)
-        if not match:
-            return None
-        result = self.mask
-        for name, value in zip(names, match.groups()):
-            result = result.replace(f"[{name}]", value)
-        return result
-
-    def _compile_regex(self):
-        """Compile the mask into a regex pattern and return pattern and sigils."""
-
-        pattern_parts = []
-        sigil_names = []
-        last_index = 0
-        matches = list(self.SIGIL_RE.finditer(self.mask))
-        for idx, match in enumerate(matches):
-            pattern_parts.append(re.escape(self.mask[last_index : match.start()]))
-            sigil_names.append(match.group(1))
-            part = "(.*)" if idx == len(matches) - 1 else "(.*?)"
-            pattern_parts.append(part)
-            last_index = match.end()
-        pattern_parts.append(re.escape(self.mask[last_index:]))
-        regex = "".join(pattern_parts)
-        return regex, sigil_names
-
-
-class Backup(Entity):
-    """Database backup metadata.
-
-    Stores the location of the exported data, creation date, size and a
-    report of the exported objects.  The actual backup process is left to
-    the view or task that creates the model instance, keeping the model
-    backend agnostic.
-    """
-
-    location = models.CharField(
-        max_length=255, help_text="Location or link to the backup file"
-    )
-    created_at = models.DateTimeField(auto_now_add=True)
-    size = models.BigIntegerField(help_text="Size of the backup in bytes")
-    report = models.JSONField(
-        default=dict,
-        blank=True,
-        help_text="Report of exported objects",
-    )
-
-    class Meta:
-        ordering = ["-created_at"]
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return self.location
 
 

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -20,17 +20,12 @@ from django.contrib import admin
 from django.contrib.sites.models import Site
 from django_celery_beat.models import PeriodicTask
 from django.conf import settings
-from .admin import RecipeAdmin
 from .actions import NodeAction
 
 from .models import (
     Node,
     ContentSample,
     NodeRole,
-    Recipe,
-    Step,
-    TextPattern,
-    Backup,
 )
 from .tasks import capture_node_screenshot, sample_clipboard
 from core.models import Message
@@ -224,14 +219,6 @@ class NodeTests(TestCase):
         node.screenshot_polling = False
         node.save()
         self.assertFalse(PeriodicTask.objects.filter(name=task_name).exists())
-
-    def test_backup_creation(self):
-        backup = Backup.objects.create(
-            location="backups/test.json", size=1234, report={"objects": 5}
-        )
-        self.assertEqual(Backup.objects.count(), 1)
-        self.assertEqual(backup.size, 1234)
-        self.assertEqual(backup.report["objects"], 5)
 
 class NodeAdminTests(TestCase):
 
@@ -428,27 +415,6 @@ class NodeActionTests(TestCase):
         finally:
             NodeAction.registry.pop("dummyaction", None)
 
-    def test_generate_backup_action_creates_backup(self):
-        hostname = socket.gethostname()
-        node = Node.objects.create(
-            hostname=hostname,
-            address="127.0.0.1",
-            port=8000,
-            mac_address=Node.get_current_mac(),
-        )
-        url = reverse(
-            "admin:nodes_node_action", args=[node.pk, "generate-db-backup"]
-        )
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment", response["Content-Disposition"])
-        self.assertEqual(Backup.objects.count(), 1)
-        backup = Backup.objects.first()
-        path = Path(settings.BASE_DIR) / backup.location
-        if path.exists():
-            path.unlink()
-
-
 
 class StartupNotificationTests(TestCase):
     def test_startup_notification_uses_ip_and_revision(self):
@@ -537,71 +503,6 @@ class NotificationManagerTests(TestCase):
                     manager = NotificationManager()
                     manager._gui_display("hi", "there")
         mock_logger.info.assert_called_once_with("%s %s", "hi", "there")
-
-
-class RecipeTests(TestCase):
-    def test_step_sync_and_text_update(self):
-        recipe = Recipe.objects.create(name="sample")
-        Step.objects.create(recipe=recipe, order=1, script="echo one")
-        Step.objects.create(recipe=recipe, order=2, script="echo two")
-        recipe.refresh_from_db()
-        self.assertEqual(recipe.full_script, "echo one\necho two")
-
-        recipe.full_script = "first\nsecond"
-
-        class DummyForm:
-            cleaned_data = {"full_script": recipe.full_script}
-
-        admin_instance = RecipeAdmin(Recipe, admin.site)
-        admin_instance.save_model(None, recipe, DummyForm(), False)
-
-        steps = list(recipe.steps.order_by("order").values_list("script", flat=True))
-        self.assertEqual(steps, ["first", "second"])
-
-
-class TextPatternMatchTests(TestCase):
-    def test_match_with_sigil(self):
-        pattern = TextPattern.objects.create(mask="This is [not] good", priority=1)
-        result = pattern.match("Indeed, This is very good.")
-        self.assertEqual(result, "This is very good")
-
-    def test_match_without_sigil(self):
-        pattern = TextPattern.objects.create(mask="simple", priority=1)
-        result = pattern.match("a simple example")
-        self.assertEqual(result, "simple")
-
-    def test_no_match(self):
-        pattern = TextPattern.objects.create(mask="missing", priority=1)
-        self.assertIsNone(pattern.match("nothing to see"))
-
-    def test_match_multiple_sigils(self):
-        pattern = TextPattern.objects.create(
-            mask="Hello [first] [last]", priority=1
-        )
-        result = pattern.match("Well, Hello John Doe!")
-        self.assertEqual(result, "Hello John Doe!")
-
-
-class TextPatternAdminActionTests(TestCase):
-    def setUp(self):
-        User = get_user_model()
-        self.user = User.objects.create_superuser(
-            "pattern_admin", "admin@example.com", "pass"
-        )
-        self.client.login(username="pattern_admin", password="pass")
-
-    @patch("pyperclip.paste")
-    def test_test_clipboard_action(self, mock_paste):
-        mock_paste.return_value = "This is very good"
-        pattern = TextPattern.objects.create(mask="This is [not] good", priority=1)
-        url = reverse("admin:nodes_textpattern_changelist")
-        response = self.client.post(
-            url,
-            {"action": "test_clipboard", "_selected_action": [pattern.pk]},
-            follow=True,
-        )
-        msgs = [m.message for m in response.wsgi_request._messages]
-        self.assertIn("Matched 'This is [not] good' -> 'This is very good'", msgs)
 
 
 class ContentSampleAdminTests(TestCase):


### PR DESCRIPTION
## Summary
- drop unused Backup, Recipe, Step, and TextPattern models
- delete related admin registrations, actions, and tests
- simplify initial migration accordingly

## Testing
- `python manage.py migrate`
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: test_simulator_stops_when_charger_closes)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a9b87a0832688e7caebf708063a