### PR TITLE
Allow unauthenticated preflight for register node

### DIFF
--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -175,6 +175,22 @@ class NodeTests(TestCase):
         )
         self.assertEqual(response["Access-Control-Allow-Credentials"], "true")
 
+    def test_register_node_allows_unauthenticated_preflight(self):
+        self.client.logout()
+        response = self.client.options(
+            reverse("register-node"),
+            HTTP_ORIGIN="http://example.com",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="Content-Type",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["Access-Control-Allow-Origin"], "http://example.com"
+        )
+        self.assertEqual(
+            response["Access-Control-Allow-Methods"], "POST, OPTIONS"
+        )
+
     def test_register_node_accepts_text_plain_payload(self):
         payload = {
             "hostname": "plain",

--- a/nodes/views.py
+++ b/nodes/views.py
@@ -91,12 +91,17 @@ def _add_cors_headers(request, response):
 
 
 @csrf_exempt
-@api_login_required
 def register_node(request):
     """Register or update a node from POSTed JSON data."""
 
     if request.method == "OPTIONS":
         response = JsonResponse({"detail": "ok"})
+        return _add_cors_headers(request, response)
+
+    if not request.user.is_authenticated:
+        response = JsonResponse(
+            {"detail": "authentication required"}, status=401
+        )
         return _add_cors_headers(request, response)
 
     if request.method != "POST":
@@ -190,6 +195,9 @@ def register_node(request):
 
     response = JsonResponse({"id": node.id})
     return _add_cors_headers(request, response)
+
+
+register_node.login_required = True
 
 
 @api_login_required


### PR DESCRIPTION
## Summary
- allow the register node view to return CORS headers for OPTIONS preflight requests without requiring authentication while still guarding POST submissions
- preserve the login_required marker on the view and add coverage to ensure unauthenticated preflight requests succeed

## Testing
- python manage.py migrate --noinput
- pytest nodes/tests.py -k "register_node_sets_cors_headers or register_node_accepts_text_plain_payload or register_node_allows_unauthenticated_preflight"

------
https://chatgpt.com/codex/tasks/task_e_68cc92d46b6c8326b2e673ee8293ad4a