### PR TITLE
Add email collector with artifact storage and polling

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -34,13 +34,18 @@ class CoreConfig(AppConfig):
         if PeriodicTask:
             lock = Path(settings.BASE_DIR) / "locks" / "celery.lck"
             if lock.exists():
-                schedule, _ = IntervalSchedule.objects.get_or_create(
-                    every=1, period=IntervalSchedule.HOURS
-                )
-                PeriodicTask.objects.get_or_create(
-                    name="poll_email_collectors",
-                    defaults={
-                        "interval": schedule,
-                        "task": "core.tasks.poll_email_collectors",
-                    },
-                )
+                from django.db.utils import OperationalError
+
+                try:
+                    schedule, _ = IntervalSchedule.objects.get_or_create(
+                        every=1, period=IntervalSchedule.HOURS
+                    )
+                    PeriodicTask.objects.get_or_create(
+                        name="poll_email_collectors",
+                        defaults={
+                            "interval": schedule,
+                            "task": "core.tasks.poll_email_collectors",
+                        },
+                    )
+                except OperationalError:  # pragma: no cover - tables not ready
+                    pass

--- a/core/apps.py
+++ b/core/apps.py
@@ -23,3 +23,24 @@ class CoreConfig(AppConfig):
         post_migrate.connect(create_default_admin, sender=self)
         patch_admin_user_datum()
         patch_admin_user_data_views()
+
+        from pathlib import Path
+        from django.conf import settings
+        try:  # pragma: no cover - optional dependency
+            from django_celery_beat.models import IntervalSchedule, PeriodicTask
+        except Exception:  # pragma: no cover - optional dependency
+            IntervalSchedule = PeriodicTask = None
+
+        if PeriodicTask:
+            lock = Path(settings.BASE_DIR) / "locks" / "celery.lck"
+            if lock.exists():
+                schedule, _ = IntervalSchedule.objects.get_or_create(
+                    every=1, period=IntervalSchedule.HOURS
+                )
+                PeriodicTask.objects.get_or_create(
+                    name="poll_email_collectors",
+                    defaults={
+                        "interval": schedule,
+                        "task": "core.tasks.poll_email_collectors",
+                    },
+                )

