### PR TITLE
Add ap-router auto-managed node feature

### DIFF
--- a/nodes/fixtures/node_features__nodefeature_ap_router.json
+++ b/nodes/fixtures/node_features__nodefeature_ap_router.json
@@ -1,0 +1,19 @@
+[
+  {
+    "model": "nodes.nodefeature",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "slug": "ap-router",
+      "display": "AP Router",
+      "roles": [
+        [
+          "Control"
+        ],
+        [
+          "Satellite"
+        ]
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add an ap-router node feature fixture that defaults to Control and Satellite roles
- detect when the local node hosts the gelectriic-ap access point via nmcli and auto-manage the feature
- extend node feature tests to cover the new fixture and detection lifecycle

## Testing
- python manage.py test nodes

------
https://chatgpt.com/codex/tasks/task_e_68cd87d71a2083268061c116224358b3