### PR TITLE
Ensure --latest replays migrations and restarts server

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,9 @@
         {
             "label": "Dev: refresh",
             "type": "shell",
-            "command": "${workspaceFolder}/env-refresh.sh",
+            "command": "${workspaceFolder}/env-refresh.sh --latest",
             "windows": {
-                "command": "${workspaceFolder}\\env-refresh.bat"
+                "command": "${workspaceFolder}\\env-refresh.bat --latest"
             },
             "problemMatcher": [],
             "detail": "Refresh virtual environment and database"
@@ -14,9 +14,9 @@
         {
             "label": "Dev: refresh clean",
             "type": "shell",
-            "command": "rm -f ${workspaceFolder}/db.sqlite3 && ${workspaceFolder}/env-refresh.sh",
+            "command": "rm -f ${workspaceFolder}/db.sqlite3 && ${workspaceFolder}/env-refresh.sh --latest",
             "windows": {
-                "command": "Remove-Item -ErrorAction SilentlyContinue \"${workspaceFolder}\\db.sqlite3\"; ${workspaceFolder}\\env-refresh.bat"
+                "command": "Remove-Item -ErrorAction SilentlyContinue \"${workspaceFolder}\\db.sqlite3\"; ${workspaceFolder}\\env-refresh.bat --latest"
             },
             "problemMatcher": [],
             "detail": "Delete database file and refresh virtual environment and database"

--- a/env-refresh.bat
+++ b/env-refresh.bat
@@ -6,6 +6,11 @@ if not exist %VENV%\Scripts\python.exe (
     echo Virtual environment not found. Run install.sh first.
     exit /b 1
 )
+set RUNNING=0
+for /f %%p in ('powershell -NoProfile -Command "Get-CimInstance Win32_Process ^| Where-Object { $_.CommandLine -match 'manage.py runserver' } ^| Select-Object -First 1 -ExpandProperty ProcessId"') do set RUNNING=1
+if %RUNNING%==1 (
+    powershell -NoProfile -Command "Get-CimInstance Win32_Process ^| Where-Object { $_.CommandLine -match 'manage.py runserver' } ^| ForEach-Object { Stop-Process -Id $_.ProcessId }"
+)
 if exist requirements.txt (
     for /f "skip=1 tokens=1" %%h in ('certutil -hashfile requirements.txt MD5') do (
         if not defined REQ_HASH set REQ_HASH=%%h
@@ -22,4 +27,7 @@ if %LATEST%==1 (
     %VENV%\Scripts\python.exe env-refresh.py --latest database
 ) else (
     %VENV%\Scripts\python.exe env-refresh.py database
+)
+if %RUNNING%==1 (
+    start "" "%~dp0start.bat" --reload
 )

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -28,6 +28,12 @@ if [ ! -f "$PYTHON" ]; then
   exit 1
 fi
 
+RUNNING=0
+if pgrep -f "manage.py runserver" >/dev/null 2>&1; then
+  RUNNING=1
+  "$SCRIPT_DIR/stop.sh" --all >/dev/null 2>&1 || true
+fi
+
 if [ -f requirements.txt ]; then
   REQ_FILE="requirements.txt"
   MD5_FILE="requirements.md5"
@@ -44,4 +50,8 @@ if [ "$LATEST" -eq 1 ]; then
   "$PYTHON" env-refresh.py --latest database
 else
   "$PYTHON" env-refresh.py database
+fi
+
+if [ "$RUNNING" -eq 1 ]; then
+  nohup "$SCRIPT_DIR/start.sh" --reload >/dev/null 2>&1 &
 fi


### PR DESCRIPTION
## Summary
- replay latest migration set when `--latest` is used
- restart any running dev server during env refresh on both Unix and Windows
- run VS Code refresh tasks with `--latest`

## Testing
- `./env-refresh.sh --latest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b33c92aed08326be557653bce71003