### PR TITLE
Allow admin default login on Control nodes

### DIFF
--- a/core/backends.py
+++ b/core/backends.py
@@ -4,6 +4,7 @@ import contextlib
 import ipaddress
 import socket
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 
@@ -69,12 +70,18 @@ def _collect_local_ip_addresses():
 class LocalhostAdminBackend(ModelBackend):
     """Allow default admin credentials only from local networks."""
 
-    _ALLOWED_NETWORKS = [
+    _ALLOWED_NETWORKS = (
         ipaddress.ip_network("::1/128"),
         ipaddress.ip_network("127.0.0.0/8"),
         ipaddress.ip_network("192.168.0.0/16"),
-    ]
+    )
+    _CONTROL_ALLOWED_NETWORKS = (ipaddress.ip_network("10.0.0.0/8"),)
     _LOCAL_IPS = _collect_local_ip_addresses()
+
+    def _iter_allowed_networks(self):
+        yield from self._ALLOWED_NETWORKS
+        if getattr(settings, "NODE_ROLE", "") == "Control":
+            yield from self._CONTROL_ALLOWED_NETWORKS
 
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username == "admin" and password == "admin" and request is not None:
@@ -87,7 +94,7 @@ class LocalhostAdminBackend(ModelBackend):
                 ip = ipaddress.ip_address(remote)
             except ValueError:
                 return None
-            allowed = any(ip in net for net in self._ALLOWED_NETWORKS)
+            allowed = any(ip in net for net in self._iter_allowed_networks())
             if not allowed and ip in self._LOCAL_IPS:
                 allowed = True
             if not allowed:

--- a/tests/test_localhost_admin_backend.py
+++ b/tests/test_localhost_admin_backend.py
@@ -1,7 +1,8 @@
 import ipaddress
 
-from django.http import HttpRequest
 from django.contrib.auth import get_user_model
+from django.http import HttpRequest
+from django.test import override_settings
 
 from core.backends import LocalhostAdminBackend
 
@@ -69,5 +70,17 @@ def test_allows_current_node_hostname():
     )
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "10.42.0.20"
+    user = backend.authenticate(req, username="admin", password="admin")
+    assert user is not None
+
+
+@override_settings(NODE_ROLE="Control")
+def test_control_role_allows_private_network():
+    User = get_user_model()
+    ensure_arthexis_user()
+    User.all_objects.filter(username="admin").delete()
+    backend = LocalhostAdminBackend()
+    req = HttpRequest()
+    req.META["REMOTE_ADDR"] = "10.42.0.15"
     user = backend.authenticate(req, username="admin", password="admin")
     assert user is not None


### PR DESCRIPTION
## Summary
- allow the LocalhostAdminBackend to grant admin/admin access when the node role is Control
- extend the login backend tests to cover Control nodes

## Testing
- pytest tests/test_localhost_admin_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2fabf6a88326a42cffd7398559c9