### PR TITLE
Enable RFID auto-detection when lock missing

### DIFF
--- a/ocpp/rfid/background_reader.py
+++ b/ocpp/rfid/background_reader.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from django.conf import settings
 
-from .constants import DEFAULT_IRQ_PIN
+from .constants import DEFAULT_IRQ_PIN, SPI_BUS, SPI_DEVICE
 
 logger = logging.getLogger(__name__)
 
@@ -20,16 +20,113 @@ except Exception:  # pragma: no cover - hardware dependent
     GPIO = None  # type: ignore
 
 IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", str(DEFAULT_IRQ_PIN)))
+_DEFAULT_SPI_DEVICE = Path(f"/dev/spidev{SPI_BUS}.{SPI_DEVICE}")
 _tag_queue: "queue.Queue[dict]" = queue.Queue()
 _thread: Optional[threading.Thread] = None
 _stop_event = threading.Event()
 _reader = None
+_auto_detect_logged = False
+
+
+def _lock_path() -> Path:
+    """Return the sentinel file that marks an installed RFID reader."""
+
+    return Path(settings.BASE_DIR) / "locks" / "rfid.lck"
+
+
+def _spi_device_path() -> Path:
+    """Return the expected SPI device path for the RFID reader."""
+
+    override = os.environ.get("RFID_SPI_DEVICE")
+    if override:
+        return Path(override)
+    return _DEFAULT_SPI_DEVICE
+
+
+def _available_spi_devices() -> list[Path]:
+    """Return the list of detected SPI devices on the system."""
+
+    try:  # pragma: no cover - filesystem availability varies
+        return sorted(Path("/dev").glob("spidev*"))
+    except Exception:  # pragma: no cover - defensive fallback
+        return []
+
+
+def _ensure_gpio_loaded() -> bool:
+    """Ensure the GPIO library is importable for hardware access."""
+
+    global GPIO
+    if GPIO is not None:
+        return True
+    try:  # pragma: no cover - hardware dependent import
+        import RPi.GPIO as gpio_mod  # type: ignore
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        logger.debug("RFID auto-detect: RPi.GPIO unavailable: %s", exc)
+        return False
+    GPIO = gpio_mod
+    return True
+
+
+def _dependencies_available() -> bool:
+    """Return ``True`` when hardware libraries required for RFID are present."""
+
+    if not _ensure_gpio_loaded():
+        return False
+    try:  # pragma: no cover - hardware dependent import
+        from mfrc522 import MFRC522  # type: ignore
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        logger.debug("RFID auto-detect: MFRC522 unavailable: %s", exc)
+        return False
+    return True
+
+
+def _has_spi_device() -> bool:
+    """Return ``True`` if the configured SPI device exists on this host."""
+
+    device = _spi_device_path()
+    if device.exists():  # pragma: no cover - filesystem probe
+        return True
+    candidates = _available_spi_devices()
+    if candidates:
+        logger.debug(
+            "RFID auto-detect: expected SPI device %s not found; available devices: %s",
+            device,
+            ", ".join(str(candidate) for candidate in candidates),
+        )
+    else:
+        logger.debug(
+            "RFID auto-detect: expected SPI device %s not found and no SPI devices detected",
+            device,
+        )
+    return False
+
+
+def _auto_detect_configured() -> bool:
+    """Best-effort detection of a connected RFID reader without lock files."""
+
+    if not _has_spi_device():
+        return False
+    if not _dependencies_available():
+        return False
+    return True
 
 
 def is_configured() -> bool:
     """Return ``True`` if an RFID reader is configured for this node."""
-    lock = Path(settings.BASE_DIR) / "locks" / "rfid.lck"
-    return lock.exists()
+    global _auto_detect_logged
+
+    lock = _lock_path()
+    if lock.exists():
+        return True
+
+    detected = _auto_detect_configured()
+    if detected and not _auto_detect_logged:
+        logger.info(
+            "RFID reader detected without lock file using SPI device %s",
+            _spi_device_path(),
+        )
+        _auto_detect_logged = True
+    return detected
 
 
 def _irq_callback(channel):  # pragma: no cover - hardware dependent


### PR DESCRIPTION
## Summary
- fall back to auto-detecting RFID hardware when the lock file is absent by checking the SPI device and required libraries
- log successful auto-detection and allow overriding the SPI device path via the environment
- cover the new detection flow with unit tests

## Testing
- pytest ocpp/test_rfid.py tests/test_rfid_background_reader.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcf28a59c83269a8ea8a0dcc2de58