### PR TITLE
Update nav labels for manuals and calculators

### DIFF
--- a/pages/context_processors.py
+++ b/pages/context_processors.py
@@ -49,8 +49,11 @@ def nav_links(request):
                 continue
             landings.append(landing)
         if landings:
-            if getattr(module.application, "name", "").lower() == "awg":
-                module.menu = "Power"
+            app_name = getattr(module.application, "name", "").lower()
+            if app_name == "awg":
+                module.menu = "Calculate"
+            elif app_name == "man":
+                module.menu = "Manuals"
             module.enabled_landings = landings
             valid_modules.append(module)
             if request.path.startswith(module.path):


### PR DESCRIPTION
## Summary
- rename the AWG navigation pill to CALCULATE in the site header
- label the manuals navigation pill MANUALS and add coverage for both pills

## Testing
- python manage.py test pages.tests.PowerNavTests

------
https://chatgpt.com/codex/tasks/task_e_68d1dca0b4bc8326b3fdaf615217e3ec