### PR TITLE
Persist user data fixtures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -267,6 +267,11 @@ fi
 
 python manage.py migrate --noinput
 
+# Load personal user data fixtures if present
+if ls data/*.json >/dev/null 2>&1; then
+    python manage.py loaddata data/*.json
+fi
+
 deactivate
 
 

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -1,7 +1,20 @@
+from pathlib import Path
+
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+from django.core.management import call_command
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "env_refresh", Path(__file__).resolve().parent.parent / "env-refresh.py"
+)
+env_refresh = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(env_refresh)
+run_database_tasks = env_refresh.run_database_tasks
 
 from core.models import OdooProfile
 from core.user_data import UserDatum
@@ -12,6 +25,9 @@ class UserDatumAdminTests(TestCase):
         User = get_user_model()
         self.user = User.objects.create_superuser("udadmin", password="pw")
         self.client.login(username="udadmin", password="pw")
+        self.data_dir = Path(settings.BASE_DIR) / "data"
+        for f in self.data_dir.glob("*.json"):
+            f.unlink()
         self.profile = OdooProfile.objects.create(
             user=self.user,
             host="http://test",
@@ -19,6 +35,13 @@ class UserDatumAdminTests(TestCase):
             username="odoo",
             password="secret",
         )
+        self.fixture_path = (
+            self.data_dir
+            / f"{self.user.pk}_core_odooprofile_{self.profile.pk}.json"
+        )
+
+    def tearDown(self):
+        self.fixture_path.unlink(missing_ok=True)
 
     def test_checkbox_displayed_on_change_form(self):
         url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
@@ -42,5 +65,44 @@ class UserDatumAdminTests(TestCase):
         self.assertTrue(
             UserDatum.objects.filter(
                 user=self.user, content_type=ct, object_id=self.profile.pk
+            ).exists()
+        )
+
+    def test_userdatum_persists_after_save(self):
+        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        data = {
+            "user": self.user.pk,
+            "host": "http://test",
+            "database": "db",
+            "username": "odoo",
+            "password": "",
+            "_user_datum": "on",
+            "_save": "Save",
+        }
+        self.client.post(url, data)
+        response = self.client.get(url)
+        self.assertContains(response, 'name="_user_datum" checked')
+
+    def test_fixture_created_and_loaded_on_env_refresh(self):
+        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        data = {
+            "user": self.user.pk,
+            "host": "http://test",
+            "database": "db",
+            "username": "odoo",
+            "password": "",
+            "_user_datum": "on",
+            "_save": "Save",
+        }
+        self.client.post(url, data)
+        self.assertTrue(self.fixture_path.exists())
+
+        call_command("flush", verbosity=0, interactive=False)
+        run_database_tasks()
+
+        ct = ContentType.objects.get_for_model(OdooProfile)
+        self.assertTrue(
+            UserDatum.objects.filter(
+                user_id=self.user.pk, content_type=ct, object_id=self.profile.pk
             ).exists()
         )


### PR DESCRIPTION
## Summary
- load personal data fixtures and recreate UserDatum links during env refresh
- import personal fixtures on installation
- test persistence and fixture reloading for user data

## Testing
- `.venv/bin/python manage.py test tests.test_user_datum_admin`

------
https://chatgpt.com/codex/tasks/task_e_68b2544b06cc8326bbea44bf6438f3d8