### PR TITLE
Adjust release progress button spacing

### DIFF
--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -19,8 +19,12 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+  }
+  .progress-actions button {
+    padding-inline: 1.1rem;
+    padding-block: 0.45rem 0.6rem;
   }
   .progress-actions form {
     display: inline;

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -19,8 +19,12 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+  }
+  .progress-actions button {
+    padding-inline: 1.1rem;
+    padding-block: 0.45rem 0.6rem;
   }
   .progress-actions form {
     display: inline;


### PR DESCRIPTION
## Summary
- increase the padding under the publish action buttons to better separate them from the checklist
- add explicit padding to the publish action buttons for a larger click target in both runtime and static templates

## Testing
- python -m pre_commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c874e907708326b79c78b6cf98b5fb