### PR TITLE
Prefer wlan1 for internet routing

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Network setup script
-# Configures eth0 with a shared static IP and creates a Wi-Fi access point on
-# wlan0 using NetworkManager (nmcli).
+# Configures eth0 with a shared static IP, connects wlan1 as the internet uplink,
+# and creates a Wi-Fi access point on wlan0 using NetworkManager (nmcli).
 
 set -euo pipefail
 
@@ -104,25 +104,16 @@ ensure_pkg nginx nginx
 ensure_pkg sshd openssh-server
 ensure_service ssh
 
-# Ensure VNC server is installed and running
-if systemctl list-unit-files | grep -q 'vncserver-x11-serviced.service'; then
-    ensure_service vncserver-x11-serviced
-else
-    ensure_pkg x11vnc x11vnc
-    ensure_service x11vnc
-fi
-
-# Ensure SSH and VNC ports are open if a firewall is active
+# Ensure SSH port is open if a firewall is active
 if command -v ufw >/dev/null 2>&1; then
     STATUS=$(ufw status 2>/dev/null || true)
     if ! echo "$STATUS" | grep -iq "inactive"; then
         ufw allow 22/tcp || true
-        ufw allow 5900/tcp || true
     fi
 fi
 
 if [[ $SKIP_FIREWALL == false ]]; then
-    PORTS=(22 5900 21114)
+    PORTS=(22 21114)
     MODE="internal"
     if [ -f "$LOCK_DIR/nginx_mode.lck" ]; then
         MODE="$(cat "$LOCK_DIR/nginx_mode.lck")"
@@ -178,10 +169,12 @@ if nmcli -t -f DEVICE device status | grep -Fxq "wlan1"; then
             nmcli connection delete "$con"
             if [[ -n "$psk" ]]; then
                 nmcli connection add type wifi ifname wlan1 con-name "$new_name" ssid "$ssid" \
-                    wifi.band a wifi-sec.key-mgmt "$key_mgmt" wifi-sec.psk "$psk" autoconnect yes
+                    wifi.band a wifi-sec.key-mgmt "$key_mgmt" wifi-sec.psk "$psk" autoconnect yes \
+                    ipv4.method auto ipv4.route-metric 100 ipv6.method ignore
             else
                 nmcli connection add type wifi ifname wlan1 con-name "$new_name" ssid "$ssid" \
-                    wifi.band a autoconnect yes
+                    wifi.band a autoconnect yes ipv4.method auto ipv4.route-metric 100 \
+                    ipv6.method ignore
             fi
         fi
     done < <(nmcli -t -f NAME connection show)
@@ -203,60 +196,67 @@ for dev in eth0 wlan0; do
     done
 done
 
-# Add persistent Hyperline connection on wlan0
-nmcli connection add type wifi ifname wlan0 con-name hyperline \
+# Obtain or prompt for WiFi password
+if [[ -n "$EXISTING_PASS" && $FORCE_PASSWORD != true ]]; then
+    WIFI_PASS="$EXISTING_PASS"
+elif [[ $FORCE_PASSWORD == true ]]; then
+    while true; do
+        read -rsp "Enter WiFi password for '$AP_NAME': " WIFI_PASS1; echo
+        read -rsp "Confirm password: " WIFI_PASS2; echo
+        if [[ "$WIFI_PASS1" == "$WIFI_PASS2" && -n "$WIFI_PASS1" ]]; then
+            WIFI_PASS="$WIFI_PASS1"
+            break
+        else
+            echo "Passwords do not match or are empty." >&2
+        fi
+    done
+else
+    WIFI_PASS="arthexis"
+fi
+
+# Configure wlan0 access point
+nmcli connection add type wifi ifname wlan0 con-name "$AP_NAME" autoconnect yes \
+    ssid "$AP_NAME" mode ap ipv4.method shared ipv4.addresses 10.42.0.1/16 \
+    ipv4.never-default yes ipv6.method ignore ipv6.never-default yes \
+    wifi.band bg wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$WIFI_PASS"
+
+# Add persistent Hyperline connection on wlan1
+nmcli connection delete hyperline 2>/dev/null || true
+nmcli connection add type wifi ifname wlan1 con-name hyperline \
     ssid "Hyperline" wifi-sec.key-mgmt wpa-psk wifi-sec.psk "arthexis" \
