### PR TITLE
Reduce padding around TODO help text

### DIFF
--- a/core/templates/core/todo_focus.html
+++ b/core/templates/core/todo_focus.html
@@ -20,7 +20,7 @@
       background: #ffffff;
       border-bottom: 1px solid rgba(15, 23, 42, 0.08);
       box-shadow: 0 2px 6px rgba(15, 23, 42, 0.06);
-      padding: 0.85rem 1.5rem;
+      padding: 0.6rem 1.5rem;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -40,7 +40,7 @@
       line-height: 1.4;
     }
     .todo-details {
-      margin-top: 0.35rem;
+      margin: 0.35rem 0 0;
       font-size: 0.85rem;
       color: #526079;
       line-height: 1.4;


### PR DESCRIPTION
## Summary
- reduce the top bar padding so the TODO help text has less surrounding whitespace
- remove the default paragraph bottom margin for help text to keep the bar compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d33ead026c8326a814096d0042e82f