### PR TITLE
Fix Security Group user selector orientation

### DIFF
--- a/core/fixtures/todos__validate_screen_security_group_add.json
+++ b/core/fixtures/todos__validate_screen_security_group_add.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Security Group add",
+      "url": "/admin/core/securitygroup/add/",
+      "request_details": "Confirm the Security Group add form renders the users selector with the available list on the left and chosen list on the right."
+    }
+  }
+]

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -312,6 +312,23 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
 .submit-row a.deletelink {
     margin-left: 0;
 }
+
+/* Keep dual-selector widgets oriented left-to-right */
+.selector {
+    flex-direction: row;
+}
+
+.selector-available {
+    order: 0;
+}
+
+.selector ul.selector-chooser {
+    order: 1;
+}
+
+.selector-chosen {
+    order: 2;
+}
 </style>
 {% endblock %}
 {% block branding %}


### PR DESCRIPTION
## Summary
- enforce a left-to-right layout for admin dual-selector widgets so the Security Group user chooser displays correctly
- add a release manager todo prompting validation of the Security Group add screen

## Testing
- pytest tests/test_profile_inline_deletion.py -k security_group_add_view_includes_delete_hiding_styles

------
https://chatgpt.com/codex/tasks/task_e_68cf32d960d0832683d0458f903e4dab