### PR TITLE
Add post-upgrade health checks for auto upgrades

### DIFF
--- a/tests/test_release_tasks.py
+++ b/tests/test_release_tasks.py
@@ -1,5 +1,6 @@
 import types
 from datetime import datetime
+from urllib.error import URLError
 
 import pytest
 
@@ -26,6 +27,17 @@ def test_no_upgrade_triggers_startup(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks.subprocess, "run", fake_run)
     monkeypatch.setattr(tasks.subprocess, "check_output", lambda *a, **k: b"1.0")
 
+    scheduled = []
+
+    def fake_apply_async(*args, **kwargs):
+        scheduled.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        tasks.verify_auto_upgrade_health,
+        "apply_async",
+        fake_apply_async,
+    )
+
     called = {}
     import nodes.apps as nodes_apps
 
@@ -36,6 +48,7 @@ def test_no_upgrade_triggers_startup(monkeypatch, tmp_path):
     tasks.check_github_updates()
 
     assert called.get("x")
+    assert scheduled == []
 
 
 @pytest.mark.role("Constellation")
@@ -61,6 +74,17 @@ def test_upgrade_shows_message(monkeypatch, tmp_path):
         lambda subject, body="": notify_calls.append((subject, body)),
     )
 
+    scheduled = []
+
+    def fake_apply_async(*args, **kwargs):
+        scheduled.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        tasks.verify_auto_upgrade_health,
+        "apply_async",
+        fake_apply_async,
+    )
+
     tasks.check_github_updates()
 
     assert any(
@@ -69,6 +93,59 @@ def test_upgrade_shows_message(monkeypatch, tmp_path):
         for subject, body in notify_calls
     )
     assert any("upgrade.sh" in cmd[0] for cmd in run_calls)
+    assert scheduled
+    first_call = scheduled[0]
+    assert first_call["kwargs"].get("countdown") == tasks.AUTO_UPGRADE_HEALTH_DELAY_SECONDS
+    assert first_call["kwargs"].get("kwargs") == {"attempt": 1}
+
+
+@pytest.mark.role("Constellation")
+def test_verify_auto_upgrade_health_retries_and_reverts(monkeypatch, tmp_path):
+    base = _setup_tmp(monkeypatch, tmp_path)
+    locks = base / "locks"
+    locks.mkdir()
+
+    scheduled = []
+
+    def fake_apply_async(*args, **kwargs):
+        scheduled.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        tasks.verify_auto_upgrade_health,
+        "apply_async",
+        fake_apply_async,
+    )
+
+    def fake_urlopen(*args, **kwargs):
+        raise URLError("down")
+
+    monkeypatch.setattr(tasks.urllib.request, "urlopen", fake_urlopen)
+
+    run_calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        run_calls.append({"args": args, "cwd": cwd, "check": check})
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(tasks.subprocess, "run", fake_run)
+
+    tasks.verify_auto_upgrade_health.run(attempt=1)
+    assert scheduled
+    assert scheduled[-1]["kwargs"].get("kwargs") == {"attempt": 2}
+    assert scheduled[-1]["kwargs"].get("countdown") == tasks.AUTO_UPGRADE_HEALTH_DELAY_SECONDS
+
+    scheduled.clear()
+    tasks.verify_auto_upgrade_health.run(attempt=2)
+    assert scheduled
+    assert scheduled[-1]["kwargs"].get("kwargs") == {"attempt": 3}
+
+    scheduled.clear()
+    tasks.verify_auto_upgrade_health.run(attempt=3)
+    assert not scheduled
+    assert run_calls
+    final_call = run_calls[-1]
+    assert final_call["args"] == ["./upgrade.sh", "--revert"]
+    assert final_call["cwd"] == base
 
 
 def _matches_upgrade_stamp(body: str) -> bool:


### PR DESCRIPTION
## Summary
- add helpers for logging and probing auto-upgrade health checks
- schedule 30-second delayed health checks after applying auto-upgrades and revert after repeated failures
- expand release task tests to cover scheduling and revert behaviour

## Testing
- pytest tests/test_release_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68d1db31aa3483268d2852c055dbaef5