### PR TITLE
feat: enable remote node registration

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -12,6 +12,7 @@ from django.http import HttpResponse
 import base64
 import pyperclip
 from pyperclip import PyperclipException
+import uuid
 from .utils import capture_screenshot, save_screenshot
 from .actions import NodeAction
 
@@ -93,19 +94,18 @@ class NodeAdmin(admin.ModelAdmin):
         return custom + urls
 
     def register_current(self, request):
-        """Create or update the Node entry for this host."""
+        """Create or update this host and offer browser node registration."""
         node, created = Node.register_current()
         if created:
             self.message_user(
                 request, f"Current host registered as {node}", messages.SUCCESS
             )
-        else:
-            self.message_user(
-                request,
-                f"Current host already registered as {node}",
-                messages.INFO,
-            )
-        return redirect("..")
+        token = uuid.uuid4().hex
+        context = {
+            "token": token,
+            "register_url": reverse("register-node"),
+        }
+        return render(request, "admin/nodes/node/register_remote.html", context)
 
     def public_key(self, request, node_id):
         node = self.get_object(request, node_id)

--- a/nodes/templates/admin/nodes/node/register_remote.html
+++ b/nodes/templates/admin/nodes/node/register_remote.html
@@ -1,0 +1,35 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Register Local Node" %}</h1>
+<p>{% trans "Attempting to register a node running on this computer." %}</p>
+<p id="result"></p>
+<script>
+(async function() {
+    const token = "{{ token }}";
+    const infoUrl = "http://localhost:8000/nodes/info/?token=" + token;
+    try {
+        const infoResp = await fetch(infoUrl);
+        const info = await infoResp.json();
+        const resp = await fetch("{{ register_url }}", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({
+                hostname: info.hostname,
+                address: info.address,
+                port: info.port,
+                mac_address: info.mac_address,
+                public_key: info.public_key,
+                token: token,
+                signature: info.token_signature
+            })
+        });
+        const result = await resp.json();
+        document.getElementById("result").textContent = result.detail || ("Registered node ID " + result.id);
+    } catch(err) {
+        document.getElementById("result").textContent = err;
+    }
+})();
+</script>
+{% endblock %}

--- a/nodes/urls.py
+++ b/nodes/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("info/", views.node_info, name="node-info"),
     path("list/", views.node_list, name="node-list"),
     path("register/", views.register_node, name="register-node"),
     path("screenshot/", views.capture, name="node-screenshot"),


### PR DESCRIPTION
## Summary
- add endpoint to expose local node details and sign registration tokens
- verify signed tokens during registration and capture public key
- provide admin page with browser script to register local nodes

## Testing
- `pytest` *(fails: TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68b25fa9d46083269f80e9cae86dabd4