### PR TITLE
feat: allow GitHub token per packager

### DIFF
--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -758,6 +758,17 @@ class Migration(migrations.Migration):
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('username', models.CharField(blank=True, max_length=100)),
                 ('token', models.CharField(blank=True, max_length=200)),
+                (
+                    'github_token',
+                    models.CharField(
+                        blank=True,
+                        max_length=200,
+                        help_text=(
+                            'Personal access token used to create GitHub pull requests. '
+                            'Used before the GITHUB_TOKEN environment variable.'
+                        ),
+                    ),
+                ),
                 ('password', models.CharField(blank=True, max_length=200)),
                 ('pypi_url', models.URLField(blank=True)),
                 ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='packager_profile', to=settings.AUTH_USER_MODEL)),

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 from datetime import date, timedelta
 
@@ -83,7 +82,7 @@ def _step_push_branch(release, ctx, log_path: Path) -> None:
         except Exception as exc:  # pragma: no cover - best effort
             _append_log(log_path, f"PR creation failed: {exc}")
     else:
-        token = os.environ.get("GITHUB_TOKEN")
+        token = release.get_github_token()
         if token:
             try:  # pragma: no cover - best effort
                 remote = subprocess.run(
@@ -124,7 +123,10 @@ def _step_push_branch(release, ctx, log_path: Path) -> None:
             except Exception as exc:
                 _append_log(log_path, f"PR creation failed: {exc}")
         else:
-            _append_log(log_path, "PR creation skipped: gh not installed and GITHUB_TOKEN not set")
+            _append_log(
+                log_path,
+                "PR creation skipped: gh not installed and no GitHub token available",
+            )
     subprocess.run(["git", "checkout", "main"], check=True)
     _append_log(log_path, "Branch pushed")
 

--- a/tests/test_github_token.py
+++ b/tests/test_github_token.py
@@ -1,0 +1,26 @@
+import os
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from core.models import PackageRelease, PackagerProfile
+
+
+class GitHubTokenTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.get(username="arthexis")
+        self.profile = PackagerProfile.objects.get(user=self.user)
+        self.release = PackageRelease.objects.get(version="0.1.1")
+
+    def test_profile_token_preferred_over_env(self):
+        self.profile.github_token = "profile-token"
+        self.profile.save()
+        with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=False):
+            self.assertEqual(self.release.get_github_token(), "profile-token")
+
+    def test_env_token_used_when_profile_missing(self):
+        self.profile.github_token = ""
+        self.profile.save()
+        with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=False):
+            self.assertEqual(self.release.get_github_token(), "env-token")


### PR DESCRIPTION
## Summary
- add `github_token` field to PackagerProfile and expose helper
- prefer profile token over env var when creating pull requests
- test token lookup precedence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4973dd3148326bb5e2a1e8d557fd0