### PR TITLE
Add spacing separators to client report form sections

### DIFF
--- a/core/templates/admin/core/clientreport/generate.html
+++ b/core/templates/admin/core/clientreport/generate.html
@@ -174,6 +174,17 @@
     color: var(--body-quiet-color, #6b7280);
   }
 
+  .client-report-form .report-section > *:not(legend):not(.section-description) {
+    padding: 0.75rem 0;
+  }
+
+  .client-report-form
+    .report-section
+    > *:not(legend):not(.section-description)
+    + *:not(legend):not(.section-description) {
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
   .client-report-form .form-group {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add vertical padding within client report form sections
- insert subtle divider lines between consecutive fields to improve separation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf473390dc8326ba0d035cce21f971