### PR TITLE
Add backup and restore scripts for untracked files

### DIFF
--- a/backup-fs.sh
+++ b/backup-fs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <archive-path>" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+archive="$1"
+if [[ "$archive" != *.tgz && "$archive" != *.tar.gz ]]; then
+  archive="${archive}.tgz"
+fi
+archive="$(realpath -m "$archive")"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+files="$(git ls-files --others --ignored --exclude-standard)"
+if [[ -z "$files" ]]; then
+  echo "No files to backup. Creating empty archive."
+  tar -czf "$archive" --files-from /dev/null
+else
+  git ls-files --others --ignored --exclude-standard -z \
+    | tar -czf "$archive" --null -T -
+fi
+
+echo "Backup created at $archive"

--- a/restore-fs.sh
+++ b/restore-fs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <archive-path>" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+archive="$(realpath -m "$1")"
+if [[ ! -f "$archive" ]]; then
+  echo "Archive not found: $archive" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+tar -xzf "$archive"
+
+echo "Restore complete from $archive"

--- a/user_manuals/migrations/0001_initial.py
+++ b/user_manuals/migrations/0001_initial.py
@@ -16,5 +16,9 @@ class Migration(migrations.Migration):
                 ("content_html", models.TextField()),
                 ("content_pdf", models.TextField(help_text="Base64 encoded PDF")),
             ],
+            options={
+                "verbose_name": "User Manual",
+                "verbose_name_plural": "User Manuals",
+            },
         ),
     ]


### PR DESCRIPTION
## Summary
- Add backup-fs.sh to archive git-ignored files into a gzipped tar
- Add restore-fs.sh to extract backup archives back into repository
- Ensure initial UserManual migration includes verbose names so env refresh leaves repo clean

## Testing
- `shellcheck backup-fs.sh restore-fs.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0df2cd1d08326b9d00685378e5349