### PR TITLE
refactor: simplify release promotion workflow

### DIFF
--- a/core/release.py
+++ b/core/release.py
@@ -361,40 +361,28 @@ def promote(
     version: str,
     creds: Optional[Credentials] = None,
 ) -> tuple[str, str, str]:
-    """Create a release branch and build the package without tests.
+    """Build the package and commit the release on the current branch.
 
-    Returns a tuple of the release commit hash, the new branch name and the
-    original branch name.
+    Returns a tuple of the release commit hash, the current branch name and the
+    original branch name (identical since no branching occurs).
     """
     current = _current_branch()
-    tmp_branch = f"release/{version}"
     if not _git_clean():
         raise ReleaseError("Git repository is not clean")
-    try:
-        try:
-            _run(["git", "checkout", "-b", tmp_branch])
-        except subprocess.CalledProcessError:
-            _run(["git", "checkout", tmp_branch])
-        build(
-            package=package,
-            version=version,
-            creds=creds,
-            tests=False,
-            dist=True,
-            git=False,
-            tag=False,
-            stash=False,
-        )
-        _run(["git", "add", "."])  # add all changes
-        _run(["git", "commit", "-m", f"Release v{version}"])
-        commit_hash = _current_commit()
-        release_name = f"{package.name}-{version}-{commit_hash[:7]}"
-        branch = f"release-{release_name}"
-        _run(["git", "branch", "-m", branch])
-    except Exception:
-        _run(["git", "checkout", current])
-        raise
-    return commit_hash, branch, current
+    build(
+        package=package,
+        version=version,
+        creds=creds,
+        tests=False,
+        dist=True,
+        git=False,
+        tag=False,
+        stash=False,
+    )
+    _run(["git", "add", "."])  # add all changes
+    _run(["git", "commit", "-m", f"Release v{version}"])
+    commit_hash = _current_commit()
+    return commit_hash, current, current
 
 
 def publish(

--- a/core/views.py
+++ b/core/views.py
@@ -130,19 +130,19 @@ def _step_promote_build(release, ctx, log_path: Path) -> None:
     release.save(update_fields=["pypi_url"])
     _append_log(log_path, "Generating build files")
     try:
-        commit_hash, branch, current = release_utils.promote(
+        try:
+            subprocess.run(["git", "fetch", "origin", "main"], check=True)
+            subprocess.run(["git", "rebase", "origin/main"], check=True)
+        except subprocess.CalledProcessError as exc:
+            subprocess.run(["git", "rebase", "--abort"], check=False)
+            raise Exception("Rebase onto main failed") from exc
+        commit_hash, _, _ = release_utils.promote(
             package=release.to_package(),
             version=release.version,
             creds=release.to_credentials(),
         )
         release.revision = commit_hash
         release.save(update_fields=["revision"])
-        subprocess.run(["git", "checkout", current], check=True)
-        subprocess.run(["git", "pull", "--rebase"], check=True)
-        # Allow merging even when the release branch and main have diverged
-        # by creating a merge commit instead of requiring a fast-forward.
-        subprocess.run(["git", "merge", "--no-ff", branch], check=True)
-        subprocess.run(["git", "branch", "-d", branch], check=True)
         diff = subprocess.run(
             [
                 "git",


### PR DESCRIPTION
## Summary
- commit releases directly on main rather than creating temporary release branches
- fetch/rebase main before building, then push updated main
- adjust tests for new promotion flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b995b969c483268ffc7914cfb0c2a9