### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,40 @@ jobs:
                       fh.write(f"| {entry['role']} | {features} |\n")
                   fh.write('\n')
           PY
+  node-tests:
+    needs: node-test-matrix
+    if: needs.node-test-matrix.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.node-test-matrix.outputs.matrix) }}
+    env:
+      NODE_ROLE: ${{ matrix.role }}
+      NODE_FEATURES: ${{ matrix.features }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run pytest with coverage
+        run: |
+          if [ -z "${NODE_FEATURES}" ]; then
+            unset NODE_FEATURES
+          fi
+          coverage run --data-file=.coverage.${{ matrix.role }} -m pytest tests
+          coverage report
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.role }}
+          path: .coverage.${{ matrix.role }}
+
   check-migrations:
     needs: node-test-matrix
     if: needs.node-test-matrix.outputs.database_changed == 'true'
@@ -63,6 +97,89 @@ jobs:
       - name: Check for missing migrations
         run: |
           python manage.py makemigrations --check --dry-run --noinput
+
+  coverage-report:
+    needs:
+      - node-test-matrix
+      - node-tests
+    if: needs.node-test-matrix.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: coverage-data
+      - name: Install coverage tooling
+        run: |
+          pip install coverage[toml]==7.10.6
+      - name: Combine coverage data
+        run: |
+          coverage combine coverage-data
+          coverage report
+          coverage xml -o coverage.xml
+          coverage json -o coverage.json
+      - name: Publish coverage summary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from collections import defaultdict
+          from pathlib import Path
+
+          data = json.loads(Path('coverage.json').read_text(encoding='utf-8'))
+          totals = data.get('totals', {})
+          total_statements = totals.get('num_statements', 0)
+          missing_statements = totals.get('missing_lines', 0)
+          if total_statements:
+              overall = (total_statements - missing_statements) / total_statements * 100
+          else:
+              overall = 100.0
+
+          package_stats: dict[str, dict[str, int]] = defaultdict(lambda: {'stmts': 0, 'miss': 0})
+          for path, info in data.get('files', {}).items():
+              summary = info.get('summary', {})
+              if not summary:
+                  continue
+              package = path.split('/', 1)[0]
+              if package == 'tests':
+                  continue
+              package_stats[package]['stmts'] += int(summary.get('num_statements', 0))
+              package_stats[package]['miss'] += int(summary.get('missing_lines', 0))
+
+          summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
+          lines = [
+              '## Test coverage\n',
+              '\n',
+              f"* **Total statements:** {total_statements}\n",
+              f"* **Missing statements:** {missing_statements}\n",
+              f"* **Overall coverage:** {overall:.2f}%\n",
+          ]
+
+          if package_stats:
+              lines.extend(['\n', '| Package | Stmts | Miss | Coverage |\n', '| --- | ---: | ---: | ---: |\n'])
+              for package, stats in sorted(package_stats.items(), key=lambda item: (-item[1]['stmts'], item[0])):
+                  stmts = stats['stmts']
+                  miss = stats['miss']
+                  coverage = 'n/a' if stmts == 0 else f"{((stmts - miss) / stmts) * 100:.2f}%"
+                  lines.append(f"| {package} | {stmts} | {miss} | {coverage} |\n")
+          lines.append('\n')
+
+          with summary_path.open('a', encoding='utf-8') as handle:
+              handle.writelines(lines)
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.xml
 
   env-refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.role }}
-          path: .coverage.${{ matrix.role }}
+          path: .coverage.${{ matrix.role }}*
 
   check-migrations:
     needs: node-test-matrix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,35 @@ Homepage = "https://arthexis.com"
 
 [tool.setuptools]
 packages = [ "core", "config", "nodes", "ocpp", "pages",]
+
+[tool.coverage.run]
+branch = true
+parallel = true
+relative_files = true
+source = [
+    "app",
+    "awg",
+    "config",
+    "core",
+    "gway",
+    "nodes",
+    "ocpp",
+    "pages",
+    "projects",
+    "utils",
+]
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+    "manage.py",
+]
+
+[tool.coverage.report]
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+    "manage.py",
+]
+precision = 2
+show_missing = true
+skip_empty = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ click-plugins==1.1.1.2
 click-repl==0.3.0
 colorama==0.4.6
 constantly==23.10.4
+coverage[toml]==7.10.6
 cron-descriptor==1.4.5
 cryptography==45.0.5
 daphne==4.2.1
@@ -60,6 +61,7 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 pyOpenSSL==25.1.0
 pyperclip==1.9.0
+pytest==8.4.2
 PySocks==1.7.1
 python-crontab==3.3.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
- run the node test matrix under coverage, upload per-role data, and publish the combined report in CI
- configure coverage.py to focus on project packages and expose detailed package summaries
- pin pytest and coverage as project dependencies so the workflow can install the required tooling

## Testing
- coverage run --data-file=.coverage.local -m pytest tests/test_release_checklist.py


------
https://chatgpt.com/codex/tasks/task_e_68cf369a48b48326b63db8a6d6fd1f1d