### PR TITLE
Add staff-only console link to charger status page

### DIFF
--- a/core/fixtures/todos__validate_screen_charger_status_console_link.json
+++ b/core/fixtures/todos__validate_screen_charger_status_console_link.json
@@ -1,0 +1,12 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "is_seed_data": false,
+      "is_deleted": false,
+      "request": "Validate screen Charger status console link",
+      "url": "/ocpp/c/<charger_id>/status/",
+      "request_details": "Ensure staff users see the View Console link at the bottom of the charger status page and that it opens the embedded console in a new tab."
+    }
+  }
+]

--- a/ocpp/templates/ocpp/charger_status.html
+++ b/ocpp/templates/ocpp/charger_status.html
@@ -88,6 +88,11 @@
     <a href="?page={{ page_obj.next_page_number }}">{% trans "Next 10" %}</a>
     {% endif %}
   </div>
+  {% if request.user.is_staff and charger.console_url %}
+  <div class="mt-4 text-end">
+    <a class="btn btn-outline-secondary" href="{% url 'charger-console' charger.charger_id %}" target="_blank" rel="noopener">{% trans "View Console" %}</a>
+  </div>
+  {% endif %}
  </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- show a staff-only "View Console" button at the bottom of the charger status page that links to the embedded vendor console
- add a QA todo reminder to validate the charger status console link screen

## Testing
- ❌ `pytest ocpp/tests.py` *(fails: Django settings module is not configured for pytest in this project)*
- ❌ `python manage.py test ocpp` *(fails: numerous pre-existing ocpp tests error or fail in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae0091d90832687fb841db182cae2