### PR TITLE
Handle HTTPS when registering visitor nodes

### DIFF
--- a/nodes/templates/admin/nodes/node/register_remote.html
+++ b/nodes/templates/admin/nodes/node/register_remote.html
@@ -8,10 +8,63 @@
 <script>
 (async function() {
     const token = "{{ token }}";
-    const infoUrl = "http://localhost:8000/nodes/info/?token=" + token;
+
+    function buildUrlVariants(url) {
+        const variants = [];
+        try {
+            const parsed = new URL(url, window.location.href);
+            if (parsed.protocol === "http:") {
+                const secure = new URL(parsed.href);
+                secure.protocol = "https:";
+                variants.push(secure.href);
+            }
+            variants.push(parsed.href);
+        } catch (err) {
+            variants.push(url);
+        }
+        return variants.filter((value, index, self) => self.indexOf(value) === index);
+    }
+
+    async function fetchJson(url, options) {
+        const response = await fetch(url, options);
+        const text = await response.text();
+        let payload;
+        try {
+            payload = JSON.parse(text);
+        } catch (err) {
+            payload = text;
+        }
+        if (!response.ok) {
+            const detail = payload && payload.detail ? payload.detail : text || response.statusText;
+            throw new Error(detail);
+        }
+        return payload;
+    }
+
+    async function fetchJsonWithFallback(urls, options) {
+        const targets = Array.isArray(urls) ? urls : [urls];
+        let lastError = null;
+        for (const target of targets) {
+            try {
+                return await fetchJson(target, options);
+            } catch (error) {
+                const message = error && error.message ? error.message : "";
+                if (error instanceof TypeError || message === "Failed to fetch") {
+                    lastError = error;
+                    continue;
+                }
+                throw error;
+            }
+        }
+        if (lastError) {
+            throw lastError;
+        }
+        throw new Error("Request failed");
+    }
+
     try {
-        const infoResp = await fetch(infoUrl);
-        const info = await infoResp.json();
+        const infoTargets = buildUrlVariants("http://localhost:8000/nodes/info/?token=" + token);
+        const info = await fetchJsonWithFallback(infoTargets);
         const resp = await fetch("{{ register_url }}", {
             method: "POST",
             headers: {"Content-Type": "application/json"},
@@ -28,7 +81,8 @@
         const result = await resp.json();
         document.getElementById("result").textContent = result.detail || ("Registered node ID " + result.id);
     } catch(err) {
-        document.getElementById("result").textContent = err;
+        const message = err && err.message ? err.message : err;
+        document.getElementById("result").textContent = message;
     }
 })();
 </script>

--- a/nodes/templates/admin/nodes/node/register_visitor.html
+++ b/nodes/templates/admin/nodes/node/register_visitor.html
@@ -26,7 +26,7 @@
     const token = "{{ token|escapejs }}";
     const hostInfoUrl = "{{ info_url|escapejs }}?token=" + token;
     const hostRegisterUrl = "{{ register_url|escapejs }}";
-    const visitorInfoUrl = "{{ visitor_info_url|escapejs }}?token=" + token;
+    const visitorInfoUrl = "{{ visitor_info_url|escapejs }}";
     const visitorRegisterUrl = "{{ visitor_register_url|escapejs }}";
     const hostResult = document.getElementById("host-result");
     const visitorResult = document.getElementById("visitor-result");
@@ -69,6 +69,43 @@
         return payload;
     }
 
+    function buildUrlVariants(url) {
+        const variants = [];
+        try {
+            const parsed = new URL(url, window.location.href);
+            if (parsed.protocol === "http:") {
+                const secure = new URL(parsed.href);
+                secure.protocol = "https:";
+                variants.push(secure.href);
+            }
+            variants.push(parsed.href);
+        } catch (err) {
+            variants.push(url);
+        }
+        return variants.filter((value, index, self) => self.indexOf(value) === index);
+    }
+
+    async function requestWithFallback(urls, options) {
+        const targets = Array.isArray(urls) ? urls : [urls];
+        let lastError = null;
+        for (const target of targets) {
+            try {
+                return await loadJson(target, options);
+            } catch (error) {
+                const message = error && error.message ? error.message : "";
+                if (error instanceof TypeError || message === "Failed to fetch") {
+                    lastError = error;
+                    continue;
+                }
+                throw error;
+            }
+        }
+        if (lastError) {
+            throw lastError;
+        }
+        throw new Error("Request failed");
+    }
+
     function buildPayload(info) {
         return {
             hostname: info.hostname,
@@ -89,9 +126,12 @@
 
     (async function() {
         try {
+            const visitorInfoTargets = buildUrlVariants(visitorInfoUrl + "?token=" + token);
+            const visitorInfoPromise = requestWithFallback(visitorInfoTargets);
+            const hostInfoPromise = loadJson(hostInfoUrl);
             const [visitorInfo, hostInfo] = await Promise.all([
-                loadJson(visitorInfoUrl),
-                loadJson(hostInfoUrl),
+                visitorInfoPromise,
+                hostInfoPromise,
             ]);
 
             if (!visitorInfo || typeof visitorInfo !== "object") {
@@ -122,7 +162,8 @@
             const visitorPayload = buildPayload(hostInfo);
             addSignature(visitorPayload, hostInfo);
             try {
-                const result = await loadJson(visitorRegisterUrl, {
+                const visitorRegisterTargets = buildUrlVariants(visitorRegisterUrl);
+                const result = await requestWithFallback(visitorRegisterTargets, {
                     method: "POST",
                     credentials: "include",
                     body: JSON.stringify(visitorPayload),


### PR DESCRIPTION
## Summary
- allow the visitor registration admin view to try HTTPS endpoints for visitor info and registration, with HTTP fallback when needed
- mirror the HTTPS fallback logic for the local node registration helper to avoid mixed-content fetch failures

## Testing
- pytest nodes/tests.py::NodeTests *(fails: django.db.utils.OperationalError: no such table: core_user)*

------
https://chatgpt.com/codex/tasks/task_e_68cf578e20548326a3a07f3e6d202a0b