### PR TITLE
Add authenticated chat data API endpoint

### DIFF
--- a/core/templates/admin/workgroupchatprofile_change_form.html
+++ b/core/templates/admin/workgroupchatprofile_change_form.html
@@ -9,3 +9,11 @@
     {% block object-tools-items %}{{ block.super }}{% endblock %}
 </ul>
 {% endblock %}
+
+{% block form_top %}
+<p class="help">
+    After generating a key, configure your GPT to call <code>/api/chat/</code>
+    and include the key in the <code>Authorization</code> header as
+    <code>Bearer &lt;key&gt;</code>.
+</p>
+{% endblock %}

--- a/core/workgroup_urls.py
+++ b/core/workgroup_urls.py
@@ -9,4 +9,5 @@ app_name = "workgroup"
 urlpatterns = [
     path("chat-profiles/<int:user_id>/", views.issue_key, name="chatprofile-issue"),
     path("assistant/test/", views.assistant_test, name="assistant-test"),
+    path("chat/", views.chat, name="chat"),
 ]

--- a/tests/test_chat_data_api.py
+++ b/tests/test_chat_data_api.py
@@ -1,0 +1,32 @@
+"""Tests for the generic chat data endpoint."""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.test import TestCase
+
+
+class ChatDataEndpointTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="alice", password="pwd")
+        issue_url = reverse("workgroup:chatprofile-issue", args=[self.user.id])
+        self.api_key = self.client.post(issue_url).json()["user_key"]
+
+    def test_requires_authentication(self):
+        url = reverse("workgroup:chat")
+        response = self.client.get(
+            url, {"model": settings.AUTH_USER_MODEL, "pk": self.user.id}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_model_data(self):
+        url = reverse("workgroup:chat")
+        response = self.client.get(
+            url,
+            {"model": settings.AUTH_USER_MODEL, "pk": self.user.id},
+            HTTP_AUTHORIZATION=f"Bearer {self.api_key}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["data"]
+        self.assertEqual(data["username"], "alice")

--- a/tests/test_chat_profile_admin.py
+++ b/tests/test_chat_profile_admin.py
@@ -27,6 +27,16 @@ class ChatProfileAdminTests(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "../generate-key/")
 
+    def test_change_form_shows_gpt_instructions(self):
+        url = reverse(
+            "admin:post_office_workgroupchatprofile_change",
+            args=[self.profile.pk],
+        )
+        response = self.client.get(url)
+        self.assertContains(response, "/api/chat/")
+        self.assertContains(response, "Authorization")
+        self.assertContains(response, "GPT")
+
     def test_generate_key_button(self):
         url = reverse(
             "admin:post_office_workgroupchatprofile_generate_key",


### PR DESCRIPTION
## Summary
- add ChatProfile-authenticated `/api/chat/` endpoint for querying any model's data
- wire up chat endpoint in workgroup URLs
- test chat data access via API key
- guide GPT setup in ChatProfile admin change view

## Testing
- `pre-commit run --files core/templates/admin/workgroupchatprofile_change_form.html tests/test_chat_profile_admin.py`
- `pytest tests/test_chat_profile_admin.py`
- `pytest` *(fails: AssertionError: assert 'psql (PostgreSQL client) is required.' in '')*


------
https://chatgpt.com/codex/tasks/task_e_68c20161eb2c8326965455ed5a49bf81