### PR TITLE
Refine README installation guidance and layout

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -7,15 +7,9 @@ Constelación Arthexis es una [suite de software](https://es.wikipedia.org/wiki/
 ## Características
 
 - Compatible con el [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/) como sistema central, gestionando:
-  - BootNotification
-  - Heartbeat
-  - StatusNotification
-  - Authorize
-  - MeterValues
-  - DiagnosticsStatusNotification
-  - StartTransaction
-  - StopTransaction
-  - FirmwareStatusNotification
+  - Ciclo de vida y sesiones: BootNotification, Heartbeat, StatusNotification, StartTransaction, StopTransaction
+  - Acceso y medición: Authorize, MeterValues
+  - Mantenimiento y firmware: DiagnosticsStatusNotification, FirmwareStatusNotification
 - Integración de [API](https://es.wikipedia.org/wiki/Interfaz_de_programaci%C3%B3n_de_aplicaciones) con [Odoo](https://www.odoo.com/) para:
   - Sincronizar credenciales de empleados mediante `res.users`
   - Consultar el catálogo de productos mediante `product.product`
@@ -26,34 +20,34 @@ Constelación Arthexis es una [suite de software](https://es.wikipedia.org/wiki/
 
 Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plataforma a distintos escenarios de despliegue.
 
-<table>
+<table border="1" cellpadding="8" cellspacing="0">
   <thead>
     <tr>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Rol</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Descripción</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Funciones comunes</th>
+      <th align="left">Rol</th>
+      <th align="left">Descripción</th>
+      <th align="left">Funciones comunes</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Investigación y desarrollo de un solo usuario</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+      <td valign="top"><strong>Terminal</strong></td>
+      <td valign="top"><strong>Investigación y desarrollo de un solo usuario</strong></td>
+      <td valign="top">GUI Toast</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Pruebas de un solo dispositivo y equipos para tareas especiales</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Control</strong></td>
+      <td valign="top"><strong>Pruebas de un solo dispositivo y equipos para tareas especiales</strong></td>
+      <td valign="top">AP Public Wi-Fi<br />Celery Queue<br />GUI Toast<br />LCD Screen<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satélite</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Periferia multidispositivo, redes y adquisición de datos</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Satélite</strong></td>
+      <td valign="top"><strong>Periferia multidispositivo, redes y adquisición de datos</strong></td>
+      <td valign="top">AP Router<br />Celery Queue<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem;">Constelación</td>
-      <td style="padding: 0.6rem 1rem;">Nube multiusuario y orquestación</td>
-      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+      <td valign="top"><strong>Constelación</strong></td>
+      <td valign="top"><strong>Nube multiusuario y orquestación</strong></td>
+      <td valign="top">Celery Queue<br />NGINX Server</td>
     </tr>
   </tbody>
 </table>
@@ -61,8 +55,7 @@ Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plat
 ## Quick Guide
 
 ### 1. Clonar
-- **[Linux](https://es.wikipedia.org/wiki/Linux)**: abre una [terminal](https://es.wikipedia.org/wiki/Interfaz_de_l%C3%ADnea_de_comandos) y ejecuta  
-  `git clone https://github.com/arthexis/arthexis.git`
+- **[Linux](https://es.wikipedia.org/wiki/Linux)**: abre una [terminal](https://es.wikipedia.org/wiki/Interfaz_de_l%C3%ADnea_de_comandos) y ejecuta `git clone https://github.com/arthexis/arthexis.git`.
 - **[Windows](https://es.wikipedia.org/wiki/Microsoft_Windows)**: abre [PowerShell](https://learn.microsoft.com/es-es/powershell/) o [Git Bash](https://gitforwindows.org/) y ejecuta el mismo comando.
 
 ### 2. Iniciar y detener

--- a/README.es.md
+++ b/README.es.md
@@ -26,12 +26,37 @@ Constelación Arthexis es una [suite de software](https://es.wikipedia.org/wiki/
 
 Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plataforma a distintos escenarios de despliegue.
 
-| Rol | Descripción | Funciones comunes |
-| --- | --- | --- |
-| Terminal | Investigación y desarrollo de un solo usuario | • GUI Toast |
-| Control | Pruebas de un solo dispositivo y equipos para tareas especiales | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
-| Satélite | Periferia multidispositivo, redes y adquisición de datos | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
-| Constelación | Nube multiusuario y orquestación | • Celery Queue<br>• NGINX Server |
+<table>
+  <thead>
+    <tr>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Rol</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Descripción</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Funciones comunes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Investigación y desarrollo de un solo usuario</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Pruebas de un solo dispositivo y equipos para tareas especiales</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satélite</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Periferia multidispositivo, redes y adquisición de datos</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem;">Constelación</td>
+      <td style="padding: 0.6rem 1rem;">Nube multiusuario y orquestación</td>
+      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Quick Guide
 
@@ -41,25 +66,30 @@ Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plat
 - **[Windows](https://es.wikipedia.org/wiki/Microsoft_Windows)**: abre [PowerShell](https://learn.microsoft.com/es-es/powershell/) o [Git Bash](https://gitforwindows.org/) y ejecuta el mismo comando.
 
 ### 2. Iniciar y detener
-Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin instalar; los roles Control, Satélite y Constelación deben instalarse primero. Ambos métodos escuchan en [`http://localhost:8000/`](http://localhost:8000/) de forma predeterminada; usa `--port` para elegir otro valor.
+Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin instalar; los roles Control, Satélite y Constelación deben instalarse primero. Ambos métodos escuchan en [`http://localhost:8000/`](http://localhost:8000/) de forma predeterminada.
 
-- **[VS Code](https://code.visualstudio.com/)**
-  - Abre la carpeta y ve al panel **Run and Debug** (`Ctrl+Shift+D`).
-  - Selecciona la configuración **Run Server** (o **Debug Server**).
-  - Presiona el botón verde de inicio. Detén el servidor con el cuadrado rojo (`Shift+F5`).
-- **[Shell](https://es.wikipedia.org/wiki/Shell_de_unidad_de_comandos)**
-  - Linux: ejecuta [`./start.sh`](start.sh) y detén con [`./stop.sh`](stop.sh).
-  - Windows: ejecuta [`start.bat`](start.bat) y detén con `Ctrl+C`.
+**[VS Code](https://code.visualstudio.com/)**
+- Abre la carpeta y ve al panel **Run and Debug** (`Ctrl+Shift+D`).
+- Selecciona la configuración **Run Server** (o **Debug Server**).
+- Presiona el botón verde de inicio. Detén el servidor con el cuadrado rojo (`Shift+F5`).
+
+**[Shell](https://es.wikipedia.org/wiki/Shell_de_unidad_de_comandos)**
+- Linux: ejecuta [`./start.sh`](start.sh) y detén con [`./stop.sh`](stop.sh).
+- Windows: ejecuta [`start.bat`](start.bat) y detén con `Ctrl+C`.
 
 ### 3. Instalar y actualizar
-- **Linux**: ejecuta [`./install.sh`](install.sh) con un flag de rol de nodo:
-  - `--terminal`: rol predeterminado si no se especifica y recomendado si no sabes cuál elegir. Los nodos Terminal también pueden usar los scripts anteriores para iniciar/detener sin instalar.
-  - `--control`: prepara el equipo de control para pruebas de un solo dispositivo.
-  - `--satellite`: configura el nodo perimetral de adquisición de datos.
-  - `--constellation`: habilita la pila de orquestación multiusuario.
-  Usa `./install.sh --help` para ver la lista completa de flags si necesitas personalizar el nodo más allá del rol. Actualiza con [`./upgrade.sh`](upgrade.sh).
+**Linux:** ejecuta [`./install.sh`](install.sh) con un flag de rol de nodo:
+- `--terminal`: rol predeterminado si no se especifica y recomendado si no sabes cuál elegir. Los nodos Terminal también pueden usar los scripts anteriores para iniciar/detener sin instalar.
+- `--control`: prepara el equipo de control para pruebas de un solo dispositivo.
+- `--satellite`: configura el nodo perimetral de adquisición de datos.
+- `--constellation`: habilita la pila de orquestación multiusuario.
+Usa `./install.sh --help` para ver la lista completa de flags si necesitas personalizar el nodo más allá del rol.
 
-- **Windows**: ejecuta [`install.bat`](install.bat) para instalar (rol Terminal) y [`upgrade.bat`](upgrade.bat) para actualizar.
+Actualiza con [`./upgrade.sh`](upgrade.sh).
+
+**Windows:**
+- Ejecuta [`install.bat`](install.bat) para instalar (rol Terminal) y [`upgrade.bat`](upgrade.bat) para actualizar.
+- No es necesario instalar para iniciar en modo Terminal (el predeterminado).
 
 ### 4. Administración
 Visita [`http://localhost:8000/admin/`](http://localhost:8000/admin/) para el [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) y [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) para la [documentación de administración](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Usa `--port` con los scripts de inicio o el instalador si necesitas exponer otro puerto.

--- a/README.fr.md
+++ b/README.fr.md
@@ -7,15 +7,9 @@ Constellation Arthexis est une [suite logicielle](https://fr.wikipedia.org/wiki/
 ## Fonctionnalités
 
 - Compatible avec le [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/) en tant que système central, prenant en charge :
-  - BootNotification
-  - Heartbeat
-  - StatusNotification
-  - Authorize
-  - MeterValues
-  - DiagnosticsStatusNotification
-  - StartTransaction
-  - StopTransaction
-  - FirmwareStatusNotification
+  - Cycle de vie et sessions : BootNotification, Heartbeat, StatusNotification, StartTransaction, StopTransaction
+  - Accès et mesure : Authorize, MeterValues
+  - Maintenance et micrologiciel : DiagnosticsStatusNotification, FirmwareStatusNotification
 - Intégration de [API](https://fr.wikipedia.org/wiki/Interface_de_programmation) avec [Odoo](https://www.odoo.com/) pour :
   - Synchroniser les identifiants employés via `res.users`
   - Consulter le catalogue produits via `product.product`
@@ -26,34 +20,34 @@ Constellation Arthexis est une [suite logicielle](https://fr.wikipedia.org/wiki/
 
 Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre à différents scénarios de déploiement.
 
-<table>
+<table border="1" cellpadding="8" cellspacing="0">
   <thead>
     <tr>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Rôle</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Description</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Fonctionnalités courantes</th>
+      <th align="left">Rôle</th>
+      <th align="left">Description</th>
+      <th align="left">Fonctionnalités courantes</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Recherche et développement monoposte</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+      <td valign="top"><strong>Terminal</strong></td>
+      <td valign="top"><strong>Recherche et développement monoposte</strong></td>
+      <td valign="top">GUI Toast</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Tests sur un appareil unique et appliances spécialisées</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Control</strong></td>
+      <td valign="top"><strong>Tests sur un appareil unique et appliances spécialisées</strong></td>
+      <td valign="top">AP Public Wi-Fi<br />Celery Queue<br />GUI Toast<br />LCD Screen<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Périphérie multi-appareils, réseau et acquisition de données</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Satellite</strong></td>
+      <td valign="top"><strong>Périphérie multi-appareils, réseau et acquisition de données</strong></td>
+      <td valign="top">AP Router<br />Celery Queue<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem;">Constellation</td>
-      <td style="padding: 0.6rem 1rem;">Orchestration et cloud multi-utilisateurs</td>
-      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+      <td valign="top"><strong>Constellation</strong></td>
+      <td valign="top"><strong>Orchestration et cloud multi-utilisateurs</strong></td>
+      <td valign="top">Celery Queue<br />NGINX Server</td>
     </tr>
   </tbody>
 </table>
@@ -61,9 +55,8 @@ Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre �
 ## Quick Guide
 
 ### 1. Cloner
-- **[Linux](https://fr.wikipedia.org/wiki/Linux)** : ouvrez un [terminal](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande) et exécutez  
-  `git clone https://github.com/arthexis/arthexis.git`
-- **[Windows](https://fr.wikipedia.org/wiki/Microsoft_Windows)** : ouvrez [PowerShell](https://learn.microsoft.com/fr-fr/powershell/) ou [Git Bash](https://gitforwindows.org/) et exécutez la même commande.
+- **[Linux](https://fr.wikipedia.org/wiki/Linux)** : ouvrez un [terminal](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande) et exécutez `git clone https://github.com/arthexis/arthexis.git`.
+- **[Windows](https://fr.wikipedia.org/wiki/Microsoft_Windows)** : ouvrez [PowerShell](https://learn.microsoft.com/fr-fr/powershell/) ou [Git Bash](https://gitforwindows.org/) et exécutez la même commande.
 
 ### 2. Démarrer et arrêter
 Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sans installation ; les rôles Control, Satellite et Constellation doivent être installés au préalable. Les deux méthodes écoutent par défaut sur [`http://localhost:8000/`](http://localhost:8000/).

--- a/README.fr.md
+++ b/README.fr.md
@@ -26,12 +26,37 @@ Constellation Arthexis est une [suite logicielle](https://fr.wikipedia.org/wiki/
 
 Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre à différents scénarios de déploiement.
 
-| Rôle | Description | Fonctionnalités courantes |
-| --- | --- | --- |
-| Terminal | Recherche et développement monoposte | • GUI Toast |
-| Control | Tests sur un appareil unique et appliances spécialisées | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
-| Satellite | Périphérie multi-appareils, réseau et acquisition de données | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
-| Constellation | Orchestration et cloud multi-utilisateurs | • Celery Queue<br>• NGINX Server |
+<table>
+  <thead>
+    <tr>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Rôle</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Description</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Fonctionnalités courantes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Recherche et développement monoposte</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Tests sur un appareil unique et appliances spécialisées</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Périphérie multi-appareils, réseau et acquisition de données</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem;">Constellation</td>
+      <td style="padding: 0.6rem 1rem;">Orchestration et cloud multi-utilisateurs</td>
+      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Quick Guide
 
@@ -41,25 +66,31 @@ Constellation Arthexis est déclinée en quatre rôles de nœud pour répondre �
 - **[Windows](https://fr.wikipedia.org/wiki/Microsoft_Windows)** : ouvrez [PowerShell](https://learn.microsoft.com/fr-fr/powershell/) ou [Git Bash](https://gitforwindows.org/) et exécutez la même commande.
 
 ### 2. Démarrer et arrêter
-Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sans installation ; les rôles Control, Satellite et Constellation doivent être installés au préalable. Les deux méthodes écoutent par défaut sur [`http://localhost:8000/`](http://localhost:8000/) ; utilisez `--port` pour choisir une autre valeur.
+Les nœuds Terminal peuvent démarrer directement avec les scripts ci-dessous sans installation ; les rôles Control, Satellite et Constellation doivent être installés au préalable. Les deux méthodes écoutent par défaut sur [`http://localhost:8000/`](http://localhost:8000/).
 
-- **[VS Code](https://code.visualstudio.com/)**
-  - Ouvrez le dossier et accédez au panneau **Run and Debug** (`Ctrl+Shift+D`).
-  - Sélectionnez la configuration **Run Server** (ou **Debug Server**).
-  - Appuyez sur le bouton vert de démarrage. Arrêtez le serveur avec le carré rouge (`Shift+F5`).
-- **[Shell](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande)**
-  - Linux : exécutez [`./start.sh`](start.sh) et arrêtez avec [`./stop.sh`](stop.sh).
-  - Windows : exécutez [`start.bat`](start.bat) et arrêtez avec `Ctrl+C`.
+**[VS Code](https://code.visualstudio.com/)**
+- Ouvrez le dossier et accédez au panneau **Run and Debug** (`Ctrl+Shift+D`).
+- Sélectionnez la configuration **Run Server** (ou **Debug Server**).
+- Appuyez sur le bouton vert de démarrage. Arrêtez le serveur avec le carré rouge (`Shift+F5`).
+
+**[Shell](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande)**
+- Linux : exécutez [`./start.sh`](start.sh) et arrêtez avec [`./stop.sh`](stop.sh).
+- Windows : exécutez [`start.bat`](start.bat) et arrêtez avec `Ctrl+C`.
 
 
 ### 3. Installer et mettre à jour
-- **Linux** : exécutez [`./install.sh`](install.sh) avec un indicateur de rôle de nœud :
-  - `--terminal` : rôle par défaut s'il n'est pas précisé et recommandé si vous hésitez. Les nœuds Terminal peuvent aussi utiliser les scripts ci-dessus pour démarrer/arrêter sans installation.
-  - `--control` : prépare l’appliance de test monoposte.
-  - `--satellite` : configure le nœud de collecte de données en périphérie.
-  - `--constellation` : active la pile d’orchestration multi-utilisateurs.
-  Utilisez `./install.sh --help` pour afficher la liste complète des indicateurs si vous devez personnaliser le nœud au-delà du rôle. Mettez à jour avec [`./upgrade.sh`](upgrade.sh).
-- **Windows** : lancez [`install.bat`](install.bat) pour installer (rôle Terminal) et [`upgrade.bat`](upgrade.bat) pour mettre à jour.
+**Linux :** exécutez [`./install.sh`](install.sh) avec un indicateur de rôle de nœud :
+- `--terminal` : rôle par défaut s'il n'est pas précisé et recommandé si vous hésitez. Les nœuds Terminal peuvent aussi utiliser les scripts ci-dessus pour démarrer/arrêter sans installation.
+- `--control` : prépare l’appliance de test monoposte.
+- `--satellite` : configure le nœud de collecte de données en périphérie.
+- `--constellation` : active la pile d’orchestration multi-utilisateurs.
+Utilisez `./install.sh --help` pour afficher la liste complète des indicateurs si vous devez personnaliser le nœud au-delà du rôle.
+
+Mettez à jour avec [`./upgrade.sh`](upgrade.sh).
+
+**Windows :**
+- Lancez [`install.bat`](install.bat) pour installer (rôle Terminal) et [`upgrade.bat`](upgrade.bat) pour mettre à jour.
+- L’installation n’est pas nécessaire pour démarrer en mode Terminal (par défaut).
 
 ### 4. Administration
 Visitez [`http://localhost:8000/admin/`](http://localhost:8000/admin/) pour l'[administration Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) et [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) pour la [documentation d’administration](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Utilisez `--port` avec les scripts de démarrage ou l’installateur pour exposer un autre port.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@ Arthexis Constellation is a [narrative-driven](https://en.wikipedia.org/wiki/Nar
 ## Features
 
 - Compatible with the [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/) central system, handling:
-  - BootNotification
-  - Heartbeat
-  - StatusNotification
-  - Authorize
-  - MeterValues
-  - DiagnosticsStatusNotification
-  - StartTransaction
-  - StopTransaction
-  - FirmwareStatusNotification
+  - Lifecycle & sessions: BootNotification, Heartbeat, StatusNotification, StartTransaction, StopTransaction
+  - Access & metering: Authorize, MeterValues
+  - Maintenance & firmware: DiagnosticsStatusNotification, FirmwareStatusNotification
 - [API](https://en.wikipedia.org/wiki/API) integration with [Odoo](https://www.odoo.com/), syncing:
   - Employee credentials via `res.users`
   - Product catalog lookups via `product.product`
@@ -28,29 +22,29 @@ Project under active development.
 
 Arthexis Constellation ships in four node roles tailored to different deployment scenarios.
 
-<table>
+<table border="1" cellpadding="8" cellspacing="0">
   <thead>
     <tr>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Role</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Description &amp; Common Features</th>
+      <th align="left">Role</th>
+      <th align="left">Description &amp; Common Features</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Single-User Research &amp; Development<br>Features: GUI Toast</td>
+      <td valign="top"><strong>Terminal</strong></td>
+      <td valign="top"><strong>Single-User Research &amp; Development</strong><br />Features: GUI Toast</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Single-Device Testing &amp; Special Task Appliances<br>Features: AP Public Wi-Fi, Celery Queue, GUI Toast, LCD Screen, NGINX Server, RFID Scanner</td>
+      <td valign="top"><strong>Control</strong></td>
+      <td valign="top"><strong>Single-Device Testing &amp; Special Task Appliances</strong><br />Features: AP Public Wi-Fi, Celery Queue, GUI Toast, LCD Screen, NGINX Server, RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Multi-Device Edge, Network &amp; Data Acquisition<br>Features: AP Router, Celery Queue, NGINX Server, RFID Scanner</td>
+      <td valign="top"><strong>Satellite</strong></td>
+      <td valign="top"><strong>Multi-Device Edge, Network &amp; Data Acquisition</strong><br />Features: AP Router, Celery Queue, NGINX Server, RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem;">Constellation</td>
-      <td style="padding: 0.6rem 1rem;">Multi-User Cloud &amp; Orchestration<br>Features: Celery Queue, NGINX Server</td>
+      <td valign="top"><strong>Constellation</strong></td>
+      <td valign="top"><strong>Multi-User Cloud &amp; Orchestration</strong><br />Features: Celery Queue, NGINX Server</td>
     </tr>
   </tbody>
 </table>
@@ -58,8 +52,7 @@ Arthexis Constellation ships in four node roles tailored to different deployment
 ## Quick Guide
 
 ### 1. Clone
-- **[Linux](https://en.wikipedia.org/wiki/Linux)**: open a [terminal](https://en.wikipedia.org/wiki/Command-line_interface) and run  
-  `git clone https://github.com/arthexis/arthexis.git`
+- **[Linux](https://en.wikipedia.org/wiki/Linux)**: open a [terminal](https://en.wikipedia.org/wiki/Command-line_interface) and run `git clone https://github.com/arthexis/arthexis.git`.
 - **[Windows](https://en.wikipedia.org/wiki/Microsoft_Windows)**: open [PowerShell](https://learn.microsoft.com/powershell/) or [Git Bash](https://gitforwindows.org/) and run the same command.
 
 ### 2. Start and stop

--- a/README.md
+++ b/README.md
@@ -28,12 +28,32 @@ Project under active development.
 
 Arthexis Constellation ships in four node roles tailored to different deployment scenarios.
 
-| Role | Description & Common Features |
-| --- | --- |
-| Terminal | Single-User Research & Development<br>Features: GUI Toast |
-| Control | Single-Device Testing & Special Task Appliances<br>Features: AP Public Wi-Fi, Celery Queue, GUI Toast, LCD Screen, NGINX Server, RFID Scanner |
-| Satellite | Multi-Device Edge, Network & Data Acquisition<br>Features: AP Router, Celery Queue, NGINX Server, RFID Scanner |
-| Constellation | Multi-User Cloud & Orchestration<br>Features: Celery Queue, NGINX Server |
+<table>
+  <thead>
+    <tr>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Role</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Description &amp; Common Features</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Single-User Research &amp; Development<br>Features: GUI Toast</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Single-Device Testing &amp; Special Task Appliances<br>Features: AP Public Wi-Fi, Celery Queue, GUI Toast, LCD Screen, NGINX Server, RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Multi-Device Edge, Network &amp; Data Acquisition<br>Features: AP Router, Celery Queue, NGINX Server, RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem;">Constellation</td>
+      <td style="padding: 0.6rem 1rem;">Multi-User Cloud &amp; Orchestration<br>Features: Celery Queue, NGINX Server</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Quick Guide
 
@@ -43,24 +63,30 @@ Arthexis Constellation ships in four node roles tailored to different deployment
 - **[Windows](https://en.wikipedia.org/wiki/Microsoft_Windows)**: open [PowerShell](https://learn.microsoft.com/powershell/) or [Git Bash](https://gitforwindows.org/) and run the same command.
 
 ### 2. Start and stop
-Terminal nodes can start directly with the scripts below without installing; Control, Satellite, and Constellation roles require installation first. Both approaches listen on [`http://localhost:8000/`](http://localhost:8000/) by default—pass `--port` to use a different value.
+Terminal nodes can start directly with the scripts below without installing; Control, Satellite, and Constellation roles require installation first. Both approaches listen on [`http://localhost:8000/`](http://localhost:8000/) by default.
 
-- **[VS Code](https://code.visualstudio.com/)**
-  - Open the folder and go to the **Run and Debug** panel (`Ctrl+Shift+D`).
-  - Select the **Run Server** (or **Debug Server**) configuration.
-  - Press the green start button. Stop the server with the red square button (`Shift+F5`).
-- **[Shell](https://en.wikipedia.org/wiki/Shell_(computing))**
-  - Linux: run [`./start.sh`](start.sh) and stop with [`./stop.sh`](stop.sh).
-  - Windows: run [`start.bat`](start.bat) and stop with `Ctrl+C`.
+**[VS Code](https://code.visualstudio.com/)**
+- Open the folder and go to the **Run and Debug** panel (`Ctrl+Shift+D`).
+- Select the **Run Server** (or **Debug Server**) configuration.
+- Press the green start button. Stop the server with the red square button (`Shift+F5`).
+
+**[Shell](https://en.wikipedia.org/wiki/Shell_(computing))**
+- Linux: run [`./start.sh`](start.sh) and stop with [`./stop.sh`](stop.sh).
+- Windows: run [`start.bat`](start.bat) and stop with `Ctrl+C`.
 
 ### 3. Install and upgrade
-- **Linux**: run [`./install.sh`](install.sh) with a node role flag:
-  - `--terminal` – default when unspecified and recommended if you're unsure. Terminal nodes can also use the start/stop scripts above without installing.
-  - `--control` – prepares the single-device testing appliance.
-  - `--satellite` – configures the edge data acquisition node.
-  - `--constellation` – enables the multi-user orchestration stack.
-  Use `./install.sh --help` to list every available flag if you need to customize the node beyond the role defaults. Upgrade with [`./upgrade.sh`](upgrade.sh).
-- **Windows**: run [`install.bat`](install.bat) to install (Terminal role) and [`upgrade.bat`](upgrade.bat) to upgrade.
+**Linux:** run [`./install.sh`](install.sh) with a node role flag:
+- `--terminal` – default when unspecified and recommended if you're unsure. Terminal nodes can also use the start/stop scripts above without installing.
+- `--control` – prepares the single-device testing appliance.
+- `--satellite` – configures the edge data acquisition node.
+- `--constellation` – enables the multi-user orchestration stack.
+Use `./install.sh --help` to list every available flag if you need to customize the node beyond the role defaults.
+
+Upgrade with [`./upgrade.sh`](upgrade.sh).
+
+**Windows:**
+- Run [`install.bat`](install.bat) to install (Terminal role) and [`upgrade.bat`](upgrade.bat) to upgrade.
+- Installation is not required to start in Terminal mode (the default).
 
 ### 4. Administration
 Visit [`http://localhost:8000/admin/`](http://localhost:8000/admin/) for the [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) and [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) for the [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Use `--port` with the start scripts or installer when you need to expose a different port.

--- a/README.ru.md
+++ b/README.ru.md
@@ -7,15 +7,9 @@
 ## Возможности
 
 - Совместим с [Open Charge Point Protocol (OCPP) 1.6](https://www.openchargealliance.org/protocols/ocpp-16/) в роли центральной системы и обрабатывает:
-  - BootNotification
-  - Heartbeat
-  - StatusNotification
-  - Authorize
-  - MeterValues
-  - DiagnosticsStatusNotification
-  - StartTransaction
-  - StopTransaction
-  - FirmwareStatusNotification
+  - Управление жизненным циклом и сессиями: BootNotification, Heartbeat, StatusNotification, StartTransaction, StopTransaction
+  - Доступ и учёт показаний: Authorize, MeterValues
+  - Обслуживание и прошивка: DiagnosticsStatusNotification, FirmwareStatusNotification
 - [API](https://ru.wikipedia.org/wiki/API) интеграция с [Odoo](https://www.odoo.com/) для:
   - Синхронизации учётных данных сотрудников через `res.users`
   - Запроса каталога продуктов через `product.product`
@@ -26,34 +20,34 @@
 
 Созвездие Arthexis поставляется в четырёх ролях узлов, чтобы адаптировать платформу к различным сценариям развёртывания.
 
-<table>
+<table border="1" cellpadding="8" cellspacing="0">
   <thead>
     <tr>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Роль</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Описание</th>
-      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Типичные функции</th>
+      <th align="left">Роль</th>
+      <th align="left">Описание</th>
+      <th align="left">Типичные функции</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Исследования и разработка для одного пользователя</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+      <td valign="top"><strong>Terminal</strong></td>
+      <td valign="top"><strong>Исследования и разработка для одного пользователя</strong></td>
+      <td valign="top">GUI Toast</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Тестирование отдельных устройств и специализированные аппаратные комплексы</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Control</strong></td>
+      <td valign="top"><strong>Тестирование отдельных устройств и специализированные аппаратные комплексы</strong></td>
+      <td valign="top">AP Public Wi-Fi<br />Celery Queue<br />GUI Toast<br />LCD Screen<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Периферийная многоприборная инфраструктура, сеть и сбор данных</td>
-      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+      <td valign="top"><strong>Satellite</strong></td>
+      <td valign="top"><strong>Периферийная многоприборная инфраструктура, сеть и сбор данных</strong></td>
+      <td valign="top">AP Router<br />Celery Queue<br />NGINX Server<br />RFID Scanner</td>
     </tr>
     <tr>
-      <td style="padding: 0.6rem 1rem;">Constellation</td>
-      <td style="padding: 0.6rem 1rem;">Многопользовательское облако и оркестрация</td>
-      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+      <td valign="top"><strong>Constellation</strong></td>
+      <td valign="top"><strong>Многопользовательское облако и оркестрация</strong></td>
+      <td valign="top">Celery Queue<br />NGINX Server</td>
     </tr>
   </tbody>
 </table>
@@ -61,8 +55,7 @@
 ## Quick Guide
 
 ### 1. Клонирование
-- **[Linux](https://ru.wikipedia.org/wiki/Linux)**: откройте [терминал](https://ru.wikipedia.org/wiki/Командная_оболочка) и выполните  
-  `git clone https://github.com/arthexis/arthexis.git`
+- **[Linux](https://ru.wikipedia.org/wiki/Linux)**: откройте [терминал](https://ru.wikipedia.org/wiki/Командная_оболочка) и выполните `git clone https://github.com/arthexis/arthexis.git`.
 - **[Windows](https://ru.wikipedia.org/wiki/Microsoft_Windows)**: откройте [PowerShell](https://learn.microsoft.com/ru-ru/powershell/) или [Git Bash](https://gitforwindows.org/) и выполните ту же команду.
 
 ### 2. Запуск и остановка

--- a/README.ru.md
+++ b/README.ru.md
@@ -26,12 +26,37 @@
 
 Созвездие Arthexis поставляется в четырёх ролях узлов, чтобы адаптировать платформу к различным сценариям развёртывания.
 
-| Роль | Описание | Типичные функции |
-| --- | --- | --- |
-| Terminal | Исследования и разработка для одного пользователя | • GUI Toast |
-| Control | Тестирование отдельных устройств и специализированные аппаратные комплексы | • AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner |
-| Satellite | Периферийная многоприборная инфраструктура, сеть и сбор данных | • AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner |
-| Constellation | Многопользовательское облако и оркестрация | • Celery Queue<br>• NGINX Server |
+<table>
+  <thead>
+    <tr>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Роль</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Описание</th>
+      <th style="padding: 0.6rem 1rem; border-bottom: 2px solid #444; text-align: left;">Типичные функции</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Terminal</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Исследования и разработка для одного пользователя</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• GUI Toast</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Control</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Тестирование отдельных устройств и специализированные аппаратные комплексы</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Public Wi-Fi<br>• Celery Queue<br>• GUI Toast<br>• LCD Screen<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Satellite</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">Периферийная многоприборная инфраструктура, сеть и сбор данных</td>
+      <td style="padding: 0.6rem 1rem; border-bottom: 1px solid #444;">• AP Router<br>• Celery Queue<br>• NGINX Server<br>• RFID Scanner</td>
+    </tr>
+    <tr>
+      <td style="padding: 0.6rem 1rem;">Constellation</td>
+      <td style="padding: 0.6rem 1rem;">Многопользовательское облако и оркестрация</td>
+      <td style="padding: 0.6rem 1rem;">• Celery Queue<br>• NGINX Server</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Quick Guide
 
@@ -41,25 +66,31 @@
 - **[Windows](https://ru.wikipedia.org/wiki/Microsoft_Windows)**: откройте [PowerShell](https://learn.microsoft.com/ru-ru/powershell/) или [Git Bash](https://gitforwindows.org/) и выполните ту же команду.
 
 ### 2. Запуск и остановка
-Узлы Terminal можно запускать напрямую приведёнными ниже скриптами без установки; роли Control, Satellite и Constellation требуют предварительной установки. Оба варианта по умолчанию слушают [`http://localhost:8000/`](http://localhost:8000/) — используйте `--port`, чтобы выбрать другой порт.
+Узлы Terminal можно запускать напрямую приведёнными ниже скриптами без установки; роли Control, Satellite и Constellation требуют предварительной установки. Оба варианта по умолчанию слушают [`http://localhost:8000/`](http://localhost:8000/).
 
-- **[VS Code](https://code.visualstudio.com/)**
-  - Откройте папку и перейдите на панель **Run and Debug** (`Ctrl+Shift+D`).
-  - Выберите конфигурацию **Run Server** (или **Debug Server**).
-  - Нажмите зелёную кнопку запуска. Остановите сервер красным квадратом (`Shift+F5`).
-- **[Shell](https://ru.wikipedia.org/wiki/Командная_оболочка)**
-  - Linux: запустите [`./start.sh`](start.sh) и остановите [`./stop.sh`](stop.sh).
-  - Windows: запустите [`start.bat`](start.bat) и остановите `Ctrl+C`.
+**[VS Code](https://code.visualstudio.com/)**
+- Откройте папку и перейдите на панель **Run and Debug** (`Ctrl+Shift+D`).
+- Выберите конфигурацию **Run Server** (или **Debug Server**).
+- Нажмите зелёную кнопку запуска. Остановите сервер красным квадратом (`Shift+F5`).
+
+**[Shell](https://ru.wikipedia.org/wiki/Командная_оболочка)**
+- Linux: запустите [`./start.sh`](start.sh) и остановите [`./stop.sh`](stop.sh).
+- Windows: запустите [`start.bat`](start.bat) и остановите `Ctrl+C`.
 
 
 ### 3. Установка и обновление
-- **Linux**: выполните [`./install.sh`](install.sh) с флагом роли узла:
-  - `--terminal` — роль по умолчанию, если флаг не указан, и рекомендуемый выбор, если вы не уверены. Узлы Terminal также могут использовать приведённые выше скрипты запуска/остановки без установки.
-  - `--control` — подготавливает устройство для тестирования одного зарядного устройства.
-  - `--satellite` — настраивает периферийный узел сбора данных.
-  - `--constellation` — включает мультипользовательский оркестратор.
-  Используйте `./install.sh --help`, чтобы увидеть полный список флагов, если требуется дополнительная настройка сверх выбранной роли. Обновляйте систему с помощью [`./upgrade.sh`](upgrade.sh).
-- **Windows**: выполните [`install.bat`](install.bat) для установки (роль Terminal) и [`upgrade.bat`](upgrade.bat) для обновления.
+**Linux:** выполните [`./install.sh`](install.sh) с флагом роли узла:
+- `--terminal` — роль по умолчанию, если флаг не указан, и рекомендуемый выбор, если вы не уверены. Узлы Terminal также могут использовать приведённые выше скрипты запуска/остановки без установки.
+- `--control` — подготавливает устройство для тестирования одного зарядного устройства.
+- `--satellite` — настраивает периферийный узел сбора данных.
+- `--constellation` — включает мультипользовательский оркестратор.
+Используйте `./install.sh --help`, чтобы увидеть полный список флагов, если требуется дополнительная настройка сверх выбранной роли.
+
+Обновляйте систему с помощью [`./upgrade.sh`](upgrade.sh).
+
+**Windows:**
+- Выполните [`install.bat`](install.bat) для установки (роль Terminal) и [`upgrade.bat`](upgrade.bat) для обновления.
+- Установка не требуется для запуска в режиме Terminal (режим по умолчанию).
 
 ### 4. Администрирование
 Перейдите на [`http://localhost:8000/admin/`](http://localhost:8000/admin/) для [панели администратора Django](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) и [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) для [административной документации](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Используйте `--port` со скриптами запуска или установщиком, если нужно открыть другой порт.


### PR DESCRIPTION
## Summary
- restyle the role overview tables with HTML markup to provide consistent padding and borders
- simplify the start/stop instructions by flattening the VS Code and shell headings and trimming redundant port guidance
- align the install/upgrade directions for Linux and Windows, adding the Terminal-mode installation note across translations

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d04bcc82408326bff745cbe99f0a53