### PR TITLE
Fix Twine upload glob handling and env-refresh release manager

### DIFF
--- a/core/release.py
+++ b/core/release.py
@@ -339,7 +339,10 @@ def build(
             username=os.environ.get("PYPI_USERNAME"),
             password=os.environ.get("PYPI_PASSWORD"),
         )
-        cmd = [sys.executable, "-m", "twine", "upload", "dist/*"]
+        files = sorted(str(p) for p in Path("dist").glob("*"))
+        if not files:
+            raise ReleaseError("dist directory is empty")
+        cmd = [sys.executable, "-m", "twine", "upload", *files]
         try:
             cmd += creds.twine_args()
         except ValueError:
@@ -432,7 +435,10 @@ def publish(*, package: Package = DEFAULT_PACKAGE, creds: Optional[Credentials] 
         username=os.environ.get("PYPI_USERNAME"),
         password=os.environ.get("PYPI_PASSWORD"),
     )
-    cmd = [sys.executable, "-m", "twine", "upload", "dist/*"]
+    files = sorted(str(p) for p in Path("dist").glob("*"))
+    if not files:
+        raise ReleaseError("dist directory is empty")
+    cmd = [sys.executable, "-m", "twine", "upload", *files]
     try:
         cmd += creds.twine_args()
     except ValueError:

--- a/env-refresh.py
+++ b/env-refresh.py
@@ -107,7 +107,7 @@ def _refresh_next_release(version: str = "0.1.2") -> None:
     PackageRelease.all_objects.filter(version=version).delete()
     PackageRelease.objects.create(
         package=package,
-        profile=package.release_manager,
+        release_manager=package.release_manager,
         version=version,
         revision=revision_utils.get_revision(),
         is_seed_data=True,

--- a/tests/test_pypi_token.py
+++ b/tests/test_pypi_token.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import mock
 
 from django.test import TestCase
@@ -12,6 +13,7 @@ class PyPITokenTests(TestCase):
         with (
             mock.patch("core.release.network_available", return_value=False),
             mock.patch.object(release.Path, "exists", return_value=True),
+            mock.patch.object(release.Path, "glob", return_value=[Path("dist/fake.whl")]),
             mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
             mock.patch("core.release._run") as run,
         ):
@@ -32,6 +34,7 @@ class PyPITokenTests(TestCase):
             mock.patch.dict(os.environ, env, clear=False),
             mock.patch("core.release.network_available", return_value=False),
             mock.patch.object(release.Path, "exists", return_value=True),
+            mock.patch.object(release.Path, "glob", return_value=[Path("dist/fake.whl")]),
             mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
             mock.patch("core.release._run") as run,
             mock.patch("core.release._manager_credentials", return_value=profile),


### PR DESCRIPTION
## Summary
- Ensure Twine uploads expand distribution files instead of relying on shell globbing
- Update env-refresh to use release_manager field for PackageRelease
- Adjust tests for new publish behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b51c52510c83268baba0d3b52dbca9