### PR TITLE
Generate QR code for references without image

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -294,7 +294,7 @@ class Reference(Entity):
     )
 
     def save(self, *args, **kwargs):
-        if self.method == "qr" and self.value:
+        if not self.image and self.value:
             qr = qrcode.QRCode(box_size=10, border=4)
             qr.add_data(self.value)
             qr.make(fit=True)
@@ -302,8 +302,6 @@ class Reference(Entity):
             buffer = BytesIO()
             img.save(buffer, format="PNG")
             filename = hashlib.sha256(self.value.encode()).hexdigest()[:16] + ".png"
-            if self.image:
-                self.image.delete(save=False)
             self.image.save(filename, ContentFile(buffer.getvalue()), save=False)
         super().save(*args, **kwargs)
 

--- a/tests/test_reference_qr_code.py
+++ b/tests/test_reference_qr_code.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from core.models import Reference
+
+TMP_MEDIA_ROOT = tempfile.mkdtemp()
+
+
+@override_settings(MEDIA_ROOT=TMP_MEDIA_ROOT)
+class ReferenceQRTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="qradm",
+            email="qr@example.com",
+            password="password",
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_qr_code_generated_for_reference_without_image(self):
+        ref = Reference.objects.create(
+            alt_text="ref",
+            method="text",
+            value="some value",
+        )
+        self.assertTrue(ref.image)
+
+    def test_qr_code_displayed_in_admin_change(self):
+        ref = Reference.objects.create(
+            alt_text="ref",
+            method="text",
+            value="some value",
+        )
+        url = reverse("admin:core_reference_change", args=[ref.pk])
+        response = self.client.get(url)
+        self.assertContains(response, ref.image.url)
+        self.assertContains(response, "<img", html=False)


### PR DESCRIPTION
## Summary
- ensure Reference objects missing a QR code generate one on save
- expose QR code image on Reference admin page
- test QR code generation and admin display

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test tests.test_reference_qr_code tests.test_rfid_admin_reference_clear`
- `python manage.py test` *(fails: ocpp.tests.ChargerAdminTests.test_admin_change_links_landing_page)*

------
https://chatgpt.com/codex/tasks/task_e_68b25eeea59083268a690807c4b9c8ae