### PR TITLE
Decouple EmailOutbox from Node

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -330,6 +330,8 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 # Email settings
+EMAIL_BACKEND = "post_office.EmailBackend"
+POST_OFFICE = {"EMAIL_BACKEND": "nodes.backends.OutboxEmailBackend"}
 DEFAULT_FROM_EMAIL = "arthexis@gmail.com"
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 

--- a/email-setup.sh
+++ b/email-setup.sh
@@ -29,10 +29,9 @@ if [[ "${SET_OUTBOX,,}" == "y" ]]; then
     read -rp "From email (leave blank to use default): " FROM_EMAIL
 
     "$PYTHON" manage.py shell <<PYTHON
-from nodes.models import Node, EmailOutbox
-node, _ = Node.register_current()
+from nodes.models import EmailOutbox
 outbox, _ = EmailOutbox.objects.update_or_create(
-    node=node,
+    id=1,
     defaults={
         "host": "$HOST",
         "port": int("$PORT"),
@@ -43,7 +42,7 @@ outbox, _ = EmailOutbox.objects.update_or_create(
         "from_email": "$FROM_EMAIL",
     },
 )
-print("Configured outbox for", node.hostname)
+print("Configured outbox")
 PYTHON
 
     read -rp "Save this outbox as a User Datum? [y/N]: " SAVE_UD
@@ -53,9 +52,8 @@ PYTHON
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from core.user_data import UserDatum
-from nodes.models import Node, EmailOutbox
-node = Node.get_local()
-outbox = EmailOutbox.objects.get(node=node)
+from nodes.models import EmailOutbox
+outbox = EmailOutbox.objects.latest("id")
 User = get_user_model()
 user = User.objects.get(username="$UD_USER")
 ct = ContentType.objects.get_for_model(EmailOutbox)

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -197,7 +197,7 @@ class EmailOutbox(NodeEmailOutbox):
 
 @admin.register(EmailOutbox)
 class EmailOutboxAdmin(EntityModelAdmin):
-    list_display = ("node", "host", "port", "username", "use_tls", "use_ssl")
+    list_display = ("host", "port", "username", "use_tls", "use_ssl")
     change_form_template = "admin/nodes/emailoutbox/change_form.html"
 
     def get_urls(self):

--- a/nodes/backends.py
+++ b/nodes/backends.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail import get_connection
+from django.conf import settings
+from django.db.models import Q
+
+from .models import EmailOutbox
+
+
+class OutboxEmailBackend(BaseEmailBackend):
+    """Email backend that selects an :class:`EmailOutbox` automatically.
+
+    If a matching outbox exists for the message's ``from_email`` (matching
+    either ``from_email`` or ``username``), that outbox's SMTP credentials are
+    used. Otherwise, the first available outbox is used. When no outboxes are
+    configured, the system falls back to Django's default SMTP settings.
+    """
+
+    def _select_outbox(self, from_email: str | None) -> EmailOutbox | None:
+        if from_email:
+            return (
+                EmailOutbox.objects.filter(
+                    Q(from_email__iexact=from_email) | Q(username__iexact=from_email)
+                ).first()
+                or EmailOutbox.objects.first()
+            )
+        return EmailOutbox.objects.first()
+
+    def send_messages(self, email_messages):
+        sent = 0
+        for message in email_messages:
+            outbox = self._select_outbox(message.from_email)
+            if outbox:
+                connection = outbox.get_connection()
+                if not message.from_email:
+                    message.from_email = (
+                        outbox.from_email or settings.DEFAULT_FROM_EMAIL
+                    )
+            else:
+                connection = get_connection(
+                    "django.core.mail.backends.smtp.EmailBackend"
+                )
+                if not message.from_email:
+                    message.from_email = settings.DEFAULT_FROM_EMAIL
+            try:
+                sent += connection.send_messages([message]) or 0
+            finally:
+                try:
+                    connection.close()
+                except Exception:  # pragma: no cover - close errors shouldn't fail send
+                    pass
+        return sent

--- a/nodes/migrations/0002_contentsample_user.py
+++ b/nodes/migrations/0002_contentsample_user.py
@@ -91,14 +91,6 @@ class Migration(migrations.Migration):
                         help_text="Default From address; usually the same as username",
                     ),
                 ),
