### PR TITLE
Explicit debug toolbar namespace

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -74,7 +74,12 @@ if settings.DEBUG:
     except ModuleNotFoundError:  # pragma: no cover - optional dependency
         pass
     else:
-        urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+        urlpatterns = [
+            path(
+                "__debug__/",
+                include(("debug_toolbar.urls", "debug_toolbar"), namespace="debug_toolbar"),
+            )
+        ] + urlpatterns
 
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
## Summary
- Ensure debug toolbar URL inclusion uses an explicit `debug_toolbar` namespace
- Verified no other debug toolbar URL patterns exist

## Testing
- `NODE_ROLE=Terminal python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68b380de982c8326afdc65aee3094546