### PR TITLE
Hide Horologia admin group when Celery disabled

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -1,7 +1,9 @@
 {% load i18n admin_extras favorites %}
 
 {% if app_list %}
+  {% celery_feature_enabled as celery_enabled %}
   {% for app in app_list %}
+    {% if app.app_label != 'django_celery_beat' or celery_enabled %}
     <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
       <table>
         <caption class="app-caption">
@@ -71,6 +73,7 @@
         {% endfor %}
       </table>
     </div>
+    {% endif %}
   {% endfor %}
 {% else %}
   <p>{% translate 'You don’t have permission to view or edit anything.' %}</p>


### PR DESCRIPTION
## Summary
- add a template tag to detect whether the Celery feature is available
- hide the Horologia admin group on the dashboard when Celery support is disabled
- add regression tests that cover the Celery feature and lock file scenarios

## Testing
- python manage.py test pages.tests.AdminDashboardAppListTests

------
https://chatgpt.com/codex/tasks/task_e_68d06c2928008326b1931e8b7b6a4c75