### PR TITLE
Skip sigils tied to missing apps during env refresh

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -255,6 +255,22 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
                     fields = obj.get("fields", {})
                     if "user" in fields and isinstance(fields["user"], int):
                         fields["user"] = user_pk_map.get(fields["user"], fields["user"])
+                    if model_label == "core.sigilroot":
+                        content_type = fields.get("content_type")
+                        app_label: str | None = None
+                        if isinstance(content_type, (list, tuple)) and content_type:
+                            app_label = content_type[0]
+                        elif isinstance(content_type, dict):
+                            app_label = content_type.get("app_label")
+                        if app_label:
+                            try:
+                                apps.get_app_config(app_label)
+                            except LookupError:
+                                prefix = fields.get("prefix", "?")
+                                print(
+                                    f"Skipping SigilRoot '{prefix}' (missing app '{app_label}')"
+                                )
+                                continue
                     if model is PackageRelease:
                         version = obj.get("fields", {}).get("version")
                         if (


### PR DESCRIPTION
## Summary
- ignore core.sigilroot fixture entries when their content type references an app that is not installed
- log the skipped prefixes so the missing integration is easy to notice during env refresh

## Testing
- python env-refresh.py database

------
https://chatgpt.com/codex/tasks/task_e_68cda95d1b988326a7d96f36316f2cd3