### PR TITLE
Fix admin app_list reverse for new apps

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -213,8 +213,9 @@ def favorite_clear(request):
     return redirect("admin:favorite_list")
 
 
-def get_admin_urls(urls):
+def get_admin_urls(original_get_urls):
     def get_urls():
+        urls = original_get_urls()
         my_urls = [
             path(
                 "favorites/<int:ct_id>/",
@@ -240,4 +241,4 @@ def get_admin_urls(urls):
     return get_urls
 
 
-admin.site.get_urls = get_admin_urls(admin.site.get_urls())
+admin.site.get_urls = get_admin_urls(admin.site.get_urls)

--- a/teams/apps.py
+++ b/teams/apps.py
@@ -3,6 +3,6 @@ from django.utils.translation import gettext_lazy as _
 
 
 class TeamsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'teams'
-    verbose_name = _('6. Workgroup')
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "teams"
+    verbose_name = _("6. Workgroup")


### PR DESCRIPTION
## Summary
- ensure custom admin URLs defer to original get_urls so newly registered apps resolve
- format teams app config to satisfy pre-commit

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68c64c5501008326ba4d6baa4fb73073