-                (
-                    "node",
-                    models.OneToOneField(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name="email_outbox",
-                        to="nodes.node",
-                    ),
-                ),
             ],
             options={
                 "verbose_name": "Email Outbox",

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -254,32 +254,17 @@ class Node(Entity):
         from_email: str | None = None,
         **kwargs,
     ):
-        """Send an email using this node's configured outbox if available."""
-        outbox = getattr(self, "email_outbox", None)
-        logger.info(
-            "Node %s sending email to %s using %s backend",
-            self.pk,
-            recipient_list,
-            "outbox" if outbox else "default",
-        )
-        if outbox:
-            result = outbox.send_mail(
-                subject, message, recipient_list, from_email, **kwargs
-            )
-            logger.info("Outbox send_mail result: %s", result)
-            return result
+        """Send an email using the default backend."""
+        logger.info("Node %s sending email to %s", self.pk, recipient_list)
         from_email = from_email or settings.DEFAULT_FROM_EMAIL
         result = send_mail(subject, message, from_email, recipient_list, **kwargs)
-        logger.info("Default send_mail result: %s", result)
+        logger.info("send_mail result: %s", result)
         return result
 
 
 class EmailOutbox(Entity):
-    """SMTP credentials for sending mail from a node."""
+    """SMTP credentials for sending mail."""
 
-    node = models.OneToOneField(
-        Node, on_delete=models.CASCADE, related_name="email_outbox"
-    )
     host = SigilShortAutoField(
         max_length=100,
         help_text=("Gmail: smtp.gmail.com. " "GoDaddy: smtpout.secureserver.net"),
@@ -317,12 +302,9 @@ class EmailOutbox(Entity):
         verbose_name = "Email Outbox"
         verbose_name_plural = "Email Outboxes"
 
-    class Meta:
-        verbose_name = "Email Outbox"
-        verbose_name_plural = "Email Outboxes"
-
     def get_connection(self):
         return get_connection(
+            "django.core.mail.backends.smtp.EmailBackend",
             host=self.host,
             port=self.port,
             username=self.username or None,

--- a/tests/test_email_outbox_admin.py
+++ b/tests/test_email_outbox_admin.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase, RequestFactory
 
 from nodes.admin import EmailOutboxAdmin, EmailOutbox as AdminEmailOutbox
-from nodes.models import EmailOutbox, Node
+from nodes.models import EmailOutbox
 
 
 class EmailOutboxAdminActionTests(TestCase):
@@ -14,14 +14,7 @@ class EmailOutboxAdminActionTests(TestCase):
         self.user = User.objects.create_superuser(
             username="admin", email="a@example.com", password="pwd"
         )
-        self.node = Node.objects.create(
-            hostname="host",
-            address="127.0.0.1",
-            port=8000,
-            mac_address="00:11:22:33:44:55",
-        )
         self.outbox = EmailOutbox.objects.create(
-            node=self.node,
             host="smtp.test",
             port=25,
             username="u",


### PR DESCRIPTION
## Summary
- configure post_office as default email backend
- add OutboxEmailBackend to pick the best EmailOutbox based on from address
- force EmailOutbox connections to use SMTP backend directly

## Testing
- `pre-commit run --files nodes/tests.py nodes/models.py nodes/backends.py config/settings.py`
- `pytest tests/test_email_outbox_admin.py nodes/tests.py::EmailOutboxTests tests/test_workgroup_admin_group.py` *(fails: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dbbe55f88326966c7a97fdf2e8d7