### PR TITLE
Normalize stored TODO URLs to loopback-safe paths

### DIFF
--- a/core/migrations/0044_todo_url_normalize_loopback.py
+++ b/core/migrations/0044_todo_url_normalize_loopback.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+from django.conf import settings
+from django.db import migrations
+
+
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
+def _collect_allowed_hosts(site_model) -> set[str]:
+    hosts: set[str] = set()
+    hosts.update(LOOPBACK_HOSTS)
+
+    for host in getattr(settings, "ALLOWED_HOSTS", []):
+        if not isinstance(host, str):
+            continue
+        normalized = host.strip().lower()
+        if not normalized or normalized.startswith("*"):
+            continue
+        hosts.add(normalized)
+        hosts.add(normalized.split(":", 1)[0])
+
+    for site in site_model.objects.all().only("domain"):
+        domain = (site.domain or "").strip().lower()
+        if not domain:
+            continue
+        hosts.add(domain)
+        hosts.add(domain.split(":", 1)[0])
+
+    hosts.discard("")
+    return hosts
+
+
+def normalize_todo_urls(apps, schema_editor):
+    Todo = apps.get_model("core", "Todo")
+    Site = apps.get_model("sites", "Site")
+
+    allowed_hosts = _collect_allowed_hosts(Site)
+
+    queryset = Todo.objects.exclude(url__exact="").iterator()
+    for todo in queryset:
+        raw_url = (todo.url or "").strip()
+        if not raw_url:
+            continue
+        try:
+            parsed = urlsplit(raw_url)
+        except ValueError:
+            continue
+
+        if not parsed.scheme or parsed.scheme.lower() not in {"http", "https"}:
+            continue
+
+        hostname = (parsed.hostname or "").strip().lower()
+        netloc = parsed.netloc.strip().lower()
+        if hostname not in allowed_hosts and netloc not in allowed_hosts:
+            continue
+
+        path = parsed.path or "/"
+        if not path.startswith("/"):
+            path = f"/{path}"
+        normalized = urlunsplit(("", "", path, parsed.query, parsed.fragment)) or "/"
+
+        if normalized != raw_url:
+            Todo.objects.filter(pk=todo.pk).update(url=normalized)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0043_reference_show_in_header"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_todo_urls, migrations.RunPython.noop),
+    ]

--- a/core/tests.py
+++ b/core/tests.py
@@ -1282,6 +1282,23 @@ class TodoFocusViewTests(TestCase):
         change_url = reverse("admin:core_todo_change", args=[todo.pk])
         self.assertContains(resp, f'src="{change_url}"')
 
+    def test_focus_view_sanitizes_loopback_absolute_url(self):
+        todo = Todo.objects.create(
+            request="Task",
+            url="http://127.0.0.1:8000/docs/?section=chart",
+        )
+        resp = self.client.get(reverse("todo-focus", args=[todo.pk]))
+        self.assertContains(resp, 'src="/docs/?section=chart"')
+
+    def test_focus_view_rejects_external_absolute_url(self):
+        todo = Todo.objects.create(
+            request="Task",
+            url="https://outside.invalid/external/",
+        )
+        resp = self.client.get(reverse("todo-focus", args=[todo.pk]))
+        change_url = reverse("admin:core_todo_change", args=[todo.pk])
+        self.assertContains(resp, f'src="{change_url}"')
+
     def test_focus_view_redirects_if_todo_completed(self):
         todo = Todo.objects.create(request="Task")
         todo.done_on = timezone.now()


### PR DESCRIPTION
## Summary
- add data migration that rewrites stored TODO URLs pointing at loopback or allowed hosts to relative paths so the focus iframe stays on the current site

## Testing
- `python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
import django
from importlib import machinery, util
import unittest

from django.test.utils import get_runner
from django.conf import settings

django.setup()

loader = machinery.SourceFileLoader('core.tests_module', 'core/tests.py')
spec = util.spec_from_loader(loader.name, loader)
module = util.module_from_spec(spec)
module.__package__ = 'core'
loader.exec_module(module)

TestRunner = get_runner(settings)
test_runner = TestRunner()

test_runner.setup_test_environment()
old_config = test_runner.setup_databases()
try:
    suite = unittest.TestSuite()
    suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(module.TodoFocusViewTests))
    result = test_runner.run_suite(suite)
finally:
    test_runner.teardown_databases(old_config)
    test_runner.teardown_test_environment()

if not result.wasSuccessful():
    exit(1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d16f6f38a88326bf786c4df1d4011c