### PR TITLE
Add view links to seed and user data admin views

### DIFF
--- a/core/fixtures/todos__validate_screen_seed_user_datum_links.json
+++ b/core/fixtures/todos__validate_screen_seed_user_datum_links.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 17,
+    "fields": {
+      "description": "Validate screen Seed/User Datum links",
+      "url": "/admin/nodes/noderole/1/change/"
+    }
+  }
+]

--- a/core/templates/admin/user_datum_change_form.html
+++ b/core/templates/admin/user_datum_change_form.html
@@ -8,13 +8,13 @@
         {% if show_user_datum %}
         <label style="color: var(--body-quiet-color); margin-left: 1em;">
             <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
-            {% trans "User Datum" %}
+            {% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]
         </label>
         {% endif %}
         {% if show_seed_datum %}
         <label style="color: var(--body-quiet-color); margin-left: 1em;">
             <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
-            {% trans "Seed Datum" %}
+            {% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]
         </label>
         {% endif %}
     </div>

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -76,6 +76,8 @@ class SeedDataAdminTests(TestCase):
         self.assertIn("Seed Datum", content)
         self.assertIn('name="_user_datum"', content)
         self.assertIn("User Datum", content)
+        self.assertIn(f'[ <a href="{reverse("admin:user_data")}">View</a> ]', content)
+        self.assertIn(f'[ <a href="{reverse("admin:seed_data")}">View</a> ]', content)
         self.assertLess(
             content.index('name="_user_datum"'),
             content.index('name="_seed_datum"'),


### PR DESCRIPTION
## Summary
- link Seed Datum and User Datum labels to their respective data lists
- cover new links in tests
- add todo reminder to validate seed/user datum links

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_seed_data.py::SeedDataAdminTests::test_checkbox_displayed_on_change_form -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5fe51996883269c3b3aeb6f4c402a