### PR TITLE
Fix admin template permission checks

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -357,9 +357,11 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     {% if docsroot %}
       <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
     {% endif %}
-    {% if user.pk and (user.has_perm('core.change_user') or user.has_perm('core.view_user')) %}
-      {% url 'admin:core_user_change' user.pk as profile_url %}
-      <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+    {% if user.pk %}
+      {% if perms.core.change_user or perms.core.view_user %}
+        {% url 'admin:core_user_change' user.pk as profile_url %}
+        <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+      {% endif %}
     {% endif %}
   {% endif %}
   {% if user.has_usable_password %}


### PR DESCRIPTION
## Summary
- update the admin base template to rely on the perms context when deciding
  whether to show the profile link, avoiding invalid template syntax

## Testing
- `poetry run python manage.py check` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_68caedbeff988326aa5b0bbe54d619cf