### PR TITLE
Add PyPI validation admin action

### DIFF
--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -34,6 +34,9 @@ class ReleaseProgressViewTests(TestCase):
         )
         self.log_dir = Path("logs")
         self.log_dir.mkdir(exist_ok=True)
+        lock_path = Path("locks") / f"release_publish_{self.release.pk}.json"
+        if lock_path.exists():
+            lock_path.unlink()
 
     def tearDown(self):
         shutil.rmtree(self.log_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add admin bulk action to validate releases against PyPI and remove missing ones
- add tests for validating and deleting releases
- ensure release progress tests remove leftover lock files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87c3042c48326823d455f04374bdb