### PR TITLE
Hide prepare next release action outside change view

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -346,7 +346,6 @@ class PackageAdmin(SaveBeforeChangeAction, EntityModelAdmin):
         "release_manager",
         "is_active",
     )
-    actions = ["prepare_next_release"]
     change_actions = ["prepare_next_release_action"]
 
     def _prepare(self, request, package):
@@ -402,13 +401,6 @@ class PackageAdmin(SaveBeforeChangeAction, EntityModelAdmin):
             self.message_user(request, "No active package", messages.ERROR)
             return redirect("admin:core_package_changelist")
         return self._prepare(request, package)
-
-    @admin.action(description="Prepare next Release")
-    def prepare_next_release(self, request, queryset):
-        if queryset.count() != 1:
-            self.message_user(request, "Select exactly one package", messages.ERROR)
-            return
-        return self._prepare(request, queryset.first())
 
     def prepare_next_release_action(self, request, obj):
         return self._prepare(request, obj)

--- a/core/templates/admin/core/package/change_list.html
+++ b/core/templates/admin/core/package/change_list.html
@@ -1,5 +1,4 @@
 {% extends "admin/change_list.html" %}
 {% block object-tools-items %}
 {{ block.super }}
-<li><a href="{% url 'admin:core_package_prepare_next_release' %}">Prepare next Release</a></li>
 {% endblock %}

--- a/core/templates/admin/core/packagerelease/change_list.html
+++ b/core/templates/admin/core/packagerelease/change_list.html
@@ -1,5 +1,4 @@
 {% extends "django_object_actions/change_list.html" %}
 {% block object-tools-items %}
 {{ block.super }}
-<li><a href="{% url 'admin:core_package_prepare_next_release' %}">Prepare next Release</a></li>
 {% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -983,6 +983,24 @@ class PackageReleaseCurrentTests(TestCase):
         self.assertFalse(self.release.is_current)
 
 
+class PackageReleaseChangelistTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User.objects.create_superuser("admin", "admin@example.com", "pw")
+        self.client.force_login(User.objects.get(username="admin"))
+
+    def test_prepare_next_release_button_hidden(self):
+        response = self.client.get(reverse("admin:core_packagerelease_changelist"))
+        self.assertNotContains(response, "Prepare next Release")
+
+    def test_refresh_from_pypi_button_present(self):
+        response = self.client.get(reverse("admin:core_packagerelease_changelist"))
+        refresh_url = reverse(
+            "admin:core_packagerelease_actions", args=["refresh_from_pypi"]
+        )
+        self.assertContains(response, refresh_url, html=False)
+
+
 class PackageAdminPrepareNextReleaseTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -1001,24 +1019,18 @@ class PackageAdminPrepareNextReleaseTests(TestCase):
         )
 
 
-class PackageReleaseChangelistTests(TestCase):
+class PackageAdminChangeViewTests(TestCase):
     def setUp(self):
         self.client = Client()
         User.objects.create_superuser("admin", "admin@example.com", "pw")
         self.client.force_login(User.objects.get(username="admin"))
+        self.package = Package.objects.get(name="arthexis")
 
-    def test_prepare_next_release_button_present(self):
-        response = self.client.get(reverse("admin:core_packagerelease_changelist"))
-        self.assertContains(
-            response, reverse("admin:core_package_prepare_next_release"), html=False
+    def test_prepare_next_release_button_visible_on_change_view(self):
+        response = self.client.get(
+            reverse("admin:core_package_change", args=[self.package.pk])
         )
-
-    def test_refresh_from_pypi_button_present(self):
-        response = self.client.get(reverse("admin:core_packagerelease_changelist"))
-        refresh_url = reverse(
-            "admin:core_packagerelease_actions", args=["refresh_from_pypi"]
-        )
-        self.assertContains(response, refresh_url, html=False)
+        self.assertContains(response, "Prepare next Release")
 
 
 class TodoDoneTests(TestCase):

--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -41,9 +41,6 @@
               {% if model.admin_url and show_changelinks %}
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
                 <td class="actions">
-                  {% if app.app_label == 'core' and model.object_name == 'Package' %}
-                    <a href="{% url 'admin:core_package_prepare_next_release' %}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">Prepare next Release</a>
-                  {% endif %}
                   {% for action in extra_actions %}
                     <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
                   {% endfor %}


### PR DESCRIPTION
## Summary
- remove the Prepare next Release shortcut from package and release changelists as well as the admin dashboard
- keep the action available on the package change form and update tests to reflect the new visibility rules

## Testing
- PYTHONPATH=/workspace/arthexis DJANGO_SETTINGS_MODULE=config.settings pytest --import-mode=importlib core/tests.py::PackageReleaseChangelistTests core/tests.py::PackageAdminPrepareNextReleaseTests core/tests.py::PackageAdminChangeViewTests

------
https://chatgpt.com/codex/tasks/task_e_68d026c0531c8326b31392389344ec67