### PR TITLE
Remove stale release branch before promotion

### DIFF
--- a/core/release.py
+++ b/core/release.py
@@ -354,7 +354,8 @@ def promote(
         try:
             _run(["git", "checkout", "-b", tmp_branch])
         except subprocess.CalledProcessError:
-            _run(["git", "checkout", tmp_branch])
+            _run(["git", "branch", "-D", tmp_branch], check=False)
+            _run(["git", "checkout", "-b", tmp_branch])
         build(
             package=package,
             creds=creds,

--- a/tests/test_release_promote.py
+++ b/tests/test_release_promote.py
@@ -1,0 +1,28 @@
+import types
+import subprocess
+
+from core import release
+
+
+def test_promote_deletes_existing_branch(monkeypatch):
+    calls = []
+    first = True
+
+    def fake_run(cmd, check=True):
+        nonlocal first
+        calls.append(cmd)
+        if cmd[:3] == ["git", "checkout", "-b"] and first:
+            first = False
+            raise subprocess.CalledProcessError(1, cmd)
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(release, "_run", fake_run)
+    monkeypatch.setattr(release, "build", lambda **kwargs: None)
+    monkeypatch.setattr(release, "_current_branch", lambda: "main")
+    monkeypatch.setattr(release, "_current_commit", lambda: "abcdef123456")
+
+    release.promote(version="1.0.0")
+
+    assert calls[0] == ["git", "checkout", "-b", "release/1.0.0"]
+    assert calls[1] == ["git", "branch", "-D", "release/1.0.0"]
+    assert calls[2] == ["git", "checkout", "-b", "release/1.0.0"]


### PR DESCRIPTION
## Summary
- delete existing `release/<version>` branch if present when promoting a release
- add regression test for branch recreation

## Testing
- `pytest tests/test_release_promote.py::test_promote_deletes_existing_branch -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b3df9a11d88326a341805bcbaf32b9