### PR TITLE
refactor: remove moved models from Business admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -208,7 +208,6 @@ class ReferenceAdmin(EntityModelAdmin):
     qr_code.short_description = "QR Code"
 
 
-@admin.register(ReleaseManager)
 class ReleaseManagerAdmin(SaveBeforeChangeAction, EntityModelAdmin):
     list_display = ("user", "pypi_username", "pypi_url")
     actions = ["test_credentials"]
@@ -360,14 +359,12 @@ class SecurityGroupAdminForm(forms.ModelForm):
         return instance
 
 
-@admin.register(SecurityGroup)
 class SecurityGroupAdmin(DjangoGroupAdmin):
     form = SecurityGroupAdminForm
     fieldsets = ((None, {"fields": ("name", "parent", "users", "permissions")}),)
     filter_horizontal = ("permissions",)
 
 
-@admin.register(InviteLead)
 class InviteLeadAdmin(EntityModelAdmin):
     list_display = ("email", "created_on", "sent_on", "short_error")
     search_fields = ("email", "comment")
@@ -455,13 +452,11 @@ class EmailCollectorInline(admin.TabularInline):
     extra = 0
 
 
-@admin.register(EmailCollector)
 class EmailCollectorAdmin(EntityModelAdmin):
     list_display = ("inbox", "subject", "sender", "body", "fragment")
     search_fields = ("subject", "sender", "body", "fragment")
 
 
-@admin.register(OdooProfile)
 class OdooProfileAdmin(SaveBeforeChangeAction, EntityModelAdmin):
     change_form_template = "django_object_actions/change_form.html"
     form = OdooProfileAdminForm
@@ -536,7 +531,6 @@ class EmailSearchForm(forms.Form):
     )
 
 
-@admin.register(EmailInbox)
 class EmailInboxAdmin(SaveBeforeChangeAction, EntityModelAdmin):
     form = EmailInboxAdminForm
     list_display = ("user", "username", "host", "protocol")
@@ -653,6 +647,7 @@ class EmailInboxAdmin(SaveBeforeChangeAction, EntityModelAdmin):
                     "results": results,
                     "queryset": queryset,
                     "action": "search_inbox",
+                    "opts": self.model._meta,
                 }
                 return TemplateResponse(
                     request, "admin/core/emailinbox/search.html", context
@@ -663,11 +658,11 @@ class EmailInboxAdmin(SaveBeforeChangeAction, EntityModelAdmin):
             "form": form,
             "queryset": queryset,
             "action": "search_inbox",
+            "opts": self.model._meta,
         }
         return TemplateResponse(request, "admin/core/emailinbox/search.html", context)
 
 
-@admin.register(ChatProfile)
 class ChatProfileAdmin(EntityModelAdmin):
     list_display = ("user", "created_at", "last_used_at", "is_active")
     readonly_fields = ("user_key_hash",)

--- a/core/templates/admin/core/emailinbox/search.html
+++ b/core/templates/admin/core/emailinbox/search.html
@@ -1,11 +1,11 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n admin_urls %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-  <a href="{% url 'admin:app_list' 'core' %}">{% trans 'Core' %}</a> ›
-  <a href="{% url 'admin:core_emailinbox_changelist' %}">{% trans 'Email Inboxes' %}</a> ›
+  <a href="{% url 'admin:app_list' opts.app_label %}">{{ opts.app_config.verbose_name }}</a> ›
+  <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> ›
   {% trans 'Search Email Inboxes' %}
 </div>
 {% endblock %}

--- a/tests/test_chat_profile_admin.py
+++ b/tests/test_chat_profile_admin.py
@@ -21,7 +21,7 @@ class ChatProfileAdminTests(TestCase):
 
     def test_change_form_has_generate_key_link(self):
         url = reverse(
-            "admin:core_chatprofile_change",
+            "admin:teams_chatprofile_change",
             args=[self.profile.pk],
         )
         response = self.client.get(url)
