### PR TITLE
Sync page theme with debug toolbar

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -196,6 +196,29 @@
           setTheme('dark');
         }
       })();
+
+      function syncDebugToolbarTheme() {
+        const button = document.getElementById('djToggleThemeButton');
+        if (!button) {
+          return;
+        }
+        const apply = () => {
+          const djdtTheme = localStorage.getItem('djdt.user-theme');
+          if (!djdtTheme) {
+            return;
+          }
+          const resolved = djdtTheme === 'auto'
+            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : djdtTheme;
+          setTheme(resolved);
+        };
+        button.addEventListener('click', () => {
+          setTimeout(apply);
+        });
+        apply();
+      }
+
+      window.addEventListener('load', syncDebugToolbarTheme);
     </script>
     <script>
       document.querySelectorAll('.nav-item.dropdown').forEach(item => {


### PR DESCRIPTION
## Summary
- synchronize site theme with Django Debug Toolbar's theme toggle
- update theme when toolbar's theme button changes localStorage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b290a159c48326ad3051db08efffb0