### PR TITLE
Ignore collected static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,9 @@ dmypy.json
 
 # local media generated during tests
 media/
+# Collected static files
+/static/
+/staticfiles/
 # Security keys generated for nodes
 security/
 # Pyre type checker


### PR DESCRIPTION
## Summary
- prevent committed collected static files by ignoring root static directories

## Testing
- `pip install whitenoise`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa608375c8326a8443935b1d743fd