### PR TITLE
Add visitor node registration handshake

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -68,6 +68,11 @@ class NodeAdmin(EntityModelAdmin):
                 name="nodes_node_register_current",
             ),
             path(
+                "register-visitor/",
+                self.admin_site.admin_view(self.register_visitor),
+                name="nodes_node_register_visitor",
+            ),
+            path(
                 "<int:node_id>/action/<str:action>/",
                 self.admin_site.admin_view(self.action_view),
                 name="nodes_node_action",
@@ -93,6 +98,25 @@ class NodeAdmin(EntityModelAdmin):
             "register_url": reverse("register-node"),
         }
         return render(request, "admin/nodes/node/register_remote.html", context)
+
+    def register_visitor(self, request):
+        """Exchange registration data with the visiting node."""
+
+        node, created = Node.register_current()
+        if created:
+            self.message_user(
+                request, f"Current host registered as {node}", messages.SUCCESS
+            )
+
+        token = uuid.uuid4().hex
+        context = {
+            "token": token,
+            "info_url": reverse("node-info"),
+            "register_url": reverse("register-node"),
+            "visitor_info_url": "http://localhost:8000/nodes/info/",
+            "visitor_register_url": "http://localhost:8000/nodes/register/",
+        }
+        return render(request, "admin/nodes/node/register_visitor.html", context)
 
     def public_key(self, request, node_id):
         node = self.get_object(request, node_id)

--- a/nodes/templates/admin/nodes/node/change_list.html
+++ b/nodes/templates/admin/nodes/node/change_list.html
@@ -7,5 +7,10 @@
             {% trans 'Register current host' %}
         </a>
     </li>
+    <li>
+        <a href="{% url 'admin:nodes_node_register_visitor' %}" class="addlink">
+            {% trans 'Register visitor node' %}
+        </a>
+    </li>
     {{ block.super }}
 {% endblock %}

