### PR TITLE
Add node email outbox support

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -18,6 +18,7 @@ from .actions import NodeAction
 
 from .models import (
     Node,
+    EmailOutbox,
     NodeRole,
     ContentSample,
     NodeTask,
@@ -208,6 +209,12 @@ class NodeAdmin(admin.ModelAdmin):
         except Exception as exc:  # pragma: no cover - unexpected errors
             self.message_user(request, str(exc), messages.ERROR)
         return redirect(reverse("admin:nodes_node_change", args=[node_id]))
+
+
+@admin.register(EmailOutbox)
+class EmailOutboxAdmin(admin.ModelAdmin):
+    list_display = ("node", "host", "port", "username", "use_tls", "use_ssl")
+
 
 class NodeRoleAdminForm(forms.ModelForm):
     nodes = forms.ModelMultipleChoiceField(

--- a/nodes/migrations/0002_contentsample_user.py
+++ b/nodes/migrations/0002_contentsample_user.py
@@ -24,6 +24,30 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.CreateModel(
+            name="EmailOutbox",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("host", models.CharField(max_length=100)),
+                ("port", models.PositiveIntegerField(default=587)),
+                ("username", models.CharField(blank=True, max_length=100)),
+                ("password", models.CharField(blank=True, max_length=100)),
+                ("use_tls", models.BooleanField(default=True)),
+                ("use_ssl", models.BooleanField(default=False)),
+                ("from_email", models.EmailField(blank=True, max_length=254)),
+                (
+                    "node",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="email_outbox",
+                        to="nodes.node",
+                    ),
+                ),
+            ],
+            bases=(core.entity.Entity,),
+        ),
+        migrations.CreateModel(
             name="User",
             fields=[],
             options={

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -28,6 +28,7 @@ from .utils import capture_screenshot
 
 from .models import (
     Node,
+    EmailOutbox,
     ContentSample,
     NodeRole,
     NetMessage,
@@ -755,6 +756,40 @@ class ContentSampleAdminTests(TestCase):
             ContentSample.objects.filter(kind=ContentSample.TEXT).count(), 1
         )
         self.assertContains(resp, "Duplicate sample not created")
+
+
+class EmailOutboxTests(TestCase):
+    def test_node_send_mail_uses_outbox(self):
+        node = Node.objects.create(
+            hostname="outboxhost",
+            address="127.0.0.1",
+            port=8000,
+            mac_address="00:11:22:33:aa:bb",
+        )
+        EmailOutbox.objects.create(
+            node=node, host="smtp.example.com", port=25, username="u", password="p"
+        )
+        with patch("nodes.models.get_connection") as gc, patch(
+            "nodes.models.send_mail"
+        ) as sm:
+            conn = MagicMock()
+            gc.return_value = conn
+            node.send_mail("sub", "msg", ["to@example.com"])
+            gc.assert_called_once_with(
+                host="smtp.example.com",
+                port=25,
+                username="u",
+                password="p",
+                use_tls=True,
+                use_ssl=False,
+            )
+            sm.assert_called_once_with(
+                "sub",
+                "msg",
+                settings.DEFAULT_FROM_EMAIL,
+                ["to@example.com"],
+                connection=conn,
+            )
 
 
 class ClipboardTaskTests(TestCase):

--- a/outbox-setup.sh
+++ b/outbox-setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$BASE_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
+exec > >(tee "$LOG_FILE") 2>&1
+cd "$BASE_DIR"
+
+read -rp "SMTP host: " HOST
+read -rp "SMTP port [587]: " PORT
+PORT=${PORT:-587}
+read -rp "SMTP username: " USERNAME
+read -rsp "SMTP password: " PASSWORD
+echo
+read -rp "Use TLS? [y/N]: " USE_TLS
+read -rp "Use SSL? [y/N]: " USE_SSL
+read -rp "From email (leave blank to use default): " FROM_EMAIL
+
+python manage.py shell <<PYTHON
+from nodes.models import Node, EmailOutbox
+node, _ = Node.register_current()
+outbox, _ = EmailOutbox.objects.update_or_create(
+    node=node,
+    defaults={
+        "host": "$HOST",
+        "port": int("$PORT"),
+        "username": "$USERNAME",
+        "password": "$PASSWORD",
+        "use_tls": "$USE_TLS".lower() == "y",
+        "use_ssl": "$USE_SSL".lower() == "y",
+        "from_email": "$FROM_EMAIL",
+    },
+)
+print("Configured outbox for", node.hostname)
+PYTHON
+
+read -rp "Save this outbox as a User Datum? [y/N]: " SAVE_UD
+if [[ "${SAVE_UD,,}" == "y" ]]; then
+    read -rp "Username: " UD_USER
+    python manage.py shell <<PYTHON
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from core.user_data import UserDatum
+from nodes.models import Node, EmailOutbox
+node = Node.get_local()
+outbox = EmailOutbox.objects.get(node=node)
+User = get_user_model()
+user = User.objects.get(username="$UD_USER")
+ct = ContentType.objects.get_for_model(EmailOutbox)
+UserDatum.objects.get_or_create(user=user, content_type=ct, object_id=outbox.pk)
+print("User datum created for", user.username)
+PYTHON
+fi

--- a/pages/views.py
+++ b/pages/views.py
@@ -129,14 +129,16 @@ def request_invite(request):
             link = request.build_absolute_uri(
                 reverse("pages:invitation-login", args=[uid, token])
             )
+            subject = _("Your invitation link")
+            body = _(
+                "Use the following link to access your account: %(link)s"
+            ) % {"link": link}
             try:
-                send_mail(
-                    _("Your invitation link"),
-                    _("Use the following link to access your account: %(link)s")
-                    % {"link": link},
-                    settings.DEFAULT_FROM_EMAIL,
-                    [email],
-                )
+                node = Node.get_local()
+                if node:
+                    node.send_mail(subject, body, [email])
+                else:
+                    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [email])
             except Exception:
                 logger.exception("Failed to send invitation email to %s", email)
         sent = True


### PR DESCRIPTION
## Summary
- add EmailOutbox model to store SMTP credentials per node and Node.send_mail helper
- expose EmailOutbox in admin and use node-specific outbox when sending invites
- provide outbox-setup.sh script to capture SMTP creds and optionally save as user datum

## Testing
- `python manage.py migrate --noinput`
- `python manage.py migrate nodes 0001 --noinput`
- `python manage.py migrate --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3d81d3074832689633104a93ef514