### PR TITLE
Use release model version for publishing

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1231,7 +1231,10 @@ class PackageRelease(Entity):
         from utils import revision as revision_utils
 
         release_utils.build(
-            package=self.to_package(), creds=self.to_credentials(), **kwargs
+            package=self.to_package(),
+            version=self.version,
+            creds=self.to_credentials(),
+            **kwargs,
         )
         self.revision = revision_utils.get_revision()
         self.save(update_fields=["revision"])

--- a/tests/test_pypi_token.py
+++ b/tests/test_pypi_token.py
@@ -14,10 +14,12 @@ class PyPITokenTests(TestCase):
             mock.patch("core.release.network_available", return_value=False),
             mock.patch.object(release.Path, "exists", return_value=True),
             mock.patch.object(release.Path, "glob", return_value=[Path("dist/fake.whl")]),
-            mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
-            mock.patch("core.release._run") as run,
+            mock.patch("core.release.subprocess.run") as run,
         ):
-            release.publish(creds=creds)
+            run.return_value.returncode = 0
+            run.return_value.stdout = ""
+            run.return_value.stderr = ""
+            release.publish(version="0.1.1", creds=creds)
         cmd = run.call_args[0][0]
         assert "__token__" in cmd
         assert "pypi-token" in cmd
@@ -35,11 +37,13 @@ class PyPITokenTests(TestCase):
             mock.patch("core.release.network_available", return_value=False),
             mock.patch.object(release.Path, "exists", return_value=True),
             mock.patch.object(release.Path, "glob", return_value=[Path("dist/fake.whl")]),
-            mock.patch.object(release.Path, "read_text", return_value="0.1.1"),
-            mock.patch("core.release._run") as run,
+            mock.patch("core.release.subprocess.run") as run,
             mock.patch("core.release._manager_credentials", return_value=profile),
         ):
-            release.publish()
+            run.return_value.returncode = 0
+            run.return_value.stdout = ""
+            run.return_value.stderr = ""
+            release.publish(version="0.1.1")
         cmd = run.call_args[0][0]
         assert "__token__" in cmd
         assert "profile-token" in cmd

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -50,9 +50,12 @@ class ReleaseProgressTests(TestCase):
         with patch("core.views.release_utils.promote", return_value=(commit_hash, "branch", "main")), \
              patch("core.views.release_utils.publish") as pub, \
              patch("core.views.shutil.which", return_value="/usr/bin/gh"), \
+             patch("core.views.requests.get") as req_get, \
              patch("core.views.subprocess.run", side_effect=run_side_effect):
+            req_get.return_value.ok = True
+            req_get.return_value.json.return_value = {"releases": {}}
             resp = self.client.get(url)
-            for i in range(3):
+            for i in range(4):
                 resp = self.client.get(f"{url}?step={i}")
 
         self.assertEqual(resp.status_code, 200)
@@ -80,9 +83,12 @@ class ReleaseProgressTests(TestCase):
         with patch("core.views.release_utils.promote", return_value=(commit_hash, "branch", "main")), \
              patch("core.views.release_utils.publish") as pub, \
              patch("core.views.shutil.which", return_value=None), \
+             patch("core.views.requests.get") as req_get, \
              patch("core.views.subprocess.run", side_effect=run_side_effect):
+            req_get.return_value.ok = True
+            req_get.return_value.json.return_value = {"releases": {}}
             resp = self.client.get(url)
-            for i in range(3):
+            for i in range(4):
                 resp = self.client.get(f"{url}?step={i}")
 
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- avoid mutating VERSION; build and publish use PackageRelease version
- verify PyPI availability before building and capture upload failures
- update tests for new publishing workflow

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6479979808326965af6e75a40e5c6