### PR TITLE
Ensure model verbose names capitalize each word

### DIFF
--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -709,8 +709,8 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "WMI code",
-                "verbose_name_plural": "WMI codes",
+                "verbose_name": "WMI Code",
+                "verbose_name_plural": "WMI Codes",
             },
         ),
         migrations.CreateModel(
@@ -748,6 +748,8 @@ class Migration(migrations.Migration):
             options={
                 "ordering": ["-visited_at"],
                 "unique_together": {("user", "url")},
+                "verbose_name": "Admin History",
+                "verbose_name_plural": "Admin Histories",
             },
         ),
         migrations.CreateModel(

--- a/core/migrations/0001_squashed_0001_initial.py
+++ b/core/migrations/0001_squashed_0001_initial.py
@@ -238,8 +238,8 @@ class Migration(migrations.Migration):
                 ('brand', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='wmi_codes', to='core.brand')),
             ],
             options={
-                'verbose_name': 'WMI code',
-                'verbose_name_plural': 'WMI codes',
+                'verbose_name': 'WMI Code',
+                'verbose_name_plural': 'WMI Codes',
             },
         ),
         migrations.CreateModel(
@@ -256,6 +256,8 @@ class Migration(migrations.Migration):
             options={
                 'ordering': ['-visited_at'],
                 'unique_together': {('user', 'url')},
+                'verbose_name': 'Admin History',
+                'verbose_name_plural': 'Admin Histories',
             },
         ),
         migrations.CreateModel(

--- a/core/models.py
+++ b/core/models.py
@@ -911,8 +911,8 @@ class WMICode(Entity):
     code = models.CharField(max_length=3, unique=True)
 
     class Meta:
-        verbose_name = _("WMI code")
-        verbose_name_plural = _("WMI codes")
+        verbose_name = _("WMI Code")
+        verbose_name_plural = _("WMI Codes")
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.code
@@ -1017,6 +1017,8 @@ class AdminHistory(Entity):
     class Meta:
         ordering = ["-visited_at"]
         unique_together = ("user", "url")
+        verbose_name = "Admin History"
+        verbose_name_plural = "Admin Histories"
 
     @property
     def admin_label(self) -> str:  # pragma: no cover - simple representation

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -24,6 +24,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['name'],
+                'verbose_name': 'Node Role',
+                'verbose_name_plural': 'Node Roles',
             },
         ),
         migrations.CreateModel(
@@ -74,6 +76,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['-created'],
+                'verbose_name': 'Node Task',
+                'verbose_name_plural': 'Node Tasks',
             },
         ),
         migrations.CreateModel(
@@ -98,6 +102,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['-created'],
+                'verbose_name': 'Net Message',
+                'verbose_name_plural': 'Net Messages',
             },
         ),
         migrations.CreateModel(

--- a/nodes/migrations/0002_contentsample_user.py
+++ b/nodes/migrations/0002_contentsample_user.py
@@ -45,6 +45,10 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
+            options={
+                "verbose_name": "Email Outbox",
+                "verbose_name_plural": "Email Outboxes",
+            },
             bases=(core.entity.Entity,),
         ),
         migrations.CreateModel(

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -34,6 +34,8 @@ class NodeRole(Entity):
 
     class Meta:
         ordering = ["name"]
+        verbose_name = "Node Role"
+        verbose_name_plural = "Node Roles"
 
     def natural_key(self):  # pragma: no cover - simple representation
         return (self.name,)
@@ -254,6 +256,10 @@ class EmailOutbox(Entity):
     use_ssl = models.BooleanField(default=False)
     from_email = models.EmailField(blank=True)
 
+    class Meta:
+        verbose_name = "Email Outbox"
+        verbose_name_plural = "Email Outboxes"
+
     def get_connection(self):
         return get_connection(
             host=self.host,
@@ -291,6 +297,8 @@ class NetMessage(Entity):
 
     class Meta:
         ordering = ["-created"]
+        verbose_name = "Net Message"
+        verbose_name_plural = "Net Messages"
 
     @classmethod
     def broadcast(cls, subject: str, body: str, seen: list[str] | None = None):
@@ -460,6 +468,8 @@ class NodeTask(Entity):
 
     class Meta:
         ordering = ["-created"]
+        verbose_name = "Node Task"
+        verbose_name_plural = "Node Tasks"
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.recipe

--- a/pages/migrations/0001_initial.py
+++ b/pages/migrations/0001_initial.py
@@ -174,6 +174,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 "abstract": False,
+                "verbose_name": "Site Badge",
+                "verbose_name_plural": "Site Badges",
             },
         ),
     ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -144,6 +144,10 @@ class SiteBadge(Entity):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"Badge for {self.site.domain}"
 
+    class Meta:
+        verbose_name = "Site Badge"
+        verbose_name_plural = "Site Badges"
+
 
 class SiteProxy(Site):
     class Meta:

--- a/tests/test_model_verbose_name_capitalization.py
+++ b/tests/test_model_verbose_name_capitalization.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+import django
+
+django.setup()
+
+from django.apps import apps
+from django.conf import settings
+from django.test import TestCase
+
+
+class ModelVerboseNameCapitalizationTests(TestCase):
+    def test_model_verbose_names_capitalized(self):
+        for app_label in getattr(settings, "LOCAL_APPS", []):
+            config = apps.get_app_config(app_label)
+            for model in config.get_models():
+                for attr in ("verbose_name", "verbose_name_plural"):
+                    name = str(getattr(model._meta, attr))
+                    if " " in name:
+                        for word in name.split():
+                            if word and word[0].isalpha():
+                                self.assertEqual(
+                                    word[0],
+                                    word[0].upper(),
+                                    f"{model.__name__} {attr} '{name}' is not capitalized",
+                                )


### PR DESCRIPTION
## Summary
- add test enforcing capitalization for verbose model names
- capitalize verbose names for models across core, nodes, and pages apps

## Testing
- `pytest tests/test_model_verbose_name_capitalization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d25c10e4832696675e69780cf3b7