### PR TITLE
feat: integrate Odoo product selection

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -110,6 +110,11 @@ urlpatterns = [
         core_views.todo_done,
         name="todo-done",
     ),
+    path(
+        "admin/core/odoo-products/",
+        core_views.odoo_products,
+        name="odoo-products",
+    ),
     path("admin/", admin.site.urls),
     path("i18n/setlang/", csrf_exempt(set_language), name="set_language"),
     path("api/", include("core.workgroup_urls")),

--- a/core/admin.py
+++ b/core/admin.py
@@ -57,6 +57,7 @@ from .models import (
     Todo,
 )
 from .user_data import EntityModelAdmin
+from .widgets import OdooProductWidget
 
 
 admin.site.unregister(Group)
@@ -956,7 +957,19 @@ class EVModelAdmin(EntityModelAdmin):
     list_filter = ("brand",)
 
 
-admin.site.register(Product)
+class ProductAdminForm(forms.ModelForm):
+    odoo_product = forms.JSONField(required=False, widget=OdooProductWidget)
+
+    class Meta:
+        model = Product
+        fields = "__all__"
+
+
+@admin.register(Product)
+class ProductAdmin(EntityModelAdmin):
+    form = ProductAdminForm
+
+
 admin.site.register(Subscription)
 
 

--- a/core/fixtures/todos__validate_screen_product_admin.json
+++ b/core/fixtures/todos__validate_screen_product_admin.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 16,
+    "fields": {
+      "description": "Validate screen Product admin",
+      "url": "/admin/core/product/"
+    }
+  }
+]

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -189,6 +189,14 @@ class Migration(migrations.Migration):
                     "renewal_period",
                     models.PositiveIntegerField(help_text="Renewal period in days"),
                 ),
+                (
+                    "odoo_product",
+                    models.JSONField(
+                        blank=True,
+                        null=True,
+                        help_text="Selected product from Odoo (id and name)",
+                    ),
+                ),
             ],
             options={
                 "abstract": False,

--- a/core/models.py
+++ b/core/models.py
@@ -1114,6 +1114,11 @@ class Product(Entity):
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     renewal_period = models.PositiveIntegerField(help_text="Renewal period in days")
+    odoo_product = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Selected product from Odoo (id and name)",
+    )
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name

--- a/core/static/core/odoo_product.js
+++ b/core/static/core/odoo_product.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('select[data-odoo-products-url]').forEach(function (sel) {
+    fetch(sel.dataset.odooProductsUrl)
+      .then(function (resp) { return resp.json(); })
+      .then(function (data) {
+        var current = sel.dataset.currentId;
+        var blank = document.createElement('option');
+        blank.value = '';
+        blank.textContent = '---------';
+        sel.appendChild(blank);
+        data.forEach(function (item) {
+          var opt = document.createElement('option');
+          opt.value = JSON.stringify(item);
+          opt.textContent = item.name;
+          if (current && String(item.id) === current) {
+            opt.selected = true;
+          }
+          sel.appendChild(opt);
+        });
+      });
+  });
+});

--- a/core/templates/widgets/odoo_product.html
+++ b/core/templates/widgets/odoo_product.html
@@ -1,0 +1,5 @@
+<select
+  name="{{ widget.name }}"
+  data-odoo-products-url="{% url 'odoo-products' %}"
+  {% include "django/forms/widgets/attrs.html" %}
+></select>

--- a/core/views.py
+++ b/core/views.py
@@ -16,6 +16,28 @@ from utils.api import api_login_required
 
 from .models import Product, Subscription, EnergyAccount, PackageRelease, Todo
 from .models import RFID
+
+
+@staff_member_required
+def odoo_products(request):
+    """Return available products from the user's Odoo instance."""
+
+    profile = getattr(request.user, "odoo_profile", None)
+    if not profile or not profile.is_verified:
+        raise Http404
+    try:
+        products = profile.execute(
+            "product.product",
+            "search_read",
+            [],
+            {"fields": ["name"], "limit": 50},
+        )
+    except Exception:
+        return JsonResponse({"detail": "Unable to fetch products"}, status=502)
+    items = [{"id": p.get("id"), "name": p.get("name", "")} for p in products]
+    return JsonResponse(items, safe=False)
+
+
 from . import release as release_utils
 
 

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -1,4 +1,5 @@
 from django import forms
+import json
 
 
 class CopyColorWidget(forms.TextInput):
@@ -21,3 +22,30 @@ class CodeEditorWidget(forms.Textarea):
     class Media:
         css = {"all": ["core/code_editor.css"]}
         js = ["core/code_editor.js"]
+
+
+class OdooProductWidget(forms.Select):
+    """Widget for selecting an Odoo product."""
+
+    template_name = "widgets/odoo_product.html"
+
+    class Media:
+        js = ["core/odoo_product.js"]
+
+    def get_context(self, name, value, attrs):
+        attrs = attrs or {}
+        if isinstance(value, dict):
+            attrs["data-current-id"] = str(value.get("id", ""))
+            value = json.dumps(value)
+        elif not value:
+            value = ""
+        return super().get_context(name, value, attrs)
+
+    def value_from_datadict(self, data, files, name):
+        raw = data.get(name)
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {}

--- a/tests/test_odoo_product.py
+++ b/tests/test_odoo_product.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import OdooProfile, User
+from core.admin import ProductAdminForm
+from core.widgets import OdooProductWidget
+
+
+class OdooProductTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="odooadmin", email="a@example.com", password="pwd"
+        )
+        OdooProfile.objects.create(
+            user=self.user,
+            host="http://test",
+            database="db",
+            username="odoo",
+            password="secret",
+            verified_on=timezone.now(),
+            odoo_uid=1,
+        )
+        self.client.force_login(self.user)
+
+    @patch.object(OdooProfile, "execute")
+    def test_odoo_products_view(self, mock_exec):
+        mock_exec.return_value = [{"id": 5, "name": "Prod"}]
+        resp = self.client.get(reverse("odoo-products"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [{"id": 5, "name": "Prod"}])
+        mock_exec.assert_called_once_with(
+            "product.product", "search_read", [], {"fields": ["name"], "limit": 50}
+        )
+
+    def test_product_admin_form_uses_widget(self):
+        form = ProductAdminForm()
+        self.assertIsInstance(form.fields["odoo_product"].widget, OdooProductWidget)


### PR DESCRIPTION
## Summary
- allow Products to store a linked Odoo product
- add admin widget that pulls product options from the user's Odoo profile
- expose endpoint and scripts to populate the new field

## Testing
- `python manage.py makemigrations --check --dry-run`
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5fa990e788326aa17b648d097f922