### PR TITLE
docs: clarify public port behaviour

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,7 +41,7 @@ Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plat
 - **[Windows](https://es.wikipedia.org/wiki/Microsoft_Windows)**: abre [PowerShell](https://learn.microsoft.com/es-es/powershell/) o [Git Bash](https://gitforwindows.org/) y ejecuta el mismo comando.
 
 ### 2. Iniciar y detener
-Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin instalar; los roles Control, Satélite y Constelación deben instalarse primero. Ambos métodos escuchan en [`http://localhost:8000/`](http://localhost:8000/) de forma predeterminada; usa `--port` para elegir otro valor.
+Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin instalar; los roles Control, Satélite y Constelación deben instalarse primero. Ambos métodos escuchan en [`http://localhost:8888/`](http://localhost:8888/) de forma predeterminada; usa `--port` para elegir otro valor, o añade `--public` para exponer el servicio en `0.0.0.0:8000` y permitir que otros dispositivos accedan (por ejemplo `http://192.168.1.10:8000/`). Las instalaciones de Constellation activan este modo público automáticamente.
 - **[VS Code](https://code.visualstudio.com/)**: abre la carpeta, ve al panel **Run and Debug** (`Ctrl+Shift+D`), selecciona la configuración **Run Server** (o **Debug Server**) y presiona el botón verde de inicio. Detén el servidor con el cuadrado rojo (`Shift+F5`).
 - **[Shell](https://es.wikipedia.org/wiki/Shell_de_unidad_de_comandos)**: en Linux ejecuta [`./start.sh`](start.sh) y detén con [`./stop.sh`](stop.sh); en Windows ejecuta [`start.bat`](start.bat) y detén con `Ctrl+C`.
 
@@ -52,10 +52,11 @@ Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin 
   - `--satellite`: configura el nodo perimetral de adquisición de datos.
   - `--constellation`: habilita la pila de orquestación multiusuario.
   Usa `./install.sh --help` para ver la lista completa de flags si necesitas personalizar el nodo más allá del rol. Actualiza con [`./upgrade.sh`](upgrade.sh).
+  Las instalaciones de Constellation se ejecutan en modo público en el puerto 8000; Terminal, Control y Satélite usan el puerto interno 8888 salvo que pases `--public` o definas otro puerto.
 - **Windows**: ejecuta [`install.bat`](install.bat) para instalar (rol Terminal) y [`upgrade.bat`](upgrade.bat) para actualizar.
 
 ### 4. Administración
-Visita [`http://localhost:8000/admin/`](http://localhost:8000/admin/) para el [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) y [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) para la [documentación de administración](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Usa `--port` con los scripts de inicio o el instalador si necesitas exponer otro puerto.
+Visita [`http://localhost:8888/admin/`](http://localhost:8888/admin/) para el [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) y [`http://localhost:8888/admindocs/`](http://localhost:8888/admindocs/) para la [documentación de administración](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Si activaste el modo público (ya sea manualmente con `--public` o instalando el rol Constellation), abre [`http://localhost:8000/`](http://localhost:8000/) en el propio host o sustituye `localhost` por la IP de la máquina al conectarte desde otro dispositivo. Usa `--port` con los scripts de inicio o el instalador si necesitas exponer otro puerto.
 
 ## Soporte
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,7 +41,7 @@ Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre �
 - **[Windows](https://fr.wikipedia.org/wiki/Microsoft_Windows)** : ouvrez [PowerShell](https://learn.microsoft.com/fr-fr/powershell/) ou [Git Bash](https://gitforwindows.org/) et exécutez la même commande.
 
 ### 2. Démarrer et arrêter
-Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sans installation ; les rôles Control, Satellite et Constellation doivent être installés au préalable. Les deux méthodes écoutent par défaut sur [`http://localhost:8000/`](http://localhost:8000/) ; utilisez `--port` pour choisir une autre valeur.
+Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sans installation ; les rôles Control, Satellite et Constellation doivent être installés au préalable. Les deux méthodes écoutent par défaut sur [`http://localhost:8888/`](http://localhost:8888/) ; utilisez `--port` pour choisir une autre valeur ou ajoutez `--public` pour exposer le service sur `0.0.0.0:8000` afin que les autres appareils puissent y accéder (par exemple `http://192.168.1.10:8000/`). Les installations Constellation activent ce mode public automatiquement.
 - **[VS Code](https://code.visualstudio.com/)** : ouvrez le dossier, rendez-vous dans le panneau **Run and Debug** (`Ctrl+Shift+D`), choisissez la configuration **Run Server** (ou **Debug Server**) et appuyez sur le bouton vert. Arrêtez le serveur avec le carré rouge (`Shift+F5`).
 - **[Shell](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande)** : sous Linux exécutez [`./start.sh`](start.sh) et arrêtez avec [`./stop.sh`](stop.sh) ; sous Windows exécutez [`start.bat`](start.bat) et arrêtez avec `Ctrl+C`.
 
@@ -52,10 +52,11 @@ Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sa
   - `--satellite` : configure le nœud de collecte de données en périphérie.
   - `--constellation` : active la pile d’orchestration multi-utilisateurs.
   Utilisez `./install.sh --help` pour afficher la liste complète des indicateurs si vous devez personnaliser le nœud au-delà du rôle. Mettez à jour avec [`./upgrade.sh`](upgrade.sh).
+  Les installations Constellation fonctionnent en mode public sur le port 8000 ; Terminal, Control et Satellite utilisent le port interne 8888 tant que vous n’ajoutez pas `--public` ou ne définissez pas un autre port.
 - **Windows** : lancez [`install.bat`](install.bat) pour installer (rôle Terminal) et [`upgrade.bat`](upgrade.bat) pour mettre à jour.
 
 ### 4. Administration
-Visitez [`http://localhost:8000/admin/`](http://localhost:8000/admin/) pour l'[administration Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) et [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) pour la [documentation d’administration](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Utilisez `--port` avec les scripts de démarrage ou l’installateur pour exposer un autre port.
+Visitez [`http://localhost:8888/admin/`](http://localhost:8888/admin/) pour l'[administration Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) et [`http://localhost:8888/admindocs/`](http://localhost:8888/admindocs/) pour la [documentation d’administration](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Si vous avez activé le mode public (manuellement avec `--public` ou via l’installation du rôle Constellation), ouvrez [`http://localhost:8000/`](http://localhost:8000/) sur la machine elle-même ou remplacez `localhost` par l’adresse IP de l’hôte depuis un autre appareil. Utilisez `--port` avec les scripts de démarrage ou l’installateur pour exposer un autre port.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Arthexis Constellation ships in four node roles tailored to different deployment
 - **[Windows](https://en.wikipedia.org/wiki/Microsoft_Windows)**: open [PowerShell](https://learn.microsoft.com/powershell/) or [Git Bash](https://gitforwindows.org/) and run the same command.
 
 ### 2. Start and stop
-Terminal nodes can start directly with the scripts below without installing; Control, Satellite, and Constellation roles require installation first. Both approaches listen on [`http://localhost:8000/`](http://localhost:8000/) by default—pass `--port` to use a different value.
+Terminal nodes can start directly with the scripts below without installing; Control, Satellite, and Constellation roles require installation first. Both approaches listen on [`http://localhost:8888/`](http://localhost:8888/) by default—pass `--port` to use a different value, or add `--public` to expose the service on `0.0.0.0:8000` so other devices can reach it (for example `http://192.168.1.10:8000/`). Constellation installations enable public mode automatically.
 - **[VS Code](https://code.visualstudio.com/)**: open the folder, go to the
   **Run and Debug** panel (`Ctrl+Shift+D`), select the **Run Server** (or
   **Debug Server**) configuration, and press the green start button. Stop the
@@ -57,10 +57,11 @@ Terminal nodes can start directly with the scripts below without installing; Con
   - `--satellite` – configures the edge data acquisition node.
   - `--constellation` – enables the multi-user orchestration stack.
   Use `./install.sh --help` to list every available flag if you need to customize the node beyond the role defaults. Upgrade with [`./upgrade.sh`](upgrade.sh).
+  Constellation installations run in public mode on port 8000; Terminal, Control, and Satellite default to the internal port 8888 unless you pass `--public` or override the port.
 - **Windows**: run [`install.bat`](install.bat) to install (Terminal role) and [`upgrade.bat`](upgrade.bat) to upgrade.
 
 ### 4. Administration
-Visit [`http://localhost:8000/admin/`](http://localhost:8000/admin/) for the [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) and [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) for the [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Use `--port` with the start scripts or installer when you need to expose a different port.
+Visit [`http://localhost:8888/admin/`](http://localhost:8888/admin/) for the [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) and [`http://localhost:8888/admindocs/`](http://localhost:8888/admindocs/) for the [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). If you've enabled public mode (either manually with `--public` or by installing the Constellation role), open [`http://localhost:8000/`](http://localhost:8000/) on the host itself or replace `localhost` with the machine's IP when connecting from another device. Use `--port` with the start scripts or installer when you need to expose a different port.
 
 ## Support
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -41,7 +41,7 @@
 - **[Windows](https://ru.wikipedia.org/wiki/Microsoft_Windows)**: откройте [PowerShell](https://learn.microsoft.com/ru-ru/powershell/) или [Git Bash](https://gitforwindows.org/) и выполните ту же команду.
 
 ### 2. Запуск и остановка
-Узлы Terminal можно запускать напрямую приведёнными ниже скриптами без установки; роли Control, Satellite и Constellation требуют предварительной установки. Оба варианта по умолчанию слушают [`http://localhost:8000/`](http://localhost:8000/) — используйте `--port`, чтобы выбрать другой порт.
+Узлы Terminal можно запускать напрямую приведёнными ниже скриптами без установки; роли Control, Satellite и Constellation требуют предварительной установки. Оба варианта по умолчанию слушают [`http://localhost:8888/`](http://localhost:8888/) — используйте `--port`, чтобы выбрать другой порт или добавьте `--public`, чтобы открыть сервис на `0.0.0.0:8000` и дать доступ другим устройствам (например, `http://192.168.1.10:8000/`). Установки Constellation автоматически включают публичный режим.
 - **[VS Code](https://code.visualstudio.com/)**: откройте папку, перейдите на панель **Run and Debug** (`Ctrl+Shift+D`), выберите конфигурацию **Run Server** (или **Debug Server**) и нажмите зелёную кнопку запуска. Остановите сервер красным квадратом (`Shift+F5`).
 - **[Shell](https://ru.wikipedia.org/wiki/Командная_оболочка)**: в Linux запустите [`./start.sh`](start.sh) и остановите [`./stop.sh`](stop.sh); в Windows запустите [`start.bat`](start.bat) и остановите `Ctrl+C`.
 
@@ -52,10 +52,11 @@
   - `--satellite` — настраивает периферийный узел сбора данных.
   - `--constellation` — включает мультипользовательский оркестратор.
   Используйте `./install.sh --help`, чтобы увидеть полный список флагов, если требуется дополнительная настройка сверх выбранной роли. Обновляйте систему с помощью [`./upgrade.sh`](upgrade.sh).
+  Установки Constellation работают в публичном режиме на порту 8000; Terminal, Control и Satellite по умолчанию используют внутренний порт 8888, пока вы не добавите `--public` или не зададите другой порт.
 - **Windows**: выполните [`install.bat`](install.bat) для установки (роль Terminal) и [`upgrade.bat`](upgrade.bat) для обновления.
 
 ### 4. Администрирование
-Перейдите на [`http://localhost:8000/admin/`](http://localhost:8000/admin/) для [панели администратора Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) и [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) для [административной документации](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Используйте `--port` со скриптами запуска или установщиком, если нужно открыть другой порт.
+Перейдите на [`http://localhost:8888/admin/`](http://localhost:8888/admin/) для [панели администратора Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) и [`http://localhost:8888/admindocs/`](http://localhost:8888/admindocs/) для [административной документации](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Если включён публичный режим (вручную через `--public` или при установке роли Constellation), откройте [`http://localhost:8000/`](http://localhost:8000/) на самом узле или замените `localhost` IP-адресом машины при подключении с другого устройства. Используйте `--port` со скриптами запуска или установщиком, если нужно открыть другой порт.
 
 ## Поддержка
 


### PR DESCRIPTION
## Summary
- clarify in each README that `--public` binds to 0.0.0.0:8000 with an example URL and that Constellation enables it automatically
- explain which node roles default to port 8888 vs 8000 and how to reach the admin URLs when public mode is enabled

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d02caa468083268525d29c659b0035