### PR TITLE
Remove bullet markers from related models list

### DIFF
--- a/pages/templates/admin/change_form.html
+++ b/pages/templates/admin/change_form.html
@@ -38,6 +38,7 @@
 
     .related-models__item {
       margin: 0;
+      list-style: none;
     }
 
     .related-models__link {


### PR DESCRIPTION
## Summary
- remove the default list marker from each Related Models entry to eliminate the stray bullet icon

## Testing
- not run (CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d03bdb09bc8326b8899882bca2ca73