### PR TITLE
Enable user datum controls for user admin

### DIFF
--- a/core/templates/admin/user_profile_change_form.html
+++ b/core/templates/admin/user_profile_change_form.html
@@ -3,28 +3,42 @@
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>
-    {% if operate_as_profile_url_template %}
-    <div
-        id="operate-as-profile-link"
-        data-url-template="{{ operate_as_profile_url_template }}"
-        data-link-text-template="{% blocktrans %}View __USER__'s profile{% endblocktrans %}"
-        data-link-text-empty="{% trans "View selected user's profile" %}"
-        {% if not operate_as_profile_url %}style="display:none;"{% endif %}
-    >
-        <a
-            id="operate-as-profile-anchor"
-            href="{% if operate_as_profile_url %}{{ operate_as_profile_url }}{% else %}#{% endif %}"
-            target="_blank"
-            rel="noopener"
+    <div style="display:flex; align-items:center; gap:1em; flex-wrap:wrap;">
+        {% if show_user_datum %}
+        <label style="color: var(--body-quiet-color); display:flex; align-items:center; gap:0.35rem;">
+            <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
+            <span>{% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]</span>
+        </label>
+        {% endif %}
+        {% if show_seed_datum %}
+        <label style="color: var(--body-quiet-color); display:flex; align-items:center; gap:0.35rem;">
+            <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
+            <span>{% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]</span>
+        </label>
+        {% endif %}
+        {% if operate_as_profile_url_template %}
+        <div
+            id="operate-as-profile-link"
+            data-url-template="{{ operate_as_profile_url_template }}"
+            data-link-text-template="{% blocktrans %}View __USER__'s profile{% endblocktrans %}"
+            data-link-text-empty="{% trans "View selected user's profile" %}"
+            {% if not operate_as_profile_url %}style="display:none;"{% endif %}
         >
-            {% if operate_as_user %}
-                {% blocktrans with username=operate_as_user %}View {{ username }}'s profile{% endblocktrans %}
-            {% else %}
-                {% trans "View selected user's profile" %}
-            {% endif %}
-        </a>
+            <a
+                id="operate-as-profile-anchor"
+                href="{% if operate_as_profile_url %}{{ operate_as_profile_url }}{% else %}#{% endif %}"
+                target="_blank"
+                rel="noopener"
+            >
+                {% if operate_as_user %}
+                    {% blocktrans with username=operate_as_user %}View {{ username }}'s profile{% endblocktrans %}
+                {% else %}
+                    {% trans "View selected user's profile" %}
+                {% endif %}
+            </a>
+        </div>
+        {% endif %}
     </div>
-    {% endif %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- expose the user datum admin mixin to the user admin so change views can surface the checkbox and persist fixtures when toggled
- refresh the user profile change form header to show the user datum controls alongside the operate-as link
- extend the user data admin tests to cover the user change view checkbox and saving/removing user fixtures

## Testing
- pytest tests/test_user_data_admin.py *(fails: django.core.management.base.CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68cf79c4def48326ae5d9d9678c45274