### PR TITLE
Add throttling and honeypot to invitation requests

### DIFF
--- a/pages/templates/pages/request_invite.html
+++ b/pages/templates/pages/request_invite.html
@@ -15,16 +15,48 @@
       <form method="post">
         {% csrf_token %}{# ensure CSRF token is included for POST submissions #}
         {{ form.non_field_errors }}
-      <div class="mb-3">
-        <label for="id_email" class="form-label">{% trans "Email" %}</label>
-        <input type="email" name="email" class="form-control" id="id_email" required>
-      </div>
-      <div class="mb-3">
-        <label for="id_comment" class="form-label">{% trans "Comment" %}</label>
-        <textarea name="comment" class="form-control" id="id_comment"></textarea>
-      </div>
-      <button type="submit" class="btn btn-primary w-100">{% trans "Send invitation" %}</button>
-    </form>
+        <div class="visually-hidden" aria-hidden="true" style="position: absolute; left: -10000px;">
+          <label for="{{ form.honeypot.id_for_label }}">{{ form.honeypot.label }}</label>
+          <input
+            type="text"
+            name="{{ form.honeypot.name }}"
+            id="{{ form.honeypot.id_for_label }}"
+            value="{{ form.honeypot.value|default_if_none:'' }}"
+            autocomplete="off"
+          >
+        </div>
+        {{ form.timestamp }}
+        <div class="mb-3">
+          <label for="{{ form.email.id_for_label }}" class="form-label">{% trans "Email" %}</label>
+          <input
+            type="email"
+            name="{{ form.email.name }}"
+            class="form-control{% if form.email.errors %} is-invalid{% endif %}"
+            id="{{ form.email.id_for_label }}"
+            value="{{ form.email.value|default_if_none:'' }}"
+            required
+          >
+          {% if form.email.errors %}
+            {% for error in form.email.errors %}
+              <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
+          {% endif %}
+        </div>
+        <div class="mb-3">
+          <label for="{{ form.comment.id_for_label }}" class="form-label">{% trans "Comment" %}</label>
+          <textarea
+            name="{{ form.comment.name }}"
+            class="form-control{% if form.comment.errors %} is-invalid{% endif %}"
+            id="{{ form.comment.id_for_label }}"
+          >{{ form.comment.value|default_if_none:'' }}</textarea>
+          {% if form.comment.errors %}
+            {% for error in form.comment.errors %}
+              <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
+          {% endif %}
+        </div>
+        <button type="submit" class="btn btn-primary w-100">{% trans "Send invitation" %}</button>
+      </form>
     {% endif %}
   </div>
 </div>

--- a/tests/test_request_invite.py
+++ b/tests/test_request_invite.py
@@ -1,0 +1,119 @@
+import datetime
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import InviteLead
+from pages import views as pages_views
+
+
+_TIMESTAMP_WIDGET = pages_views.InvitationRequestForm().fields["timestamp"].widget
+
+
+def _timestamp_value(extra_seconds: int = 2) -> str:
+    """Return a formatted timestamp older than the minimum submission interval."""
+
+    offset = pages_views.INVITATION_REQUEST_MIN_SUBMISSION_INTERVAL + datetime.timedelta(
+        seconds=extra_seconds
+    )
+    return _TIMESTAMP_WIDGET.format_value(timezone.now() - offset)
+
+
+@pytest.fixture(autouse=True)
+def stub_invitation_dependencies(monkeypatch):
+    """Avoid external dependencies when exercising the invite request view."""
+
+    monkeypatch.setattr(
+        pages_views.public_wifi, "resolve_mac_address", lambda *_: None, raising=False
+    )
+    monkeypatch.setattr(
+        pages_views.Node, "get_local", classmethod(lambda cls: None), raising=False
+    )
+    monkeypatch.setattr(
+        pages_views.mailer,
+        "send",
+        lambda *args, **kwargs: "ok",
+        raising=False,
+    )
+
+
+def test_request_invite_accepts_valid_submission():
+    client = Client()
+    email = "valid-invite@example.com"
+    InviteLead.objects.filter(email=email).delete()
+
+    response = client.post(
+        reverse("pages:request-invite"),
+        {
+            "email": email,
+            "comment": "I'd like to try the platform.",
+            "timestamp": _timestamp_value(),
+            "honeypot": "",
+        },
+    )
+
+    assert response.status_code == 200
+    assert InviteLead.objects.filter(email=email).count() == 1
+    assert response.context["sent"] is True
+    assert not response.context["form"].errors
+
+
+def test_request_invite_rejects_honeypot_submission():
+    client = Client()
+    email = "bot@example.com"
+    InviteLead.objects.filter(email=email).delete()
+
+    response = client.post(
+        reverse("pages:request-invite"),
+        {
+            "email": email,
+            "comment": "",
+            "timestamp": _timestamp_value(),
+            "honeypot": "spam bot",
+        },
+    )
+
+    assert response.status_code == 200
+    assert not InviteLead.objects.filter(email=email).exists()
+    errors = response.context["form"].non_field_errors()
+    assert pages_views.INVITATION_REQUEST_HONEYPOT_MESSAGE in errors
+
+
+def test_request_invite_throttles_repeated_requests():
+    client = Client()
+    email = "limit@example.com"
+    ip_address = "203.0.113.10"
+    InviteLead.objects.filter(email=email).delete()
+
+    limit = pages_views.INVITATION_REQUEST_THROTTLE_LIMIT
+    for _ in range(limit):
+        lead = InviteLead.objects.create(
+            email=email,
+            comment="",
+            path="/request-invite/",
+            referer="",
+            user_agent="tests",
+            ip_address=ip_address,
+        )
+        InviteLead.objects.filter(pk=lead.pk).update(
+            created_on=timezone.now() - datetime.timedelta(minutes=1)
+        )
+
+    response = client.post(
+        reverse("pages:request-invite"),
+        {
+            "email": email,
+            "comment": "",
+            "timestamp": _timestamp_value(),
+            "honeypot": "",
+        },
+        REMOTE_ADDR=ip_address,
+    )
+
+    assert response.status_code == 200
+    assert InviteLead.objects.filter(email=email).count() == limit
+    assert response.context["sent"] is False
+    errors = response.context["form"].non_field_errors()
+    assert pages_views.INVITATION_REQUEST_THROTTLE_MESSAGE in errors


### PR DESCRIPTION
## Summary
- add hidden honeypot/timestamp validation and throttling limits to the invitation request flow
- render the honeypot field in the invitation template while preserving submitted values and errors
- add regression tests covering valid, honeypot, and throttled submissions

## Testing
- pytest tests/test_request_invite.py

------
https://chatgpt.com/codex/tasks/task_e_68cf320b8e6c8326ac1e21ea20c1a57f