### PR TITLE
Add energy tariff calculator and update power navigation

### DIFF
--- a/awg/templates/awg/energy_tariff_calculator.html
+++ b/awg/templates/awg/energy_tariff_calculator.html
@@ -1,0 +1,119 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Energy Tariff Calculator" %}{% endblock %}
+{% block content %}
+<h1>{% trans "Energy Tariff Calculator" %}</h1>
+<form method="post" id="energy-tariff-calculator">
+  {% csrf_token %}
+  <div class="row g-4 mb-3">
+    <div class="col-lg-4">
+      <div class="mb-3">
+        <label class="form-label" for="kwh">{% trans "Consumption (kWh):" %}</label>
+        <input id="kwh" type="number" step="0.01" min="0.01" class="form-control" name="kwh" required value="{{ form.kwh }}" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="year">{% trans "Year:" %}</label>
+        <select id="year" name="year" class="form-select">
+          {% for year in years %}
+          <option value="{{ year }}" {% if form.year == year|stringformat:"s" %}selected{% endif %}>{{ year }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="contract_type">{% trans "Contract type:" %}</label>
+        <select id="contract_type" name="contract_type" class="form-select">
+          <option value="" {% if not form.contract_type %}selected{% endif %}>{% trans "All contract types" %}</option>
+          {% for option in contract_options %}
+          <option value="{{ option.value }}" {% if form.contract_type == option.value %}selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="col-lg-4">
+      <div class="mb-3">
+        <label class="form-label" for="zone">{% trans "Climate zone:" %}</label>
+        <select id="zone" name="zone" class="form-select">
+          <option value="" {% if not form.zone %}selected{% endif %}>{% trans "All climate zones" %}</option>
+          {% for zone in zone_options %}
+          <option value="{{ zone }}" {% if form.zone == zone %}selected{% endif %}>{{ zone }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="season">{% trans "Season:" %}</label>
+        <select id="season" name="season" class="form-select">
+          <option value="" {% if not form.season %}selected{% endif %}>{% trans "All seasons" %}</option>
+          {% for option in season_options %}
+          <option value="{{ option.value }}" {% if form.season == option.value %}selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="period">{% trans "Billing period:" %}</label>
+        <select id="period" name="period" class="form-select">
+          <option value="" {% if not form.period %}selected{% endif %}>{% trans "All billing periods" %}</option>
+          {% for option in period_options %}
+          <option value="{{ option.value }}" {% if form.period == option.value %}selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="tariff">{% trans "Tariff window:" %}</label>
+        <select id="tariff" name="tariff" class="form-select" {% if not tariff_options %}disabled{% endif %}>
+          {% for option in tariff_options %}
+          <option value="{{ option.id }}" {% if form.tariff == option.id %}selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+        <small class="text-muted d-block mt-1">
+          {% blocktrans trimmed count count=tariff_options|length %}
+            {{ count }} tariff available
+          {% plural %}
+            {{ count }} tariffs available
+          {% endblocktrans %}
+        </small>
+      </div>
+    </div>
+    <div class="col-lg-4 d-flex flex-column{% if result or error or no_tariffs %} order-first order-lg-last{% endif %}">
+      {% if not result and not error and not no_tariffs %}
+      <div class="mb-3">
+        <button type="submit" class="btn btn-primary w-100 fs-4">{% trans "Calculate" %}</button>
+      </div>
+      <p class="text-muted">{% trans "Select a CFE tariff and enter your expected kWh consumption to estimate the energy bill in MXN." %}</p>
+      {% else %}
+      {% if error %}
+      <p class="text-danger">{{ error }}</p>
+      {% elif no_tariffs %}
+      <p class="text-warning">{% trans "No tariffs match the selected filters. Try expanding your search." %}</p>
+      {% elif result %}
+      <div class="calc-result">
+        <h2>{% trans "Estimated Bill" %}</h2>
+        <table class="table table-sm">
+          <tbody>
+            <tr><th>{% trans "Tariff" %}</th><td>{{ result.tariff }}</td></tr>
+            <tr><th>{% trans "Year" %}</th><td>{{ result.tariff.year }}</td></tr>
+            <tr><th>{% trans "Contract type" %}</th><td>{{ result.tariff.get_contract_type_display }}</td></tr>
+            <tr><th>{% trans "Climate zone" %}</th><td>{{ result.tariff.zone }}</td></tr>
+            <tr><th>{% trans "Season" %}</th><td>{{ result.tariff.get_season_display }}</td></tr>
+            <tr><th>{% trans "Billing period" %}</th><td>{{ result.tariff.get_period_display }}</td></tr>
+            <tr><th>{% trans "Time window" %}</th><td>{{ result.tariff.start_time|time:"H:i" }} &ndash; {{ result.tariff.end_time|time:"H:i" }}</td></tr>
+            <tr><th>{% trans "Unit price" %}</th><td>${{ result.unit_price|floatformat:4 }} MXN/kWh</td></tr>
+            <tr><th>{% trans "Unit cost" %}</th><td>${{ result.unit_cost|floatformat:4 }} MXN/kWh</td></tr>
+            <tr><th>{% trans "Consumption" %}</th><td>{{ result.kwh|floatformat:2 }} kWh</td></tr>
+            <tr><th>{% trans "Estimated bill" %}</th><td>${{ result.total_price|floatformat:2 }} MXN</td></tr>
+            <tr><th>{% trans "Provider cost" %}</th><td>${{ result.total_cost|floatformat:2 }} MXN</td></tr>
+            <tr><th>{% trans "Gross margin" %}</th><td>${{ result.margin_total|floatformat:2 }} MXN</td></tr>
+          </tbody>
+        </table>
+        {% if result.tariff.notes %}
+        <p class="small text-muted">{{ result.tariff.notes }}</p>
+        {% endif %}
+      </div>
+      {% endif %}
+      <div class="mt-auto mb-3">
+        <button type="submit" class="btn btn-primary w-100 fs-4">{% trans "Calculate Again" %}</button>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/awg/urls.py
+++ b/awg/urls.py
@@ -6,4 +6,5 @@ app_name = "awg"
 
 urlpatterns = [
     path("", views.calculator, name="calculator"),
+    path("energy-tariff/", views.energy_tariff_calculator, name="energy_tariff"),
 ]

--- a/awg/views.py
+++ b/awg/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Literal, Optional, Union
 
 from django.shortcuts import render
@@ -11,7 +12,13 @@ from django.utils.translation import gettext as _, gettext_lazy as _lazy
 
 from pages.utils import landing
 
-from .models import CableSize, ConduitFill, CalculatorTemplate, PowerLead
+from .models import (
+    CableSize,
+    ConduitFill,
+    CalculatorTemplate,
+    EnergyTariff,
+    PowerLead,
+)
 
 
 class AWG(int):
@@ -62,6 +69,13 @@ def _format_ground_output(amount: int, label: str) -> str:
     """Return a formatted ground string including any special label."""
 
     return f"{amount} ({label})" if label else str(amount)
+
+
+def _format_decimal(value: Decimal, places: str = "0.0000") -> Decimal:
+    """Return ``value`` quantized to the requested decimal ``places``."""
+
+    quantizer = Decimal(places)
+    return value.quantize(quantizer, rounding=ROUND_HALF_UP)
 
 
 def find_conduit(awg: Union[str, int], cables: int, *, conduit: str = "emt"):
@@ -350,3 +364,163 @@ def calculator(request):
         show_in_pages=True
     ).order_by("name")
     return render(request, "awg/calculator.html", context)
+
+
+@csrf_exempt
+@landing(_lazy("Energy Tariff Calculator"))
+def energy_tariff_calculator(request):
+    """Estimate MXN costs for a given kWh consumption using CFE tariffs."""
+
+    form_data = request.POST or request.GET
+    form = {k: v for k, v in form_data.items() if v not in (None, "", "None")}
+
+    base_qs = EnergyTariff.objects.filter(unit=EnergyTariff.Unit.KWH)
+    years = sorted(base_qs.values_list("year", flat=True).distinct(), reverse=True)
+
+    context: dict[str, object] = {
+        "form": form,
+        "years": years,
+    }
+
+    if years and "year" not in form:
+        form["year"] = str(years[0])
+
+    tariffs_year = base_qs
+    year_value: Optional[int] = None
+    if "year" in form:
+        try:
+            year_value = int(form["year"])
+        except (TypeError, ValueError):
+            form.pop("year", None)
+        else:
+            tariffs_year = tariffs_year.filter(year=year_value)
+
+    contract_values = sorted(
+        tariffs_year.values_list("contract_type", flat=True).distinct()
+    )
+    context["contract_options"] = [
+        {"value": value, "label": EnergyTariff.ContractType(value).label}
+        for value in contract_values
+    ]
+
+    tariffs_contract = tariffs_year
+    contract_type = form.get("contract_type")
+    if contract_type:
+        tariffs_contract = tariffs_contract.filter(contract_type=contract_type)
+
+    zone_values = sorted(tariffs_contract.values_list("zone", flat=True).distinct())
+    context["zone_options"] = zone_values
+
+    tariffs_zone = tariffs_contract
+    zone = form.get("zone")
+    if zone:
+        tariffs_zone = tariffs_zone.filter(zone=zone)
+
+    season_values = sorted(tariffs_zone.values_list("season", flat=True).distinct())
+    context["season_options"] = [
+        {"value": value, "label": EnergyTariff.Season(value).label}
+        for value in season_values
+    ]
+
+    tariffs_season = tariffs_zone
+    season = form.get("season")
+    if season:
+        tariffs_season = tariffs_season.filter(season=season)
+
+    period_values = sorted(
+        tariffs_season.values_list("period", flat=True).distinct()
+    )
+    context["period_options"] = [
+        {"value": value, "label": EnergyTariff.Period(value).label}
+        for value in period_values
+    ]
+
+    tariffs_period = tariffs_season
+    period = form.get("period")
+    if period:
+        tariffs_period = tariffs_period.filter(period=period)
+
+    tariff_list = list(
+        tariffs_period.order_by(
+            "contract_type", "zone", "season", "period", "start_time"
+        )
+    )
+
+    if request.method == "GET" and tariff_list and "tariff" not in form:
+        form["tariff"] = str(tariff_list[0].pk)
+
+    tariff_map = {str(t.pk): t for t in tariff_list}
+
+    context["tariff_options"] = [
+        {
+            "id": str(t.pk),
+            "label": _(
+                "%(contract)s • Zone %(zone)s • %(season)s • %(period)s (%(start)s – %(end)s) @ %(price)s MXN/kWh"
+            )
+            % {
+                "contract": t.get_contract_type_display(),
+                "zone": t.zone,
+                "season": t.get_season_display(),
+                "period": t.get_period_display(),
+                "start": t.start_time.strftime("%H:%M"),
+                "end": t.end_time.strftime("%H:%M"),
+                "price": _format_decimal(t.price_mxn),
+            },
+        }
+        for t in tariff_list
+    ]
+    context["no_tariffs"] = not tariff_list
+
+    if request.method == "POST":
+        error: Optional[str] = None
+        kwh_str = request.POST.get("kwh")
+        tariff_id = request.POST.get("tariff")
+
+        if not kwh_str:
+            error = _("Enter the energy consumption in kWh.")
+        if not error:
+            if not tariff_id:
+                error = _("Select an energy tariff to continue.")
+            elif tariff_id not in tariff_map:
+                error = _("Selected tariff is not available for the chosen filters.")
+
+        kwh_value: Optional[Decimal] = None
+        if not error and kwh_str is not None:
+            try:
+                kwh_value = Decimal(kwh_str)
+            except (InvalidOperation, TypeError):
+                error = _("Energy consumption must be a number.")
+            else:
+                if kwh_value <= 0:
+                    error = _("Energy consumption must be greater than zero.")
+
+        if error:
+            context["error"] = error
+        else:
+            assert kwh_value is not None and tariff_id is not None
+            selected = tariff_map[tariff_id]
+            kwh_display = _format_decimal(kwh_value, "0.01")
+            unit_price = _format_decimal(selected.price_mxn)
+            unit_cost = _format_decimal(selected.cost_mxn)
+            total_price = (kwh_display * unit_price).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
+            total_cost = (kwh_display * unit_cost).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
+            margin_total = (total_price - total_cost).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
+
+            context["result"] = {
+                "tariff": selected,
+                "kwh": kwh_display,
+                "unit_price": unit_price,
+                "unit_cost": unit_cost,
+                "total_price": total_price,
+                "total_cost": total_cost,
+                "margin_total": margin_total,
+            }
+            form["kwh"] = str(kwh_display)
+
+    return render(request, "awg/energy_tariff_calculator.html", context)

--- a/pages/context_processors.py
+++ b/pages/context_processors.py
@@ -47,6 +47,8 @@ def nav_links(request):
                 continue
             landings.append(landing)
         if landings:
+            if getattr(module.application, "name", "").lower() == "awg":
+                module.menu = "Power"
             module.enabled_landings = landings
             valid_modules.append(module)
             if request.path.startswith(module.path):


### PR DESCRIPTION
## Summary
- add an energy tariff calculator view, URL, and template to convert kWh consumption to MXN using configured tariffs
- rename the AWG navigation pill to Power so both calculators appear under a single dropdown
- cover the new calculator flow and navigation changes with dedicated tests

## Testing
- python manage.py test awg.tests.EnergyTariffCalculatorTests pages.tests.PowerNavTests

------
https://chatgpt.com/codex/tasks/task_e_68d06ac1b8308326bfe3fc5e65dbd887