### PR TITLE
Honor language selection when serving README

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -19,6 +19,7 @@ from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.core.mail import send_mail
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from django.utils.cache import patch_vary_headers
 from core.models import InviteLead, EnergyReport
 
 import markdown
@@ -72,7 +73,9 @@ def index(request):
         toc_html = toc_html.strip()
     title = "README" if readme_file.name.startswith("README") else readme_file.stem
     context = {"content": html, "title": title, "toc": toc_html}
-    return render(request, "pages/readme.html", context)
+    response = render(request, "pages/readme.html", context)
+    patch_vary_headers(response, ["Accept-Language", "Cookie"])
+    return response
 
 
 def sitemap(request):

--- a/tests/test_readme_language.py
+++ b/tests/test_readme_language.py
@@ -21,3 +21,9 @@ class ReadmeLanguageTests(TestCase):
     def test_spanish_readme_selected(self):
         response = self.client.get("/", HTTP_ACCEPT_LANGUAGE="es")
         self.assertContains(response, "Constelación Arthexis")
+
+    def test_vary_headers_present(self):
+        response = self.client.get("/")
+        vary = response.headers.get("Vary", "")
+        self.assertIn("Accept-Language", vary)
+        self.assertIn("Cookie", vary)


### PR DESCRIPTION
## Summary
- ensure README page varies by language and cookie so cached content matches the selected locale
- add regression test for language-specific caching headers

## Testing
- `pytest tests/test_readme_language.py tests/test_language_switch.py`


------
https://chatgpt.com/codex/tasks/task_e_68c20d0221b483268bf712169f3f940f