### PR TITLE
Adjust language switcher styling

### DIFF
--- a/core/fixtures/todos__validate_screen_language_switcher.json
+++ b/core/fixtures/todos__validate_screen_language_switcher.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 22,
+    "fields": {
+      "description": "Validate screen Language switcher",
+      "url": "/"
+    }
+  }
+]

--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -78,14 +78,20 @@
       }
       .language-select {
         background-color: transparent;
-        color: inherit;
         padding: 0.25rem 0.5rem;
         padding-right: 1.5rem;
         line-height: 1.5;
         height: calc(1.5rem + 0.5rem);
-        border: 1px solid var(--bs-light);
         border-radius: 0.2rem;
         background-position: right 0.5rem center;
+      }
+      html[data-bs-theme='light'] .language-select {
+        color: var(--bs-dark);
+        border: 1px solid var(--bs-dark);
+      }
+      html[data-bs-theme='dark'] .language-select {
+        color: var(--bs-light);
+        border: 1px solid var(--bs-light);
       }
       .language-select option {
         background-color: var(--bs-body-bg);

--- a/tests/test_fixture_presence.py
+++ b/tests/test_fixture_presence.py
@@ -12,9 +12,7 @@ class FixturePresenceTests(TestCase):
         files = glob("core/fixtures/references__*.json")
         self.assertTrue(files, "Reference fixtures are missing")
         call_command("loaddata", *files)
-        self.assertTrue(
-            Reference.objects.filter(include_in_footer=True).exists()
-        )
+        self.assertTrue(Reference.objects.filter(include_in_footer=True).exists())
 
     def test_calculator_template_fixtures_exist(self):
         files = glob("awg/fixtures/calculator_templates__*.json")


### PR DESCRIPTION
## Summary
- ensure language switcher uses theme-specific colors so it stays visible in light mode
- add TODO fixture to validate language switcher screen

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60eb4d5c08326ab279406803af207