### PR TITLE
Fix TODO focus iframe URL handling

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1282,6 +1282,23 @@ class TodoFocusViewTests(TestCase):
         change_url = reverse("admin:core_todo_change", args=[todo.pk])
         self.assertContains(resp, f'src="{change_url}"')
 
+    def test_focus_view_sanitizes_loopback_absolute_url(self):
+        todo = Todo.objects.create(
+            request="Task",
+            url="http://127.0.0.1:8000/docs/?section=chart",
+        )
+        resp = self.client.get(reverse("todo-focus", args=[todo.pk]))
+        self.assertContains(resp, 'src="/docs/?section=chart"')
+
+    def test_focus_view_rejects_external_absolute_url(self):
+        todo = Todo.objects.create(
+            request="Task",
+            url="https://outside.invalid/external/",
+        )
+        resp = self.client.get(reverse("todo-focus", args=[todo.pk]))
+        change_url = reverse("admin:core_todo_change", args=[todo.pk])
+        self.assertContains(resp, f'src="{change_url}"')
+
     def test_focus_view_redirects_if_todo_completed(self):
         todo = Todo.objects.create(request="Task")
         todo.done_on = timezone.now()


### PR DESCRIPTION
## Summary
- sanitize TODO focus iframe URLs so absolute URLs reuse the current host and unsafe destinations fall back to the admin change page
- allow site and allowed hosts when rewriting iframe URLs and expand tests around loopback and external links

## Testing
- `python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
import django
from importlib import machinery, util
import unittest

from django.test.utils import get_runner
from django.conf import settings

django.setup()

loader = machinery.SourceFileLoader('core.tests_module', 'core/tests.py')
spec = util.spec_from_loader(loader.name, loader)
module = util.module_from_spec(spec)
module.__package__ = 'core'
loader.exec_module(module)

TestRunner = get_runner(settings)
test_runner = TestRunner()

test_runner.setup_test_environment()
old_config = test_runner.setup_databases()
try:
    suite = unittest.TestSuite()
    suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(module.TodoFocusViewTests))
    result = test_runner.run_suite(suite)
finally:
    test_runner.teardown_databases(old_config)
    test_runner.teardown_test_environment()

if not result.wasSuccessful():
    exit(1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d16f6f38a88326bf786c4df1d4011c