### PR TITLE
feat: group email models under Post Office admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -38,7 +38,7 @@ from .models import (
     Reference,
     OdooProfile,
     FediverseProfile,
-    EmailInbox,
+    EmailInbox as CoreEmailInbox,
     Package,
     PackageRelease,
     ReleaseManager,
@@ -380,6 +380,14 @@ class FediverseProfileAdmin(admin.ModelAdmin):
                 self.message_user(request, f"{profile}: {exc}", level=messages.ERROR)
 
 
+class EmailInbox(CoreEmailInbox):
+    class Meta:
+        proxy = True
+        app_label = "post_office"
+        verbose_name = CoreEmailInbox._meta.verbose_name
+        verbose_name_plural = CoreEmailInbox._meta.verbose_name_plural
+
+
 class EmailInboxAdminForm(forms.ModelForm):
     """Admin form for :class:`core.models.EmailInbox` with hidden password."""
 
@@ -390,7 +398,7 @@ class EmailInboxAdminForm(forms.ModelForm):
     )
 
     class Meta:
-        model = EmailInbox
+        model = CoreEmailInbox
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
@@ -444,6 +452,10 @@ class EmailInboxAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        obj.__class__ = EmailInbox
 
     @admin.action(description="Test selected inboxes")
     def test_connection(self, request, queryset):

--- a/core/templates/admin/core/emailinbox/search.html
+++ b/core/templates/admin/core/emailinbox/search.html
@@ -4,8 +4,8 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-  <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Business Models' %}</a> ›
-  <a href="{% url 'admin:core_emailinbox_changelist' %}">{% trans 'Email Inboxes' %}</a> ›
+  <a href="{% url 'admin:app_list' 'post_office' %}">{% trans 'Post Office' %}</a> ›
+  <a href="{% url 'admin:post_office_emailinbox_changelist' %}">{% trans 'Email Inboxes' %}</a> ›
   {% trans 'Search Email Inboxes' %}
 </div>
 {% endblock %}

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -18,7 +18,7 @@ from .actions import NodeAction
 
 from .models import (
     Node,
-    EmailOutbox,
+    EmailOutbox as NodeEmailOutbox,
     NodeRole,
     ContentSample,
     NodeTask,
@@ -181,9 +181,21 @@ class NodeAdmin(admin.ModelAdmin):
         return redirect(reverse("admin:nodes_node_change", args=[node_id]))
 
 
+class EmailOutbox(NodeEmailOutbox):
+    class Meta:
+        proxy = True
+        app_label = "post_office"
+        verbose_name = NodeEmailOutbox._meta.verbose_name
+        verbose_name_plural = NodeEmailOutbox._meta.verbose_name_plural
+
+
 @admin.register(EmailOutbox)
 class EmailOutboxAdmin(admin.ModelAdmin):
     list_display = ("node", "host", "port", "username", "use_tls", "use_ssl")
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        obj.__class__ = EmailOutbox
 
 
 class NodeRoleAdminForm(forms.ModelForm):

--- a/tests/test_email_inbox_search_action.py
+++ b/tests/test_email_inbox_search_action.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase, RequestFactory
 
-from core.admin import EmailInboxAdmin
+from core.admin import EmailInboxAdmin, EmailInbox as AdminEmailInbox
 from core.models import EmailInbox, User
 
 
@@ -93,11 +93,13 @@ class EmailInboxSearchTests(TestCase):
             use_ssl=True,
         )
         site = AdminSite()
-        ma = EmailInboxAdmin(EmailInbox, site)
+        ma = EmailInboxAdmin(AdminEmailInbox, site)
         factory = RequestFactory()
         request = factory.post("/", {"apply": "yes", "subject": "S"})
         request.user = admin
-        response = ma.search_inbox(request, EmailInbox.objects.filter(id=inbox.id))
+        response = ma.search_inbox(
+            request, AdminEmailInbox.objects.filter(id=inbox.id)
+        )
         self.assertEqual(response.status_code, 200)
         content = response.render().content.decode()
         self.assertIn("S", content)

--- a/tests/test_post_office_admin_group.py
+++ b/tests/test_post_office_admin_group.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.contrib.admin.sites import site
+
+from core.admin import EmailInbox as PostOfficeEmailInbox
+from nodes.admin import EmailOutbox as PostOfficeEmailOutbox
+
+
+class PostOfficeAdminGroupTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="po-admin", password="pwd", email="admin@example.com"
+        )
+        self.client.force_login(self.admin)
+
+    def test_models_registered(self):
+        registry = site._registry
+        self.assertIn(PostOfficeEmailInbox, registry)
+        self.assertIn(PostOfficeEmailOutbox, registry)
+        self.assertEqual(
+            registry[PostOfficeEmailInbox].model._meta.app_label, "post_office"
+        )
+        self.assertEqual(
+            registry[PostOfficeEmailOutbox].model._meta.app_label, "post_office"
+        )
+
+    def test_admin_index_shows_post_office_group(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, "Post Office")
+        self.assertContains(response, "Email Inboxes")
+        self.assertContains(response, "Email Outboxes")


### PR DESCRIPTION
## Summary
- show Email Inbox in Post Office admin group
- show Email Outbox in Post Office admin group
- test Post Office admin grouping

## Testing
- `python manage.py makemigrations core nodes --check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6fab99a60832691a4d908f65d0771