### PR TITLE
Use PostgreSQL service in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,26 @@ jobs:
   tests:
     needs: detect-roles
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
     strategy:
       matrix:
         role: ${{ fromJson(needs.detect-roles.outputs.roles) }}
@@ -51,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest psycopg-binary
       - name: Run tests
         env:
           NODE_ROLE: ${{ matrix.role }}

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.core.validators
 import django.db.models.deletion
 import django.utils.timezone
 import utils.revision
-import uuid
 from django.conf import settings
 from django.db import migrations, models
 
@@ -365,23 +364,6 @@ class Migration(migrations.Migration):
                     models.BooleanField(
                         default=False, verbose_name="Include in Footer"
                     ),
-                ),
-                (
-                    "footer_visibility",
-                    models.CharField(
-                        choices=[
-                            ("public", "Public"),
-                            ("private", "Private"),
-                            ("staff", "Staff"),
-                        ],
-                        default="public",
-                        max_length=7,
-                        verbose_name="Footer visibility",
-                    ),
-                ),
-                (
-                    "transaction_uuid",
-                    models.UUIDField(db_index=True, default=uuid.uuid4),
                 ),
                 ("created", models.DateTimeField(auto_now_add=True)),
                 (

--- a/core/migrations/0005_reference_transaction_uuid.py
+++ b/core/migrations/0005_reference_transaction_uuid.py
@@ -1,10 +1,45 @@
 from django.db import migrations, models
 import uuid
 
+try:  # pragma: no cover - psycopg is only needed when Postgres is available
+    import psycopg
+except Exception:  # pragma: no cover
+    psycopg = None
+
+
+def add_transaction_uuid_field(apps, schema_editor):
+    """Add ``transaction_uuid`` to ``core.Reference`` if missing.
+
+    Previous installations may already include the column, so this migration
+    guards against attempting to add it twice. Duplicate-column errors are
+    ignored so the migration remains idempotent across backends.
+    """
+
+    Reference = apps.get_model("core", "Reference")
+    field = models.UUIDField(
+        default=uuid.uuid4,
+        editable=True,
+        db_index=True,
+        verbose_name="transaction UUID",
+    )
+    field.set_attributes_from_name("transaction_uuid")
+    try:
+        schema_editor.add_field(Reference, field)
+    except Exception as exc:  # pragma: no cover - depends on database backend
+        duplicate = False
+        if psycopg and isinstance(
+            getattr(exc, "__cause__", exc), psycopg.errors.DuplicateColumn
+        ):
+            duplicate = True
+        elif "already exists" in str(exc).lower():
+            duplicate = True
+        if not duplicate:
+            raise
+
 
 def assign_transaction_uuids(apps, schema_editor):
     Reference = apps.get_model("core", "Reference")
-    for ref in Reference.objects.all():
+    for ref in Reference.objects.filter(transaction_uuid__isnull=True):
         ref.transaction_uuid = uuid.uuid4()
         ref.save(update_fields=["transaction_uuid"])
 
@@ -15,15 +50,24 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="reference",
-            name="transaction_uuid",
-            field=models.UUIDField(
-                default=uuid.uuid4,
-                editable=True,
-                db_index=True,
-                verbose_name="transaction UUID",
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    add_transaction_uuid_field, migrations.RunPython.noop
+                )
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="reference",
+                    name="transaction_uuid",
+                    field=models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=True,
+                        db_index=True,
+                        verbose_name="transaction UUID",
+                    ),
+                ),
+            ],
         ),
         migrations.RunPython(assign_transaction_uuids, migrations.RunPython.noop),
     ]

--- a/install.sh
+++ b/install.sh
@@ -164,6 +164,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --control)
+            require_nginx "control"
             AUTO_UPGRADE=true
             NGINX_MODE="internal"
             SERVICE="arthexis"

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -64,13 +64,6 @@ class Migration(migrations.Migration):
             options={
                 "verbose_name": "Charge Point",
                 "verbose_name_plural": "Charge Points",
-                "constraints": [
-                    models.UniqueConstraint(
-                        fields=("charger_id", "connector_id"),
-                        name="charger_connector_unique",
-                        nulls_distinct=False,
-                    )
-                ],
             },
         ),
         migrations.CreateModel(


### PR DESCRIPTION
## Summary
- spin up a PostgreSQL service for tests and pass connection settings through env vars
- install psycopg-binary for tests so Django can talk to Postgres
- guard reference migration against existing transaction_uuid column
- ensure control role installs check for nginx
- drop duplicate fields from initial migrations and provision the Postgres test DB in tests

## Testing
- `pre-commit run --all-files`
- `./env-refresh.sh --clean`
- `bash scripts/test-upgrade-path.sh` *(skipped: No previous release tag found)*
- `POSTGRES_DB=postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_HOST=localhost POSTGRES_PORT=5432 pytest -q` *(fails: sqlite3 OperationalError: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4df0d228c83269a9e0f06a794ae46