### PR TITLE
Address nmcli type alias for AP router detection

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -343,7 +343,10 @@ class Node(Entity):
                 conn_type = parts[2]
             elif len(parts) > 1:
                 conn_type = parts[1]
-            if name != cls.AP_ROUTER_SSID or conn_type != "wifi":
+            if name != cls.AP_ROUTER_SSID:
+                continue
+            conn_type_normalized = conn_type.strip().lower()
+            if conn_type_normalized not in {"wifi", "802-11-wireless"}:
                 continue
             try:
                 mode_result = subprocess.run(


### PR DESCRIPTION
## Summary
- broaden the nmcli AP router detection to accept wifi connections reported as 802-11-wireless

## Testing
- python manage.py test nodes

------
https://chatgpt.com/codex/tasks/task_e_68cd8a64d5c08326859d13b375104f26