### PR TITLE
Show all temperature amp columns in cable size admin list

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -12,6 +12,8 @@ class CableSizeAdmin(EntityModelAdmin):
         "material",
         "area_kcmil",
         "amps_60c",
+        "amps_75c",
+        "amps_90c",
         "line_num",
     )
     search_fields = ("awg_size", "material")

--- a/tests/test_awg_admin.py
+++ b/tests/test_awg_admin.py
@@ -24,3 +24,5 @@ class CableSizeAdminListDisplayTests(SimpleTestCase):
         admin = CableSizeAdmin(CableSize, AdminSite())
         assert "area_kcmil" in admin.list_display
         assert "amps_60c" in admin.list_display
+        assert "amps_75c" in admin.list_display
+        assert "amps_90c" in admin.list_display


### PR DESCRIPTION
## Summary
- display the 60C, 75C, and 90C ampacity columns in the Cable Size admin changelist
- extend the admin unit test to ensure all temperature columns are present

## Testing
- pytest tests/test_awg_admin.py


------
https://chatgpt.com/codex/tasks/task_e_68cdc9cbd860832699e686145bf6af28