### PR TITLE
Enable user data for all models and update sample game

### DIFF
--- a/beta/fixtures/beta.json
+++ b/beta/fixtures/beta.json
@@ -21,9 +21,9 @@
     "model": "beta.gameportal",
     "pk": 1,
     "fields": {
-      "slug": "simple",
-      "title": "Simple Demo Game",
-      "description": "A simple choice-based demo.",
+      "slug": "baseline",
+      "title": "Eternal Return",
+      "description": "Players explore the infinite Baseline, a post-temporal space built by the enigmatic Workgroup to house a Tribe of Gods.",
       "entry_material": 1
     }
   },

--- a/beta/tests.py
+++ b/beta/tests.py
@@ -13,11 +13,11 @@ class BetaTests(TestCase):
 
     def test_portal_list_displays_fixture(self):
         resp = self.client.get(reverse("beta:portal-list"))
-        self.assertContains(resp, "Simple Demo Game")
+        self.assertContains(resp, "Eternal Return")
 
     def test_portal_detail_view(self):
-        resp = self.client.get(reverse("beta:portal-detail", args=["simple"]))
-        self.assertContains(resp, "Simple Demo Game")
+        resp = self.client.get(reverse("beta:portal-detail", args=["baseline"]))
+        self.assertContains(resp, "Eternal Return")
         self.assertContains(resp, reverse("beta:material-detail", args=["start"]))
 
     def test_game_material_view(self):


### PR DESCRIPTION
## Summary
- update sample beta game fixture to the new "Eternal Return" portal
- allow every model's admin to expose a User Datum checkbox
- test user datum workflow on a non-Entity model

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a57f397883268a05e347fd7f55e4