### PR TITLE
Add public user manual views

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -68,12 +68,12 @@ def autodiscovered_urlpatterns():
 urlpatterns = [
     path(
         "admin/doc/manuals/",
-        man_views.manual_list,
+        man_views.admin_manual_list,
         name="django-admindocs-manuals",
     ),
     path(
         "admin/doc/manuals/<slug:slug>/",
-        man_views.manual_html,
+        man_views.admin_manual_detail,
         name="django-admindocs-manual-detail",
     ),
     path(

--- a/core/fixtures/todos__validate_screen_user_manuals.json
+++ b/core/fixtures/todos__validate_screen_user_manuals.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 12,
+    "fields": {
+      "description": "Validate screen User Manuals",
+      "url": "/man/"
+    }
+  }
+]

--- a/core/mailer.py
+++ b/core/mailer.py
@@ -23,18 +23,16 @@ def send(
     backend alias so that Post Office can use it when dispatching.
     """
     sender = (
-        from_email
-        or getattr(outbox, "from_email", None)
-        or settings.DEFAULT_FROM_EMAIL
+        from_email or getattr(outbox, "from_email", None) or settings.DEFAULT_FROM_EMAIL
     )
     backend = ""
     if outbox is not None:
         alias = f"outbox_{getattr(outbox, 'pk', 'tmp')}"
         if not hasattr(settings, "POST_OFFICE"):
             settings.POST_OFFICE = {}
-        settings.POST_OFFICE.setdefault("BACKENDS", {})[alias] = (
-            "django.core.mail.backends.smtp.EmailBackend"
-        )
+        settings.POST_OFFICE.setdefault("BACKENDS", {})[
+            alias
+        ] = "django.core.mail.backends.smtp.EmailBackend"
         if not hasattr(po_connections._connections, "connections"):
             po_connections._connections.connections = {}
         po_connections._connections.connections[alias] = outbox.get_connection()

--- a/man/templates/man/manual_detail.html
+++ b/man/templates/man/manual_detail.html
@@ -1,0 +1,12 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+{% block title %}{{ manual.title }}{% endblock %}
+{% block content %}
+<h1>{{ manual.title }}</h1>
+<div class="object-tools">
+  <ul>
+    <li><a href="{% url 'man:manual-pdf' manual.slug %}">{% trans "Download PDF" %}</a></li>
+  </ul>
+</div>
+{{ manual.content_html|safe }}
+{% endblock %}

--- a/man/templates/man/manual_list.html
+++ b/man/templates/man/manual_list.html
@@ -1,0 +1,16 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Manuals" %}{% endblock %}
+{% block content %}
+<h1>{% trans "Manuals" %}</h1>
+<ul>
+  {% for manual in manuals %}
+    <li>
+      <a href="{% url 'man:manual-html' manual.slug %}">{{ manual.title }}</a>
+      - {{ manual.description }}
+      - {% trans "Languages" %}: {{ manual.languages }}
+      - <a href="{% url 'man:manual-pdf' manual.slug %}">{% trans "Download PDF" %}</a>
+    </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/man/urls.py
+++ b/man/urls.py
@@ -5,6 +5,6 @@ app_name = "man"
 
 urlpatterns = [
     path("", views.manual_list, name="list"),
-    path("<slug:slug>/", views.manual_html, name="manual-html"),
+    path("<slug:slug>/", views.manual_detail, name="manual-html"),
     path("<slug:slug>/pdf/", views.manual_pdf, name="manual-pdf"),
 ]

--- a/man/views.py
+++ b/man/views.py
@@ -5,6 +5,9 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.test import RequestFactory
+from django.utils.translation import gettext as _
+
+from pages.utils import landing
 
 from .models import UserManual
 
@@ -26,7 +29,7 @@ def _admin_context(request):
     return context
 
 
-def manual_html(request, slug):
+def admin_manual_detail(request, slug):
     manual = get_object_or_404(UserManual, slug=slug)
     context = _admin_context(request)
     context["manual"] = manual
@@ -39,8 +42,19 @@ def manual_pdf(request, slug):
     return HttpResponse(pdf_data, content_type="application/pdf")
 
 
-def manual_list(request):
+def admin_manual_list(request):
     manuals = UserManual.objects.all()
     context = _admin_context(request)
     context["manuals"] = manuals
     return render(request, "admin_doc/manuals.html", context)
+
+
+@landing(_("Manuals"))
+def manual_list(request):
+    manuals = UserManual.objects.all()
+    return render(request, "man/manual_list.html", {"manuals": manuals})
+
+
+def manual_detail(request, slug):
+    manual = get_object_or_404(UserManual, slug=slug)
+    return render(request, "man/manual_detail.html", {"manual": manual})

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -77,3 +77,17 @@ class ManTests(TestCase):
         self.assertNotContains(
             response, "You don't have permission to view or edit anything."
         )
+
+    def test_public_manual_list(self):
+        response = self.client.get(reverse("man:list"))
+        self.assertContains(response, "Test Manual")
+        self.assertContains(response, "Test description")
+        self.assertContains(response, "Languages: en,fr")
+        self.assertContains(response, reverse("man:manual-pdf", args=["test-manual"]))
+        self.assertNotContains(response, 'id="nav-sidebar"')
+
+    def test_public_manual_detail(self):
+        response = self.client.get(reverse("man:manual-html", args=["test-manual"]))
+        self.assertContains(response, "hi")
+        self.assertContains(response, reverse("man:manual-pdf", args=["test-manual"]))
+        self.assertNotContains(response, 'id="nav-sidebar"')


### PR DESCRIPTION
## Summary
- add public manual list and detail views styled like the site
- route MAN navigation pill to new public views while keeping admin docs
- cover public manual pages with tests and add validation TODO

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`
- `pytest tests/test_man.py` *(fails: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ef62faf48326a739ef406e2b017a