### PR TITLE
Fix energy account fixture user reference

### DIFF
--- a/core/fixtures/energy_accounts.json
+++ b/core/fixtures/energy_accounts.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "name": "GELECTRIIC",
-      "user": ["admin"],
+      "user": 2,
       "rfids": [1],
       "service_account": true
     }


### PR DESCRIPTION
## Summary
- Reference arthexis user by primary key in energy account fixture to avoid DeserializationError during `loaddata`

## Testing
- `python env-refresh.py database`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b29c86a5f48326af0db9a70d629569