### PR TITLE
Ensure visitor registration uses reachable node address

### DIFF
--- a/tests/test_node_info_view.py
+++ b/tests/test_node_info_view.py
@@ -1,0 +1,30 @@
+import uuid
+from unittest.mock import patch
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from nodes.models import Node
+
+
+class NodeInfoViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_node_info_uses_reachable_address(self):
+        mac = Node.get_current_mac()
+        slug = f"test-node-{uuid.uuid4().hex}"
+        defaults = {
+            "hostname": "test-host",
+            "address": "127.0.0.1",
+            "port": 8123,
+            "public_endpoint": slug,
+        }
+        node, _ = Node.objects.update_or_create(mac_address=mac, defaults=defaults)
+
+        with patch("nodes.views._get_route_address", return_value="10.42.0.1") as route_mock:
+            response = self.client.get(reverse("node-info"), REMOTE_ADDR="10.42.0.2")
+
+        payload = response.json()
+        self.assertEqual(payload["address"], "10.42.0.1")
+        route_mock.assert_called_once_with("10.42.0.2", node.port)


### PR DESCRIPTION
## Summary
- derive the advertised node address from the client connection so visitor registration uses a reachable IP
- cover the updated behaviour with a dedicated node info view test

## Testing
- pytest tests/test_node_info_view.py

------
https://chatgpt.com/codex/tasks/task_e_68cf6679f6588326a8da52fc90f28b38