### PR TITLE
Adjust admin client report section padding

### DIFF
--- a/core/templates/admin/core/clientreport/generate.html
+++ b/core/templates/admin/core/clientreport/generate.html
@@ -183,7 +183,7 @@
   }
 
   .client-report-form .report-section > *:not(legend):not(.section-description) {
-    padding: 0.75rem 0;
+    padding: 0 0 0.75rem;
   }
 
   .client-report-form
@@ -191,6 +191,7 @@
     > *:not(legend):not(.section-description)
     + *:not(legend):not(.section-description) {
     border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 0.75rem;
   }
 
   .client-report-form .form-group {


### PR DESCRIPTION
## Summary
- trim excess padding applied to admin client report sections to remove the blank space under section headers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d069d753dc8326b905b2115a34c60a