### PR TITLE
Refine footer layout and display version info

### DIFF
--- a/core/templates/core/footer.html
+++ b/core/templates/core/footer.html
@@ -1,9 +1,18 @@
-<footer class="container mt-5 mt-auto">
+<footer class="container mt-5 mt-auto border-top pt-3">
   <div class="row">
-    {% for ref in footer_refs %}
-      <div class="col">
-        <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
+    {% for column in footer_columns %}
+      <div class="col-6 col-md-2">
+        <ul class="list-unstyled">
+          {% for ref in column %}
+            <li><a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a></li>
+          {% endfor %}
+        </ul>
       </div>
     {% endfor %}
+  </div>
+  <div class="row mt-3">
+    <div class="col text-center">
+      <small class="text-muted">v{{ version }}{% if revision %} r{{ revision }}{% endif %}</small>
+    </div>
   </div>
 </footer>

--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 from django import template
+from django.conf import settings
 from django.utils.safestring import mark_safe
 
 from core.models import Reference
+from utils import revision
 
 register = template.Library()
 
@@ -25,4 +29,19 @@ def ref_img(value, size=200, alt=None):
 @register.inclusion_tag("core/footer.html")
 def render_footer():
     """Render footer links for references marked to appear there."""
-    return {"footer_refs": Reference.objects.filter(include_in_footer=True)}
+    refs = list(Reference.objects.filter(include_in_footer=True))
+    columns = [refs[i::6] for i in range(6)]
+
+    version = ""
+    ver_path = Path(settings.BASE_DIR) / "VERSION"
+    if ver_path.exists():
+        version = ver_path.read_text().strip()
+
+    revision_value = revision.get_revision()
+    rev_short = revision_value[-6:] if revision_value else ""
+
+    return {
+        "footer_columns": columns,
+        "version": version,
+        "revision": rev_short,
+    }

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -79,7 +79,7 @@
     </style>
   </head>
   <body class="p-3 pb-0 d-flex flex-column min-vh-100">
-    <div class="container flex-grow-1">
+    <div class="container flex-grow-1 mb-5">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
         <div class="container-fluid">
           <a class="navbar-brand" href="/">{{ badge_site_name|default:"Arthexis" }}</a>

--- a/tests/test_footer_render.py
+++ b/tests/test_footer_render.py
@@ -13,6 +13,7 @@ from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from core.models import Reference
+from utils import revision
 
 TMP_MEDIA_ROOT = tempfile.mkdtemp()
 
@@ -33,3 +34,8 @@ class FooterRenderTests(TestCase):
         self.assertContains(response, "<footer", html=False)
         self.assertContains(response, "Example")
         self.assertContains(response, "https://example.com")
+        version = Path("VERSION").read_text().strip()
+        rev_short = revision.get_revision()[-6:]
+        self.assertContains(response, f"v{version}")
+        if rev_short:
+            self.assertContains(response, f"r{rev_short}")


### PR DESCRIPTION
## Summary
- show footer links in six reusable columns
- display version and git revision at the footer
- add extra spacing between content and footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2a05b777083269067ad2eb9a24cb0