### PR TITLE
Display fixture file names in data listings

### DIFF
--- a/core/templates/admin/data_list.html
+++ b/core/templates/admin/data_list.html
@@ -38,6 +38,7 @@
           <th>{% trans "App" %}</th>
           <th>{% trans "Model" %}</th>
           <th>{% trans "Entity" %}</th>
+          <th>{% trans "Fixture" %}</th>
         </tr>
       </thead>
       <tbody>
@@ -47,6 +48,7 @@
             <td>{{ section.opts.app_config.verbose_name|capfirst }}</td>
             <td>{{ section.opts.verbose_name|capfirst }}</td>
             <td><a href="{{ item.url }}">{{ item.label }}</a></td>
+            <td>{{ item.fixture }}</td>
           </tr>
           {% endfor %}
         {% endfor %}

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -158,6 +158,7 @@ class UserDataViewTests(TestCase):
         url = reverse("admin:user_data")
         response = self.client.get(url)
         self.assertContains(response, str(self.profile))
+        self.assertContains(response, self.fixture_path.name)
 
     def test_admin_index_shows_buttons(self):
         response = self.client.get(reverse("admin:index"))


### PR DESCRIPTION
## Summary
- show fixture file names alongside seed and user data in admin tables
- compute fixture names for seed data by scanning fixture directories
- test seed and user data views include fixture column

## Testing
- `pytest tests/test_user_datum_admin.py tests/test_seed_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68b298dc91d88326a4f8865abfb0bfd4