### PR TITLE
Remove PR URL and push releases directly to main

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -787,14 +787,13 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, admin.ModelAdmin):
         "package",
         "is_current",
         "pypi_url",
-        "pr_link",
         "revision_short",
         "published_status",
     )
     list_display_links = ("version",)
     actions = ["publish_release"]
     change_actions = ["publish_release_action"]
-    readonly_fields = ("pypi_url", "pr_url", "is_current", "revision")
+    readonly_fields = ("pypi_url", "is_current", "revision")
     fields = (
         "package",
         "release_manager",
@@ -802,7 +801,6 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, admin.ModelAdmin):
         "revision",
         "is_current",
         "pypi_url",
-        "pr_url",
     )
 
     def revision_short(self, obj):
@@ -847,10 +845,4 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, admin.ModelAdmin):
     def is_current(self, obj):
         return self._boolean_icon(obj.is_current)
 
-    def pr_link(self, obj):
-        if obj.pr_url:
-            return format_html('<a href="{0}" target="_blank">{0}</a>', obj.pr_url)
-        return ""
-
-    pr_link.short_description = "PR URL"
 

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -768,7 +768,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         max_length=200,
                         help_text=(
-                            'Personal access token used to create GitHub pull requests. '
+                            'Personal access token for GitHub operations. '
                             'Used before the GITHUB_TOKEN environment variable.'
                         ),
                     ),

--- a/core/migrations/0001_squashed_0001_initial.py
+++ b/core/migrations/0001_squashed_0001_initial.py
@@ -269,7 +269,7 @@ class Migration(migrations.Migration):
                 ('is_deleted', models.BooleanField(default=False, editable=False)),
                 ('pypi_username', models.CharField('PyPI username', blank=True, max_length=100)),
                 ('pypi_token', models.CharField('PyPI token', blank=True, max_length=200)),
-                ('github_token', models.CharField(blank=True, help_text='Personal access token used to create GitHub pull requests. Used before the GITHUB_TOKEN environment variable.', max_length=200)),
+                ('github_token', models.CharField(blank=True, help_text='Personal access token for GitHub operations. Used before the GITHUB_TOKEN environment variable.', max_length=200)),
                 ('pypi_password', models.CharField('PyPI password', blank=True, max_length=200)),
                 ('pypi_url', models.URLField('PyPI URL', blank=True)),
                 ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='release_manager', to=settings.AUTH_USER_MODEL)),

--- a/core/migrations/0007_packagerelease_pr_url.py
+++ b/core/migrations/0007_packagerelease_pr_url.py
@@ -40,11 +40,6 @@ class Migration(migrations.Migration):
                 "verbose_name_plural": "Sigil Roots",
             },
         ),
-        migrations.AddField(
-            model_name="packagerelease",
-            name="pr_url",
-            field=models.URLField("PR URL", blank=True, editable=False),
-        ),
         migrations.AlterField(
             model_name="odooprofile",
             name="host",
@@ -80,7 +75,7 @@ class Migration(migrations.Migration):
             name="github_token",
             field=core.fields.SigilShortAutoField(
                 blank=True,
-                help_text="Personal access token used to create GitHub pull requests. Used before the GITHUB_TOKEN environment variable.",
+                help_text="Personal access token for GitHub operations. Used before the GITHUB_TOKEN environment variable.",
                 max_length=200,
             ),
         ),

--- a/core/models.py
+++ b/core/models.py
@@ -1076,7 +1076,7 @@ class ReleaseManager(Entity):
         max_length=200,
         blank=True,
         help_text=(
-            "Personal access token used to create GitHub pull requests. "
+            "Personal access token for GitHub operations. "
             "Used before the GITHUB_TOKEN environment variable."
         ),
     )
@@ -1160,7 +1160,6 @@ class PackageRelease(Entity):
         max_length=40, blank=True, default=revision_utils.get_revision, editable=False
     )
     pypi_url = models.URLField("PyPI URL", blank=True, editable=False)
-    pr_url = models.URLField("PR URL", blank=True, editable=False)
 
     class Meta:
         verbose_name = "Package Release"

--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -30,9 +30,6 @@
 <p>Running...</p>
 {% else %}
 <p>All steps completed.</p>
-{% if pr_url %}
-<p><a href="{{ pr_url }}" target="_blank" rel="noopener">{{ pr_url }}</a></p>
-{% endif %}
 {% if release.pypi_url %}
 <p><a href="{{ release.pypi_url }}" target="_blank" rel="noopener">{{ release.pypi_url }}</a></p>
 {% endif %}

--- a/core/views.py
+++ b/core/views.py
@@ -114,6 +114,7 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
             ],
             check=True,
         )
+    subprocess.run(["git", "push"], check=True)
     release_name = f"{release.package.name}-{release.version}-{commit_hash[:7]}"
     new_log = log_path.with_name(f"{release_name}.log")
     log_path.rename(new_log)
@@ -349,7 +350,6 @@ def release_progress(request, pk: int, action: str):
         "error": ctx.get("error"),
         "log_content": log_content,
         "log_path": str(log_path),
-        "pr_url": ctx.get("pr_url"),
         "cert_log": ctx.get("cert_log"),
     }
     request.session[session_key] = ctx

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -28,9 +28,6 @@
 <p>Running...</p>
 {% else %}
 <p>All steps completed.</p>
-{% if pr_url %}
-<p><a href="{{ pr_url }}" target="_blank" rel="noopener">{{ pr_url }}</a></p>
-{% endif %}
 {% if release.pypi_url %}
 <p><a href="{{ release.pypi_url }}" target="_blank" rel="noopener">{{ release.pypi_url }}</a></p>
 {% endif %}

--- a/tests/test_package_release_admin_actions.py
+++ b/tests/test_package_release_admin_actions.py
@@ -65,13 +65,6 @@ class PackageReleaseAdminActionsTests(TestCase):
         self.assertIn("PyPI URL", content)
         self.assertNotIn('name="pypi_url"', content)
 
-    def test_change_page_pr_url_readonly(self):
-        change_url = reverse("admin:core_packagerelease_change", args=[self.release.pk])
-        resp = self.client.get(change_url)
-        content = resp.content.decode()
-        self.assertIn("PR URL", content)
-        self.assertNotIn('name="pr_url"', content)
-
     def test_change_page_is_current_readonly(self):
         change_url = reverse("admin:core_packagerelease_change", args=[self.release.pk])
         with patch("utils.revision.get_revision", return_value="rev"):


### PR DESCRIPTION
## Summary
- remove unused PR URL field and related admin, template and migration references
- push release commit directly to main after build
- clarify GitHub token help text

## Testing
- `python manage.py makemigrations core --check --dry-run`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b78d61a10c8326b063af0eb21632a4