### PR TITLE
Add token validation form to token builder

### DIFF
--- a/core/templates/admin/token_builder.html
+++ b/core/templates/admin/token_builder.html
@@ -4,6 +4,15 @@
 {% block content %}
 <div id="content-main">
   <h1>{{ title }}</h1>
+  <form method="post" style="margin-bottom:1em;">
+    {% csrf_token %}
+    <label for="token_input">{% trans "Token" %}</label>
+    <input type="text" name="token" id="token_input" value="{{ token }}" />
+    <button type="submit">{% trans "Validate" %}</button>
+  </form>
+  {% if token %}
+  <p>{% trans "Result" %}: {{ resolved }}</p>
+  {% endif %}
   <table>
     <thead>
       <tr><th>{% trans "Prefix" %}</th><th>{% trans "Model" %}</th><th>{% trans "Fields" %}</th></tr>

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from io import BytesIO
 from zipfile import ZipFile
 
+import os
 from django.test import TestCase, TransactionTestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -213,6 +214,16 @@ class UserDataViewTests(TestCase):
     def test_token_builder_page_loads(self):
         response = self.client.get(reverse("admin:token_builder"))
         self.assertContains(response, "Token Builder")
+
+    def test_token_builder_resolves_token_without_brackets(self):
+        os.environ["FOO"] = "BAR"
+        try:
+            response = self.client.post(
+                reverse("admin:token_builder"), {"token": "ENV.FOO"}
+            )
+        finally:
+            del os.environ["FOO"]
+        self.assertContains(response, "BAR")
 
     def test_user_data_page_has_import_export_links(self):
         response = self.client.get(reverse("admin:user_data"))


### PR DESCRIPTION
## Summary
- add token resolution helper that wraps unbracketed input
- show token validation form on the token builder page
- test token builder resolving unbracketed tokens

## Testing
- `python manage.py test tests.test_user_datum_admin.UserDataViewTests.test_token_builder_page_loads tests.test_user_datum_admin.UserDataViewTests.test_token_builder_resolves_token_without_brackets -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c104d8eb508326b8afc806db82a671