### PR TITLE
Use natural keys for module and landing fixtures

### DIFF
--- a/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/constellation__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__landing_ocpp_dashboard.json
+++ b/pages/fixtures/constellation__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__landing_ocpp_rfid.json
+++ b/pages/fixtures/constellation__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__module_ocpp.json
+++ b/pages/fixtures/constellation__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__module_rfid.json
+++ b/pages/fixtures/constellation__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/localhost__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_dashboard.json
+++ b/pages/fixtures/localhost__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__landing_ocpp_rfid.json
+++ b/pages/fixtures/localhost__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__module_ocpp.json
+++ b/pages/fixtures/localhost__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__module_rfid.json
+++ b/pages/fixtures/localhost__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_cp_simulator.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__landing_ocpp_rfid.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.landing",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__module_ocpp.json
+++ b/pages/fixtures/satellite_box__module_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__module_rfid.json
+++ b/pages/fixtures/satellite_box__module_rfid.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.module",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,


### PR DESCRIPTION
## Summary
- Drop explicit primary keys from OCPP module fixtures and rely on natural keys
- Reference modules in landing fixtures using natural keys to avoid PK collisions

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`
- `pytest tests/test_fixture_check.py::FixtureCheckTests::test_warning_for_new_fixture -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed7c20c08326bb674730a5323da7