### PR TITLE
feat: block release when TODOs pending

### DIFF
--- a/core/fixtures/todos__validate_screen_release_progress_todo_list.json
+++ b/core/fixtures/todos__validate_screen_release_progress_todo_list.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 24,
+    "fields": {
+      "description": "Validate screen Release progress TODO list",
+      "url": "/admin/core/releases/1/publish/"
+    }
+  }
+]

--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -44,6 +44,20 @@
 <pre>{{ log_content }}</pre>
 {% if error %}
 <p class="error">{{ error }}</p>
+{% if todos %}
+<h2>{% trans 'Pending TODOs' %}</h2>
+<ul>
+  {% for todo in todos %}
+  <li>
+    {% if todo.url %}
+    <a href="{{ todo.url }}" target="_blank" rel="noopener">{{ todo.description }}</a>
+    {% else %}
+    {{ todo.description }}
+    {% endif %}
+  </li>
+  {% endfor %}
+ </ul>
+{% endif %}
 <form method="get">
   <button type="submit" name="restart" value="1">{% trans 'Restart' %}</button>
 </form>

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -44,6 +44,20 @@
 <pre>{{ log_content }}</pre>
 {% if error %}
 <p class="error">{{ error }}</p>
+{% if todos %}
+<h2>{% trans 'Pending TODOs' %}</h2>
+<ul>
+  {% for todo in todos %}
+  <li>
+    {% if todo.url %}
+    <a href="{{ todo.url }}" target="_blank" rel="noopener">{{ todo.description }}</a>
+    {% else %}
+    {{ todo.description }}
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
 {% elif not done %}
 <meta http-equiv="refresh" content="1; url={{ request.path }}?step={{ current_step }}">
 <p>Running...</p>


### PR DESCRIPTION
## Summary
- prevent releases when TODO items remain
- surface pending TODO links on release progress screen
- cover new rule with tests and fixture

## Testing
- `pre-commit run --all-files`
- `python manage.py test tests.test_release_progress`


------
https://chatgpt.com/codex/tasks/task_e_68c632ea14448326bc3659419676b83a