### PR TITLE
Add user data flag to favorites admin interface

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -174,13 +174,25 @@ def favorite_toggle(request, ct_id):
         return redirect("admin:favorite_list")
     if request.method == "POST":
         label = request.POST.get("custom_label", "").strip()
-        Favorite.objects.create(user=request.user, content_type=ct, custom_label=label)
+        user_data = request.POST.get("user_data") == "on"
+        Favorite.objects.create(
+            user=request.user,
+            content_type=ct,
+            custom_label=label,
+            user_data=user_data,
+        )
         return redirect("admin:index")
     return render(request, "admin/favorite_confirm.html", {"content_type": ct})
 
 
 def favorite_list(request):
     favorites = Favorite.objects.filter(user=request.user).select_related("content_type")
+    if request.method == "POST":
+        selected = request.POST.getlist("user_data")
+        for fav in favorites:
+            fav.user_data = str(fav.pk) in selected
+            fav.save(update_fields=["user_data"])
+        return redirect("admin:favorite_list")
     return render(request, "admin/favorite_list.html", {"favorites": favorites})
 
 

--- a/pages/migrations/0001_initial.py
+++ b/pages/migrations/0001_initial.py
@@ -196,6 +196,7 @@ class Migration(migrations.Migration):
                 ("is_seed_data", models.BooleanField(default=False, editable=False)),
                 ("is_deleted", models.BooleanField(default=False, editable=False)),
                 ("custom_label", models.CharField(blank=True, max_length=100)),
+                ("user_data", models.BooleanField(default=False)),
                 (
                     "content_type",
                     models.ForeignKey(

--- a/pages/models.py
+++ b/pages/models.py
@@ -206,6 +206,7 @@ class Favorite(Entity):
     )
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     custom_label = models.CharField(max_length=100, blank=True)
+    user_data = models.BooleanField(default=False)
 
     class Meta:
         unique_together = ("user", "content_type")

--- a/pages/templates/admin/favorite_confirm.html
+++ b/pages/templates/admin/favorite_confirm.html
@@ -9,6 +9,9 @@
   <p>
     <label>{% translate "Custom Label" %}: <input type="text" name="custom_label" value=""></label>
   </p>
+  <p>
+    <label><input type="checkbox" name="user_data"> {% translate "Mark as User Data" %}</label>
+  </p>
   <div class="submit-row">
     <input type="submit" value="{% translate 'Save' %}" class="default">
     <a href="{% url 'admin:index' %}">{% translate "Cancel" %}</a>

--- a/pages/templates/admin/favorite_list.html
+++ b/pages/templates/admin/favorite_list.html
@@ -4,24 +4,32 @@
 {% block content %}
 <h1>{% translate "Favorites" %}</h1>
 {% if favorites %}
-<table class="listing">
-  <thead>
-    <tr>
-      <th>{% translate "Model" %}</th>
-      <th>{% translate "Custom Label" %}</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for fav in favorites %}
-    <tr>
-      <td>{{ fav.content_type.name }}</td>
-      <td>{{ fav.custom_label }}</td>
-      <td><a href="{% url 'admin:favorite_delete' fav.pk %}">{% translate "Remove" %}</a></td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+<form method="post">
+  {% csrf_token %}
+  <table class="listing">
+    <thead>
+      <tr>
+        <th>{% translate "Model" %}</th>
+        <th>{% translate "Custom Label" %}</th>
+        <th>{% translate "Mark as User Data" %}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for fav in favorites %}
+      <tr>
+        <td>{{ fav.content_type.name }}</td>
+        <td>{{ fav.custom_label }}</td>
+        <td><input type="checkbox" name="user_data" value="{{ fav.pk }}" {% if fav.user_data %}checked{% endif %}></td>
+        <td><a href="{% url 'admin:favorite_delete' fav.pk %}">{% translate "Remove" %}</a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <div class="submit-row">
+    <input type="submit" value="{% translate 'Save' %}" class="default">
+  </div>
+</form>
 <p><a href="{% url 'admin:favorite_clear' %}">{% translate "Remove all favorites" %}</a></p>
 {% else %}
 <p>{% translate "No favorites." %}</p>


### PR DESCRIPTION
## Summary
- allow marking favorites as user data via checkbox when adding
- let favorites list show and edit user data state

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py migrate pages zero`
- `python manage.py migrate`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b66b326b0c8326824f9937817e1243