### PR TITLE
Ensure admin change actions save model first

### DIFF
--- a/pages/templates/django_object_actions/change_form.html
+++ b/pages/templates/django_object_actions/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+  {% for tool in objectactions %}
+    <li class="objectaction-item" data-tool-name="{{ tool.name }}">
+      <button form="{{ opts.model_name }}_form" type="submit" name="_action" value="{{ tool.name }}"
+        title="{{ tool.standard_attrs.title }}"
+        {% for k, v in tool.custom_attrs.items %}
+          {{ k }}="{{ v }}"
+        {% endfor %}
+        class="{{ tool.standard_attrs.class }}">{{ tool.label|capfirst }}</button>
+    </li>
+  {% endfor %}
+  {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Save models before executing admin change actions
- Render change action buttons as form submissions
- Verify publish action saves pending edits via new test

## Testing
- `python manage.py makemigrations --check --dry-run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f20fac648326a31af227e2c3499f