### PR TITLE
Allow visitor registration without admin login

### DIFF
--- a/nodes/management/commands/check_registration_ready.py
+++ b/nodes/management/commands/check_registration_ready.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+from secrets import token_hex
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.test import Client
+from django.urls import reverse
+
+from nodes.models import Node
+
+
+class Command(BaseCommand):
+    help = "Verify that this node is ready to register with a host it visits."
+
+    def handle(self, *args, **options):
+        node, created = Node.register_current()
+        ready = True
+
+        if created:
+            self.stdout.write(
+                self.style.SUCCESS(f"Registered current node as {node.hostname}:{node.port}.")
+            )
+        else:
+            self.stdout.write(
+                f"Current node record refreshed ({node.hostname}:{node.port})."
+            )
+
+        security_dir = Path(node.base_path or settings.BASE_DIR) / "security"
+        priv_path = security_dir / f"{node.public_endpoint}"
+        pub_path = security_dir / f"{node.public_endpoint}.pub"
+
+        missing_files = [path.name for path in (priv_path, pub_path) if not path.exists()]
+        if missing_files:
+            ready = False
+            self.stderr.write(
+                self.style.ERROR(
+                    "Missing security key files: " + ", ".join(sorted(missing_files))
+                )
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS("Security key files are present."))
+
+        if node.public_key:
+            self.stdout.write(self.style.SUCCESS("Public key is stored in the database."))
+        else:
+            ready = False
+            self.stderr.write(self.style.ERROR("Public key is not stored in the database."))
+
+        client = Client()
+        token = token_hex(16)
+
+        info_response = client.get(reverse("node-info"), {"token": token})
+        if info_response.status_code != 200:
+            ready = False
+            self.stderr.write(
+                self.style.ERROR(
+                    f"/nodes/info/ returned status {info_response.status_code}."
+                )
+            )
+            info_data = {}
+        else:
+            self.stdout.write(
+                self.style.SUCCESS("Local /nodes/info/ endpoint responded successfully.")
+            )
+            try:
+                info_data = info_response.json()
+            except ValueError:
+                ready = False
+                self.stderr.write(
+                    self.style.ERROR("/nodes/info/ did not return valid JSON data.")
+                )
+                info_data = {}
+
+        if info_data:
+            if info_data.get("token_signature"):
+                self.stdout.write(self.style.SUCCESS("Token signing is available."))
+            else:
+                ready = False
+                self.stderr.write(
+                    self.style.ERROR(
+                        "Token signing is unavailable. The private key may be missing or unreadable."
+                    )
+                )
+
+        register_url = reverse("register-node")
+        options_response = client.options(
+            register_url,
+            HTTP_ORIGIN="https://example.com",
+        )
+        if (
+            options_response.status_code == 200
+            and options_response.get("Access-Control-Allow-Origin") == "https://example.com"
+        ):
+            self.stdout.write(
+                self.style.SUCCESS("CORS preflight for /nodes/register/ succeeded.")
+            )
+        else:
+            ready = False
+            self.stderr.write(
+                self.style.ERROR("CORS preflight for /nodes/register/ failed.")
+            )
+
+        if info_data.get("token_signature"):
+            payload = {
+                "hostname": info_data.get("hostname"),
+                "address": info_data.get("address"),
+                "port": info_data.get("port"),
+                "mac_address": info_data.get("mac_address"),
+                "public_key": info_data.get("public_key"),
+                "token": token,
+                "signature": info_data.get("token_signature"),
+            }
+            if "features" in info_data:
+                payload["features"] = info_data["features"]
+
+            register_response = client.post(
+                register_url,
+                data=json.dumps(payload),
+                content_type="application/json",
+                HTTP_ORIGIN="https://example.com",
+            )
+            if register_response.status_code == 200:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Signed registration request completed successfully."
+                    )
+                )
+            else:
+                ready = False
+                self.stderr.write(
+                    self.style.ERROR(
+                        "Signed registration request failed with status "
+                        f"{register_response.status_code}: {register_response.content.decode(errors='ignore')}"
+                    )
+                )
+        else:
+            ready = False
+            self.stderr.write(
+                self.style.ERROR(
+                    "Skipping signed registration test because token signing is unavailable."
+                )
+            )
+
+        if not ready:
+            raise CommandError(
+                "Visitor registration is not ready. Review the errors above and retry."
+            )
+
+        self.stdout.write(self.style.SUCCESS("Visitor registration checks passed."))

--- a/nodes/templates/admin/nodes/node/register_visitor.html
+++ b/nodes/templates/admin/nodes/node/register_visitor.html
@@ -39,6 +39,7 @@
         aborted: "{{ _('Registration aborted.')|escapejs }}",
         visitorInfoError: "{{ _('Unable to read visitor node information.')|escapejs }}",
         hostInfoError: "{{ _('Unable to read host node information.')|escapejs }}",
+        fetchAdvice: "{{ _('Make sure the visiting node is reachable. Run "./manage.py check_registration_ready" on the visiting node to verify readiness.')|escapejs }}",
     };
 
     function setStatus(element, message, isError) {
@@ -106,6 +107,21 @@
         throw new Error("Request failed");
     }
 
+    function formatError(error) {
+        let message = "";
+        if (error && typeof error.message === "string") {
+            message = error.message;
+        } else if (typeof error === "string") {
+            message = error;
+        } else if (error) {
+            message = String(error);
+        }
+        if (message === "Failed to fetch") {
+            return `${message} — ${messages.fetchAdvice}`;
+        }
+        return message || messages.partial;
+    }
+
     function buildPayload(info) {
         return {
             hostname: info.hostname,
@@ -156,7 +172,7 @@
                     setStatus(hostResult, messages.hostRegistered, false);
                 }
             } catch (error) {
-                setStatus(hostResult, error.message, true);
+                setStatus(hostResult, formatError(error), true);
             }
 
             const visitorPayload = buildPayload(hostInfo);
@@ -174,7 +190,7 @@
                     setStatus(visitorResult, messages.visitorRegistered, false);
                 }
             } catch (error) {
-                setStatus(visitorResult, error.message, true);
+                setStatus(visitorResult, formatError(error), true);
             }
 
             if (!hostResult.classList.contains("errornote") && !visitorResult.classList.contains("errornote")) {
@@ -183,7 +199,7 @@
                 setStatus(summary, messages.partial, true);
             }
         } catch (error) {
-            const message = error.message || error;
+            const message = formatError(error);
             setStatus(summary, message, true);
             if (!hostResult.classList.contains("errornote")) {
                 setStatus(hostResult, messages.aborted, true);


### PR DESCRIPTION
## Summary
- allow token-signed visitor registrations to complete without requiring an authenticated session while keeping feature updates secured
- surface actionable guidance when visitor registration requests fail in the admin flow
- add a readiness management command and regression coverage for visitor registration scenarios

## Testing
- python manage.py test nodes --verbosity=2 *(fails: Conflicting migrations detected; multiple leaf nodes in core)*

------
https://chatgpt.com/codex/tasks/task_e_68cf60208d0c83268bc7b520f35bbae9