### PR TITLE
Reduce admin header padding by 10px

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -941,6 +941,7 @@ class EVModelAdmin(EntityModelAdmin):
     list_display = ("name", "brand")
     list_filter = ("brand",)
 
+
 admin.site.register(Product)
 admin.site.register(LiveSubscription)
 

--- a/core/fixtures/todos__validate_screen_admin_header.json
+++ b/core/fixtures/todos__validate_screen_admin_header.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 18,
+    "fields": {
+      "description": "Validate screen Admin header",
+      "url": "/admin/"
+    }
+  }
+]

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -153,6 +153,8 @@ body:not(.login) #header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 body:not(.login) #branding,
@@ -173,7 +175,7 @@ body:not(.login) #site-name {
 
 body:not(.login) #site-name > a {
     margin-right: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 0;
 }
 
 body:not(.login) #site-badges {


### PR DESCRIPTION
## Summary
- remove extra top/bottom padding from the admin header bar
- add a Todo to validate the admin header screen

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68c6076b2b1c8326af58565e9cb5f919