### PR TITLE
fix: clear revision when importing past releases

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1233,6 +1233,7 @@ class PackageReleaseAdmin(SaveBeforeChangeAction, EntityModelAdmin):
                     package=package,
                     release_manager=package.release_manager,
                     version=version,
+                    revision="",
                     pypi_url=f"https://pypi.org/project/{package.name}/{version}/",
                 )
                 created += 1

--- a/core/fixtures/releases__packagerelease_0_1_3.json
+++ b/core/fixtures/releases__packagerelease_0_1_3.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.3",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.3/"
     }
   }

--- a/core/fixtures/releases__packagerelease_0_1_4.json
+++ b/core/fixtures/releases__packagerelease_0_1_4.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.4",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.4/"
     }
   }

--- a/core/fixtures/releases__packagerelease_0_1_5.json
+++ b/core/fixtures/releases__packagerelease_0_1_5.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.5",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.5/"
     }
   }

--- a/core/fixtures/releases__packagerelease_0_1_6.json
+++ b/core/fixtures/releases__packagerelease_0_1_6.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.6",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.6/"
     }
   }

--- a/core/fixtures/releases__packagerelease_0_1_7.json
+++ b/core/fixtures/releases__packagerelease_0_1_7.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.7",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.7/"
     }
   }

--- a/core/fixtures/releases__packagerelease_0_1_8.json
+++ b/core/fixtures/releases__packagerelease_0_1_8.json
@@ -13,7 +13,7 @@
         "arthexis"
       ],
       "version": "0.1.8",
-      "revision": "d9ce1c811b3bc4e93fe2432af50f80e11f28c505",
+      "revision": "",
       "pypi_url": "https://pypi.org/project/arthexis/0.1.8/"
     }
   }

--- a/core/tests.py
+++ b/core/tests.py
@@ -754,7 +754,8 @@ class PackageReleaseAdminActionTests(TestCase):
             "releases": {"1.0.0": [], "1.1.0": []}
         }
         self.admin.refresh_from_pypi(self.request, PackageRelease.objects.none())
-        self.assertTrue(PackageRelease.objects.filter(version="1.1.0").exists())
+        new_release = PackageRelease.objects.get(version="1.1.0")
+        self.assertEqual(new_release.revision, "")
         dump.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- avoid populating PackageRelease.revision when importing historical versions from PyPI
- assert that imported releases have a blank revision in the admin action tests
- update existing release fixtures to leave the revision empty

## Testing
- python manage.py test core.tests.PackageReleaseAdminActionTests
- pre-commit run --all-files
- pre-commit run --files core/admin.py core/tests.py core/fixtures/releases__packagerelease_0_1_3.json core/fixtures/releases__packagerelease_0_1_4.json core/fixtures/releases__packagerelease_0_1_5.json core/fixtures/releases__packagerelease_0_1_6.json core/fixtures/releases__packagerelease_0_1_7.json core/fixtures/releases__packagerelease_0_1_8.json

------
https://chatgpt.com/codex/tasks/task_e_68c99120bc5c832694d66e5739962183