### PR TITLE
Ensure env refresh reloads personal user fixtures

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -44,6 +44,7 @@ from django.contrib.auth import get_user_model
 
 from core.models import PackageRelease
 from core.sigil_builder import generate_model_sigils
+from core.user_data import load_user_fixtures
 
 
 def _unlink_sqlite_db(path: Path) -> None:
@@ -338,6 +339,8 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
         )
 
     # Load personal user data fixtures last
+    for user in get_user_model().objects.all():
+        load_user_fixtures(user)
 
     # Recreate any missing SigilRoots after loading fixtures
     generate_model_sigils()


### PR DESCRIPTION
## Summary
- load personal user fixtures for every user at the end of env refresh so local data is restored after a clean rebuild
- add a regression test that simulates a clean database rebuild and asserts that env-refresh restores user data fixtures

## Testing
- pytest tests/test_seed_data.py::EnvRefreshUserDataTests::test_env_refresh_loads_user_fixtures

------
https://chatgpt.com/codex/tasks/task_e_68cadca03ba88326815dc04b1d8c5e0a