### PR TITLE
Hide stale publish logs until release start

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -549,7 +549,11 @@ def release_progress(request, pk: int, action: str):
 
     done = step_count >= len(steps) and not ctx.get("error")
 
-    log_content = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+    show_log = ctx.get("started") or step_count > 0 or done or ctx.get("error")
+    if show_log and log_path.exists():
+        log_content = log_path.read_text(encoding="utf-8")
+    else:
+        log_content = ""
     next_step = (
         step_count if ctx.get("started") and not done and not ctx.get("error") else None
     )

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -65,6 +65,15 @@ class ReleaseProgressViewTests(TestCase):
         self.assertTrue(log_path.exists())
         self.assertNotIn("old data", response.context["log_content"])
 
+    def test_log_hidden_before_start(self):
+        log_path = self.log_dir / (f"{self.package.name}-{self.release.version}.log")
+        log_path.write_text("old data")
+
+        url = reverse("release-progress", args=[self.release.pk, "publish"])
+        response = self.client.get(url)
+
+        self.assertEqual(response.context["log_content"], "")
+
     def test_non_current_release_returns_404(self):
         other = PackageRelease.objects.create(
             package=self.package, version="2.0", revision=""


### PR DESCRIPTION
## Summary
- avoid showing previous release log entries before the publish workflow starts
- add a regression test that ensures publish logs stay hidden until the workflow begins

## Testing
- pytest tests/test_release_progress.py
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c84edc5c5883269f1af77b0a735265