### PR TITLE
Remove conflicting fixture primary keys

### DIFF
--- a/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__landing_ocpp_dashboard.json
+++ b/pages/fixtures/constellation__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__landing_ocpp_rfid.json
+++ b/pages/fixtures/constellation__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__module_ocpp.json
+++ b/pages/fixtures/constellation__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__module_rfid.json
+++ b/pages/fixtures/constellation__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_dashboard.json
+++ b/pages/fixtures/localhost__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_rfid.json
+++ b/pages/fixtures/localhost__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__module_ocpp.json
+++ b/pages/fixtures/localhost__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__module_rfid.json
+++ b/pages/fixtures/localhost__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_rfid.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__module_ocpp.json
+++ b/pages/fixtures/satellite_box__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__module_rfid.json
+++ b/pages/fixtures/satellite_box__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,


### PR DESCRIPTION
## Summary
- drop hard-coded primary keys from module and landing fixtures to avoid collisions when loading seed data

## Testing
- `pre-commit run --all-files`
- `./env-refresh.sh --clean`

------
https://chatgpt.com/codex/tasks/task_e_68c5edb7d39083268f9a62d917b1a593