### PR TITLE
Fix admindocs model docstring access for Django 5

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -942,7 +942,18 @@ class EVModelAdmin(EntityModelAdmin):
     list_filter = ("brand",)
 
 
-admin.site.register(Product)
+class ProductAdminForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        fields = "__all__"
+        widgets = {"odoo_product": OdooProductWidget}
+
+
+@admin.register(Product)
+class ProductAdmin(EntityModelAdmin):
+    form = ProductAdminForm
+
+
 admin.site.register(LiveSubscription)
 
 

--- a/core/admindocs.py
+++ b/core/admindocs.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 from django.core.management import get_commands, load_command_class
 from django.apps import apps
 from django.contrib.admindocs.views import (
@@ -52,10 +53,11 @@ class OrderedModelIndexView(BaseAdminDocsView):
     template_name = "admin_doc/model_index.html"
 
     def get_context_data(self, **kwargs):
-        models = [
-            m._meta
-            for m in apps.get_models()
-            if user_has_model_view_permission(self.request.user, m._meta)
-        ]
+        models = []
+        for m in apps.get_models():
+            if user_has_model_view_permission(self.request.user, m._meta):
+                meta = m._meta
+                meta.docstring = inspect.getdoc(m) or ""
+                models.append(meta)
         models.sort(key=lambda m: str(m.app_config.verbose_name))
         return super().get_context_data(**{**kwargs, "models": models})

--- a/core/fixtures/todos__validate_screen_model_documentation_docstring.json
+++ b/core/fixtures/todos__validate_screen_model_documentation_docstring.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 21,
+    "fields": {
+      "description": "Validate screen Model documentation docstring",
+      "url": "/admindocs/models/"
+    }
+  }
+]

--- a/pages/templates/admin_doc/model_index.html
+++ b/pages/templates/admin_doc/model_index.html
@@ -35,7 +35,7 @@
   {% for model in group.list %}
   <tr>
     <th scope="row"><a href="{% url 'django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
-    <td>{{ model.model.__doc__|default_if_none:""|trim|linebreaksbr }}</td>
+    <td>{{ model.docstring|default_if_none:""|linebreaksbr }}</td>
   </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- derive model docstrings in OrderedModelIndexView context and expose via `docstring` attribute
- update admindocs model index template to display docstrings without accessing `__doc__`
- add Product admin form using `OdooProductWidget` and register model with custom admin
- add TODO fixture to validate updated Model documentation screen

## Testing
- `pre-commit run --all-files`
- `bash env-refresh.sh --clean`
- `bash scripts/test-upgrade-path.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60901184083268e0d92c513a26f18