### PR TITLE
Rename Protocols group to singular

### DIFF
--- a/ocpp/apps.py
+++ b/ocpp/apps.py
@@ -6,7 +6,7 @@ from django.conf import settings
 class OcppConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "ocpp"
-    verbose_name = "3. Protocols"
+    verbose_name = "3. Protocol"
 
     def ready(self):  # pragma: no cover - startup side effects
         control_lock = Path(settings.BASE_DIR) / "locks" / "control.lck"

--- a/tests/test_admin_doc_model_groups.py
+++ b/tests/test_admin_doc_model_groups.py
@@ -30,7 +30,7 @@ class AdminDocsModelGroupsTests(TestCase):
         expected_numbered = [
             "1. Power",
             "2. Business",
-            "3. Protocols",
+            "3. Protocol",
             "4. Infrastructure",
             "5. Horologia",
             "6. Workgroup",


### PR DESCRIPTION
## Summary
- rename OCPP app verbose name from "3. Protocols" to "3. Protocol"
- update admin docs ordering test to match new group name

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f023fe7c8326aa6ce437bde870ce