### PR TITLE
Default live server sync to origin/main

### DIFF
--- a/scripts/live-server-update.bat
+++ b/scripts/live-server-update.bat
@@ -8,37 +8,32 @@ cd /d "%REPO_ROOT%"
 echo Stopping existing development server (if running)...
 powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'manage.py runserver' } | ForEach-Object { try { Stop-Process -Id $_.ProcessId -ErrorAction Stop } catch { } }" >nul 2>&1
 
+set "DEFAULT_REMOTE=origin"
+set "DEFAULT_BRANCH=main"
+set "CURRENT_BRANCH="
+
+for /f "delims=" %%B in ('git rev-parse --abbrev-ref HEAD 2^>nul') do set "CURRENT_BRANCH=%%B"
+if /I "%CURRENT_BRANCH%"=="HEAD" set "CURRENT_BRANCH="
+
+set "NEED_FALLBACK=true"
 git remote get-url upstream >nul 2>&1
 if errorlevel 1 (
-    echo No 'upstream' remote configured. Skipping fetch and pull.
-    exit /b 0
+    echo No 'upstream' remote configured.
+) else if "%CURRENT_BRANCH%"=="" (
+    echo Unable to determine the current branch for upstream sync.
+) else (
+    echo Attempting to update from upstream/%CURRENT_BRANCH%...
+    call :sync_remote upstream "%CURRENT_BRANCH%"
+    if /I "%SYNC_RESULT%"=="success" (
+        set "NEED_FALLBACK=false"
+    ) else (
+        echo Unable to update from upstream/%CURRENT_BRANCH%. Falling back to %DEFAULT_REMOTE%/%DEFAULT_BRANCH%.
+    )
 )
 
