### PR TITLE
feat: capture migration snapshot in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run migration snapshot
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          python scripts/capture_migration_state.py "${VERSION#v}"
+      - name: Test upgrade path
+        run: |
+          scripts/test_upgrade_path.sh
+      - name: Publish artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-plan
+          path: releases/${GITHUB_REF#refs/tags/}/migration-plan.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- add migration snapshot script and release workflow
+
 0.1.7 [revision 4dcd62ed8222e102edbc88c81300a774e39f095c]
 ---------------------------------------------------------
 

--- a/scripts/capture_migration_state.py
+++ b/scripts/capture_migration_state.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Capture migration plan, inspectdb output, and optional schema dump for a release."""
+import subprocess
+import sys
+import pathlib
+import os
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: capture_migration_state.py <version>")
+        sys.exit(1)
+    version = sys.argv[1]
+    out_dir = pathlib.Path("releases") / version
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Capture migrations plan
+    plan = subprocess.check_output(
+        ["python", "manage.py", "showmigrations", "--plan"], text=True
+    )
+    (out_dir / "migration-plan.txt").write_text(plan)
+
+    # Capture inspectdb output
+    inspect = subprocess.check_output(
+        ["python", "manage.py", "inspectdb"], text=True
+    )
+    (out_dir / "inspectdb.py").write_text(inspect)
+
+    # Optional: dump full schema using pg_dump if available
+    try:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+        import django
+        from django.conf import settings
+
+        django.setup()
+        db_name = settings.DATABASES["default"]["NAME"]
+        schema_path = out_dir / "schema.sql"
+        with schema_path.open("w") as fh:
+            subprocess.run(["pg_dump", "--schema-only", db_name], check=True, stdout=fh)
+    except Exception as exc:  # pragma: no cover - optional
+        # Schema dump is optional; print message and continue
+        print(f"Skipping schema dump: {exc}")
+
+    # Add files to git
+    files = [out_dir / "migration-plan.txt", out_dir / "inspectdb.py"]
+    schema_file = out_dir / "schema.sql"
+    if schema_file.exists():
+        files.append(schema_file)
+    subprocess.run(["git", "add", *map(str, files)], check=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    main()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Release helper that bumps version, captures migration state, and tags the release.
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: release.sh <version>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+
+echo "$VERSION" > VERSION
+
+python scripts/capture_migration_state.py "$VERSION"
+
+git commit -am "Release $VERSION"
+git tag -a "v$VERSION" -m "Release $VERSION"
+git push origin main --tags

--- a/scripts/test_upgrade_path.sh
+++ b/scripts/test_upgrade_path.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Test migrating from the previous release tag to the current code.
+set -euo pipefail
+
+PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
+WORKTREE_DIR=$(mktemp -d)
+
+cleanup() {
+  git worktree remove "$WORKTREE_DIR" --force >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git worktree add "$WORKTREE_DIR" "$PREV_TAG"
+
+pushd "$WORKTREE_DIR" >/dev/null
+python manage.py migrate --noinput
+popd >/dev/null
+
+python manage.py migrate --noinput


### PR DESCRIPTION
## Summary
- add capture_migration_state script to snapshot migrations, inspectdb, and optional schema
- wire script into release helper and CI workflow
- document release workflow in changelog

## Testing
- `pytest` *(fails: tests/test_chat_profile_admin.py::ChatProfileAdminTests::test_generate_key_button - AssertionError: 302 != 200)*

------
https://chatgpt.com/codex/tasks/task_e_68ba47f944148326b6733b95eaaf715a