### PR TITLE
Remove package release defaults from migrations

### DIFF
--- a/core/migrations/0006_securitygroup_parent.py
+++ b/core/migrations/0006_securitygroup_parent.py
@@ -7,7 +7,6 @@ from django.contrib.auth.hashers import make_password
 # NOTE: Prefer rewriting this latest migration over creating new ones.
 # Earlier migrations must be preserved to maintain compatibility.
 
-
 def create_securitygroups(apps, schema_editor):
     Group = apps.get_model('auth', 'Group')
     SecurityGroup = apps.get_model('core', 'SecurityGroup')
@@ -22,16 +21,6 @@ def create_packaging_defaults(apps, schema_editor):
     User = apps.get_model(app_label, model_name)
     ReleaseManager = apps.get_model('core', 'ReleaseManager')
     Package = apps.get_model('core', 'Package')
-
-    User.objects.get_or_create(
-        username="admin",
-        defaults={
-            "email": "",
-            "is_staff": True,
-            "is_superuser": True,
-            "password": make_password("admin"),
-        },
-    )
 
     user, _ = User.objects.get_or_create(
         username="arthexis",

--- a/tests/test_email_inbox_search_action.py
+++ b/tests/test_email_inbox_search_action.py
@@ -82,7 +82,7 @@ class EmailInboxSearchTests(TestCase):
 
     @patch.object(EmailInbox, "search_messages", return_value=[{"subject": "S", "from": "F", "body": "B"}])
     def test_admin_action(self, mock_search):
-        admin = User.objects.get(username="admin")
+        admin = User.objects.create(username="admin", is_staff=True, is_superuser=True)
         inbox = EmailInbox.objects.create(
             user=admin,
             host="imap.test",

--- a/tests/test_localhost_admin_backend.py
+++ b/tests/test_localhost_admin_backend.py
@@ -7,9 +7,10 @@ from core.backends import LocalhostAdminBackend
 
 
 def test_docker_network_allowed(tmp_path):
-    # Ensure the default admin exists
     User = get_user_model()
-    assert User.objects.filter(username="admin").exists()
+    User.objects.create_user(
+        username="admin", password="admin", is_staff=True, is_superuser=True
+    )
     backend = LocalhostAdminBackend()
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "172.16.5.4"


### PR DESCRIPTION
## Summary
- stop creating default admin user during packaging migration
- ensure tests create admin user explicitly when needed

## Testing
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b647597d4083269e4ea3889a381e42