### PR TITLE
Use PyPI token for uploads when available

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -39,7 +39,7 @@ from .models import (
     EmailInbox,
     Package,
     PackageRelease,
-    PackagerProfile,
+    ReleaseManager,
     SecurityGroup,
 )
 
@@ -123,8 +123,8 @@ class ReferenceAdmin(admin.ModelAdmin):
     qr_code.short_description = "QR Code"
 
 
-@admin.register(PackagerProfile)
-class PackagerProfileAdmin(admin.ModelAdmin):
+@admin.register(ReleaseManager)
+class ReleaseManagerAdmin(admin.ModelAdmin):
     list_display = ("user", "pypi_username", "pypi_url")
 
 

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -751,13 +751,13 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='PackagerProfile',
+            name='ReleaseManager',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('username', models.CharField(blank=True, max_length=100)),
-                ('token', models.CharField(blank=True, max_length=200)),
+                ('pypi_username', models.CharField('PyPI username', blank=True, max_length=100)),
+                ('pypi_token', models.CharField('PyPI token', blank=True, max_length=200)),
                 (
                     'github_token',
                     models.CharField(
@@ -769,13 +769,13 @@ class Migration(migrations.Migration):
                         ),
                     ),
                 ),
-                ('password', models.CharField(blank=True, max_length=200)),
-                ('pypi_url', models.URLField(blank=True)),
-                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='packager_profile', to=settings.AUTH_USER_MODEL)),
+                ('pypi_password', models.CharField('PyPI password', blank=True, max_length=200)),
+                ('pypi_url', models.URLField('PyPI URL', blank=True)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='release_manager', to=settings.AUTH_USER_MODEL)),
             ],
             options={
-                'verbose_name': 'Packager Profile',
-                'verbose_name_plural': 'Packager Profiles',
+                'verbose_name': 'Release Manager',
+                'verbose_name_plural': 'Release Managers',
             },
         ),
         migrations.CreateModel(
@@ -792,7 +792,7 @@ class Migration(migrations.Migration):
                 ('license', models.CharField(default='MIT', max_length=100)),
                 ('repository_url', models.URLField(default='https://github.com/arthexis/arthexis')),
                 ('homepage_url', models.URLField(default='https://arthexis.com')),
-                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
+                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),
             ],
             options={
                 'verbose_name': 'Package',
@@ -812,7 +812,7 @@ class Migration(migrations.Migration):
                 ('is_promoted', models.BooleanField(default=False, editable=False)),
                 ('is_certified', models.BooleanField(default=False, editable=False)),
                 ('package', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.package')),
-                ('profile', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
+                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),
             ],
             options={
                 'verbose_name': 'Package Release',

--- a/core/migrations/0001_squashed_0001_initial.py
+++ b/core/migrations/0001_squashed_0001_initial.py
@@ -259,21 +259,21 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name='PackagerProfile',
+            name='ReleaseManager',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('username', models.CharField(blank=True, max_length=100)),
-                ('token', models.CharField(blank=True, max_length=200)),
+                ('pypi_username', models.CharField('PyPI username', blank=True, max_length=100)),
+                ('pypi_token', models.CharField('PyPI token', blank=True, max_length=200)),
                 ('github_token', models.CharField(blank=True, help_text='Personal access token used to create GitHub pull requests. Used before the GITHUB_TOKEN environment variable.', max_length=200)),
-                ('password', models.CharField(blank=True, max_length=200)),
-                ('pypi_url', models.URLField(blank=True)),
-                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='packager_profile', to=settings.AUTH_USER_MODEL)),
+                ('pypi_password', models.CharField('PyPI password', blank=True, max_length=200)),
+                ('pypi_url', models.URLField('PyPI URL', blank=True)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='release_manager', to=settings.AUTH_USER_MODEL)),
             ],
             options={
-                'verbose_name': 'Packager Profile',
-                'verbose_name_plural': 'Packager Profiles',
+                'verbose_name': 'Release Manager',
+                'verbose_name_plural': 'Release Managers',
             },
         ),
         migrations.CreateModel(
@@ -290,7 +290,7 @@ class Migration(migrations.Migration):
                 ('license', models.CharField(default='MIT', max_length=100)),
                 ('repository_url', models.URLField(default='https://github.com/arthexis/arthexis')),
                 ('homepage_url', models.URLField(default='https://arthexis.com')),
-                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
+                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),
             ],
             options={
                 'verbose_name': 'Package',
@@ -310,7 +310,7 @@ class Migration(migrations.Migration):
                 ('is_promoted', models.BooleanField(default=False, editable=False)),
                 ('is_certified', models.BooleanField(default=False, editable=False)),
                 ('package', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.package')),
-                ('profile', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.packagerprofile')),
+                ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),
             ],
             options={
                 'verbose_name': 'Package Release',

--- a/core/migrations/0006_securitygroup_parent.py
+++ b/core/migrations/0006_securitygroup_parent.py
@@ -16,11 +16,11 @@ def create_securitygroups(apps, schema_editor):
 
 
 def create_packaging_defaults(apps, schema_editor):
-    """Ensure default package and packager profile exist."""
+    """Ensure default package and release manager exist."""
 
     app_label, model_name = settings.AUTH_USER_MODEL.split('.')
     User = apps.get_model(app_label, model_name)
-    PackagerProfile = apps.get_model('core', 'PackagerProfile')
+    ReleaseManager = apps.get_model('core', 'ReleaseManager')
     Package = apps.get_model('core', 'Package')
 
     User.objects.get_or_create(
@@ -41,7 +41,7 @@ def create_packaging_defaults(apps, schema_editor):
             "is_superuser": True,
         },
     )
-    profile, _ = PackagerProfile.objects.get_or_create(
+    manager, _ = ReleaseManager.objects.get_or_create(
         user=user,
         defaults={
             "pypi_username": "arthexis",
@@ -58,7 +58,7 @@ def create_packaging_defaults(apps, schema_editor):
             "license": "MIT",
             "repository_url": "https://github.com/arthexis/arthexis",
             "homepage_url": "https://arthexis.com",
-            "release_manager": profile,
+            "release_manager": manager,
         },
     )
 
@@ -70,38 +70,23 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameField(
-            model_name='packagerprofile',
-            old_name='token',
-            new_name='pypi_token',
-        ),
-        migrations.RenameField(
-            model_name='packagerprofile',
-            old_name='username',
-            new_name='pypi_username',
-        ),
-        migrations.RenameField(
-            model_name='packagerprofile',
-            old_name='password',
-            new_name='pypi_password',
-        ),
         migrations.AlterField(
-            model_name='packagerprofile',
+            model_name='releasemanager',
             name='pypi_token',
             field=models.CharField("PyPI token", blank=True, max_length=200),
         ),
         migrations.AlterField(
-            model_name='packagerprofile',
+            model_name='releasemanager',
             name='pypi_username',
             field=models.CharField("PyPI username", blank=True, max_length=100),
         ),
         migrations.AlterField(
-            model_name='packagerprofile',
+            model_name='releasemanager',
             name='pypi_password',
             field=models.CharField("PyPI password", blank=True, max_length=200),
         ),
         migrations.AlterField(
-            model_name='packagerprofile',
+            model_name='releasemanager',
             name='pypi_url',
             field=models.URLField(blank=True, verbose_name='PyPI URL'),
         ),

--- a/tests/test_github_token.py
+++ b/tests/test_github_token.py
@@ -4,23 +4,23 @@ from unittest import mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from core.models import PackageRelease, PackagerProfile
+from core.models import PackageRelease, ReleaseManager
 
 
 class GitHubTokenTests(TestCase):
     def setUp(self):
         self.user = get_user_model().objects.get(username="arthexis")
-        self.profile = PackagerProfile.objects.get(user=self.user)
+        self.manager = ReleaseManager.objects.get(user=self.user)
         self.release = PackageRelease.objects.get(version="0.1.1")
 
     def test_profile_token_preferred_over_env(self):
-        self.profile.github_token = "profile-token"
-        self.profile.save()
+        self.manager.github_token = "profile-token"
+        self.manager.save()
         with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=False):
             self.assertEqual(self.release.get_github_token(), "profile-token")
 
     def test_env_token_used_when_profile_missing(self):
-        self.profile.github_token = ""
-        self.profile.save()
+        self.manager.github_token = ""
+        self.manager.save()
         with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=False):
             self.assertEqual(self.release.get_github_token(), "env-token")

