### PR TITLE
Use lockfile for auto-upgrade mode

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -44,7 +44,7 @@ def birthday_greetings() -> None:
 def check_github_updates() -> None:
     """Check the GitHub repo for updates and upgrade if needed."""
     base_dir = Path(__file__).resolve().parent.parent
-    mode_file = base_dir / "AUTO_UPGRADE"
+    mode_file = base_dir / "locks" / "auto_upgrade.lck"
     mode = "version"
     if mode_file.exists():
         mode = mode_file.read_text().strip()

--- a/install.sh
+++ b/install.sh
@@ -550,10 +550,11 @@ if [ "$ENABLE_DATASETTE" != true ]; then
 fi
 
 if [ "$AUTO_UPGRADE" = true ]; then
+    rm -f AUTO_UPGRADE
     if [ "$LATEST" = true ]; then
-        echo "latest" > AUTO_UPGRADE
+        echo "latest" > "$LOCK_DIR/auto_upgrade.lck"
     else
-        echo "version" > AUTO_UPGRADE
+        echo "version" > "$LOCK_DIR/auto_upgrade.lck"
     fi
     if [ "$UPGRADE" = true ]; then
         if [ "$LATEST" = true ]; then

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -88,3 +88,9 @@ def test_install_script_role_defaults():
 
     assert "--virtual)" not in content
     assert "--particle)" not in content
+
+
+def test_install_script_uses_auto_upgrade_lockfile():
+    script_path = Path(__file__).resolve().parent.parent / "install.sh"
+    content = script_path.read_text()
+    assert "auto_upgrade.lck" in content

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -122,7 +122,6 @@ fi
 
 # Clear lock directory and other cached configuration
 rm -rf "$LOCK_DIR"
-rm -f "$BASE_DIR/AUTO_UPGRADE"
 rm -f "$BASE_DIR/requirements.md5"
 
 echo "Uninstall complete."


### PR DESCRIPTION
## Summary
- store auto-upgrade mode in `locks/auto_upgrade.lck`
- update scripts and Celery task to read/write lockfile
- add test ensuring install script references the lockfile

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean` *(fails: database is locked)*
- `pytest` *(fails: multiple tests due to environment/database lock)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d18b25748326a9a964c1c4e2f09d