### PR TITLE
Show release manager todos only on terminal nodes

### DIFF
--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -129,6 +129,12 @@ def future_action_items(context):
     if not user or not user.is_authenticated:
         return {"models": [], "todos": []}
 
+    badge_node = context.get("badge_node")
+    node_role_name = ""
+    if badge_node:
+        role = getattr(badge_node, "role", None)
+        node_role_name = getattr(role, "name", "") if role else ""
+
     model_data = {}
     first_seen = 0
     todo_ct = ContentType.objects.get_for_model(Todo)
@@ -199,7 +205,7 @@ def future_action_items(context):
     ]
 
     todos: list[dict[str, str]] = []
-    if user.has_profile(ReleaseManager):
+    if node_role_name == "Terminal" and user.has_profile(ReleaseManager):
         todos = [
             {
                 "url": todo.url or reverse("admin:core_todo_change", args=[todo.pk]),


### PR DESCRIPTION
## Summary
- gate the release manager TODO retrieval on the dashboard to Terminal nodes via the existing context
- ensure admin dashboard tests create a Terminal node by default and cover the non-Terminal case

## Testing
- python manage.py test pages.tests.FavoriteTests

------
https://chatgpt.com/codex/tasks/task_e_68cde3a94d8c8326804d4a22703e6988