### PR TITLE
Configure static files collection during startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
                 "--noreload"
             ],
             "django": true,
-            "noDebug": true
+            "noDebug": true,
+            "preLaunchTask": "Dev: collectstatic"
         },
         {
             "name": "Debug Server",
@@ -29,7 +30,8 @@
             "args": [
                 "runserver"
             ],
-            "subProcess": true
+            "subProcess": true,
+            "preLaunchTask": "Dev: collectstatic"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -62,6 +62,16 @@
             "detail": "Run manage.py subcommands"
         },
         {
+            "label": "Dev: collectstatic",
+            "type": "shell",
+            "command": "${workspaceFolder}/.venv/bin/python ${workspaceFolder}/manage.py collectstatic --noinput",
+            "windows": {
+                "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe ${workspaceFolder}\\manage.py collectstatic --noinput"
+            },
+            "problemMatcher": [],
+            "detail": "Collect static files"
+        },
+        {
             "label": "Update requirements",
             "type": "shell",
             "command": "${workspaceFolder}/install.sh && ${workspaceFolder}/.venv/bin/python ${workspaceFolder}/freeze_requirements.py",

--- a/config/settings.py
+++ b/config/settings.py
@@ -313,6 +313,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "static"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 

--- a/start.bat
+++ b/start.bat
@@ -25,4 +25,5 @@ exit /b 1
 
 :run
 if not defined RELOAD set NORELOAD=--noreload
+%VENV%\Scripts\python.exe manage.py collectstatic --noinput
 %VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT% %NORELOAD%

--- a/start.sh
+++ b/start.sh
@@ -105,6 +105,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Collect static files
+python manage.py collectstatic --noinput
+
 # Start required Celery components if requested
 if [ "$CELERY" = true ]; then
   celery -A config worker -l info &


### PR DESCRIPTION
## Summary
- define `STATIC_ROOT` so `collectstatic` stores assets in a dedicated folder
- run `manage.py collectstatic` before starting the server via scripts or VS Code tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf80b5c86083269d2a67fc29f01714