### PR TITLE
Gate RFID reader to control nodes

### DIFF
--- a/ocpp/apps.py
+++ b/ocpp/apps.py
@@ -1,4 +1,6 @@
 from django.apps import AppConfig
+from pathlib import Path
+from django.conf import settings
 
 
 class OcppConfig(AppConfig):
@@ -7,6 +9,9 @@ class OcppConfig(AppConfig):
     verbose_name = "OCPP"
 
     def ready(self):  # pragma: no cover - startup side effects
+        lock = Path(settings.BASE_DIR) / "locks" / "control.lck"
+        if not lock.exists():
+            return
         from .rfid.background_reader import start
         from .rfid.signals import tag_scanned
         from core.notifications import notify

--- a/tests/test_rfid_background_reader.py
+++ b/tests/test_rfid_background_reader.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.apps import apps
+from pathlib import Path
+from django.conf import settings
+from unittest.mock import patch
+
+
+class RFIDBackgroundReaderTests(TestCase):
+    def setUp(self):
+        self.lock = Path(settings.BASE_DIR) / "locks" / "control.lck"
+        self.lock.parent.mkdir(exist_ok=True)
+        if self.lock.exists():
+            self.lock.unlink()
+
+    def tearDown(self):
+        if self.lock.exists():
+            self.lock.unlink()
+
+    def _call_ready(self):
+        app_config = apps.get_app_config("ocpp")
+        app_config.ready()
+
+    def test_start_not_called_without_lock(self):
+        with patch("ocpp.rfid.background_reader.start") as mock_start:
+            self._call_ready()
+            self.assertFalse(mock_start.called)
+
+    def test_start_called_with_lock(self):
+        self.lock.touch()
+        with patch("ocpp.rfid.background_reader.start") as mock_start:
+            self._call_ready()
+            self.assertTrue(mock_start.called)


### PR DESCRIPTION
## Summary
- start RFID background reader only when control node lock is present
- add tests covering control lock behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3452ad8a48326b2abe486f1dd2983