### PR TITLE
Keep admin change form sections sidebar fixed

### DIFF
--- a/core/fixtures/todos__validate_screen_admin_change_form_sections.json
+++ b/core/fixtures/todos__validate_screen_admin_change_form_sections.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Admin Change Form Sections",
+      "url": "/admin/auth/user/add/",
+      "request_details": "Verify the Sections sidebar stays fixed on the admin change form when scrolling."
+    }
+  }
+]

--- a/pages/templates/admin/change_form.html
+++ b/pages/templates/admin/change_form.html
@@ -36,9 +36,14 @@
     }
 
     @media (min-width: 1024px) {
-      #content-related.changeform-sections .changeform-sections__container {
+      #content-related.changeform-sections {
         position: sticky;
         top: 1.5rem;
+      }
+
+      #content-related.changeform-sections.is-collapsed {
+        position: static;
+        top: auto;
       }
     }
 
@@ -127,6 +132,8 @@
         float: none;
         width: auto;
         margin: 1.5rem 0 0;
+        position: static;
+        top: auto;
       }
 
       #content-related.changeform-sections .changeform-sections__panel {


### PR DESCRIPTION
## Summary
- keep the admin change form sections column anchored with sticky positioning on large screens
- reset the sidebar positioning when collapsed or on small viewports to preserve the mobile layout
- add a validation TODO fixture covering the admin change form sections screen

## Testing
- pytest tests/test_email_profiles.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4aada30483269ccb2beb1c24ceb1