### PR TITLE
feat(nodes): track LCD screen capability

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -43,6 +43,7 @@ class NodeAdmin(admin.ModelAdmin):
         "public_endpoint",
         "clipboard",
         "screenshot",
+        "lcd",
         "installed_version",
         "role",
         "last_seen",
@@ -70,6 +71,12 @@ class NodeAdmin(admin.ModelAdmin):
 
     screenshot.boolean = True
     screenshot.short_description = "Screenshot"
+
+    def lcd(self, obj):
+        return obj.has_lcd_screen
+
+    lcd.boolean = True
+    lcd.short_description = "LCD"
 
 
     def get_urls(self):

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -47,6 +47,7 @@ class Migration(migrations.Migration):
                 ('base_path', models.CharField(blank=True, max_length=255)),
                 ('installed_version', models.CharField(blank=True, max_length=20)),
                 ('installed_revision', models.CharField(blank=True, max_length=40)),
+                ('has_lcd_screen', models.BooleanField(default=False)),
                 ('role', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='nodes.noderole')),
             ],
             options={


### PR DESCRIPTION
## Summary
- add `has_lcd_screen` flag to nodes and auto-detect during registration
- expose and update LCD flag in API and admin
- skip database migrations during env refresh when running inside test transactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2747e3f608326b1db80f69dfec31e