### PR TITLE
Allow arthexis system user to have profiles

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -269,7 +269,7 @@ def _cleanup_public_wifi_on_delete(sender, instance, **kwargs):
 class User(Entity, AbstractUser):
     SYSTEM_USERNAME = "arthexis"
     ADMIN_USERNAME = "admin"
-    PROFILE_RESTRICTED_USERNAMES = frozenset({SYSTEM_USERNAME})
+    PROFILE_RESTRICTED_USERNAMES = frozenset()
 
     objects = EntityUserManager()
     all_objects = DjangoUserManager()


### PR DESCRIPTION
## Summary
- remove the system user from the set of profile-restricted usernames
- add a regression test confirming the arthexis system account passes profile validation

## Testing
- pytest tests/test_assistant_profile_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d06998949083268f1144f454eded9a