### PR TITLE
feat: add prepare next release shortcut

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -183,6 +183,24 @@ class PackageAdmin(SaveBeforeChangeAction, admin.ModelAdmin):
             reverse("admin:core_packagerelease_change", args=[release.pk])
         )
 
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "prepare-next-release/",
+                self.admin_site.admin_view(self.prepare_next_release_active),
+                name="core_package_prepare_next_release",
+            )
+        ]
+        return custom + urls
+
+    def prepare_next_release_active(self, request):
+        package = Package.objects.filter(is_active=True).first()
+        if not package:
+            self.message_user(request, "No active package", messages.ERROR)
+            return redirect("admin:core_package_changelist")
+        return self._prepare(request, package)
+
     @admin.action(description="Prepare next Release")
     def prepare_next_release(self, request, queryset):
         if queryset.count() != 1:

--- a/core/templates/admin/core/package/change_list.html
+++ b/core/templates/admin/core/package/change_list.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_list.html" %}
+{% block object-tools-items %}
+{{ block.super }}
+<li><a href="{% url 'admin:core_package_prepare_next_release' %}">Prepare next Release</a></li>
+{% endblock %}

--- a/core/templates/admin/core/packagerelease/change_list.html
+++ b/core/templates/admin/core/packagerelease/change_list.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_list.html" %}
+{% block object-tools-items %}
+{{ block.super }}
+<li><a href="{% url 'admin:core_package_prepare_next_release' %}">Prepare next Release</a></li>
+{% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -30,7 +30,7 @@ from .models import (
     PackageRelease,
 )
 from django.contrib.admin.sites import AdminSite
-from core.admin import PackageReleaseAdmin
+from core.admin import PackageReleaseAdmin, PackageAdmin
 from ocpp.models import Transaction, Charger
 
 from django.core.exceptions import ValidationError
@@ -718,4 +718,35 @@ class PackageReleaseCurrentTests(TestCase):
         self.release.version = "2.0.0"
         self.release.save()
         self.assertFalse(self.release.is_current)
+
+
+class PackageAdminPrepareNextReleaseTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.site = AdminSite()
+        self.admin = PackageAdmin(Package, self.site)
+        self.admin.message_user = lambda *args, **kwargs: None
+        self.package = Package.objects.get(name="arthexis")
+
+    def test_prepare_next_release_active_creates_release(self):
+        PackageRelease.all_objects.filter(package=self.package).delete()
+        request = self.factory.get("/admin/core/package/prepare-next-release/")
+        response = self.admin.prepare_next_release_active(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            PackageRelease.all_objects.filter(package=self.package).count(), 1
+        )
+
+
+class PackageReleaseChangelistTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User.objects.create_superuser("admin", "admin@example.com", "pw")
+        self.client.force_login(User.objects.get(username="admin"))
+
+    def test_prepare_next_release_button_present(self):
+        response = self.client.get(reverse("admin:core_packagerelease_changelist"))
+        self.assertContains(
+            response, reverse("admin:core_package_prepare_next_release"), html=False
+        )
 

--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -34,6 +34,9 @@
               {% if model.admin_url and show_changelinks %}
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
                 <td class="actions">
+                  {% if app.app_label == 'core' and model.object_name == 'Package' %}
+                    <a href="{% url 'admin:core_package_prepare_next_release' %}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">Prepare next Release</a>
+                  {% endif %}
                   {% for action in extra_actions %}
                     <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
                   {% endfor %}


### PR DESCRIPTION
## Summary
- add admin view to prepare next release for active package
- show a "Prepare next Release" button in Package list and dashboard
- cover new view with tests
- expose the same button on the Package Release list for quick access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba0ab070d883268fac63067528d6aa