### PR TITLE
Ensure RFID wiring configuration is enforced

### DIFF
--- a/ocpp/rfid/background_reader.py
+++ b/ocpp/rfid/background_reader.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from django.conf import settings
 
+from .constants import DEFAULT_IRQ_PIN
+
 logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - hardware dependent
@@ -17,7 +19,7 @@ try:  # pragma: no cover - hardware dependent
 except Exception:  # pragma: no cover - hardware dependent
     GPIO = None  # type: ignore
 
-IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", "4"))
+IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", str(DEFAULT_IRQ_PIN)))
 _tag_queue: "queue.Queue[dict]" = queue.Queue()
 _thread: Optional[threading.Thread] = None
 _stop_event = threading.Event()

--- a/ocpp/rfid/constants.py
+++ b/ocpp/rfid/constants.py
@@ -1,0 +1,50 @@
+"""Shared configuration for the RFID hardware integration."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+
+# Mapping between the RC522 header labels and the Raspberry Pi connections.
+# The wiring strings mirror the labeling used in the installation manual to
+# make it easier to cross-reference hardware documentation with the code.
+MODULE_WIRING: "OrderedDict[str, str]" = OrderedDict(
+    [
+        ("SDA", "CE0"),
+        ("SCK", "SCLK"),
+        ("MOSI", "MOSI"),
+        ("MISO", "MISO"),
+        ("IRQ", "IO4"),
+        ("GND", "GND"),
+        ("RST", "IO25"),
+        ("3v3", "3v3"),
+    ]
+)
+
+
+# SPI configuration: bus 0 / device 0 corresponds to CE0 which matches the
+# ``SDA`` wiring entry above.
+SPI_BUS = 0
+SPI_DEVICE = 0
+
+
+# RPi.GPIO constants are not available in test environments, but their numeric
+# values are stable (GPIO.BCM == 11).  Using BCM numbering matches the wiring
+# table which references pins as ``IO`` identifiers.
+GPIO_PIN_MODE_BCM = 11
+
+
+# Derived GPIO pins expressed using BCM numbering.
+DEFAULT_IRQ_PIN = 4
+DEFAULT_RST_PIN = 25
+
+
+__all__ = [
+    "MODULE_WIRING",
+    "SPI_BUS",
+    "SPI_DEVICE",
+    "GPIO_PIN_MODE_BCM",
+    "DEFAULT_IRQ_PIN",
+    "DEFAULT_RST_PIN",
+]
+

--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -3,6 +3,13 @@ from django.utils import timezone
 from core.models import RFID
 from core.notifications import notify_async
 
+from .constants import (
+    DEFAULT_RST_PIN,
+    GPIO_PIN_MODE_BCM,
+    SPI_BUS,
+    SPI_DEVICE,
+)
+
 
 _deep_read_until: float = 0.0
 
@@ -35,7 +42,12 @@ def read_rfid(
         if mfrc is None:
             from mfrc522 import MFRC522  # type: ignore
 
-            mfrc = MFRC522()
+            mfrc = MFRC522(
+                bus=SPI_BUS,
+                device=SPI_DEVICE,
+                pin_mode=GPIO_PIN_MODE_BCM,
+                pin_rst=DEFAULT_RST_PIN,
+            )
     except Exception as exc:  # pragma: no cover - hardware dependent
         return {"error": str(exc)}
 


### PR DESCRIPTION
## Summary
- centralize the RC522 module wiring map and default GPIO/SPI configuration
- ensure the RFID reader code uses the documented pins when instantiating the hardware driver
- extend the RFID test suite to lock the wiring map and instantiation parameters in place

## Testing
- pytest ocpp/test_rfid.py tests/test_rfid_background_reader.py

------
https://chatgpt.com/codex/tasks/task_e_68cac74f8abc8326b9bdae996c1acd77