@@ -29,7 +29,7 @@ class ChatProfileAdminTests(TestCase):
 
     def test_change_form_shows_gpt_instructions(self):
         url = reverse(
-            "admin:core_chatprofile_change",
+            "admin:teams_chatprofile_change",
             args=[self.profile.pk],
         )
         response = self.client.get(url)

--- a/tests/test_email_inbox_admin.py
+++ b/tests/test_email_inbox_admin.py
@@ -4,12 +4,12 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib import admin
 from unittest.mock import patch
 
-from core.models import EmailInbox, EmailCollector
+from teams.models import EmailInbox, EmailCollector
+from core.models import EmailCollector as CoreEmailCollector
 from core.admin import (
     EmailInboxAdminForm,
     EmailInboxAdmin,
-    EmailInbox as AdminEmailInbox,
-    EmailCollector as AdminEmailCollector,
+    EmailCollectorAdmin,
 )
 
 
@@ -88,7 +88,7 @@ class EmailInboxAdminActionTests(TestCase):
             use_ssl=True,
         )
         self.factory = RequestFactory()
-        self.admin = EmailInboxAdmin(AdminEmailInbox, AdminSite())
+        self.admin = EmailInboxAdmin(EmailInbox, AdminSite())
 
     def test_test_inbox_action(self):
         request = self.factory.get("/")
@@ -119,7 +119,7 @@ class EmailInboxAdminActionTests(TestCase):
         from django.contrib.messages.storage.fallback import FallbackStorage
 
         request._messages = FallbackStorage(request)
-        with patch.object(EmailCollector, "collect") as mock_collect:
+        with patch.object(CoreEmailCollector, "collect") as mock_collect:
             self.admin.test_collectors(
                 request, EmailInbox.objects.filter(pk=self.inbox.pk)
             )
@@ -131,7 +131,7 @@ class EmailInboxAdminActionTests(TestCase):
         request2.user = self.user
         request2.session = self.client.session
         request2._messages = FallbackStorage(request2)
-        with patch.object(EmailCollector, "collect") as mock_collect2:
+        with patch.object(CoreEmailCollector, "collect") as mock_collect2:
             self.admin.test_collectors_action(request2, self.inbox)
             mock_collect2.assert_called_once_with(limit=1)
         messages2 = list(request2._messages)
@@ -145,7 +145,7 @@ class EmailCollectorInlineTests(TestCase):
             username="admin", email="a@example.com", password="pwd"
         )
         self.factory = RequestFactory()
-        self.admin = EmailInboxAdmin(AdminEmailInbox, AdminSite())
+        self.admin = EmailInboxAdmin(EmailInbox, AdminSite())
 
     def test_can_add_multiple_collectors(self):
         data = {
@@ -203,10 +203,10 @@ class EmailCollectorAdminTests(TestCase):
             protocol=EmailInbox.IMAP,
             use_ssl=True,
         )
-        self.admin = admin.site._registry[AdminEmailCollector]
+        self.admin = admin.site._registry[EmailCollector]
 
     def test_collector_registered_standalone(self):
-        self.assertIn(AdminEmailCollector, admin.site._registry)
+        self.assertIn(EmailCollector, admin.site._registry)
 
     def test_changelist_and_change_view(self):
         collector = EmailCollector.objects.create(inbox=self.inbox)

--- a/tests/test_email_inbox_search_action.py
+++ b/tests/test_email_inbox_search_action.py
@@ -4,8 +4,9 @@ from unittest.mock import patch
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase, RequestFactory
 
-from core.admin import EmailInboxAdmin, EmailInbox as AdminEmailInbox
-from core.models import EmailInbox, User
+from core.admin import EmailInboxAdmin
+from teams.models import EmailInbox
+from core.models import User
 
 
 class DummyIMAPSearch:
@@ -97,11 +98,11 @@ class EmailInboxSearchTests(TestCase):
             use_ssl=True,
         )
         site = AdminSite()
-        ma = EmailInboxAdmin(AdminEmailInbox, site)
+        ma = EmailInboxAdmin(EmailInbox, site)
         factory = RequestFactory()
         request = factory.post("/", {"apply": "yes", "subject": "S"})
         request.user = admin
