### PR TITLE
Add serial number and connector ID to OCPP simulator

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -286,6 +286,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                     await database_sync_to_async(CoreRFID.objects.get_or_create)(
                         rfid=id_tag.upper()
                     )
+                await self._assign_connector(payload.get("connectorId"))
                 if self.charger.require_rfid:
                     authorized = (
                         account is not None
@@ -299,6 +300,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                         account=account,
                         rfid=(id_tag or ""),
                         vin=(payload.get("vin") or ""),
+                        connector_id=payload.get("connectorId"),
                         meter_start=payload.get("meterStart"),
                         start_time=timezone.now(),
                     )

--- a/ocpp/evcs.py
+++ b/ocpp/evcs.py
@@ -176,6 +176,8 @@ async def simulate_cp(
     rfid: str,
     vin: str,
     cp_path: str,
+    serial_number: str,
+    connector_id: int,
     duration: int,
     kw_min: float,
     kw_max: float,
@@ -273,6 +275,7 @@ async def simulate_cp(
                         {
                             "chargePointModel": "Simulator",
                             "chargePointVendor": "SimVendor",
+                            "serialNumber": serial_number,
                         },
                     ]
                 )
@@ -310,7 +313,7 @@ async def simulate_cp(
                                     "meter",
                                     "MeterValues",
                                     {
-                                        "connectorId": 1,
+                                        "connectorId": connector_id,
                                         "meterValue": [
                                             {
                                                 "timestamp": time.strftime(
@@ -364,6 +367,7 @@ async def simulate_cp(
                     {
                         "chargePointModel": "Simulator",
                         "chargePointVendor": "SimVendor",
+                        "serialNumber": serial_number,
                     },
                 ]
             )
@@ -401,7 +405,7 @@ async def simulate_cp(
                                 "meter",
                                 "MeterValues",
                                 {
-                                    "connectorId": 1,
+                                    "connectorId": connector_id,
                                     "meterValue": [
                                         {
                                             "timestamp": time.strftime(
@@ -431,7 +435,7 @@ async def simulate_cp(
                     "start",
                     "StartTransaction",
                     {
-                        "connectorId": 1,
+                        "connectorId": connector_id,
                         "idTag": rfid,
                         "meterStart": meter_start,
                         "vin": vin,
@@ -459,7 +463,7 @@ async def simulate_cp(
                         "meter",
                         "MeterValues",
                         {
-                            "connectorId": 1,
+                            "connectorId": connector_id,
                             "transactionId": tx_id,
                             "meterValue": [
                                 {
@@ -522,7 +526,7 @@ async def simulate_cp(
                             "meter",
                             "MeterValues",
                             {
-                                "connectorId": 1,
+                                "connectorId": connector_id,
                                 "meterValue": [
                                     {
                                         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S")
@@ -582,6 +586,8 @@ def simulate(
     rfid: str = "FFFFFFFF",
     cp_path: str = "CPX",
     vin: str = "",
+    serial_number: str = "",
+    connector_id: int = 1,
     duration: int = 600,
     kw_min: float = 30.0,
     kw_max: float = 60.0,
@@ -614,6 +620,8 @@ def simulate(
         "rfid": rfid,
         "cp_path": cp_path,
         "vin": vin,
+        "serial_number": serial_number,
+        "connector_id": connector_id,
         "duration": duration,
         "kw_min": kw_min,
         "kw_max": kw_max,
@@ -642,6 +650,8 @@ def simulate(
                 rfid,
                 vin,
                 this_cp_path,
+                serial_number,
+                connector_id,
                 duration,
                 kw_min,
                 kw_max,
@@ -662,6 +672,8 @@ def simulate(
                     rfid,
                     vin,
                     this_cp_path,
+                    serial_number,
+                    connector_id,
                     duration,
                     kw_min,
                     kw_max,
@@ -712,6 +724,8 @@ def simulate(
                 rfid,
                 vin,
                 cp_path,
+                serial_number,
+                connector_id,
                 duration,
                 kw_min,
                 kw_max,
@@ -736,6 +750,8 @@ def simulate(
                     rfid,
                     vin,
                     this_cp_path,
+                    serial_number,
+                    connector_id,
                     duration,
                     kw_min,
                     kw_max,

--- a/ocpp/migrations/0001_initial.py
+++ b/ocpp/migrations/0001_initial.py
@@ -183,6 +183,16 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("vin", models.CharField(blank=True, max_length=17)),
+                (
+                    "serial_number",
+                    models.CharField(
+                        blank=True, max_length=100, verbose_name="Serial Number"
+                    ),
+                ),
+                (
+                    "connector_id",
+                    models.IntegerField(default=1, verbose_name="Connector ID"),
+                ),
                 ("duration", models.IntegerField(default=600)),
                 ("interval", models.FloatField(default=5.0)),
                 (
@@ -218,6 +228,7 @@ class Migration(migrations.Migration):
                     models.CharField(blank=True, max_length=20, verbose_name="RFID"),
                 ),
                 ("vin", models.CharField(blank=True, max_length=17)),
+                ("connector_id", models.IntegerField(blank=True, null=True)),
                 ("meter_start", models.IntegerField(blank=True, null=True)),
                 ("meter_stop", models.IntegerField(blank=True, null=True)),
                 (

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -180,6 +180,7 @@ class Transaction(Entity):
         verbose_name=_("RFID"),
     )
     vin = models.CharField(max_length=17, blank=True)
+    connector_id = models.IntegerField(null=True, blank=True)
     meter_start = models.IntegerField(null=True, blank=True)
     meter_stop = models.IntegerField(null=True, blank=True)
     voltage_start = models.DecimalField(
@@ -300,6 +301,8 @@ class Simulator(Entity):
         verbose_name=_("RFID"),
     )
     vin = models.CharField(max_length=17, blank=True)
+    serial_number = models.CharField(_("Serial Number"), max_length=100, blank=True)
+    connector_id = models.IntegerField(_("Connector ID"), default=1)
     duration = models.IntegerField(default=600)
     interval = models.FloatField(default=5.0)
     pre_charge_delay = models.FloatField(_("Delay"), default=10.0)
@@ -324,6 +327,8 @@ class Simulator(Entity):
             rfid=self.rfid,
             vin=self.vin,
             cp_path=self.cp_path,
+            serial_number=self.serial_number,
+            connector_id=self.connector_id,
             duration=self.duration,
             interval=self.interval,
             pre_charge_delay=self.pre_charge_delay,

--- a/ocpp/simulator.py
+++ b/ocpp/simulator.py
@@ -31,6 +31,8 @@ class SimulatorConfig:
     repeat: bool = False
     username: Optional[str] = None
     password: Optional[str] = None
+    serial_number: str = ""
+    connector_id: int = 1
 
 
 class ChargePointSimulator:
@@ -113,6 +115,7 @@ class ChargePointSimulator:
                     {
                         "chargePointModel": "Simulator",
                         "chargePointVendor": "SimVendor",
+                        "serialNumber": cfg.serial_number,
                     },
                 ]
             )
@@ -145,7 +148,7 @@ class ChargePointSimulator:
                                 "status",
                                 "StatusNotification",
                                 {
-                                    "connectorId": 1,
+                                    "connectorId": cfg.connector_id,
                                     "errorCode": "NoError",
                                     "status": "Available",
                                 },
@@ -162,7 +165,7 @@ class ChargePointSimulator:
                                 "meter",
                                 "MeterValues",
                                 {
-                                    "connectorId": 1,
+                                    "connectorId": cfg.connector_id,
                                     "meterValue": [
                                         {
                                             "timestamp": time.strftime(
@@ -192,7 +195,7 @@ class ChargePointSimulator:
                         "start",
                         "StartTransaction",
                         {
-                            "connectorId": 1,
+                            "connectorId": cfg.connector_id,
                             "idTag": cfg.rfid,
                             "meterStart": meter_start,
                             "vin": cfg.vin,
@@ -226,7 +229,7 @@ class ChargePointSimulator:
                             "meter",
                             "MeterValues",
                             {
-                                "connectorId": 1,
+                                "connectorId": cfg.connector_id,
                                 "transactionId": tx_id,
                                 "meterValue": [
                                     {

--- a/ocpp/templates/ocpp/cp_simulator.html
+++ b/ocpp/templates/ocpp/cp_simulator.html
@@ -20,10 +20,10 @@
 </ul>
 <div class="tab-content" id="cpSimContent">
   <div class="tab-pane fade show active" id="cp1" role="tabpanel" aria-labelledby="cp1-tab">
-      {% include "ocpp/cp_simulator_block.html" with cp=states.0 idx=1 params_json=params_jsons.0 state_json=state_jsons.0 default_cp_path=default_cp_paths.0 default_vin=default_vins.0 next_tab='cp2' %}
+      {% include "ocpp/cp_simulator_block.html" with cp=states.0 idx=1 params_json=params_jsons.0 state_json=state_jsons.0 default_cp_path=default_cp_paths.0 default_vin=default_vins.0 default_serial_number=default_serial_numbers.0 default_connector_id=default_connector_id next_tab='cp2' %}
   </div>
   <div class="tab-pane fade" id="cp2" role="tabpanel" aria-labelledby="cp2-tab">
-      {% include "ocpp/cp_simulator_block.html" with cp=states.1 idx=2 params_json=params_jsons.1 state_json=state_jsons.1 default_cp_path=default_cp_paths.1 default_vin=default_vins.1 prev_tab='cp1' %}
+      {% include "ocpp/cp_simulator_block.html" with cp=states.1 idx=2 params_json=params_jsons.1 state_json=state_jsons.1 default_cp_path=default_cp_paths.1 default_vin=default_vins.1 default_serial_number=default_serial_numbers.1 default_connector_id=default_connector_id prev_tab='cp1' %}
   </div>
 </div>
 {% endblock %}

--- a/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/ocpp/templates/ocpp/cp_simulator_block.html
@@ -24,6 +24,18 @@
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="mb-2">
+            <label class="form-label" for="serial_number{{ idx }}">Serial Number</label>
+            <input id="serial_number{{ idx }}" name="serial_number" value="{{ cp.params.serial_number|default:default_serial_number }}" class="form-control form-control-sm">
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
+            <label class="form-label" for="connector_id{{ idx }}">Connector ID</label>
+            <input id="connector_id{{ idx }}" name="connector_id" value="{{ cp.params.connector_id|default:default_connector_id }}" class="form-control form-control-sm">
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-4">
+          <div class="mb-2">
             <label class="form-label" for="rfid{{ idx }}">RFID</label>
             <input id="rfid{{ idx }}" name="rfid" value="{{ cp.params.rfid|default:default_rfid }}" class="form-control form-control-sm">
           </div>

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -153,6 +153,8 @@ def cp_simulator(request):
     default_host = "127.0.0.1"
     default_ws_port = "9000"
     default_cp_paths = ["CP1", "CP2"]
+    default_serial_numbers = default_cp_paths
+    default_connector_id = 1
     default_rfid = "FFFFFFFF"
     default_vins = ["WP0ZZZ00000000000", "WAUZZZ00000000000"]
 
@@ -165,6 +167,11 @@ def cp_simulator(request):
                 host=request.POST.get("host") or default_host,
                 ws_port=int(request.POST.get("ws_port") or default_ws_port),
                 cp_path=request.POST.get("cp_path") or default_cp_paths[cp_idx - 1],
+                serial_number=request.POST.get("serial_number")
+                or default_serial_numbers[cp_idx - 1],
+                connector_id=int(
+                    request.POST.get("connector_id") or default_connector_id
+                ),
                 rfid=request.POST.get("rfid") or default_rfid,
                 vin=request.POST.get("vin") or default_vins[cp_idx - 1],
                 duration=int(request.POST.get("duration") or 600),
@@ -211,6 +218,8 @@ def cp_simulator(request):
         "default_host": default_host,
         "default_ws_port": default_ws_port,
         "default_cp_paths": default_cp_paths,
+        "default_serial_numbers": default_serial_numbers,
+        "default_connector_id": default_connector_id,
         "default_rfid": default_rfid,
         "default_vins": default_vins,
         "params_jsons": params_jsons,


### PR DESCRIPTION
## Summary
- allow simulator to send serial number and configurable connector ID
- record connector ID on transactions
- expose serial and connector fields in CP simulator UI

## Testing
- `pytest`
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c5fd06a9388326b92c644eff64388d