### PR TITLE
Add Register Visitor Node action to admin dashboard

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -56,7 +56,7 @@ class NodeAdmin(EntityModelAdmin):
     change_list_template = "admin/nodes/node/change_list.html"
     change_form_template = "admin/nodes/node/change_form.html"
     form = NodeAdminForm
-    actions = ["run_task", "take_screenshots"]
+    actions = ["register_visitor", "run_task", "take_screenshots"]
     inlines = [NodeFeatureAssignmentInline]
 
     def get_urls(self):
@@ -69,7 +69,7 @@ class NodeAdmin(EntityModelAdmin):
             ),
             path(
                 "register-visitor/",
-                self.admin_site.admin_view(self.register_visitor),
+                self.admin_site.admin_view(self.register_visitor_view),
                 name="nodes_node_register_visitor",
             ),
             path(
@@ -99,7 +99,11 @@ class NodeAdmin(EntityModelAdmin):
         }
         return render(request, "admin/nodes/node/register_remote.html", context)
 
-    def register_visitor(self, request):
+    @admin.action(description="Register Visitor Node")
+    def register_visitor(self, request, queryset=None):
+        return self.register_visitor_view(request)
+
+    def register_visitor_view(self, request):
         """Exchange registration data with the visiting node."""
 
         node, created = Node.register_current()

--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -27,6 +27,10 @@ class AdminIndexActionLinkTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertContains(response, "Scan RFIDs")
         self.assertContains(response, f'href="{reverse("admin:core_rfid_scan")}"')
+        self.assertContains(response, "Register Visitor Node")
+        self.assertContains(
+            response, f'href="{reverse("admin:nodes_node_register_visitor")}"'
+        )
         self.assertNotContains(response, "Build selected packages")
         self.assertNotContains(response, "Purge selected logs")
         content = response.content.decode()


### PR DESCRIPTION
## Summary
- expose the Register Visitor Node action directly from the Nodes admin
- ensure the dashboard shows the Register Visitor Node link alongside other model actions

## Testing
- pytest tests/test_admin_index_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7c9fd870832699f7ee4de29fd2a6