### PR TITLE
Remove pre-commit job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,20 +48,6 @@ jobs:
                       fh.write(f"| {entry['role']} | {features} |\n")
                   fh.write('\n')
           PY
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install pre-commit
-      - name: Run pre-commit
-        run: pre-commit run --all-files
-
   check-migrations:
     needs: node-test-matrix
     if: needs.node-test-matrix.outputs.database_changed == 'true'


### PR DESCRIPTION
## Summary
- remove the pre-commit job from the GitHub Actions CI workflow since it is no longer needed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cec6aae1d08326a2f42d41d7cbfc82