### PR TITLE
Add automerge workflow triggered by CI success

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: Auto merge
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  merge:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = github.context.payload.workflow_run.pull_requests[0]
+            if (pr) {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              })
+            }
+


### PR DESCRIPTION
## Summary
- add workflow to automatically merge pull requests after CI succeeds

## Testing
- `pre-commit run --all-files` *(fails: black reformats existing migration file)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f22a81508326adc50a2e3b78077d