### PR TITLE
Preserve user theme selection across navigation

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -203,6 +203,9 @@
           return;
         }
         const apply = () => {
+          if (localStorage.getItem('theme')) {
+            return;
+          }
           const djdtTheme = localStorage.getItem('djdt.user-theme');
           if (!djdtTheme) {
             return;


### PR DESCRIPTION
## Summary
- prevent Django debug toolbar theme sync from overriding saved theme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b29f53cc4c8326bd073ebcee31a6f7