### PR TITLE
Add migration for Reference transaction UUID

### DIFF
--- a/core/migrations/0005_reference_transaction_uuid.py
+++ b/core/migrations/0005_reference_transaction_uuid.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+import uuid
+
+
+def assign_transaction_uuids(apps, schema_editor):
+    Reference = apps.get_model("core", "Reference")
+    for ref in Reference.objects.all():
+        ref.transaction_uuid = uuid.uuid4()
+        ref.save(update_fields=["transaction_uuid"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0004_userdatum"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="reference",
+            name="transaction_uuid",
+            field=models.UUIDField(default=uuid.uuid4, editable=True, db_index=True),
+            preserve_default=False,
+        ),
+        migrations.RunPython(assign_transaction_uuids, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add migration introducing `transaction_uuid` field to `Reference`
- populate existing reference rows with unique transaction IDs

## Testing
- `python manage.py migrate`
- `python manage.py loaddata core/fixtures/references.json`
- `python manage.py test` *(fails: NodeAdminTests.test_register_current_host, NodeAdminTests.test_register_current_updates_existing_node, ChargerAdminTests.test_admin_change_links_landing_page)*

------
https://chatgpt.com/codex/tasks/task_e_68b269d4eb58832688f70269421950de