### PR TITLE
Hide EnergyCredit admin from index

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1572,6 +1572,9 @@ class EnergyCreditAdmin(EntityModelAdmin):
             obj.created_by = request.user
         super().save_model(request, obj, form, change)
 
+    def get_model_perms(self, request):
+        return {}
+
 
 class ProductAdminForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
## Summary
- override the EnergyCredit admin's model permissions so it no longer appears in the admin index while keeping inline editing available

## Testing
- pytest tests/test_version_file.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3e561ad48326828bfec8deb3f369