### PR TITLE
Add login page translations

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -546,7 +546,7 @@ msgstr "Registrar anfitrión actual"
 #: pages/templates/pages/login.html:4
 #: pages/templates/pages/login.html:9
 msgid "Login"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #: pages/templates/pages/base.html:72
 #: pages/templates/pages/base.html:99
@@ -559,15 +559,19 @@ msgstr "Modo Claro"
 
 #: pages/templates/pages/login.html:14
 msgid "Username"
-msgstr ""
+msgstr "Nombre de usuario"
 
 #: pages/templates/pages/login.html:18
 msgid "Password"
-msgstr ""
+msgstr "Contraseña"
 
 #: pages/templates/pages/login.html:22
 msgid "Log in"
-msgstr ""
+msgstr "Iniciar sesión"
+
+#: pages/templates/pages/login.html:25
+msgid "Request email invitation"
+msgstr "Solicitar invitación por correo electrónico"
 
 #: awg/models.py:24
 msgid "Cable Size"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -46,3 +46,24 @@ msgstr "Hors ligne"
 msgid "Serial Number"
 msgstr "Numéro de série"
 
+#: pages/templates/pages/base.html:67
+#: pages/templates/pages/login.html:4
+#: pages/templates/pages/login.html:9
+msgid "Login"
+msgstr "Connexion"
+
+#: pages/templates/pages/login.html:14
+msgid "Username"
+msgstr "Nom d'utilisateur"
+
+#: pages/templates/pages/login.html:18
+msgid "Password"
+msgstr "Mot de passe"
+
+#: pages/templates/pages/login.html:22
+msgid "Log in"
+msgstr "Se connecter"
+
+#: pages/templates/pages/login.html:25
+msgid "Request email invitation"
+msgstr "Demander une invitation par e-mail"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -46,3 +46,24 @@ msgstr "Не в сети"
 msgid "Serial Number"
 msgstr "Серийный номер"
 
+#: pages/templates/pages/base.html:67
+#: pages/templates/pages/login.html:4
+#: pages/templates/pages/login.html:9
+msgid "Login"
+msgstr "Вход"
+
+#: pages/templates/pages/login.html:14
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: pages/templates/pages/login.html:18
+msgid "Password"
+msgstr "Пароль"
+
+#: pages/templates/pages/login.html:22
+msgid "Log in"
+msgstr "Войти"
+
+#: pages/templates/pages/login.html:25
+msgid "Request email invitation"
+msgstr "Запросить приглашение по электронной почте"


### PR DESCRIPTION
## Summary
- translate login page strings into Spanish, French, and Russian

## Testing
- `pre-commit run --files locale/es/LC_MESSAGES/django.po locale/fr/LC_MESSAGES/django.po locale/ru/LC_MESSAGES/django.po`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d094482483269dc5751704bec68c