### PR TITLE
feat: add release manager todo fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Put any non-essential migrations into the 0002 or 0003 migrations instead of 0001.
 - Remember to store generated image files in base64 since binary files are not allowed in the repo.
 - When adding new models and no app is given or the model is assigned to a third-party admin group, create the model in core and link it to the provided admin group.
+- Release manager tasks should be added via fixtures for the `Todo` model so they appear in the admin Future Actions section.
 - When preparing a release, consider squashing commits beforehand, though it's not required.
 - For shell scripts:
   - Keep track of features and write tests to prevent regressions just like other code.

--- a/core/admin.py
+++ b/core/admin.py
@@ -49,6 +49,7 @@ from .models import (
     SecurityGroup,
     InviteLead,
     ChatProfile,
+    Todo,
 )
 from .user_data import UserDatumAdminMixin
 
@@ -1219,3 +1220,8 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, admin.ModelAdmin):
     @admin.display(description="Is current")
     def is_current(self, obj):
         return self._boolean_icon(obj.is_current)
+
+
+@admin.register(Todo)
+class TodoAdmin(admin.ModelAdmin):
+    list_display = ("description",)

--- a/core/fixtures/todos.json
+++ b/core/fixtures/todos.json
@@ -1,0 +1,18 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 1,
+    "fields": {
+      "description": "Review release checklist",
+      "is_seed_data": true
+    }
+  },
+  {
+    "model": "core.todo",
+    "pk": 2,
+    "fields": {
+      "description": "Confirm version numbering",
+      "is_seed_data": true
+    }
+  }
+]

--- a/core/migrations/0011_invitelead_error_invitelead_sent_on.py
+++ b/core/migrations/0011_invitelead_error_invitelead_sent_on.py
@@ -10,6 +10,27 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.CreateModel(
+            name="Todo",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("description", models.CharField(max_length=255)),
+            ],
+            options={
+                "verbose_name": "TODO",
+                "verbose_name_plural": "TODOs",
+            },
+        ),
         migrations.AddField(
             model_name="invitelead",
             name="error",

--- a/core/models.py
+++ b/core/models.py
@@ -1464,3 +1464,16 @@ class ChatProfile(Entity):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"ChatProfile for {self.user}"
+
+
+class Todo(Entity):
+    """Tasks requested for the Release Manager."""
+
+    description = models.CharField(max_length=255)
+
+    class Meta:
+        verbose_name = "TODO"
+        verbose_name_plural = "TODOs"
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.description

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -107,15 +107,23 @@
     <div class="module" id="future-actions-module">
         <h2>{% translate 'Future actions' %}</h2>
         {% future_action_items as future_items %}
-            {% if future_items %}
+        {% if future_items.models %}
             <ul class="actionlist">
-                {% for item in future_items %}
-                <li class="changelink"><a href="{{ item.url }}">{{ item.label }}</a></li>
+                {% for item in future_items.models %}
+                <li class="changelink"><a href="{{ item.url }}">Create another {{ item.label }}</a></li>
                 {% endfor %}
             </ul>
-            {% else %}
+        {% endif %}
+        {% if future_items.todos %}
+            <h3>{% translate 'Release manager tasks' %}</h3>
+            <ul class="actionlist">
+                {% for todo in future_items.todos %}
+                <li class="changelink"><a href="{{ todo.url }}">{{ todo.label }}</a></li>
+                {% endfor %}
+            </ul>
+        {% elif not future_items.models %}
             <p>{% translate 'None available' %}</p>
-            {% endif %}
+        {% endif %}
     </div>
     <div class="module" id="recent-actions-module">
         <h2>{% translate 'Recent actions' %}</h2>


### PR DESCRIPTION
## Summary
- instruct agents to add release manager tasks via Todo fixtures
- register new Todo model and expose tasks in admin dashboard
- show todos under Future actions and prefix other links with "Create another"

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1ead9fbdc8326ac6fb92a574b8808