### PR TITLE
Hide invite request link when email unavailable

### DIFF
--- a/core/fixtures/todos__validate_screen_login.json
+++ b/core/fixtures/todos__validate_screen_login.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Login",
+      "url": "/login/",
+      "request_details": "Verify the login page hides the Request email invitation link when email delivery is unavailable and displays it once email is configured."
+    }
+  }
+]

--- a/pages/templates/pages/login.html
+++ b/pages/templates/pages/login.html
@@ -21,9 +21,11 @@
       {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
       <button type="submit" class="btn btn-primary w-100">{% trans "Log in" %}</button>
     </form>
+    {% if can_request_invite %}
     <div class="mt-3 text-center">
       <a href="{% url 'pages:request-invite' %}">{% trans "Request email invitation" %}</a>
     </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/pages/views.py
+++ b/pages/views.py
@@ -431,6 +431,7 @@ class CustomLoginView(LoginView):
                 "site": current_site,
                 "site_name": getattr(current_site, "name", ""),
                 "next": self.get_success_url(),
+                "can_request_invite": mailer.can_send_email(),
             }
         )
         return context


### PR DESCRIPTION
## Summary
- add a `core.mailer.can_send_email` helper so the UI can tell when outbound mail is unavailable
- hide the login page invitation request link when email sending is not configured and cover the behavior with tests
- add a validation TODO fixture for the login screen

## Testing
- python manage.py test pages.tests.LoginViewTests pages.tests.InvitationTests

------
https://chatgpt.com/codex/tasks/task_e_68cd7d22266c8326b409dbe703be32e8