### PR TITLE
Add datasette option to install and switch-role scripts

### DIFF
--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -31,6 +31,19 @@ def test_install_script_includes_particle_flag():
     assert "--particle" in content
 
 
+def test_install_script_includes_datasette_flag():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    assert "--datasette" in content
+
+
+def test_install_script_sets_up_datasette_service():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    assert "datasette-$SERVICE" in content
+    assert "datasette serve" in content
+
+
 def test_install_script_runs_env_refresh():
     script_path = Path(__file__).resolve().parent.parent / "install.sh"
     content = script_path.read_text()

--- a/tests/test_switch_role_script.py
+++ b/tests/test_switch_role_script.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+def test_switch_role_script_includes_datasette_flag():
+    script_path = Path(__file__).resolve().parent.parent / "switch-role.sh"
+    content = script_path.read_text()
+    assert "--datasette" in content
+
+
+def test_switch_role_script_controls_datasette_service():
+    script_path = Path(__file__).resolve().parent.parent / "switch-role.sh"
+    content = script_path.read_text()
+    assert "datasette-$SERVICE" in content
+    assert 'systemctl stop "datasette-$SERVICE"' in content
+    assert 'systemctl start "datasette-$SERVICE"' in content

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_uninstall_script_handles_datasette_lock():
+    script_path = Path(__file__).resolve().parent.parent / "uninstall.sh"
+    content = script_path.read_text()
+    assert "datasette.lck" in content
+
+
+def test_uninstall_script_removes_datasette_service():
+    script_path = Path(__file__).resolve().parent.parent / "uninstall.sh"
+    content = script_path.read_text()
+    assert "datasette-$SERVICE" in content
+    assert 'systemctl stop "$DATASETTE_SERVICE"' in content

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -82,6 +82,18 @@ if [ -n "$SERVICE" ] && systemctl list-unit-files | grep -Fq "${SERVICE}.service
         fi
         rm -f "$LOCK_DIR/celery.lck"
     fi
+    if [ -f "$LOCK_DIR/datasette.lck" ]; then
+        DATASETTE_SERVICE="datasette-$SERVICE"
+        if systemctl list-unit-files | grep -Fq "${DATASETTE_SERVICE}.service"; then
+            sudo systemctl stop "$DATASETTE_SERVICE" || true
+            sudo systemctl disable "$DATASETTE_SERVICE" || true
+            DATASETTE_SERVICE_FILE="/etc/systemd/system/${DATASETTE_SERVICE}.service"
+            if [ -f "$DATASETTE_SERVICE_FILE" ]; then
+                sudo rm "$DATASETTE_SERVICE_FILE"
+            fi
+        fi
+        rm -f "$LOCK_DIR/datasette.lck"
+    fi
     rm -f "$LOCK_DIR/service.lck"
 else
     pkill -f "manage.py runserver" || true


### PR DESCRIPTION
## Summary
- autostart datasette service on install
- cleanly remove datasette service when flag not set or during uninstall
- test uninstall script for datasette handling
- extend tests to assert datasette service creation and control across scripts

## Testing
- ✅ `pytest tests/test_install_script.py tests/test_switch_role_script.py tests/test_uninstall_script.py -q`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0e146c8d4832686836dd17c726611