### PR TITLE
fix: remove duplicate rpi case in reset-screen script

### DIFF
--- a/ocpp/test_rfid.py
+++ b/ocpp/test_rfid.py
@@ -19,7 +19,7 @@ from core.models import RFID
 from ocpp.rfid.reader import read_rfid, enable_deep_read
 
 
-class ScanNextViewTests(SimpleTestCase):
+class ScanNextViewTests(TestCase):
     @patch("config.middleware.Node.get_local", return_value=None)
     @patch("config.middleware.get_site")
     @patch(
@@ -125,7 +125,18 @@ class CardTypeDetectionTests(TestCase):
         return MockReader()
 
     @patch("ocpp.rfid.reader.notify_async")
-    def test_detects_ntag215(self, _mock_notify):
+    @patch("core.models.RFID.objects.get_or_create")
+    def test_detects_ntag215(self, mock_get, _mock_notify):
+        tag = MagicMock(
+            pk=1,
+            label_id=1,
+            allowed=True,
+            color="B",
+            released=False,
+            reference=None,
+            kind=RFID.NTAG215,
+        )
+        mock_get.return_value = (tag, True)
         result = read_rfid(mfrc=self._mock_ntag_reader(), cleanup=False)
         self.assertEqual(result["kind"], RFID.NTAG215)
 

--- a/reset-screen.sh
+++ b/reset-screen.sh
@@ -75,26 +75,6 @@ case "$MODE" in
     echo "dtoverlay=vc4-kms-v3d" | tee -a "$CONFIG"
     ;;
 
-  rpi)
-    echo "Resetting display to Raspberry Pi screen..."
-    # Remove HDMI and TFT settings
-    sudo sed -i '/hdmi_force_hotplug/d' "$CONFIG"
-    sudo sed -i '/hdmi_group/d' "$CONFIG"
-    sudo sed -i '/hdmi_mode/d' "$CONFIG"
-
-    sudo sed -i '/dtoverlay=ili9341/d' "$CONFIG"
-    sudo sed -i '/dtoverlay=waveshare35a/d' "$CONFIG"
-    sudo sed -i '/dtoverlay=waveshare35b/d' "$CONFIG"
-    sudo sed -i '/dtoverlay=waveshare35c/d' "$CONFIG"
-    sudo sed -i '/dtoverlay=waveshare35d/d' "$CONFIG"
-
-    # Ensure Raspberry Pi screen is enabled
-    sudo sed -i '/ignore_lcd/d' "$CONFIG"
-    echo "ignore_lcd=0" | sudo tee -a "$CONFIG"
-    sudo sed -i '/dtoverlay=vc4-kms-v3d/d' "$CONFIG"
-    echo "dtoverlay=vc4-kms-v3d" | sudo tee -a "$CONFIG"
-    ;;
-
   *)
     echo "Usage: $0 [hdmi|tft|rpi]"
     exit 1


### PR DESCRIPTION
## Summary
- remove duplicated `rpi` case block from `reset-screen.sh`
- ensure single `rpi` option resets display without sudo since script already runs as root
- convert scan view tests to `TestCase` and mock RFID lookups for NTAG detection to avoid DB errors

## Testing
- `shellcheck reset-screen.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5aec0c88326b547db570d6ad0e9