### PR TITLE
Align node feature roles across docs and fixtures

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -11,6 +11,17 @@ Constelación Arthexis es una [suite de software](https://es.wikipedia.org/wiki/
 - Funciona en [Windows 11](https://www.microsoft.com/es-es/windows/windows-11) y [Ubuntu 22.04 LTS](https://releases.ubuntu.com/22.04/)
 - Probado para la [Raspberry Pi 4 Modelo B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 
+## Arquitectura de cuatro roles
+
+Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plataforma a distintos escenarios de despliegue.
+
+| Rol | Descripción | Funciones comunes |
+| --- | --- | --- |
+| Terminal | Investigación y desarrollo de un solo usuario | • GUI Toast |
+| Control | Pruebas de un solo dispositivo y equipos para tareas especiales | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
+| Satélite | Periferia multidispositivo, redes y adquisición de datos | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
+| Constelación | Nube multiusuario y orquestación | • Celery Queue<br>• NGINX Server |
+
 ## Quick Guide
 
 ### 1. Clonar

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,6 +11,17 @@ Constellation Arthexis est une [suite logicielle](https://fr.wikipedia.org/wiki/
 - Fonctionne sur [Windows 11](https://www.microsoft.com/windows/windows-11) et [Ubuntu 22.04 LTS](https://releases.ubuntu.com/22.04/)
 - Testé pour le [Raspberry Pi 4 Modèle B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 
+## Architecture à quatre rôles
+
+Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre à différents scénarios de déploiement.
+
+| Rôle | Description | Fonctionnalités courantes |
+| --- | --- | --- |
+| Terminal | Recherche et développement monoposte | • GUI Toast |
+| Control | Tests sur un appareil unique et appliances spécialisées | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
+| Satellite | Périphérie multi-appareils, réseau et acquisition de données | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
+| Constellation | Orchestration et cloud multi-utilisateurs | • Celery Queue<br>• NGINX Server |
+
 ## Quick Guide
 
 ### 1. Cloner

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Arthexis Constellation is a [narrative-driven](https://en.wikipedia.org/wiki/Nar
 - Tested for the [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 - CONTINUOUS RELEASE
 
+## Four Role Architecture
+
+Arthexis Constellation ships in four node roles tailored to different deployment scenarios.
+
+| Role | Description | Common features |
+| --- | --- | --- |
+| Terminal | Single-User Research & Development | • GUI Toast |
+| Control | Single-Device Testing & Special Task Appliances | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
+| Satellite | Multi-Device Edge, Network & Data Acquisition | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
+| Constellation | Multi-User Cloud & Orchestration | • Celery Queue<br>• NGINX Server |
+
 ## Quick Guide
 
 ### 1. Clone

--- a/README.ru.md
+++ b/README.ru.md
@@ -11,6 +11,17 @@
 - Работает на [Windows 11](https://www.microsoft.com/windows/windows-11) и [Ubuntu 22.04 LTS](https://releases.ubuntu.com/22.04/)
 - Протестирован на [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
 
+## Архитектура из четырёх ролей
+
+Созвездие Arthexis поставляется в четырёх ролях узлов, чтобы адаптировать платформу к различным сценариям развёртывания.
+
+| Роль | Описание | Типичные функции |
+| --- | --- | --- |
+| Terminal | Исследования и разработка для одного пользователя | • GUI Toast |
+| Control | Тестирование отдельных устройств и специализированные аппаратные комплексы | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
+| Satellite | Периферийная многоприборная инфраструктура, сеть и сбор данных | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
+| Constellation | Многопользовательское облако и оркестрация | • Celery Queue<br>• NGINX Server |
+
 ## Quick Guide
 
 ### 1. Клонирование

--- a/nodes/fixtures/node_features__nodefeature_ap_router.json
+++ b/nodes/fixtures/node_features__nodefeature_ap_router.json
@@ -8,9 +8,6 @@
       "display": "AP Router",
       "roles": [
         [
-          "Control"
-        ],
-        [
           "Satellite"
         ]
       ]

--- a/nodes/fixtures/node_features__nodefeature_celery_queue.json
+++ b/nodes/fixtures/node_features__nodefeature_celery_queue.json
@@ -8,9 +8,6 @@
       "display": "Celery Queue",
       "roles": [
         [
-          "Terminal"
-        ],
-        [
           "Satellite"
         ],
         [

--- a/nodes/fixtures/node_features__nodefeature_lcd_screen.json
+++ b/nodes/fixtures/node_features__nodefeature_lcd_screen.json
@@ -8,9 +8,6 @@
       "display": "LCD Screen",
       "roles": [
         [
-          "Terminal"
-        ],
-        [
           "Control"
         ]
       ]

--- a/nodes/fixtures/node_features__nodefeature_nginx_server.json
+++ b/nodes/fixtures/node_features__nodefeature_nginx_server.json
@@ -8,9 +8,6 @@
       "display": "NGINX Server",
       "roles": [
         [
-          "Terminal"
-        ],
-        [
           "Satellite"
         ],
         [

--- a/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
+++ b/nodes/fixtures/node_features__nodefeature_rfid_scanner.json
@@ -11,13 +11,7 @@
           "Control"
         ],
         [
-          "Terminal"
-        ],
-        [
           "Satellite"
-        ],
-        [
-          "Constellation"
         ]
       ]
     }

--- a/nodes/fixtures/node_features__nodefeature_rpi_camera.json
+++ b/nodes/fixtures/node_features__nodefeature_rpi_camera.json
@@ -6,11 +6,7 @@
       "is_deleted": false,
       "slug": "rpi-camera",
       "display": "Raspberry Pi Camera",
-      "roles": [
-        [
-          "Terminal"
-        ]
-      ]
+      "roles": []
     }
   }
 ]

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -1188,7 +1188,7 @@ class NodeFeatureFixtureTests(TestCase):
         call_command("loaddata", str(fixture_path), verbosity=0)
         feature = NodeFeature.objects.get(slug="ap-router")
         role_names = set(feature.roles.values_list("name", flat=True))
-        self.assertEqual(role_names, {"Control", "Satellite"})
+        self.assertEqual(role_names, {"Satellite"})
 
 
 class NodeFeatureTests(TestCase):


### PR DESCRIPTION
## Summary
- update the Four Role Architecture tables in each README translation to reflect the reduced Terminal scope and Constellation RFID removal
- remove Terminal, Control, and Constellation assignments from the affected node feature fixtures to match the new architecture
- update the AP Router fixture test to expect only the Satellite role

## Testing
- python manage.py test nodes.tests.NodeFeatureFixtureTests

------
https://chatgpt.com/codex/tasks/task_e_68cdf08a906c83268276624d43c61c65