### PR TITLE
Style language selector to match toolbar buttons

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -76,6 +76,22 @@
         color: var(--bs-white);
         z-index: 1000;
       }
+      .language-select {
+        padding: 0.25rem 0.5rem;
+        height: calc(1.5em + 0.5rem + 2px);
+        background-color: transparent;
+        color: var(--bs-light);
+        border: 1px solid var(--bs-light);
+      }
+      .language-select:focus {
+        color: var(--bs-light);
+        background-color: transparent;
+        border-color: var(--bs-light);
+        box-shadow: none;
+      }
+      .language-select option {
+        color: var(--bs-dark);
+      }
     </style>
   </head>
   <body class="p-3 pb-0 d-flex flex-column min-vh-100">
@@ -137,9 +153,9 @@
               <form action="{% url 'set_language' %}" method="post" class="d-inline ms-2">
                 {% csrf_token %}
                 <input name="next" type="hidden" value="{{ request.get_full_path }}">
-                <select name="language" class="form-select form-select-sm d-inline w-auto" onchange="this.form.submit()">
+                <select name="language" class="form-select form-select-sm d-inline w-auto language-select bg-transparent text-light border-light" onchange="this.form.submit()">
                   {% for lang_code, lang_name in LANGUAGES %}
-                    <option value="{{ lang_code }}" {% if lang_code == LANGUAGE_CODE %}selected{% endif %}>{{ lang_name }}</option>
+                    <option value="{{ lang_code }}" {% if lang_code == LANGUAGE_CODE %}selected{% endif %}>{{ lang_code|slice:":2"|upper }}</option>
                   {% endfor %}
                 </select>
               </form>


### PR DESCRIPTION
## Summary
- Match language dropdown height and border styling to surrounding toolbar buttons
- Display language options as two-letter uppercase codes

## Testing
- `pytest` *(fails: NameError: name 'revision_utils' is not defined in env-refresh.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ddbca1d483269aa1beecc6b79f44