### PR TITLE
Add My Profile admin link

### DIFF
--- a/core/fixtures/todos__validate_screen_admin_profile_link.json
+++ b/core/fixtures/todos__validate_screen_admin_profile_link.json
@@ -1,0 +1,12 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "is_seed_data": false,
+      "is_deleted": false,
+      "request": "Validate screen Admin profile link",
+      "url": "/admin/",
+      "request_details": "Confirm the admin top navigation displays the MY PROFILE link for staff users and routes to the signed-in user's detail page."
+    }
+  }
+]

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -357,6 +357,10 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     {% if docsroot %}
       <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
     {% endif %}
+    {% if user.pk and (user.has_perm('core.change_user') or user.has_perm('core.view_user')) %}
+      {% url 'admin:core_user_change' user.pk as profile_url %}
+      <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+    {% endif %}
   {% endif %}
   {% if user.has_usable_password %}
     <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /


### PR DESCRIPTION
## Summary
- add a "MY PROFILE" link to the admin navigation pointing to the signed-in user's record when they have user permissions
- add a TODO fixture to validate the updated admin navigation manually

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cad92353d88326abdb29015bcb079e