--- a/nodes/templates/admin/nodes/node/register_visitor.html
+++ b/nodes/templates/admin/nodes/node/register_visitor.html
@@ -1,0 +1,145 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Register Visitor Node" %}</h1>
+<p>{% trans "Attempting to exchange node information between this host and the visiting instance." %}</p>
+<ul>
+    <li id="host-result">{% trans "Registering the visiting node on this server…" %}</li>
+    <li id="visitor-result">{% trans "Registering this server on the visiting node…" %}</li>
+</ul>
+<p id="result"></p>
+<script>
+(function() {
+    const token = "{{ token|escapejs }}";
+    const hostInfoUrl = "{{ info_url|escapejs }}?token=" + token;
+    const hostRegisterUrl = "{{ register_url|escapejs }}";
+    const visitorInfoUrl = "{{ visitor_info_url|escapejs }}?token=" + token;
+    const visitorRegisterUrl = "{{ visitor_register_url|escapejs }}";
+    const hostResult = document.getElementById("host-result");
+    const visitorResult = document.getElementById("visitor-result");
+    const summary = document.getElementById("result");
+    const messages = {
+        hostRegistered: "{{ _('Visitor node registered with this server.')|escapejs }}",
+        visitorRegistered: "{{ _('Host node registered with visitor.')|escapejs }}",
+        success: "{{ _('Both nodes registered successfully.')|escapejs }}",
+        partial: "{{ _('One or more registrations failed.')|escapejs }}",
+        aborted: "{{ _('Registration aborted.')|escapejs }}",
+        visitorInfoError: "{{ _('Unable to read visitor node information.')|escapejs }}",
+        hostInfoError: "{{ _('Unable to read host node information.')|escapejs }}",
+    };
+
+    function setStatus(element, message, isError) {
+        if (!element) {
+            return;
+        }
+        element.textContent = message;
+        if (isError) {
+            element.classList.add("errornote");
+        } else {
+            element.classList.remove("errornote");
+        }
+    }
+
+    async function loadJson(url, options) {
+        const response = await fetch(url, options);
+        const text = await response.text();
+        let payload;
+        try {
+            payload = JSON.parse(text);
+        } catch (err) {
+            payload = text;
+        }
+        if (!response.ok) {
+            const detail = payload && payload.detail ? payload.detail : text || response.statusText;
+            throw new Error(detail);
+        }
+        return payload;
+    }
+
+    function buildPayload(info) {
+        return {
+            hostname: info.hostname,
+            address: info.address,
+            port: info.port,
+            mac_address: info.mac_address,
+            public_key: info.public_key,
+            features: info.features || [],
+        };
+    }
+
+    function addSignature(payload, info) {
+        if (info.token_signature) {
+            payload.token = token;
+            payload.signature = info.token_signature;
+        }
+    }
+
+    (async function() {
+        try {
+            const [visitorInfo, hostInfo] = await Promise.all([
+                loadJson(visitorInfoUrl),
+                loadJson(hostInfoUrl),
+            ]);
+
+            if (!visitorInfo || typeof visitorInfo !== "object") {
+                throw new Error(messages.visitorInfoError);
+            }
+            if (!hostInfo || typeof hostInfo !== "object") {
+                throw new Error(messages.hostInfoError);
+            }
+
+            const hostPayload = buildPayload(visitorInfo);
+            addSignature(hostPayload, visitorInfo);
+            try {
+                const result = await loadJson(hostRegisterUrl, {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    credentials: "same-origin",
+                    body: JSON.stringify(hostPayload),
+                });
+                if (result && result.detail) {
+                    setStatus(hostResult, result.detail, false);
+                } else {
+                    setStatus(hostResult, messages.hostRegistered, false);
+                }
+            } catch (error) {
+                setStatus(hostResult, error.message, true);
+            }
+
+            const visitorPayload = buildPayload(hostInfo);
+            addSignature(visitorPayload, hostInfo);
+            try {
+                const result = await loadJson(visitorRegisterUrl, {
+                    method: "POST",
+                    credentials: "include",
+                    body: JSON.stringify(visitorPayload),
+                });
+                if (result && result.detail) {
+                    setStatus(visitorResult, result.detail, false);
+                } else {
+                    setStatus(visitorResult, messages.visitorRegistered, false);
+                }
+            } catch (error) {
+                setStatus(visitorResult, error.message, true);
+            }
+
+            if (!hostResult.classList.contains("errornote") && !visitorResult.classList.contains("errornote")) {
+                setStatus(summary, messages.success, false);
+            } else if (!summary.textContent) {
+                setStatus(summary, messages.partial, true);
+            }
+        } catch (error) {
+            const message = error.message || error;
+            setStatus(summary, message, true);
+            if (!hostResult.classList.contains("errornote")) {
+                setStatus(hostResult, messages.aborted, true);
+            }
+            if (!visitorResult.classList.contains("errornote")) {
+                setStatus(visitorResult, messages.aborted, true);
+            }
+        }
+    })();
+})();
+</script>
+{% endblock %}

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -156,6 +156,42 @@ class NodeTests(TestCase):
         node.refresh_from_db()
         self.assertFalse(node.has_feature("clipboard-poll"))
 
+    def test_register_node_sets_cors_headers(self):
+        payload = {
+            "hostname": "cors",
+            "address": "127.0.0.1",
+            "port": 8000,
+            "mac_address": "10:20:30:40:50:60",
+        }
+        response = self.client.post(
+            reverse("register-node"),
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_ORIGIN="http://example.com",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Access-Control-Allow-Origin"], "http://example.com"
+        )
+        self.assertEqual(response["Access-Control-Allow-Credentials"], "true")
+
+    def test_register_node_accepts_text_plain_payload(self):
+        payload = {
+            "hostname": "plain",
+            "address": "127.0.0.1",
+            "port": 8001,
+            "mac_address": "aa:bb:cc:dd:ee:ff",
+        }
+        response = self.client.post(
+            reverse("register-node"),
+            data=json.dumps(payload),
+            content_type="text/plain",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            Node.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").exists()
+        )
+
 
 class NodeRegisterCurrentTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- add an admin action and helper page to register visitor nodes and exchange certificates
- allow the node registration endpoint to respond with CORS headers so visitor instances can submit their details
- cover the new flow with tests for CORS handling and plain-text payloads

## Testing
- pytest nodes/tests.py -k "register_node_sets_cors_headers or register_node_accepts_text_plain_payload"


------
https://chatgpt.com/codex/tasks/task_e_68cc8de287708326991ac6188543699b