### PR TITLE
Manage Celery via dedicated systemd services

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,18 @@ if [ -f "$LOCK_DIR/service.lck" ]; then
         sudo systemctl status "$LCD_SERVICE" --no-pager || true
       fi
     fi
+    if [ -f "$LOCK_DIR/celery.lck" ]; then
+      CELERY_SERVICE="celery-$SERVICE_NAME"
+      CELERY_BEAT_SERVICE="celery-beat-$SERVICE_NAME"
+      if systemctl list-unit-files | grep -Fq "${CELERY_SERVICE}.service"; then
+        sudo systemctl restart "$CELERY_SERVICE"
+        sudo systemctl status "$CELERY_SERVICE" --no-pager || true
+      fi
+      if systemctl list-unit-files | grep -Fq "${CELERY_BEAT_SERVICE}.service"; then
+        sudo systemctl restart "$CELERY_BEAT_SERVICE"
+        sudo systemctl status "$CELERY_BEAT_SERVICE" --no-pager || true
+      fi
+    fi
     exit 0
   fi
 fi

--- a/stop.sh
+++ b/stop.sh
@@ -20,6 +20,18 @@ if [ -f "$LOCK_DIR/service.lck" ]; then
   if systemctl list-unit-files | grep -Fq "${SERVICE_NAME}.service"; then
     sudo systemctl stop "$SERVICE_NAME"
     sudo systemctl status "$SERVICE_NAME" --no-pager || true
+    if [ -f "$LOCK_DIR/celery.lck" ]; then
+      CELERY_SERVICE="celery-$SERVICE_NAME"
+      CELERY_BEAT_SERVICE="celery-beat-$SERVICE_NAME"
+      if systemctl list-unit-files | grep -Fq "${CELERY_BEAT_SERVICE}.service"; then
+        sudo systemctl stop "$CELERY_BEAT_SERVICE" || true
+        sudo systemctl status "$CELERY_BEAT_SERVICE" --no-pager || true
+      fi
+      if systemctl list-unit-files | grep -Fq "${CELERY_SERVICE}.service"; then
+        sudo systemctl stop "$CELERY_SERVICE" || true
+        sudo systemctl status "$CELERY_SERVICE" --no-pager || true
+      fi
+    fi
     if [ -f "$LCD_LOCK" ]; then
       LCD_SERVICE="lcd-$SERVICE_NAME"
       "$PYTHON" - <<'PY'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -61,6 +61,27 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
         fi
         rm -f "$LOCK_DIR/lcd_screen.lck"
     fi
+    if [ -f "$LOCK_DIR/celery.lck" ]; then
+        CELERY_SERVICE="celery-$SERVICE"
+        CELERY_SERVICE_FILE="/etc/systemd/system/${CELERY_SERVICE}.service"
+        if systemctl list-unit-files | grep -Fq "${CELERY_SERVICE}.service"; then
+            sudo systemctl stop "$CELERY_SERVICE" || true
+            sudo systemctl disable "$CELERY_SERVICE" || true
+            if [ -f "$CELERY_SERVICE_FILE" ]; then
+                sudo rm "$CELERY_SERVICE_FILE"
+            fi
+        fi
+        CELERY_BEAT_SERVICE="celery-beat-$SERVICE"
+        CELERY_BEAT_SERVICE_FILE="/etc/systemd/system/${CELERY_BEAT_SERVICE}.service"
+        if systemctl list-unit-files | grep -Fq "${CELERY_BEAT_SERVICE}.service"; then
+            sudo systemctl stop "$CELERY_BEAT_SERVICE" || true
+            sudo systemctl disable "$CELERY_BEAT_SERVICE" || true
+            if [ -f "$CELERY_BEAT_SERVICE_FILE" ]; then
+                sudo rm "$CELERY_BEAT_SERVICE_FILE"
+            fi
+        fi
+        rm -f "$LOCK_DIR/celery.lck"
+    fi
     rm -f "$LOCK_DIR/service.lck"
 else
     pkill -f "manage.py runserver" || true


### PR DESCRIPTION
## Summary
- install dedicated `celery` and `celery-beat` systemd units when Celery is enabled
- start/stop/upgrade scripts manage Celery services alongside the main service
- uninstall removes Celery units cleanly
- upgrade migrates existing combined service units to the new separate Celery services

## Testing
- `bash -n install.sh start.sh stop.sh uninstall.sh upgrade.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30a9814348326bfb5cdbbd00ba6b1