### PR TITLE
Handle migration conflicts automatically in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           pip install -r requirements.txt
       - name: Check for missing migrations
         run: |
-          python manage.py makemigrations --check --dry-run --noinput
+          python scripts/check_migrations.py
 
   env-refresh:
     runs-on: ubuntu-latest

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -25,6 +25,18 @@ def _local_app_labels() -> list[str]:
     return labels
 
 
+def _run_makemigrations_check(labels: list[str]) -> subprocess.CompletedProcess:
+    """Run ``makemigrations --check --dry-run`` and return the completed process."""
+
+    return subprocess.run(
+        ["python", "manage.py", "makemigrations", *labels, "--check", "--dry-run"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def main() -> int:
     # Detect merge migrations
     known_merges = {REPO_ROOT / "core" / "migrations" / "0009_merge_20250901_2230.py"}
@@ -39,19 +51,52 @@ def main() -> int:
 
     # Ensure no new migrations are needed
     try:
-        subprocess.run(
-            ["python", "manage.py", "makemigrations", *labels, "--check", "--dry-run"],
-            cwd=REPO_ROOT,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        print(
-            "Uncommitted model changes detected. Please rewrite the latest migration.",
-            file=sys.stderr,
-        )
-        return 1
+        _run_makemigrations_check(labels)
+    except subprocess.CalledProcessError as err:
+        combined_output = (err.stdout or "") + (err.stderr or "")
+        if "Conflicting migrations detected" in combined_output:
+            print(
+                "Conflicting migrations detected; attempting automatic merge.",
+                file=sys.stderr,
+            )
+            merge_result = subprocess.run(
+                ["python", "manage.py", "makemigrations", "--merge", "--noinput"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            if merge_result.returncode != 0:
+                if merge_result.stdout:
+                    sys.stderr.write(merge_result.stdout)
+                if merge_result.stderr:
+                    sys.stderr.write(merge_result.stderr)
+                print(
+                    "Automatic merge failed. Please resolve migration conflicts manually.",
+                    file=sys.stderr,
+                )
+                return 1
+            try:
+                _run_makemigrations_check(labels)
+            except subprocess.CalledProcessError as follow_err:
+                if follow_err.stdout:
+                    sys.stderr.write(follow_err.stdout)
+                if follow_err.stderr:
+                    sys.stderr.write(follow_err.stderr)
+                print(
+                    "Uncommitted model changes detected. Please rewrite the latest migration.",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            if err.stdout:
+                sys.stderr.write(err.stdout)
+            if err.stderr:
+                sys.stderr.write(err.stderr)
+            print(
+                "Uncommitted model changes detected. Please rewrite the latest migration.",
+                file=sys.stderr,
+            )
+            return 1
 
     print("Migrations check passed.")
     return 0

--- a/tests/test_check_migrations_script.py
+++ b/tests/test_check_migrations_script.py
@@ -1,6 +1,10 @@
-from pathlib import Path
+import importlib
 import shutil
 import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -45,3 +49,54 @@ class Migration(migrations.Migration):
     )
     assert result.returncode != 0
     assert "Merge migrations detected" in result.stderr
+
+
+@pytest.fixture
+def conflicting_migration_state(monkeypatch: pytest.MonkeyPatch):
+    module = importlib.import_module("scripts.check_migrations")
+    monkeypatch.setattr(module, "_local_app_labels", lambda: ["core"])
+    monkeypatch.setattr(module.django, "setup", lambda: None)
+
+    calls: list[list[str]] = []
+    state = {"first": True}
+
+    def fake_run(args: list[str], **kwargs):
+        calls.append(args)
+        if "--merge" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if "--check" in args and "--dry-run" in args:
+            if state["first"]:
+                state["first"] = False
+                error = subprocess.CalledProcessError(
+                    1,
+                    args,
+                    output=(
+                        "Conflicting migrations detected; multiple leaf nodes in the migration graph: "
+                        "core.0001, core.0002"
+                    ),
+                    stderr="",
+                )
+                # ``CalledProcessError`` produced by ``subprocess.run`` exposes both
+                # ``output`` and ``stdout`` attributes. Mirror that behaviour so the
+                # script can inspect the captured output just like in production.
+                error.stdout = error.output  # type: ignore[attr-defined]
+                raise error
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected command: {args}")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    return module, calls
+
+
+def test_conflicting_migrations_trigger_merge(
+    conflicting_migration_state: tuple[ModuleType, list[list[str]]]
+) -> None:
+    module, calls = conflicting_migration_state
+    exit_code = module.main()
+
+    assert exit_code == 0
+    check_calls = [cmd for cmd in calls if "--check" in cmd and "--dry-run" in cmd]
+    merge_calls = [cmd for cmd in calls if "--merge" in cmd]
+
+    assert len(check_calls) == 2
+    assert len(merge_calls) == 1


### PR DESCRIPTION
## Summary
- enhance `scripts/check_migrations.py` to capture makemigrations output, automatically merge conflicts, and surface helpful error context
- extend the migration check tests with a fixture that simulates a conflict and asserts the merge retry path
- invoke the migration check script from the CI workflow so the auto-merge logic runs in automation

## Testing
- pytest tests/test_check_migrations_script.py

------
https://chatgpt.com/codex/tasks/task_e_68cf47403e748326a23d02be8ba716fc