### PR TITLE
Use setup actions for Firefox in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Firefox
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y firefox firefox-geckodriver
+        uses: browser-actions/setup-firefox@v1
+      - name: Install Geckodriver
+        uses: browser-actions/setup-geckodriver@v1
       - name: Install dependencies
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- replace apt-based Firefox installation with browser-actions/setup-* steps in the UI screenshot workflow to resolve missing geckodriver packages

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdfac0800c83269dbc3552e4122cfb