--- a/core/migrations/0006_securitygroup_parent.py
+++ b/core/migrations/0006_securitygroup_parent.py
@@ -71,6 +71,42 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
+            name='EmailCollector',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('subject', models.CharField(blank=True, max_length=255)),
+                ('sender', models.CharField(blank=True, max_length=255)),
+                ('body', models.CharField(blank=True, max_length=255)),
+                ('fragment', models.CharField(blank=True, max_length=255)),
+                ('inbox', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='collectors', to='core.emailinbox')),
+            ],
+            options={
+                'verbose_name': 'Email Collector',
+                'verbose_name_plural': 'Email Collectors',
+            },
+        ),
+        migrations.CreateModel(
+            name='EmailArtifact',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_seed_data', models.BooleanField(default=False, editable=False)),
+                ('is_deleted', models.BooleanField(default=False, editable=False)),
+                ('subject', models.CharField(max_length=255)),
+                ('sender', models.CharField(max_length=255)),
+                ('body', models.TextField(blank=True)),
+                ('sigils', models.JSONField(default=dict)),
+                ('fingerprint', models.CharField(max_length=32)),
+                ('collector', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='artifacts', to='core.emailcollector')),
+            ],
+            options={
+                'verbose_name': 'Email Artifact',
+                'verbose_name_plural': 'Email Artifacts',
+                'unique_together': {('collector', 'fingerprint')},
+            },
+        ),
+        migrations.CreateModel(
             name='SecurityGroup',
             fields=[
                 (

--- a/core/models.py
+++ b/core/models.py
@@ -452,6 +452,94 @@ class EmailInbox(Entity):
         return f"{self.username}@{self.host}"
 
 
+class EmailCollector(Entity):
+    """Search an inbox for matching messages and extract data via sigils."""
+
+    inbox = models.ForeignKey(
+        "EmailInbox",
+        related_name="collectors",
+        on_delete=models.CASCADE,
+    )
+    subject = models.CharField(max_length=255, blank=True)
+    sender = models.CharField(max_length=255, blank=True)
+    body = models.CharField(max_length=255, blank=True)
+    fragment = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="Pattern with [sigils] to extract values from the body.",
+    )
+
+    def _parse_sigils(self, text: str) -> dict[str, str]:
+        """Extract values from ``text`` according to ``fragment`` sigils."""
+        if not self.fragment:
+            return {}
+        import re
+
+        parts = re.split(r"\[([^\]]+)\]", self.fragment)
+        pattern = ""
+        for idx, part in enumerate(parts):
+            if idx % 2 == 0:
+                pattern += re.escape(part)
+            else:
+                pattern += f"(?P<{part}>.+)"
+        match = re.search(pattern, text)
+        if not match:
+            return {}
+        return {k: v.strip() for k, v in match.groupdict().items()}
+
+    def collect(self, limit: int = 10) -> None:
+        """Poll the inbox and store new artifacts until an existing one is found."""
+        from .models import EmailArtifact
+
+        messages = self.inbox.search_messages(
+            subject=self.subject,
+            from_address=self.sender,
+            body=self.body,
+            limit=limit,
+        )
+        for msg in messages:
+            fp = EmailArtifact.fingerprint_for(
+                msg.get("subject", ""), msg.get("from", ""), msg.get("body", "")
+            )
+            if EmailArtifact.objects.filter(
+                collector=self, fingerprint=fp
+            ).exists():
+                break
+            EmailArtifact.objects.create(
+                collector=self,
+                subject=msg.get("subject", ""),
+                sender=msg.get("from", ""),
+                body=msg.get("body", ""),
+                sigils=self._parse_sigils(msg.get("body", "")),
+                fingerprint=fp,
+            )
+
+
+class EmailArtifact(Entity):
+    """Store messages discovered by :class:`EmailCollector`."""
+
+    collector = models.ForeignKey(
+        EmailCollector, related_name="artifacts", on_delete=models.CASCADE
+    )
+    subject = models.CharField(max_length=255)
+    sender = models.CharField(max_length=255)
+    body = models.TextField(blank=True)
+    sigils = models.JSONField(default=dict)
+    fingerprint = models.CharField(max_length=32)
+
+    @staticmethod
+    def fingerprint_for(subject: str, sender: str, body: str) -> str:
+        import hashlib
+
+        data = (subject or "") + (sender or "") + (body or "")
+        return hashlib.md5(data.encode("utf-8")).hexdigest()
+
+    class Meta:
+        unique_together = ("collector", "fingerprint")
+        verbose_name = "Email Artifact"
+        verbose_name_plural = "Email Artifacts"
+
+
 class FediverseProfile(Entity):
     """Configuration for connecting to fediverse services."""
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -86,3 +86,15 @@ def check_github_updates() -> None:
     else:
         subprocess.run(["pkill", "-f", "manage.py runserver"])
 
+
+@shared_task
+def poll_email_collectors() -> None:
+    """Poll all configured email collectors for new messages."""
+    try:
+        from .models import EmailCollector
+    except Exception:  # pragma: no cover - app not ready
+        return
+
+    for collector in EmailCollector.objects.all():
+        collector.collect()
+

--- a/tests/test_email_collector.py
+++ b/tests/test_email_collector.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+from core.models import User, EmailInbox, EmailCollector, EmailArtifact
+from core.tasks import poll_email_collectors
+
+
+class EmailCollectorTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="u")
+        self.inbox = EmailInbox.objects.create(
+            user=self.user,
+            host="imap.test",
+            port=993,
+            username="u",
+            password="p",
+            protocol=EmailInbox.IMAP,
+        )
+
+    def test_collect_creates_artifact_and_stops_on_existing(self):
+        collector = EmailCollector.objects.create(
+            inbox=self.inbox,
+            fragment="code is [code]",
+        )
+        existing = {
+            "subject": "Old",
+            "from": "a@test",
+            "body": "code is 123",
+        }
+        EmailArtifact.objects.create(
+            collector=collector,
+            subject=existing["subject"],
+            sender=existing["from"],
+            body=existing["body"],
+            sigils={"code": "123"},
+            fingerprint=EmailArtifact.fingerprint_for(
+                existing["subject"], existing["from"], existing["body"]
+            ),
+        )
+        messages = [
+            {"subject": "New", "from": "a@test", "body": "code is 456"},
+            existing,
+            {"subject": "Older", "from": "a@test", "body": "code is 789"},
+        ]
+        with patch.object(EmailInbox, "search_messages", return_value=messages):
+            collector.collect()
+        artifacts = EmailArtifact.objects.filter(collector=collector)
+        assert artifacts.count() == 2
+        new_artifact = artifacts.get(subject="New")
+        assert new_artifact.sigils == {"code": "456"}
+        assert not artifacts.filter(subject="Older").exists()
+
+    def test_poll_task_invokes_collectors(self):
+        collector = EmailCollector.objects.create(inbox=self.inbox)
+        with patch.object(EmailCollector, "collect") as mock_collect:
+            poll_email_collectors()
+            mock_collect.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add `EmailCollector` and `EmailArtifact` models for parsing inbox messages with sigils
- poll collectors hourly via Celery and store results
- cover collectors with tests

## Testing
- `python manage.py migrate`
- `python manage.py migrate core 0005`
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3c6b912508326995749f4ac4bb718