### PR TITLE
fix: ensure env refresh installs pip when missing

### DIFF
--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -67,6 +67,10 @@ fi
 
 REQ_FILE="$SCRIPT_DIR/requirements.txt"
 if [ -f "$REQ_FILE" ]; then
+  # ensure pip is available in the virtual environment
+  if ! "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    "$PYTHON" -m ensurepip --upgrade
+  fi
   MD5_FILE="$SCRIPT_DIR/requirements.md5"
   NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
   STORED_HASH=""

--- a/tests/test_env_refresh_pip.py
+++ b/tests/test_env_refresh_pip.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def clone_repo(tmp_path: Path) -> Path:
+    clone_dir = tmp_path / "repo"
+    shutil.copytree(REPO_ROOT, clone_dir)
+    return clone_dir
+
+
+def test_env_refresh_installs_pip(tmp_path: Path) -> None:
+    repo = clone_repo(tmp_path)
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", repo / ".venv"], check=True
+    )
+    (repo / "requirements.txt").write_text("")
+    # replace env-refresh.py with a no-op to avoid heavy imports
+    (repo / "env-refresh.py").write_text("if __name__ == '__main__':\n    pass\n")
+    result = subprocess.run(["bash", "env-refresh.sh"], cwd=repo)
+    assert result.returncode == 0
+    check = subprocess.run(
+        [str(repo / ".venv/bin/python"), "-m", "pip", "--version"], cwd=repo
+    )
+    assert check.returncode == 0


### PR DESCRIPTION
## Summary
- ensure `env-refresh.sh` installs pip in the virtualenv if it is missing
- add regression test verifying pip installation during env refresh

## Testing
- `pre-commit run --files env-refresh.sh tests/test_env_refresh_pip.py`
- `pytest tests/test_env_refresh_pip.py`
- `pytest` *(fails: tests/test_shell_scripts.py::test_db_setup_clean_flag - AssertionError: assert 'psql (PostgreSQL client) is required.' in '')*


------
https://chatgpt.com/codex/tasks/task_e_68c2004911d08326ab8760aee76ef19b