### PR TITLE
Show brand WMI codes in EV model admin list

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -867,7 +867,19 @@ class BrandAdmin(EntityModelAdmin):
 @admin.register(EVModel)
 class EVModelAdmin(EntityModelAdmin):
     fields = ("brand", "name")
-    list_display = ("name", "brand")
+    list_display = ("name", "brand", "brand_wmi_codes")
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.select_related("brand").prefetch_related("brand__wmi_codes")
+
+    def brand_wmi_codes(self, obj):
+        if not obj.brand:
+            return ""
+        codes = [wmi.code for wmi in obj.brand.wmi_codes.all()]
+        return ", ".join(codes)
+
+    brand_wmi_codes.short_description = "WMI codes"
 
 
 @admin.register(EnergyCredit)


### PR DESCRIPTION
## Summary
- show each EV model's brand WMI codes in the admin changelist
- prefetch brand WMI codes to avoid extra database queries when rendering the list

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c8ad0fa0e483268d63dbd15d32d1e6