### PR TITLE
Add GitHub exception auto-reporting hook

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -365,6 +365,10 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# GitHub issue reporting
+GITHUB_ISSUE_REPORTING_ENABLED = True
+GITHUB_ISSUE_REPORTING_COOLDOWN = 3600  # seconds
+
 # Logging configuration
 LOG_DIR = select_log_dir(BASE_DIR)
 os.environ.setdefault("ARTHEXIS_LOG_DIR", str(LOG_DIR))

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,5 +1,10 @@
+import logging
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
+
+
+logger = logging.getLogger(__name__)
 
 
 class CoreConfig(AppConfig):
@@ -8,8 +13,18 @@ class CoreConfig(AppConfig):
     verbose_name = _("2. Business")
 
     def ready(self):  # pragma: no cover - called by Django
+        from contextlib import suppress
+        import hashlib
+        import time
+        import traceback
+        from pathlib import Path
+
+        from django.conf import settings
         from django.contrib.auth import get_user_model
         from django.db.models.signals import post_migrate
+        from django.core.signals import got_request_exception
+
+        from core.github_helper import report_exception_to_github
         from .user_data import (
             patch_admin_user_datum,
             patch_admin_user_data_views,
@@ -40,9 +55,6 @@ class CoreConfig(AppConfig):
         patch_admin_environment_view()
         patch_admin_sigil_builder_view()
         patch_admin_history()
-
-        from pathlib import Path
-        from django.conf import settings
 
         lock = Path(settings.BASE_DIR) / "locks" / "celery.lck"
 
@@ -85,3 +97,85 @@ class CoreConfig(AppConfig):
                 cursor.close()
 
         connection_created.connect(enable_sqlite_wal)
+
+        def queue_github_issue(sender, request=None, **kwargs):
+            if not getattr(settings, "GITHUB_ISSUE_REPORTING_ENABLED", True):
+                return
+            if request is None:
+                return
+
+            exception = kwargs.get("exception")
+            if exception is None:
+                return
+
+            try:
+                tb_exc = traceback.TracebackException.from_exception(exception)
+                stack = tb_exc.stack
+                top_frame = stack[-1] if stack else None
+                fingerprint_parts = [
+                    exception.__class__.__module__,
+                    exception.__class__.__name__,
+                ]
+                if top_frame:
+                    fingerprint_parts.extend(
+                        [
+                            top_frame.filename,
+                            str(top_frame.lineno),
+                            top_frame.name,
+                        ]
+                    )
+                fingerprint = hashlib.sha256(
+                    "|".join(fingerprint_parts).encode("utf-8")
+                ).hexdigest()
+
+                cooldown = getattr(
+                    settings, "GITHUB_ISSUE_REPORTING_COOLDOWN", 3600
+                )
+                lock_dir = Path(settings.BASE_DIR) / "locks" / "github-issues"
+                fingerprint_path = None
+                now = time.time()
+
+                with suppress(OSError):
+                    lock_dir.mkdir(parents=True, exist_ok=True)
+                    fingerprint_path = lock_dir / fingerprint
+                    if fingerprint_path.exists():
+                        age = now - fingerprint_path.stat().st_mtime
+                        if age < cooldown:
+                            return
+
+                if fingerprint_path is not None:
+                    with suppress(OSError):
+                        fingerprint_path.write_text(str(now))
+
+                user_repr = None
+                user = getattr(request, "user", None)
+                if user is not None:
+                    try:
+                        if getattr(user, "is_authenticated", False):
+                            user_repr = user.get_username()
+                        else:
+                            user_repr = "anonymous"
+                    except Exception:  # pragma: no cover - defensive
+                        user_repr = str(user)
+
+                payload = {
+                    "path": getattr(request, "path", None),
+                    "method": getattr(request, "method", None),
+                    "user": user_repr,
+                    "active_app": getattr(request, "active_app", None),
+                    "fingerprint": fingerprint,
+                    "exception_class": f"{exception.__class__.__module__}.{exception.__class__.__name__}",
+                    "traceback": "".join(tb_exc.format()),
+                }
+
+                report_exception_to_github.delay(payload)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception(
+                    "Failed to queue GitHub issue from request exception"
+                )
+
+        got_request_exception.connect(
+            queue_github_issue,
+            dispatch_uid="core.github_issue_reporter",
+            weak=False,
+        )

--- a/core/github_helper.py
+++ b/core/github_helper.py
@@ -1,0 +1,25 @@
+"""Helpers for reporting exceptions to GitHub."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from celery import shared_task
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def report_exception_to_github(payload: dict[str, Any]) -> None:
+    """Send exception context to the GitHub issue helper.
+
+    The task is intentionally light-weight in this repository. Deployments can
+    replace it with an implementation that forwards ``payload`` to the
+    automation responsible for creating GitHub issues.
+    """
+
+    logger.info(
+        "Queued GitHub issue report for %s", payload.get("fingerprint", "<unknown>")
+    )

--- a/tests/test_github_issue_reporting.py
+++ b/tests/test_github_issue_reporting.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.signals import got_request_exception
+from django.test import RequestFactory
+
+import core.github_helper as github_helper
+
+
+@pytest.fixture
+def issue_reporting_env(tmp_path):
+    base_dir = settings.BASE_DIR
+    enabled = getattr(settings, "GITHUB_ISSUE_REPORTING_ENABLED", True)
+    cooldown = getattr(settings, "GITHUB_ISSUE_REPORTING_COOLDOWN", 3600)
+
+    settings.BASE_DIR = tmp_path
+    settings.GITHUB_ISSUE_REPORTING_ENABLED = True
+    settings.GITHUB_ISSUE_REPORTING_COOLDOWN = 3600
+
+    try:
+        yield tmp_path
+    finally:
+        settings.BASE_DIR = base_dir
+        settings.GITHUB_ISSUE_REPORTING_ENABLED = enabled
+        settings.GITHUB_ISSUE_REPORTING_COOLDOWN = cooldown
+
+
+def _make_exception():
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        return exc
+
+
+def _build_request():
+    request = RequestFactory().get("/boom/")
+    request.active_app = "core"
+    return request
+
+
+def test_exception_triggers_github_issue(monkeypatch, issue_reporting_env):
+    calls: list[dict[str, object]] = []
+
+    def fake_delay(payload):
+        calls.append(payload)
+
+    monkeypatch.setattr(github_helper.report_exception_to_github, "delay", fake_delay)
+
+    User = get_user_model()
+    user = User.objects.create_user(username="alice", password="secret")
+
+    request = _build_request()
+    request.user = user
+
+    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+
+    assert len(calls) == 1
+    payload = calls[0]
+    assert payload["path"] == "/boom/"
+    assert payload["method"] == "GET"
+    assert payload["user"] == "alice"
+    assert payload["active_app"] == "core"
+    assert payload["fingerprint"]
+    assert payload["exception_class"].endswith("ValueError")
+    assert "boom" in payload["traceback"]
+
+    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+
+    assert len(calls) == 1
+
+
+def test_issue_reporting_can_be_disabled(monkeypatch, issue_reporting_env):
+    settings.GITHUB_ISSUE_REPORTING_ENABLED = False
+    calls: list[dict[str, object]] = []
+
+    def fake_delay(payload):
+        calls.append(payload)
+
+    monkeypatch.setattr(github_helper.report_exception_to_github, "delay", fake_delay)
+
+    request = _build_request()
+    request.user = object()  # no authenticated user
+
+    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- connect the core app to `got_request_exception` so request metadata and a fingerprinted traceback are forwarded to the GitHub helper task when errors occur
- add configurable toggles and a lightweight Celery task stub for issue reporting
- cover the signal handler with tests that exercise queueing, deduplication, and opt-out behaviour

## Testing
- pytest tests/test_github_issue_reporting.py

------
https://chatgpt.com/codex/tasks/task_e_68cb029d344c8326ad51730a33146b31