### PR TITLE
Run Black formatting across Python modules

### DIFF
--- a/awg/admin.py
+++ b/awg/admin.py
@@ -102,7 +102,7 @@ class CalculatorTemplateAdmin(EntityModelAdmin):
         "ground",
         "calculator_link",
     )
-    
+
     @admin.display(boolean=True, description="Public", ordering="show_in_pages")
     def public(self, obj):
         return obj.show_in_pages

--- a/awg/views.py
+++ b/awg/views.py
@@ -178,9 +178,7 @@ def find_awg(
             elif limit_awg is None:
                 sizes = sorted(awg_data.keys(), reverse=True)
             else:
-                sizes = sorted(
-                    [s for s in awg_data.keys() if s >= int(AWG(limit_awg))]
-                )
+                sizes = sorted([s for s in awg_data.keys() if s >= int(AWG(limit_awg))])
 
             for awg_size in sizes:
                 base = awg_data[awg_size][1]
@@ -226,7 +224,9 @@ def find_awg(
                             if conduit:
                                 c = "emt" if conduit is True else conduit
                                 fill = find_conduit(
-                                    AWG(awg_size), n * (phases + ground_count), conduit=c
+                                    AWG(awg_size),
+                                    n * (phases + ground_count),
+                                    conduit=c,
                                 )
                                 result["conduit"] = c
                                 result["pipe_inch"] = fill["size_inch"]
@@ -239,7 +239,9 @@ def find_awg(
                             if conduit:
                                 c = "emt" if conduit is True else conduit
                                 fill = find_conduit(
-                                    AWG(awg_size), n * (phases + ground_count), conduit=c
+                                    AWG(awg_size),
+                                    n * (phases + ground_count),
+                                    conduit=c,
                                 )
                                 result["conduit"] = c
                                 result["pipe_inch"] = fill["size_inch"]
@@ -254,13 +256,13 @@ def find_awg(
                         "Voltage drop may exceed 3% with chosen parameters"
                     )
                 else:
-                    best["warning"] = _(
-                        "Voltage drop exceeds 3% with given max_awg"
-                    )
+                    best["warning"] = _("Voltage drop exceeds 3% with given max_awg")
                 if conduit:
                     c = "emt" if conduit is True else conduit
                     fill = find_conduit(
-                        AWG(best["awg"]), best["lines"] * (phases + ground_count), conduit=c
+                        AWG(best["awg"]),
+                        best["lines"] * (phases + ground_count),
+                        conduit=c,
                     )
                     best["conduit"] = c
                     best["pipe_inch"] = fill["size_inch"]

--- a/config/urls.py
+++ b/config/urls.py
@@ -110,7 +110,7 @@ urlpatterns = [
     ),
     path("admindocs/", include("django.contrib.admindocs.urls")),
     path(
-        "admin/doc/", 
+        "admin/doc/",
         RedirectView.as_view(pattern_name="django-admindocs-docroot"),
     ),
     path(

--- a/core/admin.py
+++ b/core/admin.py
@@ -1310,15 +1310,9 @@ class AssistantProfileAdmin(EntityModelAdmin):
             {
                 "mcp_status": status,
                 "mcp_server_actions": {
-                    "start": reverse(
-                        f"admin:{app_label}_{model_name}_start_server"
-                    ),
-                    "stop": reverse(
-                        f"admin:{app_label}_{model_name}_stop_server"
-                    ),
-                    "status": reverse(
-                        f"admin:{app_label}_{model_name}_status"
-                    ),
+                    "start": reverse(f"admin:{app_label}_{model_name}_start_server"),
+                    "stop": reverse(f"admin:{app_label}_{model_name}_stop_server"),
+                    "status": reverse(f"admin:{app_label}_{model_name}_status"),
                 },
             }
         )
@@ -1807,7 +1801,11 @@ class ClientReportAdmin(EntityModelAdmin):
         def __init__(self, *args, request=None, **kwargs):
             self.request = request
             super().__init__(*args, **kwargs)
-            if request and getattr(request, "user", None) and request.user.is_authenticated:
+            if (
+                request
+                and getattr(request, "user", None)
+                and request.user.is_authenticated
+            ):
                 self.fields["owner"].initial = request.user.pk
 
         def clean(self):

--- a/core/apps.py
+++ b/core/apps.py
@@ -60,14 +60,18 @@ class CoreConfig(AppConfig):
 
         from django.core.serializers import base as serializer_base
 
-        if not hasattr(serializer_base.DeserializedObject.save, "_entity_fixture_patch"):
+        if not hasattr(
+            serializer_base.DeserializedObject.save, "_entity_fixture_patch"
+        ):
             original_save = serializer_base.DeserializedObject.save
 
             @wraps(original_save)
             def patched_save(self, save_m2m=True, using=None, **kwargs):
                 obj = self.object
                 if isinstance(obj, Entity):
-                    manager = getattr(type(obj), "all_objects", type(obj)._default_manager)
+                    manager = getattr(
+                        type(obj), "all_objects", type(obj)._default_manager
+                    )
                     if using:
                         manager = manager.db_manager(using)
                     for fields in obj._unique_field_groups():
@@ -170,9 +174,7 @@ class CoreConfig(AppConfig):
                     "|".join(fingerprint_parts).encode("utf-8")
                 ).hexdigest()
 
-                cooldown = getattr(
-                    settings, "GITHUB_ISSUE_REPORTING_COOLDOWN", 3600
-                )
+                cooldown = getattr(settings, "GITHUB_ISSUE_REPORTING_COOLDOWN", 3600)
                 lock_dir = Path(settings.BASE_DIR) / "locks" / "github-issues"
                 fingerprint_path = None
                 now = time.time()
@@ -212,9 +214,7 @@ class CoreConfig(AppConfig):
 
                 report_exception_to_github.delay(payload)
             except Exception:  # pragma: no cover - defensive
-                logger.exception(
-                    "Failed to queue GitHub issue from request exception"
-                )
+                logger.exception("Failed to queue GitHub issue from request exception")
 
         got_request_exception.connect(
             queue_github_issue,

--- a/core/github_issues.py
+++ b/core/github_issues.py
@@ -26,7 +26,9 @@ def resolve_repository() -> tuple[str, str]:
 
     package = Package.objects.filter(is_active=True).first()
     repository_url = (
-        package.repository_url if package and package.repository_url else DEFAULT_PACKAGE.repository_url
+        package.repository_url
+        if package and package.repository_url
+        else DEFAULT_PACKAGE.repository_url
     )
 
     owner: str
@@ -88,7 +90,9 @@ def _has_recent_marker(lock_path: Path) -> bool:
     if not lock_path.exists():
         return False
 
-    marker_age = datetime.utcnow() - datetime.utcfromtimestamp(lock_path.stat().st_mtime)
+    marker_age = datetime.utcnow() - datetime.utcfromtimestamp(
+        lock_path.stat().st_mtime
+    )
     return marker_age < LOCK_TTL
 
 
@@ -148,7 +152,9 @@ def create_issue(
     }
     url = f"https://api.github.com/repos/{owner}/{repo}/issues"
 
-    response = requests.post(url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
+    response = requests.post(
+        url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT
+    )
     if not (200 <= response.status_code < 300):
         logger.error(
             "GitHub issue creation failed with status %s: %s",
@@ -164,4 +170,3 @@ def create_issue(
         response.status_code,
     )
     return response
-

--- a/core/mailer.py
+++ b/core/mailer.py
@@ -46,7 +46,9 @@ def send(
     if attachments:
         for attachment in attachments:
             if not isinstance(attachment, (list, tuple)) or len(attachment) != 3:
-                raise ValueError("attachments must contain (name, content, mimetype) tuples")
+                raise ValueError(
+                    "attachments must contain (name, content, mimetype) tuples"
+                )
             email.attach(*attachment)
     if content_subtype:
         email.content_subtype = content_subtype

--- a/core/management/commands/mcp_sigil_server.py
+++ b/core/management/commands/mcp_sigil_server.py
@@ -47,7 +47,9 @@ class Command(BaseCommand):
         server = SigilResolverServer(config)
         fastmcp = server.build_fastmcp()
 
-        self.stdout.write(self.style.SUCCESS(f"Starting MCP sigil resolver on {host}:{port}"))
+        self.stdout.write(
+            self.style.SUCCESS(f"Starting MCP sigil resolver on {host}:{port}")
+        )
         try:
             asyncio.run(fastmcp.run_sse_async())
         except KeyboardInterrupt:  # pragma: no cover - manual interrupt

--- a/core/mcp/__init__.py
+++ b/core/mcp/__init__.py
@@ -1,7 +1,12 @@
 """Utilities for exposing sigil resolution over MCP."""
 
 from .server import SigilResolverServer
-from .service import SigilResolverService, SigilRootCatalog, SigilSessionState, ResolutionResult
+from .service import (
+    SigilResolverService,
+    SigilRootCatalog,
+    SigilSessionState,
+    ResolutionResult,
+)
 
 __all__ = [
     "SigilResolverServer",

--- a/core/mcp/auth.py
+++ b/core/mcp/auth.py
@@ -27,7 +27,9 @@ class ApiKeyTokenVerifier(TokenVerifier):
             keys[key] = key
         return cls(keys=keys, scopes=tuple(scopes or ("sigils:read",)))
 
-    async def verify_token(self, token: str) -> AccessToken | None:  # pragma: no cover - thin wrapper
+    async def verify_token(
+        self, token: str
+    ) -> AccessToken | None:  # pragma: no cover - thin wrapper
         client_id = self.keys.get(token)
         if client_id is None:
             return None

--- a/core/mcp/schemas.py
+++ b/core/mcp/schemas.py
@@ -15,7 +15,11 @@ class ResolveOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    skip_unknown: bool = Field(default=False, alias="skipUnknown", description="Drop unresolved sigils from the output")
+    skip_unknown: bool = Field(
+        default=False,
+        alias="skipUnknown",
+        description="Drop unresolved sigils from the output",
+    )
 
 
 class ResolveSigilsPayload(BaseModel):
@@ -61,4 +65,6 @@ class SetContextResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    stored: List[str] = Field(default_factory=list, description="Model labels retained in the session context")
+    stored: List[str] = Field(
+        default_factory=list, description="Model labels retained in the session context"
+    )

--- a/core/mcp/service.py
+++ b/core/mcp/service.py
@@ -83,7 +83,10 @@ class SigilRootCatalog:
         """Return all catalogued roots sorted by prefix."""
 
         with self._lock:
-            return [entry.model_copy(deep=True) for _, entry in sorted(self._entries.items())]
+            return [
+                entry.model_copy(deep=True)
+                for _, entry in sorted(self._entries.items())
+            ]
 
     def _describe_instance(self, root: SigilRoot) -> SigilRootDescription:
         model_label: str | None = None
@@ -146,7 +149,9 @@ class SigilResolverService:
             token = f"[{token}]"
         if not token.endswith("]"):
             raise ValueError("Sigil tokens must end with ']'")
-        result = self.resolve_text(token, session_context=session_context, overrides=overrides)
+        result = self.resolve_text(
+            token, session_context=session_context, overrides=overrides
+        )
         return result.resolved
 
     def describe_root(self, prefix: str) -> SigilRootDescription:
@@ -216,7 +221,9 @@ class SigilResolverService:
         if model is None:
             raise ValueError(f"Unknown model for context assignment: {label}")
         if not issubclass(model, models.Model):  # pragma: no cover - defensive
-            raise ValueError(f"Context assignments must reference Django models: {label}")
+            raise ValueError(
+                f"Context assignments must reference Django models: {label}"
+            )
         return model
 
     def _format_model_label(self, model: type[models.Model]) -> str:

--- a/core/migrations/0031_energyaccount_live_subscription_next_renewal_and_more.py
+++ b/core/migrations/0031_energyaccount_live_subscription_next_renewal_and_more.py
@@ -16,9 +16,7 @@ def copy_live_subscriptions(apps, schema_editor):
             "live_subscription_start_date": subscription.start_date,
             "live_subscription_next_renewal": subscription.next_renewal,
         }
-        EnergyAccount.objects.filter(pk=subscription.account_id).update(
-            **update_kwargs
-        )
+        EnergyAccount.objects.filter(pk=subscription.account_id).update(**update_kwargs)
 
 
 class Migration(migrations.Migration):

--- a/core/models.py
+++ b/core/models.py
@@ -111,9 +111,7 @@ class Profile(Entity):
                 username_cache["value"] = username
                 return username
 
-            is_restricted = getattr(
-                user_model, "is_profile_restricted_username", None
-            )
+            is_restricted = getattr(user_model, "is_profile_restricted_username", None)
             if callable(is_restricted):
                 username = _resolve_username()
                 if is_restricted(username):
@@ -808,9 +806,7 @@ class EmailArtifact(Entity):
         import hashlib
 
         data = (subject or "") + (sender or "") + (body or "")
-        hasher = hashlib.md5(
-            data.encode("utf-8"), usedforsecurity=False
-        )
+        hasher = hashlib.md5(data.encode("utf-8"), usedforsecurity=False)
         return hasher.hexdigest()
 
     class Meta:
@@ -1125,8 +1121,9 @@ class EnergyAccount(Entity):
             and self.live_subscription_start_date
             and not self.live_subscription_next_renewal
         ):
-            self.live_subscription_next_renewal = self.live_subscription_start_date + timedelta(
-                days=self.live_subscription_product.renewal_period
+            self.live_subscription_next_renewal = (
+                self.live_subscription_start_date
+                + timedelta(days=self.live_subscription_product.renewal_period)
             )
         super().save(*args, **kwargs)
 
@@ -1250,15 +1247,27 @@ class ClientReportSchedule(Entity):
 
         if self.periodicity == self.PERIODICITY_DAILY:
             schedule, _ = CrontabSchedule.objects.get_or_create(
-                minute="0", hour="2", day_of_week="*", day_of_month="*", month_of_year="*"
+                minute="0",
+                hour="2",
+                day_of_week="*",
+                day_of_month="*",
+                month_of_year="*",
             )
         elif self.periodicity == self.PERIODICITY_WEEKLY:
             schedule, _ = CrontabSchedule.objects.get_or_create(
-                minute="0", hour="3", day_of_week="1", day_of_month="*", month_of_year="*"
+                minute="0",
+                hour="3",
+                day_of_week="1",
+                day_of_month="*",
+                month_of_year="*",
             )
         else:
             schedule, _ = CrontabSchedule.objects.get_or_create(
-                minute="0", hour="4", day_of_week="*", day_of_month="1", month_of_year="*"
+                minute="0",
+                hour="4",
+                day_of_week="*",
+                day_of_month="1",
+                month_of_year="*",
             )
 
         name = f"client_report_schedule_{self.pk}"
@@ -1273,7 +1282,9 @@ class ClientReportSchedule(Entity):
                 name=name, defaults=defaults
             )
             if self.periodic_task_id != periodic_task.pk:
-                type(self).objects.filter(pk=self.pk).update(periodic_task=periodic_task)
+                type(self).objects.filter(pk=self.pk).update(
+                    periodic_task=periodic_task
+                )
 
     def calculate_period(self, reference=None):
         """Return the date range covered for the next execution."""
@@ -1406,7 +1417,11 @@ class ClientReportSchedule(Entity):
                     json_file = Path(settings.BASE_DIR) / export["json_path"]
                     if json_file.exists():
                         attachments.append(
-                            (json_file.name, json_file.read_text(encoding="utf-8"), "application/json")
+                            (
+                                json_file.name,
+                                json_file.read_text(encoding="utf-8"),
+                                "application/json",
+                            )
                         )
                     subject = f"Client report {report.start_date} to {report.end_date}"
                     body = (

--- a/core/public_wifi.py
+++ b/core/public_wifi.py
@@ -112,7 +112,18 @@ def allow_mac(mac: str) -> None:
         allowlist.add(mac)
         _save_allowlist(allowlist)
     if _iptables_available():
-        check_args = ["-C", "FORWARD", "-i", "wlan0", "-m", "mac", "--mac-source", mac, "-j", "ACCEPT"]
+        check_args = [
+            "-C",
+            "FORWARD",
+            "-i",
+            "wlan0",
+            "-m",
+            "mac",
+            "--mac-source",
+            mac,
+            "-j",
+            "ACCEPT",
+        ]
         try:
             result = subprocess.run(
                 ["iptables", *check_args],

--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -41,9 +41,8 @@ def ref_img(value, size=200, alt=None):
 @register.inclusion_tag("core/footer.html", takes_context=True)
 def render_footer(context):
     """Render footer links for references marked to appear there."""
-    refs = (
-        Reference.objects.filter(include_in_footer=True)
-        .prefetch_related("roles", "features", "sites")
+    refs = Reference.objects.filter(include_in_footer=True).prefetch_related(
+        "roles", "features", "sites"
     )
     request = context.get("request")
     site = context.get("badge_site")
@@ -70,9 +69,7 @@ def render_footer(context):
         features_manager = getattr(node, "features", None)
         if features_manager is not None:
             try:
-                node_feature_ids = set(
-                    features_manager.values_list("pk", flat=True)
-                )
+                node_feature_ids = set(features_manager.values_list("pk", flat=True))
             except Exception:
                 node_feature_ids = set()
 
@@ -84,11 +81,7 @@ def render_footer(context):
 
         if required_roles or required_features or required_sites:
             allowed = False
-            if (
-                required_roles
-                and node_role_id
-                and node_role_id in required_roles
-            ):
+            if required_roles and node_role_id and node_role_id in required_roles:
                 allowed = True
             elif (
                 required_features

--- a/core/tests.py
+++ b/core/tests.py
@@ -243,7 +243,9 @@ class UserPhoneNumberTests(TestCase):
 
     def test_get_phone_numbers_by_priority_alias(self):
         user = User.objects.create_user(username="phone-alias", password="secret")
-        phone = UserPhoneNumber.objects.create(user=user, number="+14445550000", priority=3)
+        phone = UserPhoneNumber.objects.create(
+            user=user, number="+14445550000", priority=3
+        )
 
         self.assertEqual(user.get_phone_numbers_by_priority(), [phone])
 

--- a/core/tests/test_github_issues.py
+++ b/core/tests/test_github_issues.py
@@ -43,7 +43,9 @@ class TokenLookupTests(TestCase):
         release = mock.Mock()
         release.get_github_token.return_value = "release-token"
 
-        with mock.patch("core.github_issues.PackageRelease.latest", return_value=release):
+        with mock.patch(
+            "core.github_issues.PackageRelease.latest", return_value=release
+        ):
             with mock.patch.dict(os.environ, {}, clear=True):
                 token = github_issues.get_github_token()
 
@@ -69,7 +71,9 @@ class FingerprintTests(TestCase):
         super().setUp()
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
-        self.lock_patch = mock.patch("core.github_issues.LOCK_DIR", Path(self.tempdir.name))
+        self.lock_patch = mock.patch(
+            "core.github_issues.LOCK_DIR", Path(self.tempdir.name)
+        )
         self.lock_patch.start()
         self.addCleanup(self.lock_patch.stop)
 
@@ -106,8 +110,12 @@ class CreateIssueTests(TestCase):
         response.text = "boom"
         response.raise_for_status.side_effect = requests.HTTPError("boom")
 
-        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
-            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+        with mock.patch(
+            "core.github_issues.resolve_repository", return_value=("owner", "repo")
+        ):
+            with mock.patch(
+                "core.github_issues.get_github_token", return_value="token"
+            ):
                 with mock.patch("requests.post", return_value=response) as post:
                     with self.assertLogs("core.github_issues", level="ERROR") as logs:
                         with self.assertRaises(requests.HTTPError):
@@ -122,8 +130,12 @@ class ReportRuntimeIssueTaskTests(TestCase):
         response = mock.Mock()
         response.status_code = 201
 
-        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
-            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+        with mock.patch(
+            "core.github_issues.resolve_repository", return_value=("owner", "repo")
+        ):
+            with mock.patch(
+                "core.github_issues.get_github_token", return_value="token"
+            ):
                 with mock.patch("requests.post", return_value=response) as post:
                     with self.assertLogs("core.tasks", level="INFO") as logs:
                         result = report_runtime_issue("Title", "Body", labels=["bug"])
@@ -132,7 +144,9 @@ class ReportRuntimeIssueTaskTests(TestCase):
         args, kwargs = post.call_args
         self.assertEqual(args[0], "https://api.github.com/repos/owner/repo/issues")
         self.assertEqual(kwargs["timeout"], github_issues.REQUEST_TIMEOUT)
-        self.assertTrue(any("Reported runtime issue" in message for message in logs.output))
+        self.assertTrue(
+            any("Reported runtime issue" in message for message in logs.output)
+        )
 
     def test_task_logs_and_raises_on_failure(self) -> None:
         response = mock.Mock()
@@ -140,11 +154,17 @@ class ReportRuntimeIssueTaskTests(TestCase):
         response.text = "failure"
         response.raise_for_status.side_effect = requests.HTTPError("failure")
 
-        with mock.patch("core.github_issues.resolve_repository", return_value=("owner", "repo")):
-            with mock.patch("core.github_issues.get_github_token", return_value="token"):
+        with mock.patch(
+            "core.github_issues.resolve_repository", return_value=("owner", "repo")
+        ):
+            with mock.patch(
+                "core.github_issues.get_github_token", return_value="token"
+            ):
                 with mock.patch("requests.post", return_value=response):
                     with self.assertLogs("core.tasks", level="ERROR") as logs:
                         with self.assertRaises(requests.HTTPError):
                             report_runtime_issue("Title", "Body")
 
-        self.assertTrue(any("Failed to report runtime issue" in message for message in logs.output))
+        self.assertTrue(
+            any("Failed to report runtime issue" in message for message in logs.output)
+        )

--- a/core/views.py
+++ b/core/views.py
@@ -410,9 +410,9 @@ def live_subscription_list(request):
         return JsonResponse({"detail": "account_id required"}, status=400)
 
     try:
-        account = EnergyAccount.objects.select_related(
-            "live_subscription_product"
-        ).get(id=account_id)
+        account = EnergyAccount.objects.select_related("live_subscription_product").get(
+            id=account_id
+        )
     except EnergyAccount.DoesNotExist:
         return JsonResponse({"detail": "invalid account"}, status=404)
 
@@ -420,10 +420,7 @@ def live_subscription_list(request):
     product = account.live_subscription_product
     if product:
         next_renewal = account.live_subscription_next_renewal
-        if (
-            not next_renewal
-            and account.live_subscription_start_date
-        ):
+        if not next_renewal and account.live_subscription_start_date:
             next_renewal = account.live_subscription_start_date + timedelta(
                 days=product.renewal_period
             )

--- a/env-refresh.py
+++ b/env-refresh.py
@@ -46,6 +46,7 @@ from core.sigil_builder import generate_model_sigils
 from core.user_data import load_shared_user_fixtures, load_user_fixtures
 from utils.env_refresh import unlink_sqlite_db as _unlink_sqlite_db
 
+
 def _local_app_labels() -> list[str]:
     base_dir = Path(settings.BASE_DIR)
     labels: list[str] = []

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -321,7 +321,15 @@ class Node(Entity):
             return False
         try:
             result = subprocess.run(
-                [nmcli_path, "-t", "-f", "NAME,DEVICE,TYPE", "connection", "show", "--active"],
+                [
+                    nmcli_path,
+                    "-t",
+                    "-f",
+                    "NAME,DEVICE,TYPE",
+                    "connection",
+                    "show",
+                    "--active",
+                ],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -170,9 +170,7 @@ class NodeTests(TestCase):
             HTTP_ORIGIN="http://example.com",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response["Access-Control-Allow-Origin"], "http://example.com"
-        )
+        self.assertEqual(response["Access-Control-Allow-Origin"], "http://example.com")
         self.assertEqual(response["Access-Control-Allow-Credentials"], "true")
 
     def test_register_node_accepts_text_plain_payload(self):
@@ -188,9 +186,7 @@ class NodeTests(TestCase):
             content_type="text/plain",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            Node.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").exists()
-        )
+        self.assertTrue(Node.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").exists())
 
 
 class NodeRegisterCurrentTests(TestCase):

--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -127,11 +127,7 @@ class ChargerAdmin(LogViewAdminMixin, EntityModelAdmin):
         ),
         (
             "Configuration",
-            {
-                "fields": (
-                    "require_rfid",
-                )
-            },
+            {"fields": ("require_rfid",)},
         ),
         (
             "References",

--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -76,9 +76,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
         )()
         friendly_name = location_name or self.charger_id
         store.register_log_name(self.store_key, friendly_name, log_type="charger")
-        store.register_log_name(
-            self.charger_id, friendly_name, log_type="charger"
-        )
+        store.register_log_name(self.charger_id, friendly_name, log_type="charger")
         store.register_log_name(
             store.identity_key(self.charger_id, None),
             friendly_name,
@@ -108,14 +106,19 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             and self.charger.connector_id == connector_value
         ):
             return
-        if not self.aggregate_charger or self.aggregate_charger.connector_id is not None:
+        if (
+            not self.aggregate_charger
+            or self.aggregate_charger.connector_id is not None
+        ):
             self.aggregate_charger = await database_sync_to_async(
                 Charger.objects.get_or_create
             )(
                 charger_id=self.charger_id,
                 connector_id=None,
                 defaults={"last_path": self.scope.get("path", "")},
-            )[0]
+            )[
+                0
+            ]
         existing = await database_sync_to_async(
             Charger.objects.filter(
                 charger_id=self.charger_id, connector_id=connector_value
@@ -124,13 +127,16 @@ class CSMSConsumer(AsyncWebsocketConsumer):
         if existing:
             self.charger = existing
         else:
+
             def _create_connector():
                 charger, _ = Charger.objects.get_or_create(
                     charger_id=self.charger_id,
                     connector_id=connector_value,
                     defaults={"last_path": self.scope.get("path", "")},
                 )
-                if self.scope.get("path") and charger.last_path != self.scope.get("path"):
+                if self.scope.get("path") and charger.last_path != self.scope.get(
+                    "path"
+                ):
                     charger.last_path = self.scope.get("path")
                     charger.save(update_fields=["last_path"])
                 return charger
@@ -152,8 +158,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
         aggregate_name = ""
         if self.aggregate_charger:
             aggregate_name = await sync_to_async(
-                lambda: self.aggregate_charger.name
-                or self.aggregate_charger.charger_id
+                lambda: self.aggregate_charger.name or self.aggregate_charger.charger_id
             )()
         store.register_log_name(
             store.identity_key(self.charger_id, None),
@@ -236,11 +241,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                             updated_fields.add(f"{field}_{suffix}")
                     else:
                         values[field] = val
-                        if (
-                            tx_obj
-                            and field == "energy"
-                            and tx_obj.meter_start is None
-                        ):
+                        if tx_obj and field == "energy" and tx_obj.meter_start is None:
                             mult = 1000 if unit in ("kW", "kWh") else 1
                             try:
                                 tx_obj.meter_start = int(val * mult)
@@ -290,7 +291,11 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                 location_name = charger.location.name
             elif aggregate and aggregate.location_id:
                 location_name = aggregate.location.name
-            cid_value = charger.connector_slug if charger.connector_id is not None else Charger.AGGREGATE_CONNECTOR_SLUG
+            cid_value = (
+                charger.connector_slug
+                if charger.connector_id is not None
+                else Charger.AGGREGATE_CONNECTOR_SLUG
+            )
             return {
                 "location": location_name,
                 "sn": charger.charger_id,
@@ -319,9 +324,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             store.connections.pop(pending_key, None)
         store.end_session_log(self.store_key)
         store.stop_session_lock()
-        store.add_log(
-            self.store_key, f"Closed (code={close_code})", log_type="charger"
-        )
+        store.add_log(self.store_key, f"Closed (code={close_code})", log_type="charger")
 
     async def receive(self, text_data=None, bytes_data=None):
         raw = text_data

--- a/ocpp/migrations/0008_alter_charger_connector_id_and_more.py
+++ b/ocpp/migrations/0008_alter_charger_connector_id_and_more.py
@@ -33,9 +33,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(
-            normalize_connector_id_strings, migrations.RunPython.noop
-        ),
+        migrations.RunPython(normalize_connector_id_strings, migrations.RunPython.noop),
         migrations.AlterField(
             model_name="charger",
             name="connector_id",

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -280,9 +280,7 @@ class Charger(Entity):
 
         tx_active = None
         if self.connector_id is not None:
-            tx_active = store_module.get_transaction(
-                self.charger_id, self.connector_id
-            )
+            tx_active = store_module.get_transaction(self.charger_id, self.connector_id)
         qs = self.transactions.all()
         if tx_active and tx_active.pk is not None:
             qs = qs.exclude(pk=tx_active.pk)
@@ -316,7 +314,10 @@ class Charger(Entity):
             has_data = (
                 charger.transactions.exists()
                 or charger.meter_values.exists()
-                or any(store.get_logs(key, log_type="charger") for key in charger._store_keys())
+                or any(
+                    store.get_logs(key, log_type="charger")
+                    for key in charger._store_keys()
+                )
                 or any(store.transactions.get(key) for key in charger._store_keys())
                 or any(store.history.get(key) for key in charger._store_keys())
             )
@@ -485,7 +486,9 @@ class MeterReadingManager(EntityManager):
     def get_or_create(self, defaults=None, **kwargs):
         if defaults:
             defaults = self._normalize_kwargs(defaults)
-        return super().get_or_create(defaults=defaults, **self._normalize_kwargs(kwargs))
+        return super().get_or_create(
+            defaults=defaults, **self._normalize_kwargs(kwargs)
+        )
 
 
 class MeterReading(MeterValue):

--- a/ocpp/rfid/constants.py
+++ b/ocpp/rfid/constants.py
@@ -47,4 +47,3 @@ __all__ = [
     "DEFAULT_IRQ_PIN",
     "DEFAULT_RST_PIN",
 ]
-

--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -130,7 +130,7 @@ def read_rfid(
             notify_async(f"RFID {rfid}", "Read failed")
         return {"error": str(exc)}
     finally:  # pragma: no cover - cleanup hardware
-        if 'mfrc' in locals() and mfrc is not None and selected:
+        if "mfrc" in locals() and mfrc is not None and selected:
             try:
                 mfrc.MFRC522_StopCrypto1()
             except Exception:

--- a/ocpp/store.py
+++ b/ocpp/store.py
@@ -95,7 +95,9 @@ def is_connected(serial: str, connector: int | str | None = None) -> bool:
 
     if connector in (None, "", AGGREGATE_SLUG):
         prefix = f"{serial}{IDENTITY_SEPARATOR}"
-        return any(key.startswith(prefix) for key in connections) or serial in connections
+        return (
+            any(key.startswith(prefix) for key in connections) or serial in connections
+        )
     return any(key in connections for key in _candidate_keys(serial, connector))
 
 

--- a/ocpp/test_rfid.py
+++ b/ocpp/test_rfid.py
@@ -300,6 +300,7 @@ class RFIDDetectionScriptTests(SimpleTestCase):
         self.assertIn("missing hardware", buffer.getvalue())
         mock_detect.assert_called_once()
 
+
 class RestartViewTests(SimpleTestCase):
     @patch("config.middleware.Node.get_local", return_value=None)
     @patch("config.middleware.get_site")

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -116,9 +116,7 @@ class ChargerUrlFallbackTests(TestCase):
         charger.refresh_from_db()
 
         self.assertIsNotNone(charger.reference)
-        self.assertTrue(
-            charger.reference.value.startswith("http://fallback.example")
-        )
+        self.assertTrue(charger.reference.value.startswith("http://fallback.example"))
         self.assertTrue(charger.reference.value.endswith("/c/NO_SITE/"))
 
 
@@ -662,9 +660,7 @@ class ChargerLandingTests(TestCase):
     def test_connector_specific_routes_render(self):
         Charger.objects.create(charger_id="ROUTED")
         connector = Charger.objects.create(charger_id="ROUTED", connector_id=1)
-        page = self.client.get(
-            reverse("charger-page-connector", args=["ROUTED", "1"])
-        )
+        page = self.client.get(reverse("charger-page-connector", args=["ROUTED", "1"]))
         self.assertEqual(page.status_code, 200)
         status = self.client.get(
             reverse("charger-status-connector", args=["ROUTED", "1"])
@@ -751,9 +747,7 @@ class ChargerAdminTests(TestCase):
         url = reverse("admin:ocpp_charger_changelist")
         resp = self.client.get(url)
         self.assertContains(resp, charger.get_absolute_url())
-        status_url = reverse(
-            "charger-status-connector", args=["ADMIN1", "all"]
-        )
+        status_url = reverse("charger-status-connector", args=["ADMIN1", "all"])
         self.assertContains(resp, status_url)
 
     def test_admin_does_not_list_qr_link(self):
@@ -824,9 +818,7 @@ class ChargerAdminTests(TestCase):
         )
         self.assertFalse(Transaction.objects.filter(charger=charger).exists())
         self.assertFalse(MeterReading.objects.filter(charger=charger).exists())
-        self.assertNotIn(
-            store.identity_key("PURGE1", None), store.logs["charger"]
-        )
+        self.assertNotIn(store.identity_key("PURGE1", None), store.logs["charger"])
 
     def test_delete_requires_purge(self):
         charger = Charger.objects.create(charger_id="DEL1")
@@ -869,14 +861,13 @@ class LocationAdminTests(TestCase):
         self.assertEqual(resp.status_code, 200)
 
         base_change_url = reverse("admin:ocpp_charger_change", args=[base.pk])
-        connector_change_url = reverse(
-            "admin:ocpp_charger_change", args=[connector.pk]
-        )
+        connector_change_url = reverse("admin:ocpp_charger_change", args=[connector.pk])
 
         self.assertContains(resp, base_change_url)
         self.assertContains(resp, connector_change_url)
         self.assertContains(resp, f"Charge Point: {base.charger_id}")
         self.assertContains(resp, f"Charge Point: {connector.charger_id} #1")
+
 
 class TransactionAdminTests(TestCase):
     def setUp(self):
@@ -1679,12 +1670,8 @@ class ChargerStatusViewTests(TestCase):
 
     def test_aggregate_chart_includes_multiple_connectors(self):
         aggregate = Charger.objects.create(charger_id="VIEWAGG")
-        connector_one = Charger.objects.create(
-            charger_id="VIEWAGG", connector_id=1
-        )
-        connector_two = Charger.objects.create(
-            charger_id="VIEWAGG", connector_id=2
-        )
+        connector_one = Charger.objects.create(charger_id="VIEWAGG", connector_id=1)
+        connector_two = Charger.objects.create(charger_id="VIEWAGG", connector_id=2)
         base_time = timezone.now()
         tx_one = Transaction.objects.create(
             charger=connector_one, start_time=base_time, meter_start=0

--- a/pages/management/commands/capture_ui_screenshots.py
+++ b/pages/management/commands/capture_ui_screenshots.py
@@ -1,4 +1,5 @@
 """Management command to capture UI screenshots defined by specs."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -58,4 +59,3 @@ class Command(BaseCommand):
                     )
                 )
                 self.stdout.write(f"Base64 artefact stored at {result.base64_path}")
-

--- a/pages/screenshot_specs/__init__.py
+++ b/pages/screenshot_specs/__init__.py
@@ -1,4 +1,5 @@
 """Screenshot specification registry and discovery utilities."""
+
 from __future__ import annotations
 
 import importlib
@@ -38,4 +39,3 @@ def autodiscover() -> None:
             continue
         importlib.import_module(f"{package_name}.{module.name}")
     _DISCOVERED = True
-

--- a/pages/screenshot_specs/base.py
+++ b/pages/screenshot_specs/base.py
@@ -1,4 +1,5 @@
 """Utilities for declarative screenshot specifications."""
+
 from __future__ import annotations
 
 import base64
@@ -130,7 +131,9 @@ class _LiveServerHarness(StaticLiveServerTestCase):
 class ScreenshotSpecRunner:
     """Context manager that executes screenshot specs."""
 
-    def __init__(self, output_dir: Path | str, *, retention: timedelta | None = timedelta(days=7)) -> None:
+    def __init__(
+        self, output_dir: Path | str, *, retention: timedelta | None = timedelta(days=7)
+    ) -> None:
         self.output_dir = Path(output_dir)
         self.retention = retention
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -153,14 +156,18 @@ class ScreenshotSpecRunner:
         context.add_client_cookies()
         url = context.build_url(spec.url)
         screenshot_path = capture_screenshot(url, cookies=context.cookies or None)
-        sample = save_screenshot(screenshot_path, method=f"{SPEC_METHOD_PREFIX}{spec.slug}")
+        sample = save_screenshot(
+            screenshot_path, method=f"{SPEC_METHOD_PREFIX}{spec.slug}"
+        )
         self._cleanup_content_samples()
         image_path = self.output_dir / f"{spec.slug}.png"
         shutil.copyfile(screenshot_path, image_path)
         base64_path = self.output_dir / f"{spec.slug}.base64"
         encoded = base64.b64encode(image_path.read_bytes()).decode("ascii")
         base64_path.write_text(encoded, encoding="utf-8")
-        return ScreenshotResult(spec=spec, image_path=image_path, base64_path=base64_path, sample=sample)
+        return ScreenshotResult(
+            spec=spec, image_path=image_path, base64_path=base64_path, sample=sample
+        )
 
     def _cleanup_content_samples(self) -> None:
         if not self.retention:

--- a/pages/screenshot_specs/home.py
+++ b/pages/screenshot_specs/home.py
@@ -1,4 +1,5 @@
 """Home page screenshot specification."""
+
 from __future__ import annotations
 
 from .base import ScreenshotSpec, registry
@@ -13,4 +14,3 @@ registry.register(
         ],
     )
 )
-

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -218,9 +218,7 @@ class InvitationTests(TestCase):
         "pages.views.public_wifi.resolve_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     )
-    def test_invitation_login_grants_public_wifi_access(
-        self, mock_resolve, mock_grant
-    ):
+    def test_invitation_login_grants_public_wifi_access(self, mock_resolve, mock_grant):
         control_role, _ = NodeRole.objects.get_or_create(name="Control")
         feature = NodeFeature.objects.create(
             slug="ap-public-wifi", display="AP Public Wi-Fi"
@@ -672,7 +670,9 @@ class ConstellationNavTests(TestCase):
 
     def test_rfid_pill_hidden(self):
         resp = self.client.get(reverse("pages:index"))
-        nav_labels = [module.menu_label.upper() for module in resp.context["nav_modules"]]
+        nav_labels = [
+            module.menu_label.upper() for module in resp.context["nav_modules"]
+        ]
         self.assertNotIn("RFID", nav_labels)
         self.assertTrue(
             Module.objects.filter(
@@ -795,11 +795,7 @@ class LandingFixtureTests(TestCase):
         fixtures = sorted(
             fixtures,
             key=lambda path: (
-                0
-                if "__application_" in path
-                else 1
-                if "__module_" in path
-                else 2
+                0 if "__application_" in path else 1 if "__module_" in path else 2
             ),
         )
         call_command("loaddata", *fixtures)
@@ -1206,7 +1202,7 @@ class AdminModelGraphViewTests(TestCase):
         def pipe_side_effect(*args, **kwargs):
             fmt = kwargs.get("format") or (args[0] if args else None)
             if fmt == "svg":
-                return "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"
+                return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
             if fmt == "pdf":
                 return b"%PDF-1.4 mock"
             raise AssertionError(f"Unexpected format: {fmt}")
@@ -1217,8 +1213,9 @@ class AdminModelGraphViewTests(TestCase):
     def test_model_graph_renders_controls_and_download_link(self):
         url = reverse("admin-model-graph", args=["pages"])
         graph = self._mock_graph()
-        with patch("pages.views._build_model_graph", return_value=graph), patch(
-            "pages.views.shutil.which", return_value="/usr/bin/dot"
+        with (
+            patch("pages.views._build_model_graph", return_value=graph),
+            patch("pages.views.shutil.which", return_value="/usr/bin/dot"),
         ):
             response = self.client.get(url)
 
@@ -1234,8 +1231,9 @@ class AdminModelGraphViewTests(TestCase):
     def test_model_graph_pdf_download(self):
         url = reverse("admin-model-graph", args=["pages"])
         graph = self._mock_graph()
-        with patch("pages.views._build_model_graph", return_value=graph), patch(
-            "pages.views.shutil.which", return_value="/usr/bin/dot"
+        with (
+            patch("pages.views._build_model_graph", return_value=graph),
+            patch("pages.views.shutil.which", return_value="/usr/bin/dot"),
         ):
             response = self.client.get(url, {"format": "pdf"})
 
@@ -1303,18 +1301,20 @@ class ScreenshotSpecInfrastructureTests(TestCase):
             ContentSample.objects.filter(hash="old-hash").update(
                 created_at=timezone.now() - timedelta(days=8)
             )
-            with patch(
-                "pages.screenshot_specs.base.capture_screenshot", return_value=screenshot_path
-            ) as capture_mock, patch(
-                "pages.screenshot_specs.base.save_screenshot", return_value=None
-            ) as save_mock:
+            with (
+                patch(
+                    "pages.screenshot_specs.base.capture_screenshot",
+                    return_value=screenshot_path,
+                ) as capture_mock,
+                patch(
+                    "pages.screenshot_specs.base.save_screenshot", return_value=None
+                ) as save_mock,
+            ):
                 with ScreenshotSpecRunner(temp_dir) as runner:
                     result = runner.run(spec)
             self.assertTrue(result.image_path.exists())
             self.assertTrue(result.base64_path.exists())
-            self.assertEqual(
-                ContentSample.objects.filter(hash="old-hash").count(), 0
-            )
+            self.assertEqual(ContentSample.objects.filter(hash="old-hash").count(), 0)
             capture_mock.assert_called_once()
             save_mock.assert_called_once_with(screenshot_path, method="spec:spec-test")
 

--- a/pages/views.py
+++ b/pages/views.py
@@ -53,9 +53,7 @@ def _get_registered_models(app_label: str):
     """Return admin-registered models for the given app label."""
 
     registered = [
-        model
-        for model in admin.site._registry
-        if model._meta.app_label == app_label
+        model for model in admin.site._registry if model._meta.app_label == app_label
     ]
     return sorted(registered, key=lambda model: str(model._meta.verbose_name))
 
@@ -115,7 +113,7 @@ def _build_model_graph(models):
         node_ids[model] = node_id
 
         rows = [
-            "<tr><td bgcolor=\"#1f2933\" colspan=\"2\"><font color=\"white\"><b>"
+            '<tr><td bgcolor="#1f2933" colspan="2"><font color="white"><b>'
             f"{escape(model._meta.object_name)}"
             "</b></font></td></tr>"
         ]
@@ -123,7 +121,7 @@ def _build_model_graph(models):
         verbose_name = str(model._meta.verbose_name)
         if verbose_name and verbose_name != model._meta.object_name:
             rows.append(
-                "<tr><td colspan=\"2\"><i>" f"{escape(verbose_name)}" "</i></td></tr>"
+                '<tr><td colspan="2"><i>' f"{escape(verbose_name)}" "</i></td></tr>"
             )
 
         for field in model._meta.concrete_fields:
@@ -134,19 +132,25 @@ def _build_model_graph(models):
                 name = f"<u>{name}</u>"
             type_label = escape(_graph_field_type(field, model._meta.app_label))
             rows.append(
-                "<tr><td align=\"left\">" f"{name}" "</td><td align=\"left\">"
-                f"{type_label}" "</td></tr>"
+                '<tr><td align="left">'
+                f"{name}"
+                '</td><td align="left">'
+                f"{type_label}"
+                "</td></tr>"
             )
 
         for field in model._meta.local_many_to_many:
             name = escape(field.name)
             type_label = _graph_field_type(field, model._meta.app_label)
             rows.append(
-                "<tr><td align=\"left\">" f"{name}" "</td><td align=\"left\">"
-                f"{escape(type_label)}" "</td></tr>"
+                '<tr><td align="left">'
+                f"{name}"
+                '</td><td align="left">'
+                f"{escape(type_label)}"
+                "</td></tr>"
             )
 
-        label = "<\n  <table BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\" CELLPADDING=\"4\">\n    "
+        label = '<\n  <table BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">\n    '
         label += "\n    ".join(rows)
         label += "\n  </table>\n>"
         graph.node(node_id, label=label)
@@ -235,9 +239,9 @@ def admin_model_graph(request, app_label: str):
             else:
                 filename = slugify(app_config.verbose_name) or app_label
                 response = HttpResponse(pdf_output, content_type="application/pdf")
-                response[
-                    "Content-Disposition"
-                ] = f'attachment; filename="{filename}-model-graph.pdf"'
+                response["Content-Disposition"] = (
+                    f'attachment; filename="{filename}-model-graph.pdf"'
+                )
                 return response
 
         params = request.GET.copy()
@@ -274,9 +278,7 @@ def admin_model_graph(request, app_label: str):
                 "<svg", f'<svg role="img" aria-label="{escape(label)}"', 1
             )
             if not graph_svg:
-                graph_error = _(
-                    "Graphviz did not return any diagram output."
-                )
+                graph_error = _("Graphviz did not return any diagram output.")
 
     model_links = []
     for model in models:
@@ -713,7 +715,9 @@ def client_report(request):
             report.save(update_fields=["schedule"])
             messages.success(
                 request,
-                _("Client report schedule created; future reports will be generated automatically."),
+                _(
+                    "Client report schedule created; future reports will be generated automatically."
+                ),
             )
     context = {"form": form, "report": report, "schedule": schedule}
     return render(request, "pages/client_report.html", context)

--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -107,7 +107,9 @@ def scan(
     poll_interval: float = 0.1,
     stdin: Optional[TextIO] = None,
     stdout: Optional[TextIO] = None,
-    select_fn: Callable[[Sequence[TextIO], Sequence[TextIO], Sequence[TextIO], float], tuple] = select.select,
+    select_fn: Callable[
+        [Sequence[TextIO], Sequence[TextIO], Sequence[TextIO], float], tuple
+    ] = select.select,
     sleep: Callable[[float], None] = time.sleep,
 ) -> int:
     """Interactively read RFID tags until the user presses Enter."""

--- a/scripts/ci/run_screenshots.py
+++ b/scripts/ci/run_screenshots.py
@@ -54,7 +54,9 @@ def git_changed_files(base_ref: str | None) -> list[str]:
                     continue
                 try:
                     merge_base = subprocess.check_output(
-                        ["git", "merge-base", ref, "HEAD"], text=True, stderr=subprocess.DEVNULL
+                        ["git", "merge-base", ref, "HEAD"],
+                        text=True,
+                        stderr=subprocess.DEVNULL,
                     ).strip()
                 except subprocess.CalledProcessError:
                     continue
@@ -64,14 +66,18 @@ def git_changed_files(base_ref: str | None) -> list[str]:
         else:
             diff_range = "HEAD"
         diff = subprocess.check_output(
-            ["git", "diff", "--name-only", diff_range], text=True, stderr=subprocess.DEVNULL
+            ["git", "diff", "--name-only", diff_range],
+            text=True,
+            stderr=subprocess.DEVNULL,
         )
     except subprocess.CalledProcessError:
         return []
     return [line.strip() for line in diff.splitlines() if line.strip()]
 
 
-def select_specs(explicit: list[str], changed: Iterable[str], run_all: bool) -> list[ScreenshotSpec]:
+def select_specs(
+    explicit: list[str], changed: Iterable[str], run_all: bool
+) -> list[ScreenshotSpec]:
     autodiscover()
     if explicit:
         return [registry.get(slug) for slug in explicit]
@@ -86,9 +92,13 @@ def select_specs(explicit: list[str], changed: Iterable[str], run_all: bool) -> 
 
 
 def ensure_todo_fixture(spec: ScreenshotSpec) -> ManualSummary:
-    fixture = REPO_ROOT / "core" / "fixtures" / f"todos__validate_screen_{spec.slug}.json"
+    fixture = (
+        REPO_ROOT / "core" / "fixtures" / f"todos__validate_screen_{spec.slug}.json"
+    )
     if not fixture.exists():
-        return ManualSummary(slug=spec.slug, reason=spec.manual_reason or "", todo_path=None)
+        return ManualSummary(
+            slug=spec.slug, reason=spec.manual_reason or "", todo_path=None
+        )
     try:
         payload = json.loads(fixture.read_text(encoding="utf-8"))
         fields = payload[0]["fields"] if payload else {}
@@ -116,7 +126,9 @@ def write_summary(
         for item in validated:
             summary_lines.append(f"- `{item.spec.slug}` → `{item.image_path}`")
             summary_lines.append("")
-            summary_lines.append(f"![{item.spec.slug}](data:image/png;base64,{item.base64_data})")
+            summary_lines.append(
+                f"![{item.spec.slug}](data:image/png;base64,{item.base64_data})"
+            )
             summary_lines.append("")
     if manual:
         summary_lines.append("### Pending manual validation")
@@ -128,7 +140,9 @@ def write_summary(
             if url:
                 summary_lines.append(f"  - URL: {url}")
             if item.todo_path:
-                summary_lines.append(f"  - Fixture: `{item.todo_path.relative_to(REPO_ROOT)}`")
+                summary_lines.append(
+                    f"  - Fixture: `{item.todo_path.relative_to(REPO_ROOT)}`"
+                )
     if missing:
         summary_lines.append("### Missing TODO fixtures")
         summary_lines.append("")
@@ -150,7 +164,9 @@ def write_summary(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run declarative screenshot specs")
     parser.add_argument("--base-ref", help="Base reference for git diff", default=None)
-    parser.add_argument("--changed-files", nargs="*", help="Explicit list of changed files")
+    parser.add_argument(
+        "--changed-files", nargs="*", help="Explicit list of changed files"
+    )
     parser.add_argument("--spec", action="append", dest="specs", default=[])
     parser.add_argument("--output-dir", default="artifacts/ui-screens")
     parser.add_argument("--run-all", action="store_true")
@@ -163,7 +179,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if not selected:
         print("No screenshot specs selected.")
-        (output_dir / "summary.md").write_text("No screenshot specs selected.\n", encoding="utf-8")
+        (output_dir / "summary.md").write_text(
+            "No screenshot specs selected.\n", encoding="utf-8"
+        )
         return 0
 
     validated: list[ValidationSummary] = []
@@ -234,4 +252,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover - script entry
     raise SystemExit(main())
-

--- a/scripts/create_validate_screen_todo.py
+++ b/scripts/create_validate_screen_todo.py
@@ -16,7 +16,9 @@ def guess_title(slug: str) -> str:
     return " ".join(word.capitalize() for word in words if word)
 
 
-def build_fixture(slug: str, url: str, details: str, title: str | None) -> list[dict[str, object]]:
+def build_fixture(
+    slug: str, url: str, details: str, title: str | None
+) -> list[dict[str, object]]:
     label = title or guess_title(slug)
     request = f"Validate screen {label}"
     return [
@@ -33,7 +35,9 @@ def build_fixture(slug: str, url: str, details: str, title: str | None) -> list[
 
 def write_fixture(path: Path, data: list[dict[str, object]], force: bool) -> None:
     if path.exists() and not force:
-        print(f"Fixture {path} already exists. Use --force to overwrite.", file=sys.stderr)
+        print(
+            f"Fixture {path} already exists. Use --force to overwrite.", file=sys.stderr
+        )
         raise SystemExit(1)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
@@ -44,9 +48,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("slug", help="Spec slug the TODO relates to")
     parser.add_argument("--url", required=True, help="URL requiring manual validation")
-    parser.add_argument("--details", required=True, help="Additional validation context")
+    parser.add_argument(
+        "--details", required=True, help="Additional validation context"
+    )
     parser.add_argument("--title", help="Override the human friendly screen title")
-    parser.add_argument("--force", action="store_true", help="Overwrite an existing fixture")
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite an existing fixture"
+    )
     args = parser.parse_args(argv)
 
     data = build_fixture(args.slug, args.url, args.details, args.title)
@@ -57,4 +65,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover - script entry
     raise SystemExit(main())
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,13 +131,9 @@ def _feature_skip_reason(required: set[str], role: str | None) -> str:
 def pytest_collection_modifyitems(config, items):
     role = os.environ.get("NODE_ROLE")
     require_markers = _env_flag("NODE_ROLE_ONLY")
-    role_skip = (
-        pytest.mark.skip(reason=f"not run for {role} role") if role else None
-    )
+    role_skip = pytest.mark.skip(reason=f"not run for {role} role") if role else None
     missing_skip = (
-        pytest.mark.skip(
-            reason="missing role marker while NODE_ROLE_ONLY is enabled"
-        )
+        pytest.mark.skip(reason="missing role marker while NODE_ROLE_ONLY is enabled")
         if require_markers
         else None
     )

--- a/tests/test_admin_doc_model_groups.py
+++ b/tests/test_admin_doc_model_groups.py
@@ -28,7 +28,9 @@ class AdminDocsModelGroupsTests(TestCase):
             re.S,
         )
         match = pattern.search(content)
-        self.assertIsNotNone(match, f"{group_name} group should be present in admin docs")
+        self.assertIsNotNone(
+            match, f"{group_name} group should be present in admin docs"
+        )
         return match.group("body")
 
     def test_model_groups_ordered(self):

--- a/tests/test_admin_model_graph.py
+++ b/tests/test_admin_model_graph.py
@@ -19,9 +19,7 @@ class AdminModelGraphTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'data-app-graph="teams"')
-        self.assertNotContains(
-            response, reverse("admin-model-graph", args=["teams"])
-        )
+        self.assertNotContains(response, reverse("admin-model-graph", args=["teams"]))
 
     def test_admin_docs_index_links_to_model_graphs(self):
         response = self.client.get(reverse("django-admindocs-docroot"))
@@ -47,11 +45,12 @@ class AdminModelGraphTests(TestCase):
 
     def test_model_graph_view_renders_context(self):
         url = reverse("admin-model-graph", args=["teams"])
-        with mock.patch(
-            "pages.views.shutil.which", return_value="/usr/bin/dot"
-        ), mock.patch(
-            "graphviz.graphs.Digraph.pipe",
-            return_value="<svg class='mock-diagram'></svg>",
+        with (
+            mock.patch("pages.views.shutil.which", return_value="/usr/bin/dot"),
+            mock.patch(
+                "graphviz.graphs.Digraph.pipe",
+                return_value="<svg class='mock-diagram'></svg>",
+            ),
         ):
             response = self.client.get(url)
 
@@ -62,7 +61,7 @@ class AdminModelGraphTests(TestCase):
         self.assertIn("<svg", response.context["graph_svg"])
         self.assertEqual(response.context["graph_error"], "")
         self.assertContains(response, "Included models")
-        self.assertContains(response, "role=\"img\"")
+        self.assertContains(response, 'role="img"')
 
     def test_model_graph_view_handles_missing_graphviz(self):
         url = reverse("admin-model-graph", args=["teams"])

--- a/tests/test_allowed_hosts_hostname.py
+++ b/tests/test_allowed_hosts_hostname.py
@@ -12,9 +12,7 @@ def test_current_hostname_is_allowed():
 
 
 def test_mdns_variant_is_generated():
-    variants = settings_module._iter_local_hostnames(
-        "gway-001", "gway-001.arthexis"
-    )
+    variants = settings_module._iter_local_hostnames("gway-001", "gway-001.arthexis")
     assert "gway-001" in variants
     assert "gway-001.arthexis" in variants
     assert "gway-001.local" in variants

--- a/tests/test_assistant_profile_admin.py
+++ b/tests/test_assistant_profile_admin.py
@@ -85,7 +85,12 @@ class AssistantProfileAdminTests(TestCase):
 
     @mock.patch.object(mcp_process, "get_status")
     def test_status_action_reports_running_state(self, get_status):
-        get_status.return_value = {"running": True, "pid": 42, "log_excerpt": "", "last_error": ""}
+        get_status.return_value = {
+            "running": True,
+            "pid": 42,
+            "log_excerpt": "",
+            "last_error": "",
+        }
         url = reverse("admin:teams_assistantprofile_status")
         response = self.client.get(url)
         self.assertRedirects(

--- a/tests/test_env_refresh_unlink.py
+++ b/tests/test_env_refresh_unlink.py
@@ -25,7 +25,9 @@ def test_unlink_sqlite_db_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(
         env_refresh_utils, "time", SimpleNamespace(sleep=lambda s: None)
     )
-    monkeypatch.setattr(env_refresh_utils, "settings", SimpleNamespace(BASE_DIR=tmp_path))
+    monkeypatch.setattr(
+        env_refresh_utils, "settings", SimpleNamespace(BASE_DIR=tmp_path)
+    )
     unlink_func(path)
 
     assert calls["count"] == 1

--- a/tests/test_footer_render.py
+++ b/tests/test_footer_render.py
@@ -103,8 +103,9 @@ class FooterRenderTests(TestCase):
             domain="example.com", defaults={"name": "Example"}
         )
 
-        with patch("nodes.models.Node.refresh_features"), patch(
-            "nodes.models.Node.sync_feature_tasks"
+        with (
+            patch("nodes.models.Node.refresh_features"),
+            patch("nodes.models.Node.sync_feature_tasks"),
         ):
             node = Node.objects.create(
                 hostname="node1",
@@ -113,9 +114,7 @@ class FooterRenderTests(TestCase):
                 public_endpoint="node1",
                 role=terminal,
             )
-            NodeFeatureAssignment.objects.create(
-                node=node, feature=feature_enabled
-            )
+            NodeFeatureAssignment.objects.create(node=node, feature=feature_enabled)
 
         role_ref = Reference.objects.create(
             alt_text="Role Only",
@@ -148,9 +147,7 @@ class FooterRenderTests(TestCase):
         unmatched.sites.add(other_site)
 
         with patch("nodes.models.Node.get_local", return_value=node):
-            response = self.client.get(
-                reverse("pages:index"), HTTP_HOST="arthexis.com"
-            )
+            response = self.client.get(reverse("pages:index"), HTTP_HOST="arthexis.com")
 
         self.assertContains(response, "Role Only")
         self.assertContains(response, "Feature Only")
@@ -158,9 +155,7 @@ class FooterRenderTests(TestCase):
         self.assertNotContains(response, "Unmatched")
 
         with patch("nodes.models.Node.get_local", return_value=node):
-            response = self.client.get(
-                reverse("pages:index"), HTTP_HOST="testserver"
-            )
+            response = self.client.get(reverse("pages:index"), HTTP_HOST="testserver")
 
         self.assertContains(response, "Role Only")
         self.assertContains(response, "Feature Only")

--- a/tests/test_github_issue_reporting.py
+++ b/tests/test_github_issue_reporting.py
@@ -54,7 +54,9 @@ def test_exception_triggers_github_issue(monkeypatch, issue_reporting_env):
     request = _build_request()
     request.user = user
 
-    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+    got_request_exception.send(
+        sender=None, request=request, exception=_make_exception()
+    )
 
     assert len(calls) == 1
     payload = calls[0]
@@ -66,7 +68,9 @@ def test_exception_triggers_github_issue(monkeypatch, issue_reporting_env):
     assert payload["exception_class"].endswith("ValueError")
     assert "boom" in payload["traceback"]
 
-    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+    got_request_exception.send(
+        sender=None, request=request, exception=_make_exception()
+    )
 
     assert len(calls) == 1
 
@@ -83,6 +87,8 @@ def test_issue_reporting_can_be_disabled(monkeypatch, issue_reporting_env):
     request = _build_request()
     request.user = object()  # no authenticated user
 
-    got_request_exception.send(sender=None, request=request, exception=_make_exception())
+    got_request_exception.send(
+        sender=None, request=request, exception=_make_exception()
+    )
 
     assert calls == []

--- a/tests/test_localhost_admin_backend.py
+++ b/tests/test_localhost_admin_backend.py
@@ -30,6 +30,7 @@ def ensure_arthexis_user():
         delegate.save()
     return delegate
 
+
 def test_sets_operate_as_on_admin_creation():
     User = get_user_model()
     delegate = ensure_arthexis_user()

--- a/tests/test_odoo_profile_admin.py
+++ b/tests/test_odoo_profile_admin.py
@@ -177,7 +177,9 @@ class OdooProfileInlineFormTests(TestCase):
             instance=OdooProfile(user=self.user),
         )
         self.assertFalse(form.is_valid())
-        self.assertIn("Provide host, database, username, and password", form.non_field_errors()[0])
+        self.assertIn(
+            "Provide host, database, username, and password", form.non_field_errors()[0]
+        )
 
     def test_clearing_existing_profile_marks_delete(self):
         profile = OdooProfile.objects.create(

--- a/tests/test_power_admin_group.py
+++ b/tests/test_power_admin_group.py
@@ -23,4 +23,3 @@ class PowerAdminGroupTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertContains(response, "1. Power MODELS")
         self.assertContains(response, "Power Leads")
-

--- a/tests/test_profile_inline_deletion.py
+++ b/tests/test_profile_inline_deletion.py
@@ -170,7 +170,9 @@ class ProfileInlineDeletionTests(TestCase):
                     max_num=1,
                 )
                 prefix = f"{model._meta.model_name}_set"
-                data = self._build_post_data(prefix, profile.pk, self._blank_form_values(model))
+                data = self._build_post_data(
+                    prefix, profile.pk, self._blank_form_values(model)
+                )
                 formset = formset_cls(data, instance=user, prefix=prefix)
                 self.assertTrue(
                     formset.is_valid(),
@@ -207,7 +209,9 @@ class ProfileInlineDeletionTests(TestCase):
                     max_num=1,
                 )
                 prefix = f"{model._meta.model_name}_set"
-                data = self._build_post_data(prefix, profile.pk, self._blank_form_values(model))
+                data = self._build_post_data(
+                    prefix, profile.pk, self._blank_form_values(model)
+                )
                 formset = formset_cls(data, instance=group, prefix=prefix)
                 self.assertTrue(
                     formset.is_valid(),
@@ -273,7 +277,9 @@ class ProfileInlineAdminTemplateTests(TestCase):
         url = reverse("admin:teams_securitygroup_change", args=[group.pk])
         response = self.client.get(url)
         content = response.content.decode()
-        prefixes = [fs.formset.prefix for fs in response.context_data["inline_admin_formsets"]]
+        prefixes = [
+            fs.formset.prefix for fs in response.context_data["inline_admin_formsets"]
+        ]
         self.assertTrue(
             re.search(r'name="-\d+-0-DELETE"', content),
             msg="Inline delete input should render as a hidden field on security group change view",
@@ -301,7 +307,9 @@ class ProfileInlineAdminTemplateTests(TestCase):
         url = reverse("admin:teams_securitygroup_add")
         response = self.client.get(url)
         content = response.content.decode()
-        prefixes = [fs.formset.prefix for fs in response.context_data["inline_admin_formsets"]]
+        prefixes = [
+            fs.formset.prefix for fs in response.context_data["inline_admin_formsets"]
+        ]
         for prefix in prefixes:
             selector = f'[data-inline-prefix="{prefix}"] .inline-deletelink'
             self.assertTrue(
@@ -316,4 +324,3 @@ class ProfileInlineAdminTemplateTests(TestCase):
                 f'[data-inline-prefix="{prefix}"] .fieldBox.field-DELETE' in content,
                 msg=f"Expected CSS to hide field boxes for inline prefix {prefix}",
             )
-


### PR DESCRIPTION
## Summary
- format awg, core, ocpp, pages, scripts, and tests modules with Black to satisfy the project style

## Testing
- python scripts/check_migrations.py
- python scripts/ensure_validation_todos.py
- python scripts/check_nested_git_repositories.py
- bandit -ll -iii -r app awg config core gway nodes ocpp pages projects scripts tests utils
- bandit -ll -iii manage.py env-refresh.py vscode_manage.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf7c7673c8326b93bbf6e7d8167b4