### PR TITLE
Fallback to default mailer when node email send fails

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -332,7 +332,7 @@ class SecurityGroupAdmin(DjangoGroupAdmin):
 
 @admin.register(InviteLead)
 class InviteLeadAdmin(admin.ModelAdmin):
-    list_display = ("email", "created_on", "sent_on")
+    list_display = ("email", "created_on", "sent_on", "short_error")
     search_fields = ("email", "comment")
     readonly_fields = (
         "created_on",
@@ -344,6 +344,11 @@ class InviteLeadAdmin(admin.ModelAdmin):
         "sent_on",
         "error",
     )
+
+    def short_error(self, obj):
+        return (obj.error[:40] + "…") if len(obj.error) > 40 else obj.error
+
+    short_error.short_description = "error"
 
 
 class EnergyAccountRFIDForm(forms.ModelForm):


### PR DESCRIPTION
## Summary
- fallback to Django's mail backend if the node's send_mail call fails when issuing invitation emails
- store troubleshooting guidance when invite emails fail and surface errors in the admin list
- add regression test covering the fallback behaviour and error guidance

## Testing
- `python manage.py test pages.tests.InvitationTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c1de6263a48326b67cfbf9b64ff8d8