### PR TITLE
Gracefully fall back when Site is missing

### DIFF
--- a/tests/test_fixture_presence.py
+++ b/tests/test_fixture_presence.py
@@ -12,9 +12,7 @@ class FixturePresenceTests(TestCase):
         files = glob("core/fixtures/references__*.json")
         self.assertTrue(files, "Reference fixtures are missing")
         call_command("loaddata", *files)
-        self.assertTrue(
-            Reference.objects.filter(include_in_footer=True).exists()
-        )
+        self.assertTrue(Reference.objects.filter(include_in_footer=True).exists())
 
     def test_calculator_template_fixtures_exist(self):
         files = glob("awg/fixtures/calculator_templates__*.json")

--- a/utils/sites.py
+++ b/utils/sites.py
@@ -1,4 +1,5 @@
 from django.contrib.sites.models import Site
+from django.contrib.sites.requests import RequestSite
 from django.contrib.sites.shortcuts import get_current_site
 from django.http.request import split_domain_port
 
@@ -16,4 +17,7 @@ def get_site(request):
     try:
         return Site.objects.get(domain=host)
     except Site.DoesNotExist:
-        return get_current_site(request)
+        try:
+            return get_current_site(request)
+        except Site.DoesNotExist:
+            return RequestSite(request)


### PR DESCRIPTION
## Summary
- return RequestSite if no matching Site exists to avoid 500 errors
- skip legacy WorkgroupNewsArticle migration during env refresh

## Testing
- `pre-commit run --all-files`
- `scripts/test-upgrade-path.sh`
- `./env-refresh.sh --clean`


------
https://chatgpt.com/codex/tasks/task_e_68c60d27163c8326af198b7cbcf5b0ed