-        response = ma.search_inbox(request, AdminEmailInbox.objects.filter(id=inbox.id))
+        response = ma.search_inbox(request, EmailInbox.objects.filter(id=inbox.id))
         self.assertEqual(response.status_code, 200)
         content = response.render().content.decode()
         self.assertIn("S", content)

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -16,7 +16,7 @@ django.setup()
 from django.test import TestCase
 from django.conf import settings
 from nodes.models import Node, NodeRole
-from core.models import OdooProfile, SecurityGroup
+from teams.models import OdooProfile, SecurityGroup
 from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -72,7 +72,7 @@ class SeedDataAdminTests(TestCase):
         self.assertNotContains(response, "Seed Datum")
 
     def test_checkbox_displayed_on_change_form(self):
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         response = self.client.get(url)
         content = response.content.decode()
         self.assertIn('name="_seed_datum"', content)
@@ -87,14 +87,14 @@ class SeedDataAdminTests(TestCase):
         )
 
     def test_checkbox_has_form_attribute(self):
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         response = self.client.get(url)
         form_id = f"{self.profile._meta.model_name}_form"
         self.assertContains(response, f'name="_seed_datum" form="{form_id}"')
 
     def test_checkbox_not_displayed_for_non_entity(self):
         group = SecurityGroup.objects.create(name="Temp")
-        url = reverse("admin:core_securitygroup_change", args=[group.pk])
+        url = reverse("admin:teams_securitygroup_change", args=[group.pk])
         response = self.client.get(url)
         self.assertNotContains(response, 'name="_seed_datum"')
         self.assertNotContains(response, 'name="_user_datum"')
@@ -114,7 +114,7 @@ class SeedDataAdminTests(TestCase):
 
     def test_seed_datum_persists_after_save(self):
         OdooProfile.all_objects.filter(pk=self.profile.pk).update(is_seed_data=True)
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         data = {
             "user": self.user.pk,
             "host": "http://test",

--- a/tests/test_sigil_builder.py
+++ b/tests/test_sigil_builder.py
@@ -51,7 +51,7 @@ class SigilBuilderTests(TestCase):
         self.assertContains(response, "[INBOX]")
         self.assertContains(response, "[EMAIL]")
         content = response.content.decode()
-        self.assertEqual(content.count("Email Inbox"), 2)
+        self.assertEqual(content.count("Email Inbox"), 1)
 
     def test_auto_fields_include_roots(self):
         from django.contrib.contenttypes.models import ContentType

--- a/tests/test_user_data_admin.py
+++ b/tests/test_user_data_admin.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.contrib.messages import get_messages
 
-from core.models import OdooProfile
+from teams.models import OdooProfile
 
 
 class UserDataAdminTests(TransactionTestCase):
@@ -28,19 +28,19 @@ class UserDataAdminTests(TransactionTestCase):
             username="odoo",
             password="secret",
         )
-        self.fixture_path = self.data_dir / f"core_odooprofile_{self.profile.pk}.json"
+        self.fixture_path = self.data_dir / f"teams_odooprofile_{self.profile.pk}.json"
 
     def tearDown(self):
         self.fixture_path.unlink(missing_ok=True)
         call_command("flush", verbosity=0, interactive=False)
 
     def test_userdatum_checkbox(self):
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         response = self.client.get(url)
         self.assertContains(response, 'name="_user_datum"')
 
     def test_save_user_datum_creates_fixture(self):
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         data = {
             "user": self.user.pk,
             "host": "http://test",
@@ -60,7 +60,7 @@ class UserDataAdminTests(TransactionTestCase):
     def test_unchecking_removes_fixture(self):
         self.profile.is_user_data = True
         self.profile.save()
-        url = reverse("admin:core_odooprofile_change", args=[self.profile.pk])
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
         data = {
             "user": self.user.pk,
             "host": "http://test",


### PR DESCRIPTION
## Summary
- stop registering moved models under core's Business admin group
- fix EmailInbox search template for dynamic app label
- update tests to reflect new teams admin paths

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f0d230248326b489afbae06ed98d