### PR TITLE
Ignore rpi-image-gen outputs via gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # Backup files
 *.bkp
 
+# Disk images
+*.img
+*.img.xz
+
 # C extensions
 *.so
 

--- a/rpi-image-gen.sh
+++ b/rpi-image-gen.sh
@@ -152,8 +152,21 @@ chmod 700 "$RUN_DIR"
 printf '%s\n' "$PASSWORD" > "$PASSWORD_FILE"
 chmod 600 "$PASSWORD_FILE"
 
-AP_UUID="$(uuidgen)"
-ETH_UUID="$(uuidgen)"
+generate_uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import uuid
+print(uuid.uuid4())
+PY
+  else
+    error "Neither uuidgen nor python3 is available to generate UUIDs. Install uuid-runtime or Python 3."
+  fi
+}
+
+AP_UUID="$(generate_uuid)"
+ETH_UUID="$(generate_uuid)"
 
 IMAGE_NAME="arthexis-${ROLE}-${HOSTNAME}"
 CONFIG_FILE="$CONFIG_DIR/${IMAGE_NAME}.yaml"


### PR DESCRIPTION
## Summary
- generate UUIDs via uuidgen when available or fall back to python3
- surface a clear error instructing how to install uuidgen or python3 when neither is present
- ignore generated Raspberry Pi images via .gitignore instead of runtime git checks

## Testing
- not run (shellcheck unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68ceff6262548326874953d9b199220b