### PR TITLE
Match language dropdown to toolbar buttons

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -79,6 +79,13 @@
       .language-select {
         background-color: transparent;
         color: inherit;
+        padding: 0.25rem 0.5rem;
+        padding-right: 1.5rem;
+        line-height: 1.5;
+        height: calc(1.5rem + 0.5rem);
+        border: 1px solid var(--bs-light);
+        border-radius: 0.2rem;
+        background-position: right 0.5rem center;
       }
       .language-select option {
         background-color: var(--bs-body-bg);


### PR DESCRIPTION
## Summary
- Align language selector's border color and spacing with toolbar buttons
- Adjust dropdown padding and height for consistent button sizing

## Testing
- `pre-commit run --files pages/templates/pages/base.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1e4d073048326999e17d86fc80bc2