### PR TITLE
Allow merge migrations in check script

### DIFF
--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify migration state: ensure no new migrations required and no merge migrations present."""
+"""Verify migration state: ensure no new migrations required."""
 import os
 import subprocess
 import sys
@@ -92,13 +92,6 @@ def _check_migrations(labels: Iterable[str]) -> int:
 
 
 def main() -> int:
-    # Detect merge migrations
-    known_merges = {REPO_ROOT / "core" / "migrations" / "0009_merge_20250901_2230.py"}
-    for path in REPO_ROOT.rglob("migrations/*merge*.py"):
-        if path not in known_merges:
-            print(f"Merge migrations detected: {path}", file=sys.stderr)
-            return 1
-
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     django.setup()
     labels = _local_app_labels()

--- a/tests/test_check_migrations_script.py
+++ b/tests/test_check_migrations_script.py
@@ -3,6 +3,8 @@ import shutil
 import subprocess
 from types import SimpleNamespace
 
+from pathlib import Path
+
 import scripts.check_migrations as check_migrations
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -24,7 +26,7 @@ def test_check_migrations_passes() -> None:
     assert result.returncode == 0
 
 
-def test_check_migrations_fails_on_merge(tmp_path: Path) -> None:
+def test_check_migrations_allows_merge(tmp_path: Path) -> None:
     repo = clone_repo(tmp_path)
     merge_file = repo / "core" / "migrations" / "0012_merge_fake.py"
     merge_file.parent.mkdir(parents=True, exist_ok=True)
@@ -46,8 +48,8 @@ class Migration(migrations.Migration):
         capture_output=True,
         text=True,
     )
-    assert result.returncode != 0
-    assert "Merge migrations detected" in result.stderr
+    assert result.returncode == 0
+    assert "Merge migrations detected" not in result.stderr
 
 
 def test_check_migrations_attempts_merge(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- allow merge migrations by removing the explicit failure in `scripts/check_migrations.py`
- update the migration check tests to cover the new behaviour

## Testing
- pytest tests/test_check_migrations_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d0176b4544832695324bd6050efdbe