### PR TITLE
Use settings-based node role

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -31,8 +31,8 @@ def _gather_info() -> dict:
     info["mode"] = mode
     info["port"] = 8000 if mode == "public" else 8888
 
-    role_file = lock_dir / "role.lck"
-    info["role"] = role_file.read_text().strip() if role_file.exists() else "unknown"
+    # Use settings.NODE_ROLE as the single source of truth for the node role.
+    info["role"] = getattr(settings, "NODE_ROLE", "Terminal")
 
     info["features"] = {
         "celery": (lock_dir / "celery.lck").exists(),

--- a/core/test_system_info.py
+++ b/core/test_system_info.py
@@ -1,0 +1,21 @@
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+import django
+django.setup()
+
+from django.test import SimpleTestCase, override_settings
+from core.system import _gather_info
+
+
+class SystemInfoRoleTests(SimpleTestCase):
+    @override_settings(NODE_ROLE="Terminal")
+    def test_defaults_to_terminal(self):
+        info = _gather_info()
+        self.assertEqual(info["role"], "Terminal")
+
+    @override_settings(NODE_ROLE="Satellite")
+    def test_uses_settings_role(self):
+        info = _gather_info()
+        self.assertEqual(info["role"], "Satellite")

--- a/status-check.sh
+++ b/status-check.sh
@@ -38,8 +38,8 @@ fi
 
 echo "Nginx mode: $MODE"
 
-ROLE="unknown"
-if [ -f "$LOCK_DIR/role.lck" ]; then
+ROLE="${NODE_ROLE:-Terminal}"
+if [ -z "$NODE_ROLE" ] && [ -f "$LOCK_DIR/role.lck" ]; then
   ROLE="$(cat "$LOCK_DIR/role.lck")"
 fi
 echo "Node role: $ROLE"


### PR DESCRIPTION
## Summary
- show Terminal role when node role is unknown
- use settings.NODE_ROLE as single source of truth
- test system info role handling

## Testing
- `pytest core/test_system_info.py -q`
- `pytest -q` *(fails: UserDatumAdminTests.test_fixture_created_and_loaded_on_env_refresh)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b815b0dc8326bf99679506acd34d