### PR TITLE
Handle SQLite file locks during env refresh

### DIFF
--- a/tests/test_env_refresh_unlink.py
+++ b/tests/test_env_refresh_unlink.py
@@ -1,0 +1,41 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def load_unlink_function():
+    source = Path(__file__).resolve().parents[1] / "env-refresh.py"
+    module = ast.parse(source.read_text())
+    func_node = next(
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "_unlink_sqlite_db"
+    )
+    module = ast.Module([func_node], [])  # type: ignore[arg-type]
+    ast.fix_missing_locations(module)
+    namespace: dict[str, object] = {"Path": Path}
+    code = compile(module, filename="env-refresh.py", mode="exec")
+    exec(code, namespace)
+    return namespace["_unlink_sqlite_db"]  # type: ignore[return-value]
+
+
+def test_unlink_sqlite_db_retries(monkeypatch, tmp_path):
+    unlink_func = load_unlink_function()
+    path = tmp_path / "db.sqlite3"
+    path.touch()
+
+    calls = {"count": 0}
+    original_unlink = Path.unlink
+
+    def fake_unlink(self, missing_ok=False):
+        if self == path and calls["count"] == 0:
+            calls["count"] += 1
+            raise PermissionError
+        return original_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+    monkeypatch.setitem(unlink_func.__globals__, "connections", SimpleNamespace(close_all=lambda: None))
+    monkeypatch.setitem(unlink_func.__globals__, "time", SimpleNamespace(sleep=lambda s: None))
+
+    unlink_func(path)
+
+    assert calls["count"] == 1
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- add helper to close DB connections and retry removal of SQLite database files
- call helper throughout env refresh to avoid PermissionError on Windows
- add regression test for retry logic when unlinking database

## Testing
- `pytest tests/test_env_refresh_unlink.py -q`
- `pytest -q` *(fails: PackageModelTests::test_package_name_unique, SaveAsCopyTests::test_save_as_copy_creates_new_instance, UserDatumAdminTests::test_checkbox_displayed_on_change_form, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b63a691f548326a69d9c418711d64a