### PR TITLE
feat: rebase release branch before merge

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -137,6 +137,12 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
         )
         release.revision = commit_hash
         release.save(update_fields=["revision"])
+        try:
+            subprocess.run(["git", "fetch", "origin", "main"], check=True)
+            subprocess.run(["git", "rebase", "origin/main"], check=True)
+        except subprocess.CalledProcessError as exc:
+            subprocess.run(["git", "rebase", "--abort"], check=False)
+            raise Exception("Rebase onto main failed") from exc
         subprocess.run(["git", "checkout", current], check=True)
         subprocess.run(["git", "pull", "--rebase"], check=True)
         # Allow merging even when the release branch and main have diverged


### PR DESCRIPTION
## Summary
- rebase release branch onto latest main before merging
- abort release when rebase fails to surface conflicts early

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b995b969c483268ffc7914cfb0c2a9