### PR TITLE
Add standalone RFID scanner CLI and tests

### DIFF
--- a/projects/__init__.py
+++ b/projects/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for standalone hardware helpers used by Arthexis projects."""
+
+__all__ = ["rfid"]

--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -1,0 +1,193 @@
+"""Standalone helpers for interacting with the MFRC522 RFID reader."""
+
+from __future__ import annotations
+
+import select
+import sys
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Sequence, TextIO
+
+PINOUT: "OrderedDict[str, str]" = OrderedDict(
+    [
+        ("SDA", "GPIO 8 / CE0"),
+        ("SCK", "GPIO 11 / SCLK"),
+        ("MOSI", "GPIO 10 / MOSI"),
+        ("MISO", "GPIO 9 / MISO"),
+        ("IRQ", "GPIO 4"),
+        ("GND", "Ground"),
+        ("RST", "GPIO 25"),
+        ("3v3", "3.3V"),
+    ]
+)
+
+DEFAULT_SPI_DEVICE = Path("/dev/spidev0.0")
+
+
+def pinout() -> "OrderedDict[str, str]":
+    """Return a copy of the expected MFRC522 wiring map."""
+
+    return PINOUT.copy()
+
+
+def _print(message: str, stream: TextIO) -> None:
+    stream.write(f"{message}\n")
+    stream.flush()
+
+
+def _load_dependencies(stdout: TextIO):
+    """Import hardware dependencies and return ``(SimpleMFRC522, GPIO)``."""
+
+    try:  # pragma: no cover - exercised via tests with monkeypatching
+        from mfrc522 import SimpleMFRC522  # type: ignore
+    except ModuleNotFoundError as exc:
+        missing = exc.name or "mfrc522"
+        if missing == "mfrc522":
+            _print(
+                "The 'mfrc522' package is required. Install it with 'pip install mfrc522'.",
+                stdout,
+            )
+        elif missing == "spidev":
+            _print(
+                "The 'spidev' package is required to access the SPI bus. Install it with 'pip install spidev'.",
+                stdout,
+            )
+        else:
+            _print(f"Required dependency '{missing}' is missing.", stdout)
+        return None, None
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        _print(f"Failed to import mfrc522.SimpleMFRC522: {exc}", stdout)
+        return None, None
+
+    try:  # pragma: no cover - exercised via tests with monkeypatching
+        import RPi.GPIO as GPIO  # type: ignore
+    except ModuleNotFoundError:
+        _print(
+            "The 'RPi.GPIO' package is required. Install it with 'pip install RPi.GPIO'.",
+            stdout,
+        )
+        return None, None
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        _print(f"Failed to import RPi.GPIO: {exc}", stdout)
+        return None, None
+
+    return SimpleMFRC522, GPIO
+
+
+def _iter_spi_devices() -> Iterable[Path]:  # pragma: no cover - filesystem probe
+    return sorted(Path("/dev").glob("spidev*"))
+
+
+def _report_missing_spi(device: Path, stdout: TextIO) -> None:
+    _print(f"SPI device '{device}' was not found.", stdout)
+    candidates = list(_iter_spi_devices())
+    if candidates:
+        _print("Detected alternate SPI devices:", stdout)
+        for candidate in candidates:
+            _print(f"  - {candidate}", stdout)
+        _print(
+            "Move the reader to the matching bus/device or update the scanner configuration.",
+            stdout,
+        )
+    else:
+        _print(
+            "No SPI devices are available. Enable SPI via 'raspi-config', ensure 'dtparam=spi=on' in /boot/config.txt,",
+            stdout,
+        )
+        _print(
+            "load the 'spi_bcm2835' and 'spidev' kernel modules, and reboot before retrying.",
+            stdout,
+        )
+
+
+def scan(
+    *,
+    spi_device: Path | str = DEFAULT_SPI_DEVICE,
+    poll_interval: float = 0.1,
+    stdin: Optional[TextIO] = None,
+    stdout: Optional[TextIO] = None,
+    select_fn: Callable[[Sequence[TextIO], Sequence[TextIO], Sequence[TextIO], float], tuple] = select.select,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    """Interactively read RFID tags until the user presses Enter."""
+
+    stdout = stdout or sys.stdout
+    stdin = stdin or sys.stdin
+
+    reader_factory, gpio_module = _load_dependencies(stdout)
+    if reader_factory is None or gpio_module is None:
+        return 1
+
+    device = Path(spi_device)
+    if not device.exists():
+        _report_missing_spi(device, stdout)
+        return 1
+
+    try:
+        reader = reader_factory()
+    except FileNotFoundError as exc:
+        _print(
+            "Unable to access the SPI device. Ensure SPI is enabled and the reader is wired to the correct pins.",
+            stdout,
+        )
+        _print(str(exc), stdout)
+        return 1
+    except PermissionError as exc:
+        _print(
+            "Permission denied while accessing the SPI device. Run as root or add the user to the 'spi' group.",
+            stdout,
+        )
+        _print(str(exc), stdout)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        _print(f"Failed to initialize the RFID reader: {exc}", stdout)
+        return 1
+
+    _print("Scanning for RFID cards. Press Enter to stop.", stdout)
+    try:
+        while True:
+            try:
+                ready, _, _ = select_fn([stdin], [], [], 0)
+            except Exception:  # pragma: no cover - defensive fallback
+                ready = []
+            if ready:
+                try:
+                    stdin.readline()
+                except Exception:  # pragma: no cover - best effort cleanup
+                    pass
+                break
+
+            try:
+                card_id, text = reader.read_no_block()
+            except Exception as exc:  # pragma: no cover - hardware failure
+                _print(f"RFID read failed: {exc}", stdout)
+                break
+
+            if card_id:
+                clean_text = " ".join((text or "").split())
+                if clean_text:
+                    _print(f"Tag {card_id}: {clean_text}", stdout)
+                else:
+                    _print(f"Tag {card_id}", stdout)
+
+            sleep(max(poll_interval, 0))
+    except KeyboardInterrupt:  # pragma: no cover - interactive exit
+        _print("Scan interrupted by user.", stdout)
+    finally:
+        try:
+            gpio_module.cleanup()
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
+
+    return 0
+
+
+def main() -> int:
+    """Module entry point for ``python -m projects.rfid``."""
+
+    return scan()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_projects_rfid.py
+++ b/tests/test_projects_rfid.py
@@ -1,0 +1,142 @@
+import io
+from unittest.mock import MagicMock
+
+from projects import rfid
+
+
+class TestPinout:
+    def test_returns_copy(self):
+        mapping = rfid.pinout()
+        mapping["SDA"] = "changed"
+        assert mapping["SDA"] != rfid.PINOUT["SDA"]
+
+    def test_expected_wiring(self):
+        mapping = rfid.pinout()
+        assert list(mapping.items()) == list(rfid.PINOUT.items())
+
+
+class TestScan:
+    def _setup_dependencies(self, monkeypatch, reader_factory=None, gpio=None):
+        if reader_factory is None:
+            reader_factory = MagicMock()
+        if gpio is None:
+            gpio = MagicMock()
+
+        def fake_loader(stdout):
+            return reader_factory, gpio
+
+        monkeypatch.setattr(rfid, "_load_dependencies", fake_loader)
+        monkeypatch.setattr(rfid, "_iter_spi_devices", lambda: [])
+        return reader_factory, gpio
+
+    def test_missing_dependencies(self, monkeypatch):
+        buffer = io.StringIO()
+
+        def failing_loader(stdout):
+            rfid._print("install mfrc522", stdout)
+            return None, None
+
+        monkeypatch.setattr(rfid, "_load_dependencies", failing_loader)
+        exit_code = rfid.scan(stdout=buffer)
+        assert exit_code == 1
+        assert "mfrc522" in buffer.getvalue().lower()
+
+    def test_missing_spi_device_with_candidates(self, monkeypatch, tmp_path):
+        buffer = io.StringIO()
+        reader_factory, gpio = self._setup_dependencies(monkeypatch)
+        missing = tmp_path / "spidev0.0"
+        candidate = tmp_path / "spidev1.0"
+        candidate.touch()
+        monkeypatch.setattr(rfid, "_iter_spi_devices", lambda: [candidate])
+
+        exit_code = rfid.scan(spi_device=missing, stdout=buffer)
+        assert exit_code == 1
+        output = buffer.getvalue()
+        assert str(missing) in output
+        assert str(candidate) in output
+        assert not reader_factory.called
+        assert not gpio.cleanup.called
+
+    def test_permission_error(self, monkeypatch, tmp_path):
+        buffer = io.StringIO()
+
+        def factory():
+            raise PermissionError("denied")
+
+        reader_factory, gpio = self._setup_dependencies(
+            monkeypatch, reader_factory=factory
+        )
+        device = tmp_path / "spidev0.0"
+        device.touch()
+
+        exit_code = rfid.scan(spi_device=device, stdout=buffer)
+        assert exit_code == 1
+        assert "permission" in buffer.getvalue().lower()
+        assert not gpio.cleanup.called
+
+    def test_successful_scan(self, monkeypatch, tmp_path):
+        buffer = io.StringIO()
+        stdin = io.StringIO("\n")
+
+        class FakeReader:
+            def __init__(self):
+                self.calls = 0
+
+            def read_no_block(self):
+                self.calls += 1
+                if self.calls == 1:
+                    return (None, None)
+                if self.calls == 2:
+                    return (12345, "Hello\nWorld")
+                return (None, None)
+
+        factory = MagicMock(side_effect=FakeReader)
+        reader_factory, gpio = self._setup_dependencies(
+            monkeypatch, reader_factory=factory
+        )
+        device = tmp_path / "spidev0.0"
+        device.touch()
+
+        responses = iter([([], [], []), ([], [], []), ([stdin], [], [])])
+
+        def fake_select(_rlist, _wlist, _xlist, _timeout):
+            return next(responses)
+
+        exit_code = rfid.scan(
+            spi_device=device,
+            stdout=buffer,
+            stdin=stdin,
+            select_fn=fake_select,
+            sleep=lambda _t: None,
+        )
+
+        assert exit_code == 0
+        output = buffer.getvalue()
+        assert "Scanning for RFID cards" in output
+        assert "12345" in output
+        assert "Hello World" in output
+        assert reader_factory.called
+        gpio.cleanup.assert_called_once()
+
+    def test_keyboard_interrupt(self, monkeypatch, tmp_path):
+        buffer = io.StringIO()
+
+        class FakeReader:
+            def read_no_block(self):
+                raise KeyboardInterrupt
+
+        reader_factory, gpio = self._setup_dependencies(
+            monkeypatch, reader_factory=lambda: FakeReader()
+        )
+        device = tmp_path / "spidev0.0"
+        device.touch()
+
+        exit_code = rfid.scan(
+            spi_device=device,
+            stdout=buffer,
+            sleep=lambda _t: None,
+        )
+
+        assert exit_code == 0
+        assert "interrupted" in buffer.getvalue().lower()
+        gpio.cleanup.assert_called_once()


### PR DESCRIPTION
## Summary
- add a standalone `projects.rfid` helper that documents wiring, loads hardware dependencies with helpful error messages, and provides an interactive scan loop with SPI device preflight checks
- expose a lightweight `projects` package for the CLI entry point and return codes
- add unit tests that exercise the wiring helper and scanner error/success paths using dependency injection

## Testing
- pytest tests/test_projects_rfid.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb3a3e9fc88326a4ceccd7ce8f0839