### PR TITLE
Prevent share modal from closing on auto refresh

### DIFF
--- a/core/fixtures/todos__validate_screen_share_modal.json
+++ b/core/fixtures/todos__validate_screen_share_modal.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 17,
+    "fields": {
+      "description": "Validate screen Share modal",
+      "url": "/"
+    }
+  }
+]

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -331,27 +331,40 @@
           const modalEl = document.getElementById('shareModal');
           if (!btn || !modalEl) {
             return;
-        }
-        const modal = new bootstrap.Modal(modalEl);
-        btn.addEventListener('click', () => {
-          modal.show();
-        });
-        modalEl.addEventListener('shown.bs.modal', () => {
-          const url = window.location.href;
-          const input = document.getElementById('share-url');
-          const qr = document.getElementById('share-qr');
-          input.value = url;
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(url).catch(() => {});
           }
-          qr.innerHTML = '';
-          new QRCode(qr, {text: url, width: 128, height: 128});
-        });
+          const modal = new bootstrap.Modal(modalEl);
+          btn.addEventListener('click', () => {
+            modal.show();
+          });
+          modalEl.addEventListener('shown.bs.modal', () => {
+            const url = window.location.href;
+            const input = document.getElementById('share-url');
+            const qr = document.getElementById('share-qr');
+            input.value = url;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(url).catch(() => {});
+            }
+            qr.innerHTML = '';
+            new QRCode(qr, {text: url, width: 128, height: 128});
+            if (window.liveUpdateIntervalId) {
+              clearInterval(window.liveUpdateIntervalId);
+              window.liveUpdateIntervalId = null;
+            }
+          });
+          modalEl.addEventListener('hidden.bs.modal', () => {
+            if (window.LIVE_UPDATE_INTERVAL && !window.liveUpdateIntervalId) {
+              window.liveUpdateIntervalId = setInterval(
+                () => location.reload(),
+                window.LIVE_UPDATE_INTERVAL,
+              );
+            }
+          });
         })();
       </script>
     {% if request.live_update_interval %}
     <script>
-      setInterval(() => location.reload(), {{ request.live_update_interval }} * 1000);
+      window.LIVE_UPDATE_INTERVAL = {{ request.live_update_interval }} * 1000;
+      window.liveUpdateIntervalId = setInterval(() => location.reload(), window.LIVE_UPDATE_INTERVAL);
     </script>
     {% endif %}
     <svg xmlns="http://www.w3.org/2000/svg" class="base-svgs">


### PR DESCRIPTION
## Summary
- halt page auto-refresh when the share modal is open and resume afterward
- expose live update interval globally so it can be managed from the modal script
- add TODO fixture to validate the Share modal screen

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`
- `pytest` *(fails: TemplateSyntaxError: Variables and attributes may not begin with underscores: 'model.model.__doc__')*


------
https://chatgpt.com/codex/tasks/task_e_68c5fde000948326be939e4d0722ea21