### PR TITLE
Add Product admin wizard for importing Odoo products

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1768,9 +1768,187 @@ class ProductAdminForm(forms.ModelForm):
         widgets = {"odoo_product": OdooProductWidget}
 
 
+class ProductFetchWizardForm(forms.Form):
+    name = forms.CharField(label="Name", required=False)
+    default_code = forms.CharField(label="Internal reference", required=False)
+    barcode = forms.CharField(label="Barcode", required=False)
+    renewal_period = forms.IntegerField(
+        label="Renewal period (days)", min_value=1, initial=30
+    )
+
+    def __init__(self, *args, require_search_terms=True, **kwargs):
+        self.require_search_terms = require_search_terms
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned = super().clean()
+        if self.require_search_terms:
+            if not any(
+                cleaned.get(field) for field in ("name", "default_code", "barcode")
+            ):
+                raise forms.ValidationError(
+                    _("Enter at least one field to search for a product.")
+                )
+        return cleaned
+
+    def build_domain(self):
+        domain = []
+        if self.cleaned_data.get("name"):
+            domain.append(("name", "ilike", self.cleaned_data["name"]))
+        if self.cleaned_data.get("default_code"):
+            domain.append(("default_code", "ilike", self.cleaned_data["default_code"]))
+        if self.cleaned_data.get("barcode"):
+            domain.append(("barcode", "ilike", self.cleaned_data["barcode"]))
+        return domain
+
+
 @admin.register(Product)
 class ProductAdmin(EntityModelAdmin):
     form = ProductAdminForm
+    actions = ["fetch_odoo_product"]
+
+    def _odoo_profile_admin(self):
+        return self.admin_site._registry.get(OdooProfile)
+
+    def _search_odoo_products(self, profile, form):
+        domain = form.build_domain()
+        return profile.execute(
+            "product.product",
+            "search_read",
+            domain,
+            {
+                "fields": [
+                    "name",
+                    "default_code",
+                    "barcode",
+                    "description_sale",
+                ],
+                "limit": 50,
+            },
+        )
+
+    @admin.action(description="Fetch Odoo Product")
+    def fetch_odoo_product(self, request, queryset):
+        profile = getattr(request.user, "odoo_profile", None)
+        has_credentials = bool(profile and profile.is_verified)
+        profile_admin = self._odoo_profile_admin()
+        profile_url = None
+        if profile_admin is not None:
+            profile_url = profile_admin.get_my_profile_url(request)
+
+        context = {
+            "opts": self.model._meta,
+            "queryset": queryset,
+            "action": "fetch_odoo_product",
+            "has_credentials": has_credentials,
+            "profile_url": profile_url,
+        }
+
+        if not has_credentials:
+            context["credential_error"] = _(
+                "Configure your Odoo employee credentials before fetching products."
+            )
+            return TemplateResponse(
+                request, "admin/core/product/fetch_odoo.html", context
+            )
+
+        is_import = "import" in request.POST
+        form_kwargs = {"require_search_terms": not is_import}
+        if request.method == "POST":
+            form = ProductFetchWizardForm(request.POST, **form_kwargs)
+        else:
+            form = ProductFetchWizardForm()
+
+        results = None
+        selected_product_id = request.POST.get("product_id", "")
+
+        if request.method == "POST" and form.is_valid():
+            try:
+                results = self._search_odoo_products(profile, form)
+            except Exception:
+                form.add_error(None, _("Unable to fetch products from Odoo."))
+                results = []
+            else:
+                if is_import:
+                    product_id = request.POST.get("product_id")
+                    if not product_id:
+                        form.add_error(None, _("Select a product to import."))
+                    else:
+                        try:
+                            odoo_id = int(product_id)
+                        except (TypeError, ValueError):
+                            form.add_error(None, _("Invalid product selection."))
+                        else:
+                            match = next(
+                                (item for item in results if item.get("id") == odoo_id),
+                                None,
+                            )
+                            if not match:
+                                form.add_error(
+                                    None,
+                                    _(
+                                        "The selected product was not found. Run the search again."
+                                    ),
+                                )
+                            else:
+                                existing = self.model.objects.filter(
+                                    odoo_product__id=odoo_id
+                                ).first()
+                                if existing:
+                                    self.message_user(
+                                        request,
+                                        _(
+                                            "Product %(name)s already imported; opening existing record."
+                                        )
+                                        % {"name": existing.name},
+                                        level=messages.WARNING,
+                                    )
+                                    return HttpResponseRedirect(
+                                        reverse(
+                                            "admin:%s_%s_change"
+                                            % (
+                                                existing._meta.app_label,
+                                                existing._meta.model_name,
+                                            ),
+                                            args=[existing.pk],
+                                        )
+                                    )
+                                product = self.model.objects.create(
+                                    name=match.get("name") or f"Odoo Product {odoo_id}",
+                                    description=match.get("description_sale", "") or "",
+                                    renewal_period=form.cleaned_data["renewal_period"],
+                                    odoo_product={
+                                        "id": odoo_id,
+                                        "name": match.get("name", ""),
+                                    },
+                                )
+                                self.log_addition(
+                                    request, product, "Imported product from Odoo"
+                                )
+                                self.message_user(
+                                    request,
+                                    _("Imported %(name)s from Odoo.")
+                                    % {"name": product.name},
+                                )
+                                return HttpResponseRedirect(
+                                    reverse(
+                                        "admin:%s_%s_change"
+                                        % (
+                                            product._meta.app_label,
+                                            product._meta.model_name,
+                                        ),
+                                        args=[product.pk],
+                                    )
+                                )
+        context.update(
+            {
+                "form": form,
+                "results": results,
+                "selected_product_id": selected_product_id,
+            }
+        )
+        context["media"] = self.media + form.media
+        return TemplateResponse(request, "admin/core/product/fetch_odoo.html", context)
 
 
 class RFIDResource(resources.ModelResource):

