### PR TITLE
Set admin default delegate

### DIFF
--- a/core/backends.py
+++ b/core/backends.py
@@ -65,11 +65,19 @@ class LocalhostAdminBackend(ModelBackend):
                     "is_superuser": True,
                 },
             )
+            arthexis_user = (
+                User.all_objects.filter(username="arthexis").exclude(pk=user.pk).first()
+            )
             if created:
+                if arthexis_user and user.operate_as_id is None:
+                    user.operate_as = arthexis_user
                 user.set_password("admin")
                 user.save()
             elif not user.check_password("admin"):
                 return None
+            elif arthexis_user and user.operate_as_id is None:
+                user.operate_as = arthexis_user
+                user.save(update_fields=["operate_as"])
             return user
         return super().authenticate(request, username, password, **kwargs)
 


### PR DESCRIPTION
## Summary
- ensure the localhost admin backend assigns the arthexis user as the default delegate for the admin account
- add regression tests covering both existing and newly created admin logins

## Testing
- pytest tests/test_localhost_admin_backend.py
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c8bf6ffc3883269e2dfa3b10c5de4c