### PR TITLE
feat: show freshness timestamp in footer

### DIFF
--- a/tests/test_footer_admin_link.py
+++ b/tests/test_footer_admin_link.py
@@ -6,6 +6,8 @@ from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from unittest.mock import patch
+from datetime import timedelta
 
 from core.models import Package, PackageRelease
 
@@ -41,51 +43,37 @@ class FooterAdminLinkTests(TestCase):
 
     def test_shows_fresh_since_in_auto_upgrade_mode(self):
         base_dir = Path(settings.BASE_DIR)
-        auto_upgrade = base_dir / "AUTO_UPGRADE"
-        locks_dir = base_dir / "locks"
         logs_dir = base_dir / "logs"
-        pre_locks = locks_dir.exists()
+        logs_dir.mkdir(exist_ok=True)
+        log_file = logs_dir / "auto-upgrade.log"
         try:
-            auto_upgrade.write_text("version")
-            locks_dir.mkdir(exist_ok=True)
-            (locks_dir / "celery.lck").touch()
-            logs_dir.mkdir(exist_ok=True)
             now = timezone.now()
-            (logs_dir / "auto-upgrade.log").write_text(
-                f"{now.isoformat()} check_github_updates triggered\n"
-            )
+            log_file.write_text(f"{now.isoformat()} check_github_updates triggered\n")
             html = self._render(self.user)
             self.assertIn("fresh since", html)
         finally:
-            if auto_upgrade.exists():
-                auto_upgrade.unlink()
-            celery_lock = locks_dir / "celery.lck"
-            if celery_lock.exists():
-                celery_lock.unlink()
-            log_file = logs_dir / "auto-upgrade.log"
             if log_file.exists():
                 log_file.unlink()
-            if not pre_locks and locks_dir.exists():
-                try:
-                    locks_dir.rmdir()
-                except OSError:
-                    pass
 
-    def test_does_not_show_fresh_since_without_auto_upgrade(self):
+    def test_shows_fresh_since_without_auto_upgrade(self):
+        html = self._render(self.user)
+        self.assertIn("fresh since", html)
+
+    def test_fresh_since_uses_latest_timestamp(self):
         base_dir = Path(settings.BASE_DIR)
-        locks_dir = base_dir / "locks"
-        pre_locks = locks_dir.exists()
+        logs_dir = base_dir / "logs"
+        logs_dir.mkdir(exist_ok=True)
+        log_file = logs_dir / "auto-upgrade.log"
+        now = timezone.now()
+        log_file.write_text(
+            f"{(now - timedelta(hours=2)).isoformat()} check_github_updates triggered\n"
+        )
         try:
-            locks_dir.mkdir(exist_ok=True)
-            (locks_dir / "celery.lck").touch()
-            html = self._render(self.user)
-            self.assertNotIn("fresh since", html)
+            with patch("core.templatetags.ref_tags.INSTANCE_START", now - timedelta(hours=1)):
+                with patch("django.utils.timezone.now", return_value=now):
+                    html = self._render(self.user)
+            html = html.replace("\xa0", " ")
+            self.assertIn("fresh since 1 hour", html)
         finally:
-            celery_lock = locks_dir / "celery.lck"
-            if celery_lock.exists():
-                celery_lock.unlink()
-            if not pre_locks and locks_dir.exists():
-                try:
-                    locks_dir.rmdir()
-                except OSError:
-                    pass
+            if log_file.exists():
+                log_file.unlink()


### PR DESCRIPTION
## Summary
- display "fresh since" indicator in footer using latest of server startup or last upgrade log timestamp
- test footer freshness logic and visibility

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f1878d0c83269cc75103d0773c22