### PR TITLE
Add authenticated chat data API endpoint

### DIFF
--- a/core/workgroup_urls.py
+++ b/core/workgroup_urls.py
@@ -9,4 +9,5 @@ app_name = "workgroup"
 urlpatterns = [
     path("chat-profiles/<int:user_id>/", views.issue_key, name="chatprofile-issue"),
     path("assistant/test/", views.assistant_test, name="assistant-test"),
+    path("chat/", views.chat, name="chat"),
 ]

--- a/tests/test_chat_data_api.py
+++ b/tests/test_chat_data_api.py
@@ -1,0 +1,32 @@
+"""Tests for the generic chat data endpoint."""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.test import TestCase
+
+
+class ChatDataEndpointTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="alice", password="pwd")
+        issue_url = reverse("workgroup:chatprofile-issue", args=[self.user.id])
+        self.api_key = self.client.post(issue_url).json()["user_key"]
+
+    def test_requires_authentication(self):
+        url = reverse("workgroup:chat")
+        response = self.client.get(
+            url, {"model": settings.AUTH_USER_MODEL, "pk": self.user.id}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_model_data(self):
+        url = reverse("workgroup:chat")
+        response = self.client.get(
+            url,
+            {"model": settings.AUTH_USER_MODEL, "pk": self.user.id},
+            HTTP_AUTHORIZATION=f"Bearer {self.api_key}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["data"]
+        self.assertEqual(data["username"], "alice")


### PR DESCRIPTION
## Summary
- add ChatProfile-authenticated `/api/chat/` endpoint for querying any model's data
- wire up chat endpoint in workgroup URLs
- test chat data access via API key

## Testing
- `pre-commit run --files core/workgroup_views.py core/workgroup_urls.py tests/test_chat_data_api.py`
- `pytest tests/test_chat_data_api.py`
- `pytest` *(fails: AssertionError: assert 'psql (PostgreSQL client) is required.' in '')*


------
https://chatgpt.com/codex/tasks/task_e_68c20161eb2c8326965455ed5a49bf81