### PR TITLE
Update calculator template public visibility labels

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -77,7 +77,7 @@ class CalculatorTemplateAdmin(EntityModelAdmin):
     list_display = (
         "name",
         "description",
-        "show_in_pages",
+        "public",
         "meters",
         "amps",
         "volts",
@@ -102,6 +102,10 @@ class CalculatorTemplateAdmin(EntityModelAdmin):
         "ground",
         "calculator_link",
     )
+    
+    @admin.display(boolean=True, description="Public", ordering="show_in_pages")
+    def public(self, obj):
+        return obj.show_in_pages
 
     def run_calculator(self, request, queryset):
         for template in queryset:

--- a/awg/models.py
+++ b/awg/models.py
@@ -100,7 +100,9 @@ class CalculatorTemplate(Entity):
     temperature = models.PositiveIntegerField(null=True, blank=True)
     conduit = models.CharField(max_length=10, blank=True)
     ground = models.PositiveIntegerField(default=1, null=True, blank=True)
-    show_in_pages = models.BooleanField(default=False, blank=True)
+    show_in_pages = models.BooleanField(
+        _("Show in public site"), default=False, blank=True
+    )
 
     def __str__(self):  # pragma: no cover - simple representation
         return self.name


### PR DESCRIPTION
## Summary
- rename the calculator template public visibility field label to "Show in public site"
- expose the calculator template public flag in the admin list with a "Public" column

## Testing
- python manage.py test awg

------
https://chatgpt.com/codex/tasks/task_e_68cdce4601808326b00435cdd19d4858