### PR TITLE
feat: add progress feedback in upgrade script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 - Show full date and timezone in admin clock tooltip
 - Fallback to site domain in admin badge when display name missing
 - Hide Odoo profile passwords in admin forms unless updated
+- Provide progress feedback during upgrade
 
 0.1.1 [revision 76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d]
 ---------------------------------------------------------

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -36,6 +36,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 LOCAL_VERSION="0"
 [ -f VERSION ] && LOCAL_VERSION=$(cat VERSION)
 
+echo "Checking repository for updates..."
 git fetch origin "$BRANCH"
 REMOTE_VERSION="$LOCAL_VERSION"
 if git cat-file -e "origin/$BRANCH:VERSION" 2>/dev/null; then
@@ -57,14 +58,17 @@ fi
 
 # Stop running instance (if any)
 if [[ $NO_RESTART -eq 0 ]]; then
+  echo "Stopping running instance..."
   ./stop.sh --all >/dev/null 2>&1 || true
 fi
 
 # Pull latest changes
+echo "Pulling latest changes..."
 git pull --rebase
 
 # Restore stashed changes
 if [ "$STASHED" -eq 1 ]; then
+  echo "Restoring local changes..."
   git stash pop || true
 fi
 
@@ -85,7 +89,9 @@ ENV_ARGS=""
 if [[ $FORCE -eq 1 ]]; then
   ENV_ARGS="--latest"
 fi
+echo "Refreshing environment..."
 ./env-refresh.sh $ENV_ARGS
 if [[ $NO_RESTART -eq 0 ]]; then
+  echo "Restarting services..."
   ./start.sh
 fi


### PR DESCRIPTION
## Summary
- inform users when upgrade checks repo, stops services, pulls changes, and restarts
- document upgrade feedback in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b23e7f26448326be9f7baf65e9d47a