### PR TITLE
Load secret key securely and fix gitleaks

### DIFF
--- a/teams/admin.py
+++ b/teams/admin.py
@@ -10,6 +10,7 @@ from core.models import (
     OdooProfile as CoreOdooProfile,
     AssistantProfile as CoreAssistantProfile,
 )
+from awg.admin import PowerLeadAdmin as CorePowerLeadAdmin
 from nodes.models import EmailOutbox as CoreEmailOutbox
 from core.admin import (
     InviteLeadAdmin,
@@ -31,6 +32,7 @@ from .models import (
     EmailCollector,
     ReleaseManager,
     EmailOutbox,
+    PowerLead,
     OdooProfile,
     AssistantProfile,
 )
@@ -68,6 +70,11 @@ class ReleaseManagerAdminProxy(ReleaseManagerAdmin):
 
 @admin.register(EmailOutbox)
 class EmailOutboxAdminProxy(EmailOutboxAdmin):
+    pass
+
+
+@admin.register(PowerLead)
+class PowerLeadAdminProxy(CorePowerLeadAdmin):
     pass
 
 


### PR DESCRIPTION
## Summary
- load the Django secret key from environment variables or a generated lock file instead of hard-coding it in settings
- allow `dump_user_fixture` to export data for restricted users when the record is already marked as user data
- register the teams `PowerLead` proxy with the shared admin to keep it visible in admin model graphs

## Testing
- pytest tests/test_seed_data.py -q
- pytest tests/test_admin_model_graph.py -q
- gitleaks detect --no-git --source . --config .gitleaks.toml --redact --no-banner

------
https://chatgpt.com/codex/tasks/task_e_68cdf7075c608326965608fbb0716e19