### PR TITLE
Adjust admin docs grouping for specific models

### DIFF
--- a/core/admindocs.py
+++ b/core/admindocs.py
@@ -1,7 +1,9 @@
 import argparse
 import inspect
-from django.core.management import get_commands, load_command_class
+from types import SimpleNamespace
+
 from django.apps import apps
+from django.core.management import get_commands, load_command_class
 from django.contrib.admindocs.views import (
     BaseAdminDocsView,
     user_has_model_view_permission,
@@ -52,12 +54,35 @@ class CommandsView(BaseAdminDocsView):
 class OrderedModelIndexView(BaseAdminDocsView):
     template_name = "admin_doc/model_index.html"
 
+    GROUP_OVERRIDES = {
+        "ocpp.location": "core",
+        "core.rfid": "ocpp",
+        "core.aplead": "teams",
+        "core.package": "teams",
+        "core.packagerelease": "teams",
+    }
+
+    def _get_docs_app_config(self, meta):
+        override_label = self.GROUP_OVERRIDES.get(meta.label_lower)
+        if override_label:
+            return apps.get_app_config(override_label)
+        return meta.app_config
+
     def get_context_data(self, **kwargs):
         models = []
         for m in apps.get_models():
             if user_has_model_view_permission(self.request.user, m._meta):
                 meta = m._meta
                 meta.docstring = inspect.getdoc(m) or ""
-                models.append(meta)
+                app_config = self._get_docs_app_config(meta)
+                models.append(
+                    SimpleNamespace(
+                        app_label=meta.app_label,
+                        model_name=meta.model_name,
+                        object_name=meta.object_name,
+                        docstring=meta.docstring,
+                        app_config=app_config,
+                    )
+                )
         models.sort(key=lambda m: str(m.app_config.verbose_name))
         return super().get_context_data(**{**kwargs, "models": models})


### PR DESCRIPTION
## Summary
- add admin docs grouping overrides to show Charge Locations under Business and move RFIDs, AP Leads, Packages, and Package Releases to their new groups
- wrap model metadata for admindocs rendering and document the grouping expectations with a focused regression test

## Testing
- python manage.py test tests.test_admin_doc_model_groups

------
https://chatgpt.com/codex/tasks/task_e_68cb21152ac883269b8468ba956248e1