### PR TITLE
Set Mysteric Gallery footer reference to private

### DIFF
--- a/core/fixtures/references__reference_12.json
+++ b/core/fixtures/references__reference_12.json
@@ -6,7 +6,7 @@
       "alt_text": "Mysteric Gallery",
       "method": "link",
       "include_in_footer": true,
-      "footer_visibility": "public",
+      "footer_visibility": "private",
       "created": "2024-01-01T00:00:00Z",
       "roles": [
         [


### PR DESCRIPTION
## Summary
- change the Mysteric Gallery reference fixture to mark the footer visibility as private so it only shows for authenticated users

## Testing
- not run (fixture-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d45950323c8326acc45bb4c25937e1