### PR TITLE
Exclude debug toolbar requests from view tracking

### DIFF
--- a/pages/middleware.py
+++ b/pages/middleware.py
@@ -60,6 +60,9 @@ class ViewHistoryMiddleware:
         if path.startswith("/favicon") or path.startswith("/robots.txt"):
             return False
 
+        if "djdt" in request.GET:
+            return False
+
         return True
 
     def _record_visit(self, request, status_code: int, error_message: str) -> None:

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -306,6 +306,11 @@ class ViewHistoryLoggingTests(TestCase):
         self.assertEqual(entry.status_code, 404)
         self.assertNotEqual(entry.error_message, "")
 
+    def test_debug_toolbar_requests_not_tracked(self):
+        resp = self.client.get(reverse("pages:index"), {"djdt": "toolbar"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(ViewHistory.objects.exists())
+
 
 class ViewHistoryAdminTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- skip view tracking when debug toolbar query parameter is present so toolbar activity does not count as public traffic
- add a regression test covering the new exclusion

## Testing
- python manage.py test pages.tests.ViewHistoryLoggingTests.test_debug_toolbar_requests_not_tracked
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c8c70d591c8326b269db53755119ab