### PR TITLE
Handle NetMessage propagation and completion

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -31,6 +31,7 @@ from pages.models import Module, Landing, _create_landings
 from nodes.models import Node
 from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_user_model
 
 from core.user_data import UserDatum
 
@@ -209,6 +210,15 @@ def run_database_tasks(*, latest: bool = False) -> None:
     if data_dir.is_dir():
         personal = sorted(data_dir.glob("*.json"))
         if personal:
+            User = get_user_model()
+            for p in personal:
+                try:
+                    user_id = int(p.stem.split("_", 1)[0])
+                    User.objects.get_or_create(
+                        pk=user_id, defaults={"username": f"user{user_id}"}
+                    )
+                except Exception:
+                    pass
             call_command("loaddata", *[str(p) for p in personal])
             for p in personal:
                 try:

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -283,6 +283,15 @@ class NetMessageAdmin(admin.ModelAdmin):
     search_fields = ("subject", "body")
     list_filter = ("complete",)
     ordering = ("-created",)
+    readonly_fields = ("complete",)
+    actions = ["send_messages"]
+
+    def send_messages(self, request, queryset):
+        for msg in queryset:
+            msg.propagate()
+        self.message_user(request, f"{queryset.count()} messages sent")
+
+    send_messages.short_description = "Send selected messages"
 
 
 class NodeTaskForm(forms.ModelForm):

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
                 ('subject', models.CharField(blank=True, max_length=64)),
                 ('body', models.CharField(blank=True, max_length=256)),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('complete', models.BooleanField(default=False)),
+                ('complete', models.BooleanField(default=False, editable=False)),
                 (
                     'propagated_to',
                     models.ManyToManyField(

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -233,7 +233,7 @@ class NetMessage(Entity):
         Node, blank=True, related_name="received_net_messages"
     )
     created = models.DateTimeField(auto_now_add=True)
-    complete = models.BooleanField(default=False)
+    complete = models.BooleanField(default=False, editable=False)
 
     class Meta:
         ordering = ["-created"]
@@ -293,7 +293,7 @@ class NetMessage(Entity):
             self.save(update_fields=["complete"])
             return
 
-        role_order = ["Control", "Constellation", "Gateway", "Terminal"]
+        role_order = ["Control", "Constellation", "Satellite", "Terminal"]
         selected: list[Node] = []
         for role_name in role_order:
             role_nodes = [n for n in remaining if n.role and n.role.name == role_name]
@@ -313,13 +313,14 @@ class NetMessage(Entity):
                     break
 
         seen_list = seen.copy()
+        selected_ids = [str(n.uuid) for n in selected]
+        payload_seen = seen_list + selected_ids
         for node in selected:
-            seen_list.append(str(node.uuid))
             payload = {
                 "uuid": str(self.uuid),
                 "subject": self.subject,
                 "body": self.body,
-                "seen": seen_list,
+                "seen": payload_seen,
                 "sender": local_id,
             }
             payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)


### PR DESCRIPTION
## Summary
- prevent manual edits to NetMessage completion flag
- expose admin action to propagate network messages and update propagation order
- load personal fixtures after ensuring referenced users exist

## Testing
- `pytest nodes/tests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b263ea4a5483268d7f8ef64d2d4a89