### PR TITLE
Move Power Lead admin to Power group

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -119,6 +119,7 @@ class CalculatorTemplateAdmin(EntityModelAdmin):
     calculator_link.short_description = "Calculator"
 
 
+@admin.register(PowerLead)
 class PowerLeadAdmin(EntityModelAdmin):
     list_display = ("created_on", "user", "ip_address")
     search_fields = ("user__username", "ip_address")

--- a/teams/admin.py
+++ b/teams/admin.py
@@ -21,12 +21,10 @@ from core.admin import (
     OdooProfileAdmin,
     AssistantProfileAdmin,
 )
-from awg.admin import PowerLeadAdmin
 from nodes.admin import EmailOutboxAdmin
 
 from .models import (
     InviteLead,
-    PowerLead,
     User,
     SecurityGroup,
     EmailInbox,
@@ -40,11 +38,6 @@ from .models import (
 
 @admin.register(InviteLead)
 class InviteLeadAdminProxy(InviteLeadAdmin):
-    pass
-
-
-@admin.register(PowerLead)
-class PowerLeadAdminProxy(PowerLeadAdmin):
     pass
 
 

--- a/tests/test_power_admin_group.py
+++ b/tests/test_power_admin_group.py
@@ -3,10 +3,10 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.contrib.admin.sites import site
 
-from teams.models import PowerLead
+from awg.models import PowerLead
 
 
-class WorkgroupAdminGroupTests(TestCase):
+class PowerAdminGroupTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.admin = User.objects.create_superuser(
@@ -17,10 +17,10 @@ class WorkgroupAdminGroupTests(TestCase):
     def test_powerlead_registered(self):
         registry = site._registry
         self.assertIn(PowerLead, registry)
-        self.assertEqual(registry[PowerLead].model._meta.app_label, "teams")
+        self.assertEqual(registry[PowerLead].model._meta.app_label, "awg")
 
     def test_admin_index_shows_powerlead(self):
         response = self.client.get(reverse("admin:index"))
-        self.assertContains(response, "6. Workgroup MODELS")
+        self.assertContains(response, "1. Power MODELS")
         self.assertContains(response, "Power Leads")
 


### PR DESCRIPTION
## Summary
- register the AWG PowerLead model so it appears in the 1. Power admin group
- drop the Workgroup proxy admin registration and update the grouping test expectations

## Testing
- pytest tests/test_power_admin_group.py

------
https://chatgpt.com/codex/tasks/task_e_68cdca666c3c83269cd182753e33d38c