### PR TITLE
Add My Profile admin action for profile models

### DIFF
--- a/core/templates/admin/assistantprofile_change_list.html
+++ b/core/templates/admin/assistantprofile_change_list.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends "django_object_actions/change_list.html" %}
 
 {% block object-tools-items %}
 <li><a href="{{ mcp_server_actions.start }}" class="addlink">Start MCP server</a></li>

--- a/core/templates/admin/core/emailinbox/change_form.html
+++ b/core/templates/admin/core/emailinbox/change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/user_datum_change_form.html" %}
+{% extends "admin/django_object_actions_user_datum_change_form.html" %}
 {% load i18n %}
 
 {% block object-tools-items %}

--- a/core/templates/admin/django_object_actions_user_datum_change_form.html
+++ b/core/templates/admin/django_object_actions_user_datum_change_form.html
@@ -1,0 +1,22 @@
+{% extends "django_object_actions/change_form.html" %}
+{% load i18n %}
+
+{% block content_title %}
+<div style="display:flex; justify-content:space-between; align-items:center;">
+    <h1>{{ title }}</h1>
+    <div>
+        {% if show_user_datum %}
+        <label style="color: var(--body-quiet-color); margin-left: 1em;">
+            <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
+            {% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]
+        </label>
+        {% endif %}
+        {% if show_seed_datum %}
+        <label style="color: var(--body-quiet-color); margin-left: 1em;">
+            <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
+            {% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]
+        </label>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/core/templates/admin/workgroupassistantprofile_change_form.html
+++ b/core/templates/admin/workgroupassistantprofile_change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/user_datum_change_form.html" %}
+{% extends "admin/django_object_actions_user_datum_change_form.html" %}
 {% load i18n %}
 
 {% block object-tools-items %}

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -436,7 +436,7 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
         {% url 'admin:auth_user_change' user.pk as auth_profile_url %}
         {% with profile_url=teams_profile_url|default:core_profile_url|default:auth_profile_url %}
           {% if profile_url %}
-            <a href="{{ profile_url }}">{% trans 'MY PROFILE' %}</a> /
+            <a href="{{ profile_url }}">{% trans 'My User' %}</a> /
           {% endif %}
         {% endwith %}
       {% endif %}

--- a/tests/test_release_manager_admin.py
+++ b/tests/test_release_manager_admin.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 
 from core.admin import ReleaseManagerAdmin
 from core.models import ReleaseManager
@@ -32,6 +33,49 @@ class ReleaseManagerAdminActionTests(TestCase):
 
         request._messages = FallbackStorage(request)
         return request
+
+    def test_my_profile_redirects_to_existing_profile(self):
+        request = self._get_request()
+        response = self.admin.my_profile(request, ReleaseManager.objects.none())
+        self.assertEqual(response.status_code, 302)
+        expected = reverse("admin:core_releasemanager_change", args=[self.manager.pk])
+        self.assertEqual(response.url, expected)
+
+    def test_my_profile_redirects_to_add_when_missing(self):
+        self.manager.delete()
+        request = self._get_request()
+        response = self.admin.my_profile(request, ReleaseManager.objects.none())
+        self.assertEqual(response.status_code, 302)
+        expected = f"{reverse('admin:core_releasemanager_add')}?user={self.user.pk}"
+        self.assertEqual(response.url, expected)
+
+    def test_my_profile_without_add_permission_shows_error(self):
+        self.manager.delete()
+        User = get_user_model()
+        limited = User.objects.create_user(
+            username="limited", password="pwd", is_staff=True
+        )
+        request = self.factory.get("/")
+        request.user = limited
+        request.session = self.client.session
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
+        request._messages = FallbackStorage(request)
+        response = self.admin.my_profile(request, ReleaseManager.objects.none())
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("admin:core_releasemanager_changelist"),
+        )
+        messages = [m.message.lower() for m in request._messages]
+        self.assertTrue(any("permission" in message for message in messages))
+
+    def test_my_profile_change_action_redirects(self):
+        request = self._get_request()
+        response = self.admin.my_profile_action(request, self.manager)
+        self.assertEqual(response.status_code, 302)
+        expected = reverse("admin:core_releasemanager_change", args=[self.manager.pk])
+        self.assertEqual(response.url, expected)
 
     @pytest.mark.skip("Release manager credentials action not exercised in environment")
     @patch("core.admin.requests.get")


### PR DESCRIPTION
## Summary
- retitle the admin navigation link to "My User"
- add a reusable profile admin mixin and wire the new My Profile action into Release Manager, Odoo Profile, Email Inbox, and Assistant Profile admins
- update templates and tests to surface the new action on both change and change list views

## Testing
- pytest tests/test_odoo_profile_admin.py tests/test_release_manager_admin.py tests/test_email_inbox_admin.py tests/test_assistant_profile_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d03d6583a8832690527020083f35aa