### PR TITLE
Show create prompt for empty Future Actions models

### DIFF
--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -113,7 +113,7 @@
         {% if future_items.models %}
             <ul class="actionlist">
                 {% for item in future_items.models %}
-                <li class="changelink"><a href="{{ item.url }}">Browse {{ item.label|capfirst }}</a></li>
+                <li class="changelink"><a href="{{ item.url }}">{% if item.has_instances %}{% translate 'Browse' %}{% else %}{% translate 'Create some' %}{% endif %} {{ item.label|capfirst }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -136,7 +136,15 @@ def future_action_items(context):
     for entry in user.admin_history.all()[:10]:
         if entry.content_type_id in seen or not entry.url:
             continue
-        model_items.append({"url": entry.url, "label": entry.admin_label})
+        model = entry.content_type.model_class() if entry.content_type else None
+        has_instances = bool(model and model.objects.exists())
+        model_items.append(
+            {
+                "url": entry.url,
+                "label": entry.admin_label,
+                "has_instances": has_instances,
+            }
+        )
         seen.add(entry.content_type_id)
 
     # Favorites
@@ -151,7 +159,10 @@ def future_action_items(context):
         )
         url = admin_changelist_url(ct)
         if url:
-            model_items.append({"url": url, "label": label})
+            has_instances = bool(model and model.objects.exists())
+            model_items.append(
+                {"url": url, "label": label, "has_instances": has_instances}
+            )
             seen.add(ct.id)
 
     # Models with user data
@@ -166,7 +177,7 @@ def future_action_items(context):
         label = model._meta.verbose_name_plural
         url = admin_changelist_url(ct)
         if url:
-            model_items.append({"url": url, "label": label})
+            model_items.append({"url": url, "label": label, "has_instances": True})
             seen.add(ct.id)
 
     todos = [

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -763,9 +763,16 @@ class FavoriteTests(TestCase):
             ).exists()
         )
 
-    def test_dashboard_uses_browse_label(self):
+    def test_dashboard_uses_create_label_when_no_instances(self):
         ct = ContentType.objects.get_by_natural_key("pages", "application")
         Favorite.objects.create(user=self.user, content_type=ct)
+        resp = self.client.get(reverse("admin:index"))
+        self.assertContains(resp, "Create some Applications")
+
+    def test_dashboard_uses_browse_label_with_instances(self):
+        ct = ContentType.objects.get_by_natural_key("pages", "application")
+        Favorite.objects.create(user=self.user, content_type=ct)
+        Application.objects.create(name="app1")
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, "Browse Applications")
 


### PR DESCRIPTION
## Summary
- indicate when future-action models lack data by adding `has_instances`
- display "Create some [Model]" for empty models in admin dashboard
- test future actions list for empty and populated models

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py migrate --noinput`
- `pre-commit run --all-files`
- `python manage.py test pages.tests.FavoriteTests.test_dashboard_uses_create_label_when_no_instances pages.tests.FavoriteTests.test_dashboard_uses_browse_label_with_instances -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68c5fb77dad88326a7d44e5c5065c74b