### PR TITLE
fix: merge release branch without fast-forward

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -139,7 +139,9 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
         release.save(update_fields=["revision"])
         subprocess.run(["git", "checkout", current], check=True)
         subprocess.run(["git", "pull", "--rebase"], check=True)
-        subprocess.run(["git", "merge", "--ff-only", branch], check=True)
+        # Allow merging even when the release branch and main have diverged
+        # by creating a merge commit instead of requiring a fast-forward.
+        subprocess.run(["git", "merge", "--no-ff", branch], check=True)
         subprocess.run(["git", "branch", "-d", branch], check=True)
         diff = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- allow creating merge commits when integrating release branches

## Testing
- `pytest tests/test_release_tasks.py tests/test_release_logs.py tests/test_release_progress.py tests/test_dist_cleanup.py`

------
https://chatgpt.com/codex/tasks/task_e_68b98fa79044832683429023e56cf771