### PR TITLE
Add automated migration merge handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           pip install -r requirements.txt
       - name: Check for missing migrations
         run: |
-          python manage.py makemigrations --check --dry-run --noinput
+          python scripts/check_migrations.py
 
   env-refresh:
     runs-on: ubuntu-latest

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable
 
 import django
 from django.apps import apps
@@ -25,6 +26,71 @@ def _local_app_labels() -> list[str]:
     return labels
 
 
+def _run_manage(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python", "manage.py", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _combine_process_output(result: subprocess.CompletedProcess[str]) -> str:
+    parts: list[str] = []
+    if result.stdout:
+        parts.append(result.stdout)
+    if result.stderr:
+        parts.append(result.stderr)
+    return "\n".join(part.strip() for part in parts if part.strip())
+
+
+def _report_failure(message: str, result: subprocess.CompletedProcess[str]) -> None:
+    print(message, file=sys.stderr)
+    combined = _combine_process_output(result)
+    if combined:
+        print(combined, file=sys.stderr)
+
+
+def _check_migrations(labels: Iterable[str]) -> int:
+    labels_list = list(labels)
+    check_args = ("makemigrations", *labels_list, "--check", "--dry-run", "--noinput")
+    check_result = _run_manage(*check_args)
+    if check_result.returncode == 0:
+        print("Migrations check passed.")
+        return 0
+
+    combined = _combine_process_output(check_result)
+    if "Conflicting migrations detected" in combined:
+        print(
+            "Conflicting migrations detected; attempting automatic merge.",
+            file=sys.stderr,
+        )
+        merge_result = _run_manage("makemigrations", *labels_list, "--merge", "--noinput")
+        if merge_result.returncode != 0:
+            _report_failure("Automatic merge failed.", merge_result)
+            return 1
+
+        post_merge = _run_manage(*check_args)
+        if post_merge.returncode == 0:
+            print("Automatic merge migration created.", file=sys.stderr)
+            print("Migrations check passed.")
+            return 0
+
+        _report_failure(
+            "Automatic merge created but migrations are still inconsistent.",
+            post_merge,
+        )
+        return 1
+
+    print(
+        "Uncommitted model changes detected. Please rewrite the latest migration.",
+        file=sys.stderr,
+    )
+    if combined:
+        print(combined, file=sys.stderr)
+    return 1
+
+
 def main() -> int:
     # Detect merge migrations
     known_merges = {REPO_ROOT / "core" / "migrations" / "0009_merge_20250901_2230.py"}
@@ -36,25 +102,7 @@ def main() -> int:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     django.setup()
     labels = _local_app_labels()
-
-    # Ensure no new migrations are needed
-    try:
-        subprocess.run(
-            ["python", "manage.py", "makemigrations", *labels, "--check", "--dry-run"],
-            cwd=REPO_ROOT,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        print(
-            "Uncommitted model changes detected. Please rewrite the latest migration.",
-            file=sys.stderr,
-        )
-        return 1
-
-    print("Migrations check passed.")
-    return 0
+    return _check_migrations(labels)
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry

--- a/tests/test_check_migrations_script.py
+++ b/tests/test_check_migrations_script.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 import shutil
 import subprocess
+from types import SimpleNamespace
+
+import scripts.check_migrations as check_migrations
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -45,3 +48,33 @@ class Migration(migrations.Migration):
     )
     assert result.returncode != 0
     assert "Merge migrations detected" in result.stderr
+
+
+def test_check_migrations_attempts_merge(monkeypatch, capsys) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run_manage(*args: str) -> SimpleNamespace:
+        calls.append(args)
+        if "--merge" in args:
+            return SimpleNamespace(returncode=0, stdout="Merged", stderr="")
+        if "--check" in args and len(calls) == 1:
+            return SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="Conflicting migrations detected; run makemigrations --merge.",
+            )
+        return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    monkeypatch.setattr(check_migrations, "_run_manage", fake_run_manage)
+    result = check_migrations._check_migrations(["core"])
+
+    assert result == 0
+    assert calls == [
+        ("makemigrations", "core", "--check", "--dry-run", "--noinput"),
+        ("makemigrations", "core", "--merge", "--noinput"),
+        ("makemigrations", "core", "--check", "--dry-run", "--noinput"),
+    ]
+
+    captured = capsys.readouterr()
+    assert "Conflicting migrations detected" in captured.err
+    assert "Migrations check passed" in captured.out

--- a/tests/test_env_refresh_clean.py
+++ b/tests/test_env_refresh_clean.py
@@ -1,5 +1,7 @@
+import importlib.util
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def test_env_refresh_leaves_repo_clean(tmp_path):
@@ -17,3 +19,47 @@ def test_env_refresh_leaves_repo_clean(tmp_path):
         check=True,
     )
     assert result.stdout.strip() == ""
+
+
+def test_env_refresh_stashes_merge_migrations(monkeypatch, capsys):
+    repo_root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "env_refresh_stash", repo_root / "env-refresh.py"
+    )
+    env_refresh = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(env_refresh)
+
+    monkeypatch.setattr(
+        env_refresh,
+        "_merge_migration_paths",
+        lambda base_dir: ["core/migrations/9999_merge_auto.py"],
+    )
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(env_refresh.subprocess, "run", fake_run)
+
+    env_refresh._stash_merge_migrations(
+        repo_root, reason="Conflicting migrations detected"
+    )
+
+    assert run_calls == [
+        [
+            "git",
+            "stash",
+            "push",
+            "--include-untracked",
+            "-m",
+            "env-refresh merge migrations",
+            "--",
+            "core/migrations/9999_merge_auto.py",
+        ]
+    ]
+
+    captured = capsys.readouterr()
+    assert "due to conflicting migrations" in captured.out


### PR DESCRIPTION
## Summary
- teach the migration check script to retry `makemigrations` with `--merge` and re-run the dry-run check
- update the CI migration check to invoke the script so auto-merging runs in automation
- stash merge migrations created during env refresh/upgrade runs and cover both behaviours with new tests

## Testing
- pytest tests/test_check_migrations_script.py tests/test_env_refresh_clean.py

------
https://chatgpt.com/codex/tasks/task_e_68cf466fee808326827846b9985c147c