### PR TITLE
Move live server update scripts into scripts directory

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,12 +63,12 @@
         {
             "label": "Dev: prepare live server",
             "type": "shell",
-            "command": "${workspaceFolder}/live-server-update.sh",
+            "command": "${workspaceFolder}/scripts/live-server-update.sh",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
             "windows": {
-                "command": "${workspaceFolder}\\live-server-update.bat"
+                "command": "${workspaceFolder}\\scripts\\live-server-update.bat"
             },
             "problemMatcher": [],
             "detail": "Stop the development server, sync with the upstream remote, and refresh the environment before launch"

--- a/scripts/live-server-update.bat
+++ b/scripts/live-server-update.bat
@@ -2,7 +2,8 @@
 setlocal enabledelayedexpansion
 
 set "SCRIPT_DIR=%~dp0"
-cd /d "%SCRIPT_DIR%"
+for %%I in ("%SCRIPT_DIR%..") do set "REPO_ROOT=%%~fI"
+cd /d "%REPO_ROOT%"
 
 echo Stopping existing development server (if running)...
 powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'manage.py runserver' } | ForEach-Object { try { Stop-Process -Id $_.ProcessId -ErrorAction Stop } catch { } }" >nul 2>&1
@@ -40,9 +41,9 @@ if errorlevel 1 (
     exit /b 1
 )
 
-if exist "%SCRIPT_DIR%env-refresh.bat" (
+if exist "%REPO_ROOT%\env-refresh.bat" (
     echo Refreshing environment with env-refresh.bat --latest...
-    call "%SCRIPT_DIR%env-refresh.bat" --latest
+    call "%REPO_ROOT%\env-refresh.bat" --latest
     if errorlevel 1 (
         echo Environment refresh failed.
         exit /b 1

--- a/scripts/live-server-update.sh
+++ b/scripts/live-server-update.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
## Summary
- move the live server update scripts into the shared scripts/ directory
- update the shell and batch implementations to resolve the repository root from their new location
- point the VS Code live server task at the relocated scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ab1a62c88326a70ae91d3a69a3c5