### PR TITLE
Reassign admin groups for reference, leads, and security models

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -118,7 +118,15 @@ class CalculatorTemplateAdmin(admin.ModelAdmin):
     calculator_link.short_description = "Calculator"
 
 
-@admin.register(PowerLead)
+class BusinessPowerLead(PowerLead):
+    class Meta:
+        proxy = True
+        app_label = "core"
+        verbose_name = PowerLead._meta.verbose_name
+        verbose_name_plural = PowerLead._meta.verbose_name_plural
+
+
+@admin.register(BusinessPowerLead)
 class PowerLeadAdmin(admin.ModelAdmin):
     list_display = ("created_on", "user", "ip_address")
     search_fields = ("user__username", "ip_address")

--- a/core/admin.py
+++ b/core/admin.py
@@ -53,6 +53,30 @@ from .user_data import UserDatumAdminMixin
 admin.site.unregister(Group)
 
 
+class WorkgroupReleaseManager(ReleaseManager):
+    class Meta:
+        proxy = True
+        app_label = "post_office"
+        verbose_name = ReleaseManager._meta.verbose_name
+        verbose_name_plural = ReleaseManager._meta.verbose_name_plural
+
+
+class WorkgroupSecurityGroup(SecurityGroup):
+    class Meta:
+        proxy = True
+        app_label = "post_office"
+        verbose_name = SecurityGroup._meta.verbose_name
+        verbose_name_plural = SecurityGroup._meta.verbose_name_plural
+
+
+class ExperienceReference(Reference):
+    class Meta:
+        proxy = True
+        app_label = "pages"
+        verbose_name = Reference._meta.verbose_name
+        verbose_name_plural = Reference._meta.verbose_name_plural
+
+
 class SaveBeforeChangeAction(DjangoObjectActions):
     def response_change(self, request, obj):
         action = request.POST.get("_action")
@@ -66,7 +90,7 @@ class SaveBeforeChangeAction(DjangoObjectActions):
         return super().response_change(request, obj)
 
 
-@admin.register(Reference)
+@admin.register(ExperienceReference)
 class ReferenceAdmin(admin.ModelAdmin):
     list_display = (
         "alt_text",
@@ -142,7 +166,7 @@ class ReferenceAdmin(admin.ModelAdmin):
     qr_code.short_description = "QR Code"
 
 
-@admin.register(ReleaseManager)
+@admin.register(WorkgroupReleaseManager)
 class ReleaseManagerAdmin(admin.ModelAdmin):
     list_display = ("user", "pypi_username", "pypi_url")
 
@@ -226,7 +250,7 @@ class SecurityGroupAdminForm(forms.ModelForm):
     )
 
     class Meta:
-        model = SecurityGroup
+        model = WorkgroupSecurityGroup
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
@@ -244,7 +268,7 @@ class SecurityGroupAdminForm(forms.ModelForm):
         return instance
 
 
-@admin.register(SecurityGroup)
+@admin.register(WorkgroupSecurityGroup)
 class SecurityGroupAdmin(DjangoGroupAdmin):
     form = SecurityGroupAdminForm
     fieldsets = ((None, {"fields": ("name", "parent", "users", "permissions")}),)
@@ -785,6 +809,7 @@ class RFIDForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["reference"].required = False
         rel = RFID._meta.get_field("reference").remote_field
+        rel.model = ExperienceReference
         widget = self.fields["reference"].widget
         self.fields["reference"].widget = RelatedFieldWidgetWrapper(
             widget,

--- a/tests/test_business_admin_group.py
+++ b/tests/test_business_admin_group.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.contrib.admin.sites import site
+
+from awg.admin import BusinessPowerLead
+
+
+class BusinessAdminGroupTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="biz-admin", password="pwd", email="admin@example.com"
+        )
+        self.client.force_login(self.admin)
+
+    def test_powerlead_registered(self):
+        registry = site._registry
+        self.assertIn(BusinessPowerLead, registry)
+        self.assertEqual(
+            registry[BusinessPowerLead].model._meta.app_label, "core"
+        )
+
+    def test_admin_index_shows_powerlead(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, "2. Business")
+        self.assertContains(response, "Power Leads")

--- a/tests/test_experience_admin_group.py
+++ b/tests/test_experience_admin_group.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.contrib.admin.sites import site
+
+from core.admin import ExperienceReference
+
+
+class ExperienceAdminGroupTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="exp-admin", password="pwd", email="admin@example.com"
+        )
+        self.client.force_login(self.admin)
+
+    def test_reference_registered(self):
+        registry = site._registry
+        self.assertIn(ExperienceReference, registry)
+        self.assertEqual(
+            registry[ExperienceReference].model._meta.app_label, "pages"
+        )
+
+    def test_admin_index_shows_reference(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, "7. Experience")
+        self.assertContains(response, "References")

--- a/tests/test_reference_qr_code.py
+++ b/tests/test_reference_qr_code.py
@@ -44,7 +44,7 @@ class ReferenceQRTests(TestCase):
             method="text",
             value="some value",
         )
-        url = reverse("admin:core_reference_change", args=[ref.pk])
+        url = reverse("admin:pages_experiencereference_change", args=[ref.pk])
         response = self.client.get(url)
         self.assertContains(response, ref.image.url)
         self.assertContains(response, "<img", html=False)

--- a/tests/test_workgroup_admin_group.py
+++ b/tests/test_workgroup_admin_group.py
@@ -3,7 +3,11 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.contrib.admin.sites import site
 
-from core.admin import EmailInbox as PostOfficeEmailInbox
+from core.admin import (
+    EmailInbox as PostOfficeEmailInbox,
+    WorkgroupReleaseManager,
+    WorkgroupSecurityGroup,
+)
 from nodes.admin import EmailOutbox as PostOfficeEmailOutbox
 
 
@@ -19,11 +23,19 @@ class WorkgroupAdminGroupTests(TestCase):
         registry = site._registry
         self.assertIn(PostOfficeEmailInbox, registry)
         self.assertIn(PostOfficeEmailOutbox, registry)
+        self.assertIn(WorkgroupReleaseManager, registry)
+        self.assertIn(WorkgroupSecurityGroup, registry)
         self.assertEqual(
             registry[PostOfficeEmailInbox].model._meta.app_label, "post_office"
         )
         self.assertEqual(
             registry[PostOfficeEmailOutbox].model._meta.app_label, "post_office"
+        )
+        self.assertEqual(
+            registry[WorkgroupReleaseManager].model._meta.app_label, "post_office"
+        )
+        self.assertEqual(
+            registry[WorkgroupSecurityGroup].model._meta.app_label, "post_office"
         )
 
     def test_admin_index_shows_post_office_group(self):
@@ -32,3 +44,5 @@ class WorkgroupAdminGroupTests(TestCase):
         self.assertContains(response, "Email Inboxes")
         self.assertContains(response, "Email Outboxes")
         self.assertContains(response, "Chat Profiles")
+        self.assertContains(response, "Release Managers")
+        self.assertContains(response, "Security Groups")


### PR DESCRIPTION
## Summary
- Proxy ReleaseManager and SecurityGroup into Workgroup admin group
- Show Reference under Experience with updated RFID widget
- Group PowerLead with Business models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba55ce568883269a4131be299cc887