### PR TITLE
Add admin test tools for email inbox and outbox

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -505,6 +505,38 @@ class EmailInboxAdmin(admin.ModelAdmin):
     form = EmailInboxAdminForm
     list_display = ("user", "username", "host", "protocol")
     actions = ["test_connection", "search_inbox"]
+    change_form_template = "admin/core/emailinbox/change_form.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<path:object_id>/test/",
+                self.admin_site.admin_view(self.test_inbox),
+                name="post_office_emailinbox_test",
+            )
+        ]
+        return custom + urls
+
+    def test_inbox(self, request, object_id):
+        inbox = self.get_object(request, object_id)
+        if not inbox:
+            self.message_user(request, "Unknown inbox", messages.ERROR)
+            return redirect("..")
+        try:
+            inbox.test_connection()
+            self.message_user(request, "Inbox connection successful", messages.SUCCESS)
+        except Exception as exc:  # pragma: no cover - admin feedback
+            self.message_user(request, str(exc), messages.ERROR)
+        return redirect("..")
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        if object_id:
+            extra_context["test_url"] = reverse(
+                "admin:post_office_emailinbox_test", args=[object_id]
+            )
+        return super().changeform_view(request, object_id, form_url, extra_context)
     fieldsets = (
         (
             None,

--- a/core/templates/admin/core/emailinbox/change_form.html
+++ b/core/templates/admin/core/emailinbox/change_form.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    {% if test_url %}
+        <li><a href="{{ test_url }}">{% trans "Test Inbox" %}</a></li>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}

--- a/nodes/templates/admin/nodes/emailoutbox/change_form.html
+++ b/nodes/templates/admin/nodes/emailoutbox/change_form.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    {% if test_url %}
+        <li><a href="{{ test_url }}">{% trans "Test Outbox" %}</a></li>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}

--- a/tests/test_email_inbox_admin.py
+++ b/tests/test_email_inbox_admin.py
@@ -1,8 +1,10 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
+from django.contrib.admin.sites import AdminSite
+from unittest.mock import patch
 
 from core.models import EmailInbox
-from core.admin import EmailInboxAdminForm
+from core.admin import EmailInboxAdminForm, EmailInboxAdmin, EmailInbox as AdminEmailInbox
 
 
 class EmailInboxAdminFormTests(TestCase):
@@ -62,3 +64,41 @@ class EmailInboxAdminFormTests(TestCase):
         form.save()
         inbox.refresh_from_db()
         self.assertEqual(inbox.password, "newpass")
+
+
+class EmailInboxAdminActionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="admin", email="a@example.com", password="pwd"
+        )
+        self.inbox = EmailInbox.objects.create(
+            user=self.user,
+            host="imap.test",
+            port=993,
+            username="u",
+            password="p",
+            protocol=EmailInbox.IMAP,
+            use_ssl=True,
+        )
+        self.factory = RequestFactory()
+        self.admin = EmailInboxAdmin(AdminEmailInbox, AdminSite())
+
+    def test_test_inbox_action(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        request.session = self.client.session
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
+        request._messages = FallbackStorage(request)
+        with patch.object(EmailInbox, "test_connection") as mock_test:
+            response = self.admin.test_inbox(request, str(self.inbox.pk))
+            self.assertEqual(response.status_code, 302)
+            mock_test.assert_called_once()
+
+    def test_change_form_contains_link(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        response = self.admin.changeform_view(request, str(self.inbox.pk))
+        content = response.render().content.decode()
+        self.assertIn("Test Inbox", content)

--- a/tests/test_email_outbox_admin.py
+++ b/tests/test_email_outbox_admin.py
@@ -1,0 +1,50 @@
+from unittest.mock import patch
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import TestCase, RequestFactory
+
+from nodes.admin import EmailOutboxAdmin, EmailOutbox as AdminEmailOutbox
+from nodes.models import EmailOutbox, Node
+
+
+class EmailOutboxAdminActionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="admin", email="a@example.com", password="pwd"
+        )
+        self.node = Node.objects.create(
+            hostname="host",
+            address="127.0.0.1",
+            port=8000,
+            mac_address="00:11:22:33:44:55",
+        )
+        self.outbox = EmailOutbox.objects.create(
+            node=self.node,
+            host="smtp.test",
+            port=25,
+            username="u",
+            password="p",
+        )
+        self.factory = RequestFactory()
+        self.admin = EmailOutboxAdmin(AdminEmailOutbox, AdminSite())
+
+    def test_test_outbox_action(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        request.session = self.client.session
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
+        request._messages = FallbackStorage(request)
+        with patch.object(EmailOutbox, "send_mail") as mock_send:
+            response = self.admin.test_outbox(request, str(self.outbox.pk))
+            self.assertEqual(response.status_code, 302)
+            mock_send.assert_called_once()
+
+    def test_change_form_contains_link(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        response = self.admin.changeform_view(request, str(self.outbox.pk))
+        content = response.render().content.decode()
+        self.assertIn("Test Outbox", content)


### PR DESCRIPTION
## Summary
- add object tool to test email outbox connections directly from change form
- add object tool to test email inbox connections directly from change form
- cover new admin tools with tests

## Testing
- `pytest` *(fails: NameError: name 'settings' is not defined in env-refresh.py)*
- `pytest tests/test_email_inbox_admin.py tests/test_email_outbox_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a705dee08326885a50f7abd8e604