### PR TITLE
fix: correct case termination in reset-screen script

### DIFF
--- a/reset-screen
+++ b/reset-screen
@@ -49,7 +49,7 @@ case "$MODE" in
     echo "Usage: $0 [hdmi|tft]"
     exit 1
     ;;
-fi
+esac
 
 LOCK_DIR="$(cd "$(dirname "$0")" && pwd)/locks"
 sudo mkdir -p "$LOCK_DIR"


### PR DESCRIPTION
## Summary
- fix typo in `reset-screen` script causing syntax error

## Testing
- `bash -n reset-screen`
- `PATH=/tmp:$PATH ./reset-screen hdmi`
- `pre-commit run --files reset-screen` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c101e8b5d8832690d147d377522317