### PR TITLE
Restrict RFID tag validator to authenticated users

### DIFF
--- a/ocpp/rfid/views.py
+++ b/ocpp/rfid/views.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
+from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
 from pages.utils import landing
 
@@ -11,6 +12,7 @@ from .scanner import scan_sources, restart_sources, test_sources, enable_deep_re
 from .reader import validate_rfid_value
 
 
+@login_required(login_url="pages:login")
 def scan_next(request):
     """Return the next scanned RFID tag or validate a client-provided value."""
 
@@ -28,6 +30,7 @@ def scan_next(request):
     return JsonResponse(result, status=status)
 
 
+@login_required(login_url="pages:login")
 @require_POST
 def scan_restart(_request):
     """Restart the RFID scanner."""
@@ -36,6 +39,7 @@ def scan_restart(_request):
     return JsonResponse(result, status=status)
 
 
+@login_required(login_url="pages:login")
 def scan_test(_request):
     """Report wiring information for the local RFID scanner."""
     result = test_sources()
@@ -53,6 +57,7 @@ def scan_deep(_request):
 
 
 @landing("RFID Tag Validator")
+@login_required(login_url="pages:login")
 def reader(request):
     """Public page to scan RFID tags."""
     context = {

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1231,8 +1231,16 @@ class RFIDPageTests(TestCase):
         Site.objects.update_or_create(
             id=1, defaults={"domain": "testserver", "name": "pages"}
         )
+        User = get_user_model()
+        self.user = User.objects.create_user("rfid-user", password="pwd")
 
-    def test_page_renders(self):
+    def test_page_redirects_when_anonymous(self):
+        resp = self.client.get(reverse("rfid-reader"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("pages:login"), resp.url)
+
+    def test_page_renders_for_authenticated_user(self):
+        self.client.force_login(self.user)
         resp = self.client.get(reverse("rfid-reader"))
         self.assertContains(resp, "Scanner ready")
 


### PR DESCRIPTION
## Summary
- require authentication for the RFID validator page and supporting scan endpoints
- update RFID view tests to cover the new authentication requirement
- adjust public site tests to expect a redirect for anonymous users

## Testing
- python manage.py test ocpp.test_rfid
- python manage.py test pages.tests.RFIDPageTests

------
https://chatgpt.com/codex/tasks/task_e_68d42e8dcdd083268d715ae38f9b4a82