### PR TITLE
Remove Docker container scan from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,42 +149,6 @@ jobs:
       - name: Run env refresh
         run: ./env-refresh.sh --clean
 
-  container-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build container image
-        run: |
-          docker buildx build \
-            --platform linux/arm64 \
-            --tag arthexis-ci:latest \
-            --file Dockerfile \
-            --load \
-            .
-      - name: Cache Trivy database
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/trivy
-          key: ${{ runner.os }}-trivy-${{ hashFiles('Dockerfile', 'requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-trivy-
-      - name: Scan container image
-        uses: aquasecurity/trivy-action@v0
-        with:
-          scan-type: 'image'
-          image-ref: arthexis-ci:latest
-          severity: 'HIGH,CRITICAL'
-          vuln-type: 'os,library'
-          format: 'table'
-          exit-code: '1'
-          cache-dir: ~/.cache/trivy
-
   ui-screenshots:
     needs: detect-roles
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the container-scan job from the CI workflow to eliminate Docker and Trivy steps

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdd9eba4e8832687ba6f31a7d6c666