### PR TITLE
Link packager profiles to users and add release manager

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -82,12 +82,12 @@ class ReferenceAdmin(admin.ModelAdmin):
 
 @admin.register(PackagerProfile)
 class PackagerProfileAdmin(admin.ModelAdmin):
-    list_display = ("name",)
+    list_display = ("user", "username", "pypi_url")
 
 
 @admin.register(PackageHub)
 class PackageHubAdmin(admin.ModelAdmin):
-    list_display = ("name",)
+    list_display = ("name", "release_manager")
 
 
 @admin.register(SecurityGroup)

--- a/core/fixtures/package_releases.json
+++ b/core/fixtures/package_releases.json
@@ -3,8 +3,11 @@
     "model": "core.packagerprofile",
     "pk": 1,
     "fields": {
-      "name": "default",
-      "token": ""
+      "user": 2,
+      "username": "arthexis",
+      "token": "",
+      "password": "",
+      "pypi_url": "https://pypi.org/user/arthexis/"
     }
   },
   {
@@ -18,7 +21,8 @@
       "python_requires": ">=3.10",
       "license": "MIT",
       "repository_url": "https://github.com/arthexis/arthexis",
-      "homepage_url": "https://arthexis.com"
+      "homepage_url": "https://arthexis.com",
+      "release_manager": 1
     }
   },
   {

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -758,8 +758,11 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('name', models.CharField(max_length=100)),
+                ('username', models.CharField(blank=True, max_length=100)),
                 ('token', models.CharField(blank=True, max_length=200)),
+                ('password', models.CharField(blank=True, max_length=200)),
+                ('pypi_url', models.URLField(blank=True)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='packager_profile', to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Packager Profile',
@@ -780,6 +783,7 @@ class Migration(migrations.Migration):
                 ('license', models.CharField(default='MIT', max_length=100)),
                 ('repository_url', models.URLField(default='https://github.com/arthexis/arthexis')),
                 ('homepage_url', models.URLField(default='https://arthexis.com')),
+                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
             ],
             options={
                 'verbose_name': 'Package Hub',

--- a/tests/test_release_mapping.py
+++ b/tests/test_release_mapping.py
@@ -3,7 +3,7 @@ from core.models import PackageRelease
 
 
 class ReleaseMappingTests(TestCase):
-    fixtures = ["package_releases.json"]
+    fixtures = ["users.json", "package_releases.json"]
 
     def test_migration_number_formula(self):
         release = PackageRelease.objects.get(version="0.1.1")


### PR DESCRIPTION
## Summary
- link packager profiles to constellation users and capture PyPI credentials
- let package hubs choose a release manager profile for uploads
- update fixtures and tests for new profile fields

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b240ff7a608326a515917473abbb83