### PR TITLE
Align simulator CP paths and labels

### DIFF
--- a/ocpp/fixtures/simulators__gatewaysim_connector_1.json
+++ b/ocpp/fixtures/simulators__gatewaysim_connector_1.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "GatewaySim Connector 1",
-      "cp_path": "GATEWAY-12910-C1",
+      "cp_path": "GATEWAY-12910",
       "host": "192.168.129.10",
       "ws_port": 8000,
       "serial_number": "GATEWAY-12910",

--- a/ocpp/fixtures/simulators__gatewaysim_connector_2.json
+++ b/ocpp/fixtures/simulators__gatewaysim_connector_2.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "GatewaySim Connector 2",
-      "cp_path": "GATEWAY-12910-C2",
+      "cp_path": "GATEWAY-12910",
       "host": "192.168.129.10",
       "ws_port": 8000,
       "serial_number": "GATEWAY-12910",

--- a/ocpp/fixtures/simulators__localsim_connector_1.json
+++ b/ocpp/fixtures/simulators__localsim_connector_1.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "LocalSim Connector 1",
-      "cp_path": "LOCALSIM-0001-C1",
+      "cp_path": "LOCALSIM-0001",
       "host": "127.0.0.1",
       "ws_port": 8000,
       "serial_number": "LOCALSIM-0001",

--- a/ocpp/fixtures/simulators__localsim_connector_2.json
+++ b/ocpp/fixtures/simulators__localsim_connector_2.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "LocalSim Connector 2",
-      "cp_path": "LOCALSIM-0001-C2",
+      "cp_path": "LOCALSIM-0001",
       "host": "127.0.0.1",
       "ws_port": 8000,
       "serial_number": "LOCALSIM-0001",

--- a/ocpp/fixtures/simulators__routersim_connector_1.json
+++ b/ocpp/fixtures/simulators__routersim_connector_1.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "RouterSim Connector 1",
-      "cp_path": "ROUTERSIM-0420-C1",
+      "cp_path": "ROUTERSIM-0420",
       "host": "10.42.0.1",
       "ws_port": 8000,
       "serial_number": "ROUTERSIM-0420",

--- a/ocpp/fixtures/simulators__routersim_connector_2.json
+++ b/ocpp/fixtures/simulators__routersim_connector_2.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "RouterSim Connector 2",
-      "cp_path": "ROUTERSIM-0420-C2",
+      "cp_path": "ROUTERSIM-0420",
       "host": "10.42.0.1",
       "ws_port": 8000,
       "serial_number": "ROUTERSIM-0420",

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -349,7 +349,9 @@ class Simulator(Entity):
     """Preconfigured simulator that can be started from the admin."""
 
     name = models.CharField(max_length=100, unique=True)
-    cp_path = models.CharField(_("CP Path"), max_length=100)
+    cp_path = models.CharField(
+        _("Serial Number"), max_length=100, help_text=_("Charge Point WS path")
+    )
     host = models.CharField(max_length=100, default="127.0.0.1")
     ws_port = models.IntegerField(_("WS Port"), default=8000)
     rfid = models.CharField(

--- a/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/ocpp/templates/ocpp/cp_simulator_block.html
@@ -18,8 +18,9 @@
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="mb-2">
-            <label class="form-label" for="cp_path{{ idx }}">ChargePoint Path</label>
-            <input id="cp_path{{ idx }}" name="cp_path" value="{{ cp.params.cp_path|default:default_cp_path }}" class="form-control form-control-sm">
+            <label class="form-label" for="cp_path{{ idx }}">Serial Number</label>
+            <input id="cp_path{{ idx }}" name="cp_path" aria-describedby="cp_path_help{{ idx }}" value="{{ cp.params.cp_path|default:default_cp_path }}" class="form-control form-control-sm">
+            <div id="cp_path_help{{ idx }}" class="form-text">Charge Point WS path</div>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">


### PR DESCRIPTION
## Summary
- use identical `cp_path` values for paired CP simulator fixtures that target the same host while keeping connector IDs distinct
- relabel the simulator `cp_path` field as "Serial Number" and add help text describing the Charge Point WebSocket path in the admin and simulator form

## Testing
- python manage.py test ocpp.tests --keepdb *(fails: existing suite expects legacy meter reading fields and seed chargers)*

------
https://chatgpt.com/codex/tasks/task_e_68cc25dfd54483268238e4d9680229d8