### PR TITLE
Ensure modules load before landing fixtures

### DIFF
--- a/tests/test_admin_system_stop.py
+++ b/tests/test_admin_system_stop.py
@@ -21,7 +21,10 @@ class AdminSystemStopTests(TestCase):
             username="admin", email="admin@example.com", password="password"
         )
         self.staff = User.objects.create_user(
-            username="staff", email="staff@example.com", password="password", is_staff=True
+            username="staff",
+            email="staff@example.com",
+            password="password",
+            is_staff=True,
         )
 
     def test_stop_button_hidden_for_non_superuser(self):


### PR DESCRIPTION
## Summary
- add fixture sort key so modules load before landings during env refresh
- reformat test file for pre-commit compliance

## Testing
- `pre-commit run --all-files`
- `env-refresh.sh --clean` *(fails: database is locked)*
- `scripts/test-upgrade-path.sh` *(skipped: No previous release tag found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f37fdda08326882b14fbedcc273a