### PR TITLE
feat: allow aborting publish process

### DIFF
--- a/core/fixtures/todos__validate_screen_release_progress.json
+++ b/core/fixtures/todos__validate_screen_release_progress.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 16,
+    "fields": {
+      "description": "Validate screen Release progress",
+      "url": "/admin/core/releases/1/publish/"
+    }
+  }
+]

--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -68,6 +68,9 @@
 <p>{% trans 'Restarts' %}: {{ restart_count }}</p>
 <form method="get">
   <button type="submit" name="restart" value="1">{% trans 'Restart' %}</button>
+  {% if not done %}
+  <button type="submit" name="abort" value="1">{% trans 'Abort publish' %}</button>
+  {% endif %}
 </form>
 {% endblock %}
 

--- a/core/views.py
+++ b/core/views.py
@@ -9,6 +9,7 @@ from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, render, redirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.utils.translation import gettext as _
 from pathlib import Path
 import subprocess
 
@@ -390,6 +391,11 @@ def release_progress(request, pk: int, action: str):
         ctx = {"step": 0}
         if restart_path.exists():
             restart_path.unlink()
+    if request.GET.get("abort"):
+        ctx["error"] = _("Publish aborted")
+        request.session[session_key] = ctx
+        if lock_path.exists():
+            lock_path.unlink()
     restart_count = 0
     if restart_path.exists():
         try:

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -74,3 +74,14 @@ class ReleaseProgressViewTests(TestCase):
         run.assert_any_call(
             ["git", "commit", "-m", "chore: update fixtures"], check=True
         )
+
+    def test_abort_publish_stops_process(self):
+        url = reverse("release-progress", args=[self.release.pk, "publish"])
+        self.client.get(url)
+        lock_path = Path("locks") / f"release_publish_{self.release.pk}.json"
+        self.assertTrue(lock_path.exists())
+
+        response = self.client.get(f"{url}?abort=1")
+        self.assertContains(response, "Publish aborted")
+        self.assertIsNone(response.context["next_step"])
+        self.assertFalse(lock_path.exists())


### PR DESCRIPTION
## Summary
- allow publish progress to be aborted at any time
- show an abort button on the publish progress screen
- cover abort scenario with tests

## Testing
- `pre-commit run --all-files`
- `python manage.py test tests.test_release_progress -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c5f96c3b548326a94916881e51f02a