### PR TITLE
Expose EmailCollector in admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -44,7 +44,7 @@ from .models import (
     Reference,
     OdooProfile,
     EmailInbox as CoreEmailInbox,
-    EmailCollector,
+    EmailCollector as CoreEmailCollector,
     Package,
     PackageRelease,
     ReleaseManager,
@@ -486,9 +486,23 @@ class OdooProfileAdminForm(forms.ModelForm):
         return pwd
 
 
+class EmailCollector(CoreEmailCollector):
+    class Meta:
+        proxy = True
+        app_label = "post_office"
+        verbose_name = CoreEmailCollector._meta.verbose_name
+        verbose_name_plural = CoreEmailCollector._meta.verbose_name_plural
+
+
 class EmailCollectorInline(admin.TabularInline):
-    model = EmailCollector
+    model = CoreEmailCollector
     extra = 0
+
+
+@admin.register(EmailCollector)
+class EmailCollectorAdmin(EntityModelAdmin):
+    list_display = ("inbox", "subject", "sender", "body", "fragment")
+    search_fields = ("subject", "sender", "body", "fragment")
 
 
 @admin.register(OdooProfile)

--- a/core/fixtures/todos__validate_screen_emailcollector.json
+++ b/core/fixtures/todos__validate_screen_emailcollector.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 11,
+    "fields": {
+      "description": "Validate screen EmailCollector",
+      "url": "/admin/post_office/emailcollector/"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- register EmailCollector with the admin site and enable list/change views
- add tests verifying standalone EmailCollector admin functionality
- seed TODO fixture to validate the new EmailCollector screen

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_email_inbox_admin.py tests/test_email_collector.py` *(fails: database is locked)*
- `./scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean` *(fails: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dacf3adc8326b38d065e6da039b8