-    autoconnect yes ipv4.method auto ipv6.method ignore
+    autoconnect yes ipv4.method auto ipv6.method ignore ipv4.route-metric 100
 
 # Configure eth0 shared connection
 nmcli connection add type ethernet ifname eth0 con-name eth0-shared autoconnect yes \
     ipv4.method shared ipv4.addresses 192.168.129.10/16 ipv4.never-default yes \
-    ipv6.method ignore ipv6.never-default yes
+    ipv4.route-metric 10000 ipv6.method ignore ipv6.never-default yes
 
-# Attempt to connect to Hyperline network
-HYPERLINE_CONNECTED=false
-if nmcli connection up hyperline; then
-    HYPERLINE_CONNECTED=true
-else
-    echo "Failed to activate Hyperline connection; falling back to access point." >&2
-    nmcli connection delete hyperline || true
+# Attempt to connect to Hyperline network or any existing wlan1 networks
+if ! nmcli connection up hyperline; then
+    echo "Failed to activate Hyperline connection; trying existing wlan1 connections." >&2
+    while read -r con; do
+        if nmcli connection up "$con"; then
+            break
+        fi
+    done < <(nmcli -t -f NAME connection show | grep '^gate-')
 fi
 
-if [[ "$HYPERLINE_CONNECTED" != true ]]; then
-    # Obtain or prompt for WiFi password
-    if [[ -z "$EXISTING_PASS" || $FORCE_PASSWORD == true ]]; then
-        while true; do
-            read -rsp "Enter WiFi password for '$AP_NAME': " WIFI_PASS1; echo
-            read -rsp "Confirm password: " WIFI_PASS2; echo
-            if [[ "$WIFI_PASS1" == "$WIFI_PASS2" && -n "$WIFI_PASS1" ]]; then
-                WIFI_PASS="$WIFI_PASS1"
-                break
-            else
-                echo "Passwords do not match or are empty." >&2
-            fi
-        done
-    else
-        WIFI_PASS="$EXISTING_PASS"
-    fi
+# Bring up shared ethernet and access point
+nmcli connection up eth0-shared
+nmcli connection up "$AP_NAME"
 
-    # Configure wlan0 access point
-    nmcli connection add type wifi ifname wlan0 con-name "$AP_NAME" autoconnect yes \
-        ssid "$AP_NAME" mode ap ipv4.method shared ipv4.addresses 10.42.0.1/16 \
-        ipv4.never-default yes ipv6.method ignore ipv6.never-default yes \
-        wifi.band bg wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$WIFI_PASS"
+# Allow wlan0 clients to reach local services on 10.42.0.1
+if command -v iptables >/dev/null 2>&1; then
+    iptables -C INPUT -i wlan0 -d 10.42.0.1 -j ACCEPT 2>/dev/null || \
+        iptables -A INPUT -i wlan0 -d 10.42.0.1 -j ACCEPT
+fi
 
-    # Bring up connections
-    nmcli connection up eth0-shared
-    nmcli connection up "$AP_NAME"
-
-    # Allow wlan0 clients to reach local services on 10.42.0.1
-    if command -v iptables >/dev/null 2>&1; then
-        iptables -C INPUT -i wlan0 -d 10.42.0.1 -j ACCEPT 2>/dev/null || \
-            iptables -A INPUT -i wlan0 -d 10.42.0.1 -j ACCEPT
-    fi
-else
-    # Bring up shared ethernet and already-connected Hyperline WiFi
-    nmcli connection up eth0-shared
+# Ensure eth0 is not used for default routing and favor wlan1 as gateway
+ip route del default dev eth0 2>/dev/null || true
+ip route del default dev wlan0 2>/dev/null || true
+WLAN1_GW=$(nmcli -g IP4.GATEWAY device show wlan1 2>/dev/null | head -n1)
+if [[ -n "$WLAN1_GW" ]]; then
+    ip route replace default via "$WLAN1_GW" dev wlan1 2>/dev/null || true
 fi
 
 # Show final status


### PR DESCRIPTION
## Summary
- Give all wlan1 Wi-Fi profiles a low route metric so any can become the default gateway
- Try existing `gate-*` networks if Hyperline is unavailable before enabling the local AP
- Always create a `gelectriic-[hostname]` access point on wlan0 and drop VNC setup

## Testing
- `pip install whitenoise`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf96a825b08326b4fe0af52210cd42