### PR TITLE
Fix admin profile link to target user change view

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -358,9 +358,15 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
       <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
     {% endif %}
     {% if user.pk %}
-      {% if perms.core.change_user or perms.core.view_user %}
-        {% url 'admin:core_user_change' user.pk as profile_url %}
-        <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+      {% if perms.core.change_user or perms.core.view_user or perms.teams.change_user or perms.teams.view_user %}
+        {% url 'admin:teams_user_change' user.pk as teams_profile_url %}
+        {% url 'admin:core_user_change' user.pk as core_profile_url %}
+        {% url 'admin:auth_user_change' user.pk as auth_profile_url %}
+        {% with profile_url=teams_profile_url|default:core_profile_url|default:auth_profile_url %}
+          {% if profile_url %}
+            <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+          {% endif %}
+        {% endwith %}
       {% endif %}
     {% endif %}
   {% endif %}

--- a/tests/test_admin_profile_link.py
+++ b/tests/test_admin_profile_link.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+
+class AdminProfileLinkTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="profileadmin",
+            email="profileadmin@example.com",
+            password="password",
+        )
+        self.client.force_login(self.user)
+
+    def test_profile_link_points_to_user_admin(self):
+        response = self.client.get(reverse("admin:index"))
+        expected_url = reverse("admin:teams_user_change", args=[self.user.pk])
+        self.assertContains(response, "MY PROFILE")
+        self.assertContains(response, f'href="{expected_url}"')


### PR DESCRIPTION
## Summary
- ensure the admin top navigation resolves the MY PROFILE link to the available user change view
- add a regression test to confirm the link targets the user admin change page

## Testing
- pytest tests/test_admin_profile_link.py

------
https://chatgpt.com/codex/tasks/task_e_68caf1dda520832685af5e444b08a50e