### PR TITLE
feat(docs): show model descriptions

### DIFF
--- a/pages/templates/admin_doc/model_index.html
+++ b/pages/templates/admin_doc/model_index.html
@@ -1,0 +1,62 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block coltype %}colSM{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; {% translate 'Models' %}
+</div>
+{% endblock %}
+
+{% block title %}{% translate 'Models' %}{% endblock %}
+
+{% block content %}
+
+<h1>{% translate 'Model documentation' %}</h1>
+
+{% regroup models by app_config as grouped_models %}
+
+<div id="content-main">
+{% for group in grouped_models %}
+<div class="module">
+<h2 id="app-{{ group.grouper.label }}">{{ group.grouper.verbose_name }} ({{ group.grouper.name }})</h2>
+
+<table class="xfull">
+  <thead>
+    <tr>
+      <th scope="col">{% translate 'Model name' %}</th>
+      <th scope="col">{% translate 'Description' %}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for model in group.list %}
+  <tr>
+    <th scope="row"><a href="{% url 'django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
+    <td>{{ model.model.__doc__|default_if_none:""|trim|linebreaksbr }}</td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+</div>
+{% endfor %}
+
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related" class="sidebar">
+<div class="module">
+<h2>{% translate 'Model groups' %}</h2>
+<ul>
+{% regroup models by app_config as grouped_models %}
+{% for group in grouped_models %}
+    <li><a href="#app-{{ group.grouper.label }}">{{ group.grouper.verbose_name }}</a></li>
+{% endfor %}
+</ul>
+</div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- display each model's docstring alongside its name in admin docs

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c5fbc25c108326aac13d5ebb95359b