### PR TITLE
Rename admin app labels

### DIFF
--- a/awg/apps.py
+++ b/awg/apps.py
@@ -4,4 +4,4 @@ from django.apps import AppConfig
 class AwgConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "awg"
-    verbose_name = "Power Calculators"
+    verbose_name = "1. Power"

--- a/config/horologia_app.py
+++ b/config/horologia_app.py
@@ -1,0 +1,7 @@
+from django_celery_beat.apps import BeatConfig as BaseBeatConfig
+
+
+class HorologiaConfig(BaseBeatConfig):
+    """Customize Periodic Tasks app label."""
+
+    verbose_name = "5. Horologia"

--- a/config/settings.py
+++ b/config/settings.py
@@ -148,8 +148,8 @@ INSTALLED_APPS = [
     "django_object_actions",
     "django.contrib.sites",
     "channels",
-    "post_office",
-    "django_celery_beat",
+    "config.workgroup_app.WorkgroupConfig",
+    "config.horologia_app.HorologiaConfig",
 ] + LOCAL_APPS
 
 if DEBUG:

--- a/config/workgroup_app.py
+++ b/config/workgroup_app.py
@@ -1,0 +1,7 @@
+from post_office.apps import PostOfficeConfig as BasePostOfficeConfig
+
+
+class WorkgroupConfig(BasePostOfficeConfig):
+    """Customize Post Office app label."""
+
+    verbose_name = "6. Workgroup"

--- a/core/apps.py
+++ b/core/apps.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
-    verbose_name = _("Business Models")
+    verbose_name = _("2. Business")
 
     def ready(self):  # pragma: no cover - called by Django
         from django.contrib.auth import get_user_model

--- a/core/templates/admin/core/emailinbox/search.html
+++ b/core/templates/admin/core/emailinbox/search.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-  <a href="{% url 'admin:app_list' 'post_office' %}">{% trans 'Post Office' %}</a> ›
+  <a href="{% url 'admin:app_list' 'post_office' %}">{% trans '6. Workgroup' %}</a> ›
   <a href="{% url 'admin:post_office_emailinbox_changelist' %}">{% trans 'Email Inboxes' %}</a> ›
   {% trans 'Search Email Inboxes' %}
 </div>

--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -5,7 +5,7 @@
 <nav aria-label="{% translate 'Breadcrumbs' %}">
   <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-    <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Business Models' %}</a> ›
+    <a href="{% url 'admin:app_list' 'core' %}">{% trans '2. Business' %}</a> ›
     <a href="{% url 'admin:core_packagerelease_changelist' %}">{% trans 'Package Releases' %}</a> ›
     <a href="{% url 'admin:core_packagerelease_change' release.pk %}">{{ release }}</a> ›
     {{ action|capfirst }}

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -19,9 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
 "1 : 2;\n"
 
-#: core/apps.py:8
-msgid "Business Models"
-msgstr "Modelos de negocio"
+#: core/apps.py:8 core/templates/core/release_progress.html:9 pages/templates/core/release_progress.html:9
+msgid "2. Business"
+msgstr "2. Negocio"
 
 #: core/models.py:140
 msgid "Invalid municipality for the selected state"
@@ -267,9 +267,9 @@ msgstr "Español"
 msgid "Constellation"
 msgstr "Constellation"
 
-#: emails/apps.py:8
-msgid "Post Office"
-msgstr "Oficina de correos"
+#: core/templates/admin/core/emailinbox/search.html:8
+msgid "6. Workgroup"
+msgstr "6. Grupo de trabajo"
 
 #: emails/models.py:25
 msgid "Email Pattern"

--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -68,7 +68,7 @@ def _trigger_startup_notification(**_: object) -> None:
 class NodesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "nodes"
-    verbose_name = "Node Infrastructure"
+    verbose_name = "4. Infraestructure"
 
     def ready(self):  # pragma: no cover - exercised on app start
         request_started.connect(

--- a/ocpp/apps.py
+++ b/ocpp/apps.py
@@ -6,7 +6,7 @@ from django.conf import settings
 class OcppConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "ocpp"
-    verbose_name = "OCPP"
+    verbose_name = "3. Protocols"
 
     def ready(self):  # pragma: no cover - startup side effects
         lock = Path(settings.BASE_DIR) / "locks" / "control.lck"

--- a/pages/apps.py
+++ b/pages/apps.py
@@ -4,7 +4,7 @@ from django.apps import AppConfig
 class PagesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "pages"
-    verbose_name = "Web Experience"
+    verbose_name = "7. Experience"
 
     def ready(self):  # pragma: no cover - import for side effects
         from . import checks  # noqa: F401

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -5,7 +5,7 @@
 <nav aria-label="{% translate 'Breadcrumbs' %}">
   <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-    <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Business Models' %}</a> ›
+    <a href="{% url 'admin:app_list' 'core' %}">{% trans '2. Business' %}</a> ›
     <a href="{% url 'admin:core_packagerelease_changelist' %}">{% trans 'Package Releases' %}</a> ›
     <a href="{% url 'admin:core_packagerelease_change' release.pk %}">{{ release }}</a> ›
     {{ action|capfirst }}

--- a/tests/test_workgroup_admin_group.py
+++ b/tests/test_workgroup_admin_group.py
@@ -7,7 +7,7 @@ from core.admin import EmailInbox as PostOfficeEmailInbox
 from nodes.admin import EmailOutbox as PostOfficeEmailOutbox
 
 
-class PostOfficeAdminGroupTests(TestCase):
+class WorkgroupAdminGroupTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.admin = User.objects.create_superuser(
@@ -28,6 +28,6 @@ class PostOfficeAdminGroupTests(TestCase):
 
     def test_admin_index_shows_post_office_group(self):
         response = self.client.get(reverse("admin:index"))
-        self.assertContains(response, "Post Office")
+        self.assertContains(response, "6. Workgroup")
         self.assertContains(response, "Email Inboxes")
         self.assertContains(response, "Email Outboxes")


### PR DESCRIPTION
## Summary
- prefix admin apps with numbered labels
- update templates, translations, and tests for new names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7ad0597d08326b00ac83b132218fa