### PR TITLE
Remove system admin command controls

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -1,21 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-import io
 import socket
 import subprocess
 import shutil
-import argparse
-import time
 
-from django import forms
 from django.conf import settings
-from django.contrib import admin, messages
-from django.core.management import get_commands, load_command_class
-from django.http import Http404
-from django.shortcuts import redirect
+from django.contrib import admin
 from django.template.response import TemplateResponse
-from django.urls import path, reverse
+from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
 
@@ -92,123 +85,10 @@ def _gather_info() -> dict:
 
 def _system_view(request):
     info = _gather_info()
-    if request.method == "POST" and request.user.is_superuser:
-        action = request.POST.get("action")
-        stop_script = Path(settings.BASE_DIR) / "stop.sh"
-        args = [str(stop_script)]
-        if action == "stop":
-            password = request.POST.get("password", "")
-            if not request.user.check_password(password):
-                messages.error(request, _("Incorrect password."))
-            else:
-                lock_file = Path(settings.BASE_DIR) / "locks" / "charging.lck"
-                age = None
-                if lock_file.exists():
-                    age = time.time() - lock_file.stat().st_mtime
-                if lock_file.exists() and age is not None and age <= 600:
-                    messages.error(request, _("Charging session in progress."))
-                else:
-                    if info["service"]:
-                        args.append("--all")
-                    subprocess.Popen(args)
-                    return redirect(reverse("admin:index"))
-        elif action == "restart":
-            subprocess.Popen(args)
-            return redirect(reverse("admin:index"))
-
-    excluded = {
-        "shell",
-        "dbshell",
-        "createsuperuser",
-        "changepassword",
-        "startapp",
-        "startproject",
-        "runserver",
-    }
-    commands = sorted(cmd for cmd in get_commands().keys() if cmd not in excluded)
 
     context = admin.site.each_context(request)
-    context.update({"title": _("System"), "info": info, "commands": commands})
+    context.update({"title": _("System"), "info": info})
     return TemplateResponse(request, "admin/system.html", context)
-
-
-def _build_form(parser: argparse.ArgumentParser) -> type[forms.Form]:
-    fields: dict[str, forms.Field] = {}
-    for action in parser._actions:
-        if action.help == argparse.SUPPRESS or action.dest == "help":
-            continue
-        label = action.option_strings[0] if action.option_strings else action.dest
-        required = (
-            action.required
-            if action.option_strings
-            else action.nargs not in ["?", "*", argparse.OPTIONAL]
-        )
-        fields[action.dest] = forms.CharField(label=label, required=required)
-    return type("CommandForm", (forms.Form,), fields)
-
-
-def _system_command_view(request, command):
-    commands = get_commands()
-    if command not in commands:
-        raise Http404
-    app_name = commands[command]
-    cmd_instance = load_command_class(app_name, command)
-    parser = cmd_instance.create_parser("manage.py", command)
-    form_class = _build_form(parser)
-    form = form_class(request.POST or None)
-    output = ""
-
-    has_required = any(
-        (a.option_strings and a.required)
-        or (not a.option_strings and a.nargs not in ["?", "*", argparse.OPTIONAL])
-        for a in parser._actions
-        if a.help != argparse.SUPPRESS and a.dest != "help"
-    )
-
-    if not has_required and request.method == "GET":
-        out = io.StringIO()
-        cmd_instance.stdout = out
-        cmd_instance.stderr = out
-        try:
-            cmd_instance.run_from_argv(["manage.py", command])
-        except Exception as exc:
-            out.write(str(exc))
-        output = out.getvalue()
-        form = None
-    elif request.method == "POST" and form.is_valid():
-        argv = ["manage.py", command]
-        for action in parser._actions:
-            if action.help == argparse.SUPPRESS or action.dest == "help":
-                continue
-            val = form.cleaned_data.get(action.dest)
-            if val in (None, ""):
-                continue
-            if action.option_strings:
-                argv.append(action.option_strings[0])
-                if action.nargs != 0:
-                    argv.append(val)
-            else:
-                argv.append(val)
-        out = io.StringIO()
-        cmd_instance.stdout = out
-        cmd_instance.stderr = out
-        try:
-            cmd_instance.run_from_argv(argv)
-        except Exception as exc:
-            out.write(str(exc))
-        output = out.getvalue()
-        form = None
-
-    context = admin.site.each_context(request)
-    context.update(
-        {
-            "title": command,
-            "command_name": command,
-            "form": form,
-            "output": output,
-        }
-    )
-    return TemplateResponse(request, "admin/system_command.html", context)
 
 
 def patch_admin_system_view() -> None:
