### PR TITLE
feat(nodes): add reach field to network messages

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -320,9 +320,9 @@ class ContentSampleAdmin(admin.ModelAdmin):
 
 @admin.register(NetMessage)
 class NetMessageAdmin(admin.ModelAdmin):
-    list_display = ("subject", "body", "created", "complete")
+    list_display = ("subject", "body", "reach", "created", "complete")
     search_fields = ("subject", "body")
-    list_filter = ("complete",)
+    list_filter = ("complete", "reach")
     ordering = ("-created",)
     readonly_fields = ("complete",)
     actions = ["send_messages"]

--- a/nodes/migrations/0001_initial.py
+++ b/nodes/migrations/0001_initial.py
@@ -3,6 +3,7 @@
 import django.db.models.deletion
 import uuid
 from django.db import migrations, models
+import nodes.models
 
 
 class Migration(migrations.Migration):
@@ -108,6 +109,16 @@ class Migration(migrations.Migration):
                 ),
                 ('subject', models.CharField(blank=True, max_length=64)),
                 ('body', models.CharField(blank=True, max_length=256)),
+                (
+                    'reach',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        default=nodes.models.get_terminal_role,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to='nodes.noderole',
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('complete', models.BooleanField(default=False, editable=False)),
                 (

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -44,6 +44,11 @@ class NodeRole(Entity):
         return self.name
 
 
+def get_terminal_role():
+    """Return the NodeRole representing a Terminal if it exists."""
+    return NodeRole.objects.filter(name="Terminal").first()
+
+
 class Node(Entity):
     """Information about a running node in the network."""
 
@@ -336,6 +341,13 @@ class NetMessage(Entity):
     )
     subject = models.CharField(max_length=64, blank=True)
     body = models.CharField(max_length=256, blank=True)
+    reach = models.ForeignKey(
+        NodeRole,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        default=get_terminal_role,
+    )
     propagated_to = models.ManyToManyField(
         Node, blank=True, related_name="received_net_messages"
     )
@@ -348,8 +360,24 @@ class NetMessage(Entity):
         verbose_name_plural = "Net Messages"
 
     @classmethod
-    def broadcast(cls, subject: str, body: str, seen: list[str] | None = None):
-        msg = cls.objects.create(subject=subject[:64], body=body[:256])
+    def broadcast(
+        cls,
+        subject: str,
+        body: str,
+        reach: NodeRole | str | None = None,
+        seen: list[str] | None = None,
+    ):
+        role = None
+        if reach:
+            if isinstance(reach, NodeRole):
+                role = reach
+            else:
+                role = NodeRole.objects.filter(name=reach).first()
+        msg = cls.objects.create(
+            subject=subject[:64],
+            body=body[:256],
+            reach=role or get_terminal_role(),
+        )
         msg.propagate(seen=seen or [])
         return msg
 
@@ -402,7 +430,14 @@ class NetMessage(Entity):
             self.save(update_fields=["complete"])
             return
 
-        role_order = ["Control", "Constellation", "Satellite", "Terminal"]
+        reach_name = self.reach.name if self.reach else "Terminal"
+        role_map = {
+            "Terminal": ["Terminal"],
+            "Control": ["Control", "Terminal"],
+            "Satellite": ["Satellite", "Control", "Terminal"],
+            "Constellation": ["Constellation", "Satellite", "Control", "Terminal"],
+        }
+        role_order = role_map.get(reach_name, ["Terminal"])
         selected: list[Node] = []
         for role_name in role_order:
             role_nodes = [n for n in remaining if n.role and n.role.name == role_name]
@@ -414,12 +449,6 @@ class NetMessage(Entity):
                     break
             if len(selected) + self.propagated_to.count() >= target_limit:
                 break
-        if len(selected) + self.propagated_to.count() < target_limit:
-            random.shuffle(remaining)
-            for n in remaining:
-                selected.append(n)
-                if len(selected) + self.propagated_to.count() >= target_limit:
-                    break
 
         seen_list = seen.copy()
         selected_ids = [str(n.uuid) for n in selected]
@@ -430,6 +459,7 @@ class NetMessage(Entity):
                 "subject": self.subject,
                 "body": self.body,
                 "seen": payload_seen,
+                "reach": reach_name,
                 "sender": local_id,
             }
             payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)

--- a/nodes/urls.py
+++ b/nodes/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path("register/", views.register_node, name="register-node"),
     path("screenshot/", views.capture, name="node-screenshot"),
     path("net-message/", views.net_message, name="net-message"),
+    path("last-message/", views.last_net_message, name="last-net-message"),
     path("<slug:endpoint>/", views.public_node_endpoint, name="node-public-endpoint"),
 ]

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -1,10 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrahead %}
-  {{ block.super }}
-{% endblock %}
-
 {% block extrastyle %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'admin/css/dashboard.css' %}">
@@ -88,7 +84,8 @@
 {% block content_title %}
 <div id="admin-home-header" style="display:flex; justify-content:space-between; align-items:center;">
   <h1>Home</h1>
-  <div>
+  <div style="display:flex; align-items:center; gap:8px;">
+    <span id="last-netmessage" style="display:none; font-family:monospace; white-space:nowrap; margin-right:8px;"></span>
     <a class="button" href="{% url 'admin:seed_data' %}">{% translate 'Seed Data' %}</a>
     <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
     <a class="button" href="{% url 'admin:system' %}">{% translate 'System' %}</a>
@@ -148,8 +145,35 @@
             </ul>
             {% endif %}
     </div>
-  </div>
+</div>
 </div>
 {% endblock %}
 
 {% block sidebar %}{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script>
+    (function () {
+      const label = document.getElementById('last-netmessage');
+      let last = '';
+      async function fetchMessage() {
+        try {
+          const resp = await fetch('{% url 'last-net-message' %}');
+          if (!resp.ok) return;
+          const data = await resp.json();
+          const text = `${data.subject || ''} - ${data.body || ''}`.replace(/[\r\n]+/g, ' ').trim();
+          if (text && text !== last) {
+            label.textContent = text;
+            label.style.display = 'inline';
+            last = text;
+          }
+        } catch (e) {
+          // ignore errors
+        }
+      }
+      fetchMessage();
+      setInterval(fetchMessage, 6000);
+    })();
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow NetMessage to specify reach via Node roles
- propagate messages according to reach and include role in payloads
- show message reach in admin and cover propagation with tests
- expose endpoint for last network message and surface latest message on admin dashboard

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py migrate`
- `python manage.py test nodes`


------
https://chatgpt.com/codex/tasks/task_e_68b62668e05c8326afc977d007fd64ab