### PR TITLE
Restrict release manager dashboard todos

### DIFF
--- a/pages/middleware.py
+++ b/pages/middleware.py
@@ -81,7 +81,9 @@ class ViewHistoryMiddleware:
                 view_name=view_name,
             )
         except Exception:  # pragma: no cover - best effort logging
-            logger.debug("Failed to record ViewHistory for %s", full_path, exc_info=True)
+            logger.debug(
+                "Failed to record ViewHistory for %s", full_path, exc_info=True
+            )
 
     def _resolve_view_name(self, request) -> str:
         match = getattr(request, "resolver_match", None)
@@ -103,4 +105,3 @@ class ViewHistoryMiddleware:
         if module and name:
             return f"{module}.{name}"
         return name or module or ""
-

--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.urls import NoReverseMatch, reverse
 
-from core.models import Todo
+from core.models import ReleaseManager, Todo
 from core.entity import Entity
 
 register = template.Library()
@@ -174,14 +174,16 @@ def future_action_items(context):
             model_items.append({"url": url, "label": label})
             seen.add(ct.id)
 
-    todos = [
-        {
-            "url": todo.url or reverse("admin:core_todo_change", args=[todo.pk]),
-            "label": todo.request,
-            "details": todo.request_details,
-            "done_url": reverse("todo-done", args=[todo.pk]),
-        }
-        for todo in Todo.objects.filter(is_deleted=False, done_on__isnull=True)
-    ]
+    todos: list[dict[str, str]] = []
+    if ReleaseManager.objects.filter(user=user).exists():
+        todos = [
+            {
+                "url": todo.url or reverse("admin:core_todo_change", args=[todo.pk]),
+                "label": todo.request,
+                "details": todo.request_details,
+                "done_url": reverse("todo-done", args=[todo.pk]),
+            }
+            for todo in Todo.objects.filter(is_deleted=False, done_on__isnull=True)
+        ]
 
     return {"models": model_items, "todos": todos}


### PR DESCRIPTION
## Summary
- only populate dashboard release manager todos when the signed-in user has a linked ReleaseManager record
- update dashboard tests to create release managers and add coverage for the non-release-manager case
- apply Black formatting via pre-commit to the middleware logging block

## Testing
- python manage.py test pages.tests.FavoriteTests.test_dashboard_hides_todos_without_release_manager -v 2
- python manage.py test pages.tests.FavoriteTests.test_dashboard_shows_todo_with_done_button -v 2
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c86b8bdd40832684b08c7a5d938bf4