### PR TITLE
Add toggleable sections sidebar to admin change forms

### DIFF
--- a/core/fixtures/todos__validate_screen_admin_change_form_sidebar.json
+++ b/core/fixtures/todos__validate_screen_admin_change_form_sidebar.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Admin change form sidebar",
+      "url": "/admin/auth/user/add/",
+      "request_details": "Open any admin change form and confirm the sections sidebar toggles without overlapping the main form."
+    }
+  }
+]

--- a/pages/templates/admin/change_form.html
+++ b/pages/templates/admin/change_form.html
@@ -1,0 +1,308 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+
+{% block extrahead %}{{ block.super }}
+<script src="{% url 'admin:jsi18n' %}"></script>
+{{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+  <style>
+    #content-related.changeform-sections {
+      float: right;
+      width: 260px;
+      margin-right: -300px;
+    }
+
+    #content-related.changeform-sections.is-collapsed {
+      float: none;
+      width: auto;
+      margin: 1.5rem 0 0;
+    }
+
+    #content-related.changeform-sections .changeform-sections__container {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      background: var(--darkened-bg);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 1rem;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    }
+
+    @media (min-width: 1024px) {
+      #content-related.changeform-sections .changeform-sections__container {
+        position: sticky;
+        top: 1.5rem;
+      }
+    }
+
+    #content-related.changeform-sections .changeform-sections__toggle {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      background: var(--button-bg);
+      color: var(--button-fg);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+
+    #content-related.changeform-sections .changeform-sections__toggle:hover,
+    #content-related.changeform-sections .changeform-sections__toggle:focus {
+      background: var(--button-hover-bg);
+      outline: none;
+    }
+
+    #content-related.changeform-sections .changeform-sections__chevron::before {
+      content: "▾";
+      display: inline-block;
+      transition: transform 0.2s ease;
+    }
+
+    #content-related.changeform-sections.is-collapsed .changeform-sections__chevron::before {
+      transform: rotate(-90deg);
+    }
+
+    #content-related.changeform-sections .changeform-sections__panel {
+      border-top: 1px solid var(--border-color);
+      padding-top: 0.5rem;
+      max-height: 70vh;
+      overflow-y: auto;
+    }
+
+    #content-related.changeform-sections.is-collapsed .changeform-sections__panel {
+      display: none;
+    }
+
+    #content-related.changeform-sections .changeform-sections__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    #content-related.changeform-sections .changeform-sections__item {
+      margin: 0;
+    }
+
+    #content-related.changeform-sections .changeform-sections__link {
+      display: block;
+      padding: 0.4rem 0.5rem;
+      border-radius: 6px;
+      color: var(--body-fg);
+      border: 1px solid transparent;
+      transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    }
+
+    #content-related.changeform-sections .changeform-sections__link:hover,
+    #content-related.changeform-sections .changeform-sections__link:focus {
+      border-color: var(--link-fg);
+      background: var(--darkened-bg);
+      color: var(--link-fg);
+      outline: none;
+    }
+
+    .fieldset-heading,
+    .inline-heading {
+      scroll-margin-top: 80px;
+    }
+
+    @media (max-width: 1023px) {
+      #content-related.changeform-sections {
+        float: none;
+        width: auto;
+        margin: 1.5rem 0 0;
+      }
+
+      #content-related.changeform-sections .changeform-sections__panel {
+        max-height: none;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block coltype %}colMS{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}<div id="content-main">
+{% block object-tools %}
+{% if change and not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+      {% change_form_object_tools %}
+    {% endblock %}
+  </ul>
+{% endif %}
+{% endblock %}
+<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
+<div>
+{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+{% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
+{% if errors %}
+    <p class="errornote">
+    {% blocktranslate count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+    </p>
+    {{ adminform.form.non_field_errors }}
+{% endif %}
+
+{% block field_sets %}
+{% for fieldset in adminform %}
+  {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=forloop.counter0 %}
+{% endfor %}
+{% endblock %}
+
+{% block after_field_sets %}{% endblock %}
+
+{% block inline_field_sets %}
+{% for inline_admin_formset in inline_admin_formsets %}
+    {% include inline_admin_formset.opts.template %}
+{% endfor %}
+{% endblock %}
+
+{% block after_related_objects %}{% endblock %}
+
+{% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+
+{% block admin_change_form_document_ready %}
+    <script id="django-admin-form-add-constants"
+            src="{% static 'admin/js/change_form.js' %}"
+            {% if adminform and add %}
+                data-model-name="{{ opts.model_name }}"
+            {% endif %}
+            async>
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const sidebar = document.querySelector('#content-related.changeform-sections');
+      if (!sidebar) {
+        return;
+      }
+      const list = sidebar.querySelector('.changeform-sections__list');
+      const panel = sidebar.querySelector('.changeform-sections__panel');
+      const toggle = sidebar.querySelector('.changeform-sections__toggle');
+      const content = document.getElementById('content');
+
+      if (!list || !panel || !toggle || !list.querySelector('li')) {
+        sidebar.remove();
+        if (content) {
+          content.classList.remove('colMS');
+          if (!content.classList.contains('colM')) {
+            content.classList.add('colM');
+          }
+        }
+        return;
+      }
+
+      const collapseQuery = window.matchMedia ? window.matchMedia('(max-width: 1023px)') : null;
+      let userOverride = false;
+
+      function setCollapsed(state) {
+        panel.hidden = !!state;
+        toggle.setAttribute('aria-expanded', String(!state));
+        sidebar.classList.toggle('is-collapsed', state);
+        if (content) {
+          if (state) {
+            content.classList.remove('colMS');
+            if (!content.classList.contains('colM')) {
+              content.classList.add('colM');
+            }
+          } else {
+            content.classList.remove('colM');
+            if (!content.classList.contains('colMS')) {
+              content.classList.add('colMS');
+            }
+          }
+        }
+      }
+
+      function applyMedia(event) {
+        if (userOverride) {
+          return;
+        }
+        const matches = event && typeof event.matches === 'boolean' ? event.matches : false;
+        setCollapsed(matches);
+      }
+
+      if (collapseQuery) {
+        applyMedia(collapseQuery);
+        collapseQuery.addEventListener('change', applyMedia);
+      } else {
+        setCollapsed(false);
+      }
+
+      toggle.addEventListener('click', function () {
+        userOverride = true;
+        const nextState = !sidebar.classList.contains('is-collapsed');
+        setCollapsed(nextState);
+      });
+    });
+    </script>
+{% endblock %}
+
+{% comment %} JavaScript for prepopulated fields {% endcomment %}
+{% prepopulated_fields_js %}
+
+</div>
+</form></div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related" class="changeform-sections">
+  <div class="changeform-sections__container">
+    <button type="button" class="changeform-sections__toggle" aria-expanded="true" aria-controls="{{ opts.model_name }}-changeform-sections">
+      <span class="changeform-sections__label">{% translate "Sections" %}</span>
+      <span class="changeform-sections__chevron" aria-hidden="true"></span>
+    </button>
+    <nav id="{{ opts.model_name }}-changeform-sections" class="changeform-sections__panel" aria-label="{% translate 'Form sections' %}">
+      <ol class="changeform-sections__list">
+        {% for fieldset in adminform %}
+          {% if fieldset.name %}
+          <li class="changeform-sections__item">
+            <a class="changeform-sections__link" href="#fieldset-0-{{ forloop.counter0 }}-heading">{{ fieldset.name }}</a>
+          </li>
+          {% endif %}
+        {% endfor %}
+        {% for inline_admin_formset in inline_admin_formsets %}
+          <li class="changeform-sections__item">
+            <a class="changeform-sections__link" href="#{{ inline_admin_formset.formset.prefix }}-heading">
+              {% if inline_admin_formset.formset.max_num == 1 %}
+                {{ inline_admin_formset.opts.verbose_name|capfirst }}
+              {% else %}
+                {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
+              {% endif %}
+            </a>
+          </li>
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- override the default Django admin change form template to include a sticky sections sidebar with responsive toggle behaviour and automatic population from fieldsets and inlines
- add client-side logic to collapse the sidebar on smaller screens or when toggled, preventing overlap with the main form content
- register a validation TODO to manually verify the updated change form experience

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cb0f0a3c888326bb4765b965f27e15