### PR TITLE
Allow admin account to own user data

### DIFF
--- a/core/user_data.py
+++ b/core/user_data.py
@@ -44,9 +44,6 @@ def _user_allows_user_data(user) -> bool:
         return False
     username = _username_for(user)
     UserModel = get_user_model()
-    admin_username = getattr(UserModel, "ADMIN_USERNAME", "")
-    if admin_username and username == admin_username:
-        return False
     system_username = getattr(UserModel, "SYSTEM_USERNAME", "")
     if system_username and username == system_username:
         return True


### PR DESCRIPTION
## Summary
- allow the admin account to own user data fixtures by removing the username guard
- update the admin fixture regression test to expect fixtures stored under the admin account even when a system delegate is configured

## Testing
- pytest tests/test_user_data_admin.py *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4a46e8808326ae09d8ca72067546