### PR TITLE
Ensure manual PDFs download

### DIFF
--- a/core/fixtures/todos__todo_26.json
+++ b/core/fixtures/todos__todo_26.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 26,
+    "fields": {
+      "description": "Validate view manual_pdf",
+      "url": ""
+    }
+  }
+]

--- a/core/fixtures/todos__validate_screen_manual_pdf_download.json
+++ b/core/fixtures/todos__validate_screen_manual_pdf_download.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "pk": 25,
+    "fields": {
+      "description": "Validate screen Manual PDF download",
+      "url": "/man/"
+    }
+  }
+]

--- a/man/templates/man/manual_detail.html
+++ b/man/templates/man/manual_detail.html
@@ -5,7 +5,7 @@
 <h1>{{ manual.title }}</h1>
 <div class="object-tools">
   <ul>
-    <li><a href="{% url 'man:manual-pdf' manual.slug %}">{% trans "Download PDF" %}</a></li>
+    <li><a href="{% url 'man:manual-pdf' manual.slug %}" download>{% trans "Download PDF" %}</a></li>
   </ul>
 </div>
 {{ manual.content_html|safe }}

--- a/man/templates/man/manual_list.html
+++ b/man/templates/man/manual_list.html
@@ -9,7 +9,7 @@
       <a href="{% url 'man:manual-html' manual.slug %}">{{ manual.title }}</a>
       - {{ manual.description }}
       - {% trans "Languages" %}: {{ manual.languages }}
-      - <a href="{% url 'man:manual-pdf' manual.slug %}">{% trans "Download PDF" %}</a>
+      - <a href="{% url 'man:manual-pdf' manual.slug %}" download>{% trans "Download PDF" %}</a>
     </li>
   {% endfor %}
 </ul>

--- a/man/views.py
+++ b/man/views.py
@@ -39,7 +39,9 @@ def admin_manual_detail(request, slug):
 def manual_pdf(request, slug):
     manual = get_object_or_404(UserManual, slug=slug)
     pdf_data = base64.b64decode(manual.content_pdf)
-    return HttpResponse(pdf_data, content_type="application/pdf")
+    response = HttpResponse(pdf_data, content_type="application/pdf")
+    response["Content-Disposition"] = f'attachment; filename="{manual.slug}.pdf"'
+    return response
 
 
 def admin_manual_list(request):

--- a/pages/templates/admin_doc/manual_detail.html
+++ b/pages/templates/admin_doc/manual_detail.html
@@ -17,7 +17,7 @@
 <div id="content-main">
   <div class="object-tools">
     <ul>
-      <li><a href="{% url 'django-admindocs-manual-pdf' manual.slug %}">{% translate 'Download PDF' %}</a></li>
+      <li><a href="{% url 'django-admindocs-manual-pdf' manual.slug %}" download>{% translate 'Download PDF' %}</a></li>
     </ul>
   </div>
   {{ manual.content_html|safe }}

--- a/pages/templates/admin_doc/manuals.html
+++ b/pages/templates/admin_doc/manuals.html
@@ -20,7 +20,7 @@
       <a href="{% url 'django-admindocs-manual-detail' manual.slug %}">{{ manual.title }}</a>
       - {{ manual.description }}
       - {% translate 'Languages' %}: {{ manual.languages }}
-      - <a href="{% url 'django-admindocs-manual-pdf' manual.slug %}">{% translate 'Download PDF' %}</a>
+      - <a href="{% url 'django-admindocs-manual-pdf' manual.slug %}" download>{% translate 'Download PDF' %}</a>
     </li>
   {% endfor %}
   </ul>

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -57,6 +57,7 @@ class ManTests(TestCase):
         self.assertContains(
             response, reverse("django-admindocs-manual-pdf", args=["test-manual"])
         )
+        self.assertContains(response, "download")
         self.assertContains(response, 'id="nav-sidebar"')
         self.assertContains(response, 'id="nav-filter"')
         self.assertNotContains(
@@ -72,6 +73,7 @@ class ManTests(TestCase):
         self.assertContains(
             response, reverse("django-admindocs-manual-pdf", args=["test-manual"])
         )
+        self.assertContains(response, "download")
         self.assertContains(response, 'id="nav-sidebar"')
         self.assertContains(response, 'id="nav-filter"')
         self.assertNotContains(
@@ -84,10 +86,20 @@ class ManTests(TestCase):
         self.assertContains(response, "Test description")
         self.assertContains(response, "Languages: en,fr")
         self.assertContains(response, reverse("man:manual-pdf", args=["test-manual"]))
+        self.assertContains(response, "download")
         self.assertNotContains(response, 'id="nav-sidebar"')
 
     def test_public_manual_detail(self):
         response = self.client.get(reverse("man:manual-html", args=["test-manual"]))
         self.assertContains(response, "hi")
         self.assertContains(response, reverse("man:manual-pdf", args=["test-manual"]))
+        self.assertContains(response, "download")
         self.assertNotContains(response, 'id="nav-sidebar"')
+
+    def test_manual_pdf_download(self):
+        response = self.client.get(reverse("man:manual-pdf", args=["test-manual"]))
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertEqual(
+            response["Content-Disposition"],
+            'attachment; filename="test-manual.pdf"',
+        )


### PR DESCRIPTION
## Summary
- force manual_pdf view to return attachment
- add download attributes to manual PDF links
- cover manual PDF download in tests

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_man.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6470ae8d48326957f8b214b5a2f41