### PR TITLE
Restrict release progress to current package and require manual start

### DIFF
--- a/core/fixtures/todos__validate_screen_release_progress_is_current.json
+++ b/core/fixtures/todos__validate_screen_release_progress_is_current.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Release progress is current check",
+      "url": "/admin/core/releases/1/publish/"
+    }
+  }
+]

--- a/core/views.py
+++ b/core/views.py
@@ -442,6 +442,8 @@ def release_progress(request, pk: int, action: str):
     release = get_object_or_404(PackageRelease, pk=pk)
     if action != "publish":
         raise Http404("Unknown action")
+    if not release.is_current:
+        raise Http404("Release is not current")
     session_key = f"release_publish_{pk}"
     lock_path = Path("locks") / f"release_publish_{pk}.json"
     restart_path = Path("locks") / f"release_publish_{pk}.restarts"

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -1,6 +1,25 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  .todo-item { position: relative; }
+  .todo-item .todo-details {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: var(--body-bg);
+    border: 1px solid var(--hairline-color);
+    padding: 8px;
+    z-index: 1000;
+    width: 200px;
+  }
+  .todo-item:hover .todo-details { display: block; }
+</style>
+{% endblock %}
+
 {% block nav-breadcrumbs %}
 <nav aria-label="{% translate 'Breadcrumbs' %}">
   <div class="breadcrumbs">
@@ -16,11 +35,17 @@
 {% block content %}
 <h1>{{ action|capfirst }} {{ release.package.name }} {{ release.version }}</h1>
 <div>
+  {% if not started %}
   <form method="get" style="display:inline;">
-    <button type="submit" name="abort" value="1">{% trans 'Stop Publish' %}</button>
+    <input type="hidden" name="step" value="0">
+    <button type="submit" name="start" value="1">▶️ {% trans 'Start Publish' %}</button>
+  </form>
+  {% endif %}
+  <form method="get" style="display:inline;">
+    <button type="submit" name="abort" value="1" {% if not started %}disabled{% endif %}>⏹️ {% trans 'Stop Publish' %}</button>
   </form>
   <form method="get" style="display:inline;">
-    <button type="submit" name="restart" value="1">{% trans 'Restart Publish' %}</button>
+    <button type="submit" name="restart" value="1" {% if not started %}disabled{% endif %}>🔄 {% trans 'Restart Publish' %}</button>
   </form>
 </div>
 <ol>
@@ -56,15 +81,18 @@
   <input type="hidden" name="step" value="{{ current_step }}">
   <ul>
   {% for todo in todos %}
-  <li>
+  <li class="todo-item">
     <label>
       <input type="checkbox" class="todo-check">
       {% if todo.url %}
-      <a href="{{ todo.url }}" target="_blank" rel="noopener">{{ todo.request }}</a>
+      <a href="{{ todo.url }}" target="_blank" rel="noopener" class="todo-link">{{ todo.request }}</a>
       {% else %}
       {{ todo.request }}
       {% endif %}
     </label>
+    {% if todo.request_details %}
+    <div class="todo-details">{{ todo.request_details }}</div>
+    {% endif %}
   </li>
   {% endfor %}
   </ul>
@@ -81,8 +109,14 @@
 {% if error %}
 <p class="error">{{ error }}</p>
 {% elif not done %}
+{% if started and next_step is not None %}
 <meta http-equiv="refresh" content="1; url={{ request.path }}?step={{ next_step }}">
+{% endif %}
+{% if started %}
 <p>Running...</p>
+{% else %}
+<p>{% trans 'Waiting to start' %}</p>
+{% endif %}
 {% else %}
 <p>All steps completed.</p>
 {% if release.pypi_url %}
@@ -92,5 +126,16 @@
   <input type="text" id="logpath" value="{{ log_path }}" readonly>
   <button type="button" onclick="navigator.clipboard.writeText(document.getElementById('logpath').value)">Copy log path</button>
 </div>
+{% if cert_log %}
+<p>Certification logged in {{ cert_log }}</p>
 {% endif %}
+{% endif %}
+<p>{% trans 'Restarts' %}: {{ restart_count }}</p>
+<form method="get">
+  <button type="submit" name="restart" value="1" {% if not started %}disabled{% endif %}>🔄 {% trans 'Restart Publish' %}</button>
+  {% if not done %}
+  <button type="submit" name="abort" value="1" {% if not started %}disabled{% endif %}>⏹️ {% trans 'Stop Publish' %}</button>
+  {% endif %}
+</form>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- prevent visiting publish progress for non-current releases
- require manual start of publish and disable controls until started
- add validation todo for release progress current check

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_release_progress.py`


------
https://chatgpt.com/codex/tasks/task_e_68c82840ac18832688bc9d687456d875