### PR TITLE
Show upgrade freshness in footer when auto-upgrade enabled

### DIFF
--- a/core/templates/core/footer.html
+++ b/core/templates/core/footer.html
@@ -15,5 +15,6 @@
     {% else %}
       {{ release_name }}
     {% endif %}
+    {% if fresh_since %} fresh since {{ fresh_since }}{% endif %}
   </small>
 </div>

--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -1,15 +1,21 @@
+from datetime import datetime, timezone as dt_timezone
 from pathlib import Path
 
 from django import template
 from django.conf import settings
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils import timezone
+from django.utils.timesince import timesince
 
 from core.models import Reference, PackageRelease
 from core.release import DEFAULT_PACKAGE
 from utils import revision
 
 register = template.Library()
+
+
+INSTANCE_START = timezone.now()
 
 
 @register.simple_tag
@@ -52,11 +58,28 @@ def render_footer(context):
                 "admin:core_packagerelease_change", args=[release.pk]
             )
 
+    base_dir = Path(settings.BASE_DIR)
+    fresh_since = None
+    if (base_dir / "AUTO_UPGRADE").exists() and (base_dir / "locks/celery.lck").exists():
+        log_file = base_dir / "logs/auto-upgrade.log"
+        last_run = INSTANCE_START
+        if log_file.exists():
+            try:
+                last_line = log_file.read_text().strip().splitlines()[-1]
+                timestamp = last_line.split()[0]
+                last_run = datetime.fromisoformat(timestamp)
+                if timezone.is_naive(last_run):
+                    last_run = last_run.replace(tzinfo=dt_timezone.utc)
+            except Exception:
+                last_run = INSTANCE_START
+        fresh_since = timesince(last_run, timezone.now()) + " ago"
+
     context.update(
         {
             "footer_refs": refs,
             "release_name": release_name,
             "release_url": release_url,
+            "fresh_since": fresh_since,
         }
     )
     return context

--- a/tests/test_footer_admin_link.py
+++ b/tests/test_footer_admin_link.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from core.models import Package, PackageRelease
 
@@ -34,3 +38,54 @@ class FooterAdminLinkTests(TestCase):
         html = self._render(self.user)
         url = reverse("admin:core_packagerelease_change", args=[self.release.pk])
         self.assertNotIn(f'href="{url}"', html)
+
+    def test_shows_fresh_since_in_auto_upgrade_mode(self):
+        base_dir = Path(settings.BASE_DIR)
+        auto_upgrade = base_dir / "AUTO_UPGRADE"
+        locks_dir = base_dir / "locks"
+        logs_dir = base_dir / "logs"
+        pre_locks = locks_dir.exists()
+        try:
+            auto_upgrade.write_text("version")
+            locks_dir.mkdir(exist_ok=True)
+            (locks_dir / "celery.lck").touch()
+            logs_dir.mkdir(exist_ok=True)
+            now = timezone.now()
+            (logs_dir / "auto-upgrade.log").write_text(
+                f"{now.isoformat()} check_github_updates triggered\n"
+            )
+            html = self._render(self.user)
+            self.assertIn("fresh since", html)
+        finally:
+            if auto_upgrade.exists():
+                auto_upgrade.unlink()
+            celery_lock = locks_dir / "celery.lck"
+            if celery_lock.exists():
+                celery_lock.unlink()
+            log_file = logs_dir / "auto-upgrade.log"
+            if log_file.exists():
+                log_file.unlink()
+            if not pre_locks and locks_dir.exists():
+                try:
+                    locks_dir.rmdir()
+                except OSError:
+                    pass
+
+    def test_does_not_show_fresh_since_without_auto_upgrade(self):
+        base_dir = Path(settings.BASE_DIR)
+        locks_dir = base_dir / "locks"
+        pre_locks = locks_dir.exists()
+        try:
+            locks_dir.mkdir(exist_ok=True)
+            (locks_dir / "celery.lck").touch()
+            html = self._render(self.user)
+            self.assertNotIn("fresh since", html)
+        finally:
+            celery_lock = locks_dir / "celery.lck"
+            if celery_lock.exists():
+                celery_lock.unlink()
+            if not pre_locks and locks_dir.exists():
+                try:
+                    locks_dir.rmdir()
+                except OSError:
+                    pass


### PR DESCRIPTION
## Summary
- display "fresh since" with humanized time of last upgrade check in footer when Celery and AUTO_UPGRADE are enabled
- parse auto-upgrade log and fall back to instance start time if no checks have run
- test footer behaviour for auto-upgrade scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b107d3748326ada049d53918f9a4