### PR TITLE
Add container vulnerability scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,42 @@ jobs:
       - name: Run env refresh
         run: ./env-refresh.sh --clean
 
+  container-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build container image
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --tag arthexis-ci:latest \
+            --file Dockerfile \
+            --load \
+            .
+      - name: Cache Trivy database
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/trivy
+          key: ${{ runner.os }}-trivy-${{ hashFiles('Dockerfile', 'requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-
+      - name: Scan container image
+        uses: aquasecurity/trivy-action@v0
+        with:
+          scan-type: 'image'
+          image-ref: arthexis-ci:latest
+          severity: 'HIGH,CRITICAL'
+          vuln-type: 'os,library'
+          format: 'table'
+          exit-code: '1'
+          cache-dir: ~/.cache/trivy
+
   ui-screenshots:
     needs: detect-roles
     runs-on: ubuntu-latest

--- a/docs/container-security.md
+++ b/docs/container-security.md
@@ -1,0 +1,16 @@
+# Container Security Scanning
+
+The CI pipeline runs a `container-scan` job that builds the Docker image defined in [`Dockerfile`](../Dockerfile) for the `linux/arm64` platform and scans it for known vulnerabilities using [Trivy](https://github.com/aquasecurity/trivy). The scanner downloads and caches its vulnerability database between runs to speed up subsequent checks.
+
+## Remediation expectations
+
+* The job fails if any HIGH or CRITICAL vulnerabilities are reported. Address alerts by updating the Docker base image, rebuilding third-party dependencies, or upgrading the affected Python/system packages.
+* After applying fixes, rebuild the image locally (`docker buildx build --platform linux/arm64 .`) to ensure the container still builds, then re-run the CI pipeline or the Trivy scan locally (`trivy image <local-tag>`) to confirm the vulnerabilities are resolved.
+* If no vendor fix is available, track the issue and document the mitigation in the security backlog before temporarily suppressing it.
+
+## Local scanning tips
+
+1. Enable Docker Buildx and QEMU locally if you need to target the ARM64 platform (`docker buildx create --use`).
+2. Build the image with a temporary tag: `docker buildx build --platform linux/arm64 -t arthexis-local:scan --load .`.
+3. Run `trivy image arthexis-local:scan --severity HIGH,CRITICAL` to mirror the CI behaviour.
+4. Remove the temporary image afterwards (`docker image rm arthexis-local:scan`).


### PR DESCRIPTION
## Summary
- add a container-scan job that builds the ARM64 Docker image during CI and scans it with Trivy, failing on high or critical issues
- cache the Trivy vulnerability database between runs for faster scans
- document expectations for remediating container scan alerts and replicating the checks locally

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68cc8fc705e0832692dd5259383682af