### PR TITLE
Fix generate key link in ChatProfile admin

### DIFF
--- a/core/templates/admin/workgroupchatprofile_change_form.html
+++ b/core/templates/admin/workgroupchatprofile_change_form.html
@@ -4,7 +4,7 @@
 {% block object-tools %}
 <ul class="object-tools">
     {% if original %}
-    <li><a href="generate-key/" class="addlink">{% trans "Generate Key" %}</a></li>
+    <li><a href="../generate-key/" class="addlink">{% trans "Generate Key" %}</a></li>
     {% endif %}
     {% block object-tools-items %}{{ block.super }}{% endblock %}
 </ul>

--- a/tests/test_chat_profile_admin.py
+++ b/tests/test_chat_profile_admin.py
@@ -15,7 +15,15 @@ class ChatProfileAdminTests(TestCase):
         )
         self.user = User.objects.create_user(username="bob", password="pwd")
         self.profile = ChatProfile.objects.create(user=self.user, user_key_hash="0" * 64)
-        self.client.login(username="admin", password="pwd")
+        self.client.force_login(self.admin)
+
+    def test_change_form_has_generate_key_link(self):
+        url = reverse(
+            "admin:post_office_workgroupchatprofile_change",
+            args=[self.profile.pk],
+        )
+        response = self.client.get(url)
+        self.assertContains(response, '../generate-key/')
 
     def test_generate_key_button(self):
         url = reverse(


### PR DESCRIPTION
## Summary
- fix generate key button to direct to key page
- test presence of generate key link and key generation

## Testing
- `pytest tests/test_chat_profile_admin.py tests/test_chat_profile_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba4d6e23288326af365d1abe4b960d