### PR TITLE
Protect client report generation

### DIFF
--- a/pages/templates/pages/client_report.html
+++ b/pages/templates/pages/client_report.html
@@ -2,8 +2,26 @@
 {% load i18n %}
 {% block content %}
 <h1>{% trans "Client Report" %}</h1>
+{% if not request.user.is_authenticated %}
+  <div class="notification warning" role="alert">
+    {% if login_url %}
+      {% blocktrans trimmed with login_url=login_url %}
+        Please <a href="{{ login_url }}">log in</a> to generate client reports.
+      {% endblocktrans %}
+    {% else %}
+      {% trans "Please log in to generate client reports." %}
+    {% endif %}
+  </div>
+{% endif %}
 <form method="post" id="report-form" class="client-report-form">
   {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="form-errors" role="alert">
+      {% for error in form.non_field_errors %}
+        <p class="error">{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
   <fieldset class="report-section" aria-describedby="id_period-help">
     <legend class="section-title">{% trans "Reporting period" %}</legend>
     <div class="form-group">
@@ -83,7 +101,7 @@
     </div>
   </fieldset>
   <div class="form-actions">
-    <button type="submit" class="button button-primary" id="generate-report-button">
+    <button type="submit" class="button button-primary" id="generate-report-button"{% if not request.user.is_authenticated %} disabled aria-disabled="true"{% endif %}>
       {% trans "Generate report" %}
     </button>
   </div>
@@ -201,6 +219,36 @@
     list-style: none;
   }
 
+  .notification {
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .notification.warning {
+    background-color: #fef3c7;
+    color: #92400e;
+  }
+
+  .notification.warning a {
+    color: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+  }
+
+  .form-errors {
+    border-left: 4px solid #dc2626;
+    background-color: #fee2e2;
+    color: #7f1d1d;
+    padding: 1rem 1.25rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .form-errors .error {
+    margin: 0;
+  }
+
   .client-report-form .help-text {
     margin: 0;
     font-size: 0.85rem;
@@ -227,6 +275,11 @@
     font-size: 1rem;
     font-weight: 600;
     border-radius: 6px;
+  }
+
+  #generate-report-button[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   @media (max-width: 40rem) {

--- a/tests/test_client_report_generation.py
+++ b/tests/test_client_report_generation.py
@@ -10,6 +10,8 @@ import django
 django.setup()
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -21,6 +23,11 @@ from ocpp.models import Charger, Transaction
 class ClientReportGenerationTests(TestCase):
     def setUp(self):
         self.client = Client()
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="reporter", email="reporter@example.com", password="secret"
+        )
         self.charger = Charger.objects.create(charger_id="C1")
         self.rfid1 = RFID.objects.create(rfid="A1B2C3")
         self.rfid2 = RFID.objects.create(rfid="D4E5F6")
@@ -45,9 +52,27 @@ class ClientReportGenerationTests(TestCase):
             meter_stop=500,
         )
 
-    def test_generate_report(self):
+    def test_anonymous_post_rejected(self):
         day = timezone.now().date()
         url = reverse("pages:client-report")
+        resp = self.client.post(
+            url,
+            {
+                "period": "range",
+                "start": day,
+                "end": day,
+                "recurrence": ClientReportSchedule.PERIODICITY_NONE,
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "log in</a> to generate client reports.")
+        self.assertContains(resp, "You must log in to generate client reports.")
+        self.assertFalse(ClientReport.objects.exists())
+
+    def test_generate_report_authenticated(self):
+        day = timezone.now().date()
+        url = reverse("pages:client-report")
+        self.client.force_login(self.user)
         resp = self.client.post(
             url,
             {
@@ -65,7 +90,7 @@ class ClientReportGenerationTests(TestCase):
         report = ClientReport.objects.get()
         self.assertEqual(report.start_date, day)
         self.assertEqual(report.end_date, day)
-        self.assertIsNone(report.owner)
+        self.assertEqual(report.owner, self.user)
         export = report.data.get("export")
         self.assertIsNotNone(export)
         html_path = Path(settings.BASE_DIR) / export["html_path"]
@@ -77,3 +102,32 @@ class ClientReportGenerationTests(TestCase):
         self.assertIn(str(self.rfid2.label_id), subjects)
         html_path.unlink()
         json_path.unlink()
+
+    def test_repeated_generation_throttled(self):
+        day = timezone.now().date()
+        url = reverse("pages:client-report")
+        payload = {
+            "period": "range",
+            "start": day,
+            "end": day,
+            "recurrence": ClientReportSchedule.PERIODICITY_NONE,
+        }
+        self.client.force_login(self.user)
+
+        first = self.client.post(url, payload)
+        self.assertEqual(first.status_code, 200)
+        report = ClientReport.objects.get()
+        export = report.data.get("export")
+        html_path = Path(settings.BASE_DIR) / export["html_path"]
+        json_path = Path(settings.BASE_DIR) / export["json_path"]
+        self.assertTrue(html_path.exists())
+        self.assertTrue(json_path.exists())
+        html_path.unlink()
+        json_path.unlink()
+
+        second = self.client.post(url, payload)
+        self.assertEqual(second.status_code, 200)
+        self.assertContains(
+            second, "Client reports can only be generated periodically.", status_code=200
+        )
+        self.assertEqual(ClientReport.objects.count(), 1)


### PR DESCRIPTION
## Summary
- require authentication to submit the client report form and throttle repeated submissions
- show a login prompt and validation errors on the client report page for anonymous users
- extend client report tests to cover anonymous rejection, authenticated success, and throttling behaviour

## Testing
- pytest tests/test_client_report_generation.py
- pytest tests/test_rfid_client_report.py

------
https://chatgpt.com/codex/tasks/task_e_68cf321bc2e48326b359c94cdf52eae4