--- a/core/templates/admin/core/product/fetch_odoo.html
+++ b/core/templates/admin/core/product/fetch_odoo.html
@@ -1,0 +1,84 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block extrahead %}{{ block.super }}{{ media }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+  <a href="{% url 'admin:app_list' opts.app_label %}">{{ opts.app_config.verbose_name }}</a> ›
+  <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> ›
+  {% trans 'Fetch Odoo Product' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{% trans 'Fetch Odoo Product' %}</h1>
+{% if credential_error %}
+  <div class="messagelist">
+    <div class="error">{{ credential_error }}
+      {% if profile_url %}
+        <a href="{{ profile_url }}">{% trans 'Manage Odoo credentials' %}</a>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
+{% if has_credentials %}
+<form method="post" action="">
+  {% csrf_token %}
+  <fieldset class="module aligned">
+    {% for field in form.visible_fields %}
+      <div class="form-row">
+        {{ field.errors }}
+        {{ field.label_tag }} {{ field }}
+        {% if field.help_text %}<p class="help">{{ field.help_text }}</p>{% endif %}
+      </div>
+    {% endfor %}
+    {{ form.non_field_errors }}
+    {% for obj in queryset %}
+      <input type="hidden" name="_selected_action" value="{{ obj.pk }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="{{ action }}">
+    <input type="hidden" name="apply" value="yes">
+  </fieldset>
+  {% if results is not None %}
+    <h2>{% trans 'Search results' %}</h2>
+    <table class="adminlist">
+      <thead>
+        <tr>
+          <th>{% trans 'Select' %}</th>
+          <th>{% trans 'Name' %}</th>
+          <th>{% trans 'Internal reference' %}</th>
+          <th>{% trans 'Barcode' %}</th>
+          <th>{% trans 'Description' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for product in results %}
+          <tr>
+            <td>
+              <input type="radio" name="product_id" value="{{ product.id }}"{% if product.id|stringformat:'s' == selected_product_id %} checked{% endif %}>
+            </td>
+            <td>{{ product.name }}</td>
+            <td>{{ product.default_code }}</td>
+            <td>{{ product.barcode }}</td>
+            <td>{{ product.description_sale }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5">{% trans 'No products found.' %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  <div class="submit-row">
+    <button type="submit" name="search" value="yes" class="button">{% trans 'Search' %}</button>
+    {% if results %}
+      <button type="submit" name="import" value="yes" class="button default">{% trans 'Import selected product' %}</button>
+    {% endif %}
+  </div>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/test_odoo_product.py
+++ b/tests/test_odoo_product.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.contrib.admin.sites import site as default_site
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from core.models import OdooProfile, User
+from core.models import OdooProfile, Product, User
 from core.admin import ProductAdminForm
 from core.widgets import OdooProductWidget
 
@@ -38,3 +40,134 @@ class OdooProductTests(TestCase):
     def test_product_admin_form_uses_widget(self):
         form = ProductAdminForm()
         self.assertIsInstance(form.fields["odoo_product"].widget, OdooProductWidget)
+
+
+class ProductAdminFetchWizardTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="productadmin", email="admin@example.com", password="pwd"
+        )
+        self.factory = RequestFactory()
+        # Use the registered admin instance so profile links are available.
+        self.admin = default_site._registry[Product]
+
+    def _prepare_request(self, data):
+        request = self.factory.post("/admin/core/product/", data)
+        request.user = self.user
+        request.session = self.client.session
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_wizard_requires_credentials(self):
+        request = self._prepare_request(
+            {"action": "fetch_odoo_product", "_selected_action": []}
+        )
+        response = self.admin.fetch_odoo_product(request, Product.objects.none())
+        self.assertEqual(response.status_code, 200)
+        content = response.render().content.decode()
+        self.assertIn("Configure your Odoo employee credentials", content)
+        profile_admin = self.admin._odoo_profile_admin()
+        if profile_admin is not None:
+            expected_url = profile_admin.get_my_profile_url(request)
+            self.assertIn(expected_url, content)
+
+    @patch.object(OdooProfile, "execute")
+    def test_search_shows_results(self, mock_execute):
+        OdooProfile.objects.create(
+            user=self.user,
+            host="http://odoo",
+            database="db",
+            username="api",
+            password="secret",
+            verified_on=timezone.now(),
+            odoo_uid=5,
+        )
+        mock_execute.return_value = [
+            {
+                "id": 7,
+                "name": "Widget",
+                "default_code": "SKU-7",
+                "barcode": "ABC",
+                "description_sale": "Great widget",
+            }
+        ]
+        request = self._prepare_request(
+            {
+                "action": "fetch_odoo_product",
+                "_selected_action": [],
+                "search": "yes",
+                "name": "Wid",
+                "renewal_period": "30",
+            }
+        )
+        response = self.admin.fetch_odoo_product(request, Product.objects.none())
+        self.assertEqual(response.status_code, 200)
+        mock_execute.assert_called_once_with(
+            "product.product",
+            "search_read",
+            [("name", "ilike", "Wid")],
+            {
+                "fields": [
+                    "name",
+                    "default_code",
+                    "barcode",
+                    "description_sale",
+                ],
+                "limit": 50,
+            },
+        )
+        content = response.render().content.decode()
+        self.assertIn("Widget", content)
+
+    @patch.object(OdooProfile, "execute")
+    def test_import_creates_product(self, mock_execute):
+        OdooProfile.objects.create(
+            user=self.user,
+            host="http://odoo",
+            database="db",
+            username="api",
+            password="secret",
+            verified_on=timezone.now(),
+            odoo_uid=5,
+        )
+        mock_execute.return_value = [
+            {
+                "id": 11,
+                "name": "Imported",
+                "default_code": "IMP-1",
+                "barcode": "BRC",
+                "description_sale": "Imported from Odoo",
+            }
+        ]
+        request = self._prepare_request(
+            {
+                "action": "fetch_odoo_product",
+                "_selected_action": [],
+                "import": "yes",
+                "product_id": "11",
+                "renewal_period": "45",
+            }
+        )
+        response = self.admin.fetch_odoo_product(request, Product.objects.none())
+        self.assertEqual(response.status_code, 302)
+        mock_execute.assert_called_once_with(
+            "product.product",
+            "search_read",
+            [],
+            {
+                "fields": [
+                    "name",
+                    "default_code",
+                    "barcode",
+                    "description_sale",
+                ],
+                "limit": 50,
+            },
+        )
+        product = Product.objects.get()
+        self.assertEqual(product.name, "Imported")
+        self.assertEqual(product.renewal_period, 45)
+        self.assertEqual(product.odoo_product, {"id": 11, "name": "Imported"})
+        self.assertEqual(
+            response.url, reverse("admin:core_product_change", args=[product.pk])
+        )


### PR DESCRIPTION
## Summary
- add an admin action and wizard for Products to search Odoo items and import a selection
- surface guidance with a link to configure Odoo employee credentials when missing
- cover the wizard flow and import behaviour with targeted tests

## Testing
- pytest tests/test_odoo_product.py

------
https://chatgpt.com/codex/tasks/task_e_68d0969a86f08326b8f6bb89008479cf