### PR TITLE
Show AWG calculator results above form on mobile

### DIFF
--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -86,7 +86,7 @@
         </select>
       </div>
     </div>
-    <div class="col-lg-6 d-flex flex-column">
+    <div class="col-lg-6 d-flex flex-column{% if result or error or no_cable %} order-first order-lg-last{% endif %}">
       {% if not result and not error and not no_cable %}
       <div class="mb-3">
         <button type="submit" class="btn btn-primary w-100 fs-4">{% trans "Calculate" %}</button>

--- a/awg/tests.py
+++ b/awg/tests.py
@@ -70,6 +70,29 @@ class AWGCalculatorTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "No Suitable Cable Found")
 
+    def test_results_column_reordered_on_mobile(self):
+        url = reverse("awg:calculator")
+        resp = self.client.get(url)
+        content = resp.content.decode()
+        self.assertNotIn("order-first", content)
+        self.assertNotIn("order-lg-last", content)
+
+        data = {
+            "meters": "10",
+            "amps": "40",
+            "volts": "220",
+            "material": "cu",
+            "max_lines": "1",
+            "phases": "2",
+            "temperature": "60",
+            "conduit": "emt",
+            "ground": "1",
+        }
+        resp = self.client.post(url, data)
+        content = resp.content.decode()
+        self.assertIn("order-first", content)
+        self.assertIn("order-lg-last", content)
+
     def test_query_params_prefill_form(self):
         url = (
             reverse("awg:calculator")


### PR DESCRIPTION
## Summary
- Reorder AWG calculator results column on small screens so it appears above the input form
- Add test ensuring result column uses responsive order classes when displaying results

## Testing
- `pytest`
- `python manage.py test awg.tests.AWGCalculatorTests.test_results_column_reordered_on_mobile`


------
https://chatgpt.com/codex/tasks/task_e_68b270109cc88326a9eaa5bc3d8d3962