### PR TITLE
Implement MCP sigil resolver server

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -220,6 +220,31 @@ ASGI_APPLICATION = "config.asgi.application"
 CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 
+# MCP sigil resolver configuration
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return default
+
+
+def _split_env_list(name: str) -> list[str]:
+    raw = os.environ.get(name)
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+MCP_SIGIL_SERVER = {
+    "host": os.environ.get("MCP_SIGIL_HOST", "127.0.0.1"),
+    "port": _env_int("MCP_SIGIL_PORT", 8800),
+    "api_keys": _split_env_list("MCP_SIGIL_API_KEYS"),
+    "required_scopes": ["sigils:read"],
+    "issuer_url": os.environ.get("MCP_SIGIL_ISSUER_URL"),
+    "resource_server_url": os.environ.get("MCP_SIGIL_RESOURCE_URL"),
+}
+
+
 # Custom user model
 AUTH_USER_MODEL = "core.User"
 

--- a/core/management/commands/mcp_sigil_server.py
+++ b/core/management/commands/mcp_sigil_server.py
@@ -1,0 +1,54 @@
+"""Run the MCP sigil resolver as a standalone SSE server."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from core.mcp.server import SigilResolverServer
+
+
+class Command(BaseCommand):
+    help = "Start the MCP sigil resolver server over SSE."
+
+    def add_arguments(self, parser) -> None:  # pragma: no cover - exercised via handle
+        parser.add_argument("--host", help="Override the configured bind host.")
+        parser.add_argument("--port", type=int, help="Override the configured port.")
+        parser.add_argument(
+            "--public",
+            action="store_true",
+            help="Bind to all interfaces (0.0.0.0) regardless of configuration.",
+        )
+        parser.add_argument(
+            "--no-auth",
+            action="store_true",
+            help="Disable API key authentication for local experimentation.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        config = dict(getattr(settings, "MCP_SIGIL_SERVER", {}))
+        host = options.get("host") or config.get("host", "127.0.0.1")
+        if options.get("public"):
+            host = "0.0.0.0"
+
+        port = options.get("port", config.get("port", 8800))
+        try:
+            port = int(port)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise CommandError("Port must be an integer") from exc
+
+        if options.get("no_auth"):
+            config["api_keys"] = []
+
+        config.update({"host": host, "port": port})
+        server = SigilResolverServer(config)
+        fastmcp = server.build_fastmcp()
+
+        self.stdout.write(self.style.SUCCESS(f"Starting MCP sigil resolver on {host}:{port}"))
+        try:
+            asyncio.run(fastmcp.run_sse_async())
+        except KeyboardInterrupt:  # pragma: no cover - manual interrupt
+            self.stdout.write(self.style.WARNING("Shutting down MCP sigil resolver"))

--- a/core/mcp/__init__.py
+++ b/core/mcp/__init__.py
@@ -1,0 +1,12 @@
+"""Utilities for exposing sigil resolution over MCP."""
+
+from .server import SigilResolverServer
+from .service import SigilResolverService, SigilRootCatalog, SigilSessionState, ResolutionResult
+
+__all__ = [
+    "SigilResolverServer",
+    "SigilResolverService",
+    "SigilRootCatalog",
+    "SigilSessionState",
+    "ResolutionResult",
+]

--- a/core/mcp/auth.py
+++ b/core/mcp/auth.py
@@ -1,0 +1,34 @@
+"""Authentication helpers for the MCP sigil resolver server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+
+
+@dataclass(frozen=True)
+class ApiKeyTokenVerifier(TokenVerifier):
+    """Simple :class:`TokenVerifier` implementation backed by static API keys."""
+
+    keys: Mapping[str, str]
+    scopes: tuple[str, ...]
+
+    @classmethod
+    def from_keys(
+        cls, api_keys: Iterable[str], *, scopes: Iterable[str] | None = None
+    ) -> "ApiKeyTokenVerifier":
+        keys: dict[str, str] = {}
+        for raw_key in api_keys:
+            key = raw_key.strip()
+            if not key:
+                continue
+            keys[key] = key
+        return cls(keys=keys, scopes=tuple(scopes or ("sigils:read",)))
+
+    async def verify_token(self, token: str) -> AccessToken | None:  # pragma: no cover - thin wrapper
+        client_id = self.keys.get(token)
+        if client_id is None:
+            return None
+        return AccessToken(token=token, client_id=client_id, scopes=list(self.scopes))

