### PR TITLE
Prefer natural keys for fixtures

### DIFF
--- a/core/fixtures/references__reference_1.json
+++ b/core/fixtures/references__reference_1.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 1,
     "fields": {
       "value": "https://arthexis.com",
       "alt_text": "Arthexis Online",

--- a/core/fixtures/references__reference_10.json
+++ b/core/fixtures/references__reference_10.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 10,
     "fields": {
       "value": "https://dealer.porsche.com/mx/monterrey/es-MX",
       "alt_text": "Porsche Center",

--- a/core/fixtures/references__reference_11.json
+++ b/core/fixtures/references__reference_11.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 11,
     "fields": {
       "value": "https://en.wikipedia.org/wiki/MIT_License",
       "alt_text": "MIT License",

--- a/core/fixtures/references__reference_12.json
+++ b/core/fixtures/references__reference_12.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 12,
     "fields": {
       "value": "https://ko-fi.com/arthexis/gallery",
       "alt_text": "Mysteric Gallery",

--- a/core/fixtures/references__reference_2.json
+++ b/core/fixtures/references__reference_2.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 2,
     "fields": {
       "value": "https://pypi.org/project/arthexis/",
       "alt_text": "Arthexis on PyPI",

--- a/core/fixtures/references__reference_3.json
+++ b/core/fixtures/references__reference_3.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 3,
     "fields": {
       "value": "https://www.gelectriic.com",
       "alt_text": "Gelectriic Solutions",

--- a/core/fixtures/references__reference_4.json
+++ b/core/fixtures/references__reference_4.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 4,
     "fields": {
       "value": "https://www.python.org/",
       "alt_text": "Python",

--- a/core/fixtures/references__reference_5.json
+++ b/core/fixtures/references__reference_5.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 5,
     "fields": {
       "value": "https://www.djangoproject.com/",
       "alt_text": "Django",

--- a/core/fixtures/references__reference_6.json
+++ b/core/fixtures/references__reference_6.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 6,
     "fields": {
       "value": "https://openchargealliance.org/protocols/open-charge-point-protocol/",
       "alt_text": "OCPP",

--- a/core/fixtures/references__reference_7.json
+++ b/core/fixtures/references__reference_7.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 7,
     "fields": {
       "value": "https://docs.celeryq.dev/en/stable/",
       "alt_text": "Celery",

--- a/core/fixtures/references__reference_8.json
+++ b/core/fixtures/references__reference_8.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 8,
     "fields": {
       "value": "https://github.com/arthexis/arthexis",
       "alt_text": "GitHub Repo",

--- a/core/fixtures/references__reference_9.json
+++ b/core/fixtures/references__reference_9.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.reference",
-    "pk": 9,
     "fields": {
       "value": "https://www.odoo.com/partners",
       "alt_text": "Odoo Partners",

--- a/core/fixtures/sigil_roots__acct.json
+++ b/core/fixtures/sigil_roots__acct.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 33,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__app.json
+++ b/core/fixtures/sigil_roots__app.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 48,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__awg.json
+++ b/core/fixtures/sigil_roots__awg.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 45,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__badge.json
+++ b/core/fixtures/sigil_roots__badge.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 50,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__calc.json
+++ b/core/fixtures/sigil_roots__calc.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 47,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__cfill.json
+++ b/core/fixtures/sigil_roots__cfill.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 46,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__chat.json
+++ b/core/fixtures/sigil_roots__chat.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 28,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__clock.json
+++ b/core/fixtures/sigil_roots__clock.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 29,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__cp.json
+++ b/core/fixtures/sigil_roots__cp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 41,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__cron.json
+++ b/core/fixtures/sigil_roots__cron.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 12,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__debug.json
+++ b/core/fixtures/sigil_roots__debug.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 54,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__eart.json
+++ b/core/fixtures/sigil_roots__eart.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 31,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__ecoll.json
+++ b/core/fixtures/sigil_roots__ecoll.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 26,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__ev.json
+++ b/core/fixtures/sigil_roots__ev.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 9,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__evb.json
+++ b/core/fixtures/sigil_roots__evb.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 23,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__evm.json
+++ b/core/fixtures/sigil_roots__evm.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 19,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__fav.json
+++ b/core/fixtures/sigil_roots__fav.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 52,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__feat.json
+++ b/core/fixtures/sigil_roots__feat.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 1,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__hist.json
+++ b/core/fixtures/sigil_roots__hist.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 20,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__inbox.json
+++ b/core/fixtures/sigil_roots__inbox.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 17,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__inter.json
+++ b/core/fixtures/sigil_roots__inter.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 13,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__invl.json
+++ b/core/fixtures/sigil_roots__invl.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 16,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__land.json
+++ b/core/fixtures/sigil_roots__land.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 51,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__lives.json
+++ b/core/fixtures/sigil_roots__lives.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 8,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__loc.json
+++ b/core/fixtures/sigil_roots__loc.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 40,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__log.json
+++ b/core/fixtures/sigil_roots__log.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 2,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__man.json
+++ b/core/fixtures/sigil_roots__man.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 53,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__meter.json
+++ b/core/fixtures/sigil_roots__meter.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 43,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__mgr.json
+++ b/core/fixtures/sigil_roots__mgr.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 6,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__mod.json
+++ b/core/fixtures/sigil_roots__mod.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 49,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__msg.json
+++ b/core/fixtures/sigil_roots__msg.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 30,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__node.json
+++ b/core/fixtures/sigil_roots__node.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 27,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__odoo.json
+++ b/core/fixtures/sigil_roots__odoo.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 7,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__outbox.json
+++ b/core/fixtures/sigil_roots__outbox.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 24,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__pkg.json
+++ b/core/fixtures/sigil_roots__pkg.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 37,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__powl.json
+++ b/core/fixtures/sigil_roots__powl.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 39,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__prod.json
+++ b/core/fixtures/sigil_roots__prod.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 36,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__ref.json
+++ b/core/fixtures/sigil_roots__ref.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 32,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__rel.json
+++ b/core/fixtures/sigil_roots__rel.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 21,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__role.json
+++ b/core/fixtures/sigil_roots__role.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 18,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__rpt.json
+++ b/core/fixtures/sigil_roots__rpt.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 34,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__sample.json
+++ b/core/fixtures/sigil_roots__sample.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 22,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__sec.json
+++ b/core/fixtures/sigil_roots__sec.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 11,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__sess.json
+++ b/core/fixtures/sigil_roots__sess.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 4,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__sim.json
+++ b/core/fixtures/sigil_roots__sim.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 44,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__site.json
+++ b/core/fixtures/sigil_roots__site.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 5,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__sol.json
+++ b/core/fixtures/sigil_roots__sol.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 10,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__task.json
+++ b/core/fixtures/sigil_roots__task.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 14,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__todo.json
+++ b/core/fixtures/sigil_roots__todo.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 38,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__txn.json
+++ b/core/fixtures/sigil_roots__txn.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 42,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__type.json
+++ b/core/fixtures/sigil_roots__type.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 3,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__user.json
+++ b/core/fixtures/sigil_roots__user.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 25,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/sigil_roots__wmi.json
+++ b/core/fixtures/sigil_roots__wmi.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.sigilroot",
-    "pk": 35,
     "fields": {
       "is_seed_data": false,
       "is_deleted": false,

--- a/core/fixtures/todos__validate_screen_admin_client_report.json
+++ b/core/fixtures/todos__validate_screen_admin_client_report.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 21,
     "fields": {
       "request": "Validate screen Admin Client Report",
       "url": "/admin/core/clientreport/"

--- a/core/fixtures/todos__validate_screen_admin_rfid_client_report.json
+++ b/core/fixtures/todos__validate_screen_admin_rfid_client_report.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 22,
     "fields": {
       "request": "Validate screen Admin RFID Client Report",
       "url": "/admin/core/rfid/report/"

--- a/core/fixtures/todos__validate_screen_client_report.json
+++ b/core/fixtures/todos__validate_screen_client_report.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 20,
     "fields": {
       "request": "Validate screen Client Report",
       "url": "/client-report/"

--- a/core/fixtures/todos__validate_screen_release_progress.json
+++ b/core/fixtures/todos__validate_screen_release_progress.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 16,
     "fields": {
       "request": "Validate screen Release progress",
       "url": "/admin/core/releases/1/publish/"

--- a/core/fixtures/todos__validate_screen_system.json
+++ b/core/fixtures/todos__validate_screen_system.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 12,
     "fields": {
       "request": "Validate screen System",
       "url": "/admin/system/"

--- a/core/fixtures/todos__validate_screen_user_manuals.json
+++ b/core/fixtures/todos__validate_screen_user_manuals.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.todo",
-    "pk": 12,
     "fields": {
       "request": "Validate screen User Manuals",
       "url": "/man/"

--- a/core/fixtures/users__arthexis.json
+++ b/core/fixtures/users__arthexis.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "core.user",
-    "pk": 1,
     "fields": {
       "username": "arthexis",
       "email": "arthexis@gmail.com",

--- a/nodes/fixtures/node_features__nodefeature_celery_queue.json
+++ b/nodes/fixtures/node_features__nodefeature_celery_queue.json
@@ -1,13 +1,25 @@
 [
   {
     "model": "nodes.nodefeature",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
       "slug": "celery-queue",
       "display": "Celery Queue",
-      "roles": [["Terminal"], ["Satellite"], ["Control"], ["Constellation"]]
+      "roles": [
+        [
+          "Terminal"
+        ],
+        [
+          "Satellite"
+        ],
+        [
+          "Control"
+        ],
+        [
+          "Constellation"
+        ]
+      ]
     }
   }
 ]

--- a/nodes/fixtures/node_features__nodefeature_lcd_screen.json
+++ b/nodes/fixtures/node_features__nodefeature_lcd_screen.json
@@ -1,13 +1,19 @@
 [
   {
     "model": "nodes.nodefeature",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
       "slug": "lcd-screen",
       "display": "LCD Screen",
-      "roles": [["Terminal"], ["Control"]]
+      "roles": [
+        [
+          "Terminal"
+        ],
+        [
+          "Control"
+        ]
+      ]
     }
   }
 ]

--- a/nodes/fixtures/node_features__nodefeature_nginx_server.json
+++ b/nodes/fixtures/node_features__nodefeature_nginx_server.json
@@ -1,13 +1,25 @@
 [
   {
     "model": "nodes.nodefeature",
-    "pk": 4,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
       "slug": "nginx-server",
       "display": "NGINX Server",
-      "roles": [["Terminal"], ["Satellite"], ["Control"], ["Constellation"]]
+      "roles": [
+        [
+          "Terminal"
+        ],
+        [
+          "Satellite"
+        ],
+        [
+          "Control"
+        ],
+        [
+          "Constellation"
+        ]
+      ]
     }
   }
 ]

--- a/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
+++ b/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
@@ -1,13 +1,22 @@
 [
   {
     "model": "nodes.nodefeature",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
       "slug": "rfid-scanner",
       "display": "RFID Scanner",
-      "roles": [["Terminal"], ["Satellite"], ["Constellation"]]
+      "roles": [
+        [
+          "Terminal"
+        ],
+        [
+          "Satellite"
+        ],
+        [
+          "Constellation"
+        ]
+      ]
     }
   }
 ]

--- a/nodes/fixtures/node_roles__noderole_constellation.json
+++ b/nodes/fixtures/node_roles__noderole_constellation.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "nodes.noderole",
-    "pk": 2,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/nodes/fixtures/node_roles__noderole_control.json
+++ b/nodes/fixtures/node_roles__noderole_control.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "nodes.noderole",
-    "pk": 3,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/nodes/fixtures/node_roles__noderole_satellite.json
+++ b/nodes/fixtures/node_roles__noderole_satellite.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "nodes.noderole",
-    "pk": 4,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/nodes/fixtures/node_roles__noderole_terminal.json
+++ b/nodes/fixtures/node_roles__noderole_terminal.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "nodes.noderole",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/constellation__application_ocpp.json
+++ b/pages/fixtures/constellation__application_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.application",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/localhost__application_ocpp.json
+++ b/pages/fixtures/localhost__application_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.application",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/satellite_box__application_ocpp.json
+++ b/pages/fixtures/satellite_box__application_ocpp.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "pages.application",
-    "pk": 1,
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,

--- a/pages/fixtures/sites__site_10_42_0_1.json
+++ b/pages/fixtures/sites__site_10_42_0_1.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "sites.site",
-    "pk": 3,
     "fields": {
       "domain": "10.42.0.1",
       "name": "Router"

--- a/pages/fixtures/sites__site_127_0_0_1.json
+++ b/pages/fixtures/sites__site_127_0_0_1.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "sites.site",
-    "pk": 1,
     "fields": {
       "domain": "127.0.0.1",
       "name": "Local"

--- a/pages/fixtures/sites__site_192_168_129_10.json
+++ b/pages/fixtures/sites__site_192_168_129_10.json
@@ -1,7 +1,6 @@
 [
   {
     "model": "sites.site",
-    "pk": 2,
     "fields": {
       "domain": "192.168.129.10",
       "name": "Gateway"


### PR DESCRIPTION
## Summary
- add natural key managers for SigilRoot, Reference, and Todo models
- drop explicit primary keys from seed fixtures to rely on natural keys

## Testing
- `pre-commit run --all-files`
- `python manage.py test` *(fails: OperationalError: no such table: ocpp_charger)*

------
https://chatgpt.com/codex/tasks/task_e_68c70ef02ff48326b68bab7fd96fa9e1