### PR TITLE
Restore cable size and conduit fill fixtures

### DIFF
--- a/awg/fixtures/cable_sizes__cablesize_1.json
+++ b/awg/fixtures/cable_sizes__cablesize_1.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 1,
+    "fields": {
+      "awg_size": "-4",
+      "material": "cu",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 409,
+      "amps_75c": 483,
+      "amps_90c": 546,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_10.json
+++ b/awg/fixtures/cable_sizes__cablesize_10.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 10,
+    "fields": {
+      "awg_size": "-1",
+      "material": "cu",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 262,
+      "amps_75c": 315,
+      "amps_90c": 357,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_11.json
+++ b/awg/fixtures/cable_sizes__cablesize_11.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 11,
+    "fields": {
+      "awg_size": "-1",
+      "material": "cu",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 200,
+      "amps_75c": 240,
+      "amps_90c": 272,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_12.json
+++ b/awg/fixtures/cable_sizes__cablesize_12.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 12,
+    "fields": {
+      "awg_size": "-1",
+      "material": "cu",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 125,
+      "amps_75c": 150,
+      "amps_90c": 170,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_13.json
+++ b/awg/fixtures/cable_sizes__cablesize_13.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 13,
+    "fields": {
+      "awg_size": "1",
+      "material": "cu",
+      "dia_in": 0.2893,
+      "dia_mm": 7.348,
+      "area_kcmil": 83.7,
+      "area_mm2": 42.4,
+      "k_ohm_km": 0.4066,
+      "k_ohm_kft": 0.1239,
+      "amps_60c": 110,
+      "amps_75c": 130,
+      "amps_90c": 145,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_14.json
+++ b/awg/fixtures/cable_sizes__cablesize_14.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 14,
+    "fields": {
+      "awg_size": "2",
+      "material": "cu",
+      "dia_in": 0.2576,
+      "dia_mm": 6.544,
+      "area_kcmil": 66.4,
+      "area_mm2": 33.4,
+      "k_ohm_km": 0.5127,
+      "k_ohm_kft": 0.1563,
+      "amps_60c": 95,
+      "amps_75c": 115,
+      "amps_90c": 130,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_15.json
+++ b/awg/fixtures/cable_sizes__cablesize_15.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 15,
+    "fields": {
+      "awg_size": "3",
+      "material": "cu",
+      "dia_in": 0.2294,
+      "dia_mm": 5.827,
+      "area_kcmil": 52.6,
+      "area_mm2": 26.7,
+      "k_ohm_km": 0.6465,
+      "k_ohm_kft": 0.197,
+      "amps_60c": 85,
+      "amps_75c": 100,
+      "amps_90c": 115,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_16.json
+++ b/awg/fixtures/cable_sizes__cablesize_16.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 16,
+    "fields": {
+      "awg_size": "4",
+      "material": "cu",
+      "dia_in": 0.2043,
+      "dia_mm": 5.189,
+      "area_kcmil": 41.7,
+      "area_mm2": 21.2,
+      "k_ohm_km": 0.8152,
+      "k_ohm_kft": 0.2485,
+      "amps_60c": 70,
+      "amps_75c": 85,
+      "amps_90c": 95,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_17.json
+++ b/awg/fixtures/cable_sizes__cablesize_17.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 17,
+    "fields": {
+      "awg_size": "6",
+      "material": "cu",
+      "dia_in": 0.162,
+      "dia_mm": 4.115,
+      "area_kcmil": 26.3,
+      "area_mm2": 13.3,
+      "k_ohm_km": 1.296,
+      "k_ohm_kft": 0.3951,
+      "amps_60c": 55,
+      "amps_75c": 65,
+      "amps_90c": 75,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_18.json
+++ b/awg/fixtures/cable_sizes__cablesize_18.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 18,
+    "fields": {
+      "awg_size": "8",
+      "material": "cu",
+      "dia_in": 0.1285,
+      "dia_mm": 3.264,
+      "area_kcmil": 16.5,
+      "area_mm2": 8.37,
+      "k_ohm_km": 2.061,
+      "k_ohm_kft": 0.6282,
+      "amps_60c": 40,
+      "amps_75c": 50,
+      "amps_90c": 55,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_19.json
+++ b/awg/fixtures/cable_sizes__cablesize_19.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 19,
+    "fields": {
+      "awg_size": "10",
+      "material": "cu",
+      "dia_in": 0.1019,
+      "dia_mm": 2.588,
+      "area_kcmil": 10.4,
+      "area_mm2": 5.26,
+      "k_ohm_km": 3.277,
+      "k_ohm_kft": 0.9989,
+      "amps_60c": 30,
+      "amps_75c": 35,
+      "amps_90c": 40,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_2.json
+++ b/awg/fixtures/cable_sizes__cablesize_2.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 2,
+    "fields": {
+      "awg_size": "-4",
+      "material": "cu",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 312,
+      "amps_75c": 368,
+      "amps_90c": 416,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_20.json
+++ b/awg/fixtures/cable_sizes__cablesize_20.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 20,
+    "fields": {
+      "awg_size": "12",
+      "material": "cu",
+      "dia_in": 0.0808,
+      "dia_mm": 2.053,
+      "area_kcmil": 6.53,
+      "area_mm2": 3.31,
+      "k_ohm_km": 5.211,
+      "k_ohm_kft": 1.588,
+      "amps_60c": 20,
+      "amps_75c": 25,
+      "amps_90c": 30,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_21.json
+++ b/awg/fixtures/cable_sizes__cablesize_21.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 21,
+    "fields": {
+      "awg_size": "14",
+      "material": "cu",
+      "dia_in": 0.0641,
+      "dia_mm": 1.628,
+      "area_kcmil": 4.11,
+      "area_mm2": 2.08,
+      "k_ohm_km": 8.286,
+      "k_ohm_kft": 2.525,
+      "amps_60c": 15,
+      "amps_75c": 20,
+      "amps_90c": 25,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_22.json
+++ b/awg/fixtures/cable_sizes__cablesize_22.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 22,
+    "fields": {
+      "awg_size": "-4",
+      "material": "al",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 315,
+      "amps_75c": 378,
+      "amps_90c": 430,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_23.json
+++ b/awg/fixtures/cable_sizes__cablesize_23.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 23,
+    "fields": {
+      "awg_size": "-4",
+      "material": "al",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 240,
+      "amps_75c": 288,
+      "amps_90c": 328,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_24.json
+++ b/awg/fixtures/cable_sizes__cablesize_24.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 24,
+    "fields": {
+      "awg_size": "-4",
+      "material": "al",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 150,
+      "amps_75c": 180,
+      "amps_90c": 205,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_25.json
+++ b/awg/fixtures/cable_sizes__cablesize_25.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 25,
+    "fields": {
+      "awg_size": "-3",
+      "material": "al",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 273,
+      "amps_75c": 325,
+      "amps_90c": 367,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_26.json
+++ b/awg/fixtures/cable_sizes__cablesize_26.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 26,
+    "fields": {
+      "awg_size": "-3",
+      "material": "al",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 208,
+      "amps_75c": 248,
+      "amps_90c": 280,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_27.json
+++ b/awg/fixtures/cable_sizes__cablesize_27.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 27,
+    "fields": {
+      "awg_size": "-3",
+      "material": "al",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 130,
+      "amps_75c": 155,
+      "amps_90c": 175,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_28.json
+++ b/awg/fixtures/cable_sizes__cablesize_28.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 28,
+    "fields": {
+      "awg_size": "-2",
+      "material": "al",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 241,
+      "amps_75c": 283,
+      "amps_90c": 315,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_29.json
+++ b/awg/fixtures/cable_sizes__cablesize_29.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 29,
+    "fields": {
+      "awg_size": "-2",
+      "material": "al",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 184,
+      "amps_75c": 216,
+      "amps_90c": 240,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_3.json
+++ b/awg/fixtures/cable_sizes__cablesize_3.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 3,
+    "fields": {
+      "awg_size": "-4",
+      "material": "cu",
+      "dia_in": 0.46,
+      "dia_mm": 11.684,
+      "area_kcmil": 212.0,
+      "area_mm2": 107.0,
+      "k_ohm_km": 0.1608,
+      "k_ohm_kft": 0.04901,
+      "amps_60c": 195,
+      "amps_75c": 230,
+      "amps_90c": 260,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_30.json
+++ b/awg/fixtures/cable_sizes__cablesize_30.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 30,
+    "fields": {
+      "awg_size": "-2",
+      "material": "al",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 115,
+      "amps_75c": 135,
+      "amps_90c": 150,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_31.json
+++ b/awg/fixtures/cable_sizes__cablesize_31.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 31,
+    "fields": {
+      "awg_size": "-1",
+      "material": "al",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 210,
+      "amps_75c": 252,
+      "amps_90c": 283,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_32.json
+++ b/awg/fixtures/cable_sizes__cablesize_32.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 32,
+    "fields": {
+      "awg_size": "-1",
+      "material": "al",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 160,
+      "amps_75c": 192,
+      "amps_90c": 216,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_33.json
+++ b/awg/fixtures/cable_sizes__cablesize_33.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 33,
+    "fields": {
+      "awg_size": "-1",
+      "material": "al",
+      "dia_in": 0.3249,
+      "dia_mm": 8.251,
+      "area_kcmil": 106.0,
+      "area_mm2": 53.5,
+      "k_ohm_km": 0.3224,
+      "k_ohm_kft": 0.09827,
+      "amps_60c": 100,
+      "amps_75c": 120,
+      "amps_90c": 135,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_34.json
+++ b/awg/fixtures/cable_sizes__cablesize_34.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 34,
+    "fields": {
+      "awg_size": "1",
+      "material": "al",
+      "dia_in": 0.2893,
+      "dia_mm": 7.348,
+      "area_kcmil": 83.7,
+      "area_mm2": 42.4,
+      "k_ohm_km": 0.4066,
+      "k_ohm_kft": 0.1239,
+      "amps_60c": 85,
+      "amps_75c": 100,
+      "amps_90c": 115,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_35.json
+++ b/awg/fixtures/cable_sizes__cablesize_35.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 35,
+    "fields": {
+      "awg_size": "2",
+      "material": "al",
+      "dia_in": 0.2576,
+      "dia_mm": 6.544,
+      "area_kcmil": 66.4,
+      "area_mm2": 33.4,
+      "k_ohm_km": 0.5127,
+      "k_ohm_kft": 0.1563,
+      "amps_60c": 75,
+      "amps_75c": 90,
+      "amps_90c": 100,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_36.json
+++ b/awg/fixtures/cable_sizes__cablesize_36.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 36,
+    "fields": {
+      "awg_size": "3",
+      "material": "al",
+      "dia_in": 0.2294,
+      "dia_mm": 5.827,
+      "area_kcmil": 52.6,
+      "area_mm2": 26.7,
+      "k_ohm_km": 0.6465,
+      "k_ohm_kft": 0.197,
+      "amps_60c": 65,
+      "amps_75c": 75,
+      "amps_90c": 85,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_37.json
+++ b/awg/fixtures/cable_sizes__cablesize_37.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 37,
+    "fields": {
+      "awg_size": "4",
+      "material": "al",
+      "dia_in": 0.2043,
+      "dia_mm": 5.189,
+      "area_kcmil": 41.7,
+      "area_mm2": 21.2,
+      "k_ohm_km": 0.8152,
+      "k_ohm_kft": 0.2485,
+      "amps_60c": 55,
+      "amps_75c": 65,
+      "amps_90c": 75,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_38.json
+++ b/awg/fixtures/cable_sizes__cablesize_38.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 38,
+    "fields": {
+      "awg_size": "6",
+      "material": "al",
+      "dia_in": 0.162,
+      "dia_mm": 4.115,
+      "area_kcmil": 26.3,
+      "area_mm2": 13.3,
+      "k_ohm_km": 1.296,
+      "k_ohm_kft": 0.3951,
+      "amps_60c": 40,
+      "amps_75c": 50,
+      "amps_90c": 55,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_39.json
+++ b/awg/fixtures/cable_sizes__cablesize_39.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 39,
+    "fields": {
+      "awg_size": "8",
+      "material": "al",
+      "dia_in": 0.1285,
+      "dia_mm": 3.264,
+      "area_kcmil": 16.5,
+      "area_mm2": 8.37,
+      "k_ohm_km": 2.061,
+      "k_ohm_kft": 0.6282,
+      "amps_60c": 35,
+      "amps_75c": 40,
+      "amps_90c": 45,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_4.json
+++ b/awg/fixtures/cable_sizes__cablesize_4.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 4,
+    "fields": {
+      "awg_size": "-3",
+      "material": "cu",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 346,
+      "amps_75c": 420,
+      "amps_90c": 472,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_40.json
+++ b/awg/fixtures/cable_sizes__cablesize_40.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 40,
+    "fields": {
+      "awg_size": "10",
+      "material": "al",
+      "dia_in": 0.1019,
+      "dia_mm": 2.588,
+      "area_kcmil": 10.4,
+      "area_mm2": 5.26,
+      "k_ohm_km": 3.277,
+      "k_ohm_kft": 0.9989,
+      "amps_60c": 25,
+      "amps_75c": 30,
+      "amps_90c": 35,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_41.json
+++ b/awg/fixtures/cable_sizes__cablesize_41.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 41,
+    "fields": {
+      "awg_size": "12",
+      "material": "al",
+      "dia_in": 0.0808,
+      "dia_mm": 2.053,
+      "area_kcmil": 6.53,
+      "area_mm2": 3.31,
+      "k_ohm_km": 5.211,
+      "k_ohm_kft": 1.588,
+      "amps_60c": 15,
+      "amps_75c": 20,
+      "amps_90c": 25,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_42.json
+++ b/awg/fixtures/cable_sizes__cablesize_42.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 42,
+    "fields": {
+      "awg_size": "14",
+      "material": "al",
+      "dia_in": 0.0641,
+      "dia_mm": 1.628,
+      "area_kcmil": 4.11,
+      "area_mm2": 2.08,
+      "k_ohm_km": 8.286,
+      "k_ohm_kft": 2.525,
+      "amps_60c": 0,
+      "amps_75c": 0,
+      "amps_90c": 0,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_5.json
+++ b/awg/fixtures/cable_sizes__cablesize_5.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 5,
+    "fields": {
+      "awg_size": "-3",
+      "material": "cu",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 264,
+      "amps_75c": 320,
+      "amps_90c": 360,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_6.json
+++ b/awg/fixtures/cable_sizes__cablesize_6.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 6,
+    "fields": {
+      "awg_size": "-3",
+      "material": "cu",
+      "dia_in": 0.4096,
+      "dia_mm": 10.405,
+      "area_kcmil": 168.0,
+      "area_mm2": 85.0,
+      "k_ohm_km": 0.2028,
+      "k_ohm_kft": 0.0618,
+      "amps_60c": 165,
+      "amps_75c": 200,
+      "amps_90c": 225,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_7.json
+++ b/awg/fixtures/cable_sizes__cablesize_7.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 7,
+    "fields": {
+      "awg_size": "-2",
+      "material": "cu",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 304,
+      "amps_75c": 367,
+      "amps_90c": 409,
+      "line_num": 3
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_8.json
+++ b/awg/fixtures/cable_sizes__cablesize_8.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 8,
+    "fields": {
+      "awg_size": "-2",
+      "material": "cu",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 232,
+      "amps_75c": 280,
+      "amps_90c": 312,
+      "line_num": 2
+    }
+  }
+]

--- a/awg/fixtures/cable_sizes__cablesize_9.json
+++ b/awg/fixtures/cable_sizes__cablesize_9.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "model": "awg.cablesize",
+    "pk": 9,
+    "fields": {
+      "awg_size": "-2",
+      "material": "cu",
+      "dia_in": 0.3648,
+      "dia_mm": 9.266,
+      "area_kcmil": 133.0,
+      "area_mm2": 67.4,
+      "k_ohm_km": 0.2557,
+      "k_ohm_kft": 0.07793,
+      "amps_60c": 145,
+      "amps_75c": 175,
+      "amps_90c": 195,
+      "line_num": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_1.json
+++ b/awg/fixtures/conduit_fills__conduitfill_1.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 1,
+    "fields": {
+      "trade_size": "1/2",
+      "conduit": "EMT",
+      "awg_14": 12,
+      "awg_4": 1,
+      "awg_000": null,
+      "awg_10": 5,
+      "awg_8": 3,
+      "awg_12": 9,
+      "awg_6": 2,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": null,
+      "awg_0000": null,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_10.json
+++ b/awg/fixtures/conduit_fills__conduitfill_10.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 10,
+    "fields": {
+      "trade_size": "1",
+      "conduit": "IMC",
+      "awg_14": 39,
+      "awg_4": 4,
+      "awg_000": 1,
+      "awg_10": 18,
+      "awg_8": 10,
+      "awg_12": 29,
+      "awg_6": 7,
+      "awg_1": 2,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 4,
+      "awg_2": 3
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_11.json
+++ b/awg/fixtures/conduit_fills__conduitfill_11.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 11,
+    "fields": {
+      "trade_size": "1",
+      "conduit": "RMC",
+      "awg_14": 36,
+      "awg_4": 4,
+      "awg_000": 1,
+      "awg_10": 17,
+      "awg_8": 9,
+      "awg_12": 26,
+      "awg_6": 7,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 3,
+      "awg_2": 3
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_12.json
+++ b/awg/fixtures/conduit_fills__conduitfill_12.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 12,
+    "fields": {
+      "trade_size": "1",
+      "conduit": "FMC",
+      "awg_14": 33,
+      "awg_4": 4,
+      "awg_000": 1,
+      "awg_10": 15,
+      "awg_8": 9,
+      "awg_12": 24,
+      "awg_6": 6,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 3,
+      "awg_2": 3
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_13.json
+++ b/awg/fixtures/conduit_fills__conduitfill_13.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 13,
+    "fields": {
+      "trade_size": "1 1/4",
+      "conduit": "EMT",
+      "awg_14": 61,
+      "awg_4": 7,
+      "awg_000": 1,
+      "awg_10": 28,
+      "awg_8": 16,
+      "awg_12": 45,
+      "awg_6": 12,
+      "awg_1": 4,
+      "awg_0": 3,
+      "awg_00": 2,
+      "awg_0000": 1,
+      "awg_3": 6,
+      "awg_2": 5
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_14.json
+++ b/awg/fixtures/conduit_fills__conduitfill_14.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 14,
+    "fields": {
+      "trade_size": "1 1/4",
+      "conduit": "IMC",
+      "awg_14": 68,
+      "awg_4": 8,
+      "awg_000": 2,
+      "awg_10": 31,
+      "awg_8": 18,
+      "awg_12": 49,
+      "awg_6": 13,
+      "awg_1": 4,
+      "awg_0": 3,
+      "awg_00": 3,
+      "awg_0000": 1,
+      "awg_3": 6,
+      "awg_2": 5
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_15.json
+++ b/awg/fixtures/conduit_fills__conduitfill_15.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 15,
+    "fields": {
+      "trade_size": "1 1/4",
+      "conduit": "RMC",
+      "awg_14": 63,
+      "awg_4": 7,
+      "awg_000": 1,
+      "awg_10": 29,
+      "awg_8": 16,
+      "awg_12": 46,
+      "awg_6": 12,
+      "awg_1": 4,
+      "awg_0": 3,
+      "awg_00": 2,
+      "awg_0000": 1,
+      "awg_3": 6,
+      "awg_2": 5
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_16.json
+++ b/awg/fixtures/conduit_fills__conduitfill_16.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 16,
+    "fields": {
+      "trade_size": "1 1/4",
+      "conduit": "FMC",
+      "awg_14": 52,
+      "awg_4": 6,
+      "awg_000": 1,
+      "awg_10": 24,
+      "awg_8": 14,
+      "awg_12": 38,
+      "awg_6": 10,
+      "awg_1": 3,
+      "awg_0": 2,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 5,
+      "awg_2": 4
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_17.json
+++ b/awg/fixtures/conduit_fills__conduitfill_17.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 17,
+    "fields": {
+      "trade_size": "1 1/2",
+      "conduit": "EMT",
+      "awg_14": 84,
+      "awg_4": 10,
+      "awg_000": 3,
+      "awg_10": 38,
+      "awg_8": 22,
+      "awg_12": 61,
+      "awg_6": 16,
+      "awg_1": 5,
+      "awg_0": 4,
+      "awg_00": 3,
+      "awg_0000": 2,
+      "awg_3": 8,
+      "awg_2": 7
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_18.json
+++ b/awg/fixtures/conduit_fills__conduitfill_18.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 18,
+    "fields": {
+      "trade_size": "1 1/2",
+      "conduit": "IMC",
+      "awg_14": 91,
+      "awg_4": 11,
+      "awg_000": 3,
+      "awg_10": 42,
+      "awg_8": 24,
+      "awg_12": 67,
+      "awg_6": 17,
+      "awg_1": 5,
+      "awg_0": 4,
+      "awg_00": 4,
+      "awg_0000": 2,
+      "awg_3": 9,
+      "awg_2": 7
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_19.json
+++ b/awg/fixtures/conduit_fills__conduitfill_19.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 19,
+    "fields": {
+      "trade_size": "1 1/2",
+      "conduit": "RMC",
+      "awg_14": 85,
+      "awg_4": 10,
+      "awg_000": 3,
+      "awg_10": 39,
+      "awg_8": 22,
+      "awg_12": 62,
+      "awg_6": 16,
+      "awg_1": 5,
+      "awg_0": 4,
+      "awg_00": 3,
+      "awg_0000": 2,
+      "awg_3": 8,
+      "awg_2": 7
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_2.json
+++ b/awg/fixtures/conduit_fills__conduitfill_2.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 2,
+    "fields": {
+      "trade_size": "1/2",
+      "conduit": "IMC",
+      "awg_14": 14,
+      "awg_4": 1,
+      "awg_000": null,
+      "awg_10": 6,
+      "awg_8": 3,
+      "awg_12": 10,
+      "awg_6": 2,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": null,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_20.json
+++ b/awg/fixtures/conduit_fills__conduitfill_20.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 20,
+    "fields": {
+      "trade_size": "1 1/2",
+      "conduit": "FMC",
+      "awg_14": 76,
+      "awg_4": 9,
+      "awg_000": 2,
+      "awg_10": 35,
+      "awg_8": 20,
+      "awg_12": 56,
+      "awg_6": 14,
+      "awg_1": 4,
+      "awg_0": 4,
+      "awg_00": 3,
+      "awg_0000": 1,
+      "awg_3": 7,
+      "awg_2": 6
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_21.json
+++ b/awg/fixtures/conduit_fills__conduitfill_21.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 21,
+    "fields": {
+      "trade_size": "2",
+      "conduit": "EMT",
+      "awg_14": 138,
+      "awg_4": 16,
+      "awg_000": 5,
+      "awg_10": 63,
+      "awg_8": 36,
+      "awg_12": 101,
+      "awg_6": 26,
+      "awg_1": 8,
+      "awg_0": 7,
+      "awg_00": 6,
+      "awg_0000": 4,
+      "awg_3": 13,
+      "awg_2": 11
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_22.json
+++ b/awg/fixtures/conduit_fills__conduitfill_22.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 22,
+    "fields": {
+      "trade_size": "2",
+      "conduit": "IMC",
+      "awg_14": 149,
+      "awg_4": 17,
+      "awg_000": 5,
+      "awg_10": 69,
+      "awg_8": 39,
+      "awg_12": 109,
+      "awg_6": 28,
+      "awg_1": 9,
+      "awg_0": 8,
+      "awg_00": 6,
+      "awg_0000": 4,
+      "awg_3": 15,
+      "awg_2": 12
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_23.json
+++ b/awg/fixtures/conduit_fills__conduitfill_23.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 23,
+    "fields": {
+      "trade_size": "2",
+      "conduit": "RMC",
+      "awg_14": 140,
+      "awg_4": 16,
+      "awg_000": 5,
+      "awg_10": 64,
+      "awg_8": 37,
+      "awg_12": 102,
+      "awg_6": 27,
+      "awg_1": 8,
+      "awg_0": 7,
+      "awg_00": 6,
+      "awg_0000": 4,
+      "awg_3": 14,
+      "awg_2": 11
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_24.json
+++ b/awg/fixtures/conduit_fills__conduitfill_24.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 24,
+    "fields": {
+      "trade_size": "2",
+      "conduit": "FMC",
+      "awg_14": 135,
+      "awg_4": 16,
+      "awg_000": 5,
+      "awg_10": 62,
+      "awg_8": 35,
+      "awg_12": 98,
+      "awg_6": 25,
+      "awg_1": 8,
+      "awg_0": 7,
+      "awg_00": 6,
+      "awg_0000": 4,
+      "awg_3": 13,
+      "awg_2": 11
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_25.json
+++ b/awg/fixtures/conduit_fills__conduitfill_25.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 25,
+    "fields": {
+      "trade_size": "2 1/2",
+      "conduit": "EMT",
+      "awg_14": 241,
+      "awg_4": 28,
+      "awg_000": 8,
+      "awg_10": 111,
+      "awg_8": 64,
+      "awg_12": 176,
+      "awg_6": 46,
+      "awg_1": 15,
+      "awg_0": 12,
+      "awg_00": 10,
+      "awg_0000": 7,
+      "awg_3": 24,
+      "awg_2": 20
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_26.json
+++ b/awg/fixtures/conduit_fills__conduitfill_26.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 26,
+    "fields": {
+      "trade_size": "2 1/2",
+      "conduit": "IMC",
+      "awg_14": 211,
+      "awg_4": 25,
+      "awg_000": 7,
+      "awg_10": 97,
+      "awg_8": 56,
+      "awg_12": 154,
+      "awg_6": 40,
+      "awg_1": 13,
+      "awg_0": 11,
+      "awg_00": 9,
+      "awg_0000": 6,
+      "awg_3": 21,
+      "awg_2": 17
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_27.json
+++ b/awg/fixtures/conduit_fills__conduitfill_27.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 27,
+    "fields": {
+      "trade_size": "2 1/2",
+      "conduit": "RMC",
+      "awg_14": 200,
+      "awg_4": 23,
+      "awg_000": 7,
+      "awg_10": 92,
+      "awg_8": 53,
+      "awg_12": 146,
+      "awg_6": 38,
+      "awg_1": 12,
+      "awg_0": 10,
+      "awg_00": 8,
+      "awg_0000": 6,
+      "awg_3": 20,
+      "awg_2": 17
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_28.json
+++ b/awg/fixtures/conduit_fills__conduitfill_28.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 28,
+    "fields": {
+      "trade_size": "2 1/2",
+      "conduit": "FMC",
+      "awg_14": 202,
+      "awg_4": 24,
+      "awg_000": 7,
+      "awg_10": 93,
+      "awg_8": 53,
+      "awg_12": 147,
+      "awg_6": 38,
+      "awg_1": 12,
+      "awg_0": 10,
+      "awg_00": 9,
+      "awg_0000": 6,
+      "awg_3": 20,
+      "awg_2": 17
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_29.json
+++ b/awg/fixtures/conduit_fills__conduitfill_29.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 29,
+    "fields": {
+      "trade_size": "3",
+      "conduit": "EMT",
+      "awg_14": 364,
+      "awg_4": 43,
+      "awg_000": 13,
+      "awg_10": 167,
+      "awg_8": 96,
+      "awg_12": 266,
+      "awg_6": 69,
+      "awg_1": 22,
+      "awg_0": 19,
+      "awg_00": 16,
+      "awg_0000": 11,
+      "awg_3": 36,
+      "awg_2": 30
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_3.json
+++ b/awg/fixtures/conduit_fills__conduitfill_3.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 3,
+    "fields": {
+      "trade_size": "1/2",
+      "conduit": "RMC",
+      "awg_14": 13,
+      "awg_4": 1,
+      "awg_000": null,
+      "awg_10": 6,
+      "awg_8": 3,
+      "awg_12": 9,
+      "awg_6": 2,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": null,
+      "awg_0000": null,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_30.json
+++ b/awg/fixtures/conduit_fills__conduitfill_30.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 30,
+    "fields": {
+      "trade_size": "3",
+      "conduit": "IMC",
+      "awg_14": 326,
+      "awg_4": 38,
+      "awg_000": 12,
+      "awg_10": 150,
+      "awg_8": 86,
+      "awg_12": 238,
+      "awg_6": 62,
+      "awg_1": 20,
+      "awg_0": 17,
+      "awg_00": 14,
+      "awg_0000": 9,
+      "awg_3": 32,
+      "awg_2": 27
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_31.json
+++ b/awg/fixtures/conduit_fills__conduitfill_31.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 31,
+    "fields": {
+      "trade_size": "3",
+      "conduit": "RMC",
+      "awg_14": 309,
+      "awg_4": 36,
+      "awg_000": 11,
+      "awg_10": 142,
+      "awg_8": 82,
+      "awg_12": 225,
+      "awg_6": 59,
+      "awg_1": 19,
+      "awg_0": 16,
+      "awg_00": 13,
+      "awg_0000": 9,
+      "awg_3": 31,
+      "awg_2": 26
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_32.json
+++ b/awg/fixtures/conduit_fills__conduitfill_32.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 32,
+    "fields": {
+      "trade_size": "3",
+      "conduit": "FMC",
+      "awg_14": 291,
+      "awg_4": 34,
+      "awg_000": 10,
+      "awg_10": 134,
+      "awg_8": 77,
+      "awg_12": 212,
+      "awg_6": 55,
+      "awg_1": 18,
+      "awg_0": 15,
+      "awg_00": 12,
+      "awg_0000": 8,
+      "awg_3": 29,
+      "awg_2": 24
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_33.json
+++ b/awg/fixtures/conduit_fills__conduitfill_33.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 33,
+    "fields": {
+      "trade_size": "3 1/2",
+      "conduit": "EMT",
+      "awg_14": 476,
+      "awg_4": 56,
+      "awg_000": 17,
+      "awg_10": 219,
+      "awg_8": 126,
+      "awg_12": 347,
+      "awg_6": 91,
+      "awg_1": 29,
+      "awg_0": 25,
+      "awg_00": 20,
+      "awg_0000": 14,
+      "awg_3": 47,
+      "awg_2": 40
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_34.json
+++ b/awg/fixtures/conduit_fills__conduitfill_34.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 34,
+    "fields": {
+      "trade_size": "3 1/2",
+      "conduit": "IMC",
+      "awg_14": 436,
+      "awg_4": 51,
+      "awg_000": 16,
+      "awg_10": 200,
+      "awg_8": 115,
+      "awg_12": 318,
+      "awg_6": 83,
+      "awg_1": 27,
+      "awg_0": 23,
+      "awg_00": 19,
+      "awg_0000": 13,
+      "awg_3": 43,
+      "awg_2": 36
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_35.json
+++ b/awg/fixtures/conduit_fills__conduitfill_35.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 35,
+    "fields": {
+      "trade_size": "3 1/2",
+      "conduit": "RMC",
+      "awg_14": 412,
+      "awg_4": 48,
+      "awg_000": 15,
+      "awg_10": 189,
+      "awg_8": 109,
+      "awg_12": 301,
+      "awg_6": 79,
+      "awg_1": 25,
+      "awg_0": 21,
+      "awg_00": 18,
+      "awg_0000": 12,
+      "awg_3": 41,
+      "awg_2": 34
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_36.json
+++ b/awg/fixtures/conduit_fills__conduitfill_36.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 36,
+    "fields": {
+      "trade_size": "3 1/2",
+      "conduit": "FMC",
+      "awg_14": 396,
+      "awg_4": 46,
+      "awg_000": 14,
+      "awg_10": 182,
+      "awg_8": 105,
+      "awg_12": 289,
+      "awg_6": 76,
+      "awg_1": 24,
+      "awg_0": 20,
+      "awg_00": 17,
+      "awg_0000": 12,
+      "awg_3": 39,
+      "awg_2": 33
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_37.json
+++ b/awg/fixtures/conduit_fills__conduitfill_37.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 37,
+    "fields": {
+      "trade_size": "4",
+      "conduit": "EMT",
+      "awg_14": 608,
+      "awg_4": 71,
+      "awg_000": 22,
+      "awg_10": 279,
+      "awg_8": 161,
+      "awg_12": 443,
+      "awg_6": 116,
+      "awg_1": 37,
+      "awg_0": 32,
+      "awg_00": 26,
+      "awg_0000": 18,
+      "awg_3": 60,
+      "awg_2": 51
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_38.json
+++ b/awg/fixtures/conduit_fills__conduitfill_38.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 38,
+    "fields": {
+      "trade_size": "4",
+      "conduit": "IMC",
+      "awg_14": 562,
+      "awg_4": 66,
+      "awg_000": 20,
+      "awg_10": 258,
+      "awg_8": 149,
+      "awg_12": 410,
+      "awg_6": 107,
+      "awg_1": 35,
+      "awg_0": 29,
+      "awg_00": 24,
+      "awg_0000": 17,
+      "awg_3": 56,
+      "awg_2": 47
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_39.json
+++ b/awg/fixtures/conduit_fills__conduitfill_39.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 39,
+    "fields": {
+      "trade_size": "4",
+      "conduit": "RMC",
+      "awg_14": 531,
+      "awg_4": 62,
+      "awg_000": 19,
+      "awg_10": 244,
+      "awg_8": 140,
+      "awg_12": 387,
+      "awg_6": 101,
+      "awg_1": 33,
+      "awg_0": 27,
+      "awg_00": 23,
+      "awg_0000": 16,
+      "awg_3": 53,
+      "awg_2": 44
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_4.json
+++ b/awg/fixtures/conduit_fills__conduitfill_4.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 4,
+    "fields": {
+      "trade_size": "1/2",
+      "conduit": "FMC",
+      "awg_14": 13,
+      "awg_4": 1,
+      "awg_000": null,
+      "awg_10": 6,
+      "awg_8": 3,
+      "awg_12": 9,
+      "awg_6": 2,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": null,
+      "awg_0000": null,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_40.json
+++ b/awg/fixtures/conduit_fills__conduitfill_40.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 40,
+    "fields": {
+      "trade_size": "4",
+      "conduit": "FMC",
+      "awg_14": 518,
+      "awg_4": 61,
+      "awg_000": 18,
+      "awg_10": 238,
+      "awg_8": 137,
+      "awg_12": 378,
+      "awg_6": 99,
+      "awg_1": 32,
+      "awg_0": 27,
+      "awg_00": 22,
+      "awg_0000": 15,
+      "awg_3": 51,
+      "awg_2": 43
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_5.json
+++ b/awg/fixtures/conduit_fills__conduitfill_5.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 5,
+    "fields": {
+      "trade_size": "3/4",
+      "conduit": "EMT",
+      "awg_14": 22,
+      "awg_4": 2,
+      "awg_000": 1,
+      "awg_10": 10,
+      "awg_8": 6,
+      "awg_12": 16,
+      "awg_6": 4,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_6.json
+++ b/awg/fixtures/conduit_fills__conduitfill_6.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 6,
+    "fields": {
+      "trade_size": "3/4",
+      "conduit": "IMC",
+      "awg_14": 24,
+      "awg_4": 3,
+      "awg_000": 1,
+      "awg_10": 11,
+      "awg_8": 6,
+      "awg_12": 17,
+      "awg_6": 4,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 2,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_7.json
+++ b/awg/fixtures/conduit_fills__conduitfill_7.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 7,
+    "fields": {
+      "trade_size": "3/4",
+      "conduit": "RMC",
+      "awg_14": 22,
+      "awg_4": 2,
+      "awg_000": 1,
+      "awg_10": 10,
+      "awg_8": 6,
+      "awg_12": 16,
+      "awg_6": 4,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_8.json
+++ b/awg/fixtures/conduit_fills__conduitfill_8.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 8,
+    "fields": {
+      "trade_size": "3/4",
+      "conduit": "FMC",
+      "awg_14": 22,
+      "awg_4": 2,
+      "awg_000": 1,
+      "awg_10": 10,
+      "awg_8": 6,
+      "awg_12": 16,
+      "awg_6": 4,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 1,
+      "awg_2": 1
+    }
+  }
+]

--- a/awg/fixtures/conduit_fills__conduitfill_9.json
+++ b/awg/fixtures/conduit_fills__conduitfill_9.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "model": "awg.conduitfill",
+    "pk": 9,
+    "fields": {
+      "trade_size": "1",
+      "conduit": "EMT",
+      "awg_14": 35,
+      "awg_4": 4,
+      "awg_000": 1,
+      "awg_10": 16,
+      "awg_8": 9,
+      "awg_12": 26,
+      "awg_6": 7,
+      "awg_1": 1,
+      "awg_0": 1,
+      "awg_00": 1,
+      "awg_0000": 1,
+      "awg_3": 3,
+      "awg_2": 3
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- repopulate CableSize fixtures with original data
- repopulate ConduitFill fixtures with original data

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9f440748326a7d4a0721ecbd234