### PR TITLE
Enable energy report generation in admin

### DIFF
--- a/core/templates/admin/core/energyreport/change_list.html
+++ b/core/templates/admin/core/energyreport/change_list.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_list.html" %}
+{% block object-tools-items %}
+{{ block.super }}
+<li><a href="{% url 'admin:core_energyreport_generate' %}">Generate Report</a></li>
+{% endblock %}

--- a/core/templates/admin/core/energyreport/generate.html
+++ b/core/templates/admin/core/energyreport/generate.html
@@ -1,0 +1,24 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+<h1>Energy Report</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Generate</button>
+</form>
+{% if report %}
+  <h2>Report from {{ report.start_date }} to {{ report.end_date }}</h2>
+  <table class="adminlist">
+    <thead>
+      <tr><th>RFID/Account</th><th>Sessions</th><th>Total kWh</th></tr>
+    </thead>
+    <tbody>
+      {% for row in report.data.rows %}
+        <tr><td>{{ row.subject }}</td><td>{{ row.count }}</td><td>{{ row.kw|floatformat:2 }}</td></tr>
+      {% empty %}
+        <tr><td colspan="3">No data available.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+{% endblock %}

--- a/tests/test_admin_energy_report.py
+++ b/tests/test_admin_energy_report.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+from datetime import timedelta
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import RFID, EnergyReport, EnergyAccount
+from ocpp.models import Charger, Transaction
+
+
+class AdminEnergyReportTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="pass"
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.charger = Charger.objects.create(charger_id="C1")
+        self.rfid1 = RFID.objects.create(rfid="A1B2C3")
+        self.rfid2 = RFID.objects.create(rfid="D4E5F6")
+        self.account = EnergyAccount.objects.create(name="ACCOUNT")
+        self.account.rfids.add(self.rfid1)
+        start = timezone.now()
+        Transaction.objects.create(
+            charger=self.charger,
+            rfid=self.rfid1.rfid,
+            start_time=start,
+            stop_time=start + timedelta(hours=1),
+            meter_start=0,
+            meter_stop=1000,
+        )
+        Transaction.objects.create(
+            charger=self.charger,
+            rfid=self.rfid2.rfid,
+            start_time=start,
+            stop_time=start + timedelta(hours=1),
+            meter_start=0,
+            meter_stop=500,
+        )
+
+    def test_generate_report_via_admin(self):
+        day = timezone.now().date()
+        url = reverse("admin:core_energyreport_generate")
+        resp = self.client.post(url, {"start": day, "end": day})
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.account.name)
+        self.assertContains(resp, str(self.rfid2.label_id))
+        self.assertNotContains(resp, self.rfid1.rfid)
+        self.assertNotContains(resp, self.rfid2.rfid)
+        report = EnergyReport.objects.get()
+        self.assertEqual(report.start_date, day)
+        self.assertEqual(report.end_date, day)
+        subjects = {row["subject"] for row in report.data["rows"]}
+        self.assertIn(self.account.name, subjects)
+        self.assertIn(str(self.rfid2.label_id), subjects)


### PR DESCRIPTION
## Summary
- add admin interface for generating energy reports with date range form
- expose a 'Generate Report' link from Energy Report changelist
- test admin energy report generation

## Testing
- `python manage.py migrate --noinput`
- `pytest tests/test_energy_report_generation.py tests/test_rfid_energy_report.py tests/test_admin_energy_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68c047fc6a3c8326b22a34efaea6a07c