### PR TITLE
Avoid role fallback in NodeFeature.is_enabled

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -108,8 +108,6 @@ class NodeFeature(Entity):
         if lock:
             base_path = Path(node.base_path or settings.BASE_DIR)
             return (base_path / "locks" / lock).exists()
-        if node.role:
-            return self.roles.filter(pk=node.role.pk).exists()
         return False
 
 

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -1236,6 +1236,21 @@ class NodeFeatureTests(TestCase):
             with patch("core.notifications.supports_gui_toast", return_value=False):
                 self.assertFalse(feature.is_enabled)
 
+    def test_role_membership_alone_does_not_enable_feature(self):
+        feature = NodeFeature.objects.create(
+            slug="custom-feature", display="Custom Feature"
+        )
+        feature.roles.add(self.role)
+        with patch(
+            "nodes.models.Node.get_current_mac", return_value="00:11:22:33:44:55"
+        ):
+            self.assertFalse(feature.is_enabled)
+        NodeFeatureAssignment.objects.create(node=self.node, feature=feature)
+        with patch(
+            "nodes.models.Node.get_current_mac", return_value="00:11:22:33:44:55"
+        ):
+            self.assertTrue(feature.is_enabled)
+
     @patch("nodes.models.Node._has_rpi_camera", return_value=True)
     def test_rpi_camera_detection(self, mock_camera):
         feature = NodeFeature.objects.create(


### PR DESCRIPTION
## Summary
- stop using node roles as a fallback when checking `NodeFeature.is_enabled`
- add a regression test to ensure role membership alone does not enable a feature

## Testing
- ./manage.py test nodes.tests.NodeFeatureTests

------
https://chatgpt.com/codex/tasks/task_e_68cd87f786cc8326abfcd9967c22b176