### PR TITLE
Improve client report section legend styling

### DIFF
--- a/core/templates/admin/core/clientreport/generate.html
+++ b/core/templates/admin/core/clientreport/generate.html
@@ -164,9 +164,17 @@
   .client-report-form .section-title {
     font-size: 1.1rem;
     font-weight: 600;
-    margin: 0 0 1.25rem;
-    padding-bottom: 0.5rem;
+  }
+
+  .client-report-form legend.section-title {
+    display: block;
+    box-sizing: border-box;
+    width: calc(100% + 3rem);
+    margin: -1.5rem -1.5rem 1.25rem;
+    padding: 1.25rem 1.5rem 1rem;
+    background-color: inherit;
     border-bottom: 1px solid var(--hairline-color, rgba(255, 255, 255, 0.15));
+    border-radius: 8px 8px 0 0;
   }
 
   .client-report-form .section-description {

--- a/pages/templates/pages/client_report.html
+++ b/pages/templates/pages/client_report.html
@@ -185,9 +185,17 @@
   .client-report-form .section-title {
     font-size: 1.1rem;
     font-weight: 600;
-    margin: 0 0 1.25rem;
-    padding-bottom: 0.5rem;
+  }
+
+  .client-report-form legend.section-title {
+    display: block;
+    box-sizing: border-box;
+    width: calc(100% + 3rem);
+    margin: -1.5rem -1.5rem 1.25rem;
+    padding: 1.25rem 1.5rem 1rem;
+    background-color: inherit;
     border-bottom: 1px solid var(--hairline-color, rgba(0, 0, 0, 0.12));
+    border-radius: 8px 8px 0 0;
   }
 
   .client-report-form .section-description {


### PR DESCRIPTION
## Summary
- update the client report form section legends to sit flush within the fieldset background on the public page
- mirror the legend styling adjustments on the admin client report generator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf46edac248326888d2a8334628799