### PR TITLE
fix: add twine to release requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,8 @@ content-type = "text/markdown"
 Repository = "https://github.com/arthexis/arthexis"
 Homepage = "https://arthexis.com"
 
+[project.optional-dependencies]
+release = ["twine==6.1.0"]
+
 [tool.setuptools]
 packages = [ "core", "config", "nodes", "ocpp", "pages",]

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ toml==0.10.2
 trio==0.30.0
 trio-websocket==0.12.2
 Twisted==25.5.0
+twine==6.1.0
 txaio==25.6.1
 typing-inspection==0.4.1
 typing_extensions==4.14.1


### PR DESCRIPTION
## Summary
- include twine in requirements for PyPI uploads
- expose optional `release` extras with twine

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b66b8e36548326b43fbbe44d7a835a