### PR TITLE
Allow public OCPP dashboard with websocket rate limiting

### DIFF
--- a/ocpp/templates/ocpp/dashboard.html
+++ b/ocpp/templates/ocpp/dashboard.html
@@ -5,6 +5,15 @@
 
 {% block content %}
 <h1>{% trans "Charge Points" %}</h1>
+{% if show_demo_notice %}
+<div class="alert alert-info" role="alert">
+  <h2 class="h5 mb-2">{% trans "Demo OCPP 1.6 CSMS" %}</h2>
+  <p class="mb-1">{% trans "Everyone is welcome to use this demo to test their charge points." %}</p>
+  <p class="mb-1">{% blocktrans with limit=ws_rate_limit %}Rate limiting applies (maximum {{ limit }} simultaneous connections per IP).{% endblocktrans %}</p>
+  <p class="mb-0">{% blocktrans %}Use the following WebSocket URL format, replacing &lt;CHARGE_POINT_ID&gt; with your charge point identifier:{% endblocktrans %}</p>
+  <pre class="mb-0"><code>{{ demo_ws_url }}</code></pre>
+</div>
+{% endif %}
 <table class="table">
   <thead>
     <tr>

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -989,6 +989,78 @@ class CSMSConsumerTests(TransactionTestCase):
         store.transactions.pop(key2, None)
 
 
+    async def test_rate_limit_blocks_third_connection(self):
+        store.ip_connections.clear()
+        ip = "203.0.113.10"
+        communicator1 = ClientWebsocketCommunicator(
+            application, "/IPLIMIT1/", client=(ip, 1001)
+        )
+        communicator2 = ClientWebsocketCommunicator(
+            application, "/IPLIMIT2/", client=(ip, 1002)
+        )
+        communicator3 = ClientWebsocketCommunicator(
+            application, "/IPLIMIT3/", client=(ip, 1003)
+        )
+        other = ClientWebsocketCommunicator(
+            application, "/OTHERIP/", client=("198.51.100.5", 2001)
+        )
+        connected1 = connected2 = connected_other = False
+        try:
+            connected1, _ = await communicator1.connect()
+            self.assertTrue(connected1)
+            connected2, _ = await communicator2.connect()
+            self.assertTrue(connected2)
+            connected3, code = await communicator3.connect()
+            self.assertFalse(connected3)
+            self.assertEqual(code, 4003)
+            connected_other, _ = await other.connect()
+            self.assertTrue(connected_other)
+        finally:
+            if connected1:
+                await communicator1.disconnect()
+            if connected2:
+                await communicator2.disconnect()
+            if connected_other:
+                await other.disconnect()
+
+    async def test_rate_limit_allows_reconnect_after_disconnect(self):
+        store.ip_connections.clear()
+        ip = "203.0.113.20"
+        communicator1 = ClientWebsocketCommunicator(
+            application, "/LIMITRESET1/", client=(ip, 3001)
+        )
+        communicator2 = ClientWebsocketCommunicator(
+            application, "/LIMITRESET2/", client=(ip, 3002)
+        )
+        communicator3 = ClientWebsocketCommunicator(
+            application, "/LIMITRESET3/", client=(ip, 3003)
+        )
+        communicator3_retry = None
+        connected1 = connected2 = connected3_retry = False
+        try:
+            connected1, _ = await communicator1.connect()
+            self.assertTrue(connected1)
+            connected2, _ = await communicator2.connect()
+            self.assertTrue(connected2)
+            connected3, code = await communicator3.connect()
+            self.assertFalse(connected3)
+            self.assertEqual(code, 4003)
+            await communicator1.disconnect()
+            connected1 = False
+            communicator3_retry = ClientWebsocketCommunicator(
+                application, "/LIMITRESET4/", client=(ip, 3004)
+            )
+            connected3_retry, _ = await communicator3_retry.connect()
+            self.assertTrue(connected3_retry)
+        finally:
+            if connected1:
+                await communicator1.disconnect()
+            if connected2:
+                await communicator2.disconnect()
+            if connected3_retry and communicator3_retry is not None:
+                await communicator3_retry.disconnect()
+
+
 class ChargerLandingTests(TestCase):
     def setUp(self):
         self.client = Client()
@@ -2369,3 +2441,52 @@ class LiveUpdateViewTests(TestCase):
         resp = self.client.get(reverse("cp-simulator"))
         self.assertEqual(resp.context["request"].live_update_interval, 5)
         self.assertContains(resp, "setInterval(() => location.reload()")
