### PR TITLE
chore: create release and upload migration plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,20 @@ jobs:
         with:
           name: migration-plan
           path: releases/${GITHUB_REF#refs/tags/}/migration-plan.txt
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+      - name: Upload migration plan
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: releases/${{ github.ref_name }}/migration-plan.txt
+          asset_name: migration-plan.txt
+          asset_content_type: text/plain


### PR DESCRIPTION
## Summary
- create GitHub release when a tag is pushed
- upload migration plan text file to the release assets

## Testing
- `pre-commit run --files .github/workflows/release.yml` (fails: error: RPC failed; HTTP 403)
- `act -n --eventpath event.json -W .github/workflows/release.yml` (fails: couldn't get a valid docker connection)


------
https://chatgpt.com/codex/tasks/task_e_68c0f77de3208326abd673106e08f5c4