--- a/core/mcp/schemas.py
+++ b/core/mcp/schemas.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas shared by the MCP sigil resolver."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, MutableMapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ContextAssignments = Mapping[str, str | int | None]
+MutableContextAssignments = MutableMapping[str, str | int | None]
+
+
+class ResolveOptions(BaseModel):
+    """Optional switches supported by the ``resolveSigils`` tool."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    skip_unknown: bool = Field(default=False, alias="skipUnknown", description="Drop unresolved sigils from the output")
+
+
+class ResolveSigilsPayload(BaseModel):
+    """Incoming payload for the ``resolveSigils`` tool."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    text: str
+    context: Dict[str, str | int | None] | None = None
+    options: ResolveOptions | None = None
+
+
+class ResolveSigilsResponse(BaseModel):
+    """Structured response returned by ``resolveSigils``."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resolved: str
+    metadata: Dict[str, List[str]] = Field(default_factory=dict)
+
+
+class SigilRootDescription(BaseModel):
+    """Metadata describing a known ``SigilRoot`` entry."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    prefix: str
+    context_type: str = Field(alias="contextType")
+    model: str | None = None
+    fields: List[str] = Field(default_factory=list)
+
+
+class SetContextPayload(BaseModel):
+    """Payload for ``setContext`` calls."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    context: Dict[str, str | int | None] = Field(default_factory=dict)
+
+
+class SetContextResponse(BaseModel):
+    """Response emitted after storing session context."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    stored: List[str] = Field(default_factory=list, description="Model labels retained in the session context")

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -1,0 +1,181 @@
+"""Integration glue between Django sigils and the MCP FastMCP server."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+from weakref import WeakKeyDictionary
+
+from django.db.models.signals import post_delete, post_save
+
+from core.models import SigilRoot
+
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp.server import Context, FastMCP
+
+from .auth import ApiKeyTokenVerifier
+from .schemas import ResolveOptions, ResolveSigilsResponse, SetContextResponse
+from .service import (
+    ResolutionResult,
+    SigilResolverService,
+    SigilRootCatalog,
+    SigilSessionState,
+)
+
+
+class SigilResolverServer:
+    """Factory that wires the sigil resolver into a FastMCP server."""
+
+    def __init__(self, config: Mapping[str, Any] | None = None) -> None:
+        self.config = self._normalize_config(config or {})
+        self.catalog = SigilRootCatalog()
+        self.service = SigilResolverService(self.catalog)
+        self._sessions: WeakKeyDictionary[Any, SigilSessionState] = WeakKeyDictionary()
+        self._save_uid = f"mcp_sigil_root_save_{id(self)}"
+        self._delete_uid = f"mcp_sigil_root_delete_{id(self)}"
+        post_save.connect(self._handle_root_saved, sender=SigilRoot, dispatch_uid=self._save_uid)
+        post_delete.connect(self._handle_root_deleted, sender=SigilRoot, dispatch_uid=self._delete_uid)
+
+    def build_fastmcp(self) -> FastMCP:
+        """Create and configure a :class:`FastMCP` instance."""
+
+        token_verifier = None
+        auth_settings = None
+        api_keys = self.config["api_keys"]
+        scopes = self.config["required_scopes"]
+        if api_keys:
+            token_verifier = ApiKeyTokenVerifier.from_keys(api_keys, scopes=scopes)
+            base_url = self.config["resource_server_url"] or self._default_base_url()
+            issuer_url = self.config["issuer_url"] or base_url
+            auth_settings = AuthSettings(
+                issuer_url=issuer_url,
+                resource_server_url=base_url,
+                required_scopes=list(token_verifier.scopes),
+            )
+
+        server = FastMCP(
+            name="Sigil Resolver",
+            instructions=self.config["instructions"],
+            host=self.config["host"],
+            port=self.config["port"],
+            auth=auth_settings,
+            token_verifier=token_verifier,
+        )
+        self._register_tools(server)
+        self._register_resources(server)
+        return server
+
+    def _register_tools(self, server: FastMCP) -> None:
+        @server.tool(
+            name="resolveSigils",
+            description="Resolve Arthexis sigils embedded in free-form text.",
+        )
+        def resolve_sigils(
+            text: str,
+            context: dict[str, str | int | None] | None = None,
+            options: ResolveOptions | None = None,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            state = self._session_state(ctx)
+            result = self.service.resolve_text(
+                text,
+                session_context=state.context,
+                overrides=context,
+                options=options,
+            )
+            return self._format_resolution(result)
+
+        @server.tool(
+            name="resolveSingle",
+            description="Resolve a single sigil token.",
+        )
+        def resolve_single(
+            sigil: str,
+            context: dict[str, str | int | None] | None = None,
+            ctx: Context | None = None,
+        ) -> str:
+            state = self._session_state(ctx)
+            return self.service.resolve_single(
+                sigil,
+                session_context=state.context,
+                overrides=context,
+            )
+
+        @server.tool(
+            name="setContext",
+            description="Persist model identifiers for subsequent resolutions within the same session.",
+        )
+        def set_context(
+            context: dict[str, str | int | None],
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            state = self._session_state(ctx)
+            stored = self.service.update_session_context(state, context)
+            response = SetContextResponse(stored=stored)
+            return response.model_dump(by_alias=True)
+
+        @server.tool(
+            name="describeSigilRoot",
+            description="Return metadata about a configured sigil root.",
+        )
+        def describe_sigil_root(prefix: str) -> dict[str, Any]:
+            description = self.service.describe_root(prefix)
+            return description.model_dump(by_alias=True)
+
+    def _register_resources(self, server: FastMCP) -> None:
+        @server.resource(
+            "resource://sigils/roots",
+            name="sigilRoots",
+            title="Sigil Roots",
+            description="List of configured sigil roots.",
+            mime_type="application/json",
+        )
+        def sigil_roots_resource() -> str:
+            entries = [root.model_dump(by_alias=True) for root in self.service.list_roots()]
+            return json.dumps({"roots": entries}, indent=2)
+
+    def _session_state(self, ctx: Context | None) -> SigilSessionState:
+        if ctx is None or ctx.session is None:  # pragma: no cover - defensive guard
+            return SigilSessionState()
+        session = ctx.session
+        state = self._sessions.get(session)
+        if state is None:
+            state = SigilSessionState()
+            self._sessions[session] = state
+        return state
+
+    def _format_resolution(self, result: ResolutionResult) -> dict[str, Any]:
+        response = ResolveSigilsResponse(
+            resolved=result.resolved,
+            metadata={"unresolved": result.unresolved},
+        )
+        return response.model_dump(by_alias=True)
+
+    def _default_base_url(self) -> str:
+        host = self.config["host"]
+        if host in {"0.0.0.0", "::"}:
+            host = "127.0.0.1"
+        return f"http://{host}:{self.config['port']}"
+
+    def _normalize_config(self, config: Mapping[str, Any]) -> dict[str, Any]:
+        host = config.get("host", "127.0.0.1")
+        port = int(config.get("port", 8800))
+        instructions = config.get(
+            "instructions",
+            "Resolve Arthexis sigils over the Model Context Protocol.",
+        )
+        return {
+            "host": host,
+            "port": port,
+            "api_keys": list(config.get("api_keys", [])),
+            "required_scopes": list(config.get("required_scopes", ["sigils:read"])),
+            "issuer_url": config.get("issuer_url"),
+            "resource_server_url": config.get("resource_server_url"),
+            "instructions": instructions,
+        }
+
+    def _handle_root_saved(self, sender: type[SigilRoot], instance: SigilRoot, **kwargs: Any) -> None:
+        self.catalog.update_from_instance(instance)
+
+    def _handle_root_deleted(self, sender: type[SigilRoot], instance: SigilRoot, **kwargs: Any) -> None:
+        self.catalog.remove(instance.prefix)

--- a/core/mcp/service.py
+++ b/core/mcp/service.py
@@ -1,0 +1,241 @@
+"""Core domain services shared by the MCP sigil resolver."""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, field
+from typing import Mapping, MutableMapping, Sequence
+
+from django.apps import apps
+from django.db import models
+
+from core.models import SigilRoot
+from core.sigil_context import clear_context, set_context
+from core.sigil_resolver import resolve_sigils
+
+from .schemas import (
+    ContextAssignments,
+    MutableContextAssignments,
+    ResolveOptions,
+    SigilRootDescription,
+)
+
+_SIGIL_PATTERN = re.compile(r"\[([^\[\]]+)\]")
+
+
+@dataclass
+class ResolutionResult:
+    """Represents the outcome of a text resolution operation."""
+
+    resolved: str
+    unresolved: list[str]
+
+
+@dataclass
+class SigilSessionState:
+    """Per-connection state maintained by the MCP resolver."""
+
+    context: MutableMapping[type[models.Model], str] = field(default_factory=dict)
+
+    def copy_context(self) -> dict[type[models.Model], str]:
+        return dict(self.context)
+
+
+class SigilRootCatalog:
+    """Caches ``SigilRoot`` metadata for fast lookups."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._entries: dict[str, SigilRootDescription] = {}
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Refresh the in-memory cache from the database."""
+
+        with self._lock:
+            self._entries.clear()
+            for root in SigilRoot.objects.select_related("content_type"):
+                self._entries[root.prefix.upper()] = self._describe_instance(root)
+
+    def update_from_instance(self, root: SigilRoot) -> None:
+        """Update a single catalog entry using the provided model instance."""
+
+        with self._lock:
+            self._entries[root.prefix.upper()] = self._describe_instance(root)
+
+    def remove(self, prefix: str) -> None:
+        """Remove a cached entry when a ``SigilRoot`` is deleted."""
+
+        with self._lock:
+            self._entries.pop(prefix.upper(), None)
+
+    def describe(self, prefix: str) -> SigilRootDescription:
+        """Return metadata for the requested prefix."""
+
+        with self._lock:
+            entry = self._entries.get(prefix.upper())
+            if entry is None:
+                raise ValueError(f"Unknown sigil root: {prefix}")
+            return entry.model_copy(deep=True)
+
+    def list_roots(self) -> list[SigilRootDescription]:
+        """Return all catalogued roots sorted by prefix."""
+
+        with self._lock:
+            return [entry.model_copy(deep=True) for _, entry in sorted(self._entries.items())]
+
+    def _describe_instance(self, root: SigilRoot) -> SigilRootDescription:
+        model_label: str | None = None
+        fields: list[str] = []
+        if root.content_type:
+            model = root.content_type.model_class()
+            if model is not None:
+                model_label = f"{model._meta.app_label}.{model._meta.object_name}"
+                fields = sorted(field.name.upper() for field in model._meta.fields)
+        return SigilRootDescription(
+            prefix=root.prefix.upper(),
+            contextType=root.context_type,
+            model=model_label,
+            fields=fields,
+        )
+
+
+class SigilResolverService:
+    """High-level operations exposed by the MCP sigil resolver."""
+
+    def __init__(self, catalog: SigilRootCatalog | None = None) -> None:
+        self.catalog = catalog or SigilRootCatalog()
+
+    def resolve_text(
+        self,
+        text: str,
+        *,
+        session_context: Mapping[type[models.Model], str] | None = None,
+        overrides: ContextAssignments | None = None,
+        options: ResolveOptions | None = None,
+    ) -> ResolutionResult:
+        """Resolve sigils in ``text`` applying any provided context."""
+
+        merged_context = self._merge_context(session_context, overrides)
+        if merged_context:
+            set_context(merged_context)
+        try:
+            resolved = resolve_sigils(text)
+        finally:
+            if merged_context:
+                clear_context()
+        unresolved = self._collect_unresolved(text, resolved)
+        if options and options.skip_unknown and unresolved:
+            resolved = self._strip_unresolved(resolved, unresolved)
+        return ResolutionResult(resolved=resolved, unresolved=unresolved)
+
+    def resolve_single(
+        self,
+        sigil: str,
+        *,
+        session_context: Mapping[type[models.Model], str] | None = None,
+        overrides: ContextAssignments | None = None,
+    ) -> str:
+        """Resolve a single sigil token returning its value."""
+
+        token = sigil.strip()
+        if not token:
+            raise ValueError("Sigil token cannot be empty")
+        if not token.startswith("["):
+            token = f"[{token}]"
+        if not token.endswith("]"):
+            raise ValueError("Sigil tokens must end with ']'")
+        result = self.resolve_text(token, session_context=session_context, overrides=overrides)
+        return result.resolved
+
+    def describe_root(self, prefix: str) -> SigilRootDescription:
+        """Return cached metadata for the requested sigil root."""
+
+        return self.catalog.describe(prefix)
+
+    def list_roots(self) -> list[SigilRootDescription]:
+        """Return all known sigil roots."""
+
+        return self.catalog.list_roots()
+
+    def update_session_context(
+        self,
+        state: SigilSessionState,
+        assignments: MutableContextAssignments | None,
+    ) -> list[str]:
+        """Persist ``assignments`` into the session's context map."""
+
+        if assignments is None:
+            state.context.clear()
+            return []
+
+        if not assignments:
+            state.context.clear()
+            return []
+
+        normalized = self._normalize_context(assignments)
+        removed: list[type[models.Model]] = []
+        for label, raw_value in assignments.items():
+            model = self._resolve_model_label(label)
+            if raw_value is None or raw_value == "":
+                removed.append(model)
+        for model in removed:
+            state.context.pop(model, None)
+        state.context.update(normalized)
+        return sorted(self._format_model_label(model) for model in state.context.keys())
+
+    def _merge_context(
+        self,
+        session_context: Mapping[type[models.Model], str] | None,
+        overrides: ContextAssignments | None,
+    ) -> dict[type[models.Model], str]:
+        merged: dict[type[models.Model], str] = {}
+        if session_context:
+            merged.update(session_context)
+        if overrides:
+            merged.update(self._normalize_context(overrides))
+        return merged
+
+    def _normalize_context(
+        self, context: ContextAssignments | MutableContextAssignments
+    ) -> dict[type[models.Model], str]:
+        normalized: dict[type[models.Model], str] = {}
+        for label, value in context.items():
+            if value is None or value == "":
+                continue
+            model = self._resolve_model_label(label)
+            normalized[model] = str(value)
+        return normalized
+
+    def _resolve_model_label(self, label: str) -> type[models.Model]:
+        if not label or "." not in label:
+            raise ValueError("Context keys must be formatted as 'app_label.ModelName'")
+        app_label, model_name = label.split(".", 1)
+        model = apps.get_model(app_label, model_name)
+        if model is None:
+            raise ValueError(f"Unknown model for context assignment: {label}")
+        if not issubclass(model, models.Model):  # pragma: no cover - defensive
+            raise ValueError(f"Context assignments must reference Django models: {label}")
+        return model
+
+    def _format_model_label(self, model: type[models.Model]) -> str:
+        return f"{model._meta.app_label}.{model._meta.object_name}"
+
+    def _collect_unresolved(self, original: str, resolved: str) -> list[str]:
+        source_tokens = {match.group(1) for match in _SIGIL_PATTERN.finditer(original)}
+        unresolved: list[str] = []
+        for match in _SIGIL_PATTERN.finditer(resolved):
+            token = match.group(1)
+            if token in source_tokens and token not in unresolved:
+                unresolved.append(token)
+        return unresolved
+
+    def _strip_unresolved(self, text: str, unresolved: Sequence[str]) -> str:
+        if not unresolved:
+            return text
+        unresolved_set = set(unresolved)
+        return _SIGIL_PATTERN.sub(
+            lambda match: "" if match.group(1) in unresolved_set else match.group(0),
+            text,
+        )

