### PR TITLE
Preserve unresolved sigils and log resolution errors

### DIFF
--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -40,3 +40,31 @@ class SigilResolutionTests(TestCase):
         rendered = tmpl.render(Context({"profile": profile}))
         expected = f"lang={settings.LANGUAGE_CODE}"
         self.assertEqual(rendered, expected)
+
+    def test_unresolved_env_sigil_left_intact(self):
+        profile = OdooProfile.objects.create(
+            user=self.user,
+            host="path=[ENV.MISSING_PATH]",
+            database="db",
+            username="odoo",
+            password="secret",
+        )
+        tmpl = Template("{{ profile.host }}")
+        with self.assertLogs("core.entity", level="WARNING") as cm:
+            rendered = tmpl.render(Context({"profile": profile}))
+        self.assertEqual(rendered, "path=[ENV.MISSING_PATH]")
+        self.assertIn("Missing environment variable for sigil [ENV.MISSING_PATH]", cm.output[0])
+
+    def test_unknown_root_sigil_left_intact(self):
+        profile = OdooProfile.objects.create(
+            user=self.user,
+            host="url=[FOO.BAR]",
+            database="db",
+            username="odoo",
+            password="secret",
+        )
+        tmpl = Template("{{ profile.host }}")
+        with self.assertLogs("core.entity", level="WARNING") as cm:
+            rendered = tmpl.render(Context({"profile": profile}))
+        self.assertEqual(rendered, "url=[FOO.BAR]")
+        self.assertIn("Unknown sigil root [FOO]", cm.output[0])


### PR DESCRIPTION
## Summary
- keep unresolved sigils in text and log resolution failures quietly
- add tests covering missing environment variables and unknown sigil roots

## Testing
- `python manage.py test tests.test_sigil_resolution -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc59dd70832687a0f7e5734351a4