### PR TITLE
Align install role defaults for auto-upgrade and latest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 - Fallback to site domain in admin badge when display name missing
 - Hide Odoo profile passwords in admin forms unless updated
 - Provide progress feedback during upgrade
+- Adjust install defaults: Control uses --latest with auto-upgrade; Satellite and Constellation omit --latest
 
 0.1.1 [revision 76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d]
 ---------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,7 @@ while [[ $# -gt 0 ]]; do
             AUTO_UPGRADE=true
             NGINX_MODE="internal"
             SERVICE="arthexis"
-            LATEST=true
+            LATEST=false
             ENABLE_CELERY=true
             NODE_ROLE="Gateway"
             shift

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 def test_install_script_runs_migrate():
     script_path = Path(__file__).resolve().parent.parent / "install.sh"
@@ -23,4 +24,27 @@ def test_install_script_requires_nginx_for_roles():
     content = script_path.read_text()
     for role in ("satellite", "control", "constellation"):
         assert f'require_nginx "{role}"' in content
+
+
+def test_install_script_role_defaults():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+
+    def block(flag: str) -> str:
+        pattern = rf"--{flag}\)(.*?)\n\s*;;"
+        match = re.search(pattern, content, re.S)
+        assert match, f"block for {flag} not found"
+        return match.group(1)
+
+    satellite = block("satellite")
+    assert "AUTO_UPGRADE=true" in satellite
+    assert "LATEST=false" in satellite
+
+    constellation = block("constellation")
+    assert "AUTO_UPGRADE=true" in constellation
+    assert "LATEST=false" in constellation
+
+    control = block("control")
+    assert "AUTO_UPGRADE=true" in control
+    assert "LATEST=true" in control
 


### PR DESCRIPTION
## Summary
- ensure satellite installs auto-upgrade without --latest
- test install role defaults and document behavior

## Testing
- `pytest tests/test_install_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b256b05cfc8326aca861b03bf496fd