### PR TITLE
Fix footer rendering at bottom of site

### DIFF
--- a/core/templates/core/footer.html
+++ b/core/templates/core/footer.html
@@ -1,0 +1,9 @@
+<footer class="container mt-5 mt-auto">
+  <div class="row">
+    {% for ref in footer_refs %}
+      <div class="col">
+        <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
+      </div>
+    {% endfor %}
+  </div>
+</footer>

--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -1,0 +1,28 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+from core.models import Reference
+
+register = template.Library()
+
+
+@register.simple_tag
+def ref_img(value, size=200, alt=None):
+    """Return an <img> tag with the stored reference image for the value."""
+    ref, created = Reference.objects.get_or_create(
+        value=value, defaults={"alt_text": alt or value}
+    )
+    alt_text = alt or ref.alt_text or "reference"
+    if ref.alt_text != alt_text:
+        ref.alt_text = alt_text
+    ref.uses += 1
+    ref.save()
+    return mark_safe(
+        f'<img src="{ref.image.url}" width="{size}" height="{size}" alt="{ref.alt_text}" />'
+    )
+
+
+@register.inclusion_tag("core/footer.html")
+def render_footer():
+    """Render footer links for references marked to appear there."""
+    return {"footer_refs": Reference.objects.filter(include_in_footer=True)}

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n ref_tags %}
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}" data-bs-theme="light">
   <head>
@@ -152,6 +152,7 @@
       </nav>
       {% block content %}{% endblock %}
     </div>
+    {% render_footer %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       function setTheme(theme) {

--- a/tests/test_footer_render.py
+++ b/tests/test_footer_render.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from core.models import Reference
+
+TMP_MEDIA_ROOT = tempfile.mkdtemp()
+
+
+@override_settings(MEDIA_ROOT=TMP_MEDIA_ROOT)
+class FooterRenderTests(TestCase):
+    def setUp(self):
+        Reference.objects.create(
+            alt_text="Example",
+            value="https://example.com",
+            method="link",
+            include_in_footer=True,
+        )
+        self.client = Client()
+
+    def test_footer_contains_reference(self):
+        response = self.client.get(reverse("pages:login"))
+        self.assertContains(response, "<footer", html=False)
+        self.assertContains(response, "Example")
+        self.assertContains(response, "https://example.com")


### PR DESCRIPTION
## Summary
- Render footer links using new template tag and template.
- Load and invoke footer rendering in base layout.
- Add regression test for footer display.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b28267437483269fe10213848ee025