### PR TITLE
Limit future action links to top entries

### DIFF
--- a/pages/templatetags/favorites.py
+++ b/pages/templatetags/favorites.py
@@ -12,6 +12,7 @@ def favorite_ct_id(app_label, model_name):
         model = apps.get_model(app_label, model_name)
     except LookupError:
         return None
+    ContentType.objects.clear_cache()
     ct = ContentType.objects.get_for_model(model)
     return ct.id
 


### PR DESCRIPTION
## Summary
- update the admin dashboard future actions tag to aggregate history, favorites, and user data counts and surface only the four most frequent links
- clear the content type cache when resolving favorite content types so missing entries can be recreated without stale references
- add a regression test for the new dashboard behavior and reset the content type cache during favorite admin tests

## Testing
- python manage.py test pages.tests.FavoriteTests
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c874ca26488326804af7e182652013