### PR TITLE
Add French and Russian translations with language selector

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -304,6 +304,8 @@ LANGUAGE_CODE = "en-us"
 LANGUAGES = [
     ("en", _("English")),
     ("es", _("Spanish")),
+    ("fr", _("French")),
+    ("ru", _("Russian")),
 ]
 
 LOCALE_PATHS = [BASE_DIR / "locale"]

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -660,3 +660,11 @@ msgstr "Entradas"
 #: core/templates/core/release_progress.html:30 pages/templates/core/release_progress.html:30
 msgid "Models"
 msgstr "Modelos"
+
+#: config/settings.py:308
+msgid "French"
+msgstr "Francés"
+
+#: config/settings.py:309
+msgid "Russian"
+msgstr "Ruso"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,32 @@
+# French translations for Arthexis
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Arthexis\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-19 07:06-0600\n"
+"PO-Revision-Date: 2024-07-13 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: config/settings.py:304
+msgid "English"
+msgstr "Anglais"
+
+#: config/settings.py:305
+msgid "Spanish"
+msgstr "Espagnol"
+
+#: config/settings.py:306
+msgid "French"
+msgstr "Français"
+
+#: config/settings.py:307
+msgid "Russian"
+msgstr "Russe"
+

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,32 @@
+# Russian translations for Arthexis
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Arthexis\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-19 07:06-0600\n"
+"PO-Revision-Date: 2024-07-13 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#: config/settings.py:304
+msgid "English"
+msgstr "Английский"
+
+#: config/settings.py:305
+msgid "Spanish"
+msgstr "Испанский"
+
+#: config/settings.py:306
+msgid "French"
+msgstr "Французский"
+
+#: config/settings.py:307
+msgid "Russian"
+msgstr "Русский"
+

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -331,10 +331,11 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
   <form action="{% url 'set_language' %}" method="post" style="display: inline;">
     {% csrf_token %}
     <input name="next" type="hidden" value="{{ request.get_full_path }}">
-    <input name="language" type="hidden" value="{% if LANGUAGE_CODE|slice:':2' == 'en' %}es{% else %}en{% endif %}">
-    <button type="submit" style="background: none; border: none; color: var(--header-link-color); cursor: pointer;">
-      {% if LANGUAGE_CODE|slice:':2' == 'en' %}{% trans 'Spanish' %}{% else %}{% trans 'English' %}{% endif %}
-    </button>
+    <select name="language" onchange="this.form.submit()" style="background: none; border: none; color: var(--header-link-color); cursor: pointer;">
+      {% for lang_code, lang_name in LANGUAGES %}
+        <option value="{{ lang_code }}" {% if lang_code == LANGUAGE_CODE %}selected{% endif %}>{{ lang_name }}</option>
+      {% endfor %}
+    </select>
   </form>
   {% include "admin/color_theme_toggle.html" %}
 {% endblock %}

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -137,14 +137,11 @@
               <form action="{% url 'set_language' %}" method="post" class="d-inline ms-2">
                 {% csrf_token %}
                 <input name="next" type="hidden" value="{{ request.get_full_path }}">
-                <input name="language" type="hidden" value="{% if LANGUAGE_CODE|slice:":2" == 'en' %}es{% else %}en{% endif %}">
-                <button class="btn btn-sm btn-outline-light" type="submit" aria-label="{% if LANGUAGE_CODE|slice:":2" == 'en' %}{% trans 'Spanish' %}{% else %}{% trans 'English' %}{% endif %}">
-                  <svg aria-hidden="true" width="1.5rem" height="1.5rem">
-                    <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="currentColor" font-size="0.8rem" font-weight="bold">
-                      {% if LANGUAGE_CODE|slice:":2" == 'en' %}ES{% else %}EN{% endif %}
-                    </text>
-                  </svg>
-                </button>
+                <select name="language" class="form-select form-select-sm d-inline w-auto" onchange="this.form.submit()">
+                  {% for lang_code, lang_name in LANGUAGES %}
+                    <option value="{{ lang_code }}" {% if lang_code == LANGUAGE_CODE %}selected{% endif %}>{{ lang_name }}</option>
+                  {% endfor %}
+                </select>
               </form>
               <button id="share-button" class="btn btn-sm btn-outline-light ms-2" type="button" aria-label="{% trans 'Share' %}">
                 <svg aria-hidden="true" width="1.5rem" height="1.5rem">


### PR DESCRIPTION
## Summary
- include French and Russian in supported languages
- show language selector dropdown on site and admin
- add base translation files for French and Russian

## Testing
- `pre-commit run --files config/settings.py pages/templates/admin/base_site.html pages/templates/pages/base.html locale/es/LC_MESSAGES/django.po locale/fr/LC_MESSAGES/django.po locale/ru/LC_MESSAGES/django.po`
- `python manage.py test tests.test_language_switch 2>&1 | tee /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c1ca16d7c48326b40f6363d881b0fb