### PR TITLE
Print version and revision on server startup

### DIFF
--- a/app/management/commands/runserver.py
+++ b/app/management/commands/runserver.py
@@ -1,12 +1,16 @@
 import os
 import webbrowser
+from pathlib import Path
 
 from django.apps import apps
 from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+from django.conf import settings
 from daphne.management.commands.runserver import (
     Command as RunserverCommand,
     get_default_application,
 )
+
+from utils import revision
 
 class Command(RunserverCommand):
     """Extended runserver command that also prints WebSocket URLs and admin link."""
@@ -33,6 +37,15 @@ class Command(RunserverCommand):
         self.stdout.write(
             f"Admin available at {http_scheme}://{host}:{server_port}/admin/"
         )
+
+        ver_path = Path(settings.BASE_DIR) / "VERSION"
+        version = ver_path.read_text().strip() if ver_path.exists() else ""
+        rev_value = revision.get_revision()
+        rev_short = rev_value[-6:] if rev_value else ""
+        msg = f"Version: v{version}"
+        if rev_short:
+            msg += f" r{rev_short}"
+        self.stdout.write(msg)
 
         if os.environ.get("DJANGO_DEV_RELOAD") and os.environ.get("RUN_MAIN") == "true":
             webbrowser.open(f"{http_scheme}://{host}:{server_port}/")

--- a/manage.py
+++ b/manage.py
@@ -42,6 +42,19 @@ def main() -> None:
                 f"Admin available at {http_scheme}://{host}:{server_port}/admin/"
             )
 
+            from pathlib import Path
+            from django.conf import settings
+            from utils import revision
+
+            ver_path = Path(settings.BASE_DIR) / "VERSION"
+            version = ver_path.read_text().strip() if ver_path.exists() else ""
+            rev_value = revision.get_revision()
+            rev_short = rev_value[-6:] if rev_value else ""
+            msg = f"Version: v{version}"
+            if rev_short:
+                msg += f" r{rev_short}"
+            self.stdout.write(msg)
+
         original_on_bind = core_runserver.Command.on_bind
         core_runserver.Command.on_bind = patched_on_bind
     except ImportError as exc:  # pragma: no cover - Django bootstrap


### PR DESCRIPTION
## Summary
- show application version and git revision when the development server binds to a port
- include version and revision output in manage.py's runserver patch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3de1545d083268228c8f41ec493fe