### PR TITLE
Fix admin related widget button layout

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -256,17 +256,38 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     background: var(--selected-row);
 }
 
+.related-widget-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: nowrap;
+}
+
+.related-widget-wrapper input,
+.related-widget-wrapper select,
+.related-widget-wrapper textarea {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto !important;
+}
+
 /* Ensure related object buttons match theme */
 .related-widget-wrapper-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 2px;
-    margin-left: 4px;
+    box-sizing: border-box;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
     border: 1px solid var(--border-color);
     border-radius: 4px;
     background: var(--button-bg);
     color: var(--button-fg);
+}
+
+.related-widget-wrapper > .related-widget-wrapper-link {
+    margin-left: 0;
 }
 
 .related-widget-wrapper-link:hover {


### PR DESCRIPTION
## Summary
- keep related reference widgets inline and prevent controls from wrapping onto new lines
- allow the related reference input to flex while sizing action buttons to square dimensions for consistent styling

## Testing
- not run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf4b1398c883269d63bf176a1e8034