### PR TITLE
Handle post_office migration base error

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -231,7 +231,7 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
         except InvalidBasesError as exc:
             if "post_office.WorkgroupNewsArticle" in str(exc):
                 call_command(
-                    "migrate", "post_office", "0014", fake=True, interactive=False
+                    "migrate", "post_office", "0015", fake=True, interactive=False
                 )
                 call_command("migrate", interactive=False)
             else:


### PR DESCRIPTION
## Summary
- fake post_office 0015 migration when WorkgroupNewsArticle base cannot be resolved

## Testing
- `pre-commit run --all-files`
- `./env-refresh.sh --clean --latest`

------
https://chatgpt.com/codex/tasks/task_e_68c612105ec48326a054fbd254495abf