### PR TITLE
Show fixture filenames in seed data view

### DIFF
--- a/core/templates/admin/data_list.html
+++ b/core/templates/admin/data_list.html
@@ -49,7 +49,7 @@
             <td>{{ section.opts.app_config.verbose_name|capfirst }}</td>
             <td>{{ section.opts.verbose_name|capfirst }}</td>
             <td><a href="{{ item.url }}">{{ item.label }}</a></td>
-            <td>{{ item.fixture }}</td>
+            <td>{{ item.fixture.name }}</td>
           </tr>
           {% endfor %}
         {% endfor %}


### PR DESCRIPTION
## Summary
- add helper to locate seed fixture paths
- display fixture filenames for seed and user data

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_seed_data.py::SeedDataViewTests::test_seed_data_view_shows_fixture -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5dacabf2483269f823491afaf4750