### PR TITLE
docs: clarify todo url guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Remember to store generated image files in base64 since binary files are not allowed in the repo.
 - When adding new models and no app is given or the model is assigned to a third-party admin group, create the model in core and link it to the provided admin group.
 - Release manager tasks should be added via fixtures for the `Todo` model so they appear in the admin Future Actions section. Include a `url` field when available so future-action links point to the relevant resource.
+  - When you provide a Django admin URL, confirm that the view actually exists. Use the `admin:<app>_<model>_<action>` route names with ``reverse`` (for example, ``python manage.py shell -c "from django.urls import reverse; print(reverse('admin:core_todo_changelist'))"``) or check the registered admin classes before linking. If there is no accessible admin page, leave the ``url`` blank and add guidance in ``request_details`` instead of pointing to a nonexistent path.
 - Whenever a user reports a repeated error or regression, create a corresponding Release manager `Todo` to review and validate the implemented solution.
 - After modifying a view or any part of the GUI, add a `Todo` fixture titled `Validate screen [Screen]` and set its `url` to the screen needing manual validation.
 - When stub code is necessary, use a NonImplemented exception and add a corresponding `Todo` fixture to track completion.


### PR DESCRIPTION
## Summary
- clarify agent guidance for release manager TODO fixtures
- document how to verify Django admin URLs before assigning them to Release Manager tasks

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d0032c30608326a5634501e80effee