### PR TITLE
Fix geckodriver action reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
       - name: Install Geckodriver
-        uses: browser-actions/setup-geckodriver@v1
+        uses: browser-actions/setup-geckodriver@v0.0.0
       - name: Install dependencies
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- update the CI workflow to use the published setup-geckodriver action tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdff4375488326a72cfbca6afb45a0