### PR TITLE
feat: add footer references

### DIFF
--- a/core/fixtures/references.json
+++ b/core/fixtures/references.json
@@ -64,5 +64,49 @@
       "include_in_footer": true,
       "created": "2024-01-01T00:00:00Z"
     }
+  },
+  {
+    "model": "core.reference",
+    "pk": 7,
+    "fields": {
+      "value": "https://docs.celeryq.dev/en/stable/",
+      "alt_text": "Celery",
+      "method": "link",
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
+    }
+  },
+  {
+    "model": "core.reference",
+    "pk": 8,
+    "fields": {
+      "value": "https://github.com/arthexis/arthexis",
+      "alt_text": "GitHub Repo",
+      "method": "link",
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
+    }
+  },
+  {
+    "model": "core.reference",
+    "pk": 9,
+    "fields": {
+      "value": "https://www.odoo.com/partners",
+      "alt_text": "Odoo Ready",
+      "method": "link",
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
+    }
+  },
+  {
+    "model": "core.reference",
+    "pk": 10,
+    "fields": {
+      "value": "https://porschemonterrey.com",
+      "alt_text": "Porsche Monterrey",
+      "method": "link",
+      "include_in_footer": true,
+      "created": "2024-01-01T00:00:00Z"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- include Celery, GitHub repo, Odoo Ready, and Porsche Monterrey links in footer fixtures

## Testing
- `pytest` *(fails: TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2606bfa64832691fdb47e7ed787c0