### PR TITLE
Skip fixture check during migration squash

### DIFF
--- a/core/release.py
+++ b/core/release.py
@@ -422,6 +422,7 @@ def promote(
                     "core",
                     "0001",
                     "--noinput",
+                    "--skip-checks",
                 ],
                 check=False,
             )


### PR DESCRIPTION
## Summary
- add `--skip-checks` when squashing migrations to avoid fixture warnings that caused release loops

## Testing
- `python manage.py test core.tests.ReleaseProcessTests.test_release_progress_restart` *(fails: '1' != '2')*


------
https://chatgpt.com/codex/tasks/task_e_68b8f340d6e483268cb625fa89be1478