### PR TITLE
Harden admin model graph permissions

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -27,6 +27,7 @@ from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.cache import never_cache
 from django.utils.cache import patch_vary_headers
 from core.models import InviteLead, ClientReport
+from django.core.exceptions import PermissionDenied
 
 try:  # pragma: no cover - optional dependency guard
     from graphviz import Digraph
@@ -51,6 +52,31 @@ def _get_registered_models(app_label: str):
         if model._meta.app_label == app_label
     ]
     return sorted(registered, key=lambda model: str(model._meta.verbose_name))
+
+
+def _filter_models_for_request(models, request):
+    """Filter ``models`` to only those viewable by ``request.user``."""
+
+    allowed = []
+    for model in models:
+        model_admin = admin.site._registry.get(model)
+        if model_admin is None:
+            continue
+        if not model_admin.has_module_permission(request):
+            continue
+        if not model_admin.has_view_permission(request, obj=None):
+            continue
+        allowed.append(model)
+    return allowed
+
+
+def _admin_has_app_permission(request, app_label: str) -> bool:
+    """Return whether the admin user can access the given app."""
+
+    has_app_permission = getattr(admin.site, "has_app_permission", None)
+    if callable(has_app_permission):
+        return has_app_permission(request, app_label)
+    return bool(admin.site.get_app_list(request, app_label))
 
 
 def _resolve_related_model(field, default_app_label: str):
@@ -189,6 +215,13 @@ def admin_model_graph(request, app_label: str):
     models = _get_registered_models(app_label)
     if not models:
         raise Http404("No admin models registered for this application")
+
+    if not _admin_has_app_permission(request, app_label):
+        raise PermissionDenied
+
+    models = _filter_models_for_request(models, request)
+    if not models:
+        raise PermissionDenied
 
     if Digraph is None:  # pragma: no cover - dependency missing is unexpected
         raise Http404("Graph visualization support is unavailable")


### PR DESCRIPTION
## Summary
- ensure the admin model graph view enforces app access permission before rendering the diagram
- filter the model graph contents to only include models the requesting user can view

## Testing
- pytest tests/test_admin_model_graph.py tests/test_workgroup_admin_group.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9003bae4832691cd24209c0bd93a