### PR TITLE
Ensure control nodes load RFID feature

### DIFF
--- a/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
+++ b/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
@@ -8,6 +8,9 @@
       "display": "RFID Scanner",
       "roles": [
         [
+          "Control"
+        ],
+        [
           "Terminal"
         ],
         [


### PR DESCRIPTION
## Summary
- include the Control node role in the RFID scanner feature seed fixture
- add a regression test that verifies the fixture assigns the RFID feature to the Control role

## Testing
- python manage.py test nodes.tests.NodeFeatureFixtureTests
- pre-commit run --files nodes/fixtures/node_features__nodefeature_rfid_scanner.json nodes/tests.py

------
https://chatgpt.com/codex/tasks/task_e_68ca20c181ec8326b3cf29b042af62d3