### PR TITLE
Fix infrastructure app spelling

### DIFF
--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -68,7 +68,7 @@ def _trigger_startup_notification(**_: object) -> None:
 class NodesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "nodes"
-    verbose_name = "4. Infraestructure"
+    verbose_name = "2. Infrastructure"
 
     def ready(self):  # pragma: no cover - exercised on app start
         request_started.connect(


### PR DESCRIPTION
## Summary
- rename `nodes` app verbose name to **2. Infrastructure**

## Testing
- `pytest -q` *(fails: ReleaseProgressViewTests::test_stale_log_removed_on_start, UserDatumAdminTests::test_fixture_created_and_loaded_on_env_refresh)*

------
https://chatgpt.com/codex/tasks/task_e_68b84f8e7e548326bda7afc4c51fea55