### PR TITLE
Fix admin dashboard module header width

### DIFF
--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -78,15 +78,25 @@
     .dashboard-main td.actions .actionlink:first-child {
         margin-left: 0;
     }
+    .dashboard-main .module table {
+        width: 100%;
+    }
     .dashboard-main .app-caption {
         display: flex;
         align-items: baseline;
         gap: 0.5rem;
+        width: 100%;
+        box-sizing: border-box;
+    }
+    .dashboard-main .app-caption .section {
+        flex: 1 1 auto;
     }
     .dashboard-main .diagram-link {
         font-size: 0.75rem;
         text-transform: none;
         font-weight: normal;
+        margin-left: auto;
+        white-space: nowrap;
     }
     .dashboard-side .actionlist li {
         position: relative;


### PR DESCRIPTION
## Summary
- ensure admin dashboard module tables span the full module width so captions fill the header background
- stretch app captions and align the diagram link to keep module headers visually consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc9a7e3dbc8326ae889e864f71b79c