### PR TITLE
Add email inbox model with connection test

### DIFF
--- a/core/migrations/0004_userdatum.py
+++ b/core/migrations/0004_userdatum.py
@@ -48,4 +48,44 @@ class Migration(migrations.Migration):
                 "unique_together": {("user", "content_type", "object_id")},
             },
         ),
+        migrations.CreateModel(
+            name="EmailInbox",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("host", models.CharField(max_length=255)),
+                ("port", models.PositiveIntegerField(default=993)),
+                ("username", models.CharField(max_length=255)),
+                ("password", models.CharField(max_length=255)),
+                (
+                    "protocol",
+                    models.CharField(
+                        choices=[("imap", "IMAP"), ("pop3", "POP3")],
+                        max_length=5,
+                    ),
+                ),
+                ("use_ssl", models.BooleanField(default=True)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="email_inboxes",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Email Inbox",
+                "verbose_name_plural": "Email Inboxes",
+            },
+        ),
     ]

--- a/tests/test_email_inbox.py
+++ b/tests/test_email_inbox.py
@@ -1,0 +1,84 @@
+import imaplib
+import poplib
+import pytest
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from unittest.mock import patch
+
+from core.models import User, EmailInbox
+
+
+class DummyIMAP:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def login(self, username, password):
+        if username == "bad":
+            raise Exception("fail")
+
+    def logout(self):
+        pass
+
+
+class DummyPOP:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def user(self, username):
+        if username == "bad":
+            raise Exception("fail")
+
+    def pass_(self, password):
+        if password == "bad":
+            raise Exception("fail")
+
+    def quit(self):
+        pass
+
+
+class EmailInboxTests(TestCase):
+    @patch("imaplib.IMAP4_SSL", new=lambda h, p: DummyIMAP(h, p))
+    def test_imap_connection_success(self):
+        user = User.objects.create(username="imap")
+        inbox = EmailInbox.objects.create(
+            user=user,
+            host="imap.test",
+            port=993,
+            username="good",
+            password="p",
+            protocol=EmailInbox.IMAP,
+            use_ssl=True,
+        )
+        assert inbox.test_connection() is True
+
+    @patch("poplib.POP3_SSL", new=lambda h, p: DummyPOP(h, p))
+    def test_pop_connection_success(self):
+        user = User.objects.create(username="pop")
+        inbox = EmailInbox.objects.create(
+            user=user,
+            host="pop.test",
+            port=995,
+            username="good",
+            password="p",
+            protocol=EmailInbox.POP3,
+            use_ssl=True,
+        )
+        assert inbox.test_connection() is True
+
+    @patch("imaplib.IMAP4_SSL", new=lambda h, p: DummyIMAP(h, p))
+    def test_connection_failure(self):
+        user = User.objects.create(username="bad")
+        inbox = EmailInbox.objects.create(
+            user=user,
+            host="imap.test",
+            port=993,
+            username="bad",
+            password="p",
+            protocol=EmailInbox.IMAP,
+            use_ssl=True,
+        )
+        with pytest.raises(ValidationError):
+            inbox.test_connection()

--- a/tests/test_email_inbox_admin.py
+++ b/tests/test_email_inbox_admin.py
@@ -1,0 +1,64 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from core.models import EmailInbox
+from core.admin import EmailInboxAdminForm
+
+
+class EmailInboxAdminFormTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="mail", password="pwd")
+
+    def _create_inbox(self, password="secret"):
+        return EmailInbox.objects.create(
+            user=self.user,
+            host="mail.test",
+            port=993,
+            username="mail",
+            password=password,
+            protocol=EmailInbox.IMAP,
+            use_ssl=True,
+        )
+
+    def test_password_field_hidden_and_blank_initial(self):
+        inbox = self._create_inbox()
+        form = EmailInboxAdminForm(instance=inbox)
+        html = form.as_p()
+        self.assertIn('type="password"', html)
+        self.assertNotIn("secret", html)
+
+    def test_blank_password_keeps_existing(self):
+        inbox = self._create_inbox()
+        data = {
+            "user": self.user.pk,
+            "host": "mail2.test",
+            "port": 993,
+            "username": "mail",
+            "password": "",
+            "protocol": EmailInbox.IMAP,
+            "use_ssl": True,
+        }
+        form = EmailInboxAdminForm(data, instance=inbox)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        inbox.refresh_from_db()
+        self.assertEqual(inbox.password, "secret")
+        self.assertEqual(inbox.host, "mail2.test")
+
+    def test_new_password_saved(self):
+        inbox = self._create_inbox()
+        data = {
+            "user": self.user.pk,
+            "host": "mail.test",
+            "port": 993,
+            "username": "mail",
+            "password": "newpass",
+            "protocol": EmailInbox.IMAP,
+            "use_ssl": True,
+        }
+        form = EmailInboxAdminForm(data, instance=inbox)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        inbox.refresh_from_db()
+        self.assertEqual(inbox.password, "newpass")

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
 from django.core.management import call_command
+from django.contrib.messages import get_messages
 
 import importlib.util
 
@@ -22,6 +23,7 @@ from core.user_data import UserDatum
 
 class UserDatumAdminTests(TestCase):
     def setUp(self):
+        call_command("flush", verbosity=0, interactive=False)
         User = get_user_model()
         self.user = User.objects.create_superuser("udadmin", password="pw")
         self.client.login(username="udadmin", password="pw")
@@ -75,7 +77,7 @@ class UserDatumAdminTests(TestCase):
                 user=self.user, content_type=ct, object_id=self.profile.pk
             ).exists()
         )
-        messages = [m.message for m in response.context["messages"]]
+        messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertTrue(
             any(str(self.fixture_path) in msg for msg in messages),
         )


### PR DESCRIPTION
## Summary
- add EmailInbox model for IMAP/POP credentials
- expose EmailInbox admin with password handling and connection test action
- cover email inbox functionality with unit tests
- ensure user datum and email inbox tests run in isolation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b25e9319688326936d8e3cdc950e67