### PR TITLE
Ensure package releases persist to fixture on save

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from django.core.validators import RegexValidator
 from django.core.exceptions import ValidationError
 from django.apps import apps
-from django.db.models.signals import m2m_changed, post_delete
+from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 from datetime import timedelta
 from django.contrib.contenttypes.models import ContentType
@@ -1257,8 +1257,9 @@ class PackageRelease(Entity):
         return self.revision[-6:] if self.revision else ""
 
 
-@receiver(post_delete, sender=PackageRelease)
-def _delete_release_fixture(sender, instance, **kwargs) -> None:
+@receiver([post_save, post_delete], sender=PackageRelease)
+def _update_release_fixture(sender, instance, **kwargs) -> None:
+    """Keep the release fixture in sync with the database."""
     PackageRelease.dump_fixture()
 
 # Ensure each RFID can only be linked to one energy account

--- a/tests/test_release_fixture_cleanup.py
+++ b/tests/test_release_fixture_cleanup.py
@@ -30,3 +30,8 @@ class ReleaseFixtureCleanupTests(TestCase):
         data = self.fixture_path.read_text()
         self.assertNotIn("1.0.0", data)
 
+    def test_create_updates_fixture(self):
+        PackageRelease.objects.create(package=self.package, version="2.0.0")
+        data = self.fixture_path.read_text()
+        self.assertIn("2.0.0", data)
+


### PR DESCRIPTION
## Summary
- keep `releases.json` fixture synchronized on every save or delete of a `PackageRelease`
- verify fixture updates when creating releases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67ba3a1a88326a784ff8ef34ec7e8