### PR TITLE
Add Operate As profile link to user admin change view

### DIFF
--- a/core/fixtures/todos__validate_screen_user_operate_as_profile_link.json
+++ b/core/fixtures/todos__validate_screen_user_operate_as_profile_link.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen User Operate As Profile Link",
+      "url": "/admin/core/user/",
+      "request_details": "Open a user change page, select an Operate As user, and confirm the profile link appears and updates for the chosen user."
+    }
+  }
+]

--- a/core/templates/admin/user_profile_change_form.html
+++ b/core/templates/admin/user_profile_change_form.html
@@ -1,7 +1,85 @@
 {% extends "admin/change_form.html" %}
+{% load i18n %}
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>
+    {% if operate_as_profile_url_template %}
+    <div
+        id="operate-as-profile-link"
+        data-url-template="{{ operate_as_profile_url_template }}"
+        data-link-text-template="{% blocktrans %}View __USER__'s profile{% endblocktrans %}"
+        data-link-text-empty="{% trans "View selected user's profile" %}"
+        {% if not operate_as_profile_url %}style="display:none;"{% endif %}
+    >
+        <a
+            id="operate-as-profile-anchor"
+            href="{% if operate_as_profile_url %}{{ operate_as_profile_url }}{% else %}#{% endif %}"
+            target="_blank"
+            rel="noopener"
+        >
+            {% if operate_as_user %}
+                {% blocktrans with username=operate_as_user %}View {{ username }}'s profile{% endblocktrans %}
+            {% else %}
+                {% trans "View selected user's profile" %}
+            {% endif %}
+        </a>
+    </div>
+    {% endif %}
 </div>
+{% endblock %}
+
+{% block extrajs %}
+{{ block.super }}
+{% if operate_as_profile_url_template %}
+<script>
+(function() {
+    const container = document.getElementById("operate-as-profile-link");
+    if (!container) {
+        return;
+    }
+    const select = document.getElementById("id_operate_as");
+    if (!select) {
+        container.style.display = "none";
+        return;
+    }
+    const urlTemplate = container.dataset.urlTemplate || "";
+    const link = container.querySelector("a");
+    const textTemplate = container.dataset.linkTextTemplate || "";
+    const emptyText = container.dataset.linkTextEmpty || "";
+    const update = () => {
+        const value = select.value;
+        if (!value) {
+            container.style.display = "none";
+            if (link) {
+                link.removeAttribute("href");
+                if (emptyText) {
+                    link.textContent = emptyText;
+                }
+            }
+            return;
+        }
+        const selectedOption = select.options[select.selectedIndex];
+        const label = selectedOption ? selectedOption.text.trim() : "";
+        if (link) {
+            if (urlTemplate) {
+                link.href = urlTemplate.replace("__ID__", value);
+            }
+            if (label) {
+                if (textTemplate) {
+                    link.textContent = textTemplate.replace("__USER__", label);
+                } else if (emptyText) {
+                    link.textContent = emptyText;
+                }
+            } else if (emptyText) {
+                link.textContent = emptyText;
+            }
+        }
+        container.style.display = "";
+    };
+    select.addEventListener("change", update);
+    update();
+})();
+</script>
+{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- expose the selected Operate As user's profile context in the admin change view
- render a dynamic "Operate As" profile link in the user change form template
- add a Todo fixture to manually validate the updated user change screen

## Testing
- pytest core/tests.py -k operate_as *(fails: import mismatch between core.tests package and core/tests.py module)*

------
https://chatgpt.com/codex/tasks/task_e_68cf33decbcc8326bca095798314fe88