### PR TITLE
Fix alignment of client report section legend

### DIFF
--- a/core/templates/admin/core/clientreport/generate.html
+++ b/core/templates/admin/core/clientreport/generate.html
@@ -157,7 +157,7 @@
   .client-report-form fieldset {
     border: 1px solid var(--hairline-color, rgba(255, 255, 255, 0.2));
     border-radius: 8px;
-    padding: 1.5rem;
+    padding: 0 1.5rem 1.5rem;
     background-color: var(--darkened-bg, rgba(255, 255, 255, 0.02));
   }
 
@@ -170,7 +170,7 @@
     display: block;
     box-sizing: border-box;
     width: calc(100% + 3rem);
-    margin: -1.5rem -1.5rem 1.25rem;
+    margin: 0 -1.5rem 1.25rem;
     padding: 1.25rem 1.5rem 1rem;
     background-color: inherit;
     border-bottom: 1px solid var(--hairline-color, rgba(255, 255, 255, 0.15));


### PR DESCRIPTION
## Summary
- align the client report admin fieldset padding so the header sits flush with the border
- adjust the legend spacing to remove the slight right edge misalignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d09ac2c24c8326a2c4048a99a46f0c