### PR TITLE
Hide Todo admin link and restrict creation

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1210,3 +1210,20 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, EntityModelAdmin):
 @admin.register(Todo)
 class TodoAdmin(EntityModelAdmin):
     list_display = ("description", "url")
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def get_model_perms(self, request):
+        return {}
+
+    def render_change_form(
+        self, request, context, add=False, change=False, form_url="", obj=None
+    ):
+        context = super().render_change_form(
+            request, context, add=add, change=change, form_url=form_url, obj=obj
+        )
+        context["show_user_datum"] = False
+        context["show_seed_datum"] = False
+        context["show_save_as_copy"] = False
+        return context

--- a/core/tests.py
+++ b/core/tests.py
@@ -800,3 +800,19 @@ class TodoUrlValidationTests(TestCase):
         todo = Todo(description="Task", url="https://example.com/path")
         with self.assertRaises(ValidationError):
             todo.full_clean()
+
+
+class TodoAdminPermissionTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User.objects.create_superuser("admin", "admin@example.com", "pw")
+        self.client.force_login(User.objects.get(username="admin"))
+
+    def test_add_view_disallowed(self):
+        resp = self.client.get(reverse("admin:core_todo_add"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_change_form_hides_save_as_copy(self):
+        todo = Todo.objects.create(description="Task")
+        resp = self.client.get(reverse("admin:core_todo_change", args=[todo.pk]))
+        self.assertNotContains(resp, "Save as a copy")

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -773,12 +773,25 @@ class FavoriteTests(TestCase):
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, 'href="/docs/"')
 
-    def test_dashboard_shows_done_button(self):
+    def test_dashboard_shows_todo_with_done_button(self):
         todo = Todo.objects.create(description="Do thing")
         resp = self.client.get(reverse("admin:index"))
         done_url = reverse("todo-done", args=[todo.pk])
+        self.assertContains(resp, todo.description)
         self.assertContains(resp, f'action="{done_url}"')
         self.assertContains(resp, "DONE")
+
+    def test_dashboard_excludes_todo_changelist_link(self):
+        ct = ContentType.objects.get_for_model(Todo)
+        Favorite.objects.create(user=self.user, content_type=ct)
+        AdminHistory.objects.create(
+            user=self.user,
+            content_type=ct,
+            url=reverse("admin:core_todo_changelist"),
+        )
+        Todo.objects.create(description="Task", is_user_data=True)
+        resp = self.client.get(reverse("admin:index"))
+        self.assertNotContains(resp, reverse("admin:core_todo_changelist"))
 
 
 class DatasetteTests(TestCase):


### PR DESCRIPTION
## Summary
- hide Todo model from admin app list and prevent adding new items
- filter Todos out of dashboard model links while retaining fixture-based tasks
- test dashboard still shows Todo items with Done button

## Testing
- `pre-commit run --files pages/tests.py`
- `pre-commit run --all-files` *(fails: black reformatted teams/apps.py)*
- `pytest core/tests.py::TodoDoneTests::test_mark_done_deletes_and_updates_fixture core/tests.py::TodoAdminPermissionTests::test_add_view_disallowed pages/tests.py::FavoriteTests::test_dashboard_shows_todo_with_done_button pages/tests.py::FavoriteTests::test_dashboard_excludes_todo_changelist_link pages/tests.py::FavoriteTests::test_dashboard_uses_todo_url_if_set` *(fails: NoReverseMatch for teams app)*

------
https://chatgpt.com/codex/tasks/task_e_68c64ad7277083269de0f382b8c9a521