### PR TITLE
Rename Token Builder to Sigil Builder and expose auto-resolvable fields

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -16,8 +16,8 @@ class CoreConfig(AppConfig):
         )
         from .system import patch_admin_system_view
         from .environment import patch_admin_environment_view
-        from .token_builder import (
-            patch_admin_token_builder_view,
+        from .sigil_builder import (
+            patch_admin_sigil_builder_view,
             generate_model_sigils,
         )
         from . import checks  # noqa: F401
@@ -38,7 +38,7 @@ class CoreConfig(AppConfig):
         patch_admin_user_data_views()
         patch_admin_system_view()
         patch_admin_environment_view()
-        patch_admin_token_builder_view()
+        patch_admin_sigil_builder_view()
 
         from pathlib import Path
         from django.conf import settings

--- a/core/templates/admin/sigil_builder.html
+++ b/core/templates/admin/sigil_builder.html
@@ -6,11 +6,11 @@
   <h1>{{ title }}</h1>
   <form method="post" style="margin-bottom:1em;">
     {% csrf_token %}
-    <label for="token_input">{% trans "Token" %}</label>
-    <input type="text" name="token" id="token_input" value="{{ token }}" size="60" />
+    <label for="sigil_input">{% trans "Sigil" %}</label>
+    <input type="text" name="sigil" id="sigil_input" value="{{ sigil }}" size="60" />
     <button type="submit">{% trans "Validate" %}</button>
   </form>
-  {% if token %}
+  {% if sigil %}
   <p>{% trans "Result" %}: {{ resolved }}</p>
   {% endif %}
   <table>
@@ -26,6 +26,22 @@
       </tr>
     {% empty %}
       <tr><td colspan="3">{% trans "No Sigil Roots." %}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <h2 style="margin-top:1em;">{% trans "Auto-resolvable Fields" %}</h2>
+  <table>
+    <thead>
+      <tr><th>{% trans "Model" %}</th><th>{% trans "Field" %}</th></tr>
+    </thead>
+    <tbody>
+    {% for item in auto_fields %}
+      <tr>
+        <td>{{ item.model }}</td>
+        <td>{{ item.field }}</td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="2">{% trans "No auto-resolvable fields." %}</td></tr>
     {% endfor %}
     </tbody>
   </table>

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -90,7 +90,7 @@
     <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
     <a class="button" href="{% url 'admin:system' %}">{% translate 'System' %}</a>
     <a class="button" href="{% url 'admin:environment' %}">{% translate 'Environment' %}</a>
-    <a class="button" href="{% url 'admin:token_builder' %}">{% translate 'Token Builder' %}</a>
+    <a class="button" href="{% url 'admin:sigil_builder' %}">{% translate 'Sigil Builder' %}</a>
   </div>
 </div>
 {% endblock %}

--- a/tests/test_env_refresh_unlink.py
+++ b/tests/test_env_refresh_unlink.py
@@ -51,6 +51,11 @@ def test_unlink_sqlite_db_retries(monkeypatch, tmp_path):
     monkeypatch.setitem(
         unlink_func.__globals__, "shutil", SimpleNamespace(copy2=lambda *a, **k: None)
     )
+    monkeypatch.setitem(
+        unlink_func.__globals__,
+        "revision_utils",
+        SimpleNamespace(get_revision=lambda: "rev"),
+    )
 
     unlink_func(path)
 

--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from core.models import SigilRoot, OdooProfile, EmailInbox, InviteLead
 from nodes.models import NodeRole
-from core.token_builder import _resolve_token
+from core.sigil_builder import _resolve_sigil
 from core.sigil_context import set_context, clear_context
 
 
@@ -231,4 +231,4 @@ class SigilResolutionTests(TestCase):
             name="Other", description="[NR=Terminal.DESCRIPTION]"
         )
         self.assertEqual(other.resolve_sigils("description"), term.description)
-        self.assertEqual(_resolve_token("[NR=Terminal.DESCRIPTION]"), term.description)
+        self.assertEqual(_resolve_sigil("[NR=Terminal.DESCRIPTION]"), term.description)

--- a/tests/test_user_datum_admin.py
+++ b/tests/test_user_datum_admin.py
@@ -206,7 +206,7 @@ class UserDataViewTests(TestCase):
         self.assertContains(response, reverse("admin:user_data"))
         self.assertContains(response, reverse("admin:system"))
         self.assertContains(response, reverse("admin:environment"))
-        self.assertContains(response, reverse("admin:token_builder"))
+        self.assertContains(response, reverse("admin:sigil_builder"))
 
     def test_system_page_loads(self):
         response = self.client.get(reverse("admin:system"))
@@ -219,15 +219,15 @@ class UserDataViewTests(TestCase):
         self.assertContains(response, "PATH")
         self.assertContains(response, "DEBUG")
 
-    def test_token_builder_page_loads(self):
-        response = self.client.get(reverse("admin:token_builder"))
-        self.assertContains(response, "Token Builder")
+    def test_sigil_builder_page_loads(self):
+        response = self.client.get(reverse("admin:sigil_builder"))
+        self.assertContains(response, "Sigil Builder")
 
-    def test_token_builder_resolves_token_without_brackets(self):
+    def test_sigil_builder_resolves_sigil_without_brackets(self):
         os.environ["FOO"] = "BAR"
         try:
             response = self.client.post(
-                reverse("admin:token_builder"), {"token": "ENV.FOO"}
+                reverse("admin:sigil_builder"), {"sigil": "ENV.FOO"}
             )
         finally:
             del os.environ["FOO"]


### PR DESCRIPTION
## Summary
- rename Token Builder to Sigil Builder throughout admin and tests
- list auto-resolvable model fields in Sigil Builder view
- adjust unlink sqlite test for new revision lookup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1dfa9e02c832682b6da42ea4d1812