### PR TITLE
Squash merge after successful CI

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,12 +17,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = github.context.payload.workflow_run.pull_requests[0]
+            const pr = github.context.payload.workflow_run.pull_requests[0];
             if (pr) {
-              await github.rest.pulls.merge({
+              const { data: fullPR } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number
-              })
+              });
+
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                merge_method: 'squash'
+              });
+
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${fullPR.head.ref}`
+              });
             }
 


### PR DESCRIPTION
## Summary
- squash merge pull requests automatically after CI passes
- delete merged branches automatically

## Testing
- `pre-commit run --files .github/workflows/automerge.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c705128fb883268377d9cfba9eca01