### PR TITLE
fix: store build revision and rename publish flag

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -462,11 +462,17 @@ class PackageReleaseAdmin(admin.ModelAdmin):
         "hub",
         "version",
         "pypi_url",
-        "is_live",
+        "revision_short",
         "is_promoted",
         "is_certified",
+        "is_published",
     )
     actions = ["promote_release", "publish_to_index"]
+
+    def revision_short(self, obj):
+        return obj.revision_short
+
+    revision_short.short_description = "revision"
 
     @admin.action(description="Promote selected releases")
     def promote_release(self, request, queryset):
@@ -494,8 +500,8 @@ class PackageReleaseAdmin(admin.ModelAdmin):
                 continue
             try:
                 cfg.publish()
-                cfg.is_live = True
-                cfg.save(update_fields=["is_live"])
+                cfg.is_published = True
+                cfg.save(update_fields=["is_published"])
                 self.message_user(request, f"Published {cfg.hub.name}", messages.SUCCESS)
             except Exception as exc:
                 self.message_user(request, str(exc), messages.ERROR)

--- a/core/fixtures/package_releases.json
+++ b/core/fixtures/package_releases.json
@@ -34,7 +34,7 @@
       "version": "0.0.0",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.0.0/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }
@@ -48,7 +48,7 @@
       "version": "0.0.1",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.0.1/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }
@@ -62,7 +62,7 @@
       "version": "0.1.0",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.0/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }
@@ -76,7 +76,7 @@
       "version": "0.1.1",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.1/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }
@@ -90,7 +90,7 @@
       "version": "0.1.2",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.2/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }
@@ -104,7 +104,7 @@
       "version": "1.0.0",
       "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/1.0.0/",
-      "is_live": false,
+      "is_published": false,
       "is_promoted": false,
       "is_certified": false
     }

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -769,7 +769,7 @@ class Migration(migrations.Migration):
                 ('version', models.CharField(default='0.0.0', max_length=20, unique=True)),
                 ('revision', models.CharField(blank=True, max_length=40)),
                 ('pypi_url', models.URLField(blank=True)),
-                ('is_live', models.BooleanField(default=False)),
+                ('is_published', models.BooleanField(default=False)),
                 ('is_promoted', models.BooleanField(default=False, editable=False)),
                 ('is_certified', models.BooleanField(default=False, editable=False)),
                 ('hub', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.packagehub')),


### PR DESCRIPTION
## Summary
- rename PackageRelease.is_live to is_published
- record git revision for builds and show short hash in admin
- install `build` module automatically during packaging

## Testing
- `python manage.py makemigrations --check --dry-run`
- `pytest -q` *(fails: IntegrityError in user datum admin tests)*
- `python manage.py migrate --noinput`


------
https://chatgpt.com/codex/tasks/task_e_68b25d64fd7083269e1eec9ca2367568