### PR TITLE
fix: correct static URL to restore admin styles

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -302,8 +302,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = "static/"
-MEDIA_URL = "media/"
+STATIC_URL = "/static/"
+MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 # Email settings


### PR DESCRIPTION
## Summary
- fix static and media URLs to be absolute so admin assets load correctly

## Testing
- `pytest` *(fails: IntegrityError in ReleaseProgressTests)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f7fbf548326873f08b292107615