### PR TITLE
Retry internet check before failing network setup

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -395,10 +395,15 @@ if [[ $RUN_ROUTING == true ]]; then
 
     nmcli device status
 
-    if check_connectivity; then
-        echo "Internet connectivity confirmed."
-    else
-        echo "No internet connectivity after configuration." >&2
-        exit 1
-    fi
+    ATTEMPTS=0
+    while ! check_connectivity; do
+        ATTEMPTS=$((ATTEMPTS+1))
+        if [[ $ATTEMPTS -ge 5 ]]; then
+            echo "No internet connectivity after configuration." >&2
+            exit 1
+        fi
+        echo "No internet connectivity yet; retrying in 5 seconds..." >&2
+        sleep 5
+    done
+    echo "Internet connectivity confirmed."
 fi


### PR DESCRIPTION
## Summary
- retry internet connectivity check before failing network setup

## Testing
- `python -m pre_commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c3c79c66e48326bef0c88348cbcf26