### PR TITLE
Rename Public Wi-Fi Access model labels to Wi-Fi Lease

### DIFF
--- a/core/migrations/0037_alter_publicwifiaccess_options.py
+++ b/core/migrations/0037_alter_publicwifiaccess_options.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0036_user_last_visit_ip_address"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="publicwifiaccess",
+            options={
+                "unique_together": {("user", "mac_address")},
+                "verbose_name": "Wi-Fi Lease",
+                "verbose_name_plural": "Wi-Fi Leases",
+            },
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -225,7 +225,7 @@ class InviteLead(Lead):
 
 
 class PublicWifiAccess(Entity):
-    """Allow public Wi-Fi clients onto the wider internet."""
+    """Represent a Wi-Fi lease granted to a client for internet access."""
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -239,8 +239,8 @@ class PublicWifiAccess(Entity):
 
     class Meta:
         unique_together = ("user", "mac_address")
-        verbose_name = "Public Wi-Fi Access"
-        verbose_name_plural = "Public Wi-Fi Access"
+        verbose_name = "Wi-Fi Lease"
+        verbose_name_plural = "Wi-Fi Leases"
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.user} -> {self.mac_address}"


### PR DESCRIPTION
## Summary
- update the PublicWifiAccess model metadata and docstring to present the resource as a Wi-Fi lease
- add a migration adjusting the verbose names while preserving the unique constraint

## Testing
- poetry run python manage.py makemigrations core *(fails: ModuleNotFoundError: No module named 'celery')*


------
https://chatgpt.com/codex/tasks/task_e_68ced1dadcf883269ba35374e4322b76