### PR TITLE
Add live update helper and enable auto-refresh on select pages

### DIFF
--- a/core/liveupdate.py
+++ b/core/liveupdate.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+
+def live_update(interval=5):
+    """Decorator to mark function-based views for automatic refresh."""
+
+    def decorator(view):
+        @wraps(view)
+        def wrapped(request, *args, **kwargs):
+            setattr(request, "live_update_interval", interval)
+            return view(request, *args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+class LiveUpdateMixin:
+    """Mixin to enable automatic refresh for class-based views."""
+
+    live_update_interval = 5
+
+    def dispatch(self, request, *args, **kwargs):
+        setattr(request, "live_update_interval", self.live_update_interval)
+        return super().dispatch(request, *args, **kwargs)

--- a/core/tests_liveupdate.py
+++ b/core/tests_liveupdate.py
@@ -1,0 +1,17 @@
+from django.test import RequestFactory, TestCase
+from django.views.generic import TemplateView
+
+from core.liveupdate import LiveUpdateMixin
+
+
+class DummyView(LiveUpdateMixin, TemplateView):
+    template_name = "pages/base.html"
+    live_update_interval = 7
+
+
+class LiveUpdateMixinTests(TestCase):
+    def test_mixin_sets_request_interval(self):
+        factory = RequestFactory()
+        request = factory.get("/")
+        DummyView.as_view()(request)
+        self.assertEqual(request.live_update_interval, 7)

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -1283,3 +1283,20 @@ class EfficiencyCalculatorViewTests(TestCase):
         url = reverse("ev-efficiency")
         resp = self.client.post(url, {"distance": "100", "energy": "20"})
         self.assertContains(resp, "5.00")
+
+
+class LiveUpdateViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="lu", password="pw")
+        self.client.force_login(self.user)
+
+    def test_dashboard_includes_interval(self):
+        resp = self.client.get(reverse("ocpp-dashboard"))
+        self.assertEqual(resp.context["request"].live_update_interval, 5)
+        self.assertContains(resp, "setInterval(() => location.reload()")
+
+    def test_cp_simulator_includes_interval(self):
+        resp = self.client.get(reverse("cp-simulator"))
+        self.assertEqual(resp.context["request"].live_update_interval, 5)
+        self.assertContains(resp, "setInterval(() => location.reload()")

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from utils.api import api_login_required
 
 from pages.utils import landing
+from core.liveupdate import live_update
 
 from . import store
 from .models import Transaction, Charger
@@ -124,6 +125,7 @@ def charger_detail(request, cid):
 
 @login_required
 @landing("Dashboard")
+@live_update()
 def dashboard(request):
     """Landing page listing all known chargers and their status."""
     chargers = []
@@ -142,6 +144,7 @@ def dashboard(request):
 
 @login_required
 @landing("CP Simulator")
+@live_update()
 def cp_simulator(request):
     """Public landing page to control the OCPP charge point simulator."""
     default_host = "127.0.0.1"

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -347,8 +347,13 @@
           qr.innerHTML = '';
           new QRCode(qr, {text: url, width: 128, height: 128});
         });
-      })();
+        })();
+      </script>
+    {% if request.live_update_interval %}
+    <script>
+      setInterval(() => location.reload(), {{ request.live_update_interval }} * 1000);
     </script>
+    {% endif %}
     <svg xmlns="http://www.w3.org/2000/svg" class="base-svgs">
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-moon"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
       <symbol viewBox="0 0 24 24" width="1.5rem" height="1.5rem" id="icon-sun"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -779,3 +779,13 @@ class DatasetteTests(TestCase):
             self.assertContains(resp, 'href="/data/"')
         finally:
             lock_file.unlink(missing_ok=True)
+
+
+class EnergyReportLiveUpdateTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_energy_report_includes_interval(self):
+        resp = self.client.get(reverse("pages:energy-report"))
+        self.assertEqual(resp.context["request"].live_update_interval, 5)
+        self.assertContains(resp, "setInterval(() => location.reload()")

--- a/pages/views.py
+++ b/pages/views.py
@@ -23,6 +23,7 @@ from core.models import InviteLead, EnergyReport
 
 import markdown
 from pages.utils import landing
+from core.liveupdate import live_update
 from .models import Module
 
 
@@ -192,9 +193,7 @@ def request_invite(request):
                     "Invitation email sent to %s (user %s): %s", email, user.pk, result
                 )
             except Exception as exc:
-                lead.error = (
-                    f"{exc}. Ensure the email service is reachable and settings are correct."
-                )
+                lead.error = f"{exc}. Ensure the email service is reachable and settings are correct."
                 logger.exception("Failed to send invitation email to %s", email)
         if lead.sent_on or lead.error:
             lead.save(update_fields=["sent_on", "error"])
@@ -296,6 +295,7 @@ class EnergyReportForm(forms.Form):
         return cleaned
 
 
+@live_update()
 def energy_report(request):
     form = EnergyReportForm(request.POST or None)
     report = None


### PR DESCRIPTION
## Summary
- add `live_update` decorator and mixin to flag views for automatic refresh
- inject reload script via base template when views opt in
- apply live update to dashboard, simulator, and energy report views with tests

## Testing
- `pre-commit run --files core/liveupdate.py pages/templates/pages/base.html ocpp/views.py pages/views.py ocpp/tests.py pages/tests.py core/tests_liveupdate.py`
- `pre-commit run --files ocpp/tests.py core/tests_liveupdate.py`
- `python manage.py test ocpp.tests.LiveUpdateViewTests pages.tests.EnergyReportLiveUpdateTests core.tests_liveupdate.LiveUpdateMixinTests`

------
https://chatgpt.com/codex/tasks/task_e_68c2042567c48326821f58c97d2642a1