### PR TITLE
Skip debug toolbar when unavailable

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -145,7 +145,12 @@ INSTALLED_APPS = [
 ] + LOCAL_APPS
 
 if DEBUG:
-    INSTALLED_APPS += ["debug_toolbar"]
+    try:
+        import debug_toolbar  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        pass
+    else:
+        INSTALLED_APPS += ["debug_toolbar"]
 
 SITE_ID = 1
 
@@ -163,8 +168,13 @@ MIDDLEWARE = [
 ]
 
 if DEBUG:
-    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
-    INTERNAL_IPS = ["127.0.0.1", "localhost"]
+    try:
+        import debug_toolbar  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        pass
+    else:
+        MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+        INTERNAL_IPS = ["127.0.0.1", "localhost"]
 
 CSRF_FAILURE_VIEW = "pages.views.csrf_failure"
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -69,8 +69,12 @@ urlpatterns = [
 urlpatterns += autodiscovered_urlpatterns()
 
 if settings.DEBUG:
-    import debug_toolbar
+    try:
+        import debug_toolbar
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        pass
+    else:
+        urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
 
-    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
## Summary
- avoid crashing when `debug_toolbar` is missing by importing it conditionally in settings and URLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b29b0f643c832695c021f972952246