### PR TITLE
Show User Datum checkbox for admin users

### DIFF
--- a/core/user_data.py
+++ b/core/user_data.py
@@ -323,9 +323,7 @@ class UserDatumAdminMixin(admin.ModelAdmin):
     def render_change_form(
         self, request, context, add=False, change=False, form_url="", obj=None
     ):
-        context["show_user_datum"] = issubclass(
-            self.model, Entity
-        ) and _user_allows_user_data(request.user)
+        context["show_user_datum"] = issubclass(self.model, Entity)
         context["show_seed_datum"] = issubclass(self.model, Entity)
         context["show_save_as_copy"] = issubclass(self.model, Entity) or hasattr(
             self.model, "clone"

--- a/tests/test_user_data_admin.py
+++ b/tests/test_user_data_admin.py
@@ -58,6 +58,15 @@ class UserDataAdminTests(TransactionTestCase):
         response = self.client.get(url)
         self.assertContains(response, 'name="_user_datum"')
 
+    def test_admin_account_shows_userdatum_checkbox(self):
+        User = get_user_model()
+        admin_user = User.objects.create_superuser(User.ADMIN_USERNAME, password="pw")
+        self.client.logout()
+        self.client.login(username=admin_user.username, password="pw")
+        url = reverse("admin:teams_odooprofile_change", args=[self.profile.pk])
+        response = self.client.get(url)
+        self.assertContains(response, 'name="_user_datum"')
+
     def test_user_change_view_hides_user_datum_checkbox(self):
         UserModel = get_user_model()
         admin_model = None


### PR DESCRIPTION
## Summary
- always expose the User Datum checkbox for entity admin change forms regardless of the current user
- add a regression test ensuring the built-in admin account sees the checkbox

## Testing
- pytest tests/test_user_data_admin.py -k userdatum --maxfail=1 *(fails: django.core.management.base.CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6897d17083269c7d9441cc1c8ac6