### PR TITLE
Add inactivity-based auto-reload for homepage

### DIFF
--- a/pages/templates/pages/readme.html
+++ b/pages/templates/pages/readme.html
@@ -15,4 +15,20 @@
     {{ content|safe }}
   </div>
 </div>
+<script>
+  (function () {
+    const RELOAD_DELAY = 5 * 60 * 1000;
+    let timer;
+    const resetTimer = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        window.location.reload();
+      }, RELOAD_DELAY);
+    };
+    ["click", "mousemove", "keydown", "scroll", "touchstart"].forEach((evt) => {
+      document.addEventListener(evt, resetTimer, { passive: true });
+    });
+    resetTimer();
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- auto-reload homepage after 5 minutes of inactivity

## Testing
- `pytest` *(fails: tests/test_footer_admin_link.py::FooterAdminLinkTests::test_shows_fresh_since_in_auto_upgrade_mode - AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b5c2f3108326b1a8b5887889c195