### PR TITLE
Fix ocpp formatting and resolve migration conflict

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -492,11 +492,8 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                     if self.charger:
                         targets.append(self.charger)
                     aggregate = self.aggregate_charger
-                    if (
-                        aggregate
-                        and not any(
-                            target.pk == aggregate.pk for target in targets if target.pk
-                        )
+                    if aggregate and not any(
+                        target.pk == aggregate.pk for target in targets if target.pk
                     ):
                         targets.append(aggregate)
                     for target in targets:
@@ -518,7 +515,10 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                 if updates["diagnostics_location"]:
                     log_message += ", location=%s" % updates["diagnostics_location"]
                 store.add_log(self.store_key, log_message, log_type="charger")
-                if self.aggregate_charger and self.aggregate_charger.connector_id is None:
+                if (
+                    self.aggregate_charger
+                    and self.aggregate_charger.connector_id is None
+                ):
                     aggregate_key = store.identity_key(self.charger_id, None)
                     if aggregate_key != self.store_key:
                         store.add_log(aggregate_key, log_message, log_type="charger")
@@ -599,9 +599,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                         )
                 if timestamp_value is None:
                     timestamp_value = timezone.now()
-                await self._update_firmware_state(
-                    status, status_info, timestamp_value
-                )
+                await self._update_firmware_state(status, status_info, timestamp_value)
                 store.add_log(
                     self.store_key,
                     "FirmwareStatusNotification: "

--- a/ocpp/migrations/0011_charger_dependency_order.py
+++ b/ocpp/migrations/0011_charger_dependency_order.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ocpp", "0010_charger_diagnostics_location_and_more"),
+        (
+            "ocpp",
+            "0010_charger_firmware_status_charger_firmware_status_info_and_more",
+        ),
+        (
+            "ocpp",
+            "0010_charger_last_error_code_charger_last_status_and_more",
+        ),
+    ]
+
+    operations = []

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -276,9 +276,7 @@ class CSMSConsumerTests(TransactionTestCase):
             "timestamp": ts.isoformat(),
         }
 
-        await communicator.send_json_to(
-            [2, "1", "FirmwareStatusNotification", payload]
-        )
+        await communicator.send_json_to([2, "1", "FirmwareStatusNotification", payload])
         response = await communicator.receive_json_from()
         self.assertEqual(response, [3, "1", {}])
 
@@ -296,7 +294,9 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertIsNotNone(recorded_ts)
         self.assertEqual(recorded_ts.replace(microsecond=0), ts)
 
-        log_entries = store.get_logs(store.identity_key("FWSTAT", None), log_type="charger")
+        log_entries = store.get_logs(
+            store.identity_key("FWSTAT", None), log_type="charger"
+        )
         self.assertTrue(
             any("FirmwareStatusNotification" in entry for entry in log_entries)
         )
@@ -334,9 +334,7 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertEqual(detail_payload["firmwareTimestamp"], ts.isoformat())
         self.assertIn('id="firmware-status">Installing<', html)
         self.assertIn('id="firmware-status-info">Applying patch<', html)
-        match = re.search(
-            r'id="firmware-timestamp"[^>]*data-iso="([^"]+)"', html
-        )
+        match = re.search(r'id="firmware-timestamp"[^>]*data-iso="([^"]+)"', html)
         self.assertIsNotNone(match)
         parsed_iso = datetime.fromisoformat(match.group(1))
         self.assertAlmostEqual(parsed_iso.timestamp(), ts.timestamp(), places=3)
@@ -597,12 +595,8 @@ class CSMSConsumerTests(TransactionTestCase):
         aggregate, connector = await database_sync_to_async(_fetch)()
         self.assertEqual(aggregate.diagnostics_status, "Uploaded")
         self.assertEqual(connector.diagnostics_status, "Uploaded")
-        self.assertEqual(
-            aggregate.diagnostics_location, "https://example.com/diag.tar"
-        )
-        self.assertEqual(
-            connector.diagnostics_location, "https://example.com/diag.tar"
-        )
+        self.assertEqual(aggregate.diagnostics_location, "https://example.com/diag.tar")
+        self.assertEqual(connector.diagnostics_location, "https://example.com/diag.tar")
         self.assertEqual(aggregate.diagnostics_timestamp, reported_at)
         self.assertEqual(connector.diagnostics_timestamp, reported_at)
 
@@ -1943,10 +1937,10 @@ class ChargerStatusViewTests(TestCase):
         resp = self.client.get(reverse("charger-status", args=[charger.charger_id]))
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Diagnostics")
-        self.assertContains(resp, "id=\"diagnostics-status\"")
+        self.assertContains(resp, 'id="diagnostics-status"')
         self.assertContains(resp, "Uploaded")
-        self.assertContains(resp, "id=\"diagnostics-timestamp\"")
-        self.assertContains(resp, "id=\"diagnostics-location\"")
+        self.assertContains(resp, 'id="diagnostics-timestamp"')
+        self.assertContains(resp, 'id="diagnostics-location"')
         self.assertContains(resp, "https://example.com/report.tar")
 
     def test_connector_status_prefers_connector_diagnostics(self):
@@ -2130,12 +2124,8 @@ class ChargerApiDiagnosticsTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         payload = resp.json()
         self.assertEqual(payload["diagnosticsStatus"], "Uploaded")
-        self.assertEqual(
-            payload["diagnosticsTimestamp"], reported_at.isoformat()
-        )
-        self.assertEqual(
-            payload["diagnosticsLocation"], "https://example.com/diag.tar"
-        )
+        self.assertEqual(payload["diagnosticsTimestamp"], reported_at.isoformat())
+        self.assertEqual(payload["diagnosticsLocation"], "https://example.com/diag.tar")
 
     def test_list_includes_diagnostics_fields(self):
         reported_at = timezone.now().replace(microsecond=0)

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -277,7 +277,11 @@ def charger_list(request):
             active_transactions.append(active_payload)
         state, color = _charger_state(
             charger,
-            tx_obj if charger.connector_id is not None else (sessions if sessions else None),
+            (
+                tx_obj
+                if charger.connector_id is not None
+                else (sessions if sessions else None)
+            ),
         )
         data.append(
             {
@@ -373,7 +377,11 @@ def charger_detail(request, cid, connector=None):
     log = store.get_logs(log_key, log_type="charger")
     state, color = _charger_state(
         charger,
-        tx_obj if charger.connector_id is not None else (sessions if sessions else None),
+        (
+            tx_obj
+            if charger.connector_id is not None
+            else (sessions if sessions else None)
+        ),
     )
     return JsonResponse(
         {
@@ -543,7 +551,9 @@ def charger_page(request, cid, connector=None):
         )
         if tx:
             active_connector_count = 1
-    state_source = tx if charger.connector_id is not None else (sessions if sessions else None)
+    state_source = (
+        tx if charger.connector_id is not None else (sessions if sessions else None)
+    )
     state, color = _charger_state(charger, state_source)
     language_cookie = request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
     preferred_language = "es"


### PR DESCRIPTION
## Summary
- apply Black formatting to the ocpp consumers, views, and tests modules
- add a follow-up migration that ties together the existing parallel 0010 ocpp migrations to remove the conflict detected by makemigrations

## Testing
- python scripts/check_migrations.py
- pre-commit run --all-files *(fails: git fetch returned 403 while creating the bandit hook environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdff91c0f08326b037da7f30402b97