### PR TITLE
Rename PackageHub to Package and refresh release

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -34,7 +34,7 @@ from .models import (
     Reference,
     OdooProfile,
     EmailInbox,
-    PackageHub,
+    Package,
     PackageRelease,
     PackagerProfile,
 )
@@ -123,9 +123,9 @@ class PackagerProfileAdmin(admin.ModelAdmin):
     list_display = ("user", "username", "pypi_url")
 
 
-@admin.register(PackageHub)
-class PackageHubAdmin(admin.ModelAdmin):
-    list_display = ("name", "release_manager")
+@admin.register(Package)
+class PackageAdmin(admin.ModelAdmin):
+    list_display = ("name", "description", "homepage_url", "release_manager")
 
 
 @admin.register(SecurityGroup)
@@ -549,14 +549,15 @@ class RFIDAdmin(ImportExportModelAdmin):
 @admin.register(PackageRelease)
 class PackageReleaseAdmin(admin.ModelAdmin):
     list_display = (
-        "hub",
         "version",
+        "package",
         "pypi_url",
         "revision_short",
         "is_promoted",
         "is_certified",
         "is_published",
     )
+    list_display_links = ("version",)
     actions = ["promote_release", "publish_to_index"]
 
     def revision_short(self, obj):
@@ -572,7 +573,7 @@ class PackageReleaseAdmin(admin.ModelAdmin):
                 cfg.promote()
                 cfg.is_promoted = True
                 cfg.save(update_fields=["is_promoted"])
-                self.message_user(request, f"Promoted {cfg.hub.name}", messages.SUCCESS)
+                self.message_user(request, f"Promoted {cfg.package.name}", messages.SUCCESS)
             except ValidationError as exc:
                 self.message_user(request, "; ".join(exc.messages), messages.ERROR)
             except Exception as exc:
@@ -584,7 +585,7 @@ class PackageReleaseAdmin(admin.ModelAdmin):
             if not cfg.is_certified:
                 self.message_user(
                     request,
-                    f"{cfg.hub.name} {cfg.version} is not certified",
+                    f"{cfg.package.name} {cfg.version} is not certified",
                     messages.ERROR,
                 )
                 continue
@@ -592,6 +593,6 @@ class PackageReleaseAdmin(admin.ModelAdmin):
                 cfg.publish()
                 cfg.is_published = True
                 cfg.save(update_fields=["is_published"])
-                self.message_user(request, f"Published {cfg.hub.name}", messages.SUCCESS)
+                self.message_user(request, f"Published {cfg.package.name}", messages.SUCCESS)
             except Exception as exc:
                 self.message_user(request, str(exc), messages.ERROR)

--- a/core/fixtures/package_releases.json
+++ b/core/fixtures/package_releases.json
@@ -11,7 +11,7 @@
     }
   },
   {
-    "model": "core.packagehub",
+    "model": "core.package",
     "pk": 1,
     "fields": {
       "name": "arthexis",
@@ -29,7 +29,7 @@
     "model": "core.packagerelease",
     "pk": 1,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "0.0.0",
       "revision": "",
@@ -43,7 +43,7 @@
     "model": "core.packagerelease",
     "pk": 2,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "0.0.1",
       "revision": "",
@@ -57,7 +57,7 @@
     "model": "core.packagerelease",
     "pk": 3,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "0.1.0",
       "revision": "",
@@ -71,7 +71,7 @@
     "model": "core.packagerelease",
     "pk": 4,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "0.1.1",
       "revision": "",
@@ -85,7 +85,7 @@
     "model": "core.packagerelease",
     "pk": 5,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "0.1.2",
       "revision": "",
@@ -99,7 +99,7 @@
     "model": "core.packagerelease",
     "pk": 6,
     "fields": {
-      "hub": 1,
+      "package": 1,
       "profile": 1,
       "version": "1.0.0",
       "revision": "",

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -748,7 +748,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='PackageHub',
+            name='Package',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
@@ -764,8 +764,8 @@ class Migration(migrations.Migration):
                 ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
             ],
             options={
-                'verbose_name': 'Package Hub',
-                'verbose_name_plural': 'Package Hubs',
+                'verbose_name': 'Package',
+                'verbose_name_plural': 'Packages',
             },
         ),
         migrations.CreateModel(
@@ -780,7 +780,7 @@ class Migration(migrations.Migration):
                 ('is_published', models.BooleanField(default=False)),
                 ('is_promoted', models.BooleanField(default=False, editable=False)),
                 ('is_certified', models.BooleanField(default=False, editable=False)),
-                ('hub', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.packagehub')),
+                ('package', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.package')),
                 ('profile', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
             ],
             options={

--- a/core/migrations/0005_reference_transaction_uuid.py
+++ b/core/migrations/0005_reference_transaction_uuid.py
@@ -19,7 +19,6 @@ class Migration(migrations.Migration):
             model_name="reference",
             name="transaction_uuid",
             field=models.UUIDField(default=uuid.uuid4, editable=True, db_index=True),
-            preserve_default=False,
         ),
         migrations.RunPython(assign_transaction_uuids, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
## Summary
- rename PackageHub model to Package and update release references
- add description and homepage to Package admin list
- recreate upcoming package release during env refresh and link version in admin

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python env-refresh.py database`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b27cca5a6083268bed076965c65ad8