### PR TITLE
Show PyPI link after release

### DIFF
--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -31,7 +31,10 @@
 {% else %}
 <p>All steps completed.</p>
 {% if pr_url %}
-<p><a href="{{ pr_url }}" target="_blank">{{ pr_url }}</a></p>
+<p><a href="{{ pr_url }}" target="_blank" rel="noopener">{{ pr_url }}</a></p>
+{% endif %}
+{% if release.pypi_url %}
+<p><a href="{{ release.pypi_url }}" target="_blank" rel="noopener">{{ release.pypi_url }}</a></p>
 {% endif %}
 <div>
   <input type="text" id="logpath" value="{{ log_path }}" readonly>

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -29,7 +29,10 @@
 {% else %}
 <p>All steps completed.</p>
 {% if pr_url %}
-<p><a href="{{ pr_url }}" target="_blank">{{ pr_url }}</a></p>
+<p><a href="{{ pr_url }}" target="_blank" rel="noopener">{{ pr_url }}</a></p>
+{% endif %}
+{% if release.pypi_url %}
+<p><a href="{{ release.pypi_url }}" target="_blank" rel="noopener">{{ release.pypi_url }}</a></p>
 {% endif %}
 <div>
   <input type="text" id="logpath" value="{{ log_path }}" readonly>

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -62,7 +62,12 @@ class ReleaseProgressTests(TestCase):
         self.assertContains(resp, "All steps completed")
         self.assertContains(
             resp,
-            '<a href="http://example.com/pr/1" target="_blank">http://example.com/pr/1</a>',
+            '<a href="http://example.com/pr/1" target="_blank" rel="noopener">http://example.com/pr/1</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a href="https://pypi.org/project/pkg/1.0.0/" target="_blank" rel="noopener">https://pypi.org/project/pkg/1.0.0/</a>',
             html=True,
         )
         release.refresh_from_db()
@@ -94,6 +99,11 @@ class ReleaseProgressTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "All steps completed")
         self.assertIsNone(resp.context["pr_url"])
+        self.assertContains(
+            resp,
+            '<a href="https://pypi.org/project/pkg/1.1.0/" target="_blank" rel="noopener">https://pypi.org/project/pkg/1.1.0/</a>',
+            html=True,
+        )
         release.refresh_from_db()
         self.assertTrue(release.is_published)
         pub.assert_called_once()


### PR DESCRIPTION
## Summary
- display PyPI release link on completion of publish workflow
- ensure GitHub and PyPI links open in new tabs
- test for GitHub and PyPI links in release progress view

## Testing
- `pytest tests/test_release_progress.py`


------
https://chatgpt.com/codex/tasks/task_e_68b679b54bf48326ac870161a1a5f304