### PR TITLE
fix: handle email errors in invitation form

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -129,13 +129,16 @@ def request_invite(request):
             link = request.build_absolute_uri(
                 reverse("pages:invitation-login", args=[uid, token])
             )
-            send_mail(
-                _("Your invitation link"),
-                _("Use the following link to access your account: %(link)s")
-                % {"link": link},
-                None,
-                [email],
-            )
+            try:
+                send_mail(
+                    _("Your invitation link"),
+                    _("Use the following link to access your account: %(link)s")
+                    % {"link": link},
+                    settings.DEFAULT_FROM_EMAIL,
+                    [email],
+                )
+            except Exception:
+                logger.exception("Failed to send invitation email to %s", email)
         sent = True
     return render(request, "pages/request_invite.html", {"form": form, "sent": sent})
 


### PR DESCRIPTION
## Summary
- handle send_mail exceptions when requesting an invitation
- remove obsolete README sidebar test that referenced removed README.base.md

## Testing
- `python manage.py test pages`
- `python manage.py test pages.tests.InvitationTests`


------
https://chatgpt.com/codex/tasks/task_e_68b3c314ff588326b9ddeb48ff50e789