### PR TITLE
Add system status admin page

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -14,6 +14,7 @@ class CoreConfig(AppConfig):
             patch_admin_user_datum,
             patch_admin_user_data_views,
         )
+        from .system import patch_admin_system_view
 
         def create_default_admin(**kwargs):
             User = get_user_model()
@@ -23,6 +24,7 @@ class CoreConfig(AppConfig):
         post_migrate.connect(create_default_admin, sender=self)
         patch_admin_user_datum()
         patch_admin_user_data_views()
+        patch_admin_system_view()
 
         from pathlib import Path
         from django.conf import settings

--- a/core/system.py
+++ b/core/system.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+import socket
+import subprocess
+import shutil
+
+from django.conf import settings
+from django.contrib import admin
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy as _
+
+
+def _gather_info() -> dict:
+    """Collect basic system information similar to status-check.sh."""
+    base_dir = Path(settings.BASE_DIR)
+    lock_dir = base_dir / "locks"
+    info: dict[str, object] = {}
+
+    info["installed"] = (base_dir / ".venv").exists()
+
+    service_file = lock_dir / "service.lck"
+    info["service"] = (
+        service_file.read_text().strip() if service_file.exists() else ""
+    )
+
+    mode_file = lock_dir / "nginx_mode.lck"
+    mode = mode_file.read_text().strip() if mode_file.exists() else "internal"
+    info["mode"] = mode
+    info["port"] = 8000 if mode == "public" else 8888
+
+    role_file = lock_dir / "role.lck"
+    info["role"] = role_file.read_text().strip() if role_file.exists() else "unknown"
+
+    info["features"] = {
+        "celery": (lock_dir / "celery.lck").exists(),
+        "lcd_screen": (lock_dir / "lcd_screen.lck").exists(),
+        "control": (lock_dir / "control.lck").exists(),
+    }
+
+    running = False
+    service_status = ""
+    service = info["service"]
+    if service and shutil.which("systemctl"):
+        try:
+            result = subprocess.run(
+                ["systemctl", "is-active", str(service)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            service_status = result.stdout.strip()
+            running = service_status == "active"
+        except Exception:
+            pass
+    else:
+        try:
+            subprocess.run(
+                ["pgrep", "-f", "manage.py runserver"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            running = True
+        except Exception:
+            running = False
+    info["running"] = running
+    info["service_status"] = service_status
+
+    try:
+        hostname = socket.gethostname()
+        ip_list = socket.gethostbyname_ex(hostname)[2]
+    except Exception:
+        hostname = ""
+        ip_list = []
+    info["hostname"] = hostname
+    info["ip_addresses"] = ip_list
+
+    return info
+
+
+def _system_view(request):
+    info = _gather_info()
+    if request.method == "POST" and request.user.is_superuser:
+        action = request.POST.get("action")
+        stop_script = Path(settings.BASE_DIR) / "stop.sh"
+        args = [str(stop_script)]
+        if action == "stop" and info["service"]:
+            args.append("--all")
+        subprocess.Popen(args)
+        return redirect(reverse("admin:index"))
+
+    context = admin.site.each_context(request)
+    context.update({"title": _("System"), "info": info})
+    return TemplateResponse(request, "admin/system.html", context)
+
+
+def patch_admin_system_view() -> None:
+    """Add custom admin view for system information."""
+    original_get_urls = admin.site.get_urls
+
+    def get_urls():
+        urls = original_get_urls()
+        custom = [
+            path("system/", admin.site.admin_view(_system_view), name="system"),
+        ]
+        return custom + urls
+
+    admin.site.get_urls = get_urls

--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -1,0 +1,49 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{{ title }}</h1>
+  <dl>
+    <dt>{% trans "Application installed" %}</dt>
+    <dd>{{ info.installed }}</dd>
+    <dt>{% trans "Service" %}</dt>
+    <dd>{% if info.service %}{{ info.service }}{% else %}{% trans "not installed" %}{% endif %}</dd>
+    <dt>{% trans "Nginx mode" %}</dt>
+    <dd>{{ info.mode }} ({{ info.port }})</dd>
+    <dt>{% trans "Node role" %}</dt>
+    <dd>{{ info.role }}</dd>
+    <dt>{% trans "Features" %}</dt>
+    <dd>
+      <ul>
+        <li>{% trans "Celery" %}: {{ info.features.celery }}</li>
+        <li>{% trans "LCD screen" %}: {{ info.features.lcd_screen }}</li>
+        <li>{% trans "Control" %}: {{ info.features.control }}</li>
+      </ul>
+    </dd>
+    <dt>{% trans "Running" %}</dt>
+    <dd>{{ info.running }}</dd>
+    {% if info.service %}
+    <dt>{% trans "Service status" %}</dt>
+    <dd>{{ info.service_status }}</dd>
+    {% endif %}
+    <dt>{% trans "Hostname" %}</dt>
+    <dd>{{ info.hostname }}</dd>
+    <dt>{% trans "IP addresses" %}</dt>
+    <dd>{{ info.ip_addresses|join:" " }}</dd>
+  </dl>
+
+  {% if user.is_superuser %}
+  <form method="post">
+    {% csrf_token %}
+    {% if info.service %}
+      <p>{% trans "This instance is managed by a service daemon. Restart will momentarily stop the service which will be brought back up automatically." %}</p>
+      <button class="button" type="submit" name="action" value="restart">{% trans "Restart" %}</button>
+      <button class="button" type="submit" name="action" value="stop">{% trans "Stop" %}</button>
+    {% else %}
+      <button class="button" type="submit" name="action" value="stop">{% trans "Stop" %}</button>
+    {% endif %}
+  </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -91,8 +91,9 @@
   <div>
     <a class="button" href="{% url 'admin:seed_data' %}">{% translate 'Seed Data' %}</a>
     <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
+    <a class="button" href="{% url 'admin:system' %}">{% translate 'System' %}</a>
   </div>
- </div>
+</div>
 {% endblock %}
 
 {% block nav-breadcrumbs %}{% endblock %}

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -202,6 +202,11 @@ class UserDataViewTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertContains(response, reverse("admin:seed_data"))
         self.assertContains(response, reverse("admin:user_data"))
+        self.assertContains(response, reverse("admin:system"))
+
+    def test_system_page_loads(self):
+        response = self.client.get(reverse("admin:system"))
+        self.assertContains(response, "Hostname")
 
     def test_user_data_page_has_import_export_links(self):
         response = self.client.get(reverse("admin:user_data"))


### PR DESCRIPTION
## Summary
- add `System` button on admin home
- expose system status info with stop/restart controls
- cover system page with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ac0bd58883268a0c234edb42d891