@@ -219,11 +99,6 @@ def patch_admin_system_view() -> None:
         urls = original_get_urls()
         custom = [
             path("system/", admin.site.admin_view(_system_view), name="system"),
-            path(
-                "system/command/<str:command>/",
-                admin.site.admin_view(_system_command_view),
-                name="system_command",
-            ),
         ]
         return custom + urls
 

--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -3,61 +3,40 @@
 
 {% block content %}
 <div id="content-main">
-  <div style="display:flex; gap:2rem;">
-    <div style="flex:0 0 200px;">
-      {% if user.is_superuser %}
-      <form method="post" style="margin-bottom:1rem;">
-        {% csrf_token %}
-        {% if info.service %}
-          <p>{% trans "This instance is managed by a service daemon. Restart will momentarily stop the service which will be brought back up automatically." %}</p>
-          <button class="button" type="submit" name="action" value="restart">{% trans "Restart" %}</button>
-        {% endif %}
-        <label for="id_password">{% trans "Confirm password" %}</label>
-        <input type="password" name="password" id="id_password">
-        <button class="button" type="submit" name="action" value="stop">{% trans "Stop Server" %}</button>
-      </form>
-      <div class="command-list">
-        {% for cmd in commands %}
-          <p><a class="button" href="{% url 'admin:system_command' cmd %}">{{ cmd }}</a></p>
-        {% endfor %}
-      </div>
+  <div>
+    <h1>{{ title }}</h1>
+    <dl>
+      <dt>{% trans "Application installed" %}</dt>
+      <dd>{{ info.installed }}</dd>
+      <dt>{% trans "Service" %}</dt>
+      <dd>{% if info.service %}{{ info.service }}{% else %}{% trans "not installed" %}{% endif %}</dd>
+      <dt>{% trans "Nginx mode" %}</dt>
+      <dd>{{ info.mode }} ({{ info.port }})</dd>
+      <dt>{% trans "Node role" %}</dt>
+      <dd>{{ info.role }}</dd>
+      {% if info.screen_mode %}
+      <dt>{% trans "Display mode" %}</dt>
+      <dd>{{ info.screen_mode }}</dd>
       {% endif %}
-    </div>
-    <div style="flex:1;">
-      <h1>{{ title }}</h1>
-      <dl>
-        <dt>{% trans "Application installed" %}</dt>
-        <dd>{{ info.installed }}</dd>
-        <dt>{% trans "Service" %}</dt>
-        <dd>{% if info.service %}{{ info.service }}{% else %}{% trans "not installed" %}{% endif %}</dd>
-        <dt>{% trans "Nginx mode" %}</dt>
-        <dd>{{ info.mode }} ({{ info.port }})</dd>
-        <dt>{% trans "Node role" %}</dt>
-        <dd>{{ info.role }}</dd>
-        {% if info.screen_mode %}
-        <dt>{% trans "Display mode" %}</dt>
-        <dd>{{ info.screen_mode }}</dd>
-        {% endif %}
-        <dt>{% trans "Features" %}</dt>
-        <dd>
-          <ul>
-            <li>{% trans "Celery" %}: {{ info.features.celery }}</li>
-            <li>{% trans "LCD screen" %}: {{ info.features.lcd_screen }}</li>
-            <li>{% trans "Control" %}: {{ info.features.control }}</li>
-          </ul>
-        </dd>
-        <dt>{% trans "Running" %}</dt>
-        <dd>{{ info.running }}</dd>
-        {% if info.service %}
-        <dt>{% trans "Service status" %}</dt>
-        <dd>{{ info.service_status }}</dd>
-        {% endif %}
-        <dt>{% trans "Hostname" %}</dt>
-        <dd>{{ info.hostname }}</dd>
-        <dt>{% trans "IP addresses" %}</dt>
-        <dd>{{ info.ip_addresses|join:" " }}</dd>
-      </dl>
-    </div>
+      <dt>{% trans "Features" %}</dt>
+      <dd>
+        <ul>
+          <li>{% trans "Celery" %}: {{ info.features.celery }}</li>
+          <li>{% trans "LCD screen" %}: {{ info.features.lcd_screen }}</li>
+          <li>{% trans "Control" %}: {{ info.features.control }}</li>
+        </ul>
+      </dd>
+      <dt>{% trans "Running" %}</dt>
+      <dd>{{ info.running }}</dd>
+      {% if info.service %}
+      <dt>{% trans "Service status" %}</dt>
+      <dd>{{ info.service_status }}</dd>
+      {% endif %}
+      <dt>{% trans "Hostname" %}</dt>
+      <dd>{{ info.hostname }}</dd>
+      <dt>{% trans "IP addresses" %}</dt>
+      <dd>{{ info.ip_addresses|join:" " }}</dd>
+    </dl>
   </div>
 </div>
 {% endblock %}

