### PR TITLE
Clarify PyPI credentials in packager profile

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -125,7 +125,7 @@ class ReferenceAdmin(admin.ModelAdmin):
 
 @admin.register(PackagerProfile)
 class PackagerProfileAdmin(admin.ModelAdmin):
-    list_display = ("user", "username", "pypi_url")
+    list_display = ("user", "pypi_username", "pypi_url")
 
 
 @admin.register(Package)

--- a/core/migrations/0006_securitygroup_parent.py
+++ b/core/migrations/0006_securitygroup_parent.py
@@ -44,7 +44,7 @@ def create_packaging_defaults(apps, schema_editor):
     profile, _ = PackagerProfile.objects.get_or_create(
         user=user,
         defaults={
-            "username": "arthexis",
+            "pypi_username": "arthexis",
             "pypi_url": "https://pypi.org/user/arthexis/",
         },
     )
@@ -70,6 +70,41 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RenameField(
+            model_name='packagerprofile',
+            old_name='token',
+            new_name='pypi_token',
+        ),
+        migrations.RenameField(
+            model_name='packagerprofile',
+            old_name='username',
+            new_name='pypi_username',
+        ),
+        migrations.RenameField(
+            model_name='packagerprofile',
+            old_name='password',
+            new_name='pypi_password',
+        ),
+        migrations.AlterField(
+            model_name='packagerprofile',
+            name='pypi_token',
+            field=models.CharField("PyPI token", blank=True, max_length=200),
+        ),
+        migrations.AlterField(
+            model_name='packagerprofile',
+            name='pypi_username',
+            field=models.CharField("PyPI username", blank=True, max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='packagerprofile',
+            name='pypi_password',
+            field=models.CharField("PyPI password", blank=True, max_length=200),
+        ),
+        migrations.AlterField(
+            model_name='packagerprofile',
+            name='pypi_url',
+            field=models.URLField(blank=True, verbose_name='PyPI URL'),
+        ),
         migrations.AddField(
             model_name='reference',
             name='footer_visibility',

--- a/core/models.py
+++ b/core/models.py
@@ -1028,8 +1028,8 @@ class PackagerProfile(Entity):
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="packager_profile"
     )
-    username = models.CharField(max_length=100, blank=True)
-    token = models.CharField(max_length=200, blank=True)
+    pypi_username = models.CharField("PyPI username", max_length=100, blank=True)
+    pypi_token = models.CharField("PyPI token", max_length=200, blank=True)
     github_token = models.CharField(
         max_length=200,
         blank=True,
@@ -1038,8 +1038,8 @@ class PackagerProfile(Entity):
             "Used before the GITHUB_TOKEN environment variable."
         ),
     )
-    password = models.CharField(max_length=200, blank=True)
-    pypi_url = models.URLField(blank=True)
+    pypi_password = models.CharField("PyPI password", max_length=200, blank=True)
+    pypi_url = models.URLField("PyPI URL", blank=True)
 
     class Meta:
         verbose_name = "Packager Profile"
@@ -1054,10 +1054,12 @@ class PackagerProfile(Entity):
 
     def to_credentials(self) -> Credentials | None:
         """Return credentials for this profile."""
-        if self.token:
-            return Credentials(token=self.token)
-        if self.username and self.password:
-            return Credentials(username=self.username, password=self.password)
+        if self.pypi_token:
+            return Credentials(token=self.pypi_token)
+        if self.pypi_username and self.pypi_password:
+            return Credentials(
+                username=self.pypi_username, password=self.pypi_password
+            )
         return None
 
 


### PR DESCRIPTION
## Summary
- rename PackagerProfile credential fields to pypi_username/pypi_password/pypi_token
- label PyPI URL explicitly
- update admin and migration logic for new field names

## Testing
- `python manage.py migrate --noinput`
- `python manage.py migrate core 0005 --noinput`
- `python manage.py migrate --noinput`
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a61bcfa483268a61e607739cfeb9