### PR TITLE
ci: use localhost for postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
     strategy:
       matrix:
         role: ${{ fromJson(needs.detect-roles.outputs.roles) }}


### PR DESCRIPTION
## Summary
- point tests job to localhost Postgres

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: database locked, command errors)*
- `bash scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean` *(fails: IntegrityError: pages_landing.module_id)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e910531c8326bae8ad86f56e54be