### PR TITLE
Ensure stable env refresh and log directories

### DIFF
--- a/config/logging.py
+++ b/config/logging.py
@@ -13,9 +13,11 @@ class ActiveAppFileHandler(TimedRotatingFileHandler):
     """File handler that writes to a file named after the active app."""
 
     def _current_file(self) -> Path:
+        log_dir = Path(settings.LOG_DIR)
+        log_dir.mkdir(parents=True, exist_ok=True)
         if "test" in sys.argv:
-            return Path(settings.LOG_DIR) / "tests.log"
-        return Path(settings.LOG_DIR) / f"{get_active_app()}.log"
+            return log_dir / "tests.log"
+        return log_dir / f"{get_active_app()}.log"
 
     def emit(self, record: logging.LogRecord) -> None:
         current = str(self._current_file())
@@ -29,7 +31,9 @@ class ActiveAppFileHandler(TimedRotatingFileHandler):
     def rotation_filename(self, default_name: str) -> str:
         """Place rotated logs inside the old log directory."""
         default_path = Path(default_name)
-        return str(Path(settings.OLD_LOG_DIR) / default_path.name)
+        old_log_dir = Path(settings.OLD_LOG_DIR)
+        old_log_dir.mkdir(parents=True, exist_ok=True)
+        return str(old_log_dir / default_path.name)
 
     def getFilesToDelete(self):
         """Return files to delete in the old log directory respecting backupCount."""

--- a/env-refresh.py
+++ b/env-refresh.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 from pathlib import Path
 import json
 import tempfile
@@ -317,9 +318,14 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
                 except Exception:
                     continue
 
-    # Update fixtures and migrations hash files after successful run
-    (Path(settings.BASE_DIR) / "fixtures.md5").write_text(fixture_hash)
+    # Update the migrations hash file after a successful run and restore the
+    # fixtures hash from version control to keep the repository clean.
     hash_file.write_text(new_hash)
+    subprocess.run(
+        ["git", "checkout", "--", "fixtures.md5"],
+        cwd=settings.BASE_DIR,
+        check=False,
+    )
 
 
 TASKS = {"database": run_database_tasks}


### PR DESCRIPTION
## Summary
- Create log directories before writing and ensure rotation directories exist
- Reset `fixtures.md5` via git checkout to leave repo clean after env-refresh

## Testing
- `pytest tests/test_env_refresh_clean.py::test_env_refresh_leaves_repo_clean -q`
- `pytest tests/test_sigil_resolution.py::SigilResolutionTests::test_unknown_root_sigil_left_intact -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e173fc748326be9074117102fa7f