### PR TITLE
Add charger console URL and admin proxy

### DIFF
--- a/core/fixtures/todos__validate_screen_charger_console.json
+++ b/core/fixtures/todos__validate_screen_charger_console.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 15,
+    "fields": {
+      "description": "Validate screen Charger Console",
+      "url": "/admin/ocpp/charger/"
+    }
+  }
+]

--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -78,6 +78,7 @@ class ChargerAdmin(EntityModelAdmin):
                     "last_heartbeat",
                     "last_meter_values",
                     "last_path",
+                    "console_url",
                     "location",
                 )
             },
@@ -89,7 +90,7 @@ class ChargerAdmin(EntityModelAdmin):
             },
         ),
     )
-    readonly_fields = ("last_heartbeat", "last_meter_values")
+    readonly_fields = ("last_heartbeat", "last_meter_values", "console_url")
     list_display = (
         "charger_id",
         "connector_id",
@@ -99,6 +100,7 @@ class ChargerAdmin(EntityModelAdmin):
         "session_kw",
         "total_kw_display",
         "page_link",
+        "console_link",
         "log_link",
         "status_link",
     )
@@ -127,6 +129,17 @@ class ChargerAdmin(EntityModelAdmin):
         return ""
 
     qr_link.short_description = "QR Code"
+
+    def console_link(self, obj):
+        from django.utils.html import format_html
+        from django.urls import reverse
+
+        if obj.console_url:
+            url = reverse("charger-console", args=[obj.charger_id])
+            return format_html('<a href="{}" target="_blank">console</a>', url)
+        return ""
+
+    console_link.short_description = "Console"
 
     def log_link(self, obj):
         from django.utils.html import format_html

--- a/ocpp/migrations/0004_user_data_field.py
+++ b/ocpp/migrations/0004_user_data_field.py
@@ -16,6 +16,11 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False, editable=False),
         ),
         migrations.AddField(
+            model_name="charger",
+            name="console_url",
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
             model_name="location",
             name="is_user_data",
             field=models.BooleanField(default=False, editable=False),

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -69,6 +69,7 @@ class Charger(Entity):
         related_name="chargers",
     )
     last_path = models.CharField(max_length=255, blank=True)
+    console_url = models.URLField(blank=True)
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.charger_id

--- a/ocpp/templates/ocpp/charger_console.html
+++ b/ocpp/templates/ocpp/charger_console.html
@@ -1,0 +1,8 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ charger.charger_id }} - {% trans "Console" %}{% endblock %}
+
+{% block content %}
+<iframe src="{% url 'charger-console-proxy' charger.charger_id %}" style="width:100%;height:90vh;border:none;"></iframe>
+{% endblock %}

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -246,6 +246,26 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertIn("1", connectors)
         self.assertIn("2", connectors)
 
+    @patch("ocpp.consumers.requests.get")
+    async def test_console_url_recorded(self, mock_get):
+        mock_get.return_value.status_code = 200
+        communicator = WebsocketCommunicator(application, "/CONS1/")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="CONS1")
+        self.assertTrue(charger.console_url)
+        await communicator.disconnect()
+
+    @patch("ocpp.consumers.requests.get")
+    async def test_console_url_not_recorded_when_unreachable(self, mock_get):
+        mock_get.side_effect = Exception("nope")
+        communicator = WebsocketCommunicator(application, "/CONS2/")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="CONS2")
+        self.assertFalse(charger.console_url)
+        await communicator.disconnect()
+
     async def test_transaction_created_from_meter_values(self):
         communicator = WebsocketCommunicator(application, "/NOSTART/")
         connected, _ = await communicator.connect()
@@ -579,6 +599,22 @@ class ChargerAdminTests(TestCase):
         log_url = reverse("charger-log", args=["LOG1"]) + "?type=charger"
         self.assertContains(resp, log_url)
 
+    def test_admin_lists_console_link(self):
+        charger = Charger.objects.create(
+            charger_id="CON1", console_url="http://1.2.3.4"
+        )
+        url = reverse("admin:ocpp_charger_changelist")
+        resp = self.client.get(url)
+        console_url = reverse("charger-console", args=["CON1"])
+        self.assertContains(resp, console_url)
+
+    def test_admin_hides_console_link_without_url(self):
+        Charger.objects.create(charger_id="CON2")
+        url = reverse("admin:ocpp_charger_changelist")
+        resp = self.client.get(url)
+        console_url = reverse("charger-console", args=["CON2"])
+        self.assertNotContains(resp, console_url)
+
     def test_admin_change_links_landing_page(self):
         charger = Charger.objects.create(charger_id="CHANGE1")
         url = reverse("admin:ocpp_charger_change", args=[charger.pk])
@@ -642,6 +678,30 @@ class ChargerAdminTests(TestCase):
         )
         self.client.post(delete_url, {"post": "yes"})
         self.assertFalse(Charger.objects.filter(pk=charger.pk).exists())
+
+
+class ConsoleProxyTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="user", password="pw", email="user@example.com"
+        )
+        self.client.force_login(self.user)
+        self.charger = Charger.objects.create(
+            charger_id="PROXY", console_url="http://example.com"
+        )
+
+    @patch("ocpp.views.requests.request")
+    def test_proxy_forwards_response(self, mock_req):
+        mock_resp = mock_req.return_value
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "text/plain"}
+        mock_resp.content = b"ok"
+        url = reverse("charger-console-proxy", args=["PROXY"])
+        resp = self.client.get(url)
+        self.assertEqual(resp.content, b"ok")
+        self.assertEqual(resp.status_code, 200)
 
 
 class TransactionAdminTests(TestCase):

--- a/ocpp/urls.py
+++ b/ocpp/urls.py
@@ -16,5 +16,16 @@ urlpatterns = [
     ),
     path("log/<str:cid>/", views.charger_log_page, name="charger-log"),
     path("c/<str:cid>/status/", views.charger_status, name="charger-status"),
+    path("console/<str:cid>/", views.charger_console, name="charger-console"),
+    path(
+        "console/<str:cid>/proxy/",
+        views.charger_console_proxy,
+        name="charger-console-proxy",
+    ),
+    path(
+        "console/<str:cid>/proxy/<path:path>",
+        views.charger_console_proxy,
+        name="charger-console-proxy",
+    ),
     path("rfid/", include("ocpp.rfid.urls")),
 ]


### PR DESCRIPTION
## Summary
- store reachable console URLs for new chargers and expose a proxy link in the admin
- add iframe-based console proxy and validation todo fixture

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean` *(fails: NOT NULL constraint failed: pages_module.application_id)*
- `python manage.py test ocpp.tests` *(fails: missing fixtures and TypeError in MeterReading)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fa2acf1c83268b240f6fb0fca1a1