### PR TITLE
fix(admin): load net message after DOM ready

### DIFF
--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -153,8 +153,9 @@
 {% block extrahead %}
   {{ block.super }}
   <script>
-    (function () {
+    window.addEventListener('DOMContentLoaded', () => {
       const label = document.getElementById('last-netmessage');
+      if (!label) return;
       let last = '';
       async function fetchMessage() {
         try {
@@ -173,6 +174,6 @@
       }
       fetchMessage();
       setInterval(fetchMessage, 6000);
-    })();
+    });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure dashboard fetches and displays last NetMessage only after the DOM is ready

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba4cdbf1f48326bafc60496fe3b12f