### PR TITLE
Ensure runserver serves static assets

### DIFF
--- a/app/management/commands/runserver.py
+++ b/app/management/commands/runserver.py
@@ -1,10 +1,23 @@
 import os
 import webbrowser
 
-from daphne.management.commands.runserver import Command as RunserverCommand
+from django.apps import apps
+from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+from daphne.management.commands.runserver import (
+    Command as RunserverCommand,
+    get_default_application,
+)
 
 class Command(RunserverCommand):
     """Extended runserver command that also prints WebSocket URLs and admin link."""
+
+    def get_application(self, options):
+        """Serve static files even when DEBUG is False."""
+        staticfiles_installed = apps.is_installed("django.contrib.staticfiles")
+        use_static_handler = options.get("use_static_handler", staticfiles_installed)
+        if use_static_handler:
+            return ASGIStaticFilesHandler(get_default_application())
+        return get_default_application()
 
     def on_bind(self, server_port):
         super().on_bind(server_port)


### PR DESCRIPTION
## Summary
- serve static files in the custom runserver command regardless of DEBUG

## Testing
- `pytest`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68b39fbb0aa48326b490cbc6c76019ce