### PR TITLE
Handle existing release branches and correct PyPI published checks

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -935,11 +935,16 @@ class PackageRelease(Entity):
         self.pypi_url = (
             f"https://pypi.org/project/{self.package.name}/{self.version}/"
         )
+        self.is_published = False
         try:  # pragma: no cover - network check best effort
             import requests
 
-            resp = requests.head(self.pypi_url, timeout=5)
-            self.is_published = resp.status_code == 200
+            resp = requests.get(
+                f"https://pypi.org/pypi/{self.package.name}/json", timeout=5
+            )
+            if resp.ok:
+                releases = resp.json().get("releases", {})
+                self.is_published = self.version in releases
         except Exception:
             self.is_published = False
         super().save(*args, **kwargs)

--- a/core/release.py
+++ b/core/release.py
@@ -347,7 +347,10 @@ def promote(
     current = _current_branch()
     branch = f"release/{version}"
     try:
-        _run(["git", "checkout", "-b", branch])
+        try:
+            _run(["git", "checkout", "-b", branch])
+        except subprocess.CalledProcessError:
+            _run(["git", "checkout", branch])
         build(
             package=package,
             creds=creds,


### PR DESCRIPTION
## Summary
- ensure package release `is_published` reflects real state on PyPI
- allow promotion to reuse existing `release/<version>` branch

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2873300e48326b48696dba1a445b6