### PR TITLE
Handle missing models in personal fixtures

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -267,7 +267,7 @@ def run_database_tasks(*, latest: bool = False) -> None:
                     )
                 except Exception:
                     pass
-            call_command("loaddata", *[str(p) for p in personal])
+            call_command("loaddata", *[str(p) for p in personal], ignorenonexistent=True)
             for p in personal:
                 try:
                     user_id, app_label, model, obj_id = p.stem.split("_", 3)


### PR DESCRIPTION
## Summary
- avoid env-refresh crash when personal fixtures reference removed models

## Testing
- `pytest tests/test_seed_data.py -q`
- `python env-refresh.py database`

------
https://chatgpt.com/codex/tasks/task_e_68b3a5a137148326a9c55ed8befff23b