### PR TITLE
Reassign EV admin models to Business and clean up menus

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -30,6 +30,9 @@ from .models import (
     User,
     EnergyAccount,
     ElectricVehicle,
+    Brand,
+    EVModel,
+    WMICode,
     EnergyCredit,
     ClientReport,
     Product,
@@ -823,7 +826,37 @@ class EnergyAccountAdmin(EntityModelAdmin):
 @admin.register(ElectricVehicle)
 class ElectricVehicleAdmin(EntityModelAdmin):
     list_display = ("vin", "license_plate", "brand", "model", "account")
+    search_fields = (
+        "vin",
+        "license_plate",
+        "brand__name",
+        "model__name",
+        "account__name",
+    )
     fields = ("account", "vin", "license_plate", "brand", "model")
+
+
+class WMICodeInline(admin.TabularInline):
+    model = WMICode
+    extra = 0
+
+
+@admin.register(Brand)
+class BrandAdmin(EntityModelAdmin):
+    fields = ("name",)
+    list_display = ("name", "wmi_codes_display")
+    inlines = [WMICodeInline]
+
+    def wmi_codes_display(self, obj):
+        return ", ".join(obj.wmi_codes.values_list("code", flat=True))
+
+    wmi_codes_display.short_description = "WMI codes"
+
+
+@admin.register(EVModel)
+class EVModelAdmin(EntityModelAdmin):
+    fields = ("brand", "name")
+    list_display = ("name", "brand")
 
 
 @admin.register(EnergyCredit)

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -24,9 +24,7 @@ from .models import (
     NodeFeature,
     ContentSample,
     NetMessage,
-    User,
 )
-from core.admin import UserAdmin as CoreUserAdmin
 from core.user_data import EntityModelAdmin
 
 
@@ -367,6 +365,3 @@ class NetMessageAdmin(EntityModelAdmin):
         self.message_user(request, f"{queryset.count()} messages sent")
 
     send_messages.short_description = "Send selected messages"
-
-
-admin.site.register(User, CoreUserAdmin)

--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -16,9 +16,6 @@ from .models import (
     MeterValue,
     Transaction,
     Location,
-    ElectricVehicle,
-    Brand,
-    EVModel,
 )
 from .simulator import ChargePointSimulator
 from . import store
@@ -26,10 +23,7 @@ from .transactions_io import (
     export_transactions,
     import_transactions as import_transactions_data,
 )
-from core.admin import RFIDAdmin
-from core.models import WMICode
 from core.user_data import EntityModelAdmin
-from .models import RFID
 
 
 class LocationAdminForm(forms.ModelForm):
@@ -397,42 +391,3 @@ class MeterValueAdmin(EntityModelAdmin):
     )
     date_hierarchy = "timestamp"
     list_filter = ("charger", MeterValueDateFilter)
-
-
-@admin.register(ElectricVehicle)
-class ElectricVehicleAdmin(EntityModelAdmin):
-    list_display = ("vin", "license_plate", "brand", "model", "account")
-    search_fields = (
-        "vin",
-        "license_plate",
-        "brand__name",
-        "model__name",
-        "account__name",
-    )
-    fields = ("account", "vin", "license_plate", "brand", "model")
-
-
-class WMICodeInline(admin.TabularInline):
-    model = WMICode
-    extra = 0
-
-
-@admin.register(Brand)
-class BrandAdmin(EntityModelAdmin):
-    fields = ("name",)
-    list_display = ("name", "wmi_codes_display")
-    inlines = [WMICodeInline]
-
-    def wmi_codes_display(self, obj):
-        return ", ".join(obj.wmi_codes.values_list("code", flat=True))
-
-    wmi_codes_display.short_description = "WMI codes"
-
-
-@admin.register(EVModel)
-class EVModelAdmin(EntityModelAdmin):
-    fields = ("brand", "name")
-    list_display = ("name", "brand")
-
-
-admin.site.register(RFID, RFIDAdmin)

--- a/tests/test_admin_object_history.py
+++ b/tests/test_admin_object_history.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
 
-from ocpp.models import Brand
+from core.models import Brand
 
 
 class AdminObjectHistoryTests(TestCase):
@@ -25,7 +25,7 @@ class AdminObjectHistoryTests(TestCase):
         self.client.force_login(self.user)
 
     def test_history_tracks_old_and_new_values(self):
-        add_url = reverse("admin:ocpp_brand_add")
+        add_url = reverse("admin:core_brand_add")
         self.client.post(
             add_url,
             {
@@ -48,7 +48,7 @@ class AdminObjectHistoryTests(TestCase):
         self.assertIn("Added", msg)
         self.assertIn("name='OldBrand'", msg)
 
-        change_url = reverse("admin:ocpp_brand_change", args=[brand.pk])
+        change_url = reverse("admin:core_brand_change", args=[brand.pk])
         self.client.post(
             change_url,
             {


### PR DESCRIPTION
## Summary
- register EV brands, models, and vehicles within the core admin so they appear under the Business group
- drop the Protocol admin registrations for EV models and RFIDs and stop exposing the User proxy from Infrastructure
- update the admin history test to use the new core brand routes

## Testing
- pytest tests/test_admin_object_history.py tests/test_rfid_admin_reference_clear.py
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c8436f4d088326a856cd6a08ee2653