### PR TITLE
fix: restore node role fixtures

### DIFF
--- a/nodes/fixtures/node_roles__noderole_constellation.json
+++ b/nodes/fixtures/node_roles__noderole_constellation.json
@@ -1,1 +1,12 @@
-[]
+[
+  {
+    "model": "nodes.noderole",
+    "pk": 2,
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "name": "Constellation",
+      "description": "Multi-User Cloud & Orchestration"
+    }
+  }
+]

--- a/nodes/fixtures/node_roles__noderole_control.json
+++ b/nodes/fixtures/node_roles__noderole_control.json
@@ -1,1 +1,12 @@
-[]
+[
+  {
+    "model": "nodes.noderole",
+    "pk": 3,
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "name": "Control",
+      "description": "Single-Device Testing & Special Task Appliances"
+    }
+  }
+]

--- a/nodes/fixtures/node_roles__noderole_satellite.json
+++ b/nodes/fixtures/node_roles__noderole_satellite.json
@@ -1,1 +1,12 @@
-[]
+[
+  {
+    "model": "nodes.noderole",
+    "pk": 4,
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "name": "Satellite",
+      "description": "Multi-Device Edge, Network & Data Acquisition"
+    }
+  }
+]

--- a/nodes/fixtures/node_roles__noderole_terminal.json
+++ b/nodes/fixtures/node_roles__noderole_terminal.json
@@ -1,12 +1,12 @@
 [
-{
-  "model": "nodes.noderole",
-  "pk": 1,
-  "fields": {
-    "is_seed_data": false,
-    "is_deleted": false,
-    "name": "Updated",
-    "description": ""
+  {
+    "model": "nodes.noderole",
+    "pk": 1,
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "name": "Terminal",
+      "description": "Single-User Research & Development"
+    }
   }
-}
 ]

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -233,3 +233,10 @@ class SeedDataViewTests(TestCase):
     def test_seed_data_view_shows_fixture(self):
         response = self.client.get(reverse("admin:seed_data"))
         self.assertContains(response, "node_roles__noderole_terminal.json")
+
+    def test_node_role_fixtures_present(self):
+        names = set(NodeRole.objects.values_list("name", flat=True))
+        self.assertEqual(
+            names,
+            {"Terminal", "Constellation", "Control", "Satellite"},
+        )

--- a/tests/test_update_fixtures_command.py
+++ b/tests/test_update_fixtures_command.py
@@ -1,28 +1,29 @@
 import json
-import shutil
 from pathlib import Path
+import tempfile
 
-from django.conf import settings
 from django.core.management import call_command
+from django.test import override_settings
 from nodes.models import NodeRole
 
 
 def test_update_fixtures_updates_changed_objects():
     role = NodeRole.objects.create(name="Original")
-    fixture_dir = Path(settings.BASE_DIR) / "temp_app" / "fixtures"
-    fixture_dir.mkdir(parents=True)
-    fixture_path = fixture_dir / "node_roles.json"
-    from django.core import serializers
+    with tempfile.TemporaryDirectory() as tmp:
+        base_dir = Path(tmp)
+        fixture_dir = base_dir / "temp_app" / "fixtures"
+        fixture_dir.mkdir(parents=True)
+        fixture_path = fixture_dir / "node_roles.json"
+        from django.core import serializers
 
-    fixture_path.write_text(serializers.serialize("json", [role], indent=2))
+        fixture_path.write_text(serializers.serialize("json", [role], indent=2))
 
-    role.name = "Updated"
-    role.save()
+        role.name = "Updated"
+        role.save()
 
-    call_command("update_fixtures")
+        with override_settings(BASE_DIR=base_dir):
+            call_command("update_fixtures")
 
-    data = json.loads(fixture_path.read_text())
-    assert data[0]["fields"]["name"] == "Updated"
-
+        data = json.loads(fixture_path.read_text())
+        assert data[0]["fields"]["name"] == "Updated"
     role.delete()
-    shutil.rmtree(fixture_dir.parent)


### PR DESCRIPTION
## Summary
- restore NodeRole fixtures for Terminal, Constellation, Control, and Satellite
- isolate update_fixtures test to avoid modifying project fixtures
- verify seed data includes all node roles

## Testing
- `pytest tests/test_update_fixtures_command.py::test_update_fixtures_updates_changed_objects tests/test_seed_data.py::SeedDataViewTests::test_seed_data_view_shows_fixture tests/test_seed_data.py::SeedDataViewTests::test_node_role_fixtures_present -q`
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd376a5c8326883e095eeed0740a