### PR TITLE
Ensure My Profile action visible on dashboard

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -226,7 +226,7 @@ class ProfileAdminMixin:
         return HttpResponseRedirect(changelist_url)
 
     @admin.action(description=_("My Profile"))
-    def my_profile(self, request, queryset):
+    def my_profile(self, request, queryset=None):
         return self._redirect_to_my_profile(request)
 
     def my_profile_action(self, request, obj=None):
@@ -234,6 +234,18 @@ class ProfileAdminMixin:
 
     my_profile_action.label = _("My Profile")
     my_profile_action.short_description = _("My Profile")
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if "my_profile" not in actions:
+            action = getattr(self, "my_profile", None)
+            if action is not None:
+                actions["my_profile"] = (
+                    action,
+                    "my_profile",
+                    getattr(action, "short_description", _("My Profile")),
+                )
+        return actions
 
 
 @admin.register(ExperienceReference)

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1,4 +1,4 @@
-from django.test import Client, TestCase, override_settings
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from urllib.parse import quote
 from django.contrib.auth import get_user_model
@@ -16,6 +16,7 @@ from pages.screenshot_specs import (
 )
 from django.apps import apps as django_apps
 from core import mailer
+from core.admin import ProfileAdminMixin
 from core.models import AdminHistory, InviteLead, Package, ReleaseManager, Todo
 from django.core.files.uploadedfile import SimpleUploadedFile
 import base64
@@ -1288,6 +1289,37 @@ class FavoriteTests(TestCase):
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, "Release manager tasks")
         self.assertContains(resp, todo.request)
+
+
+class AdminActionListTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        User.objects.filter(username="action-admin").delete()
+        self.user = User.objects.create_superuser(
+            username="action-admin",
+            password="pwd",
+            email="action@example.com",
+        )
+        self.factory = RequestFactory()
+
+    def test_profile_actions_available_without_selection(self):
+        from pages.templatetags.admin_extras import model_admin_actions
+
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        registered = [
+            (model._meta.app_label, model._meta.object_name)
+            for model, admin_instance in admin.site._registry.items()
+            if isinstance(admin_instance, ProfileAdminMixin)
+        ]
+
+        for app_label, object_name in registered:
+            with self.subTest(model=f"{app_label}.{object_name}"):
+                actions = model_admin_actions(context, app_label, object_name)
+                labels = {action["label"] for action in actions}
+                self.assertIn("My Profile", labels)
 
 
 class AdminModelGraphViewTests(TestCase):


### PR DESCRIPTION
## Summary
- allow profile admin action to run without requiring a queryset and expose it through the standard action registry
- add regression coverage ensuring every registered profile admin advertises the My Profile shortcut on the dashboard

## Testing
- pytest tests/test_release_manager_admin.py tests/test_odoo_profile_admin.py tests/test_email_inbox_admin.py tests/test_assistant_profile_admin.py pages/tests.py::AdminActionListTests -q

------
https://chatgpt.com/codex/tasks/task_e_68d07086983483269b9334736c306d4d