### PR TITLE
Use arthexis as default user and lazy-create admin

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -17,12 +17,17 @@ class CoreConfig(AppConfig):
         from .system import patch_admin_system_view
         from .environment import patch_admin_environment_view
 
-        def create_default_admin(**kwargs):
+        def create_default_arthexis(**kwargs):
             User = get_user_model()
-            if not User.objects.exists():
-                User.objects.create_superuser("admin", password="admin")
+            if not User.all_objects.exists():
+                User.all_objects.create_superuser(
+                    pk=1,
+                    username="arthexis",
+                    email="arthexis@gmail.com",
+                    password="arthexis",
+                )
 
-        post_migrate.connect(create_default_admin, sender=self)
+        post_migrate.connect(create_default_arthexis, sender=self)
         patch_admin_user_datum()
         patch_admin_user_data_views()
         patch_admin_system_view()

--- a/core/backends.py
+++ b/core/backends.py
@@ -57,5 +57,26 @@ class LocalhostAdminBackend(ModelBackend):
             allowed = any(ip in net for net in self._ALLOWED_NETWORKS)
             if not allowed:
                 return None
+            User = get_user_model()
+            user, created = User.all_objects.get_or_create(
+                username="admin",
+                defaults={
+                    "is_staff": True,
+                    "is_superuser": True,
+                },
+            )
+            if created:
+                user.set_password("admin")
+                user.save()
+            elif not user.check_password("admin"):
+                return None
+            return user
         return super().authenticate(request, username, password, **kwargs)
+
+    def get_user(self, user_id):
+        User = get_user_model()
+        try:
+            return User.all_objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None
 

--- a/core/entity.py
+++ b/core/entity.py
@@ -24,7 +24,11 @@ class EntityManager(models.Manager):
 
 class EntityUserManager(DjangoUserManager):
     def get_queryset(self):
-        return EntityQuerySet(self.model, using=self._db).filter(is_deleted=False)
+        return (
+            EntityQuerySet(self.model, using=self._db)
+            .filter(is_deleted=False)
+            .exclude(username="admin")
+        )
 
 
 class Entity(models.Model):

--- a/core/fixtures/energy_accounts.json
+++ b/core/fixtures/energy_accounts.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "name": "GELECTRIIC",
-      "user": 2,
+      "user": 1,
       "rfids": [1],
       "service_account": true
     }

--- a/core/fixtures/users.json
+++ b/core/fixtures/users.json
@@ -1,7 +1,7 @@
 [
   {
     "model": "core.user",
-    "pk": 2,
+    "pk": 1,
     "fields": {
       "username": "arthexis",
       "email": "arthexis@gmail.com",

--- a/core/tests.py
+++ b/core/tests.py
@@ -34,17 +34,17 @@ from .backends import LocalhostAdminBackend
 
 
 class DefaultAdminTests(TestCase):
-    def test_admin_created_and_local_only(self):
-        self.assertTrue(User.objects.filter(username="admin").exists())
-        backend = LocalhostAdminBackend()
+    def test_arthexis_is_default_user(self):
+        self.assertTrue(User.objects.filter(username="arthexis").exists())
+        self.assertFalse(User.all_objects.filter(username="admin").exists())
 
-        for ip in ["127.0.0.1", "192.168.1.5", "10.42.0.8", "172.16.0.1"]:
-            req = HttpRequest()
-            req.META["REMOTE_ADDR"] = ip
-            self.assertIsNotNone(
-                backend.authenticate(req, username="admin", password="admin"),
-                f"{ip} should allow admin login",
-            )
+    def test_admin_created_and_local_only(self):
+        backend = LocalhostAdminBackend()
+        req = HttpRequest()
+        req.META["REMOTE_ADDR"] = "127.0.0.1"
+        user = backend.authenticate(req, username="admin", password="admin")
+        self.assertIsNotNone(user)
+        self.assertEqual(user.pk, 2)
 
         remote = HttpRequest()
         remote.META["REMOTE_ADDR"] = "10.0.0.1"

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -20,7 +20,7 @@ from core.models import Package, PackageRelease
 class ReleaseProgressTests(TestCase):
     def setUp(self):
         User = get_user_model()
-        self.admin, _ = User.objects.get_or_create(
+        self.admin, _ = User.all_objects.get_or_create(
             username="admin",
             defaults={"email": "a@example.com", "is_superuser": True, "is_staff": True},
         )

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -50,7 +50,7 @@ class UserDatumAdminTests(TransactionTestCase):
         self.fixture_path.unlink(missing_ok=True)
         call_command("flush", verbosity=0, interactive=False)
         User = get_user_model()
-        User.objects.filter(username="admin").delete()
+        User.all_objects.filter(username="admin").delete()
 
     def test_checkbox_displayed_on_change_form(self):
         url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])


### PR DESCRIPTION
## Summary
- ensure arthexis superuser is created post-migrate with id 1
- lazily create admin user for local network logins and hide admin from normal queries
- update fixtures and tests to use arthexis and new admin workflow

## Testing
- `python manage.py migrate --noinput`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b65bba91148326b2feefc0cc47d6ab