### PR TITLE
fix: update version file during release

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -43,6 +43,16 @@ def _changelog_notes(version: str) -> str:
 
 def _step_check_pypi(release, ctx, log_path: Path) -> None:
     from . import release as release_utils
+    from packaging.version import Version
+
+    version_path = Path("VERSION")
+    if version_path.exists():
+        current = version_path.read_text(encoding="utf-8").strip()
+        if current and Version(release.version) < Version(current):
+            raise Exception(
+                f"Version {release.version} is older than existing {current}"
+            )
+    version_path.write_text(release.version + "\n", encoding="utf-8")
 
     _append_log(log_path, f"Checking if version {release.version} exists on PyPI")
     if release_utils.network_available():

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -100,7 +100,8 @@
 {% block content %}
 <div class="dashboard" id="admin-dashboard">
   <div id="content-main" class="dashboard-main">
-    {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+    {% filtered_app_list app_list as filtered_app_list %}
+    {% include "admin/app_list.html" with app_list=filtered_app_list show_changelinks=True %}
 </div>
 <div class="dashboard-side" id="recent-boxes">
     <div class="module" id="future-actions-module">


### PR DESCRIPTION
## Summary
- update check step in release flow to write VERSION file and fail if version would decrease
- add test coverage for VERSION updates and backwards checks
- filter admin app list to remove models already shown in future actions

## Testing
- `python manage.py test tests.test_release_progress -v 2`
- `python manage.py test pages.tests.FavoriteTests.test_dashboard_merges_duplicate_future_actions -v 2`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b673911c9c83269bc94cd19ac226d9