### PR TITLE
Move user datum checkbox into profile headers

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -834,7 +834,6 @@ PROFILE_INLINE_CONFIG = {
                 None,
                 {
                     "fields": (
-                        "user_datum",
                         "host",
                         "database",
                         "username",
@@ -854,7 +853,6 @@ PROFILE_INLINE_CONFIG = {
     EmailInbox: {
         "form": EmailInboxInlineForm,
         "fields": (
-            "user_datum",
             "username",
             "host",
             "port",
@@ -866,7 +864,6 @@ PROFILE_INLINE_CONFIG = {
     EmailOutbox: {
         "form": EmailOutboxInlineForm,
         "fields": (
-            "user_datum",
             "password",
             "host",
             "port",
@@ -879,7 +876,6 @@ PROFILE_INLINE_CONFIG = {
     ReleaseManager: {
         "form": ReleaseManagerInlineForm,
         "fields": (
-            "user_datum",
             "pypi_username",
             "pypi_token",
             "github_token",
@@ -914,6 +910,7 @@ def _build_profile_inline(model, owner_field):
         "can_delete": True,
         "verbose_name": verbose_name,
         "verbose_name_plural": verbose_name_plural,
+        "template": "admin/edit_inline/profile_stacked.html",
     }
     if "fieldsets" in config:
         attrs["fieldsets"] = config["fieldsets"]


### PR DESCRIPTION
## Summary
- ensure profile inlines render with the custom stacked template so the User Datum checkbox appears in the header
- remove the user_datum field from inline field/fieldset definitions to avoid rendering the old help text block

## Testing
- pytest tests/test_user_data_admin.py tests/test_seed_data.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9703107883269b108fd4663ce5be