### PR TITLE
fix: prevent upgrade script from hanging

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -98,5 +98,6 @@ echo "Refreshing environment..."
 ./env-refresh.sh $ENV_ARGS
 if [[ $NO_RESTART -eq 0 ]]; then
   echo "Restarting services..."
-  ./start.sh
+  nohup ./start.sh >/dev/null 2>&1 &
+  echo "Services restarted"
 fi


### PR DESCRIPTION
## Summary
- run start script in background during upgrade to avoid hanging terminal

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30a9814348326bfb5cdbbd00ba6b1