### PR TITLE
Use single text box for operation effect

### DIFF
--- a/nodes/migrations/0002_contentsample_user.py
+++ b/nodes/migrations/0002_contentsample_user.py
@@ -47,6 +47,8 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("template", core.fields.SigilLongCheckField(blank=True)),
+                ("command", core.fields.SigilLongAutoField(blank=True)),
+                ("is_django", models.BooleanField(default=False)),
             ],
             options={"ordering": ["name"]},
             bases=(core.entity.Entity,),
@@ -89,7 +91,7 @@ class Migration(migrations.Migration):
             bases=(core.entity.Entity,),
         ),
         migrations.CreateModel(
-            name="Effect",
+            name="Logbook",
             fields=[
                 (
                     "id",
@@ -106,37 +108,8 @@ class Migration(migrations.Migration):
                     "operation",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="effects",
-                        to="nodes.operation",
-                    ),
-                ),
-                ("command", core.fields.SigilLongAutoField()),
-                ("order", models.PositiveIntegerField(default=0)),
-                ("is_django", models.BooleanField(default=False)),
-            ],
-            options={"ordering": ["order"]},
-            bases=(core.entity.Entity,),
-        ),
-        migrations.CreateModel(
-            name="Logbook",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("is_seed_data", models.BooleanField(default=False, editable=False)),
-                ("is_deleted", models.BooleanField(default=False, editable=False)),
-                (
-                    "effect",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
                         related_name="logs",
-                        to="nodes.effect",
+                        to="nodes.operation",
                     ),
                 ),
                 (

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -587,6 +587,8 @@ class Operation(Entity):
 
     name = models.SlugField(unique=True)
     template = SigilLongCheckField(blank=True)
+    command = SigilLongAutoField(blank=True)
+    is_django = models.BooleanField(default=False)
     next_operations = models.ManyToManyField(
         "self",
         through="Interrupt",
@@ -624,30 +626,13 @@ class Interrupt(Entity):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
-
-
-class Effect(Entity):
-    """Shell or Django command executed by an operation."""
-
-    operation = models.ForeignKey(
-        Operation, on_delete=models.CASCADE, related_name="effects"
-    )
-    command = SigilLongAutoField()
-    order = models.PositiveIntegerField(default=0)
-    is_django = models.BooleanField(default=False)
-
-    class Meta:
-        ordering = ["order"]
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"{self.operation}: {self.command[:20]}"
-
+ 
 
 class Logbook(Entity):
-    """Record of executed effects."""
+    """Record of executed operations."""
 
-    effect = models.ForeignKey(
-        Effect, on_delete=models.CASCADE, related_name="logs"
+    operation = models.ForeignKey(
+        Operation, on_delete=models.CASCADE, related_name="logs"
     )
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -670,7 +655,7 @@ class Logbook(Entity):
         verbose_name_plural = "Logbook"
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"{self.effect} @ {self.created:%Y-%m-%d %H:%M:%S}"
+        return f"{self.operation} @ {self.created:%Y-%m-%d %H:%M:%S}"
 
 
 UserModel = get_user_model()

--- a/nodes/templates/admin/nodes/operation/run.html
+++ b/nodes/templates/admin/nodes/operation/run.html
@@ -27,18 +27,18 @@
     <input type="submit" value="{% trans 'Continue' %}">
   </form>
 {% elif running %}
-  <p>{% trans "Effect running..." %}</p>
+  <p>{% trans "Command running..." %}</p>
 {% else %}
   <form method="post">
     {% csrf_token %}
-    <input type="submit" value="{% trans 'Run next effect' %}">
+    <input type="submit" value="{% trans 'Run command' %}">
   </form>
 {% endif %}
 
 <div class="logs">
   {% for log in logs %}
     <div class="log-entry">
-      <strong>{{ log.effect.command }}</strong>
+      <strong>{{ log.input_text }}</strong>
       {% if log.output %}<pre>{{ log.output }}</pre>{% endif %}
       {% if log.error %}<pre class="error">{{ log.error }}</pre>{% endif %}
     </div>

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -37,7 +37,7 @@ from .tasks import capture_node_screenshot, sample_clipboard
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import serialization, hashes
 from core.models import PackageRelease
-from .models import Operation, Effect
+from .models import Operation
 from .admin import RUN_CONTEXTS
 
 
@@ -1080,15 +1080,13 @@ class OperationWorkflowTests(TestCase):
         RUN_CONTEXTS.clear()
 
     def test_unresolved_sigils_prompt(self):
-        op = Operation.objects.create(name="op1")
-        Effect.objects.create(operation=op, command="[ENV.MISSING]")
+        op = Operation.objects.create(name="op1", command="[ENV.MISSING]")
         url = reverse("admin:nodes_operation_run", args=[op.pk])
         resp = self.client.post(url, follow=True)
         self.assertContains(resp, 'name="ENV__MISSING"')
 
     def test_continue_effect(self):
-        op = Operation.objects.create(name="op2")
-        Effect.objects.create(operation=op, command="...")
+        op = Operation.objects.create(name="op2", command="...")
         url = reverse("admin:nodes_operation_run", args=[op.pk])
         resp = self.client.post(url, follow=True)
         self.assertContains(resp, 'value="Continue"')


### PR DESCRIPTION
## Summary
- convert Effect model into `command` field on Operation
- update admin workflow, templates, and tests for single-command operations

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9933750148326a9640747547793ba