-for /f "delims=" %%B in ('git rev-parse --abbrev-ref HEAD') do set BRANCH=%%B
-
-if "%BRANCH%"=="" (
-    echo Unable to determine the current branch. Skipping fetch and pull.
-    exit /b 0
-)
-
-echo Fetching updates from upstream...
-git fetch upstream
-if errorlevel 1 (
-    echo Failed to fetch from upstream.
-    exit /b 1
-)
-
-git show-ref --verify --quiet refs/remotes/upstream/%BRANCH%
-if errorlevel 1 (
-    echo No matching upstream branch for %BRANCH%. Skipping pull.
-    exit /b 0
-)
-
-echo Pulling latest commits for %BRANCH%...
-git pull --ff-only upstream %BRANCH%
-if errorlevel 1 (
-    echo Failed to pull from upstream.
-    exit /b 1
+if /I "%NEED_FALLBACK%"=="true" (
+    echo Using default upstream %DEFAULT_REMOTE%/%DEFAULT_BRANCH%...
+    call :sync_remote "%DEFAULT_REMOTE%" "%DEFAULT_BRANCH%"
 )
 
 if exist "%REPO_ROOT%\env-refresh.bat" (
@@ -53,3 +48,49 @@ if exist "%REPO_ROOT%\env-refresh.bat" (
 )
 
 exit /b 0
+
+:sync_remote
+set "REMOTE=%~1"
+set "BRANCH=%~2"
+set "SYNC_RESULT=fail"
+
+git remote get-url %REMOTE% >nul 2>&1
+if errorlevel 1 (
+    echo Remote '%REMOTE%' not configured. Skipping fetch and pull.
+    goto :eof
+)
+
+echo Fetching updates from %REMOTE%/%BRANCH%...
+git fetch %REMOTE% %BRANCH%
+if errorlevel 1 (
+    echo Failed to fetch from %REMOTE%/%BRANCH%.
+    goto :eof
+)
+
+git show-ref --verify --quiet refs/remotes/%REMOTE%/%BRANCH%
+if errorlevel 1 (
+    echo No matching %REMOTE%/%BRANCH% found. Skipping pull.
+    goto :eof
+)
+
+if "%CURRENT_BRANCH%"=="" (
+    echo Detached HEAD state detected; skipping pull for %REMOTE%/%BRANCH%.
+    set "SYNC_RESULT=success"
+    goto :eof
+)
+
+if /I not "%CURRENT_BRANCH%"=="%BRANCH%" (
+    echo Current branch "%CURRENT_BRANCH%" does not match "%BRANCH%". Skipping pull.
+    set "SYNC_RESULT=success"
+    goto :eof
+)
+
+echo Pulling latest commits for %BRANCH% from %REMOTE%...
+git pull --ff-only %REMOTE% %BRANCH%
+if errorlevel 1 (
+    echo Failed to pull from %REMOTE%/%BRANCH%.
+    goto :eof
+)
+
+set "SYNC_RESULT=success"
+goto :eof

--- a/scripts/live-server-update.sh
+++ b/scripts/live-server-update.sh
@@ -14,25 +14,74 @@ if [ -x "$REPO_ROOT/stop.sh" ]; then
 fi
 
 REFRESH_SCRIPT="$REPO_ROOT/env-refresh.sh"
+DEFAULT_REMOTE="origin"
+DEFAULT_BRANCH="main"
 
-if git remote get-url upstream >/dev/null 2>&1; then
-  echo "Fetching updates from upstream..."
-  git fetch upstream
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [ "$current_branch" = "HEAD" ]; then
+  current_branch=""
+fi
 
-  current_branch="$(git rev-parse --abbrev-ref HEAD)"
-  if [ -z "$current_branch" ]; then
-    echo "Unable to determine the current branch. Skipping pull." >&2
-  else
-    echo "Checking for upstream branch $current_branch..."
-    if git show-ref --verify --quiet "refs/remotes/upstream/${current_branch}"; then
-      echo "Pulling latest commits for ${current_branch}..."
-      git pull --ff-only upstream "$current_branch"
+sync_remote_branch() {
+  local remote="$1"
+  local branch="$2"
+
+  if ! git remote get-url "$remote" >/dev/null 2>&1; then
+    echo "Remote '$remote' not configured. Skipping fetch and pull."
+    return 1
+  fi
+
+  echo "Fetching updates from ${remote}/${branch}..."
+  if ! git fetch "$remote" "$branch"; then
+    echo "Failed to fetch from ${remote}/${branch}." >&2
+    return 1
+  fi
+
+  if ! git show-ref --verify --quiet "refs/remotes/${remote}/${branch}"; then
+    echo "No matching ${remote}/${branch} found. Skipping pull."
+    return 1
+  fi
+
+  if [ -z "$current_branch" ] || [ "$branch" != "$current_branch" ]; then
+    if [ -z "$current_branch" ]; then
+      echo "Detached HEAD state detected; skipping pull for ${remote}/${branch}."
     else
-      echo "No matching upstream branch for ${current_branch}. Skipping pull."
+      echo "Current branch '$current_branch' does not match '$branch'. Skipping pull."
     fi
+    return 0
+  fi
+
+  echo "Pulling latest commits for ${branch} from ${remote}..."
+  if ! git pull --ff-only "$remote" "$branch"; then
+    echo "Failed to pull from ${remote}/${branch}." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+synced="false"
+
+if [ -n "$current_branch" ] && git remote get-url upstream >/dev/null 2>&1; then
+  echo "Attempting to update from upstream/${current_branch}..."
+  if sync_remote_branch "upstream" "$current_branch"; then
+    synced="true"
+  else
+    echo "Unable to update from upstream/${current_branch}. Falling back to ${DEFAULT_REMOTE}/${DEFAULT_BRANCH}."
   fi
 else
-  echo "No 'upstream' remote configured. Skipping fetch and pull."
+  if [ -z "$current_branch" ]; then
+    echo "Unable to determine the current branch for upstream sync."
+  else
+    echo "No 'upstream' remote configured."
+  fi
+  echo "Using default upstream ${DEFAULT_REMOTE}/${DEFAULT_BRANCH}."
+fi
+
+if [ "$synced" != "true" ]; then
+  if ! sync_remote_branch "$DEFAULT_REMOTE" "$DEFAULT_BRANCH"; then
+    echo "Skipping pull; ${DEFAULT_REMOTE}/${DEFAULT_BRANCH} could not be updated."
+  fi
 fi
 
 if [ -x "$REFRESH_SCRIPT" ]; then


### PR DESCRIPTION
## Summary
- ensure the VS Code live server prep script falls back to origin/main when the upstream remote is unavailable
- mirror the fallback and fetch logic in the Windows live-server update script

## Testing
- bash -n scripts/live-server-update.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1dab750888326a2984631018b9c89