### PR TITLE
feat(admin): add future actions sidebar

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -21,6 +21,7 @@ from django.utils.html import format_html
 import json
 import uuid
 from django_object_actions import DjangoObjectActions
+from .user_data import UserDatumAdminMixin
 from .models import (
     User,
     EnergyAccount,
@@ -241,7 +242,8 @@ class UserAdmin(DjangoUserAdmin):
 
 
 @admin.register(Address)
-class AddressAdmin(admin.ModelAdmin):
+class AddressAdmin(UserDatumAdminMixin, admin.ModelAdmin):
+    change_form_template = "admin/user_datum_change_form.html"
     list_display = ("street", "number", "municipality", "state", "postal_code")
     search_fields = ("street", "municipality", "postal_code")
 
@@ -275,7 +277,8 @@ class OdooProfileAdminForm(forms.ModelForm):
 
 
 @admin.register(OdooProfile)
-class OdooProfileAdmin(admin.ModelAdmin):
+class OdooProfileAdmin(UserDatumAdminMixin, admin.ModelAdmin):
+    change_form_template = "admin/user_datum_change_form.html"
     form = OdooProfileAdminForm
     list_display = ("user", "host", "database", "verified_on")
     readonly_fields = ("verified_on", "odoo_uid", "name", "email")

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -6,6 +6,7 @@ import django.core.validators
 import django.db.models.deletion
 import django.utils.timezone
 import core.entity
+import utils.revision
 from django.conf import settings
 from django.db import migrations, models
 import uuid
@@ -787,7 +788,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('name', models.CharField(default='arthexis', max_length=100)),
+                ('name', models.CharField(default='arthexis', max_length=100, unique=True)),
                 ('description', models.CharField(default='Django-based MESH system', max_length=255)),
                 ('author', models.CharField(default='Rafael J. Guillén-Osorio', max_length=100)),
                 ('email', models.EmailField(default='tecnologia@gelectriic.com', max_length=254)),
@@ -809,7 +810,7 @@ class Migration(migrations.Migration):
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('version', models.CharField(default='0.0.0', max_length=20)),
-                ('revision', models.CharField(blank=True, max_length=40)),
+                ('revision', models.CharField(blank=True, max_length=40, default=utils.revision.get_revision, editable=False)),
                 ('pypi_url', models.URLField('PyPI URL', blank=True, editable=False)),
                 ('package', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.package')),
                 ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),

--- a/core/migrations/0001_squashed_0001_initial.py
+++ b/core/migrations/0001_squashed_0001_initial.py
@@ -7,6 +7,7 @@ import django.core.validators
 import django.db.models.deletion
 import django.utils.timezone
 import uuid
+import utils.revision
 from django.conf import settings
 from django.db import migrations, models
 
@@ -284,7 +285,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
-                ('name', models.CharField(default='arthexis', max_length=100)),
+                ('name', models.CharField(default='arthexis', max_length=100, unique=True)),
                 ('description', models.CharField(default='Django-based MESH system', max_length=255)),
                 ('author', models.CharField(default='Rafael J. Guillén-Osorio', max_length=100)),
                 ('email', models.EmailField(default='tecnologia@gelectriic.com', max_length=254)),
@@ -306,7 +307,7 @@ class Migration(migrations.Migration):
                 ('is_seed_data', models.BooleanField(default=False, editable=False)),
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('version', models.CharField(default='0.0.0', max_length=20)),
-                ('revision', models.CharField(blank=True, max_length=40)),
+                ('revision', models.CharField(blank=True, max_length=40, default=utils.revision.get_revision, editable=False)),
                 ('pypi_url', models.URLField('PyPI URL', blank=True, editable=False)),
                 ('package', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='releases', to='core.package')),
                 ('release_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='core.releasemanager')),

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -503,9 +503,9 @@ msgstr ""
 msgid "Django administration"
 msgstr ""
 
-#: pages/templates/admin/index.html:131
-msgid "Recent admin lists"
-msgstr ""
+#: pages/templates/admin/index.html:109
+msgid "Future actions"
+msgstr "Acciones futuras"
 
 #: pages/templates/admin/index.html:140
 #: pages/templates/admin/index.html:150

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load i18n static admin_extras %}
 
 {% block extrastyle %}
   {{ block.super }}
@@ -103,13 +103,26 @@
     {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
 </div>
 <div class="dashboard-side" id="recent-boxes">
-    <div class="module" id="recent-history-module">
-        <h2>{% translate 'Recent admin lists' %}</h2>
-        {% with history=user.admin_history.all|slice:":10" %}
-            {% if history %}
+    <div class="module" id="future-actions-module">
+        <h2>{% translate 'Future actions' %}</h2>
+        {% with history=user.admin_history.all|slice:":10" favorites=user.favorites.all %}
+        {% user_data_content_types as user_data_cts %}
+            {% if history or favorites or user_data_cts %}
             <ul class="actionlist">
                 {% for item in history %}
                 <li class="changelink"><a href="{{ item.url }}">{{ item.admin_label }}</a></li>
+                {% endfor %}
+                {% for fav in favorites %}
+                {% admin_changelist_url fav.content_type as url %}
+                {% if url %}
+                <li class="changelink"><a href="{{ url }}">{{ fav.custom_label|default:fav.content_type.name }}</a></li>
+                {% endif %}
+                {% endfor %}
+                {% for ct in user_data_cts %}
+                {% admin_changelist_url ct as url %}
+                {% if url %}
+                <li class="changelink"><a href="{{ url }}">{{ ct.name }}</a></li>
+                {% endif %}
                 {% endfor %}
             </ul>
             {% else %}


### PR DESCRIPTION
## Summary
- add `Future actions` box to admin dashboard
- show recent admin history, favorite models, and user data models
- add helper template tags and tests
- fix user datum change forms and persist package uniqueness in migrations

## Testing
- `python manage.py compilemessages`
- `python manage.py makemigrations --check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b632b48ecc8326a6713054c285d5d3