### PR TITLE
Enable Django autoreload for VS Code Run Server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
                 "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
             },
             "program": "${workspaceFolder}/vscode_manage.py",
-            "args": ["runserver", "--noreload"],
+            "args": ["runserver"],
             "django": true,
             "noDebug": true
         },


### PR DESCRIPTION
## Summary
- Allow Django's autoreloader in VS Code by removing the `--noreload` flag from the Run Server configuration.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3d6f57304832684b00da4a13f58fa