### PR TITLE
Ensure register visitor node admin action uses admin chrome

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -9,6 +9,7 @@ from django.db.models import Count
 from django.conf import settings
 from pathlib import Path
 from django.http import HttpResponse
+from django.utils.translation import gettext_lazy as _
 import base64
 import pyperclip
 from pyperclip import PyperclipException
@@ -114,6 +115,9 @@ class NodeAdmin(EntityModelAdmin):
 
         token = uuid.uuid4().hex
         context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "title": _("Register Visitor Node"),
             "token": token,
             "info_url": reverse("node-info"),
             "register_url": reverse("register-node"),

--- a/nodes/templates/admin/nodes/node/register_visitor.html
+++ b/nodes/templates/admin/nodes/node/register_visitor.html
@@ -1,14 +1,26 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+{% if has_permission %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name|capfirst }}</a>
+  &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {% trans "Register Visitor Node" %}
+</div>
+{% endif %}
+{% endblock %}
 
 {% block content %}
-<h1>{% trans "Register Visitor Node" %}</h1>
-<p>{% trans "Attempting to exchange node information between this host and the visiting instance." %}</p>
-<ul>
-    <li id="host-result">{% trans "Registering the visiting node on this server…" %}</li>
-    <li id="visitor-result">{% trans "Registering this server on the visiting node…" %}</li>
-</ul>
-<p id="result"></p>
+<div id="content-main">
+  <p>{% trans "Attempting to exchange node information between this host and the visiting instance." %}</p>
+  <ul>
+      <li id="host-result">{% trans "Registering the visiting node on this server…" %}</li>
+      <li id="visitor-result">{% trans "Registering this server on the visiting node…" %}</li>
+  </ul>
+  <p id="result"></p>
+</div>
 <script>
 (function() {
     const token = "{{ token|escapejs }}";


### PR DESCRIPTION
## Summary
- provide admin context for the Register Visitor Node action view so it renders navigation and breadcrumbs
- update the template to include the model breadcrumbs while keeping the existing registration workflow

## Testing
- pytest tests/test_admin_index_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68cf329ef7dc8326a8fe2104dc83bc85