### PR TITLE
Add management command for broadcasting Net Messages

### DIFF
--- a/nodes/management/commands/message.py
+++ b/nodes/management/commands/message.py
@@ -1,0 +1,42 @@
+"""Management command to broadcast :class:`~nodes.models.NetMessage` entries."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from nodes.models import NetMessage
+
+
+class Command(BaseCommand):
+    """Send a network message across nodes."""
+
+    help = "Broadcast a Net Message to the network"
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("subject", help="Subject or first line of the message")
+        parser.add_argument(
+            "body",
+            nargs="?",
+            default="",
+            help="Optional body text for the message",
+        )
+        parser.add_argument(
+            "--reach",
+            dest="reach",
+            help="Optional node role name that limits propagation",
+        )
+        parser.add_argument(
+            "--seen",
+            nargs="+",
+            dest="seen",
+            help="UUIDs of nodes that have already seen the message",
+        )
+
+    def handle(self, *args, **options):
+        subject: str = options["subject"]
+        body: str = options["body"]
+        reach: str | None = options.get("reach")
+        seen: list[str] | None = options.get("seen")
+
+        NetMessage.broadcast(subject=subject, body=body, reach=reach, seen=seen)
+        self.stdout.write(self.style.SUCCESS("Net message broadcast"))

--- a/tests/test_message_command.py
+++ b/tests/test_message_command.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.core.management import call_command
+from unittest.mock import patch
+
+
+def test_message_management_command_calls_netmessage_broadcast():
+    with patch("nodes.management.commands.message.NetMessage.broadcast") as broadcast:
+        call_command("message", "subject", "body")
+    broadcast.assert_called_once_with(
+        subject="subject", body="body", reach=None, seen=None
+    )
+
+
+def test_message_management_command_passes_optional_arguments():
+    with patch("nodes.management.commands.message.NetMessage.broadcast") as broadcast:
+        call_command("message", "subject", "body", "--reach", "Control", "--seen", "a", "b")
+    broadcast.assert_called_once_with(
+        subject="subject", body="body", reach="Control", seen=["a", "b"]
+    )


### PR DESCRIPTION
## Summary
- add a ``message`` management command that broadcasts network messages with optional reach and seen parameters
- cover the new command with unit tests that ensure the broadcast call receives the expected arguments

## Testing
- pytest tests/test_message_command.py
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c8855e20cc8326991daf0e202624e2