### PR TITLE
Expand release manager token widgets

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -211,7 +211,18 @@ class ReferenceAdmin(EntityModelAdmin):
     qr_code.short_description = "QR Code"
 
 
+class ReleaseManagerAdminForm(forms.ModelForm):
+    class Meta:
+        model = ReleaseManager
+        fields = "__all__"
+        widgets = {
+            "pypi_token": forms.Textarea(attrs={"rows": 3, "style": "width: 40em;"}),
+            "github_token": forms.Textarea(attrs={"rows": 3, "style": "width: 40em;"}),
+        }
+
+
 class ReleaseManagerAdmin(SaveBeforeChangeAction, EntityModelAdmin):
+    form = ReleaseManagerAdminForm
     list_display = ("user", "pypi_username", "pypi_url")
     actions = ["test_credentials"]
     change_actions = ["test_credentials_action"]


### PR DESCRIPTION
## Summary
- render the Release Manager admin using a custom form so the PyPI and GitHub token fields display in longer text areas

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c85c1f26c4832692da2a4ff9f7f296