### PR TITLE
feat(nodes): add network message propagation

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -32,13 +32,11 @@ from .models import (
     EVModel,
     RFID,
     Reference,
-    Message,
     OdooProfile,
     PackageHub,
     PackageRelease,
     PackagerProfile,
 )
-from .notifications import notify
 from . import release
 
 
@@ -107,20 +105,6 @@ class AccountRFIDForm(forms.ModelForm):
         if rfid.accounts.exclude(pk=self.instance.account_id).exists():
             raise forms.ValidationError("RFID is already assigned to another account")
         return rfid
-
-
-@admin.register(Message)
-class MessageAdmin(admin.ModelAdmin):
-    list_display = ("subject", "body", "node", "created")
-    search_fields = ("subject", "body")
-    ordering = ("-created",)
-    actions = ["send_messages"]
-
-    @admin.action(description="Send selected messages")
-    def send_messages(self, request, queryset):
-        for msg in queryset:
-            notify(msg.subject, msg.body)
-        self.message_user(request, f"{queryset.count()} messages sent")
 
 
 class AccountRFIDInline(admin.TabularInline):

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -723,36 +723,6 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name="Message",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("is_seed_data", models.BooleanField(default=False, editable=False)),
-                ("is_deleted", models.BooleanField(default=False, editable=False)),
-                ("subject", models.CharField(blank=True, max_length=32)),
-                ("body", models.CharField(blank=True, max_length=32)),
-                (
-                    "node",
-                    models.ForeignKey(
-                        blank=True,
-                        null=True,
-                        on_delete=django.db.models.deletion.SET_NULL,
-                        related_name="messages",
-                        to="nodes.node",
-                    ),
-                ),
-                ("created", models.DateTimeField(auto_now_add=True)),
-            ],
-            options={"ordering": ["-created"]},
-        ),
-        migrations.CreateModel(
             name='PackagerProfile',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/core/models.py
+++ b/core/models.py
@@ -639,27 +639,6 @@ class AdminHistory(Entity):
         return model._meta.verbose_name_plural if model else self.content_type.name
 
 
-class Message(Entity):
-    """System message that can be sent to LCD or GUI."""
-
-    subject = models.CharField(max_length=32, blank=True)
-    body = models.CharField(max_length=32, blank=True)
-    node = models.ForeignKey(
-        "nodes.Node",
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
-        related_name="messages",
-    )
-    created = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        ordering = ["-created"]
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"{self.subject} {self.body}".strip()
-
-
 class PackagerProfile(Entity):
     """Store credentials for publishing packages."""
 

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -20,6 +20,7 @@ from .models import (
     NodeRole,
     ContentSample,
     NodeTask,
+    NetMessage,
 )
 
 
@@ -274,6 +275,14 @@ class ContentSampleAdmin(admin.ModelAdmin):
             '<img src="data:image/png;base64,{}" style="max-width:100%;" />',
             encoded,
         )
+
+
+@admin.register(NetMessage)
+class NetMessageAdmin(admin.ModelAdmin):
+    list_display = ("subject", "body", "created", "complete")
+    search_fields = ("subject", "body")
+    list_filter = ("complete",)
+    ordering = ("-created",)
 
 
 class NodeTaskForm(forms.ModelForm):

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -76,6 +76,30 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
+            name='NetMessage',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, unique=True)),
+                ('subject', models.CharField(blank=True, max_length=64)),
+                ('body', models.CharField(blank=True, max_length=256)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('complete', models.BooleanField(default=False)),
+                (
+                    'propagated_to',
+                    models.ManyToManyField(
+                        blank=True,
+                        related_name='received_net_messages',
+                        to='nodes.node',
+                    ),
+                ),
+            ],
+            options={
+                'ordering': ['-created'],
+            },
+        ),
+        migrations.CreateModel(
             name='ContentSample',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -26,9 +26,9 @@ from .models import (
     Node,
     ContentSample,
     NodeRole,
+    NetMessage,
 )
 from .tasks import capture_node_screenshot, sample_clipboard
-from core.models import Message
 
 
 class NodeTests(TestCase):
@@ -172,10 +172,9 @@ class NodeTests(TestCase):
             url, data="hello", content_type="text/plain"
         )
         self.assertEqual(post_resp.status_code, 200)
-        self.assertEqual(Message.objects.count(), 1)
-        msg = Message.objects.first()
+        self.assertEqual(NetMessage.objects.count(), 1)
+        msg = NetMessage.objects.first()
         self.assertEqual(msg.body, "hello")
-        self.assertEqual(msg.node, node)
 
     def test_public_api_disabled(self):
         node = Node.objects.create(

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from unittest.mock import patch, call, MagicMock
 import socket
 import base64
+import json
+import uuid
 from tempfile import TemporaryDirectory
 import shutil
 import time
@@ -29,6 +31,8 @@ from .models import (
     NetMessage,
 )
 from .tasks import capture_node_screenshot, sample_clipboard
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives import serialization, hashes
 
 
 class NodeTests(TestCase):
@@ -186,6 +190,55 @@ class NodeTests(TestCase):
         url = reverse("node-public-endpoint", args=[node.public_endpoint])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 404)
+
+    def test_net_message_requires_signature(self):
+        payload = {
+            "uuid": str(uuid.uuid4()),
+            "subject": "s",
+            "body": "b",
+            "seen": [],
+            "sender": str(uuid.uuid4()),
+        }
+        resp = self.client.post(
+            reverse("net-message"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_net_message_with_valid_signature(self):
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_key = key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        sender = Node.objects.create(
+            hostname="sender",
+            address="10.0.0.1",
+            port=8000,
+            mac_address="00:11:22:33:44:cc",
+            public_key=public_key,
+        )
+        msg_id = str(uuid.uuid4())
+        payload = {
+            "uuid": msg_id,
+            "subject": "hello",
+            "body": "world",
+            "seen": [],
+            "sender": str(sender.uuid),
+        }
+        payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        signature = key.sign(
+            payload_json.encode(), padding.PKCS1v15(), hashes.SHA256()
+        )
+        resp = self.client.post(
+            reverse("net-message"),
+            data=payload_json,
+            content_type="application/json",
+            HTTP_X_SIGNATURE=base64.b64encode(signature).decode(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(NetMessage.objects.filter(uuid=msg_id).exists())
 
     def test_clipboard_polling_creates_task(self):
         node = Node.objects.create(

--- a/nodes/urls.py
+++ b/nodes/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path("list/", views.node_list, name="node-list"),
     path("register/", views.register_node, name="register-node"),
     path("screenshot/", views.capture, name="node-screenshot"),
+    path("net-message/", views.net_message, name="net-message"),
     path("<slug:endpoint>/", views.public_node_endpoint, name="node-public-endpoint"),
 ]


### PR DESCRIPTION
## Summary
- replace core Message with nodes.NetMessage designed for network broadcast
- propagate messages across nodes with role-based selection and completion tracking
- expose API to receive and relay messages

## Testing
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b245df83488326bac51a7428973279