### PR TITLE
fix: enable autoreload in VS Code debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             },
             "program": "${workspaceFolder}/vscode_manage.py",
             "args": ["runserver"],
-            "django": true
+            "subProcess": true
         }
     ]
 }

--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -58,10 +58,27 @@ def render_footer(context):
                 "admin:core_packagerelease_change", args=[release.pk]
             )
 
+    fresh_since = None
+    base_dir = Path(settings.BASE_DIR)
+    auto_upgrade = base_dir / "AUTO_UPGRADE"
+    lock_file = base_dir / "locks" / "celery.lck"
+    log_file = base_dir / "logs" / "auto-upgrade.log"
+    if auto_upgrade.exists() and lock_file.exists() and log_file.exists():
+        try:
+            first_line = log_file.read_text().splitlines()[0]
+            timestamp = first_line.split(" ", 1)[0]
+            dt = datetime.fromisoformat(timestamp)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=dt_timezone.utc)
+            fresh_since = timesince(dt, timezone.now())
+        except Exception:
+            fresh_since = None
+
     return {
         "footer_refs": refs,
         "release_name": release_name,
         "release_url": release_url,
         "request": context.get("request"),
+        "fresh_since": fresh_since,
     }
 


### PR DESCRIPTION
## Summary
- enable Django autoreload when using VS Code's Debug Server
- attach debugger to subprocesses spawned by Django's reloader
- show 'fresh since' footer message when auto-upgrade mode is active

## Testing
- `pytest tests/test_footer_admin_link.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3b656979c832694c8c5a9b37af824