### PR TITLE
Enforce IP-only admin credential access

### DIFF
--- a/tests/test_localhost_admin_backend.py
+++ b/tests/test_localhost_admin_backend.py
@@ -1,5 +1,3 @@
-import ipaddress
-
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.test import override_settings
@@ -39,6 +37,7 @@ def test_sets_operate_as_on_admin_creation():
     backend = LocalhostAdminBackend()
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "127.0.0.1"
+    req.META["HTTP_HOST"] = "127.0.0.1"
     user = backend.authenticate(req, username="admin", password="admin")
     assert user is not None
     user.refresh_from_db()
@@ -56,20 +55,19 @@ def test_blocks_docker_bridge_addresses():
     backend = LocalhostAdminBackend()
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "172.17.0.2"
+    req.META["HTTP_HOST"] = "127.0.0.1"
     user = backend.authenticate(req, username="admin", password="admin")
     assert user is None
 
 
-def test_allows_current_node_hostname():
+def test_allows_wifi_ap_subnet_via_ip_login():
     User = get_user_model()
     ensure_arthexis_user()
     User.all_objects.filter(username="admin").delete()
     backend = LocalhostAdminBackend()
-    backend._LOCAL_IPS = tuple(
-        set(backend._LOCAL_IPS) | {ipaddress.ip_address("10.42.0.20")}
-    )
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "10.42.0.20"
+    req.META["HTTP_HOST"] = "10.42.0.1"
     user = backend.authenticate(req, username="admin", password="admin")
     assert user is not None
 
@@ -82,6 +80,7 @@ def test_control_role_allows_private_network():
     backend = LocalhostAdminBackend()
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "10.42.0.15"
+    req.META["HTTP_HOST"] = "10.42.0.1"
     user = backend.authenticate(req, username="admin", password="admin")
     assert user is not None
 
@@ -98,7 +97,19 @@ def test_respects_disabled_admin_flag():
     backend = LocalhostAdminBackend()
     req = HttpRequest()
     req.META["REMOTE_ADDR"] = "127.0.0.1"
+    req.META["HTTP_HOST"] = "127.0.0.1"
     assert backend.authenticate(req, username="admin", password="admin") is None
     admin.refresh_from_db()
     assert admin.is_active is False
     assert User.all_objects.filter(username="admin").count() == 1
+
+
+def test_hostname_access_is_blocked():
+    User = get_user_model()
+    ensure_arthexis_user()
+    User.all_objects.filter(username="admin").delete()
+    backend = LocalhostAdminBackend()
+    req = HttpRequest()
+    req.META["REMOTE_ADDR"] = "127.0.0.1"
+    req.META["HTTP_HOST"] = "gway-qk32000"
+    assert backend.authenticate(req, username="admin", password="admin") is None


### PR DESCRIPTION
## Summary
- require numeric IP hosts before granting default admin logins and include the 10.42.0.0/16 subnet
- extend the LocalhostAdminBackend tests to cover IP-host scenarios and hostname rejection

## Testing
- pytest tests/test_localhost_admin_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d193b3615c8326a44b02ec9a0b35de