### PR TITLE
Add operator registration with key generation

### DIFF
--- a/nodes/migrations/0002_contentsample_user.py
+++ b/nodes/migrations/0002_contentsample_user.py
@@ -24,6 +24,31 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.CreateModel(
+            name="Operator",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("public_key", models.TextField(blank=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={"abstract": False},
+        ),
+        migrations.CreateModel(
             name="User",
             fields=[],
             options={

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -230,6 +230,28 @@ class Node(Entity):
             PeriodicTask.objects.filter(name=task_name).delete()
 
 
+class Operator(Entity):
+    """User allowed to access this node."""
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
+    )
+    public_key = models.TextField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return str(self.user)
+
+    def key_path(self) -> Path:
+        auth_dir = Path(settings.BASE_DIR) / "security" / "authorized_keys"
+        return auth_dir / f"{self.user.username}.pub"
+
+    def delete(self, using=None, keep_parents=False):
+        path = self.key_path()
+        if path.exists():
+            path.unlink()
+        super().delete(using=using, keep_parents=keep_parents)
+
+
 class NetMessage(Entity):
     """Message propagated across nodes."""
 

--- a/nodes/templates/admin/nodes/operator/change_list.html
+++ b/nodes/templates/admin/nodes/operator/change_list.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:nodes_operator_register' %}" class="addlink">
+            {% trans 'Register as Operator' %}
+        </a>
+    </li>
+    <li>
+        <a href="{% url 'admin:nodes_operator_putty_help' %}" class="viewsitelink">
+            {% trans 'Using PuTTY with Operator Key' %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}

--- a/nodes/templates/admin/nodes/operator/putty_help.html
+++ b/nodes/templates/admin/nodes/operator/putty_help.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Using PuTTY with your operator key" %}</h1>
+<ol>
+    <li>{% trans "Register as operator and download the provided .key file." %}</li>
+    <li>{% trans "Open PuTTYgen, click 'Load', and select the downloaded key file." %}</li>
+    <li>{% trans "Save the converted key as a .ppk file." %}</li>
+    <li>{% trans "Open PuTTY and enter the host name and port of your instance." %}</li>
+    <li>{% trans "Under Connection → SSH → Auth, browse for the .ppk file and connect." %}</li>
+</ol>
+<p>{% trans "You will then have access using your operator credentials." %}</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Operator model to track users with node access and remove key file on deletion
- add admin registration action generating key pair and authorized key file
- expose register link in Operator admin list with PuTTY usage help and test key lifecycle

## Testing
- `python manage.py makemigrations nodes --dry-run --check`
- `python manage.py migrate --noinput`
- `python manage.py migrate nodes 0001 --noinput`
- `python manage.py migrate --noinput`
- `pytest nodes/tests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3dcb1d99c8326b64a64addfab24bb