### PR TITLE
feat: add canary docker test

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,0 +1,20 @@
+# Canary Dockerfile used to validate upgrades before applying them to the host
+FROM --platform=linux/arm64 ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip python3-venv \
+    build-essential libffi-dev libssl-dev libpq-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set work directory inside container
+WORKDIR /app
+
+# Copy current project into container
+COPY . .
+
+# On startup, prepare environment and run a non-destructive upgrade test
+CMD ["bash", "-c", "./env-refresh.sh --clean && ./upgrade.sh --no-restart"]

--- a/core/sigil_builder.py
+++ b/core/sigil_builder.py
@@ -39,10 +39,16 @@ def generate_model_sigils(**kwargs) -> None:
         # Ensure built-in configuration roots exist without violating the
         # unique ``prefix`` constraint, even if older databases already have
         # entries with a different ``context_type``.
-        SigilRoot.objects.update_or_create(
-            prefix__iexact=prefix,
-            defaults={"prefix": prefix, "context_type": SigilRoot.Context.CONFIG},
-        )
+        root = SigilRoot.objects.filter(prefix__iexact=prefix).first()
+        if root:
+            root.prefix = prefix
+            root.context_type = SigilRoot.Context.CONFIG
+            root.save(update_fields=["prefix", "context_type"])
+        else:
+            SigilRoot.objects.create(
+                prefix=prefix,
+                context_type=SigilRoot.Context.CONFIG,
+            )
 
     existing = {p.upper() for p in SigilRoot.objects.values_list("prefix", flat=True)}
     for model in apps.get_models():

--- a/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 2,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Constellation", "/ocpp/"],
-      "path": "/ocpp/simulator/",
-      "label": "CP Simulator",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/constellation__landing_ocpp_dashboard.json
+++ b/pages/fixtures/constellation__landing_ocpp_dashboard.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 1,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Constellation", "/ocpp/"],
-      "path": "/ocpp/",
-      "label": "Dashboard",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/constellation__landing_ocpp_rfid.json
+++ b/pages/fixtures/constellation__landing_ocpp_rfid.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 3,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Constellation", "/ocpp/rfid/"],
-      "path": "/ocpp/rfid/",
-      "label": "RFID Scanner",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 2,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Terminal", "/ocpp/"],
-      "path": "/ocpp/simulator/",
-      "label": "CP Simulator",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/localhost__landing_ocpp_dashboard.json
+++ b/pages/fixtures/localhost__landing_ocpp_dashboard.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 1,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Terminal", "/ocpp/"],
-      "path": "/ocpp/",
-      "label": "Dashboard",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/localhost__landing_ocpp_rfid.json
+++ b/pages/fixtures/localhost__landing_ocpp_rfid.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 3,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Terminal", "/ocpp/rfid/"],
-      "path": "/ocpp/rfid/",
-      "label": "RFID Scanner",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 2,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Satellite", "/ocpp/"],
-      "path": "/ocpp/simulator/",
-      "label": "CP Simulator",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 1,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Satellite", "/ocpp/"],
-      "path": "/ocpp/",
-      "label": "Dashboard",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/pages/fixtures/satellite_box__landing_ocpp_rfid.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_rfid.json
@@ -1,15 +1,1 @@
-[
-  {
-    "model": "pages.landing",
-    "pk": 3,
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": ["Satellite", "/ocpp/rfid/"],
-      "path": "/ocpp/rfid/",
-      "label": "RFID Scanner",
-      "enabled": true,
-      "description": ""
-    }
-  }
-]
+[]

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -11,6 +11,7 @@ cd "$BASE_DIR"
 FORCE=0
 CLEAN=0
 NO_RESTART=0
+CANARY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --latest)
@@ -25,12 +26,24 @@ while [[ $# -gt 0 ]]; do
       NO_RESTART=1
       shift
       ;;
+    --canary)
+      CANARY=1
+      shift
+      ;;
     *)
       echo "Unknown option: $1" >&2
       exit 1
       ;;
   esac
 done
+
+# Run in canary mode if requested
+if [[ $CANARY -eq 1 ]]; then
+  echo "Running canary upgrade test in Docker..."
+  docker build -t arthexis-canary -f Dockerfile.canary .
+  docker run --rm arthexis-canary
+  exit $?
+fi
 
 # Determine current and remote versions
 BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
## Summary
- add Dockerfile.canary to run upgrade smoke tests in a container
- allow upgrade.sh to run canary Docker build via new `--canary` flag
- clean landing fixtures and streamline SigilRoot creation to avoid SQLite locks

## Testing
- `python3 -m pre_commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c5eb96d8cc8326852492c385b0ccdd