### PR TITLE
Rename transactions to CP transactions

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -613,9 +613,9 @@ msgstr "Requiere autorización RFID"
 msgid "Transaction"
 msgstr "Transacción"
 
-#: ocpp/models.py:141
-msgid "Transactions"
-msgstr "Transacciones"
+#: ocpp/models.py:175
+msgid "CP Transactions"
+msgstr "Transacciones CP"
 
 #: ocpp/models.py:194
 msgid "Meter Reading"

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -124,7 +124,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'verbose_name': 'Transaction',
-                'verbose_name_plural': 'Transactions',
+                'verbose_name_plural': 'CP Transactions',
             },
         ),
         migrations.CreateModel(

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -172,7 +172,7 @@ class Transaction(Entity):
 
     class Meta:
         verbose_name = _("Transaction")
-        verbose_name_plural = _("Transactions")
+        verbose_name_plural = _("CP Transactions")
 
     @property
     def kw(self) -> float:

--- a/ocpp/simulator.py
+++ b/ocpp/simulator.py
@@ -94,6 +94,10 @@ class ChargePointSimulator:
                         log_type="simulator",
                     )
                     raise
+                except websockets.exceptions.ConnectionClosed:
+                    self.status = "stopped"
+                    self._stop_event.set()
+                    raise
                 except Exception:
                     self.status = "error"
                     raise

--- a/ocpp/templates/admin/ocpp/transaction/export.html
+++ b/ocpp/templates/admin/ocpp/transaction/export.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
-<h1>Export Transactions</h1>
+<h1>Export CP Transactions</h1>
 <form method="post">
   {% csrf_token %}
   {{ form.as_p }}

--- a/ocpp/templates/admin/ocpp/transaction/import.html
+++ b/ocpp/templates/admin/ocpp/transaction/import.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
-<h1>Import Transactions</h1>
+<h1>Import CP Transactions</h1>
 <form method="post" enctype="multipart/form-data">
   {% csrf_token %}
   {{ form.as_p }}

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -1027,7 +1027,11 @@ class ChargePointSimulatorTests(TransactionTestCase):
         sim = ChargePointSimulator(cfg)
         store.simulators[99] = sim
         try:
-            with patch("ocpp.simulator.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            async def fake_wait_for(coro, timeout):
+                coro.close()
+                raise asyncio.TimeoutError
+
+            with patch("ocpp.simulator.asyncio.wait_for", fake_wait_for):
                 started, status, _ = await asyncio.to_thread(sim.start)
             await asyncio.to_thread(sim._thread.join)
             self.assertFalse(started)


### PR DESCRIPTION
## Summary
- rename `Transactions` to `CP Transactions` across OCPP app
- translate to Spanish
- ensure simulator stops when charger closes and clean up timeout test

## Testing
- `python manage.py makemigrations ocpp --check`
- `python manage.py test ocpp -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b7b9b4ea148326b13fe565846b6331