### PR TITLE
Remove AP Lead references from docs and tests

### DIFF
--- a/core/admindocs.py
+++ b/core/admindocs.py
@@ -57,7 +57,6 @@ class OrderedModelIndexView(BaseAdminDocsView):
     GROUP_OVERRIDES = {
         "ocpp.location": "core",
         "core.rfid": "ocpp",
-        "core.aplead": "teams",
         "core.package": "teams",
         "core.packagerelease": "teams",
     }

--- a/tests/test_admin_doc_model_groups.py
+++ b/tests/test_admin_doc_model_groups.py
@@ -64,10 +64,6 @@ class AdminDocsModelGroupsTests(TestCase):
             "django-admindocs-models-detail",
             kwargs={"app_label": "core", "model_name": "rfid"},
         )
-        ap_lead_link = reverse(
-            "django-admindocs-models-detail",
-            kwargs={"app_label": "core", "model_name": "aplead"},
-        )
         package_link = reverse(
             "django-admindocs-models-detail",
             kwargs={"app_label": "core", "model_name": "package"},
@@ -83,6 +79,6 @@ class AdminDocsModelGroupsTests(TestCase):
         self.assertIn(f'href="{rfid_link}"', protocol_section)
         self.assertNotIn(f'href="{rfid_link}"', business_section)
 
-        for link in (ap_lead_link, package_link, package_release_link):
+        for link in (package_link, package_release_link):
             self.assertIn(f'href="{link}"', workgroup_section)
             self.assertNotIn(f'href="{link}"', business_section)

--- a/tests/test_workgroup_admin_group.py
+++ b/tests/test_workgroup_admin_group.py
@@ -24,7 +24,3 @@ class WorkgroupAdminGroupTests(TestCase):
         self.assertContains(response, "6. Workgroup MODELS")
         self.assertContains(response, "Power Leads")
 
-    def test_admin_index_hides_aplead(self):
-        response = self.client.get(reverse("admin:index"))
-        self.assertContains(response, "6. Workgroup MODELS")
-        self.assertNotContains(response, "AP Leads")


### PR DESCRIPTION
## Summary
- remove the old AP Lead grouping override from the admin docs configuration
- stop the admin docs tests from referencing the removed AP Lead model
- drop the admin index regression test that still mentioned the AP Lead label

## Testing
- pytest tests/test_workgroup_admin_group.py tests/test_admin_doc_model_groups.py

------
https://chatgpt.com/codex/tasks/task_e_68cc54383f408326a97e1a2dfee15716