### PR TITLE
Clean up unpromoted releases on startup

### DIFF
--- a/tests/test_node_release_cleanup.py
+++ b/tests/test_node_release_cleanup.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import TestCase
+
+from core.models import Package, PackageRelease
+from nodes.apps import _ensure_release
+from utils import revision
+
+
+class EnsureReleaseTests(TestCase):
+    def test_ensure_release_updates_and_cleans(self):
+        package, _ = Package.objects.get_or_create(name="arthexis")
+        stale = PackageRelease.objects.create(package=package, version="0.0.0")
+        version = Path("VERSION").read_text().strip()
+        release = PackageRelease.objects.get(package=package, version=version)
+        release.revision = "old"
+        release.save(update_fields=["revision"])
+
+        _ensure_release()
+
+        current_rev = revision.get_revision()
+        release.refresh_from_db()
+        self.assertEqual(release.revision, current_rev)
+        self.assertFalse(PackageRelease.objects.filter(pk=stale.pk).exists())
+        self.assertEqual(
+            PackageRelease.objects.filter(package=package).count(), 1
+        )

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -34,7 +34,7 @@ class ReleaseProgressTests(TestCase):
         url = reverse("release-progress", args=[release.pk, "promote"])
         commit_hash = "abcdef1234567890"
         with patch("core.views.release_utils.promote", return_value=(commit_hash, "branch", "main")), \
-             patch("core.views.call_command"), \
+             patch("core.views.serializers.serialize", return_value="[]"), \
              patch("core.views.subprocess.run"):
             resp = self.client.get(url, follow=True)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- prune package release fixtures to only include promoted releases
- ensure nodes auto-create or update current release and remove stale ones
- add regression test for release cleanup and adjust promotion test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3ae453f208326b22d856901413ab6