### PR TITLE
Add basic tests for shell scripts

### DIFF
--- a/backup-fs.sh
+++ b/backup-fs.sh
@@ -3,11 +3,16 @@ set -euo pipefail
 
 usage() {
   echo "Usage: $0 <archive-path>" >&2
-  exit 1
 }
 
 if [[ $# -ne 1 ]]; then
   usage
+  exit 1
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
 fi
 
 archive="$1"

--- a/db-setup.sh
+++ b/db-setup.sh
@@ -16,21 +16,20 @@ flock -n 200 || { echo "Another instance of $(basename "$0") is running." >&2; e
 
 usage() {
     cat <<USAGE
-Usage: $0 [--remove]
+Usage: $0 [--clean]
 
 Configure or remove PostgreSQL database settings for this project.
 Without arguments the script will configure the database.
-  --remove   Remove the database configuration and drop the database/user.
-  -h, --help Show this help message and exit.
+  --clean, --remove  Remove the database configuration and drop the database/user.
+  -h, --help         Show this help message and exit.
 USAGE
 }
 
 REMOVE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --remove)
+        --clean|--remove)
             REMOVE=1
-            shift
             ;;
         -h|--help)
             usage

--- a/restore-fs.sh
+++ b/restore-fs.sh
@@ -3,11 +3,16 @@ set -euo pipefail
 
 usage() {
   echo "Usage: $0 <archive-path>" >&2
-  exit 1
 }
 
 if [[ $# -ne 1 ]]; then
   usage
+  exit 1
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
 fi
 
 archive="$(realpath -m "$1")"

--- a/tests/test_shell_scripts.py
+++ b/tests/test_shell_scripts.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import shutil
+import subprocess
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def clone_repo(tmp_path: Path) -> Path:
+    clone_dir = tmp_path / "repo"
+    shutil.copytree(REPO_ROOT, clone_dir)
+    return clone_dir
+
+
+SCRIPTS_WITH_HELP = [p for p in REPO_ROOT.glob("*.sh") if "--help" in p.read_text()]
+
+
+@pytest.mark.parametrize("script_path", SCRIPTS_WITH_HELP)
+def test_script_help(script_path: Path) -> None:
+    result = subprocess.run(["bash", str(script_path), "--help"], cwd=REPO_ROOT)
+    assert result.returncode == 0
+
+
+def test_backup_restore_roundtrip(tmp_path: Path) -> None:
+    repo = clone_repo(tmp_path)
+    sample = repo / "example.log"
+    sample.write_text("data")
+    archive = repo / "backup.tgz"
+    subprocess.run(["bash", "backup-fs.sh", str(archive)], cwd=repo, check=True)
+    sample.unlink()
+    subprocess.run(["bash", "restore-fs.sh", str(archive)], cwd=repo, check=True)
+    assert sample.read_text() == "data"
+
+
+def test_db_setup_clean_flag(tmp_path: Path) -> None:
+    repo = clone_repo(tmp_path)
+    result = subprocess.run(
+        ["bash", "db-setup.sh", "--clean"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "psql (PostgreSQL client) is required." in combined


### PR DESCRIPTION
## Summary
- support `--help` in backup and restore scripts
- allow `db-setup.sh` to use a `--clean` flag
- test shell script help, backup/restore round-trip, and `db-setup.sh --clean`

## Testing
- `pre-commit run --files backup-fs.sh restore-fs.sh db-setup.sh tests/test_shell_scripts.py`
- `pytest tests/test_shell_scripts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5b958108326a6f4e3ef85ac6080