### PR TITLE
docs: expand README with explanatory links

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,21 +2,21 @@
 
 ## Propósito
 
-Arthexis Constellation es una suite narrativa basada en Django que centraliza herramientas para gestionar infraestructura de carga y orquestar productos y servicios relacionados con la energía.
+Constelación Arthexis es una [suite de software](https://es.wikipedia.org/wiki/Suite_de_software) [impulsada por la narrativa](https://es.wikipedia.org/wiki/Narrativa) basada en [Django](https://www.djangoproject.com/) que centraliza herramientas para gestionar la [infraestructura de carga de vehículos eléctricos](https://es.wikipedia.org/wiki/Punto_de_recarga) y orquestar [productos](https://es.wikipedia.org/wiki/Producto_(econom%C3%ADa)) y [servicios](https://es.wikipedia.org/wiki/Servicio_(econom%C3%ADa)) relacionados con la [energía](https://es.wikipedia.org/wiki/Energ%C3%ADa).
 
 ## Características
 
-- Compatible con cargadores OCPP 1.6
-- Integración de APIs con Odoo 1.6
-- Funciona en Windows 11 y Ubuntu 22
-- Probado para Raspberry Pi 4B
+- Compatible con el [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/)
+- Integración de [API](https://es.wikipedia.org/wiki/Interfaz_de_programaci%C3%B3n_de_aplicaciones) con [Odoo](https://www.odoo.com/) 1.6
+- Funciona en [Windows 11](https://www.microsoft.com/es-es/windows/windows-11) y [Ubuntu 22.04 LTS](https://releases.ubuntu.com/22.04/)
+- Probado para la [Raspberry Pi 4 Modelo B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 
 ## Soporte
 
-Contáctenos en tecnologia arroba gelectriic punto com o visite nuestro sitio web https://www.gelectriic.com/ para servicios profesionales y soporte comercial.
+Contáctenos en [tecnologia@gelectriic.com](mailto:tecnologia@gelectriic.com) o visite nuestro [sitio web](https://www.gelectriic.com/) para [servicios profesionales](https://es.wikipedia.org/wiki/Servicios_profesionales) y [soporte comercial](https://es.wikipedia.org/wiki/Soporte_t%C3%A9cnico).
 
 ## Sobre mí
 
-> "¿Qué? ¿También quieres saber sobre mí? Bueno, disfruto el desarrollo de software, los juegos de rol, largas caminatas por la playa y una cuarta cosa secreta."
+> "¿Qué? ¿También quieres saber sobre mí? Bueno, disfruto el [desarrollo de software](https://es.wikipedia.org/wiki/Desarrollo_de_software), los [juegos de rol](https://es.wikipedia.org/wiki/Juego_de_rol), largas caminatas por la [playa](https://es.wikipedia.org/wiki/Playa) y una cuarta cosa secreta."
 > --Arthexis
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 ## Purpose
 
-Arthexis Constellation is a narrative-driven Django-based suite that centralizes tools for managing charging infrastructure and orchestrating energy-related products and services.
+Arthexis Constellation is a [narrative-driven](https://en.wikipedia.org/wiki/Narrative) [Django](https://www.djangoproject.com/)-based [software suite](https://en.wikipedia.org/wiki/Software_suite) that centralizes tools for managing [electric vehicle charging infrastructure](https://en.wikipedia.org/wiki/Charging_station) and orchestrating [energy](https://en.wikipedia.org/wiki/Energy)-related [products](https://en.wikipedia.org/wiki/Product_(business)) and [services](https://en.wikipedia.org/wiki/Service_(economics)).
 
 ## Features
 
-- Compatible with OCPP 1.6 chargers
-- API integration with Odoo 1.6
-- Runs on Windows 11 and Ubuntu 22
-- Tested for Raspberry Pi 4B
+- Compatible with the [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/)
+- [API](https://en.wikipedia.org/wiki/API) integration with [Odoo](https://www.odoo.com/) 1.6
+- Runs on [Windows 11](https://www.microsoft.com/windows/windows-11) and [Ubuntu 22.04 LTS](https://releases.ubuntu.com/22.04/)
+- Tested for the [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 
 ## Support
 
-Contact us at tecnologia at gelectriic dot com or visit our [web page](https://www.gelectriic.com/) for professional services and commercial support.
+Contact us at [tecnologia@gelectriic.com](mailto:tecnologia@gelectriic.com) or visit our [web page](https://www.gelectriic.com/) for [professional services](https://en.wikipedia.org/wiki/Professional_services) and [commercial support](https://en.wikipedia.org/wiki/Technical_support).
 
 ## About Me
 
-> "What, you want to know about me too? Well, I enjoy developing software, role-playing games, long walks on the beach and a fourth secret thing."
+> "What, you want to know about me too? Well, I enjoy [developing software](https://en.wikipedia.org/wiki/Software_development), [role-playing games](https://en.wikipedia.org/wiki/Role-playing_game), long walks on the [beach](https://en.wikipedia.org/wiki/Beach) and a fourth secret thing."
 > --Arthexis
+


### PR DESCRIPTION
## Summary
- link most terms in English README to external explanations
- mirror the linked content in Spanish README

## Testing
- `pytest` *(fails: KeyboardInterrupt during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4af22eb4832691c9b1e78d2512b8