### PR TITLE
Restore change link label and open changelists in new tab

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -62,7 +62,7 @@
                   {% if model.view_only %}
                     <a href="{{ model.admin_url }}" class="viewlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'View' %}</a>
                   {% else %}
-                    <a href="{{ model.admin_url }}" class="changelink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Browse' %}</a>
+                    <a href="{{ model.admin_url }}" class="changelink" aria-describedby="{{ app.app_label }}-{{ model_name }}" target="_blank" rel="noopener noreferrer">{% translate 'Change' %}</a>
                   {% endif %}
                 </td>
               {% elif show_changelinks %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -163,7 +163,7 @@
         {% if future_items.models %}
             <ul class="actionlist">
                 {% for item in future_items.models %}
-                <li class="changelink"><a href="{{ item.url }}">Browse {{ item.label|capfirst }}</a></li>
+                <li class="changelink"><a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">Change {{ item.label|capfirst }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1229,11 +1229,12 @@ class FavoriteTests(TestCase):
             ).exists()
         )
 
-    def test_dashboard_uses_browse_label(self):
+    def test_dashboard_uses_change_label(self):
         ct = ContentType.objects.get_by_natural_key("pages", "application")
         Favorite.objects.create(user=self.user, content_type=ct)
         resp = self.client.get(reverse("admin:index"))
-        self.assertContains(resp, "Browse Applications")
+        self.assertContains(resp, "Change Applications")
+        self.assertContains(resp, 'target="_blank" rel="noopener noreferrer"')
 
     def test_dashboard_links_to_focus_view(self):
         todo = Todo.objects.create(request="Check docs", url="/docs/")


### PR DESCRIPTION
## Summary
- replace the dashboard "Browse" changelist label with the original "Change" wording and open it in a new tab
- align the future actions model links with the new label and behavior
- update the dashboard test to cover the new text and target attributes

## Testing
- python manage.py test pages.tests.FavoriteTests.test_dashboard_uses_change_label


------
https://chatgpt.com/codex/tasks/task_e_68d098f18580832684ffe652c4db4895