### PR TITLE
Skip empty user data fixtures during import

### DIFF
--- a/tests/test_user_data_admin.py
+++ b/tests/test_user_data_admin.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from django import forms
 from django.contrib import admin
@@ -169,3 +170,13 @@ class UserDataAdminTests(TransactionTestCase):
                 load_user_fixtures(self.user)
                 instance.refresh_from_db()
                 self.assertTrue(instance.is_user_data)
+
+    def test_load_user_fixture_skips_empty_files(self):
+        empty = self.data_dir / "core_todo_1.json"
+        empty.write_text("[]", encoding="utf-8")
+
+        with patch("core.user_data.call_command") as mock_call:
+            load_user_fixtures(self.user)
+
+        self.assertFalse(empty.exists())
+        mock_call.assert_not_called()


### PR DESCRIPTION
## Summary
- skip empty JSON fixture files when loading user data so stale exports no longer trigger Django warnings
- remove empty user fixture files and leave existing loader behaviour unchanged for valid data
- add a regression test confirming empty user fixtures are ignored and do not invoke `loaddata`

## Testing
- pytest tests/test_user_data_admin.py::UserDataAdminTests::test_load_user_fixture_skips_empty_files -q

------
https://chatgpt.com/codex/tasks/task_e_68cae87189488326b693f045526ad4a1