### PR TITLE
Fix LIVES sigil content type

### DIFF
--- a/core/fixtures/sigil_roots__lives.json
+++ b/core/fixtures/sigil_roots__lives.json
@@ -8,7 +8,7 @@
       "context_type": "entity",
       "content_type": [
         "core",
-        "livesubscription"
+        "energyaccount"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- update the LIVES sigil fixture to reference the EnergyAccount content type

## Testing
- python env-refresh.py database

------
https://chatgpt.com/codex/tasks/task_e_68cdac97b51083268adc1284f2b43c0d