### PR TITLE
Link My Profile admin actions to profile change view

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -247,6 +247,21 @@ class ProfileAdminMixin:
                 )
         return actions
 
+    def get_urls(self):
+        urls = super().get_urls()
+        opts = self.model._meta
+        custom = [
+            path(
+                "my-profile/",
+                self.admin_site.admin_view(self._my_profile_view),
+                name=f"{opts.app_label}_{opts.model_name}_my_profile",
+            )
+        ]
+        return custom + urls
+
+    def _my_profile_view(self, request):
+        return self._redirect_to_my_profile(request)
+
 
 @admin.register(ExperienceReference)
 class ReferenceAdmin(EntityModelAdmin):

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -386,6 +386,16 @@ class AdminDashboardAppListTests(TestCase):
         resp = self.client.get(reverse("admin:index"))
         self.assertContains(resp, "5. Horologia MODELS")
 
+    def test_my_profile_action_links_to_direct_view(self):
+        ReleaseManager.objects.create(user=self.admin)
+        profile_url = reverse("admin:core_releasemanager_my_profile")
+
+        dashboard = self.client.get(reverse("admin:index"))
+        self.assertContains(dashboard, f'href="{profile_url}"')
+
+        app_list = self.client.get(reverse("admin:app_list", args=["core"]))
+        self.assertContains(app_list, f'href="{profile_url}"')
+
 
 class AdminSidebarTests(TestCase):
     def setUp(self):
@@ -1321,6 +1331,16 @@ class AdminActionListTests(TestCase):
                 actions = model_admin_actions(context, app_label, object_name)
                 labels = {action["label"] for action in actions}
                 self.assertIn("My Profile", labels)
+
+                target = next(
+                    (action for action in actions if action["label"] == "My Profile"),
+                    None,
+                )
+                self.assertIsNotNone(target)
+                expected_url = reverse(
+                    f"admin:{app_label}_{object_name.lower()}_my_profile"
+                )
+                self.assertEqual(target["url"], expected_url)
 
 
 class AdminModelGraphViewTests(TestCase):

--- a/tests/test_release_manager_admin.py
+++ b/tests/test_release_manager_admin.py
@@ -77,6 +77,13 @@ class ReleaseManagerAdminActionTests(TestCase):
         expected = reverse("admin:core_releasemanager_change", args=[self.manager.pk])
         self.assertEqual(response.url, expected)
 
+    def test_my_profile_direct_link_redirects(self):
+        self.client.force_login(self.user)
+        url = reverse("admin:core_releasemanager_my_profile")
+        response = self.client.get(url)
+        expected = reverse("admin:core_releasemanager_change", args=[self.manager.pk])
+        self.assertRedirects(response, expected, fetch_redirect_response=False)
+
     @pytest.mark.skip("Release manager credentials action not exercised in environment")
     @patch("core.admin.requests.get")
     def test_test_credentials_action(self, mock_get):


### PR DESCRIPTION
## Summary
- expose a dedicated `my-profile/` admin URL for profile-based admins so the dashboard and app list links redirect straight to the change form
- extend dashboard and admin action list tests to cover the new direct link
- add a release manager regression test exercising the `my-profile` shortcut endpoint

## Testing
- pytest tests/test_release_manager_admin.py
- python manage.py test --noinput pages.tests.AdminDashboardAppListTests.test_my_profile_action_links_to_direct_view
- python manage.py test --noinput pages.tests.AdminActionListTests.test_profile_actions_available_without_selection

------
https://chatgpt.com/codex/tasks/task_e_68d07ffc09688326ad3ca4708489e48a