--- a/tests/test_admin_system_stop.py
+++ b/tests/test_admin_system_stop.py
@@ -10,12 +10,10 @@ django.setup()
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from django.urls import reverse
-from unittest.mock import patch
-import time
+from django.urls import NoReverseMatch, reverse
 
 
-class AdminSystemStopTests(TestCase):
+class AdminSystemViewTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.superuser = User.objects.create_superuser(
@@ -28,48 +26,20 @@ class AdminSystemStopTests(TestCase):
             is_staff=True,
         )
 
-    def test_stop_button_hidden_for_non_superuser(self):
+    def test_system_page_displays_information(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse("admin:system"))
+        self.assertContains(response, "Application installed")
+        self.assertNotContains(response, "Stop Server")
+        self.assertNotContains(response, "Restart")
+
+    def test_system_page_accessible_to_staff_without_controls(self):
         self.client.force_login(self.staff)
         response = self.client.get(reverse("admin:system"))
+        self.assertContains(response, "Application installed")
         self.assertNotContains(response, "Stop Server")
+        self.assertNotContains(response, "Restart")
 
-    def test_stop_requires_password(self):
-        self.client.force_login(self.superuser)
-        url = reverse("admin:system")
-        with patch("core.system.subprocess.Popen") as popen:
-            response = self.client.post(url, {"action": "stop", "password": "wrong"})
-        self.assertEqual(popen.call_count, 1)
-        self.assertContains(response, "Incorrect password")
-
-    def test_stop_with_correct_password(self):
-        self.client.force_login(self.superuser)
-        lock_dir = Path(__file__).resolve().parent.parent / "locks"
-        lock_dir.mkdir(exist_ok=True)
-        lock_file = lock_dir / "charging.lck"
-        lock_file.touch()
-        old = time.time() - 700
-        os.utime(lock_file, (old, old))
-        url = reverse("admin:system")
-        with patch("core.system.subprocess.Popen") as popen:
-            response = self.client.post(url, {"action": "stop", "password": "password"})
-        self.assertEqual(popen.call_count, 2)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], reverse("admin:index"))
-        lock_file.unlink()
-        if not any(lock_dir.iterdir()):
-            lock_dir.rmdir()
-
-    def test_stop_blocked_by_recent_lock(self):
-        self.client.force_login(self.superuser)
-        lock_dir = Path(__file__).resolve().parent.parent / "locks"
-        lock_dir.mkdir(exist_ok=True)
-        lock_file = lock_dir / "charging.lck"
-        lock_file.touch()
-        url = reverse("admin:system")
-        with patch("core.system.subprocess.Popen") as popen:
-            response = self.client.post(url, {"action": "stop", "password": "password"})
-        self.assertEqual(popen.call_count, 1)
-        self.assertContains(response, "Charging session in progress")
-        lock_file.unlink()
-        if not any(lock_dir.iterdir()):
-            lock_dir.rmdir()
+    def test_system_command_route_removed(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse("admin:system_command", args=["check"])


### PR DESCRIPTION
## Summary
- remove the command execution logic from the admin system view
- simplify the system admin template to only display information
- update tests to reflect the removal of system commands and buttons

## Testing
- pytest tests/test_admin_system_stop.py

------
https://chatgpt.com/codex/tasks/task_e_68d09d15807c8326bb612a2746e58e47