### PR TITLE
Rename SYS sigil root to CONF

### DIFF
--- a/core/migrations/0045_rename_sys_sigil_root.py
+++ b/core/migrations/0045_rename_sys_sigil_root.py
@@ -1,0 +1,70 @@
+from django.db import migrations
+
+
+def _rename_sys_to_conf(apps, schema_editor):
+    SigilRoot = apps.get_model("core", "SigilRoot")
+    conf_root = SigilRoot.objects.filter(prefix__iexact="CONF").first()
+    for root in SigilRoot.objects.filter(prefix__iexact="SYS"):
+        if conf_root and conf_root.pk != root.pk:
+            updated_fields = []
+            if conf_root.prefix != "CONF":
+                conf_root.prefix = "CONF"
+                updated_fields.append("prefix")
+            if conf_root.context_type != "config":
+                conf_root.context_type = "config"
+                updated_fields.append("context_type")
+            if updated_fields:
+                conf_root.save(update_fields=updated_fields)
+            root.delete()
+        else:
+            updated_fields = []
+            if root.prefix != "CONF":
+                root.prefix = "CONF"
+                updated_fields.append("prefix")
+            if root.context_type != "config":
+                root.context_type = "config"
+                updated_fields.append("context_type")
+            if updated_fields:
+                root.save(update_fields=updated_fields)
+            conf_root = root
+
+
+def _rename_conf_to_sys(apps, schema_editor):
+    SigilRoot = apps.get_model("core", "SigilRoot")
+    sys_root = SigilRoot.objects.filter(prefix__iexact="SYS").first()
+    for root in SigilRoot.objects.filter(prefix__iexact="CONF"):
+        if sys_root and sys_root.pk != root.pk:
+            updated_fields = []
+            if sys_root.prefix != "SYS":
+                sys_root.prefix = "SYS"
+                updated_fields.append("prefix")
+            if sys_root.context_type != "config":
+                sys_root.context_type = "config"
+                updated_fields.append("context_type")
+            if updated_fields:
+                sys_root.save(update_fields=updated_fields)
+            root.delete()
+        else:
+            updated_fields = []
+            if root.prefix != "SYS":
+                root.prefix = "SYS"
+                updated_fields.append("prefix")
+            if root.context_type != "config":
+                root.context_type = "config"
+                updated_fields.append("context_type")
+            if updated_fields:
+                root.save(update_fields=updated_fields)
+            sys_root = root
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0044_todo_url_normalize_loopback"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _rename_sys_to_conf, _rename_conf_to_sys
+        ),
+    ]

