### PR TITLE
Add GitHub issue reporting helper and task

### DIFF
--- a/core/github_issues.py
+++ b/core/github_issues.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import requests
+
+from .models import Package, PackageRelease
+from .release import DEFAULT_PACKAGE
+
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+LOCK_DIR = BASE_DIR / "locks" / "github-issues"
+LOCK_TTL = timedelta(hours=1)
+REQUEST_TIMEOUT = 10
+
+
+def resolve_repository() -> tuple[str, str]:
+    """Return the ``(owner, repo)`` tuple for the active package."""
+
+    package = Package.objects.filter(is_active=True).first()
+    repository_url = (
+        package.repository_url if package and package.repository_url else DEFAULT_PACKAGE.repository_url
+    )
+
+    owner: str
+    repo: str
+
+    if repository_url.startswith("git@"):
+        _, _, remainder = repository_url.partition(":")
+        path = remainder
+    else:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(repository_url)
+        path = parsed.path
+
+    path = path.strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) < 2:
+        raise ValueError(f"Invalid repository URL: {repository_url!r}")
+
+    owner, repo = segments[-2], segments[-1]
+    return owner, repo
+
+
+def get_github_token() -> str:
+    """Return the configured GitHub token.
+
+    Preference is given to the latest :class:`~core.models.PackageRelease`.
+    When unavailable, fall back to the ``GITHUB_TOKEN`` environment variable.
+    """
+
+    latest_release = PackageRelease.latest()
+    if latest_release:
+        token = latest_release.get_github_token()
+        if token:
+            return token
+
+    try:
+        return os.environ["GITHUB_TOKEN"]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError("GitHub token is not configured") from exc
+
+
+def _ensure_lock_dir() -> None:
+    LOCK_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _fingerprint_digest(fingerprint: str) -> str:
+    return hashlib.sha256(str(fingerprint).encode("utf-8")).hexdigest()
+
+
+def _fingerprint_path(fingerprint: str) -> Path:
+    return LOCK_DIR / _fingerprint_digest(fingerprint)
+
+
+def _has_recent_marker(lock_path: Path) -> bool:
+    if not lock_path.exists():
+        return False
+
+    marker_age = datetime.utcnow() - datetime.utcfromtimestamp(lock_path.stat().st_mtime)
+    return marker_age < LOCK_TTL
+
+
+def build_issue_payload(
+    title: str,
+    body: str,
+    labels: Iterable[str] | None = None,
+    fingerprint: str | None = None,
+) -> Mapping[str, object] | None:
+    """Return an API payload for GitHub issues.
+
+    When ``fingerprint`` is provided, duplicate submissions within ``LOCK_TTL``
+    are ignored by returning ``None``. A marker is kept on disk to prevent
+    repeated reports during the cooldown window.
+    """
+
+    payload: dict[str, object] = {"title": title, "body": body}
+
+    if labels:
+        deduped = list(dict.fromkeys(labels))
+        if deduped:
+            payload["labels"] = deduped
+
+    if fingerprint:
+        _ensure_lock_dir()
+        lock_path = _fingerprint_path(fingerprint)
+        if _has_recent_marker(lock_path):
+            logger.info("Skipping GitHub issue for active fingerprint %s", fingerprint)
+            return None
+
+        lock_path.write_text(datetime.utcnow().isoformat(), encoding="utf-8")
+        digest = _fingerprint_digest(fingerprint)
+        payload["body"] = f"{body}\n\n<!-- fingerprint:{digest} -->"
+
+    return payload
+
+
+def create_issue(
+    title: str,
+    body: str,
+    labels: Iterable[str] | None = None,
+    fingerprint: str | None = None,
+) -> requests.Response | None:
+    """Create a GitHub issue using the configured repository and token."""
+
+    payload = build_issue_payload(title, body, labels=labels, fingerprint=fingerprint)
+    if payload is None:
+        return None
+
+    owner, repo = resolve_repository()
+    token = get_github_token()
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {token}",
+        "User-Agent": "arthexis-runtime-reporter",
+    }
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+
+    response = requests.post(url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
+    if not (200 <= response.status_code < 300):
+        logger.error(
+            "GitHub issue creation failed with status %s: %s",
+            response.status_code,
+            response.text,
+        )
+        response.raise_for_status()
+
+    logger.info(
+        "GitHub issue created for %s/%s with status %s",
+        owner,
+        repo,
+        response.status_code,
+    )
+    return response
+

--- a/core/tests/test_github_issues.py
+++ b/core/tests/test_github_issues.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import requests
+from django.test import TestCase
+
+from core import github_issues
+from core.models import Package
+from core.tasks import report_runtime_issue
+
+
+class ResolveRepositoryTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        Package.objects.all().delete()
+
+    def test_active_package_repository_is_used(self) -> None:
+        Package.objects.create(
+            name="custom",
+            repository_url="https://github.com/example/project.git",
+            is_active=True,
+        )
+
+        owner, repo = github_issues.resolve_repository()
+
+        self.assertEqual(owner, "example")
+        self.assertEqual(repo, "project")
+
+    def test_default_repository_is_used_as_fallback(self) -> None:
+        owner, repo = github_issues.resolve_repository()
+
+        self.assertEqual(owner, "arthexis")
+        self.assertEqual(repo, "arthexis")
+
+
+class TokenLookupTests(TestCase):
+    def test_token_comes_from_latest_release(self) -> None:
+        release = mock.Mock()
+        release.get_github_token.return_value = "release-token"
+
+        with mock.patch("core.github_issues.PackageRelease.latest", return_value=release):
+            with mock.patch.dict(os.environ, {}, clear=True):
+                token = github_issues.get_github_token()
+
+        self.assertEqual(token, "release-token")
+        release.get_github_token.assert_called_once_with()
+
+    def test_token_falls_back_to_environment(self) -> None:
+        with mock.patch("core.github_issues.PackageRelease.latest", return_value=None):
+            with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=True):
+                token = github_issues.get_github_token()
+
+        self.assertEqual(token, "env-token")
+
+    def test_missing_token_raises(self) -> None:
+        with mock.patch("core.github_issues.PackageRelease.latest", return_value=None):
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with self.assertRaises(RuntimeError):
+                    github_issues.get_github_token()
+
+
+class FingerprintTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.lock_patch = mock.patch("core.github_issues.LOCK_DIR", Path(self.tempdir.name))
+        self.lock_patch.start()
+        self.addCleanup(self.lock_patch.stop)
+
+    def test_build_issue_payload_deduplicates_fingerprints(self) -> None:
+        payload = github_issues.build_issue_payload(
+            "Runtime failure",
+            "Stack trace",
+            labels=["bug", "bug", "runtime"],
+            fingerprint="critical-path",
+        )
+
+        self.assertIsNotNone(payload)
+        self.assertEqual(payload["labels"], ["bug", "runtime"])
+        self.assertIn("<!-- fingerprint:", payload["body"])
+
+        digest = hashlib.sha256("critical-path".encode("utf-8")).hexdigest()
+        marker_path = Path(self.tempdir.name) / digest
+        self.assertTrue(marker_path.exists())
+
+        duplicate = github_issues.build_issue_payload(
+            "Runtime failure",
+            "Stack trace",
+            labels=["bug"],
+            fingerprint="critical-path",
+        )
+
+        self.assertIsNone(duplicate)
+
+
+class CreateIssueTests(TestCase):
+    def test_http_errors_raise_and_log(self) -> None:
+        response = mock.Mock()
+        response.status_code = 500
+        response.text = "boom"
+        response.raise_for_status.side_effect = requests.HTTPError("boom")
+
+        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
+            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+                with mock.patch("requests.post", return_value=response) as post:
+                    with self.assertLogs("core.github_issues", level="ERROR") as logs:
+                        with self.assertRaises(requests.HTTPError):
+                            github_issues.create_issue("Title", "Body")
+
+        post.assert_called_once()
+        self.assertIn("GitHub issue creation failed", "".join(logs.output))
+
+
+class ReportRuntimeIssueTaskTests(TestCase):
+    def test_task_reports_successfully(self) -> None:
+        response = mock.Mock()
+        response.status_code = 201
+
+        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
+            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+                with mock.patch("requests.post", return_value=response) as post:
+                    with self.assertLogs("core.tasks", level="INFO") as logs:
+                        result = report_runtime_issue("Title", "Body", labels=["bug"])
+
+        self.assertIs(result, response)
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], "https://api.github.com/repos/owner/repo/issues")
+        self.assertEqual(kwargs["timeout"], github_issues.REQUEST_TIMEOUT)
+        self.assertTrue(any("Reported runtime issue" in message for message in logs.output))
+
+    def test_task_logs_and_raises_on_failure(self) -> None:
+        response = mock.Mock()
+        response.status_code = 500
+        response.text = "failure"
+        response.raise_for_status.side_effect = requests.HTTPError("failure")
+
+        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
+            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+                with mock.patch("requests.post", return_value=response):
+                    with self.assertLogs("core.tasks", level="ERROR") as logs:
+                        with self.assertRaises(requests.HTTPError):
+                            report_runtime_issue("Title", "Body")
+
+        self.assertTrue(any("Failed to report runtime issue" in message for message in logs.output))


### PR DESCRIPTION
## Summary
- add a reusable helper for reporting GitHub issues with repository resolution, token lookup, and fingerprint deduplication
- create a Celery task that forwards runtime issue reports to GitHub and records logging
- cover the helper and task behaviour with targeted unit tests

## Testing
- `python manage.py test core.tests.test_github_issues`


------
https://chatgpt.com/codex/tasks/task_e_68cb02909c0083268c4522373183eaef