### PR TITLE
Show detected node features on system admin page

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -36,11 +36,68 @@ def _gather_info() -> dict:
     # Use settings.NODE_ROLE as the single source of truth for the node role.
     info["role"] = getattr(settings, "NODE_ROLE", "Terminal")
 
-    info["features"] = {
-        "celery": (lock_dir / "celery.lck").exists(),
-        "lcd_screen": (lock_dir / "lcd_screen.lck").exists(),
-        "control": (lock_dir / "control.lck").exists(),
-    }
+    features: list[dict[str, object]] = []
+    try:
+        from nodes.models import Node, NodeFeature
+    except Exception:
+        info["features"] = features
+    else:
+        feature_map: dict[str, dict[str, object]] = {}
+
+        def _add_feature(feature: NodeFeature, flag: str) -> None:
+            slug = getattr(feature, "slug", "") or ""
+            if not slug:
+                return
+            display = (getattr(feature, "display", "") or "").strip()
+            normalized = display or slug.replace("-", " ").title()
+            entry = feature_map.setdefault(
+                slug,
+                {
+                    "slug": slug,
+                    "display": normalized,
+                    "expected": False,
+                    "actual": False,
+                },
+            )
+            if display:
+                entry["display"] = display
+            entry[flag] = True
+
+        try:
+            expected_features = (
+                NodeFeature.objects.filter(roles__name=info["role"]).only("slug", "display").distinct()
+            )
+        except Exception:
+            expected_features = []
+        try:
+            for feature in expected_features:
+                _add_feature(feature, "expected")
+        except Exception:
+            pass
+
+        try:
+            local_node = Node.get_local()
+        except Exception:
+            local_node = None
+
+        actual_features = []
+        if local_node:
+            try:
+                actual_features = list(local_node.features.only("slug", "display"))
+            except Exception:
+                actual_features = []
+
+        try:
+            for feature in actual_features:
+                _add_feature(feature, "actual")
+        except Exception:
+            pass
+
+        features = sorted(
+            feature_map.values(),
+            key=lambda item: str(item.get("display", "")).lower(),
+        )
+        info["features"] = features
 
     running = False
     service_status = ""

--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -20,11 +20,28 @@
       {% endif %}
       <dt>{% trans "Features" %}</dt>
       <dd>
+        {% if info.features %}
         <ul>
-          <li>{% trans "Celery" %}: {{ info.features.celery }}</li>
-          <li>{% trans "LCD screen" %}: {{ info.features.lcd_screen }}</li>
-          <li>{% trans "Control" %}: {{ info.features.control }}</li>
+          {% for feature in info.features %}
+          <li>
+            {{ feature.display }}
+            {% if feature.expected or feature.actual %}
+              (
+              {% if feature.expected and feature.actual %}
+                {% trans "expected and actual" %}
+              {% elif feature.expected %}
+                {% trans "expected" %}
+              {% else %}
+                {% trans "actual" %}
+              {% endif %}
+              )
+            {% endif %}
+          </li>
+          {% endfor %}
         </ul>
+        {% else %}
+        <em>{% trans "No features detected" %}</em>
+        {% endif %}
       </dd>
       <dt>{% trans "Running" %}</dt>
       <dd>{{ info.running }}</dd>

--- a/core/test_system_info.py
+++ b/core/test_system_info.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
@@ -8,7 +9,8 @@ import django
 django.setup()
 
 from django.conf import settings
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
+from nodes.models import Node, NodeFeature, NodeRole
 from core.system import _gather_info
 
 
@@ -41,3 +43,51 @@ class SystemInfoScreenModeTests(SimpleTestCase):
             lock_file.unlink()
             if not any(lock_dir.iterdir()):
                 lock_dir.rmdir()
+
+
+class SystemInfoFeatureTests(TestCase):
+    @override_settings(NODE_ROLE="Terminal")
+    def test_features_include_expected_and_actual(self):
+        role = NodeRole.objects.create(name="Terminal")
+
+        expected_only = NodeFeature.objects.create(
+            slug="rfid-scanner", display="RFID Scanner"
+        )
+        expected_only.roles.add(role)
+
+        both = NodeFeature.objects.create(
+            slug="celery-queue", display="Celery Queue"
+        )
+        both.roles.add(role)
+
+        NodeFeature.objects.create(slug="lcd-screen", display="LCD Screen")
+
+        with TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            locks_dir = base_path / "locks"
+            locks_dir.mkdir()
+            (locks_dir / "celery.lck").touch()
+            (locks_dir / "lcd_screen.lck").touch()
+
+            Node.objects.create(
+                hostname="local",
+                address="127.0.0.1",
+                port=8000,
+                mac_address=Node.get_current_mac(),
+                role=role,
+                base_path=str(base_path),
+            )
+
+            info = _gather_info()
+
+        features = {feature["slug"]: feature for feature in info["features"]}
+
+        self.assertEqual(
+            set(features.keys()), {"celery-queue", "lcd-screen", "rfid-scanner"}
+        )
+        self.assertTrue(features["celery-queue"]["expected"])
+        self.assertTrue(features["celery-queue"]["actual"])
+        self.assertFalse(features["lcd-screen"]["expected"])
+        self.assertTrue(features["lcd-screen"]["actual"])
+        self.assertTrue(features["rfid-scanner"]["expected"])
+        self.assertFalse(features["rfid-scanner"]["actual"])


### PR DESCRIPTION
## Summary
- derive system admin feature list from NodeRole expectations and the local node's detected features
- render each feature once with labels indicating whether it is expected, detected, or both and show a fallback when none are available
- cover the new aggregation with a database-backed test that exercises expected-only, actual-only, and overlapping features

## Testing
- python manage.py test core.test_system_info


------
https://chatgpt.com/codex/tasks/task_e_68d0b00888088326bfff77c49592b943