### PR TITLE
Align admin action button size with history link

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -941,6 +941,7 @@ class EVModelAdmin(EntityModelAdmin):
     list_display = ("name", "brand")
     list_filter = ("brand",)
 
+
 admin.site.register(Product)
 admin.site.register(LiveSubscription)
 

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -277,7 +277,7 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     border-radius: 15px;
     display: block;
     float: left;
-    padding: 5px 12px;
+    padding: 3px 12px;
     background: var(--object-tools-bg);
     color: var(--object-tools-fg);
     font-weight: 400;


### PR DESCRIPTION
## Summary
- match padding of custom admin action buttons with history link for consistent sizing
- run pre-commit to format code

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68c5ffd9c89c8326a4d5dc1be58d4b1a