### PR TITLE
Rename RFID admin action

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -930,7 +930,7 @@ class RFIDAdmin(ImportExportModelAdmin):
     def scan_rfids(self, request, queryset):
         return redirect("admin:core_rfid_scan")
 
-    scan_rfids.short_description = "Scan new RFIDs"
+    scan_rfids.short_description = "Scan RFIDs"
 
     def get_urls(self):
         urls = super().get_urls()

--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -25,7 +25,7 @@ class AdminIndexActionLinkTests(TestCase):
 
     def test_custom_action_links_display(self):
         response = self.client.get(reverse("admin:index"))
-        self.assertContains(response, "Scan new RFIDs")
+        self.assertContains(response, "Scan RFIDs")
         self.assertContains(response, f'href="{reverse("admin:core_rfid_scan")}"')
         self.assertNotContains(response, "Build selected packages")
         self.assertNotContains(response, "Purge selected logs")


### PR DESCRIPTION
## Summary
- rename admin action to display "Scan RFIDs"
- adjust admin index test for new action text

## Testing
- `pytest -q` (fails: Unique constraint failed on core_user.username; send_invite_command assertion)
- `pytest tests/test_admin_index_actions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1c46b1f7c8326bc7ae1d2a3994165