### PR TITLE
Ensure auto-upgrade task is recreated automatically

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -105,6 +105,7 @@ class CoreConfig(AppConfig):
         lock = Path(settings.BASE_DIR) / "locks" / "celery.lck"
 
         if lock.exists():
+            from .auto_upgrade import ensure_auto_upgrade_periodic_task
 
             def ensure_email_collector_task(**kwargs):
                 try:  # pragma: no cover - optional dependency
@@ -131,6 +132,8 @@ class CoreConfig(AppConfig):
                     pass
 
             post_migrate.connect(ensure_email_collector_task, sender=self)
+            post_migrate.connect(ensure_auto_upgrade_periodic_task, sender=self)
+            ensure_auto_upgrade_periodic_task()
 
         from django.db.backends.signals import connection_created
 

--- a/core/auto_upgrade.py
+++ b/core/auto_upgrade.py
@@ -1,0 +1,54 @@
+"""Helpers for managing the auto-upgrade scheduler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+
+
+AUTO_UPGRADE_TASK_NAME = "auto-upgrade-check"
+AUTO_UPGRADE_TASK_PATH = "core.tasks.check_github_updates"
+
+
+def ensure_auto_upgrade_periodic_task(
+    sender=None, *, base_dir: Path | None = None, **kwargs
+) -> None:
+    """Ensure the auto-upgrade periodic task exists.
+
+    The function is signal-safe so it can be wired to Django's
+    ``post_migrate`` hook. When called directly the ``sender`` and
+    ``**kwargs`` parameters are ignored.
+    """
+
+    del sender, kwargs  # Unused when invoked as a Django signal handler.
+
+    if base_dir is None:
+        base_dir = Path(settings.BASE_DIR)
+    else:
+        base_dir = Path(base_dir)
+
+    lock_dir = base_dir / "locks"
+    mode_file = lock_dir / "auto_upgrade.lck"
+    if not mode_file.exists():
+        return
+
+    try:  # pragma: no cover - optional dependency failures
+        from django_celery_beat.models import IntervalSchedule, PeriodicTask
+        from django.db.utils import OperationalError, ProgrammingError
+    except Exception:
+        return
+
+    try:
+        schedule, _ = IntervalSchedule.objects.get_or_create(
+            every=10, period=IntervalSchedule.MINUTES
+        )
+        PeriodicTask.objects.update_or_create(
+            name=AUTO_UPGRADE_TASK_NAME,
+            defaults={
+                "interval": schedule,
+                "task": AUTO_UPGRADE_TASK_PATH,
+            },
+        )
+    except (OperationalError, ProgrammingError):  # pragma: no cover - DB not ready
+        return

--- a/install.sh
+++ b/install.sh
@@ -615,16 +615,9 @@ if [ "$AUTO_UPGRADE" = true ]; then
     fi
     source .venv/bin/activate
     python manage.py shell <<'PYCODE'
-from django_celery_beat.models import IntervalSchedule, PeriodicTask
-from django.utils.text import slugify
+from core.auto_upgrade import ensure_auto_upgrade_periodic_task
 
-schedule, _ = IntervalSchedule.objects.get_or_create(
-    every=10, period=IntervalSchedule.MINUTES
-)
-PeriodicTask.objects.update_or_create(
-    name=slugify("auto upgrade check"),
-    defaults={"interval": schedule, "task": "core.tasks.check_github_updates"},
-)
+ensure_auto_upgrade_periodic_task()
 PYCODE
     deactivate
 elif [ "$UPGRADE" = true ]; then

--- a/tests/test_auto_upgrade_scheduler.py
+++ b/tests/test_auto_upgrade_scheduler.py
@@ -1,0 +1,26 @@
+from django_celery_beat.models import IntervalSchedule, PeriodicTask
+
+from core.auto_upgrade import ensure_auto_upgrade_periodic_task, AUTO_UPGRADE_TASK_NAME, AUTO_UPGRADE_TASK_PATH
+
+
+def test_ensure_auto_upgrade_task_skips_without_lock(tmp_path):
+    PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
+
+    ensure_auto_upgrade_periodic_task(base_dir=tmp_path)
+
+    assert not PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).exists()
+
+
+def test_ensure_auto_upgrade_task_creates_periodic(tmp_path):
+    PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
+
+    locks_dir = tmp_path / "locks"
+    locks_dir.mkdir()
+    (locks_dir / "auto_upgrade.lck").write_text("latest")
+
+    ensure_auto_upgrade_periodic_task(base_dir=tmp_path)
+
+    task = PeriodicTask.objects.get(name=AUTO_UPGRADE_TASK_NAME)
+    assert task.task == AUTO_UPGRADE_TASK_PATH
+    assert task.interval.every == 10
+    assert task.interval.period == IntervalSchedule.MINUTES


### PR DESCRIPTION
## Summary
- add a reusable helper to ensure the auto-upgrade Celery task exists when the lockfile is present
- hook the helper into app startup and the installer so control nodes recover the task automatically
- add regression tests covering the helper behaviour

## Testing
- pytest tests/test_auto_upgrade_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68cf19a1a05c8326ac35afca08dd28f3