### PR TITLE
Direct profile actions to change views

### DIFF
--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -79,14 +79,19 @@ def model_admin_actions(context, app_label, model_name):
         if action_name == "delete_selected" or uses_queryset(func):
             continue
         url = None
+        if action_name == "my_profile":
+            getter = getattr(model_admin, "get_my_profile_url", None)
+            if callable(getter):
+                url = getter(request)
         base = f"admin:{model_admin.opts.app_label}_{model_admin.opts.model_name}_"
-        try:
-            url = reverse(base + action_name)
-        except NoReverseMatch:
+        if not url:
             try:
-                url = reverse(base + action_name.split("_")[0])
+                url = reverse(base + action_name)
             except NoReverseMatch:
-                url = reverse(base + "changelist") + f"?action={action_name}"
+                try:
+                    url = reverse(base + action_name.split("_")[0])
+                except NoReverseMatch:
+                    url = reverse(base + "changelist") + f"?action={action_name}"
         actions.append({"url": url, "label": description or _name.replace("_", " ")})
     return actions
 

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1335,7 +1335,7 @@ class AdminActionListTests(TestCase):
             with self.subTest(model=f"{app_label}.{object_name}"):
                 actions = model_admin_actions(context, app_label, object_name)
                 labels = {action["label"] for action in actions}
-                self.assertIn("My Profile", labels)
+                self.assertIn("Active Profile", labels)
 
 
 class AdminModelGraphViewTests(TestCase):

--- a/tests/test_admin_profile_link.py
+++ b/tests/test_admin_profile_link.py
@@ -26,5 +26,5 @@ class AdminProfileLinkTests(TestCase):
     def test_profile_link_points_to_user_admin(self):
         response = self.client.get(reverse("admin:index"))
         expected_url = reverse("admin:teams_user_change", args=[self.user.pk])
-        self.assertContains(response, "MY PROFILE")
+        self.assertContains(response, "Active Profile")
         self.assertContains(response, f'href="{expected_url}"')


### PR DESCRIPTION
## Summary
- rename profile actions to "Active Profile" and expose a helper to compute the target admin URL
- update dashboard/admin action generation to link directly to the resolved profile change view
- refresh admin profile link tests for the new label and behavior

## Testing
- pytest tests/test_admin_profile_link.py tests/test_assistant_profile_admin.py tests/test_release_manager_admin.py tests/test_odoo_profile_admin.py tests/test_email_inbox_admin.py pages/tests.py::AdminActionListTests::test_profile_actions_available_without_selection

------
https://chatgpt.com/codex/tasks/task_e_68d08477ba3c832696c87e7ffa9f2e51