### PR TITLE
Add VS Code live server launch configs that sync with upstream

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,37 @@
             ],
             "subProcess": true,
             "preLaunchTask": "Dev: collectstatic"
+        },
+        {
+            "name": "Run Live Server",
+            "type": "python",
+            "request": "launch",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "windows": {
+                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+            },
+            "program": "${workspaceFolder}/vscode_manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "noDebug": true,
+            "preLaunchTask": "Dev: prepare live server"
+        },
+        {
+            "name": "Debug Live Server",
+            "type": "python",
+            "request": "launch",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "windows": {
+                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+            },
+            "program": "${workspaceFolder}/vscode_manage.py",
+            "args": [
+                "runserver"
+            ],
+            "subProcess": true,
+            "preLaunchTask": "Dev: prepare live server"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,6 +61,19 @@
             "detail": "Stop Django development server processes"
         },
         {
+            "label": "Dev: prepare live server",
+            "type": "shell",
+            "command": "${workspaceFolder}/live-server-update.sh",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "windows": {
+                "command": "${workspaceFolder}\\live-server-update.bat"
+            },
+            "problemMatcher": [],
+            "detail": "Stop the development server, sync with the upstream remote, and refresh the environment before launch"
+        },
+        {
             "label": "Dev: manage",
             "type": "shell",
             "command": "${workspaceFolder}/manage.sh",

--- a/live-server-update.bat
+++ b/live-server-update.bat
@@ -1,0 +1,54 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+echo Stopping existing development server (if running)...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'manage.py runserver' } | ForEach-Object { try { Stop-Process -Id $_.ProcessId -ErrorAction Stop } catch { } }" >nul 2>&1
+
+git remote get-url upstream >nul 2>&1
+if errorlevel 1 (
+    echo No 'upstream' remote configured. Skipping fetch and pull.
+    exit /b 0
+)
+
+for /f "delims=" %%B in ('git rev-parse --abbrev-ref HEAD') do set BRANCH=%%B
+
+if "%BRANCH%"=="" (
+    echo Unable to determine the current branch. Skipping fetch and pull.
+    exit /b 0
+)
+
+echo Fetching updates from upstream...
+git fetch upstream
+if errorlevel 1 (
+    echo Failed to fetch from upstream.
+    exit /b 1
+)
+
+git show-ref --verify --quiet refs/remotes/upstream/%BRANCH%
+if errorlevel 1 (
+    echo No matching upstream branch for %BRANCH%. Skipping pull.
+    exit /b 0
+)
+
+echo Pulling latest commits for %BRANCH%...
+git pull --ff-only upstream %BRANCH%
+if errorlevel 1 (
+    echo Failed to pull from upstream.
+    exit /b 1
+)
+
+if exist "%SCRIPT_DIR%env-refresh.bat" (
+    echo Refreshing environment with env-refresh.bat --latest...
+    call "%SCRIPT_DIR%env-refresh.bat" --latest
+    if errorlevel 1 (
+        echo Environment refresh failed.
+        exit /b 1
+    )
+) else (
+    echo env-refresh.bat not found. Skipping environment refresh.
+)
+
+exit /b 0

--- a/live-server-update.sh
+++ b/live-server-update.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$REPO_ROOT"
+
+if [ -x "$REPO_ROOT/stop.sh" ]; then
+  echo "Stopping existing development server (if running)..."
+  if ! "$REPO_ROOT/stop.sh"; then
+    echo "The stop script exited with a non-zero status; continuing anyway." >&2
+  fi
+fi
+
+if ! git remote get-url upstream >/dev/null 2>&1; then
+  echo "No 'upstream' remote configured. Skipping fetch and pull."
+  exit 0
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ -z "$current_branch" ]; then
+  echo "Unable to determine the current branch. Skipping fetch and pull." >&2
+  exit 0
+fi
+
+echo "Fetching updates from upstream..."
+git fetch upstream
+
+echo "Checking for upstream branch $current_branch..."
+if git show-ref --verify --quiet "refs/remotes/upstream/${current_branch}"; then
+  echo "Pulling latest commits for ${current_branch}..."
+  git pull --ff-only upstream "$current_branch"
+  REFRESH_SCRIPT="$REPO_ROOT/env-refresh.sh"
+  if [ -x "$REFRESH_SCRIPT" ]; then
+    echo "Refreshing environment with env-refresh.sh --latest..."
+    "$REFRESH_SCRIPT" --latest
+  elif [ -f "$REFRESH_SCRIPT" ]; then
+    echo "env-refresh.sh is not marked executable. Attempting to run with bash." >&2
+    bash "$REFRESH_SCRIPT" --latest
+  else
+    echo "env-refresh.sh not found. Skipping environment refresh." >&2
+  fi
+else
+  echo "No matching upstream branch for ${current_branch}. Skipping pull."
+fi


### PR DESCRIPTION
## Summary
- add scripts and a VS Code task to stop the dev server and sync the active branch with the upstream remote
- provide new "Run Live Server" and "Debug Live Server" launch configurations that leverage the upstream sync task
- ensure the live server update scripts refresh the environment after syncing with upstream

## Testing
- ./live-server-update.sh

------
https://chatgpt.com/codex/tasks/task_e_68d02ea7b6bc832694ca629a2ce4526c