### PR TITLE
Include timestamp in upgrade notification

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from celery import shared_task
@@ -57,7 +57,9 @@ def check_github_updates() -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "auto-upgrade.log"
     with log_file.open("a") as fh:
-        fh.write(f"{datetime.utcnow().isoformat()} check_github_updates triggered\n")
+        fh.write(
+            f"{datetime.now(UTC).isoformat()} check_github_updates triggered\n"
+        )
 
     notify = None
     startup = None
@@ -69,6 +71,8 @@ def check_github_updates() -> None:
         from nodes.apps import _startup_notification as startup  # type: ignore
     except Exception:
         startup = None
+
+    upgrade_stamp = f"@{datetime.now(UTC).isoformat()}"
 
     if mode == "latest":
         local = (
@@ -93,7 +97,7 @@ def check_github_updates() -> None:
                 startup()
             return
         if notify:
-            notify("Upgrading...", "")
+            notify("Upgrading...", upgrade_stamp)
         args = ["./upgrade.sh", "--latest", "--no-restart"]
     else:
         local = "0"
@@ -117,11 +121,13 @@ def check_github_updates() -> None:
                 startup()
             return
         if notify:
-            notify("Upgrading...", "")
+            notify("Upgrading...", upgrade_stamp)
         args = ["./upgrade.sh", "--no-restart"]
 
     with log_file.open("a") as fh:
-        fh.write(f"{datetime.utcnow().isoformat()} running: {' '.join(args)}\n")
+        fh.write(
+            f"{datetime.now(UTC).isoformat()} running: {' '.join(args)}\n"
+        )
 
     subprocess.run(args, cwd=base_dir, check=True)
 

--- a/tests/test_release_tasks.py
+++ b/tests/test_release_tasks.py
@@ -1,4 +1,5 @@
 import types
+from datetime import datetime
 
 import pytest
 
@@ -62,5 +63,18 @@ def test_upgrade_shows_message(monkeypatch, tmp_path):
 
     tasks.check_github_updates()
 
-    assert ("Upgrading...", "") in notify_calls
+    assert any(
+        subject == "Upgrading..."
+        and body.startswith("@")
+        and _is_iso_datetime(body[1:])
+        for subject, body in notify_calls
+    )
     assert any("upgrade.sh" in cmd[0] for cmd in run_calls)
+
+
+def _is_iso_datetime(candidate: str) -> bool:
+    try:
+        datetime.fromisoformat(candidate)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
## Summary
- add an ISO-8601 timestamp line to the upgrade notification body so the LCD shows when the process started
- switch auto-upgrade logging to timezone-aware timestamps for consistency
- adjust the release task test to validate the timestamped notification format

## Testing
- pytest tests/test_release_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68d0341ff69c8326ba0d860f4821b032