### PR TITLE
Enforce Pi 4-only support in rpi-image-gen

### DIFF
--- a/rpi-image-gen.sh
+++ b/rpi-image-gen.sh
@@ -255,11 +255,13 @@ else
   echo "Using device layer '$DEVICE_LAYER_CANONICAL'."
 fi
 
-case "$DEVICE_LAYER_CANONICAL" in
-  rpi5|rpi-cm5)
-    error "Device layer '$DEVICE_LAYER_CANONICAL' targets hardware newer than the Raspberry Pi 4B, which is not supported. Use --device pi4 or an earlier model."
-    ;;
-esac
+if [[ "$DEVICE_LAYER_CANONICAL" != "rpi4" ]]; then
+  if [[ "$DEVICE_LAYER_REQUEST" != "$DEVICE_LAYER_CANONICAL" ]]; then
+    error "Device layer '$DEVICE_LAYER_REQUEST' resolves to unsupported canonical layer '$DEVICE_LAYER_CANONICAL'. This tool only supports the Raspberry Pi 4."
+  else
+    error "Device layer '$DEVICE_LAYER_CANONICAL' is not supported. This tool only supports the Raspberry Pi 4."
+  fi
+fi
 
 ensure_dependencies() {
   local dependencies_sh="$RPI_DIR/lib/dependencies.sh"


### PR DESCRIPTION
## Summary
- reject any resolved device layer whose canonical name is not rpi4 so unsupported hardware is caught consistently
- clarify the resulting error messaging to state that only Raspberry Pi 4 builds are supported

## Testing
- bash -n rpi-image-gen.sh
- ./rpi-image-gen.sh --help | head

------
https://chatgpt.com/codex/tasks/task_e_68d077043464832695ec031320979713