### PR TITLE
Add admin user data screen and buttons

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -10,7 +10,10 @@ class CoreConfig(AppConfig):
     def ready(self):  # pragma: no cover - called by Django
         from django.contrib.auth import get_user_model
         from django.db.models.signals import post_migrate
-        from .user_data import patch_admin_user_datum
+        from .user_data import (
+            patch_admin_user_datum,
+            patch_admin_user_data_views,
+        )
 
         def create_default_admin(**kwargs):
             User = get_user_model()
@@ -19,3 +22,4 @@ class CoreConfig(AppConfig):
 
         post_migrate.connect(create_default_admin, sender=self)
         patch_admin_user_datum()
+        patch_admin_user_data_views()

--- a/core/templates/admin/data_list.html
+++ b/core/templates/admin/data_list.html
@@ -1,0 +1,26 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+<div id="content-main">
+  {% if sections %}
+    {% for section in sections %}
+      <div class="module">
+        <table>
+          <caption>{{ section.opts.verbose_name_plural|capfirst }}</caption>
+          <tbody>
+            {% for item in section.items %}
+            <tr>
+              <th scope="row"><a href="{{ item.url }}">{{ item.label }}</a></th>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endfor %}
+  {% else %}
+    <p>{% trans 'None available' %}</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/core/user_data.py
+++ b/core/user_data.py
@@ -10,6 +10,9 @@ from django.core.management import call_command
 from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext as _
 
 from .entity import Entity
 
@@ -150,3 +153,59 @@ def patch_admin_user_datum() -> None:
             attrs,
         )
         admin.site.register(model, Patched)
+
+
+def _seed_data_view(request):
+    """Display all entities marked as seed data."""
+    sections = []
+    for model, model_admin in admin.site._registry.items():
+        if not issubclass(model, Entity):
+            continue
+        objs = model.objects.filter(is_seed_data=True)
+        if not objs.exists():
+            continue
+        items = []
+        for obj in objs:
+            url = reverse(
+                f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change",
+                args=[obj.pk],
+            )
+            items.append({"url": url, "label": str(obj)})
+        sections.append({"opts": model._meta, "items": items})
+    context = admin.site.each_context(request)
+    context.update({"title": _("Seed Data"), "sections": sections})
+    return TemplateResponse(request, "admin/data_list.html", context)
+
+
+def _user_data_view(request):
+    """Display all user datum entities for the current user."""
+    sections = {}
+    qs = UserDatum.objects.filter(user=request.user).select_related("content_type")
+    for ud in qs:
+        model = ud.content_type.model_class()
+        obj = ud.entity
+        url = reverse(
+            f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change",
+            args=[obj.pk],
+        )
+        section = sections.setdefault(model._meta, [])
+        section.append({"url": url, "label": str(obj)})
+    section_list = [{"opts": opts, "items": items} for opts, items in sections.items()]
+    context = admin.site.each_context(request)
+    context.update({"title": _("User Data"), "sections": section_list})
+    return TemplateResponse(request, "admin/data_list.html", context)
+
+
+def patch_admin_user_data_views() -> None:
+    """Add custom admin views for seed and user data listings."""
+    original_get_urls = admin.site.get_urls
+
+    def get_urls():
+        urls = original_get_urls()
+        custom = [
+            path("seed-data/", admin.site.admin_view(_seed_data_view), name="seed_data"),
+            path("user-data/", admin.site.admin_view(_user_data_view), name="user_data"),
+        ]
+        return custom + urls
+
+    admin.site.get_urls = get_urls

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -88,6 +88,10 @@
 {% block content_title %}
 <div id="admin-home-header" style="display:flex; justify-content:space-between; align-items:center;">
   <h1>Home</h1>
+  <div>
+    <a class="button" href="{% url 'admin:seed_data' %}">{% translate 'Seed Data' %}</a>
+    <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
+  </div>
  </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show Seed Data and new User Data buttons on the admin dashboard
- add custom admin views listing seed data and each user's saved data
- reuse shared template to display entity lists

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b267f8c6c88326834d418fd820329d