### PR TITLE
Use title case for user profile inline headings

### DIFF
--- a/core/templates/admin/user_profile_change_form.html
+++ b/core/templates/admin/user_profile_change_form.html
@@ -1,6 +1,17 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 
+{% block extrastyle %}
+{{ block.super }}
+<style>
+body.app-teams.model-user.change-form #OdooProfile-group .inline-heading,
+body.app-teams.model-user.change-form #ReleaseManager-group .inline-heading,
+body.app-teams.model-user.change-form #ChatProfile-group .inline-heading {
+    text-transform: none;
+}
+</style>
+{% endblock %}
+
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>


### PR DESCRIPTION
## Summary
- add a user admin change form stylesheet override that removes the uppercase transform from profile inline headings
- keep the existing change form title content unchanged

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cb030b46e88326ba487ff1cdde1dbd