### PR TITLE
Handle missing site on login

### DIFF
--- a/core/fixtures/todos__validate_screen_login.json
+++ b/core/fixtures/todos__validate_screen_login.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Login",
+      "url": "/login/"
+    }
+  }
+]

--- a/pages/views.py
+++ b/pages/views.py
@@ -144,6 +144,18 @@ class CustomLoginView(LoginView):
             return redirect(self.get_success_url())
         return super().dispatch(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = super(LoginView, self).get_context_data(**kwargs)
+        current_site = get_site(self.request)
+        context.update(
+            {
+                "site": current_site,
+                "site_name": getattr(current_site, "name", ""),
+                "next": self.get_success_url(),
+            }
+        )
+        return context
+
     def get_success_url(self):
         redirect_url = self.get_redirect_url()
         if redirect_url:

--- a/tests/test_login_view_no_site.py
+++ b/tests/test_login_view_no_site.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.contrib.sites.models import Site
+from django.test import TestCase
+from django.urls import reverse
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+django.setup()
+
+
+class LoginViewNoSiteTests(TestCase):
+    def setUp(self):
+        Site.objects.all().delete()
+
+    def test_login_page_renders_without_site(self):
+        response = self.client.get(reverse("pages:login"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- prevent login page from failing when no Site exists
- add TODO fixture for validating login screen
- test login view without Site record

## Testing
- `pytest tests/test_login_view_no_site.py tests/test_footer_render.py tests/test_footer_no_references.py`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c81a8a22a08326aee88935ba3b079b