### PR TITLE
Hide manual sigil textarea when validating file uploads

### DIFF
--- a/core/sigil_builder.py
+++ b/core/sigil_builder.py
@@ -88,16 +88,27 @@ def _sigil_builder_view(request):
 
     sigils_text = ""
     resolved_text = ""
+    show_sigils_input = True
+    show_result = False
     if request.method == "POST":
         sigils_text = request.POST.get("sigils_text", "")
+        source_text = sigils_text
         upload = request.FILES.get("sigils_file")
         if upload:
-            sigils_text = upload.read().decode("utf-8", errors="ignore")
+            source_text = upload.read().decode("utf-8", errors="ignore")
+            show_sigils_input = False
         else:
             single = request.POST.get("sigil", "")
             if single:
-                sigils_text = f"[{single}]" if not single.startswith("[") else single
-        resolved_text = resolve_sigils_in_text(sigils_text) if sigils_text else ""
+                source_text = (
+                    f"[{single}]" if not single.startswith("[") else single
+                )
+                sigils_text = source_text
+        if source_text:
+            resolved_text = resolve_sigils_in_text(source_text)
+            show_result = True
+        if upload:
+            sigils_text = ""
 
     context = admin.site.each_context(request)
     context.update(
@@ -108,6 +119,8 @@ def _sigil_builder_view(request):
             "auto_fields": auto_fields,
             "sigils_text": sigils_text,
             "resolved_text": resolved_text,
+            "show_sigils_input": show_sigils_input,
+            "show_result": show_result,
         }
     )
     return TemplateResponse(request, "admin/sigil_builder.html", context)

--- a/core/templates/admin/sigil_builder.html
+++ b/core/templates/admin/sigil_builder.html
@@ -6,12 +6,14 @@
   <h1>{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" style="margin-bottom:1em;">
     {% csrf_token %}
+    {% if show_sigils_input %}
     <label for="sigils_text">{% trans "Sigils" %}</label>
     <textarea name="sigils_text" id="sigils_text" rows="10" cols="80" style="width:100%;">{{ sigils_text }}</textarea>
+    {% endif %}
     <input type="file" name="sigils_file" id="sigils_file" />
     <button type="submit">{% trans "Validate" %}</button>
   </form>
-  {% if sigils_text %}
+  {% if show_result %}
   <label for="resolved_text">{% trans "Result" %}</label>
   <textarea id="resolved_text" rows="10" cols="80" style="width:100%;" readonly>{{ resolved_text }}</textarea>
   {% endif %}

--- a/tests/test_sigil_builder.py
+++ b/tests/test_sigil_builder.py
@@ -31,6 +31,8 @@ class SigilBuilderTests(TestCase):
             {"sigils_file": upload},
         )
         self.assertContains(response, settings.LANGUAGE_CODE)
+        self.assertFalse(response.context["show_sigils_input"])
+        self.assertTrue(response.context["show_result"])
 
     def test_builder_groups_multiple_roots(self):
         from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
## Summary
- hide the manual sigil textarea when a validation request comes from a file upload
- drive template rendering off of new context flags so the result panel still appears without the input
- extend the sigil builder test to cover the new flags for file uploads

## Testing
- python manage.py test tests.test_sigil_builder

------
https://chatgpt.com/codex/tasks/task_e_68d073edc1dc83269997cf2a49012825