### PR TITLE
feat: auto-commit fixture changes during release

### DIFF
--- a/core/fixtures/packages.json
+++ b/core/fixtures/packages.json
@@ -1,0 +1,19 @@
+[
+  {
+    "model": "core.package",
+    "pk": 1,
+    "fields": {
+      "is_seed_data": false,
+      "is_deleted": false,
+      "name": "arthexis",
+      "description": "Django-based MESH system",
+      "author": "Rafael J. Guillén-Osorio",
+      "email": "tecnologia@gelectriic.com",
+      "python_requires": ">=3.10",
+      "license": "MIT",
+      "repository_url": "https://github.com/arthexis/arthexis",
+      "homepage_url": "https://arthexis.com",
+      "release_manager": 1
+    }
+  }
+]

--- a/core/fixtures/release_managers.json
+++ b/core/fixtures/release_managers.json
@@ -1,0 +1,16 @@
+[
+  {
+    "model": "core.releasemanager",
+    "pk": 1,
+    "fields": {
+      "is_seed_data": false,
+      "is_deleted": false,
+      "user": 1,
+      "pypi_username": "",
+      "pypi_token": "",
+      "github_token": "",
+      "pypi_password": "",
+      "pypi_url": ""
+    }
+  }
+]

--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -20,6 +20,27 @@
   <li>{% if forloop.counter0 < current_step %}✅{% elif forloop.counter0 == current_step and not done and not error %}⏳{% else %}⬜{% endif %} {{ step }}</li>
 {% endfor %}
 </ol>
+{% if fixtures %}
+<h2>{% trans 'Fixture changes' %}</h2>
+<table>
+  <thead>
+    <tr>
+      <th>{% trans 'Fixture' %}</th>
+      <th>{% trans 'Entries' %}</th>
+      <th>{% trans 'Models' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for fx in fixtures %}
+    <tr>
+      <td>{{ fx.path }}</td>
+      <td>{{ fx.count }}</td>
+      <td>{{ fx.models|join:', ' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 <pre>{{ log_content }}</pre>
 {% if error %}
 <p class="error">{{ error }}</p>

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -644,3 +644,19 @@ msgstr "Simuladores CP"
 #: core/models.py:921
 msgid "License Plate"
 msgstr "Placa"
+
+#: core/templates/core/release_progress.html:24 pages/templates/core/release_progress.html:24
+msgid "Fixture changes"
+msgstr "Cambios de fixtures"
+
+#: core/templates/core/release_progress.html:28 pages/templates/core/release_progress.html:28
+msgid "Fixture"
+msgstr "Fixture"
+
+#: core/templates/core/release_progress.html:29 pages/templates/core/release_progress.html:29
+msgid "Entries"
+msgstr "Entradas"
+
+#: core/templates/core/release_progress.html:30 pages/templates/core/release_progress.html:30
+msgid "Models"
+msgstr "Modelos"

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -20,6 +20,27 @@
   <li>{% if forloop.counter0 < current_step %}✅{% elif forloop.counter0 == current_step and not done and not error %}⏳{% else %}⬜{% endif %} {{ step }}</li>
 {% endfor %}
 </ol>
+{% if fixtures %}
+<h2>{% trans 'Fixture changes' %}</h2>
+<table>
+  <thead>
+    <tr>
+      <th>{% trans 'Fixture' %}</th>
+      <th>{% trans 'Entries' %}</th>
+      <th>{% trans 'Models' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for fx in fixtures %}
+    <tr>
+      <td>{{ fx.path }}</td>
+      <td>{{ fx.count }}</td>
+      <td>{{ fx.models|join:', ' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 <pre>{{ log_content }}</pre>
 {% if error %}
 <p class="error">{{ error }}</p>

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 import shutil
+import subprocess
+from unittest import mock
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
@@ -19,6 +21,7 @@ from utils import revision
 class ReleaseProgressViewTests(TestCase):
     def setUp(self):
         User = get_user_model()
+        User.all_objects.filter(username="admin").delete()
         self.user = User.objects.create_superuser(
             username="admin", email="admin@example.com", password="password"
         )
@@ -46,3 +49,30 @@ class ReleaseProgressViewTests(TestCase):
 
         self.assertEqual(response.context["log_content"], "")
         self.assertFalse(log_path.exists())
+
+    @mock.patch("core.views.release_utils._git_clean", return_value=False)
+    @mock.patch("core.views.release_utils.network_available", return_value=False)
+    def test_dirty_fixtures_committed(self, net, git_clean):
+        fixture_path = Path("core/fixtures/releases.json")
+        original = fixture_path.read_text(encoding="utf-8")
+        fixture_path.write_text("[]", encoding="utf-8")
+        self.addCleanup(lambda: fixture_path.write_text(original, encoding="utf-8"))
+
+        def fake_run(cmd, capture_output=False, text=False, check=False, **kwargs):
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=" M core/fixtures/releases.json\n", stderr=""
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock.patch("core.views.subprocess.run", side_effect=fake_run) as run:
+            url = reverse("release-progress", args=[self.release.pk, "publish"])
+            response = self.client.get(f"{url}?step=0")
+
+        self.assertContains(response, "core/fixtures/releases.json")
+        run.assert_any_call(
+            ["git", "add", "core/fixtures/releases.json"], check=True
+        )
+        run.assert_any_call(
+            ["git", "commit", "-m", "chore: update fixtures"], check=True
+        )


### PR DESCRIPTION
## Summary
- auto-commit fixture files when they are the only dirty git changes
- show committed fixture summary on release progress screen
- add missing package and release manager fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8669acbb48326b20179624a38dd4d