### PR TITLE
fix: rebase before pushing release metadata

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -101,6 +101,7 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
         release.save(update_fields=["revision"])
         PackageRelease.dump_fixture()
         subprocess.run(["git", "checkout", current], check=True)
+        subprocess.run(["git", "pull", "--rebase"], check=True)
         subprocess.run(["git", "merge", "--ff-only", branch], check=True)
         subprocess.run(["git", "branch", "-d", branch], check=True)
         diff = subprocess.run(


### PR DESCRIPTION
## Summary
- ensure release promotion pulls latest main branch before merging and pushing
- test rebase step to avoid non-fast-forward errors

## Testing
- `python manage.py test` *(fails: pages.tests.FavoriteTests.test_dashboard_merges_duplicate_future_actions)*
- `python manage.py test core.tests.ReleaseProcessTests.test_promote_pulls_rebase_before_merge`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3dd225483268010658597bba4a2