--- a/tests/test_pypi_token.py
+++ b/tests/test_pypi_token.py
@@ -1,0 +1,45 @@
+import os
+from unittest import mock
+
+from django.test import TestCase
+
+from core import release
+
+
+class PyPITokenTests(TestCase):
+    def test_publish_uses_token_when_password_missing(self):
+        creds = release.Credentials(token="pypi-token", username="ignored", password=None)
+        with (
+            mock.patch("core.release.network_available", return_value=False),
+            mock.patch.object(release.Path, "exists", return_value=True),
+            mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
+            mock.patch("core.release._run") as run,
+        ):
+            release.publish(creds=creds)
+        cmd = run.call_args[0][0]
+        assert "__token__" in cmd
+        assert "pypi-token" in cmd
+        assert "ignored" not in cmd
+
+    def test_publish_prefers_profile_over_env(self):
+        profile = release.Credentials(token="profile-token")
+        env = {
+            "PYPI_API_TOKEN": "env-token",
+            "PYPI_USERNAME": "env-user",
+            "PYPI_PASSWORD": "env-pass",
+        }
+        with (
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch("core.release.network_available", return_value=False),
+            mock.patch.object(release.Path, "exists", return_value=True),
+            mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
+            mock.patch("core.release._run") as run,
+            mock.patch("core.release._manager_credentials", return_value=profile),
+        ):
+            release.publish()
+        cmd = run.call_args[0][0]
+        assert "__token__" in cmd
+        assert "profile-token" in cmd
+        assert "env-user" not in cmd
+        assert "env-pass" not in cmd
+        assert "env-token" not in cmd

--- a/tests/test_release_mapping.py
+++ b/tests/test_release_mapping.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from core.models import Package, PackageRelease, PackagerProfile
+from core.models import Package, PackageRelease, ReleaseManager
 
 
 class ReleaseMappingTests(TestCase):
@@ -9,10 +9,10 @@ class ReleaseMappingTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         user = get_user_model().objects.get(username="arthexis")
-        profile = PackagerProfile.objects.get(user=user)
+        manager = ReleaseManager.objects.get(user=user)
         package = Package.objects.get(name="arthexis")
         PackageRelease.objects.get_or_create(
-            version="0.1.1", defaults={"package": package, "profile": profile}
+            version="0.1.1", defaults={"package": package, "release_manager": manager}
         )
 
     def test_migration_number_formula(self):


### PR DESCRIPTION
## Summary
- load release credentials from the Release Manager model before falling back to environment variables
- retroactively rename Packager Profile model to Release Manager
- test that Release Manager tokens override environment credentials

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test tests.test_release_mapping tests.test_github_token tests.test_pypi_token -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b511bdb3488326bee7509760338daa