### PR TITLE
Enable WAL mode for SQLite tests

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -274,7 +274,7 @@ else:
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": BASE_DIR / "db.sqlite3",
-            "OPTIONS": {"timeout": 30},
+            "OPTIONS": {"timeout": 60},
             "TEST": {"NAME": BASE_DIR / "test_db.sqlite3"},
         }
     }

--- a/core/apps.py
+++ b/core/apps.py
@@ -74,3 +74,15 @@ class CoreConfig(AppConfig):
                     pass
 
             post_migrate.connect(ensure_email_collector_task, sender=self)
+
+        from django.db.backends.signals import connection_created
+
+        def enable_sqlite_wal(**kwargs):
+            connection = kwargs.get("connection")
+            if connection.vendor == "sqlite":
+                cursor = connection.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL;")
+                cursor.execute("PRAGMA busy_timeout=60000;")
+                cursor.close()
+
+        connection_created.connect(enable_sqlite_wal)


### PR DESCRIPTION
## Summary
- increase SQLite connection timeout
- enable WAL mode and busy timeout on SQLite connections

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean` *(fails: NOT NULL constraint failed: pages_module.application_id)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a03286ec8326bda59411728a8260