### PR TITLE
Add model status indicator in admin

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -24,6 +24,8 @@
                 {% if ct_id %}
                   <a href="{% url 'admin:favorite_toggle' ct_id %}?next={{ request.get_full_path|urlencode }}" class="favorite-star{% if fav %} favorited{% endif %}" title="Toggle favorite">&#9733;</a>
                 {% endif %}
+                {% model_db_status app.app_label model.object_name as model_ok %}
+                <span class="model-status {% if model_ok %}ok{% else %}missing{% endif %}"></span>
                 {% if model.admin_url %}
                   <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ fav.custom_label|default:model.name }}</a>
                 {% else %}

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -219,6 +219,20 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     color: gold;
 }
 
+.model-status {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 4px;
+}
+.model-status.ok {
+    background: #28a745;
+}
+.model-status.missing {
+    background: #dc3545;
+}
+
 /* Ensure related object buttons match theme */
 .related-widget-wrapper-link {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- show red/green dot next to each model indicating database install status
- add model_db_status template tag
- style new status dot in admin base template

## Testing
- `pytest pages/tests.py` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d4954a588326aef462fce02d661f