### PR TITLE
Update four role architecture table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Arthexis Constellation is a [narrative-driven](https://en.wikipedia.org/wiki/Nar
 
 Arthexis Constellation ships in four node roles tailored to different deployment scenarios.
 
-| Role | Description | Common features |
-| --- | --- | --- |
-| Terminal | Single-User Research & Development | • GUI Toast |
-| Control | Single-Device Testing & Special Task Appliances | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
-| Satellite | Multi-Device Edge, Network & Data Acquisition | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
-| Constellation | Multi-User Cloud & Orchestration | • Celery Queue<br>• NGINX Server |
+| Role | Description & Common Features |
+| --- | --- |
+| Terminal | Single-User Research & Development<br>Features: GUI Toast |
+| Control | Single-Device Testing & Special Task Appliances<br>Features: AP Public Wi-Fi, Celery Queue, GUI Toast, LCD Screen, NGINX Server, RFID Scanner |
+| Satellite | Multi-Device Edge, Network & Data Acquisition<br>Features: AP Router, Celery Queue, NGINX Server, RFID Scanner |
+| Constellation | Multi-User Cloud & Orchestration<br>Features: Celery Queue, NGINX Server |
 
 ## Quick Guide
 


### PR DESCRIPTION
## Summary
- convert the Four Role Architecture table to two columns
- add comma-separated node features beneath each role description

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68ceb4093bec8326818999836a389661