### PR TITLE
Preserve raw sigil values when editing admin forms

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -29,6 +29,12 @@ class _SigilBaseField:
     def value_from_object(self, obj):
         return obj.__dict__.get(self.attname)
 
+    def pre_save(self, model_instance, add):
+        # ``models.Field.pre_save`` uses ``getattr`` which would resolve the
+        # sigil descriptor. Persist the raw database value instead so env-based
+        # placeholders remain intact when editing through admin forms.
+        return self.value_from_object(model_instance)
+
 
 class SigilCheckFieldMixin(_SigilBaseField):
     descriptor_class = _CheckSigilDescriptor


### PR DESCRIPTION
## Summary
- ensure sigil-backed admin fields read the raw database value instead of resolved secrets
- reapply cleaned sigil strings after validation for OdooProfile and EmailInbox admin forms
- add regression coverage protecting against sigil placeholders being replaced with resolved data

## Testing
- `pytest tests/test_email_inbox_admin.py tests/test_odoo_profile_admin.py`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c8c91a82f083269b849ddefa2181b5