### PR TITLE
Adjust tooltip offset for release progress todos

### DIFF
--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -139,7 +139,7 @@
   .todo-item .todo-details {
     display: none;
     position: absolute;
-    left: 0;
+    left: 1.75rem;
     top: 100%;
     background: var(--body-bg);
     border: 1px solid var(--hairline-color);

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -139,7 +139,7 @@
   .todo-item .todo-details {
     display: none;
     position: absolute;
-    left: 0;
+    left: 1.75rem;
     top: 100%;
     background: var(--body-bg);
     border: 1px solid var(--hairline-color);


### PR DESCRIPTION
## Summary
- offset the release progress TODO tooltip so it no longer overlaps the checkbox column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced21d43b083268f66602919e693da