### PR TITLE
Disable dashboard traffic widget animation

### DIFF
--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -326,6 +326,7 @@
               })),
             },
             options: {
+              animation: false,
               responsive: true,
               maintainAspectRatio: false,
               plugins: {


### PR DESCRIPTION
## Summary
- disable Chart.js animations for the Public site traffic mini chart on the admin dashboard so the graph renders without the on-load transition

## Testing
- pytest pages/tests.py -k viewhistory *(fails: django.db.utils.OperationalError: no such table: django_site)*

------
https://chatgpt.com/codex/tasks/task_e_68d0992ec87083268fd36ea18bb3984a