### PR TITLE
Ensure live server prep always refreshes env

### DIFF
--- a/scripts/live-server-update.sh
+++ b/scripts/live-server-update.sh
@@ -13,35 +13,34 @@ if [ -x "$REPO_ROOT/stop.sh" ]; then
   fi
 fi
 
-if ! git remote get-url upstream >/dev/null 2>&1; then
-  echo "No 'upstream' remote configured. Skipping fetch and pull."
-  exit 0
-fi
+REFRESH_SCRIPT="$REPO_ROOT/env-refresh.sh"
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
-if [ -z "$current_branch" ]; then
-  echo "Unable to determine the current branch. Skipping fetch and pull." >&2
-  exit 0
-fi
+if git remote get-url upstream >/dev/null 2>&1; then
+  echo "Fetching updates from upstream..."
+  git fetch upstream
 
-echo "Fetching updates from upstream..."
-git fetch upstream
-
-echo "Checking for upstream branch $current_branch..."
-if git show-ref --verify --quiet "refs/remotes/upstream/${current_branch}"; then
-  echo "Pulling latest commits for ${current_branch}..."
-  git pull --ff-only upstream "$current_branch"
-  REFRESH_SCRIPT="$REPO_ROOT/env-refresh.sh"
-  if [ -x "$REFRESH_SCRIPT" ]; then
-    echo "Refreshing environment with env-refresh.sh --latest..."
-    "$REFRESH_SCRIPT" --latest
-  elif [ -f "$REFRESH_SCRIPT" ]; then
-    echo "env-refresh.sh is not marked executable. Attempting to run with bash." >&2
-    bash "$REFRESH_SCRIPT" --latest
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [ -z "$current_branch" ]; then
+    echo "Unable to determine the current branch. Skipping pull." >&2
   else
-    echo "env-refresh.sh not found. Skipping environment refresh." >&2
+    echo "Checking for upstream branch $current_branch..."
+    if git show-ref --verify --quiet "refs/remotes/upstream/${current_branch}"; then
+      echo "Pulling latest commits for ${current_branch}..."
+      git pull --ff-only upstream "$current_branch"
+    else
+      echo "No matching upstream branch for ${current_branch}. Skipping pull."
+    fi
   fi
-
 else
-  echo "No matching upstream branch for ${current_branch}. Skipping pull."
+  echo "No 'upstream' remote configured. Skipping fetch and pull."
+fi
+
+if [ -x "$REFRESH_SCRIPT" ]; then
+  echo "Refreshing environment with env-refresh.sh --latest..."
+  "$REFRESH_SCRIPT" --latest
+elif [ -f "$REFRESH_SCRIPT" ]; then
+  echo "env-refresh.sh is not marked executable. Attempting to run with bash." >&2
+  bash "$REFRESH_SCRIPT" --latest
+else
+  echo "env-refresh.sh not found. Skipping environment refresh." >&2
 fi


### PR DESCRIPTION
## Summary
- always invoke env-refresh after preparing the live server, even if there is no upstream remote or branch to pull
- keep the fetch/pull behaviour intact while ensuring the environment refresh is triggered in all cases

## Testing
- bash -n scripts/live-server-update.sh

------
https://chatgpt.com/codex/tasks/task_e_68d152cd466c8326bc6036f5b017a9d0