### PR TITLE
Hide Constellation RFID navigation module

### DIFF
--- a/pages/context_processors.py
+++ b/pages/context_processors.py
@@ -20,7 +20,7 @@ def nav_links(request):
     role = node.role if node else None
     if role:
         modules = (
-            Module.objects.filter(node_role=role)
+            Module.objects.filter(node_role=role, is_deleted=False)
             .select_related("application")
             .prefetch_related("landings")
         )

--- a/pages/fixtures/constellation__landing_ocpp_rfid.json
+++ b/pages/fixtures/constellation__landing_ocpp_rfid.json
@@ -4,7 +4,7 @@
     "model": "pages.landing",
     "fields": {
       "is_seed_data": true,
-      "is_deleted": false,
+      "is_deleted": true,
       "module": ["Constellation", "/ocpp/rfid/"],
       "path": "/ocpp/rfid/",
       "label": "RFID Scanner",

--- a/pages/fixtures/constellation__module_rfid.json
+++ b/pages/fixtures/constellation__module_rfid.json
@@ -3,7 +3,7 @@
     "model": "pages.module",
     "fields": {
       "is_seed_data": true,
-      "is_deleted": false,
+      "is_deleted": true,
       "node_role": ["Constellation"],
       "application": ["ocpp"],
       "path": "/ocpp/rfid/",


### PR DESCRIPTION
## Summary
- mark the Constellation RFID module and landing fixtures as deleted so the pill is no longer seeded
- filter the navigation context to ignore soft-deleted modules and add coverage for the Constellation role navigation
- update the Constellation fixture loading test to prepare required data and keep the RFID landing creation idempotent

## Testing
- python manage.py test pages.tests.ConstellationNavTests.test_rfid_pill_hidden
- python manage.py test pages.tests.LandingFixtureTests.test_constellation_fixture_loads_without_duplicates

------
https://chatgpt.com/codex/tasks/task_e_68cdef6dd380832696fa0d61a8ae420f