### PR TITLE
Add related models section to admin change view

### DIFF
--- a/pages/templates/admin/change_form.html
+++ b/pages/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls static admin_modify %}
+{% load i18n admin_urls static admin_modify admin_extras %}
 
 {% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
 
@@ -140,6 +140,48 @@
         max-height: none;
       }
     }
+
+    .related-models {
+      margin-top: 2rem;
+    }
+
+    .related-models__title {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin: 0 0 0.75rem;
+    }
+
+    .related-models__list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .related-models__item {
+      margin: 0;
+    }
+
+    .related-models__link {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.35rem 0.75rem;
+      border-radius: 9999px;
+      border: 1px solid var(--border-color);
+      text-decoration: none;
+      font-weight: 600;
+      color: var(--body-fg);
+      transition: color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .related-models__link:hover,
+    .related-models__link:focus {
+      color: var(--link-fg);
+      border-color: var(--link-fg);
+      outline: none;
+    }
   </style>
 {% endblock %}
 
@@ -197,6 +239,20 @@
 {% block after_related_objects %}{% endblock %}
 
 {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+
+{% related_admin_models opts as related_models %}
+{% if related_models %}
+  <section class="related-models" aria-labelledby="related-models-title">
+    <h2 id="related-models-title" class="related-models__title">{% translate "Related Models" %}</h2>
+    <ul class="related-models__list">
+      {% for related in related_models %}
+        <li class="related-models__item">
+          <a class="related-models__link" href="{{ related.url }}">{{ related.label }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}
 
 {% block admin_change_form_document_ready %}
     <script id="django-admin-form-add-constants"


### PR DESCRIPTION
## Summary
- add a template tag that collects registered admin changelists for models related by relations or inheritance
- render a Related Models panel beneath the submit row in the admin change form with horizontal link styling

## Testing
- pytest *(fails: NameError: name 'Path' is not defined in tests/test_check_migrations_script.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d01122934083268e9a8c205d2900a0