### PR TITLE
Restore calculator template fixtures and guard fixture presence

### DIFF
--- a/awg/fixtures/calculator_templates__calculatortemplate_dc_fast_charger.json
+++ b/awg/fixtures/calculator_templates__calculatortemplate_dc_fast_charger.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "model": "awg.calculatortemplate",
+    "pk": 2,
+    "fields": {
+      "name": "DC Fast Charger",
+      "description": "Commercial DC charging for 1 or 2 EVs.",
+      "amps": 120,
+      "volts": 400,
+      "material": "cu",
+      "max_lines": 2,
+      "phases": 2,
+      "temperature": 75,
+      "ground": 1,
+      "show_in_pages": true
+    }
+  }
+]

--- a/awg/fixtures/calculator_templates__calculatortemplate_ev_charger.json
+++ b/awg/fixtures/calculator_templates__calculatortemplate_ev_charger.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "model": "awg.calculatortemplate",
+    "pk": 1,
+    "fields": {
+      "name": "EV Charger",
+      "description": "Residential charging for a single EV.",
+      "amps": 40,
+      "volts": 220,
+      "material": "cu",
+      "max_lines": 1,
+      "phases": 2,
+      "temperature": 60,
+      "ground": 1,
+      "show_in_pages": true
+    }
+  }
+]

--- a/tests/test_fixture_presence.py
+++ b/tests/test_fixture_presence.py
@@ -1,0 +1,23 @@
+from glob import glob
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from core.models import Reference
+from awg.models import CalculatorTemplate
+
+
+class FixturePresenceTests(TestCase):
+    def test_footer_reference_fixtures_exist(self):
+        files = glob("core/fixtures/references__*.json")
+        self.assertTrue(files, "Reference fixtures are missing")
+        call_command("loaddata", *files)
+        self.assertTrue(
+            Reference.objects.filter(include_in_footer=True).exists()
+        )
+
+    def test_calculator_template_fixtures_exist(self):
+        files = glob("awg/fixtures/calculator_templates__*.json")
+        self.assertTrue(files, "CalculatorTemplate fixtures are missing")
+        call_command("loaddata", *files)
+        self.assertTrue(CalculatorTemplate.objects.exists())


### PR DESCRIPTION
## Summary
- populate AWG calculator template fixtures for EV Charger and DC Fast Charger
- add tests ensuring footer reference and calculator template fixtures remain

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_fixture_presence.py`


------
https://chatgpt.com/codex/tasks/task_e_68c60ad723b48326927539fa707dbd35