### PR TITLE
Route email through Post Office and start Celery workers by default

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -332,6 +332,8 @@ MEDIA_ROOT = BASE_DIR / "media"
 # Email settings
 DEFAULT_FROM_EMAIL = "arthexis@gmail.com"
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
+# All outgoing mail is queued via django-post-office; Celery workers must process the queue.
+EMAIL_BACKEND = "post_office.EmailBackend"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/start.sh
+++ b/start.sh
@@ -60,10 +60,8 @@ fi
 # Determine default port based on nginx mode if present
 PORT=""
 RELOAD=false
-CELERY=false
-if [ -f "$LOCK_DIR/celery.lck" ]; then
-  CELERY=true
-fi
+# Celery workers process Post Office's email queue; enable by default.
+CELERY=true
 if [ -f "$LOCK_DIR/nginx_mode.lck" ]; then
   MODE="$(cat "$LOCK_DIR/nginx_mode.lck")"
 else
@@ -101,14 +99,14 @@ while [[ $# -gt 0 ]]; do
       PORT=8888
       shift
       ;;
-    *)
+      *)
       echo "Usage: $0 [--port PORT] [--reload] [--public|--internal] [--celery|--no-celery]" >&2
       exit 1
       ;;
   esac
 done
 
-# Start required Celery components if requested
+# Start Celery components to handle queued email if enabled
 if [ "$CELERY" = true ]; then
   celery -A config worker -l info &
   CELERY_WORKER_PID=$!


### PR DESCRIPTION
## Summary
- Send all email through django-post-office's backend
- Start Celery workers by default so queued email is delivered

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`
- `pytest` *(fails: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4df9dff80832685258c512ae5051a