### PR TITLE
Add daily birthday greeting broadcast and email

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -3,6 +3,12 @@
 import logging
 
 from celery import shared_task
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.mail import send_mail
+from django.utils import timezone
+
+from nodes.models import NetMessage
 
 logger = logging.getLogger(__name__)
 
@@ -11,3 +17,20 @@ logger = logging.getLogger(__name__)
 def heartbeat() -> None:
     """Log a simple heartbeat message."""
     logger.info("Heartbeat task executed")
+
+
+@shared_task
+def birthday_greetings() -> None:
+    """Send birthday greetings to users via Net Message and email."""
+    User = get_user_model()
+    today = timezone.localdate()
+    for user in User.objects.filter(birthday=today):
+        NetMessage.broadcast("Happy bday!", user.username)
+        if user.email:
+            send_mail(
+                "Happy bday!",
+                f"Happy bday! {user.username}",
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                fail_silently=True,
+            )

--- a/config/settings.py
+++ b/config/settings.py
@@ -378,5 +378,9 @@ CELERY_BEAT_SCHEDULE = {
     "heartbeat": {
         "task": "app.tasks.heartbeat",
         "schedule": crontab(minute="*/5"),
-    }
+    },
+    "birthday_greetings": {
+        "task": "app.tasks.birthday_greetings",
+        "schedule": crontab(hour=9, minute=0),
+    },
 }

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -287,6 +287,7 @@ class Migration(migrations.Migration):
                         max_length=20,
                     ),
                 ),
+                ("birthday", models.DateField(blank=True, null=True)),
                 ("has_charger", models.BooleanField(default=False)),
                 (
                     "groups",

--- a/core/models.py
+++ b/core/models.py
@@ -240,6 +240,7 @@ class User(Entity, AbstractUser):
         blank=True,
         help_text="Optional contact phone number",
     )
+    birthday = models.DateField(null=True, blank=True)
     address = models.ForeignKey(
         Address,
         null=True,

--- a/tests/test_birthday_greetings.py
+++ b/tests/test_birthday_greetings.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, override_settings
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.core import mail
+
+from app.tasks import birthday_greetings
+from nodes.models import NetMessage
+
+
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+class BirthdayGreetingsTaskTests(TestCase):
+    def test_birthday_greetings_sends_net_message_and_email(self):
+        User = get_user_model()
+        today = timezone.localdate()
+        user = User.objects.create_user(
+            username="alice",
+            password="x",
+            birthday=today,
+            email="alice@example.com",
+        )
+        initial = NetMessage.objects.count()
+        birthday_greetings()
+        self.assertEqual(NetMessage.objects.count(), initial + 1)
+        msg = NetMessage.objects.order_by("-created").first()
+        self.assertEqual(msg.subject, "Happy bday!")
+        self.assertEqual(msg.body, user.username)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Happy bday!", mail.outbox[0].subject)
+        self.assertIn(user.username, mail.outbox[0].body)


### PR DESCRIPTION
## Summary
- store optional user birthdays
- broadcast and email daily birthday greetings at 9 AM
- test birthday greeting task

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate --noinput`
- `pre-commit run --files app/tasks.py config/settings.py core/migrations/0001_initial.py core/models.py tests/test_birthday_greetings.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b50a1ffc832680bd6325a60fa28d