### PR TITLE
Allow www.arthexis.com host

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -85,6 +85,7 @@ ALLOWED_HOSTS = [
     "10.42.0.0/16",
     "192.168.0.0/16",
     "arthexis.com",
+    "www.arthexis.com",
 ]
 
 


### PR DESCRIPTION
## Summary
- allow requests from `www.arthexis.com` by whitelisting it in `ALLOWED_HOSTS`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba35b2151883268e67b9e1196dedd1