### PR TITLE
Add user data flag to serialized sigil test

### DIFF
--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -327,6 +327,7 @@ class SigilResolutionTests(TestCase):
                 "fields": {
                     "is_seed_data": False,
                     "is_deleted": False,
+                    "is_user_data": False,
                     "name": "Terminal",
                     "description": "term role",
                 },


### PR DESCRIPTION
## Summary
- ensure NodeRole serialized sigil includes `is_user_data`

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_sigil_resolution.py::SigilResolutionTests::test_node_role_serialized_sigil -q` *(fails: django.db.utils.OperationalError: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dacf088c832697d29832e53782f7