--- a/man/migrations/0005_mcp_sigil_manual.py
+++ b/man/migrations/0005_mcp_sigil_manual.py
@@ -1,0 +1,156 @@
+from django.db import migrations
+
+HTML = """<h1>MCP Sigil Resolver Server – Design Proposal</h1>
+<h2>Background</h2>
+<p>Sigils are currently resolved inside the Django application through <code>core.sigil_resolver</code>, which inspects the <code>SigilRoot</code> configuration, looks up model instances, and falls back to a <code>gway</code> subprocess for unknown roots. The resolver supports nested sigils, dynamic model lookups, environment variables, and per-thread context provided through <code>core.sigil_context</code>. Sigil metadata is surfaced in the admin via the Sigil Builder view, which lists known roots and lets administrators experiment with resolution.</p>
+<p>The product roadmap calls for exposing the same capabilities outside of Django via OpenAI's Model Context Protocol (MCP) so connectors can resolve sigils over SSE.</p>
+<h2>Goals</h2>
+<ul>
+  <li>Provide an MCP-compliant server that exposes the existing resolution logic without duplicating business rules.</li>
+  <li>Enable secure remote resolution for arbitrary text with nested sigils as well as utility discovery (e.g., which roots exist).</li>
+  <li>Support opt-in per-session context (current user, current entity instances) so downstream agents can resolve contextual sigils accurately.</li>
+  <li>Keep the <code>gway</code> fallback so existing external integrations remain functional, but make it optional when MCP adoption is complete.</li>
+</ul>
+<h2>Non-Goals</h2>
+<ul>
+  <li>Replacing the in-process Django resolver.</li>
+  <li>Offering arbitrary database access beyond the existing sigil semantics.</li>
+  <li>Shipping a production-grade authentication service; the first version will rely on API keys and reverse proxies.</li>
+</ul>
+<h2>Protocol Surface</h2>
+<p>The server will expose the following MCP constructs:</p>
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>Name</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tool</td>
+      <td><code>resolveSigils</code></td>
+      <td>Resolve one or more sigils inside a text payload using the current session context. Input schema: <code>{ "text": string, "context": {"model": {"app_label.ModelName": "pk"}}, "options": {"skipUnknown": bool}}</code>. Returns <code>{ "resolved": string, "metadata": {"unresolved": [string]}}</code>.</td>
+    </tr>
+    <tr>
+      <td>Tool</td>
+      <td><code>resolveSingle</code></td>
+      <td>Resolve a single sigil token and return its value or unresolved form. Thin wrapper that validates the sigil shape before delegating to <code>resolveSigils</code> for reuse.</td>
+    </tr>
+    <tr>
+      <td>Tool</td>
+      <td><code>describeSigilRoot</code></td>
+      <td>Provide metadata for a given sigil root (fields, context type) leveraging the same data that powers the Sigil Builder view.</td>
+    </tr>
+    <tr>
+      <td>Tool</td>
+      <td><code>setContext</code></td>
+      <td>Update the thread-local sigil context using <code>set_context</code> to mimic how the resolver infers instances from request state.</td>
+    </tr>
+    <tr>
+      <td>Resource</td>
+      <td><code>sigilRoots</code> (optional streaming)</td>
+      <td>Publish changes to <code>SigilRoot</code> objects so long-lived MCP sessions can react to new roots without polling. Implemented via Django signals.</td>
+    </tr>
+  </tbody>
+</table>
+<p>The server’s <code>list_tools</code> handler simply advertises the tools above, while <code>call_tool</code> dispatches to a per-session service class that wraps <code>resolve_sigils</code> and <code>_resolve_token</code> logic so every invocation reuses the battle-tested paths.</p>
+<h2>Server Architecture</h2>
+<pre><code>manage.py mcp_sigil_server
+└── SigilResolverServer (mcp.server.sse.SseServer)
+    ├── SigilSessionState (per-connection context)
+    │   └── SigilContextAdapter ↔ core.sigil_context
+    ├── SigilResolverService
+    │   └── uses core.sigil_resolver.resolve_sigils
+    └── SigilRootCatalog (queries SigilRoot + caches metadata)
+</code></pre>
+<ul>
+  <li><strong>Entry point</strong> – New Django management command <code>mcp_sigil_server</code> imports <code>django.setup()</code>, instantiates an <code>SseServer</code> from the <code>modelcontextprotocol</code> reference implementation, and serves it over an HTTP listener (default <code>127.0.0.1:8800</code>).</li>
+  <li><strong>Session state</strong> – On <code>accept_session</code>, capture authentication headers, initialize a <code>SigilSessionState</code>, and register a connection-specific logger so unresolved sigils continue to log warnings via <code>logger.warning</code> just like the in-process resolver.</li>
+  <li><strong>Resolver service</strong> – Wrap the existing <code>resolve_sigils</code> function. Before each call, apply any session context by temporarily invoking <code>set_context</code> / <code>clear_context</code>. After resolution, detect which tokens remained unresolved by diffing the output against the input and by checking the metadata returned from <code>_failed_resolution</code>.</li>
+  <li><strong>Sigil root catalog</strong> – Provide cached metadata for <code>describeSigilRoot</code> and resource streaming by reusing the query logic from <code>core.sigil_builder</code> (select related content type, list fields, etc.).</li>
+  <li><strong>Gway integration</strong> – Keep <code>_resolve_with_gway</code> untouched; the MCP server simply imports <code>resolve_sigils</code>, so the fallback path still shells out when no root is found.</li>
+</ul>
+<h2>Configuration &amp; Security</h2>
+<ul>
+  <li><strong>Dependencies</strong> – Add <code>modelcontextprotocol</code> (Python MCP reference SDK) to <code>requirements.txt</code> and vendor reusable schemas in a small <code>core/mcp/schemas.py</code> module to avoid duplicating JSON schema definitions across handlers.</li>
+  <li><strong>Settings</strong> – Introduce <code>settings.MCP_SIGIL_SERVER = {"host": "127.0.0.1", "port": 8800, "api_key": "..."}</code>. The management command reads these values and optionally the <code>--public</code> flag to bind to <code>0.0.0.0</code> behind an ingress controller.</li>
+  <li><strong>Authentication</strong> – Expect an <code>Authorization: Bearer &lt;token&gt;</code> header on <code>createSession</code>. Reject the request unless the token matches <code>settings.MCP_SIGIL_API_KEYS</code> (list) so multiple connectors can be provisioned without redeploying the service.</li>
+  <li><strong>Rate limiting</strong> – Start with a simple per-session throttle (e.g., <code>options.maxRequestsPerMinute</code>) enforced inside the session state. Upgrade to Redis-backed limits later if required.</li>
+</ul>
+<h2>Implementation Plan</h2>
+<ol>
+  <li><strong>Foundations</strong>
+    <ul>
+      <li>Add the dependency and create <code>core/mcp/__init__.py</code>, <code>core/mcp/server.py</code>, and <code>core/mcp/schemas.py</code> with Pydantic models to validate tool arguments before passing them to Django.</li>
+      <li>Implement <code>SigilResolverService</code> that exposes <code>resolve_text</code>, <code>resolve_single</code>, <code>set_context</code>, and <code>describe_root</code>. It should call <code>resolve_sigils</code> and interact with <code>SigilRoot</code> directly.</li>
+    </ul>
+  </li>
+  <li><strong>MCP server</strong>
+    <ul>
+      <li>Wire the service into an <code>SseServer</code> inside the management command. Handle lifecycle events (session start/end) to clear context using <code>clear_context</code> to prevent leaks.</li>
+      <li>Expose the tools and resources by implementing the relevant decorators from the MCP SDK.</li>
+    </ul>
+  </li>
+  <li><strong>Admin &amp; Ops</strong>
+    <ul>
+      <li>Document how to create API keys and register the connector. Provide example <code>curl</code> traces to validate the SSE handshake.</li>
+      <li>Extend deployment scripts (e.g., <code>start.sh</code> or a systemd unit) so the MCP server can run alongside Django in production.</li>
+    </ul>
+  </li>
+  <li><strong>Testing</strong>
+    <ul>
+      <li>Unit-test the service class against fixtures already used by <code>tests/test_sigil_resolution.py</code> to ensure parity with in-process resolution.</li>
+      <li>Add an async integration test that spins up the SSE server on an ephemeral port, runs through <code>list_tools</code> and <code>call_tool</code>, and verifies resolution and authorization behavior.</li>
+      <li>Reuse existing factories to assert context-aware lookups (e.g., entity sigils with <code>filter_field</code> rules).</li>
+    </ul>
+  </li>
+</ol>
+<h2>Operational Considerations</h2>
+<ul>
+  <li><strong>Observability</strong> – Emit structured JSON logs for each tool call (input length, number of tokens resolved, duration). Ship basic metrics via Prometheus or StatsD.</li>
+  <li><strong>Error handling</strong> – Map Django validation errors to MCP <code>ToolError</code> responses so clients get actionable messages. Unexpected exceptions should surface as <code>InternalError</code> while still logging stack traces.</li>
+  <li><strong>Scalability</strong> – Because the resolver relies on Django ORM calls, keep the MCP server colocated with the Django app or share the same settings module/environment to avoid mismatched configuration.</li>
+</ul>
+<h2>Future Enhancements</h2>
+<ul>
+  <li>Add <code>prompt</code> registrations so LLM clients can request example instructions for building sigils.</li>
+  <li>Support long-running background resolution jobs via MCP <code>jobs</code> once the reference SDK stabilizes.</li>
+  <li>Replace the <code>gway</code> fallback with a dedicated MCP tool that proxies to whatever eventually supersedes gway, allowing observability and retries over the same channel.</li>
+</ul>"""
+
+PDF = """JVBERi0xLjMKJZOMi54gUmVwb3J0TGFiIEdlbmVyYXRlZCBQREYgZG9jdW1lbnQgaHR0cDovL3d3dy5yZXBvcnRsYWIuY29tCjEgMCBvYmoKPDwKL0YxIDIgMCBSIC9GMiAzIDAgUiAvRjMgNCAwIFIgL0Y0IDUgMCBSCj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9CYXNlRm9udCAvSGVsdmV0aWNhIC9FbmNvZGluZyAvV2luQW5zaUVuY29kaW5nIC9OYW1lIC9GMSAvU3VidHlwZSAvVHlwZTEgL1R5cGUgL0ZvbnQKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL0Jhc2VGb250IC9IZWx2ZXRpY2EtQm9sZCAvRW5jb2RpbmcgL1dpbkFuc2lFbmNvZGluZyAvTmFtZSAvRjIgL1N1YnR5cGUgL1R5cGUxIC9UeXBlIC9Gb250Cj4+CmVuZG9iago0IDAgb2JqCjw8Ci9CYXNlRm9udCAvWmFwZkRpbmdiYXRzIC9OYW1lIC9GMyAvU3VidHlwZSAvVHlwZTEgL1R5cGUgL0ZvbnQKPj4KZW5kb2JqCjUgMCBvYmoKPDwKL0Jhc2VGb250IC9TeW1ib2wgL05hbWUgL0Y0IC9TdWJ0eXBlIC9UeXBlMSAvVHlwZSAvRm9udAo+PgplbmRvYmoKNiAwIG9iago8PAovQ29udGVudHMgMTEgMCBSIC9NZWRpYUJveCBbIDAgMCA2MTIgNzkyIF0gL1BhcmVudCAxMCAwIFIgL1Jlc291cmNlcyA8PAovRm9udCAxIDAgUiAvUHJvY1NldCBbIC9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9JbWFnZUkgXQo+PiAvUm90YXRlIDAgL1RyYW5zIDw8Cgo+PiAKICAvVHlwZSAvUGFnZQo+PgplbmRvYmoKNyAwIG9iago8PAovQ29udGVudHMgMTIgMCBSIC9NZWRpYUJveCBbIDAgMCA2MTIgNzkyIF0gL1BhcmVudCAxMCAwIFIgL1Jlc291cmNlcyA8PAovRm9udCAxIDAgUiAvUHJvY1NldCBbIC9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9JbWFnZUkgXQo+PiAvUm90YXRlIDAgL1RyYW5zIDw8Cgo+PiAKICAvVHlwZSAvUGFnZQo+PgplbmRvYmoKOCAwIG9iago8PAovUGFnZU1vZGUgL1VzZU5vbmUgL1BhZ2VzIDEwIDAgUiAvVHlwZSAvQ2F0YWxvZwo+PgplbmRvYmoKOSAwIG9iago8PAovQXV0aG9yIChhbm9ueW1vdXMpIC9DcmVhdGlvbkRhdGUgKEQ6MjAyNTA5MTYyMzUzNTQrMDAnMDAnKSAvQ3JlYXRvciAoUmVwb3J0TGFiIFBERiBMaWJyYXJ5IC0gd3d3LnJlcG9ydGxhYi5jb20pIC9LZXl3b3JkcyAoKSAvTW9kRGF0ZSAoRDoyMDI1MDkxNjIzNTM1NCswMCcwMCcpIC9Qcm9kdWNlciAoUmVwb3J0TGFiIFBERiBMaWJyYXJ5IC0gd3d3LnJlcG9ydGxhYi5jb20pIAogIC9TdWJqZWN0ICh1bnNwZWNpZmllZCkgL1RpdGxlICh1bnRpdGxlZCkgL1RyYXBwZWQgL0ZhbHNlCj4+CmVuZG9iagoxMCAwIG9iago8PAovQ291bnQgMiAvS2lkcyBbIDYgMCBSIDcgMCBSIF0gL1R5cGUgL1BhZ2VzCj4+CmVuZG9iagoxMSAwIG9iago8PAovRmlsdGVyIFsgL0FTQ0lJODVEZWNvZGUgL0ZsYXRlRGVjb2RlIF0gL0xlbmd0aCAyMzQyCj4+CnN0cmVhbQpHYXVITGdNUnJqJnEvKS1lQzFTNkNOVWdLJyptQUFhJiluSkRNRyJEYDtmckJXZ2YuZ1pjUU86RCs0J2hIXHVAQz4udEpZInFzQGQ5SnUtXmw7WCVob0VJUD9walpFW0lAU15OY1hSbGNkVk1BNEdKdVk0ckJRUyIvIkRZKk8zWyVpZjxcQzpxc0hWPmAvRVojblNOOWcoTVdSUlM9VyZENEZMUmFpNyJHQzA8XSlpZWs0RE5vTidqQDdvU1tJRDE2Zy1TaiNgTGVxVT51RDYrUU1RdEJdaFRJN10jPUY5WztQZGJGQD4+bVw1b2RLLCIsYjFbOUZcXEJ1R049b0knZS8wQyxxM1hVSUpQRztnNi0rZlhcJzFpMilwP19vbkgqKUFEcFw8LDJbSmlbLCVbJF9aQ2BaInM2OSU+clU9PWdiOjdkREkmS0o2SkMtdDpNaUosWGViKVA2J3RSSCcsJTE6US1jYVMkI182LSEqWDxbTmRTSFRTQWQ6VTxuOixgRE4zSGpFZmZcc1JSKC5qJDZGJSZsWDVALTUvPS4yLjpjTEEsQUw0alYvL05SaSlsRjBqZkdFbiRHJG1HTTVCVmtCcXVdYUJka1AqK05TSlBAKU8nUDwnOyJVcihONjo+ZyI2PiZIak5uUyhwVyMwdT5ZJVU4bWJKOjVPQ2xrW1VaOCJvSWJRZ2lpNTtiLzk/bVlMK3NTcSNjUGpmKkpDIVQmX2g0WC5nRDcnZklLXC9dWUtlaTR1TkAlTWJNNGcra287S1NZQiooaWJRZFVmYWhFM2gjLyElP3VaPC88czclOFBjYygmS2w4SWlJYkcyXFdRJTZsTDE8bk4wMWZ0VGBVPS4vWmttMSxDYi85aEpzR0JuQSw8cV9LN2ZdLjNdXihAUUhOUnBeczxPWXNTPiM1WWEtWFQ6TjRmUzFCOE9AKS9fSjI2XFZDK0o1WWRDZF5mOGI2MXJDJUltdXRwVj9yLGYiX11MJ1tCWS1rJlM3KWI4LTRMNWU3X2VsIyNqcTpDSkhTXGttJHVjSXJJXydbNU1PRFEvXl9cImFlRlIoKjdKUDQ1aUQ+NFhoWStVcE41UFY1JHAzczhTImxfOzloX0ZPNixJZi4hT0JyVk5HOWMqblckdU5OQWZvY2oibzpudGNlOVdiM21QaGRcRGRUQGpQbmJ0Wm9MVm9EPVE+T11OK1NLW2QoTGY8YVROYVptWF02NDlBLjVkYCk+ZHBPND1hZUk3Pj5QM1s6IkNKbTlaSW5Ka08wQjMpLGBxKj0tV0EwayYoREMpOkdDSFAlOUFBZUoqLUNvLU43UWVhNz9VRUxDZXI1JiZpYmk7JTdHNjRQMThCbDlFal4hL29jTzwjWT8lVC5ndE8nKldGSUJpak04JFZWOywzUCpUQW8xKChkTnRDL21JOWksa2BfLUFxMioqa21bSDUtQmJZVUEubjlHSE02UGIndWhgLyovbkc6cURJRFhUQUpDJmtEYFlpcWVPTWpYcS4tUFBlKiJQXSg7NSImRD1qQjdzdW5fZTAlbjFtUTZAV19bMnBOM2NeQi9VUEdTImpoY2RHaW0+IW4iXT4tYkxGRmgyK0tnO15AU04nX0FVIStnNEFQci4vLHJnYi07Tz8lPkxbZUI+Z3FzbVQhJFBVMVVhX0VqJlctTyFjcjtfOzU2Yi5BITVVISUzWmc6P1hVaWY6J0U6Sy8yXj5GXUhrVjorXiY3RmpHQzlsb1MpKioqVEMpa1kmTFQxc2YjMEI8YyYlJXBLV1FIO15IJytdSj4ick9dbkAuNlhZPU5qTENNZ0AjPVBtQ1pLVEp0O2dIJF5yIyNMTFM6aC87I3VHYi1nO0lsVW1TMUZePzVCZkJqMyEmWnA4MFUxM0RySzJLTj1eVyQ5V2pINmR1JlgrVjFjZjVIZyJGIjJTQ2BeblQ+ZSpdNEBfcS1PP2t1YEotN2tUK2VSYydYMUk4bklUSiM5RmY6VXNXXk1Ka04/VGZbJGpCXm8uRElia11PczVgOV1VLVVlYk9qP19HYkMpc3JHSW5MJ1lsLzEjN0EiU2o5QGRKcykyITVVcDwzbUBSZjlFLG9TVXI6PHBLSyYnbiVkSGknVjNMRWtUSCd1NDgnZT1RLi5pXXNuNmhgTlskKFxwRk1XckxQPDdOI05hMyYhPm4xYW1JZFVaOSdUcyt1JVEyYFUpOUJvZXBjSVVXQjQ/WHFMSjtzalQxW3A5KTEsbzNDYFstc0dEbzchZyhXbWdgTWBARUAhY28xS2pxPS4lSkAiSkhNXFVSSWAxMjVQLEA5XD05SkYybWs9bilcXGo3PGQnaFJxTXQ7bShwRT1OTlVBY1Y3TzYvSEoqPjomK1ZhRlRZTjBZQEprMzkrLmtObT1JKnBaPj4+JnFdWUYrcjlVUUxmPmxbUlA5S3NLKSEpOSxING90XT5vWFVJJT06YVlpbDI0KGdyMCJRLlJtVWE+Q1FGQUBnam9GWF9NN2NGUGZMLzAnLW9tLSJtIV05QTdRcG8lJzNJbE4hP3JnaWtNZXAzT0lCP29UIyVQKlMnZEcmVWJBW2tIX0RmcFo7UShmNTJnTGEsOEc7RG9gJTdRYFBLW2glWy8wRDBrPWlVMDxmX29kdWchOyNcOU5TcCM9N1Q7clgxQFYnOChLSGFvYzVjaFxSdFFCUWJ0dHFWbDgyTiYqTCRDKkNIP2luLWFkPydBI05daW1nZkM5R1M4NThZIyUvQWs0LmYmYzNxaWVNczhjWVd1aSwrYWojO14yZWdDZD08QzpvbFFkV0sxaHFUQE5aLWBqInJgST5tXWc/WWE7ZiRMLyVkaXBGXTxeTzQ8WFhLM3FbOmRsQzolMWZeQ1MtZF5FLzYhNShJKCo2LS4/cFFKc10iLUBTWEJvRUY+ZFomUSIjJm82Ol9yWlVIbi47cyNUdTM4PURpIVw8YDFBZ0ZVcnQ2RW5ZPz9fI2RxTzAtKmJBJlBrY2lkJWxjL19lUz9iXDFKLlZqSXNLLl84WT5ULEBAWzgoMUsmQDkrKU1ZZiNrMyopI0NkbC05WUVDUGsuMSVNIWROJSU+bmw7Jk4pQGo3RydULCU9NDpeUk1JLTYncVVkQi1+PmVuZHN0cmVhbQplbmRvYmoKMTIgMCBvYmoKPDwKL0ZpbHRlciBbIC9BU0NJSTg1RGVjb2RlIC9GbGF0ZURlY29kZSBdIC9MZW5ndGggNTk0Cj4+CnN0cmVhbQpHYXNKTzk1aVE9Jjs5TkonbHRrW1UzOCJETlIpPEpULE9MckZOZTtqZElLPTQuSWM8Ol5bST1YKlZZKyNKZz9IMyk9QkdaLlhbRFsuU25Scz9RMzYmLm9cQnAyNipfMSdxMCZDMWAlb1NTV3UsM0JmTjpOcylPWkNNUWVTSWNhLFk/LVQ+bmcoQFVgSCI/YjwvMj0/dSxdc1xOKkc8NjwkL0RDWFhDKzE6WzY2RHFmPS91U2ROaG5FWGNVLyxJcExxIUs1JSloJiZAOD4xaDZcYnNqXUtIO1VbQzY1RUo4RXBtQVxQVkFRRzVLQXFiOCdFLzdISFBMaXEuK1hYRE1TRl8wPlhGR2twNDpIUS4sX0s8NiIxUEpvbjVLKXVuOnQjaklSYm5IKjA0VTFNZEcqR2QzazNHRC4tWy4xQTxoVTxiSSdubiIlS2deNm9ZdTRVcCYraUhFL2dcS2k6WWd1IVFOai4kdVVfRD1fcUIyaydCN0hUcSsqZzklSmtiPzosQyhFKUZHKnJiXz5JJ2dDYGpCZTxjI01xcldmOGhkblpCPnAsUS5SPj5HYilOS2JZI21vMW85ODAmWDovY2NeNEtfPD9ZJis8PSpXQSdlPGM+MllGY0ZIdExDYyImbkpSRDZNUV4pQi8yQDtuQ0dgMyE3JyMrOUpyUDpdOiJKb1czJy8wZms4ISUyVWoxVTJVRW9IMCpTRVsiKClFY0JqK05gX0siLm9KJVFGNTI8LGFMOC91OGtzWS9UZj0jPDc7I0BqbmVeOUUjR151LShCfj5lbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCAxMwowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwNzMgMDAwMDAgbiAKMDAwMDAwMDEzNCAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAwIG4gCjAwMDAwMDAzNTMgMDAwMDAgbiAKMDAwMDAwMDQzNiAwMDAwMCBuIAowMDAwMDAwNTEzIDAwMDAwIG4gCjAwMDAwMDA3MDggMDAwMDAgbiAKMDAwMDAwMDkwMyAwMDAwMCBuIAowMDAwMDAwOTcyIDAwMDAwIG4gCjAwMDAwMDEyNjggMDAwMDAgbiAKMDAwMDAwMTMzNCAwMDAwMCBuIAowMDAwMDAzNzY4IDAwMDAwIG4gCnRyYWlsZXIKPDwKL0lEIApbPDQ1Nzk2MzIyNjc1NGRiNGIwNGRjOTNkZmMzMjkzM2I2Pjw0NTc5NjMyMjY3NTRkYjRiMDRkYzkzZGZjMzI5MzNiNj5dCiUgUmVwb3J0TGFiIGdlbmVyYXRlZCBQREYgZG9jdW1lbnQgLS0gZGlnZXN0IChodHRwOi8vd3d3LnJlcG9ydGxhYi5jb20pCgovSW5mbyA5IDAgUgovUm9vdCA4IDAgUgovU2l6ZSAxMwo+PgpzdGFydHhyZWYKNDQ1MwolJUVPRgo="""
+
+
+def create_manual(apps, schema_editor):
+    UserManual = apps.get_model("man", "UserManual")
+    UserManual.objects.update_or_create(
+        slug="mcp-sigil-resolver",
+        defaults={
+            "title": "MCP Sigil Resolver Server",
+            "description": "Design and implementation plan for the MCP sigil resolver server.",
+            "languages": "en",
+            "content_html": HTML,
+            "content_pdf": PDF,
+            "is_seed_data": True,
+            "is_user_data": False,
+            "is_deleted": False,
+        },
+    )
+
+
+def delete_manual(apps, schema_editor):
+    UserManual = apps.get_model("man", "UserManual")
+    UserManual.objects.filter(slug="mcp-sigil-resolver").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("man", "0004_user_data_field"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_manual, delete_manual),
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ incremental==24.7.2
 kombu==5.5.4
 libipld==3.1.1
 Markdown==3.8.2
