### PR TITLE
Run network setup on first boot in RPi image

### DIFF
--- a/rpi-image-gen.sh
+++ b/rpi-image-gen.sh
@@ -1220,6 +1220,16 @@ SERVICE_NAME="arthexis"
 if [ -r "$ARTHEXIS_HOME/locks/service.lck" ]; then
   SERVICE_NAME="$(head -n1 "$ARTHEXIS_HOME/locks/service.lck")"
 fi
+NETWORK_SETUP_SCRIPT="$ARTHEXIS_HOME/network-setup.sh"
+if [ -x "$NETWORK_SETUP_SCRIPT" ]; then
+  echo "Running Arthexis network setup via $NETWORK_SETUP_SCRIPT"
+  if ! "$NETWORK_SETUP_SCRIPT"; then
+    echo "Arthexis network setup failed" >&2
+    exit 1
+  fi
+else
+  echo "Network setup script not found at $NETWORK_SETUP_SCRIPT" >&2
+fi
 declare -a units=("redis-server" "nginx" "NetworkManager" "ssh" "$SERVICE_NAME")
 if [ -f "$ARTHEXIS_HOME/locks/celery.lck" ]; then
   units+=("celery-$SERVICE_NAME" "celery-beat-$SERVICE_NAME")

--- a/rpi-image-gen.sh
+++ b/rpi-image-gen.sh
@@ -1223,7 +1223,7 @@ fi
 NETWORK_SETUP_SCRIPT="$ARTHEXIS_HOME/network-setup.sh"
 if [ -x "$NETWORK_SETUP_SCRIPT" ]; then
   echo "Running Arthexis network setup via $NETWORK_SETUP_SCRIPT"
-  if ! "$NETWORK_SETUP_SCRIPT"; then
+  if ! "$NETWORK_SETUP_SCRIPT" --no-vnc; then
     echo "Arthexis network setup failed" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- ensure the first-boot provisioning script invokes network-setup so the network is configured automatically when an image boots

## Testing
- bash -n rpi-image-gen.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0b66fbe888326b748f4e4b4ef45db