### PR TITLE
Add charge point links to location admin

### DIFF
--- a/ocpp/templates/admin/ocpp/location/change_form.html
+++ b/ocpp/templates/admin/ocpp/location/change_form.html
@@ -2,11 +2,20 @@
 {% load i18n %}
 
 {% block object-tools-items %}
-  {% if original and original.latitude != None and original.longitude != None %}
-    {% with coord=original.latitude|stringformat:"s"|add:","|add:original.longitude|stringformat:"s" %}
-      <li><a href="https://www.waze.com/ul?ll={{ coord|urlencode }}&navigate=yes" target="_blank" rel="noopener noreferrer">{% trans "Open in Waze" %}</a></li>
-      <li><a href="https://maps.google.com/?q={{ coord|urlencode }}" target="_blank" rel="noopener noreferrer">{% trans "Open in Maps" %}</a></li>
-    {% endwith %}
+  {% if original %}
+    {% for charger in original.chargers.all %}
+      <li>
+        <a href="{% url 'admin:ocpp_charger_change' charger.pk %}">
+          {% trans "Charge Point" %}: {{ charger.charger_id }}{% if charger.connector_id %} #{{ charger.connector_id }}{% endif %}
+        </a>
+      </li>
+    {% endfor %}
+    {% if original.latitude != None and original.longitude != None %}
+      {% with coord=original.latitude|stringformat:"s"|add:","|add:original.longitude|stringformat:"s" %}
+        <li><a href="https://www.waze.com/ul?ll={{ coord|urlencode }}&navigate=yes" target="_blank" rel="noopener noreferrer">{% trans "Open in Waze" %}</a></li>
+        <li><a href="https://maps.google.com/?q={{ coord|urlencode }}" target="_blank" rel="noopener noreferrer">{% trans "Open in Maps" %}</a></li>
+      {% endwith %}
+    {% endif %}
   {% endif %}
   {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- show related charge points on the charge location change form via admin object tools
- exercise the new links with a location admin regression test

## Testing
- python manage.py test ocpp.tests.LocationAdminTests

------
https://chatgpt.com/codex/tasks/task_e_68ccc135c9048326b00f0b518a18fcc7