--- a/core/sigil_builder.py
+++ b/core/sigil_builder.py
@@ -17,7 +17,7 @@ from .sigil_resolver import (
 def generate_model_sigils(**kwargs) -> None:
     """Ensure built-in configuration SigilRoot entries exist."""
     SigilRoot = apps.get_model("core", "SigilRoot")
-    for prefix in ["ENV", "SYS"]:
+    for prefix in ["ENV", "CONF"]:
         # Ensure built-in configuration roots exist without violating the
         # unique ``prefix`` constraint, even if older databases already have
         # entries with a different ``context_type``.
@@ -43,9 +43,9 @@ def _sigil_builder_view(request):
             "label": _("Environment"),
         },
         {
-            "prefix": "SYS",
+            "prefix": "CONF",
             "url": reverse("admin:system"),
-            "label": _("System"),
+            "label": _("Configuration"),
         },
     ]
     for root in SigilRoot.objects.filter(

--- a/core/sigil_resolver.py
+++ b/core/sigil_resolver.py
@@ -15,10 +15,6 @@ from .sigil_context import get_context
 logger = logging.getLogger("core.entity")
 
 
-LEGACY_SIGIL_ROOT_ALIASES: dict[str, str] = {
-    "SYS": "CONF",
-}
-
 def _is_wizard_mode() -> bool:
     """Return ``True`` when the application is running in wizard mode."""
 
@@ -152,19 +148,11 @@ def _resolve_token(token: str, current: Optional[models.Model] = None) -> str:
     if instance_id:
         instance_id = resolve_sigils(instance_id, current)
     SigilRoot = apps.get_model("core", "SigilRoot")
-    lookup_alias = LEGACY_SIGIL_ROOT_ALIASES.get(lookup_root)
     try:
         root = SigilRoot.objects.get(prefix__iexact=lookup_root)
     except SigilRoot.DoesNotExist:
-        if lookup_alias:
-            try:
-                root = SigilRoot.objects.get(prefix__iexact=lookup_alias)
-            except SigilRoot.DoesNotExist:
-                logger.warning("Unknown sigil root [%s]", lookup_root)
-                return _failed_resolution(original_token)
-        else:
-            logger.warning("Unknown sigil root [%s]", lookup_root)
-            return _failed_resolution(original_token)
+        logger.warning("Unknown sigil root [%s]", lookup_root)
+        return _failed_resolution(original_token)
     except Exception:
         logger.exception(
             "Error resolving sigil [%s.%s]",

--- a/core/sigil_resolver.py
+++ b/core/sigil_resolver.py
@@ -176,7 +176,7 @@ def _resolve_token(token: str, current: Optional[models.Model] = None) -> str:
                     key_upper or normalized_key or raw_key or "",
                 )
                 return _failed_resolution(original_token)
-            if root.prefix.upper() == "SYS":
+            if root.prefix.upper() == "CONF":
                 for candidate in [normalized_key, key_upper, key_lower]:
                     if not candidate:
                         continue

--- a/tests/test_sigil_builder.py
+++ b/tests/test_sigil_builder.py
@@ -17,13 +17,13 @@ class SigilBuilderTests(TestCase):
         self.client.force_login(self.user)
 
     def test_resolve_multiple_sigils_in_text(self):
-        text = "Lang: [SYS.LANGUAGE-CODE], Debug: [SYS.DEBUG]"
+        text = "Lang: [CONF.LANGUAGE-CODE], Debug: [CONF.DEBUG]"
         resolved = resolve_sigils_in_text(text)
         expected = f"Lang: {settings.LANGUAGE_CODE}, Debug: {settings.DEBUG}"
         self.assertEqual(resolved, expected)
 
     def test_file_upload_resolves_sigils(self):
-        content = "[SYS.LANGUAGE-CODE]"
+        content = "[CONF.LANGUAGE-CODE]"
         upload = BytesIO(content.encode("utf-8"))
         upload.name = "sigils.txt"
         response = self.client.post(

--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -117,7 +117,7 @@ class SigilResolutionTests(TestCase):
         self.assertEqual(rendered, "user=odoo")
 
     @override_settings(LEGACY_SIGIL_VALUE="legacy")
-    def test_legacy_sys_sigil_alias(self):
+    def test_conf_sigil_resolution(self):
         SigilRoot.objects.update_or_create(
             prefix="CONF",
             defaults={
@@ -125,7 +125,7 @@ class SigilResolutionTests(TestCase):
                 "content_type": None,
             },
         )
-        resolved = sigil_resolver._resolve_token("SYS.LEGACY_SIGIL_VALUE")
+        resolved = sigil_resolver._resolve_token("CONF.LEGACY_SIGIL_VALUE")
         self.assertEqual(resolved, "legacy")
 
     def test_entity_sigil_hyphen_field(self):

--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -335,17 +335,17 @@ class SigilResolutionTests(TestCase):
         finally:
             del os.environ["sigil_test_var"]
 
-    def test_sys_sigil(self):
+    def test_conf_sigil(self):
         with self.settings(SIGIL_TEST_SETTING="sys-val"):
             self.assertEqual(
-                resolve_sigils_in_text("[SYS.SIGIL_TEST_SETTING]"),
+                resolve_sigils_in_text("[CONF.SIGIL_TEST_SETTING]"),
                 "sys-val",
             )
 
-    def test_sys_sigil_case_insensitive(self):
+    def test_conf_sigil_case_insensitive(self):
         with self.settings(sigil_case_setting="sys-lower"):
             self.assertEqual(
-                resolve_sigils_in_text("[SYS.sigil_case_setting]"),
+                resolve_sigils_in_text("[CONF.sigil_case_setting]"),
                 "sys-lower",
             )
 


### PR DESCRIPTION
## Summary
- rename the built-in SYS sigil root to CONF throughout the resolver and builder
- adjust tests and admin labelling to reflect the new CONF prefix
- add a migration to rename existing SYS sigil root records to CONF

## Testing
- python manage.py migrate --noinput
- pytest tests/test_sigil_builder.py tests/test_sigil_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68d465ac4af08326afb607681aad4214