### PR TITLE
Guard ReleaseManager natural key for unsaved fixtures

### DIFF
--- a/core/fixtures/sigil_roots__rpt.json
+++ b/core/fixtures/sigil_roots__rpt.json
@@ -8,7 +8,7 @@
       "context_type": "entity",
       "content_type": [
         "core",
-        "energyreport"
+        "clientreport"
       ]
     }
   }

--- a/core/models.py
+++ b/core/models.py
@@ -1294,11 +1294,16 @@ class ReleaseManager(Profile):
     objects = ReleaseManagerManager()
 
     def natural_key(self):
-        pkg = self.package_set.first()
         owner = self.owner_display()
         if self.group_id and owner:
             owner = f"group:{owner}"
-        return (owner or "", pkg.name if pkg else "")
+
+        pkg_name = ""
+        if self.pk:
+            pkg = self.package_set.first()
+            pkg_name = pkg.name if pkg else ""
+
+        return (owner or "", pkg_name)
 
     profile_fields = (
         "pypi_username",


### PR DESCRIPTION
## Summary
- avoid dereferencing package_set in ReleaseManager.natural_key until the instance has been saved so fixtures without primary keys load cleanly
- point the RPT sigil root fixture at the renamed core.ClientReport content type

## Testing
- python manage.py migrate --noinput
- python manage.py loaddata core/fixtures/users__arthexis.json core/fixtures/_release_managers__arthexis.json core/fixtures/packages__arthexis.json core/fixtures/sigil_roots__rpt.json

------
https://chatgpt.com/codex/tasks/task_e_68cad2e575508326aa58f6bb0f9aed0e