### PR TITLE
Ensure release progress page has complete breadcrumbs

### DIFF
--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -1,12 +1,16 @@
 {% extends "admin/base_site.html" %}
+{% load i18n %}
 
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-  <a href="{% url 'admin:index' %}">Home</a> ›
-  <a href="{% url 'admin:core_packagerelease_changelist' %}">Package Releases</a> ›
-  <a href="{% url 'admin:core_packagerelease_change' release.pk %}">{{ release }}</a> ›
-  {{ action|capfirst }}
-</div>
+{% block nav-breadcrumbs %}
+<nav aria-label="{% translate 'Breadcrumbs' %}">
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+    <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Business Models' %}</a> ›
+    <a href="{% url 'admin:core_packagerelease_changelist' %}">{% trans 'Package Releases' %}</a> ›
+    <a href="{% url 'admin:core_packagerelease_change' release.pk %}">{{ release }}</a> ›
+    {{ action|capfirst }}
+  </div>
+</nav>
 {% endblock %}
 
 {% block content %}

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -1,4 +1,18 @@
 {% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block nav-breadcrumbs %}
+<nav aria-label="{% translate 'Breadcrumbs' %}">
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+    <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Business Models' %}</a> ›
+    <a href="{% url 'admin:core_packagerelease_changelist' %}">{% trans 'Package Releases' %}</a> ›
+    <a href="{% url 'admin:core_packagerelease_change' release.pk %}">{{ release }}</a> ›
+    {{ action|capfirst }}
+  </div>
+</nav>
+{% endblock %}
+
 {% block content %}
 <h1>{{ action|capfirst }} {{ release.package.name }} {{ release.version }}</h1>
 <ol>

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -81,6 +81,15 @@ class ReleaseProgressTests(TestCase):
             log_path.read_text(),
         )
 
+    def test_promote_progress_breadcrumbs(self):
+        release = PackageRelease.objects.create(package=self.package, version="3.0.0")
+        url = reverse("release-progress", args=[release.pk, "promote"])
+        resp = self.client.get(url)
+        app_url = reverse("admin:app_list", args=("core",))
+        self.assertContains(resp, f'<a href="{app_url}">Business Models</a>')
+        list_url = reverse("admin:core_packagerelease_changelist")
+        self.assertContains(resp, f'<a href="{list_url}">Package Releases</a>')
+
     def test_publish_progress_creates_log(self):
         release = PackageRelease.objects.create(
             package=self.package,


### PR DESCRIPTION
## Summary
- show full breadcrumb trail including app and release links on release progress page
- test breadcrumbs rendering on promote workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a4b0a7bc83269a38a455cf4692e0