### PR TITLE
Require Redis for non-terminal install modes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 - Hide Odoo profile passwords in admin forms unless updated
 - Provide progress feedback during upgrade
 - Adjust install defaults: Control uses --latest with auto-upgrade; Satellite and Constellation omit --latest
+- Require Redis for non-terminal installs and configure Celery broker
 
 0.1.1 [revision 76f70b6a72c78fcdf143a19ddcc88a0fbd209b3d]
 ---------------------------------------------------------

--- a/start.sh
+++ b/start.sh
@@ -34,6 +34,14 @@ if [ ! -d .venv ]; then
 fi
 source .venv/bin/activate
 
+# Load any .env files to configure environment variables
+for env_file in *.env; do
+  [ -f "$env_file" ] || continue
+  set -a
+  . "$env_file"
+  set +a
+done
+
 # Determine default port based on nginx mode if present
 PORT=""
 RELOAD=false


### PR DESCRIPTION
## Summary
- check for Redis and generate redis.env when installing satellite, control, or constellation nodes
- load redis.env via systemd so Celery uses Redis
- source .env files in start.sh to expose broker settings

## Testing
- `bash -n install.sh`
- `bash -n start.sh`
- `pytest` *(fails: tests/test_user_datum_admin.py::UserDatumAdminTests::test_fixture_created_and_loaded_on_env_refresh, tests/test_user_datum_admin.py::UserDatumAdminTests::test_userdatum_created_when_checked)*

------
https://chatgpt.com/codex/tasks/task_e_68b25998d8308326847ff26fd11366c7