### PR TITLE
Adjust admin object tool button padding

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -279,7 +279,7 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     border-radius: 15px;
     display: block;
     float: left;
-    padding: 3px 12px;
+    padding: 5px 12px;
     line-height: 1rem;
     background: var(--object-tools-bg);
     color: var(--object-tools-fg);


### PR DESCRIPTION
## Summary
- increase the vertical padding on object tool buttons so their height matches the history link

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c85a69c0208326bd5feae6149e7502