### PR TITLE
Keep profile password fields empty when unchanged

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -502,6 +502,25 @@ def _raw_instance_value(instance, field_name):
         return field.value_from_object(instance)
 
 
+class KeepExistingValue:
+    """Sentinel indicating a field should retain its stored value."""
+
+    __slots__ = ("field",)
+
+    def __init__(self, field: str):
+        self.field = field
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"<KeepExistingValue field={self.field!r}>"
+
+
+def keep_existing(field: str) -> KeepExistingValue:
+    return KeepExistingValue(field)
+
+
 def _restore_sigil_values(form, field_names):
     """Reset sigil fields on ``form.instance`` to their raw form values."""
 
@@ -510,6 +529,8 @@ def _restore_sigil_values(form, field_names):
             continue
         if name in form.cleaned_data:
             raw = form.cleaned_data[name]
+            if isinstance(raw, KeepExistingValue):
+                raw = _raw_instance_value(form.instance, name)
         else:
             raw = _raw_instance_value(form.instance, name)
         setattr(form.instance, name, raw)
@@ -539,7 +560,7 @@ class OdooProfileAdminForm(forms.ModelForm):
     def clean_password(self):
         pwd = self.cleaned_data.get("password")
         if not pwd and self.instance.pk:
-            return _raw_instance_value(self.instance, "password")
+            return keep_existing("password")
         return pwd
 
     def _post_clean(self):
@@ -574,7 +595,7 @@ class EmailInboxAdminForm(forms.ModelForm):
     def clean_password(self):
         pwd = self.cleaned_data.get("password")
         if not pwd and self.instance.pk:
-            return _raw_instance_value(self.instance, "password")
+            return keep_existing("password")
         return pwd
 
     def _post_clean(self):
@@ -628,6 +649,8 @@ class ProfileFormMixin(forms.ModelForm):
 
     @staticmethod
     def _is_empty_value(value) -> bool:
+        if isinstance(value, KeepExistingValue):
+            return True
         if isinstance(value, bool):
             return not value
         if value in (None, "", [], (), {}, set()):
@@ -750,7 +773,7 @@ class EmailOutboxInlineForm(ProfileFormMixin, forms.ModelForm):
     def clean_password(self):
         pwd = self.cleaned_data.get("password")
         if not pwd and self.instance.pk:
-            return _raw_instance_value(self.instance, "password")
+            return keep_existing("password")
         return pwd
 
     def _post_clean(self):

--- a/tests/test_email_inbox_admin.py
+++ b/tests/test_email_inbox_admin.py
@@ -12,6 +12,7 @@ from core.admin import (
     EmailInboxAdminForm,
     EmailInboxAdmin,
     EmailCollectorAdmin,
+    KeepExistingValue,
 )
 
 
@@ -95,7 +96,10 @@ class EmailInboxAdminFormTests(TestCase):
         }
         form = EmailInboxAdminForm(data, instance=inbox)
         self.assertTrue(form.is_valid(), form.errors)
-        self.assertEqual(form.cleaned_data["password"], "[ENV.SMTP_PASSWORD]")
+        value = form.cleaned_data["password"]
+        self.assertIsInstance(value, KeepExistingValue)
+        self.assertEqual(value.field, "password")
+        self.assertFalse(value)
         field = form.instance._meta.get_field("password")
         self.assertEqual(field.value_from_object(form.instance), "[ENV.SMTP_PASSWORD]")
         saved = form.save()

--- a/tests/test_odoo_profile_admin.py
+++ b/tests/test_odoo_profile_admin.py
@@ -9,7 +9,12 @@ from django.test import RequestFactory, TestCase
 from django.http import QueryDict
 
 from core.models import OdooProfile
-from core.admin import OdooProfileAdmin, OdooProfileAdminForm, OdooProfileInlineForm
+from core.admin import (
+    KeepExistingValue,
+    OdooProfileAdmin,
+    OdooProfileAdminForm,
+    OdooProfileInlineForm,
+)
 
 
 class OdooProfileAdminFormTests(TestCase):
@@ -84,7 +89,10 @@ class OdooProfileAdminFormTests(TestCase):
         }
         form = OdooProfileAdminForm(data, instance=profile)
         self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data["password"], "[ENV.ODOO_PASSWORD]")
+        value = form.cleaned_data["password"]
+        self.assertIsInstance(value, KeepExistingValue)
+        self.assertEqual(value.field, "password")
+        self.assertFalse(value)
         field = form.instance._meta.get_field("password")
         self.assertEqual(field.value_from_object(form.instance), "[ENV.ODOO_PASSWORD]")
         saved = form.save()


### PR DESCRIPTION
## Summary
- introduce a KeepExistingValue sentinel so profile passwords can keep their stored values without contributing form data
- return the sentinel when profile password fields are submitted blank and treat it as empty in profile form handling
- refresh the admin form tests for Odoo and email profiles to assert the new behavior

## Testing
- pytest tests/test_odoo_profile_admin.py tests/test_email_inbox_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3f2ba7a48326a5f59282a212c995