### PR TITLE
Add share toolbar button with clipboard copy and QR code

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -146,14 +146,35 @@
                   </svg>
                 </button>
               </form>
+              <button id="share-button" class="btn btn-sm btn-outline-light ms-2" type="button" aria-label="{% trans 'Share' %}">
+                <svg aria-hidden="true" width="1.5rem" height="1.5rem">
+                  <use href="#icon-share"></use>
+                </svg>
+              </button>
             </div>
           </div>
         </div>
       </nav>
       {% block content %}{% endblock %}
     </div>
+    <div class="modal fade" id="shareModal" tabindex="-1" aria-labelledby="shareModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="shareModalLabel">{% trans 'Share' %}</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+          </div>
+          <div class="modal-body text-center">
+            <p class="mb-2">{% trans 'Link copied to clipboard' %}</p>
+            <input type="text" class="form-control mb-3" id="share-url" readonly>
+            <div id="share-qr"></div>
+          </div>
+        </div>
+      </div>
+    </div>
     {% render_footer %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
     <script>
       function setTheme(theme) {
         document.documentElement.setAttribute('data-bs-theme', theme);
@@ -280,10 +301,35 @@
         });
       });
     </script>
+    <script>
+      (function() {
+        const btn = document.getElementById('share-button');
+        const modalEl = document.getElementById('shareModal');
+        if (!btn || !modalEl) {
+          return;
+        }
+        const modal = new bootstrap.Modal(modalEl);
+        btn.addEventListener('click', () => {
+          modal.show();
+        });
+        modalEl.addEventListener('shown.bs.modal', () => {
+          const url = window.location.href;
+          const input = document.getElementById('share-url');
+          const qr = document.getElementById('share-qr');
+          input.value = url;
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).catch(() => {});
+          }
+          qr.innerHTML = '';
+          new QRCode(qr, {text: url, width: 128, height: 128});
+        });
+      })();
+    </script>
     <svg xmlns="http://www.w3.org/2000/svg" class="base-svgs">
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-moon"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-sun"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-person"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></symbol>
+      <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-share"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></symbol>
     </svg>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add toolbar share button with share icon
- show modal that copies URL to clipboard and renders QR code
- include QRCode.js dependency and script for modal

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b463780e1c832691fbdb6b0380fed0