### PR TITLE
Set mmdebstrap unshare mode for rpi image generation

### DIFF
--- a/rpi-image-gen.sh
+++ b/rpi-image-gen.sh
@@ -424,6 +424,7 @@ cat > "$LAYER_FILE" <<'LAYER'
 # METAEND
 ---
 mmdebstrap:
+  mode: unshare
   packages:
     - sudo
     - git


### PR DESCRIPTION
## Summary
- configure the generated arthexis layer to request mmdebstrap's unshare mode so podman rootless builds satisfy bdebstrap requirements

## Testing
- pytest tests/test_admin_profile_link.py::AdminProfileLinkTests::test_profile_link_points_to_user_admin --tb=line -q *(fails: missing “MY PROFILE” link in admin response)*

------
https://chatgpt.com/codex/tasks/task_e_68d0823e2e8883269ea13e6ac5605554