### PR TITLE
feat: add custom label support for RFIDs

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -953,6 +953,7 @@ class RFIDResource(resources.ModelResource):
         fields = (
             "label_id",
             "rfid",
+            "custom_label",
             "reference",
             "allowed",
             "color",
@@ -993,6 +994,7 @@ class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
     list_display = (
         "label_id",
         "rfid",
+        "custom_label",
         "color",
         "kind",
         "released",
@@ -1002,7 +1004,7 @@ class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
         "last_seen_on",
     )
     list_filter = ("color", "released", "allowed")
-    search_fields = ("label_id", "rfid")
+    search_fields = ("label_id", "rfid", "custom_label")
     autocomplete_fields = ["energy_accounts"]
     raw_id_fields = ["reference"]
     actions = ["scan_rfids"]

--- a/core/fixtures/todos__validate_screen_rfid_admin.json
+++ b/core/fixtures/todos__validate_screen_rfid_admin.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 23,
+    "fields": {
+      "description": "Validate screen RFID admin",
+      "url": "/admin/core/rfid/"
+    }
+  }
+]

--- a/core/management/commands/export_rfids.py
+++ b/core/management/commands/export_rfids.py
@@ -36,6 +36,7 @@ class Command(BaseCommand):
         rows = (
             (
                 t.rfid,
+                t.custom_label,
                 ",".join(str(a.id) for a in t.energy_accounts.all()),
                 str(t.allowed),
                 t.color,
@@ -47,11 +48,27 @@ class Command(BaseCommand):
             with open(path, "w", newline="", encoding="utf-8") as fh:
                 writer = csv.writer(fh)
                 writer.writerow(
-                    ["rfid", "energy_accounts", "allowed", "color", "released"]
+                    [
+                        "rfid",
+                        "custom_label",
+                        "energy_accounts",
+                        "allowed",
+                        "color",
+                        "released",
+                    ]
                 )
                 writer.writerows(rows)
         else:
             writer = csv.writer(self.stdout)
-            writer.writerow(["rfid", "energy_accounts", "allowed", "color", "released"])
+            writer.writerow(
+                [
+                    "rfid",
+                    "custom_label",
+                    "energy_accounts",
+                    "allowed",
+                    "color",
+                    "released",
+                ]
+            )
             writer.writerows(rows)
         self.stdout.write(self.style.SUCCESS("Exported {} tags".format(qs.count())))

--- a/core/management/commands/import_rfids.py
+++ b/core/management/commands/import_rfids.py
@@ -32,6 +32,7 @@ class Command(BaseCommand):
                 for row in reader:
                     rfid = row.get("rfid", "").strip()
                     energy_accounts = row.get("energy_accounts", "").strip()
+                    custom_label = row.get("custom_label", "").strip()
                     allowed = row.get("allowed", "True").strip().lower() != "false"
                     color = row.get("color", RFID.BLACK).strip().upper() or RFID.BLACK
                     released = row.get("released", "False").strip().lower() == "true"
@@ -46,6 +47,7 @@ class Command(BaseCommand):
                     tag, _ = RFID.objects.update_or_create(
                         rfid=rfid.upper(),
                         defaults={
+                            "custom_label": custom_label,
                             "allowed": allowed,
                             "color": color,
                             "released": released,

--- a/core/migrations/0013_user_data_field.py
+++ b/core/migrations/0013_user_data_field.py
@@ -106,6 +106,16 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False, editable=False),
         ),
         migrations.AddField(
+            model_name="rfid",
+            name="custom_label",
+            field=models.CharField(
+                blank=True,
+                max_length=32,
+                verbose_name="Custom Label",
+                help_text="Optional custom label for this RFID.",
+            ),
+        ),
+        migrations.AddField(
             model_name="sigilroot",
             name="is_user_data",
             field=models.BooleanField(default=False, editable=False),

--- a/core/models.py
+++ b/core/models.py
@@ -569,6 +569,12 @@ class RFID(Entity):
             )
         ],
     )