+
+
+class DashboardAccessTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.constellation_role, _ = NodeRole.objects.get_or_create(
+            name="Constellation"
+        )
+        self.terminal_role, _ = NodeRole.objects.get_or_create(name="Terminal")
+        Site.objects.update_or_create(
+            id=1, defaults={"domain": "testserver", "name": ""}
+        )
+        self.app, _ = Application.objects.get_or_create(name="ocpp")
+        Module.objects.update_or_create(
+            node_role=self.constellation_role,
+            path="/ocpp/",
+            defaults={"application": self.app},
+        )
+        Module.objects.update_or_create(
+            node_role=self.terminal_role,
+            path="/ocpp/",
+            defaults={"application": self.app},
+        )
+
+    def _set_role(self, role):
+        Node.objects.update_or_create(
+            mac_address=Node.get_current_mac(),
+            defaults={
+                "hostname": "localhost",
+                "address": "127.0.0.1",
+                "role": role,
+            },
+        )
+
+    def test_non_constellation_requires_login(self):
+        self._set_role(self.terminal_role)
+        resp = self.client.get(reverse("ocpp-dashboard"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("pages:login"), resp["Location"])
+
+    def test_constellation_dashboard_public(self):
+        self._set_role(self.constellation_role)
+        resp = self.client.get(reverse("ocpp-dashboard"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Demo OCPP 1.6 CSMS")
+        self.assertIn("demo_ws_url", resp.context)
+        self.assertIn("ws_rate_limit", resp.context)
+        self.assertEqual(resp.context["ws_rate_limit"], store.MAX_CONNECTIONS_PER_IP)
+        self.assertTrue(resp.context["demo_ws_url"].startswith("ws"))

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -9,12 +9,15 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404
 from django.core.paginator import Paginator
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.utils.translation import gettext_lazy as _, gettext, ngettext
 from django.urls import NoReverseMatch, reverse
 from django.conf import settings
 from django.utils import translation
 
 from utils.api import api_login_required
+
+from nodes.models import Node
 
 from pages.utils import landing
 from core.liveupdate import live_update
@@ -410,11 +413,17 @@ def charger_detail(request, cid, connector=None):
     )
 
 
-@login_required
 @landing("Dashboard")
 @live_update()
 def dashboard(request):
     """Landing page listing all known chargers and their status."""
+    node = Node.get_local()
+    role = node.role if node else None
+    is_constellation = bool(role and role.name == "Constellation")
+    if not request.user.is_authenticated and not is_constellation:
+        return redirect_to_login(
+            request.get_full_path(), login_url=reverse("pages:login")
+        )
     chargers = []
     for charger in Charger.objects.all():
         tx_obj = store.get_transaction(charger.charger_id, charger.connector_id)
@@ -426,7 +435,16 @@ def dashboard(request):
             )
         state, color = _charger_state(charger, tx_obj)
         chargers.append({"charger": charger, "state": state, "color": color})
-    return render(request, "ocpp/dashboard.html", {"chargers": chargers})
+    scheme = "wss" if request.is_secure() else "ws"
+    host = request.get_host()
+    ws_url = f"{scheme}://{host}/ocpp/<CHARGE_POINT_ID>/"
+    context = {
+        "chargers": chargers,
+        "show_demo_notice": is_constellation,
+        "demo_ws_url": ws_url,
+        "ws_rate_limit": store.MAX_CONNECTIONS_PER_IP,
+    }
+    return render(request, "ocpp/dashboard.html", context)
 
 
 @login_required

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -703,6 +703,10 @@ class ConstellationNavTests(TestCase):
             ).exists()
         )
 
+    def test_ocpp_dashboard_visible(self):
+        resp = self.client.get(reverse("pages:index"))
+        self.assertContains(resp, 'href="/ocpp/"')
+
 
 class StaffNavVisibilityTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- allow anonymous access to the OCPP dashboard when the local node role is Constellation and expose demo metadata in the template
- show a demo notice above the charger list with WebSocket instructions and the enforced connection limit
- enforce a two-connection-per-IP limit for websocket consumers and add regression tests for navigation visibility and rate limiting

## Testing
- python manage.py test pages.tests.ConstellationNavTests.test_ocpp_dashboard_visible
- python manage.py test ocpp.tests.DashboardAccessTests
- python.manage.py test ocpp.tests.CSMSConsumerTests.test_rate_limit_blocks_third_connection ocpp.tests.CSMSConsumerTests.test_rate_limit_allows_reconnect_after_disconnect

------
https://chatgpt.com/codex/tasks/task_e_68cf1be6a4c48326a16c2e08962114ec