### PR TITLE
Gracefully handle missing django_site table during site lookup

### DIFF
--- a/tests/test_sites_utils.py
+++ b/tests/test_sites_utils.py
@@ -1,0 +1,50 @@
+import pytest
+
+from django.contrib.sites.requests import RequestSite
+from django.contrib.sites.models import Site
+from django.db import DatabaseError
+from django.http import HttpRequest
+
+from utils.sites import get_site
+
+
+def _build_request(host="testserver"):
+    request = HttpRequest()
+    request.META["HTTP_HOST"] = host
+    return request
+
+
+def test_get_site_returns_request_site_when_database_unavailable(monkeypatch):
+    request = _build_request()
+
+    def raise_database_error(*args, **kwargs):
+        raise DatabaseError("no such table: django_site")
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("get_current_site should not be called when the database is unavailable")
+
+    monkeypatch.setattr("utils.sites.Site.objects.get", raise_database_error)
+    monkeypatch.setattr("utils.sites.get_current_site", fail_if_called)
+
+    site = get_site(request)
+
+    assert isinstance(site, RequestSite)
+    assert site.domain == "testserver"
+
+
+def test_get_site_handles_database_error_during_current_site_lookup(monkeypatch):
+    request = _build_request()
+
+    def raise_does_not_exist(*args, **kwargs):
+        raise Site.DoesNotExist()
+
+    def raise_database_error(*args, **kwargs):
+        raise DatabaseError("no such table: django_site")
+
+    monkeypatch.setattr("utils.sites.Site.objects.get", raise_does_not_exist)
+    monkeypatch.setattr("utils.sites.get_current_site", raise_database_error)
+
+    site = get_site(request)
+
+    assert isinstance(site, RequestSite)
+    assert site.domain == "testserver"

--- a/utils/sites.py
+++ b/utils/sites.py
@@ -1,6 +1,7 @@
 from django.contrib.sites.models import Site
 from django.contrib.sites.requests import RequestSite
 from django.contrib.sites.shortcuts import get_current_site
+from django.db import DatabaseError
 from django.http.request import split_domain_port
 
 
@@ -17,7 +18,11 @@ def get_site(request):
     try:
         return Site.objects.get(domain=host)
     except Site.DoesNotExist:
-        try:
-            return get_current_site(request)
-        except Site.DoesNotExist:
-            return RequestSite(request)
+        pass
+    except DatabaseError:
+        return RequestSite(request)
+
+    try:
+        return get_current_site(request)
+    except (Site.DoesNotExist, DatabaseError):
+        return RequestSite(request)


### PR DESCRIPTION
## Summary
- update the site lookup helper to fall back to RequestSite when the database is unavailable
- add regression tests covering database errors during both site queries

## Testing
- pytest tests/test_sites_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cec1e7fc64832683216ce04dedd360