### PR TITLE
Expand connector labels for navigation clarity

### DIFF
--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -136,8 +136,16 @@ class Charger(Entity):
         """Return a short human readable label for this connector."""
 
         if self.connector_id is None:
-            return _("All")
-        return str(self.connector_id)
+            return _("All Connectors")
+
+        special_labels = {
+            1: _("Connector 1 (Left)"),
+            2: _("Connector 2 (Right)"),
+        }
+        if self.connector_id in special_labels:
+            return special_labels[self.connector_id]
+
+        return _("Connector %(number)s") % {"number": self.connector_id}
 
     def identity_slug(self) -> str:
         """Return a unique slug for this charger identity."""


### PR DESCRIPTION
## Summary
- update the charger connector label helper to return more descriptive labels for the aggregate view and individual connectors

## Testing
- python manage.py test ocpp

------
https://chatgpt.com/codex/tasks/task_e_68cc780e2d9c8326b9bba8ea82135b83