### PR TITLE
Add guard against nested git repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
         entry: python scripts/ensure_validation_todos.py
         language: system
         pass_filenames: false
+      - id: nested-git-repositories
+        name: Prevent nested Git repositories
+        entry: python scripts/check_nested_git_repositories.py
+        language: system
+        pass_filenames: false

--- a/scripts/check_nested_git_repositories.py
+++ b/scripts/check_nested_git_repositories.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Fail when nested Git repositories are present in the tree."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
+
+from utils.git_checks import find_nested_git_repositories
+
+
+def main() -> int:
+    nested = find_nested_git_repositories(BASE_DIR)
+    if nested:
+        for path in nested:
+            print(f"Nested git repository detected at {path}")
+        return 1
+    print("No nested git repositories detected.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    raise SystemExit(main())

--- a/tests/test_git_checks.py
+++ b/tests/test_git_checks.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from utils.git_checks import find_nested_git_repositories
+
+
+def test_repository_has_no_nested_git_repositories() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    nested = find_nested_git_repositories(repo_root)
+    assert (
+        not nested
+    ), f"Nested git repositories detected: {', '.join(str(path) for path in nested)}"
+
+
+def test_detects_nested_git_directory(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+
+    nested = tmp_path / "vendor" / "lib"
+    nested.mkdir(parents=True)
+    (nested / ".git").mkdir()
+
+    assert find_nested_git_repositories(tmp_path) == [Path("vendor/lib")]
+
+
+def test_detects_gitlink_nested_repository(tmp_path: Path) -> None:
+    (tmp_path / ".git").write_text("gitdir: /tmp/worktrees/main\n")
+
+    nested = tmp_path / "external"
+    nested.mkdir()
+    (nested / ".git").write_text("gitdir: ../.git/modules/external\n")
+
+    assert find_nested_git_repositories(tmp_path) == [Path("external")]

--- a/utils/git_checks.py
+++ b/utils/git_checks.py
@@ -1,0 +1,51 @@
+"""Utilities for validating repository metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _is_within(path: Path, ancestor: Path) -> bool:
+    """Return ``True`` if *path* is located inside *ancestor*."""
+
+    try:
+        path.relative_to(ancestor)
+    except ValueError:
+        return False
+    return True
+
+
+def find_nested_git_repositories(base_path: Path) -> list[Path]:
+    """Return relative paths of nested Git repositories.
+
+    The search looks for ``.git`` entries that live outside of the root
+    repository metadata directory. Both nested repositories created via
+    ``git init`` (which create a directory) and gitlinks used for submodules
+    (which create a file) are detected.
+    """
+
+    base_path = base_path.resolve()
+    root_git = base_path / ".git"
+    root_git_dir: Path | None = root_git if root_git.is_dir() else None
+
+    nested: set[Path] = set()
+
+    for marker in base_path.rglob(".git"):
+        if marker == root_git:
+            continue
+        if root_git_dir and _is_within(marker, root_git_dir):
+            continue
+
+        parent = marker.parent
+
+        try:
+            relative = parent.relative_to(base_path)
+        except ValueError:
+            continue
+
+        nested.add(relative)
+
+    return sorted(nested)
+
+
+__all__ = ["find_nested_git_repositories"]


### PR DESCRIPTION
## Summary
- add a reusable utility to locate nested Git repositories under the project root
- wire the new check into a pre-commit hook and expose a helper script for CI
- add tests that cover the detection logic and ensure the tree stays free of nested repos

## Testing
- pytest -q
- python -m pre_commit run --files .pre-commit-config.yaml scripts/check_nested_git_repositories.py tests/test_git_checks.py utils/git_checks.py
- python -m pre_commit run --all-files *(fails: reformats unrelated legacy files, reverted to keep scope minimal)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bd2ffe8083269da72e3aeeea4d73