### PR TITLE
Install geckodriver manually in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,16 @@ jobs:
       - name: Install Firefox
         uses: browser-actions/setup-firefox@v1
       - name: Install Geckodriver
-        uses: browser-actions/setup-geckodriver@v0.0.0
+        run: |
+          set -euo pipefail
+          GECKODRIVER_VERSION=0.34.0
+          curl -sSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz" \
+            -o geckodriver.tar.gz
+          tar -xzf geckodriver.tar.gz
+          rm geckodriver.tar.gz
+          sudo mv geckodriver /usr/local/bin/geckodriver
+          sudo chmod +x /usr/local/bin/geckodriver
+          geckodriver --version
       - name: Install dependencies
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- replace the unversioned setup-geckodriver action with a manual download script
- ensure the workflow installs a specific geckodriver release and verifies the install

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce00eb044c832692be23197e662ffb