### PR TITLE
Decouple database reset from --latest in env refresh

### DIFF
--- a/env-refresh.bat
+++ b/env-refresh.bat
@@ -36,8 +36,7 @@ if exist requirements.txt (
         echo %REQ_HASH%>requirements.md5
     )
 )
-if %LATEST%==1 (
-    %VENV%\Scripts\python.exe env-refresh.py --latest database
-) else (
-    %VENV%\Scripts\python.exe env-refresh.py database
-)
+set "ARGS="
+if %LATEST%==1 set "ARGS=%ARGS% --latest"
+if %CLEAN%==1 set "ARGS=%ARGS% --clean"
+%VENV%\Scripts\python.exe env-refresh.py %ARGS% database

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -50,8 +50,11 @@ if [ -f requirements.txt ]; then
   fi
 fi
 
+ARGS=""
 if [ "$LATEST" -eq 1 ]; then
-  "$PYTHON" env-refresh.py --latest database
-else
-  "$PYTHON" env-refresh.py database
+  ARGS="$ARGS --latest"
 fi
+if [ "$CLEAN" -eq 1 ]; then
+  ARGS="$ARGS --clean"
+fi
+"$PYTHON" env-refresh.py $ARGS database


### PR DESCRIPTION
## Summary
- Add optional `--clean` flag to env-refresh to handle database resets
- Update shell and batch wrappers to pass `--clean` to env-refresh.py
- Keep `--latest` from resetting the database unless `--clean` is specified

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b671359fac8326a2f89b9b47aef66d