### PR TITLE
Format upgrade notification timestamp for LCD

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -71,7 +71,7 @@ def check_github_updates() -> None:
     except Exception:
         startup = None
 
-    upgrade_stamp = f"@{timezone.now().isoformat()}"
+    upgrade_stamp = timezone.localtime().strftime("@%Y%m%d %H%M%S")
 
     if mode == "latest":
         local = (

--- a/tests/test_release_tasks.py
+++ b/tests/test_release_tasks.py
@@ -65,16 +65,17 @@ def test_upgrade_shows_message(monkeypatch, tmp_path):
 
     assert any(
         subject == "Upgrading..."
-        and body.startswith("@")
-        and _is_iso_datetime(body[1:])
+        and _is_lcd_timestamp(body)
         for subject, body in notify_calls
     )
     assert any("upgrade.sh" in cmd[0] for cmd in run_calls)
 
 
-def _is_iso_datetime(candidate: str) -> bool:
+def _is_lcd_timestamp(candidate: str) -> bool:
+    if len(candidate) > 16:
+        return False
     try:
-        datetime.fromisoformat(candidate)
+        datetime.strptime(candidate, "@%Y%m%d %H%M%S")
     except ValueError:
         return False
     return True


### PR DESCRIPTION
## Summary
- format the upgrade notification timestamp to a compact 16-character LCD-friendly string
- update the release task test to validate the new timestamp format

## Testing
- pytest tests/test_release_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68d087f1d1cc8326915a87d63323f1de