### PR TITLE
Allow release promotion when repo appears dirty and move progress URL

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,7 @@ from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import set_language
 from django.utils.translation import gettext_lazy as _
+from core import views as core_views
 
 admin.site.site_header = _("Constellation")
 admin.site.site_title = _("Constellation")
@@ -61,6 +62,11 @@ def autodiscovered_urlpatterns():
 
 urlpatterns = [
     path("admin/doc/", include("django.contrib.admindocs.urls")),
+    path(
+        "admin/core/releases/<int:pk>/<str:action>/",
+        core_views.release_progress,
+        name="release-progress",
+    ),
     path("admin/", admin.site.urls),
     path("i18n/setlang/", csrf_exempt(set_language), name="set_language"),
     path("", include("pages.urls")),

--- a/core/release.py
+++ b/core/release.py
@@ -366,10 +366,24 @@ def promote(
             dist=True,
             git=False,
             tag=False,
+            stash=True,
         )
         try:  # best effort
-            _run([sys.executable, "manage.py", "squashmigrations", "core", "0001"], check=False)
+            _run(
+                [
+                    sys.executable,
+                    "manage.py",
+                    "squashmigrations",
+                    "core",
+                    "0001",
+                    "--noinput",
+                ],
+                check=False,
+            )
         except Exception:
+            # The squashmigrations command may not be available or could fail
+            # (e.g. when no migrations exist). Any errors should not interrupt
+            # the release promotion flow.
             pass
         _run(["git", "add", "."])  # add all changes
         _run(["git", "commit", "-m", f"Release v{version}"])

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,9 +8,4 @@ urlpatterns = [
     path("products/", views.product_list, name="product-list"),
     path("subscribe/", views.add_subscription, name="add-subscription"),
     path("list/", views.subscription_list, name="subscription-list"),
-    path(
-        "releases/<int:pk>/<str:action>/",
-        views.release_progress,
-        name="release-progress",
-    ),
 ]


### PR DESCRIPTION
## Summary
- Auto-stash during release promotion build to avoid false 'repo not clean' errors
- Expose release progress under `/admin/core/releases/` and remove it from API URLs
- Run `squashmigrations` non-interactively to prevent debug prompts during promotion

## Testing
- `pytest -q tests/test_release_progress.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4597efba88326b7f31b6b81b8bf9c