### PR TITLE
Maintain connector colors in charger charts

### DIFF
--- a/core/fixtures/todos__validate_screen_charger_status.json
+++ b/core/fixtures/todos__validate_screen_charger_status.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Charger Status",
+      "url": "/ocpp/c/LOCALSIM-0001/status/",
+      "request_details": "Confirm connector color assignments remain consistent for individual and aggregate charger views."
+    }
+  }
+]

--- a/ocpp/templates/ocpp/charger_status.html
+++ b/ocpp/templates/ocpp/charger_status.html
@@ -155,6 +155,43 @@
     { border: 'rgba(147,112,219,1)', background: 'rgba(147,112,219,0.3)' },
     { border: 'rgba(255,140,0,1)', background: 'rgba(255,140,0,0.3)' }
   ];
+  const CONNECTOR_COLOR_MAP = {
+    1: COLOR_PALETTE[0],
+    2: COLOR_PALETTE[1],
+  };
+
+  function parseConnectorId(dataset) {
+    if (!dataset) {
+      return null;
+    }
+    if (dataset.connector_id !== undefined && dataset.connector_id !== null) {
+      const numericId = Number(dataset.connector_id);
+      if (!Number.isNaN(numericId)) {
+        return numericId;
+      }
+    }
+    if (typeof dataset.label === 'string') {
+      const match = dataset.label.match(/connector\s*(\d+)/i) || dataset.label.match(/^(\d+)$/);
+      if (match) {
+        const numericId = Number(match[1]);
+        if (!Number.isNaN(numericId)) {
+          return numericId;
+        }
+      }
+    }
+    return null;
+  }
+
+  function getPaletteForDataset(dataset, index) {
+    const connectorId = parseConnectorId(dataset);
+    if (
+      connectorId !== null &&
+      Object.prototype.hasOwnProperty.call(CONNECTOR_COLOR_MAP, connectorId)
+    ) {
+      return CONNECTOR_COLOR_MAP[connectorId];
+    }
+    return COLOR_PALETTE[index % COLOR_PALETTE.length];
+  }
 
   function parseChartPayload(root) {
     if (!root || !root.querySelector) {
@@ -184,7 +221,7 @@
       return Number.isNaN(parsed.getTime()) ? ts : parsed.toLocaleTimeString();
     });
     chartData.datasets = (payload.datasets || []).map((dataset, index) => {
-      const palette = COLOR_PALETTE[index % COLOR_PALETTE.length];
+      const palette = getPaletteForDataset(dataset, index);
       const values = Array.isArray(dataset.values)
         ? dataset.values.map((value) => {
             if (value === null || value === undefined || value === '') {


### PR DESCRIPTION
## Summary
- include connector identifiers in charger status chart datasets and surface them to the template
- ensure the chart script pins connector 1 and 2 to their orange and blue colors regardless of dataset order
- add regression coverage for connector identifiers and log a TODO to validate the charger status screen manually

## Testing
- python manage.py test ocpp.tests.ChargerStatusViewTests

------
https://chatgpt.com/codex/tasks/task_e_68cc7c00b2fc8326a442bd5560f76b7f