### PR TITLE
Add gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,40 @@ jobs:
               issue_number: context.issue.number,
               body
             });
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Gitleaks
+        run: |
+          set -eo pipefail
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz \
+            -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz
+          sudo install gitleaks /usr/local/bin/gitleaks
+      - name: Scan working tree for secrets
+        run: |
+          set -eo pipefail
+          gitleaks detect --no-git --source . --config .gitleaks.toml --redact --no-banner
+      - name: Scan git history for secrets
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          GITLEAKS_HISTORY_RANGE: ${{ github.event_name == 'pull_request' && format('{0}..{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || (github.event_name == 'push' && format('{0}..{1}', github.event.before, github.sha) || '') }}
+        run: |
+          set -eo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$PR_BASE_REF" ]; then
+            git fetch --no-tags --prune --depth=0 origin "$PR_BASE_REF"
+          fi
+          LOG_OPTS="--no-merges"
+          if [ -n "$GITLEAKS_HISTORY_RANGE" ] && git rev-list $GITLEAKS_HISTORY_RANGE >/dev/null 2>&1; then
+            LOG_OPTS="$LOG_OPTS $GITLEAKS_HISTORY_RANGE"
+          else
+            LOG_OPTS="$LOG_OPTS --max-count=200"
+          fi
+          gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --log-opts="$LOG_OPTS"
   tests:
     needs: detect-roles
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+title = "ArtHexis Gitleaks Configuration"
+
+[extend]
+useDefault = true
+
+[allowlist]
+  description = "Ignore known placeholder credentials in tests"
+  regexes = [
+    '''password=\"password\"'''
+  ]
+
+[[rules]]
+id = "hashicorp-tf-password"
+
+[rules.allowlist]
+  regexTarget = "line"
+  regexes = [
+    '''password="password"'''
+  ]

--- a/docs/development/secret-scanning.md
+++ b/docs/development/secret-scanning.md
@@ -1,0 +1,37 @@
+# Secret Scanning
+
+The CI pipeline runs automated secret scans to prevent accidental exposure of credentials. Every pull request executes a
+[Gitleaks](https://github.com/gitleaks/gitleaks) scan against the committed history of the change and the working tree to catch
+leaks before they land on the main branch. The scanner is configured with [`.gitleaks.toml`](../../.gitleaks.toml) so that
+legitimate placeholder credentials used in test fixtures are ignored while any other matches will fail the build.
+
+## Running the scanner locally
+
+Run the same checks locally before pushing a branch so that failures can be resolved early. The commands below download the
+Gitleaks binary, scan the working tree, and then scan the commit range that would be sent to a pull request.
+
+```bash
+curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz \
+  | tar -xz -C /tmp gitleaks
+/tmp/gitleaks detect --no-git --source . --config .gitleaks.toml --redact --no-banner
+/tmp/gitleaks detect --source . --config .gitleaks.toml --redact --no-banner \
+  --log-opts "--no-merges origin/main..HEAD"
+```
+
+Adjust the branch name in the final command to match the base branch of your pull request.
+
+## If a real secret is detected
+
+1. **Rotate the secret immediately.** Regenerate the credential in the upstream system (cloud provider, payment gateway, etc.)
+   so the exposed value no longer works.
+2. **Remove the secret from the repository.** Replace it with configuration that reads from environment variables or another
+   secure storage location. Update or purge any committed files that contained the value.
+3. **Force-push only after sanitising history.** If the secret exists in previous commits on the branch, rewrite the branch
+   history (for example with `git rebase -i` or `git filter-repo`) to remove the value and force-push the cleaned branch.
+4. **Re-run Gitleaks locally.** Execute the commands above to confirm the issue is resolved before opening or updating the pull
+   request.
+5. **Notify the maintainers.** Open an issue or contact the project maintainers privately so that any deployed environments or
+   dependent services using the old secret can also be rotated.
+
+Following the steps above ensures that the automated scans remain actionable and that any genuine credential exposure is handled
+quickly and safely.


### PR DESCRIPTION
## Summary
- add a CI job that installs and runs gitleaks against both the workspace and relevant git history
- add a repository gitleaks configuration to suppress known placeholder test credentials while keeping other findings actionable
- document how contributors can run the scanner locally and handle real secret exposure

## Testing
- gitleaks detect --no-git --source . --config .gitleaks.toml --no-banner --redact
- gitleaks detect --source . --config .gitleaks.toml --no-banner --redact


------
https://chatgpt.com/codex/tasks/task_e_68cc8fb85ad88326814578e73abb1d31