### PR TITLE
Remove Model graph link from admin dashboard

### DIFF
--- a/core/fixtures/todos__validate_screen_admin_dashboard.json
+++ b/core/fixtures/todos__validate_screen_admin_dashboard.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Admin Dashboard",
+      "url": "/admin/",
+      "request_details": "Confirm the Home dashboard renders without the Model graph link and that the header styling is correct."
+    }
+  }
+]

--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -6,12 +6,6 @@
       <table>
         <caption class="app-caption">
           <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }} MODELS</a>
-          <a
-            href="{% url 'admin-model-graph' app.app_label %}"
-            class="diagram-link"
-            data-app-graph="{{ app.app_label }}"
-            title="{% translate 'Open relationship diagram' %}"
-          >{% translate 'Model graph' %}</a>
         </caption>
         <thead class="visually-hidden">
           <tr>

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -82,21 +82,12 @@
         width: 100%;
     }
     .dashboard-main .app-caption {
-        display: flex;
-        align-items: baseline;
-        gap: 0.5rem;
         width: 100%;
         box-sizing: border-box;
     }
     .dashboard-main .app-caption .section {
-        flex: 1 1 auto;
-    }
-    .dashboard-main .diagram-link {
-        font-size: 0.75rem;
-        text-transform: none;
-        font-weight: normal;
-        margin-left: auto;
-        white-space: nowrap;
+        display: block;
+        width: 100%;
     }
     .dashboard-side .actionlist li {
         position: relative;

--- a/tests/test_admin_model_graph.py
+++ b/tests/test_admin_model_graph.py
@@ -15,10 +15,11 @@ class AdminModelGraphTests(TestCase):
         )
         self.client.force_login(self.user)
 
-    def test_admin_index_contains_graph_links(self):
+    def test_admin_index_omits_graph_links(self):
         response = self.client.get(reverse("admin:index"))
-        self.assertContains(response, 'data-app-graph="teams"')
-        self.assertContains(
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'data-app-graph="teams"')
+        self.assertNotContains(
             response, reverse("admin-model-graph", args=["teams"])
         )
 


### PR DESCRIPTION
## Summary
- remove the Model graph shortcut from the admin dashboard modules and navigation sidebar
- simplify dashboard caption styling to resolve the header row visual glitch
- update admin model graph regression test expectations and add a validation todo for the dashboard

## Testing
- pytest tests/test_admin_model_graph.py

------
https://chatgpt.com/codex/tasks/task_e_68ccb739fa108326b675978e1fcdc78a