### PR TITLE
Refine admin data list layout

### DIFF
--- a/core/templates/admin/data_list.html
+++ b/core/templates/admin/data_list.html
@@ -4,15 +4,15 @@
 {% block extrastyle %}
 {{ block.super }}
 <style>
-  #content-main {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
+  #content-main table {
+    width: 100%;
   }
-
-  #content-main .module {
-    flex: 1 0 calc(50% - 1rem);
-    box-sizing: border-box;
+  #content-main .actions {
+    margin-bottom: 1rem;
+  }
+  #content-main .actions form {
+    display: inline;
+    margin-left: 1rem;
   }
 </style>
 {% endblock %}
@@ -21,33 +21,34 @@
 <h1>{{ title }}</h1>
 <div id="content-main">
   {% if import_export %}
-    <div class="module">
-      <h2>{% trans "User Data" %}</h2>
-      <div class="form-row">
-        <a class="button" href="{% url 'admin:user_data_export' %}">{% trans "Export" %}</a>
-        <form action="{% url 'admin:user_data_import' %}" method="post" enctype="multipart/form-data" style="margin-top:1rem;">
-          {% csrf_token %}
-          <input type="file" name="data_zip" accept=".zip" />
-          <input type="submit" class="button" value="{% trans 'Import' %}" />
-        </form>
-      </div>
+    <div class="actions">
+      <a class="button" href="{% url 'admin:user_data_export' %}">{% trans "Export" %}</a>
+      <form action="{% url 'admin:user_data_import' %}" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        <input type="file" name="data_zip" accept=".zip" />
+        <input type="submit" class="button" value="{% trans 'Import' %}" />
+      </form>
     </div>
   {% endif %}
   {% if sections %}
-    {% for section in sections %}
-      <div class="module">
-        <table>
-          <caption>{{ section.opts.verbose_name_plural|capfirst }}</caption>
-          <tbody>
-            {% for item in section.items %}
-            <tr>
-              <th scope="row"><a href="{{ item.url }}">{{ item.label }}</a></th>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    {% endfor %}
+    <table>
+      <thead>
+        <tr>
+          <th>{% trans "Model" %}</th>
+          <th>{% trans "Entity" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for section in sections %}
+          {% for item in section.items %}
+          <tr>
+            <td>{{ section.opts.verbose_name|capfirst }}</td>
+            <td><a href="{{ item.url }}">{{ item.label }}</a></td>
+          </tr>
+          {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
   {% else %}
     <p>{% trans 'None available' %}</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- present Seed Data and User Data in a single full-width table
- move import/export links above the table and avoid duplicate headings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b28be1a3a88326876561f7a771fa28