### PR TITLE
fix: prevent env-refresh clean from generating releases

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -37,7 +37,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
 
 from core.user_data import UserDatum
-from core.models import Package, PackageRelease
+from core.models import PackageRelease
 from utils import revision as revision_utils
 
 
@@ -113,21 +113,6 @@ def _remove_integrator_from_auth_migration() -> None:
         line for line in content.splitlines() if "integrator" not in line
     )
     path.write_text(patched + ("\n" if not patched.endswith("\n") else ""))
-
-
-def _refresh_next_release(version: str = "0.1.2") -> None:
-    """Recreate the pending package release for the given version."""
-    package = Package.objects.first()
-    if not package:
-        return
-    PackageRelease.all_objects.filter(version=version).delete()
-    PackageRelease.objects.create(
-        package=package,
-        release_manager=package.release_manager,
-        version=version,
-        revision=revision_utils.get_revision(),
-        is_seed_data=True,
-    )
 
 
 def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
@@ -272,9 +257,6 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
     # Ensure Application and Module entries exist for local apps
     call_command("register_site_apps")
     Landing.objects.update(is_seed_data=True)
-
-    # Recreate the upcoming package release to track latest revision
-    _refresh_next_release()
 
     # Ensure current node is registered or updated
     node, _ = Node.register_current()

--- a/tests/test_env_refresh_clean.py
+++ b/tests/test_env_refresh_clean.py
@@ -1,30 +1,19 @@
 import subprocess
-import importlib.util
 from pathlib import Path
 
-from django.core.management import call_command
-from django.conf import settings
 
+def test_env_refresh_leaves_repo_clean(tmp_path):
+    base_dir = Path(__file__).resolve().parent.parent
+    clone_dir = tmp_path / "clone"
+    subprocess.run(["git", "clone", str(base_dir), str(clone_dir)], check=True)
 
-def test_env_refresh_leaves_repo_clean():
-    base_dir = Path(settings.BASE_DIR)
+    subprocess.run(["python", "env-refresh.py", "--clean"], cwd=clone_dir, check=True)
 
-    spec = importlib.util.spec_from_file_location("env_refresh", base_dir / "env-refresh.py")
-    env_refresh = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(env_refresh)
-
-    local_apps = env_refresh._local_app_labels()
-
-    # Ensure no new migrations are needed
-    call_command("makemigrations", *local_apps, interactive=False, check=True)
-
-    # Confirm repository is clean
     result = subprocess.run(
         ["git", "status", "--porcelain"],
-        cwd=base_dir,
+        cwd=clone_dir,
         capture_output=True,
         text=True,
         check=True,
     )
     assert result.stdout.strip() == ""
-


### PR DESCRIPTION
## Summary
- stop `env-refresh` from creating a pending release and writing `core/fixtures/releases.json`
- cover `env-refresh --clean` with an isolated repo test to ensure no changes remain

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7976818748326848541c91813ec37