+    custom_label = models.CharField(
+        max_length=32,
+        blank=True,
+        verbose_name="Custom Label",
+        help_text="Optional custom label for this RFID.",
+    )
     key_a = models.CharField(
         max_length=12,
         default="FFFFFFFFFFFF",

--- a/core/tests.py
+++ b/core/tests.py
@@ -113,7 +113,7 @@ class RFIDBatchApiTests(TestCase):
         self.client.force_login(self.user)
 
     def test_export_rfids(self):
-        tag_black = RFID.objects.create(rfid="CARD999")
+        tag_black = RFID.objects.create(rfid="CARD999", custom_label="Main Tag")
         tag_white = RFID.objects.create(rfid="CARD998", color=RFID.WHITE)
         self.account.rfids.add(tag_black, tag_white)
         response = self.client.get(reverse("rfid-batch"))
@@ -124,6 +124,7 @@ class RFIDBatchApiTests(TestCase):
                 "rfids": [
                     {
                         "rfid": "CARD999",
+                        "custom_label": "Main Tag",
                         "energy_accounts": [self.account.id],
                         "allowed": True,
                         "color": "B",
@@ -142,6 +143,7 @@ class RFIDBatchApiTests(TestCase):
                 "rfids": [
                     {
                         "rfid": "CARD111",
+                        "custom_label": "",
                         "energy_accounts": [],
                         "allowed": True,
                         "color": "W",
@@ -161,6 +163,7 @@ class RFIDBatchApiTests(TestCase):
                 "rfids": [
                     {
                         "rfid": "CARD112",
+                        "custom_label": "",
                         "energy_accounts": [],
                         "allowed": True,
                         "color": "B",
@@ -175,6 +178,7 @@ class RFIDBatchApiTests(TestCase):
             "rfids": [
                 {
                     "rfid": "A1B2C3D4",
+                    "custom_label": "Imported Tag",
                     "energy_accounts": [self.account.id],
                     "allowed": True,
                     "color": "W",
@@ -192,6 +196,7 @@ class RFIDBatchApiTests(TestCase):
         self.assertTrue(
             RFID.objects.filter(
                 rfid="A1B2C3D4",
+                custom_label="Imported Tag",
                 energy_accounts=self.account,
                 color=RFID.WHITE,
                 released=True,
@@ -237,6 +242,11 @@ class RFIDValidationTests(TestCase):
         acc.rfids.add(tag)
         found = RFID.get_account_by_rfid("abcd1234")
         self.assertEqual(found, acc)
+
+    def test_custom_label_length(self):
+        tag = RFID(rfid="FACE1234", custom_label="x" * 33)
+        with self.assertRaises(ValidationError):
+            tag.full_clean()
 
 
 class RFIDAssignmentTests(TestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -323,6 +323,7 @@ def rfid_batch(request):
         tags = [
             {
                 "rfid": t.rfid,
+                "custom_label": t.custom_label,
                 "energy_accounts": list(t.energy_accounts.values_list("id", flat=True)),
                 "allowed": t.allowed,
                 "color": t.color,
@@ -353,6 +354,7 @@ def rfid_batch(request):
             released = row.get("released", False)
             if isinstance(released, str):
                 released = released.lower() == "true"
+            custom_label = (row.get("custom_label") or "").strip()
 
             tag, _ = RFID.objects.update_or_create(
                 rfid=rfid.upper(),
@@ -360,6 +362,7 @@ def rfid_batch(request):
                     "allowed": allowed,
                     "color": color,
                     "released": released,
+                    "custom_label": custom_label,
                 },
             )
             if energy_accounts:


### PR DESCRIPTION
## Summary
- allow RFIDs to store an optional 32 character custom label
- expose the custom label in admin, batch API, and CSV import/export
- add tests and fixtures for new RFID label

## Testing
- `pre-commit run --all-files`
- `python manage.py test core.tests.RFIDBatchApiTests core.tests.RFIDValidationTests`


------
https://chatgpt.com/codex/tasks/task_e_68c61f7e28608326896afae86a63bc64