### PR TITLE
Use request as natural key for TODO and rewrite fixtures

### DIFF
--- a/core/fixtures/todos__validate_screen_release_progress_start_button.json
+++ b/core/fixtures/todos__validate_screen_release_progress_start_button.json
@@ -1,9 +1,8 @@
 [
   {
     "model": "core.todo",
-    "pk": 23,
     "fields": {
-      "request": "Validate screen Release progress",
+      "request": "Validate screen Release progress start button",
       "url": "/admin/core/releases/1/publish/"
     }
   }

--- a/core/models.py
+++ b/core/models.py
@@ -1414,5 +1414,8 @@ class Todo(Entity):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.request
 
-    def natural_key(self):  # pragma: no cover - simple representation
+    def natural_key(self):
+        """Use the request field as the natural key."""
         return (self.request,)
+
+    natural_key.dependencies = []


### PR DESCRIPTION
## Summary
- define `Todo.natural_key` so fixtures can refer to todos by request
- rewrite release progress TODO fixture to rely on natural key

## Testing
- `pre-commit run --files core/models.py core/fixtures/todos__validate_screen_release_progress_start_button.json`
- `python manage.py makemigrations --check`
- `pytest tests/test_release_progress.py core/tests.py pages/tests.py` *(fails: NameError: name 'Address' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c751cc44b88326bb3579e5a2766b81