### PR TITLE
Ensure stop script handles missing sudo non-interactively

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -14,37 +14,44 @@ if [ -d "$BASE_DIR/.venv" ]; then
   PYTHON="$BASE_DIR/.venv/bin/python"
 fi
 
+# Use non-interactive sudo if available
+SUDO="sudo -n"
+if ! $SUDO true 2>/dev/null; then
+  SUDO=""
+fi
+
 # If a systemd service was installed, stop it instead of killing processes
 if [ -f "$LOCK_DIR/service.lck" ]; then
   SERVICE_NAME="$(cat "$LOCK_DIR/service.lck")"
   if systemctl list-unit-files | grep -Fq "${SERVICE_NAME}.service"; then
-    sudo systemctl stop "$SERVICE_NAME"
-    sudo systemctl status "$SERVICE_NAME" --no-pager || true
-    if [ -f "$LOCK_DIR/celery.lck" ]; then
-      CELERY_SERVICE="celery-$SERVICE_NAME"
-      CELERY_BEAT_SERVICE="celery-beat-$SERVICE_NAME"
-      if systemctl list-unit-files | grep -Fq "${CELERY_BEAT_SERVICE}.service"; then
-        sudo systemctl stop "$CELERY_BEAT_SERVICE" || true
-        sudo systemctl status "$CELERY_BEAT_SERVICE" --no-pager || true
+    if $SUDO systemctl stop "$SERVICE_NAME" 2>/dev/null; then
+      $SUDO systemctl status "$SERVICE_NAME" --no-pager || true
+      if [ -f "$LOCK_DIR/celery.lck" ]; then
+        CELERY_SERVICE="celery-$SERVICE_NAME"
+        CELERY_BEAT_SERVICE="celery-beat-$SERVICE_NAME"
+        if systemctl list-unit-files | grep -Fq "${CELERY_BEAT_SERVICE}.service"; then
+          $SUDO systemctl stop "$CELERY_BEAT_SERVICE" || true
+          $SUDO systemctl status "$CELERY_BEAT_SERVICE" --no-pager || true
+        fi
+        if systemctl list-unit-files | grep -Fq "${CELERY_SERVICE}.service"; then
+          $SUDO systemctl stop "$CELERY_SERVICE" || true
+          $SUDO systemctl status "$CELERY_SERVICE" --no-pager || true
+        fi
       fi
-      if systemctl list-unit-files | grep -Fq "${CELERY_SERVICE}.service"; then
-        sudo systemctl stop "$CELERY_SERVICE" || true
-        sudo systemctl status "$CELERY_SERVICE" --no-pager || true
-      fi
-    fi
-    if [ -f "$LCD_LOCK" ]; then
-      LCD_SERVICE="lcd-$SERVICE_NAME"
-      "$PYTHON" - <<'PY'
+      if [ -f "$LCD_LOCK" ]; then
+        LCD_SERVICE="lcd-$SERVICE_NAME"
+        "$PYTHON" - <<'PY'
 from core.notifications import notify
 notify("Goodbye!")
 PY
-      sleep 1
-      if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
-        sudo systemctl stop "$LCD_SERVICE"
-        sudo systemctl status "$LCD_SERVICE" --no-pager || true
+        sleep 1
+        if systemctl list-unit-files | grep -Fq "${LCD_SERVICE}.service"; then
+          $SUDO systemctl stop "$LCD_SERVICE" || true
+          $SUDO systemctl status "$LCD_SERVICE" --no-pager || true
+        fi
       fi
+      exit 0
     fi
-    exit 0
   fi
 fi
 
@@ -70,26 +77,25 @@ while [[ $# -gt 0 ]]; do
 done
 
 PATTERN="manage.py runserver"
-# Assumes passwordless sudo for process management
 if [ "$ALL" = true ]; then
-  sudo pkill -f "$PATTERN" || true
+  pkill -f "$PATTERN" || true
 else
-  sudo pkill -f "$PATTERN 0.0.0.0:$PORT" || true
+  pkill -f "$PATTERN 0.0.0.0:$PORT" || true
 fi
 # Also stop any Celery components started by start.sh
-sudo pkill -f "celery -A config" || true
+pkill -f "celery -A config" || true
 
 # Wait for processes to fully terminate
 if [ "$ALL" = true ]; then
-  while sudo pgrep -f "$PATTERN" > /dev/null; do
+  while pgrep -f "$PATTERN" >/dev/null 2>&1; do
     sleep 0.5
   done
 else
-  while sudo pgrep -f "$PATTERN 0.0.0.0:$PORT" > /dev/null; do
+  while pgrep -f "$PATTERN 0.0.0.0:$PORT" >/dev/null 2>&1; do
     sleep 0.5
   done
 fi
-while sudo pgrep -f "celery -A config" > /dev/null; do
+while pgrep -f "celery -A config" >/dev/null 2>&1; do
   sleep 0.5
 done
 


### PR DESCRIPTION
## Summary
- prevent `stop.sh` from prompting for sudo passwords by using non-interactive sudo
- fall back to process termination when service stop fails
- remove unnecessary sudo usage in process kill/wait loops

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3362a4f64832686be0fe33eaa954b