### PR TITLE
Adjust auto-upgrade interval for latest channel

### DIFF
--- a/core/auto_upgrade.py
+++ b/core/auto_upgrade.py
@@ -39,9 +39,12 @@ def ensure_auto_upgrade_periodic_task(
     except Exception:
         return
 
+    mode = mode_file.read_text().strip() or "version"
+    interval_minutes = 5 if mode == "latest" else 10
+
     try:
         schedule, _ = IntervalSchedule.objects.get_or_create(
-            every=10, period=IntervalSchedule.MINUTES
+            every=interval_minutes, period=IntervalSchedule.MINUTES
         )
         PeriodicTask.objects.update_or_create(
             name=AUTO_UPGRADE_TASK_NAME,

--- a/tests/test_auto_upgrade_scheduler.py
+++ b/tests/test_auto_upgrade_scheduler.py
@@ -11,12 +11,27 @@ def test_ensure_auto_upgrade_task_skips_without_lock(tmp_path):
     assert not PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).exists()
 
 
-def test_ensure_auto_upgrade_task_creates_periodic(tmp_path):
+def test_ensure_auto_upgrade_task_uses_latest_interval(tmp_path):
     PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
 
     locks_dir = tmp_path / "locks"
     locks_dir.mkdir()
     (locks_dir / "auto_upgrade.lck").write_text("latest")
+
+    ensure_auto_upgrade_periodic_task(base_dir=tmp_path)
+
+    task = PeriodicTask.objects.get(name=AUTO_UPGRADE_TASK_NAME)
+    assert task.task == AUTO_UPGRADE_TASK_PATH
+    assert task.interval.every == 5
+    assert task.interval.period == IntervalSchedule.MINUTES
+
+
+def test_ensure_auto_upgrade_task_uses_version_interval(tmp_path):
+    PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
+
+    locks_dir = tmp_path / "locks"
+    locks_dir.mkdir()
+    (locks_dir / "auto_upgrade.lck").write_text("version")
 
     ensure_auto_upgrade_periodic_task(base_dir=tmp_path)
 


### PR DESCRIPTION
## Summary
- update the auto-upgrade scheduler to respect the latest channel's 5-minute cadence
- extend scheduler tests to cover both latest and version channel intervals

## Testing
- pytest tests/test_auto_upgrade_scheduler.py *(fails: django.core.management.base.CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5a816a248326a739d314e0d0e3a7