### PR TITLE
Add EV efficiency calculator

### DIFF
--- a/ocpp/templates/ocpp/efficiency_calculator.html
+++ b/ocpp/templates/ocpp/efficiency_calculator.html
@@ -1,0 +1,50 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "EV Efficiency Calculator" %}{% endblock %}
+{% block content %}
+<style>
+  #efficiency-calculator input.form-control {
+    height: calc(2.25rem + 2px);
+  }
+</style>
+<h1>{% trans "EV Efficiency Calculator" %}</h1>
+<form method="post" id="efficiency-calculator">
+  {% csrf_token %}
+  <div class="row g-4 mb-3">
+    <div class="col-lg-3">
+      <div class="mb-3">
+        <label class="form-label" for="distance">{% trans "Distance (km)" %}</label>
+        <input id="distance" type="number" step="0.01" class="form-control" name="distance" required min="0.01" value="{{ form.distance }}" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="energy">{% trans "Energy Used (kWh)" %}</label>
+        <input id="energy" type="number" step="0.01" class="form-control" name="energy" required min="0.01" value="{{ form.energy }}" />
+      </div>
+    </div>
+    <div class="col-lg-6 d-flex flex-column{% if result or error %} order-first order-lg-last{% endif %}">
+      {% if not result and not error %}
+      <div class="mb-3">
+        <button type="submit" class="btn btn-primary w-100 fs-4">{% trans "Calculate" %}</button>
+      </div>
+      {% else %}
+        {% if error %}
+        <p class="text-danger">{% blocktrans %}Error: {{ error }}{% endblocktrans %}</p>
+        {% elif result %}
+        <div class="calc-result">
+          <h2>{% trans "Calculator Results" %}</h2>
+          <table class="table table-sm">
+            <tbody>
+              <tr><th>{% trans "km per kWh" %}</th><td>{{ result.km_per_kwh|floatformat:2 }}</td></tr>
+              <tr><th>{% trans "Wh per km" %}</th><td>{{ result.wh_per_km|floatformat:2 }}</td></tr>
+            </tbody>
+          </table>
+        </div>
+        {% endif %}
+      <div class="mt-auto mb-3">
+        <button type="submit" class="btn btn-primary w-100 fs-4">{% trans "Calculate Again" %}</button>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -1208,3 +1208,22 @@ class ChargerSessionPaginationTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.context["transactions"]), 15)
+
+
+class EfficiencyCalculatorViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="eff", password="secret", email="eff@example.com"
+        )
+        self.client.force_login(self.user)
+
+    def test_get_view(self):
+        url = reverse("ev-efficiency")
+        resp = self.client.get(url)
+        self.assertContains(resp, "EV Efficiency Calculator")
+
+    def test_post_calculation(self):
+        url = reverse("ev-efficiency")
+        resp = self.client.post(url, {"distance": "100", "energy": "20"})
+        self.assertContains(resp, "5.00")

--- a/ocpp/urls.py
+++ b/ocpp/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("log/<str:cid>/", views.charger_log_page, name="charger-log"),
     path("c/<str:cid>/status/", views.charger_status, name="charger-status"),
     path("rfid/", include("ocpp.rfid.urls")),
+    path("efficiency/", views.efficiency_calculator, name="ev-efficiency"),
 ]

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -7,6 +7,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404
 from django.core.paginator import Paginator
 from django.contrib.auth.decorators import login_required
+from django.utils.translation import gettext_lazy as _
 
 from utils.api import api_login_required
 
@@ -302,6 +303,30 @@ def charger_log_page(request, cid):
         "ocpp/charger_logs.html",
         {"charger": charger, "log": log},
     )
+
+
+@login_required
+@landing("EV Efficiency")
+def efficiency_calculator(request):
+    """Simple EV efficiency calculator."""
+    form = {k: v for k, v in (request.POST or request.GET).items() if v not in (None, "")}
+    context: dict[str, object] = {"form": form}
+    if request.method == "POST":
+        try:
+            distance = float(request.POST.get("distance"))
+            energy = float(request.POST.get("energy"))
+            if distance <= 0 or energy <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            context["error"] = _("Invalid input values")
+        else:
+            km_per_kwh = distance / energy
+            wh_per_km = (energy * 1000) / distance
+            context["result"] = {
+                "km_per_kwh": km_per_kwh,
+                "wh_per_km": wh_per_km,
+            }
+    return render(request, "ocpp/efficiency_calculator.html", context)
 
 @csrf_exempt
 @api_login_required

--- a/pages/fixtures/constellation.json
+++ b/pages/fixtures/constellation.json
@@ -49,6 +49,14 @@
     }
   },
   {
+    "model": "pages.landing",
+    "fields": {
+      "module": ["Constellation", "/ocpp/"],
+      "path": "/ocpp/efficiency/",
+      "label": "EV Efficiency"
+    }
+  },
+  {
     "model": "pages.module",
     "fields": {
       "node_role": [

--- a/pages/fixtures/gway_box.json
+++ b/pages/fixtures/gway_box.json
@@ -32,6 +32,14 @@
     }
   },
   {
+    "model": "pages.landing",
+    "fields": {
+      "module": ["Gateway", "/ocpp/"],
+      "path": "/ocpp/efficiency/",
+      "label": "EV Efficiency"
+    }
+  },
+  {
     "model": "pages.module",
     "fields": {
       "node_role": ["Gateway"],

--- a/pages/fixtures/localhost.json
+++ b/pages/fixtures/localhost.json
@@ -32,6 +32,14 @@
     }
   },
   {
+    "model": "pages.landing",
+    "fields": {
+      "module": ["Terminal", "/ocpp/"],
+      "path": "/ocpp/efficiency/",
+      "label": "EV Efficiency"
+    }
+  },
+  {
     "model": "pages.module",
     "fields": {
       "node_role": ["Terminal"],

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
@@ -21,7 +21,7 @@ from core.models import OdooProfile
 from core.user_data import UserDatum
 
 
-class UserDatumAdminTests(TestCase):
+class UserDatumAdminTests(TransactionTestCase):
     def setUp(self):
         call_command("flush", verbosity=0, interactive=False)
         User = get_user_model()


### PR DESCRIPTION
## Summary
- add EV efficiency calculator view and template styled like AWG calculator
- expose calculator in OCPP module navigation via fixtures
- test calculator behavior
- fix user datum admin test by running migrations outside atomic transactions

## Testing
- `python -m pytest`
- `python manage.py test ocpp.tests.EfficiencyCalculatorViewTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b27351bdc48326844f9c588b4d22b1