### PR TITLE
Handle missing pip in env refresh

### DIFF
--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -34,6 +34,19 @@ if [ ! -f "$PYTHON" ]; then
 fi
 
 
+# Ensure pip is available; attempt to install if missing
+if ! "$PYTHON" -m pip --version >/dev/null 2>&1; then
+  echo "pip not found in virtual environment. Attempting to install with ensurepip..." >&2
+  if "$PYTHON" -m ensurepip --upgrade >/dev/null 2>&1 && \
+     "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    :
+  else
+    echo "Failed to install pip automatically. On Debian/Ubuntu/WSL, ensure python3-venv is installed and rerun ./install.sh." >&2
+    exit 1
+  fi
+fi
+
+
 if [ "$CLEAN" -eq 1 ]; then
   DB_FILE="$SCRIPT_DIR/db.sqlite3"
   if [ -f "$DB_FILE" ]; then


### PR DESCRIPTION
## Summary
- ensure `env-refresh.sh` installs pip if missing, with WSL guidance
- verify pip availability after attempting installation

## Testing
- `pytest tests/test_env_refresh_clean.py::test_env_refresh_leaves_repo_clean tests/test_env_refresh_unlink.py::test_unlink_sqlite_db_retries -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c0f28b76508326837bfd11a3074323