### PR TITLE
Increase Postgres connection timeout

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -245,7 +245,7 @@ def _postgres_available() -> bool:
         "password": os.environ.get("POSTGRES_PASSWORD", ""),
         "host": os.environ.get("POSTGRES_HOST", "localhost"),
         "port": os.environ.get("POSTGRES_PORT", "5432"),
-        "connect_timeout": 1,
+        "connect_timeout": 10,
     }
     try:
         with contextlib.closing(psycopg.connect(**params)):


### PR DESCRIPTION
## Summary
- raise Postgres `connect_timeout` to 10 seconds in settings for more lenient availability checks

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e91327b88326ae721c0366cad9bf