### PR TITLE
Allow release promotion when repo appears dirty and move progress URL

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,7 @@ from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import set_language
 from django.utils.translation import gettext_lazy as _
+from core import views as core_views
 
 admin.site.site_header = _("Constellation")
 admin.site.site_title = _("Constellation")
@@ -61,6 +62,11 @@ def autodiscovered_urlpatterns():
 
 urlpatterns = [
     path("admin/doc/", include("django.contrib.admindocs.urls")),
+    path(
+        "admin/core/releases/<int:pk>/<str:action>/",
+        core_views.release_progress,
+        name="release-progress",
+    ),
     path("admin/", admin.site.urls),
     path("i18n/setlang/", csrf_exempt(set_language), name="set_language"),
     path("", include("pages.urls")),

--- a/core/release.py
+++ b/core/release.py
@@ -346,7 +346,7 @@ def promote(
     """Create a release branch and build the package without tests.
 
     Returns a tuple of the release commit hash, the new branch name and the
-    original branch so the caller can switch back after pushing.
+    original branch name.
     """
     current = _current_branch()
     tmp_branch = f"release/{version}"
@@ -366,10 +366,24 @@ def promote(
             dist=True,
             git=False,
             tag=False,
+            stash=True,
         )
         try:  # best effort
-            _run([sys.executable, "manage.py", "squashmigrations", "core", "0001"], check=False)
+            _run(
+                [
+                    sys.executable,
+                    "manage.py",
+                    "squashmigrations",
+                    "core",
+                    "0001",
+                    "--noinput",
+                ],
+                check=False,
+            )
         except Exception:
+            # The squashmigrations command may not be available or could fail
+            # (e.g. when no migrations exist). Any errors should not interrupt
+            # the release promotion flow.
             pass
         _run(["git", "add", "."])  # add all changes
         _run(["git", "commit", "-m", f"Release v{version}"])

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,9 +8,4 @@ urlpatterns = [
     path("products/", views.product_list, name="product-list"),
     path("subscribe/", views.add_subscription, name="add-subscription"),
     path("list/", views.subscription_list, name="subscription-list"),
-    path(
-        "releases/<int:pk>/<str:action>/",
-        views.release_progress,
-        name="release-progress",
-    ),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -28,7 +28,7 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
     from . import release as release_utils
 
     _append_log(log_path, "Generating build files")
-    commit_hash, branch, current = release_utils.promote(
+    commit_hash, branch, _current = release_utils.promote(
         package=release.to_package(),
         version=release.version,
         creds=release.to_credentials(),
@@ -36,7 +36,6 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
     release.revision = commit_hash
     release.save(update_fields=["revision"])
     ctx["branch"] = branch
-    ctx["current"] = current
     release_name = f"{release.package.name}-{release.version}-{commit_hash[:7]}"
     new_log = log_path.with_name(f"{release_name}.log")
     log_path.rename(new_log)
@@ -60,10 +59,9 @@ def _step_dump_fixture(release, ctx, log_path: Path) -> None:
 
 def _step_push_branch(release, ctx, log_path: Path) -> None:
     branch = ctx.get("branch")
-    current = ctx.get("current")
     _append_log(log_path, f"Pushing branch {branch}")
     subprocess.run(["git", "push", "-u", "origin", branch], check=True)
-    subprocess.run(["git", "checkout", current], check=True)
+    subprocess.run(["git", "checkout", "main"], check=True)
     _append_log(log_path, "Branch pushed")
 
 


### PR DESCRIPTION
## Summary
- Auto-stash during release promotion build to avoid false 'repo not clean' errors
- Expose release progress under `/admin/core/releases/` and remove it from API URLs
- Run `squashmigrations` non-interactively to prevent debug prompts during promotion
- After a certified release branch is pushed, automatically return to the `main` branch

## Testing
- `pytest -q tests/test_release_progress.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4597efba88326b7f31b6b81b8bf9c