+mcp==1.14.0
 mfrc522==0.0.7; sys_platform == "linux"
 outcome==1.3.0.post0
 packaging==25.0

--- a/tests/test_mcp_sigil_server.py
+++ b/tests/test_mcp_sigil_server.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from core.mcp.schemas import ResolveOptions
+from core.mcp.server import SigilResolverServer
+from core.mcp.service import ResolutionResult, SigilResolverService, SigilRootCatalog, SigilSessionState
+from core.models import OdooProfile, SigilRoot
+
+
+class SigilResolverServiceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = get_user_model().objects.create(username="resolver", email="resolver@example.com")
+        cls.profile = OdooProfile.objects.create(
+            user=cls.user,
+            host="h",
+            database="db",
+            username="odoo",
+            password="secret",
+        )
+        ct = ContentType.objects.get_for_model(OdooProfile)
+        SigilRoot.objects.update_or_create(
+            prefix="ODOO",
+            defaults={
+                "context_type": SigilRoot.Context.ENTITY,
+                "content_type": ct,
+            },
+        )
+
+    def test_resolve_text_uses_session_context(self) -> None:
+        catalog = SigilRootCatalog()
+        catalog.refresh()
+        service = SigilResolverService(catalog)
+        state = SigilSessionState()
+        state.context[OdooProfile] = str(self.profile.pk)
+        result = service.resolve_text("user=[ODOO.USERNAME]", session_context=state.context)
+        self.assertIsInstance(result, ResolutionResult)
+        self.assertEqual(result.resolved, "user=odoo")
+        self.assertEqual(result.unresolved, [])
+
+    def test_skip_unknown_tokens(self) -> None:
+        service = SigilResolverService(SigilRootCatalog())
+        result = service.resolve_text(
+            "value=[UNKNOWN.THING]",
+            options=ResolveOptions(skipUnknown=True),
+        )
+        self.assertEqual(result.resolved, "value=")
+        self.assertEqual(result.unresolved, ["UNKNOWN.THING"])
+
+    def test_update_session_context_clears_entries(self) -> None:
+        service = SigilResolverService(SigilRootCatalog())
+        state = SigilSessionState()
+        stored = service.update_session_context(state, {"core.OdooProfile": self.profile.pk})
+        self.assertEqual(stored, ["core.OdooProfile"])
+        stored = service.update_session_context(state, {"core.OdooProfile": None})
+        self.assertEqual(stored, [])
+
+
+class SigilResolverServerTests(TestCase):
+    def setUp(self) -> None:
+        self.server = SigilResolverServer({"api_keys": [], "host": "127.0.0.1", "port": 0})
+
+    def test_catalog_updates_via_signals(self) -> None:
+        ct = ContentType.objects.get_for_model(OdooProfile)
+        prefix = "MCPTEST"
+        SigilRoot.objects.create(prefix=prefix, context_type=SigilRoot.Context.ENTITY, content_type=ct)
+        description = self.server.catalog.describe(prefix)
+        self.assertEqual(description.prefix, prefix)
+        SigilRoot.objects.filter(prefix=prefix).delete()
+        with self.assertRaises(ValueError):
+            self.server.catalog.describe(prefix)
+
+    def test_build_fastmcp_respects_authentication_toggle(self) -> None:
+        secured = SigilResolverServer({"api_keys": ["secret"], "host": "127.0.0.1", "port": 9000})
+        secured_server = secured.build_fastmcp()
+        self.assertIsNotNone(secured_server._token_verifier)
+        self.assertIsNotNone(secured_server.settings.auth)
+
+        open_server = SigilResolverServer({"api_keys": [], "host": "127.0.0.1", "port": 9000})
+        open_fastmcp = open_server.build_fastmcp()
+        self.assertIsNone(open_fastmcp._token_verifier)
+        self.assertIsNone(open_fastmcp.settings.auth)
+
+    def test_resource_lists_roots(self) -> None:
+        fastmcp = self.server.build_fastmcp()
+        resource = asyncio.run(fastmcp._resource_manager.get_resource("resource://sigils/roots"))
+        payload = self.server.service.list_roots()
+        rendered = json.loads(asyncio.run(resource.read()))
+        expected = sorted(
+            (entry.model_dump(by_alias=True) for entry in payload),
+            key=lambda item: item["prefix"],
+        )
+        self.assertEqual(expected, sorted(rendered["roots"], key=lambda item: item["prefix"]))


### PR DESCRIPTION
## Summary
- build an MCP FastMCP server and service layer that exposes sigil resolution tools and a roots resource
- add configuration, authentication helpers, and a management command to run the SSE server
- cover resolver behavior with Django tests for context handling, catalog updates, and resource wiring

## Testing
- python manage.py test tests.test_mcp_sigil_server

------
https://chatgpt.com/codex/tasks/task_e_68c9f0d27ac08326b3c683f378f186c1