### PR TITLE
test: ensure env refresh leaves repo clean

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -42,6 +42,7 @@ from .models import (
     ReleaseManager,
     SecurityGroup,
 )
+from .user_data import UserDatumAdminMixin
 
 
 admin.site.unregister(Group)
@@ -241,9 +242,17 @@ class UserAdmin(DjangoUserAdmin):
 
 
 @admin.register(Address)
-class AddressAdmin(admin.ModelAdmin):
+class AddressAdmin(UserDatumAdminMixin, admin.ModelAdmin):
+    change_form_template = "admin/user_datum_change_form.html"
     list_display = ("street", "number", "municipality", "state", "postal_code")
     search_fields = ("street", "municipality", "postal_code")
+
+    def save_model(self, request, obj, form, change):
+        if "_saveacopy" in request.POST:
+            obj.pk = None
+            super().save_model(request, obj, form, False)
+        else:
+            super().save_model(request, obj, form, change)
 
 
 class OdooProfileAdminForm(forms.ModelForm):
@@ -275,7 +284,8 @@ class OdooProfileAdminForm(forms.ModelForm):
 
 
 @admin.register(OdooProfile)
-class OdooProfileAdmin(admin.ModelAdmin):
+class OdooProfileAdmin(UserDatumAdminMixin, admin.ModelAdmin):
+    change_form_template = "admin/user_datum_change_form.html"
     form = OdooProfileAdminForm
     list_display = ("user", "host", "database", "verified_on")
     readonly_fields = ("verified_on", "odoo_uid", "name", "email")

--- a/core/migrations/0007_packagerelease_pr_url.py
+++ b/core/migrations/0007_packagerelease_pr_url.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations, models
 import core.fields
+import utils.revision
 
 
 class Migration(migrations.Migration):
@@ -119,6 +120,21 @@ class Migration(migrations.Migration):
                 default="imap",
                 help_text="IMAP keeps emails on the server for access across devices; POP3 downloads messages to a single device and may remove them from the server",
                 max_length=5,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="package",
+            name="name",
+            field=models.CharField(default="arthexis", max_length=100, unique=True),
+        ),
+        migrations.AlterField(
+            model_name="packagerelease",
+            name="revision",
+            field=models.CharField(
+                blank=True,
+                default=utils.revision.get_revision,
+                editable=False,
+                max_length=40,
             ),
         ),
     ]

--- a/core/user_data.py
+++ b/core/user_data.py
@@ -155,8 +155,9 @@ class UserDatumAdminMixin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         copied = "_saveacopy" in request.POST
-        if copied and hasattr(obj, "clone"):
-            obj = obj.clone()
+        if copied:
+            obj = obj.clone() if hasattr(obj, "clone") else obj
+            obj.pk = None
             form.instance = obj
             try:
                 super().save_model(request, obj, form, False)

--- a/tests/test_env_refresh_clean.py
+++ b/tests/test_env_refresh_clean.py
@@ -1,0 +1,30 @@
+import subprocess
+import importlib.util
+from pathlib import Path
+
+from django.core.management import call_command
+from django.conf import settings
+
+
+def test_env_refresh_leaves_repo_clean():
+    base_dir = Path(settings.BASE_DIR)
+
+    spec = importlib.util.spec_from_file_location("env_refresh", base_dir / "env-refresh.py")
+    env_refresh = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(env_refresh)
+
+    local_apps = env_refresh._local_app_labels()
+
+    # Ensure no new migrations are needed
+    call_command("makemigrations", *local_apps, interactive=False, check=True)
+
+    # Confirm repository is clean
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=base_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == ""
+


### PR DESCRIPTION
## Summary
- rewrite latest migration to keep Package name unique and PackageRelease revision default in sync
- add test verifying `makemigrations` produces no changes and git repo stays clean
- hook Address and OdooProfile admins into `UserDatumAdminMixin`, implementing `save_as_copy` support and user-datum checkbox

## Testing
- `pytest tests/test_env_refresh_clean.py -q`
- `pytest tests/test_user_datum_admin.py::UserDatumAdminTests::test_checkbox_displayed_on_change_form tests/test_save_as_copy.py::SaveAsCopyTests::test_save_as_copy_creates_new_instance -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6377836e88326850da7cf85f88b2c