### PR TITLE
Add temporary password management command and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 
 # Disk images
 *.img
+
+# Test databases
+test_db.sqlite3
 *.img.xz
 
 # C extensions

--- a/config/settings.py
+++ b/config/settings.py
@@ -519,6 +519,7 @@ AUTH_USER_MODEL = "core.User"
 
 # Enable RFID authentication backend and restrict default admin login to localhost
 AUTHENTICATION_BACKENDS = [
+    "core.backends.TempPasswordBackend",
     "core.backends.LocalhostAdminBackend",
     "core.backends.TOTPBackend",
     "core.backends.RFIDBackend",

--- a/core/management/commands/temp_password.py
+++ b/core/management/commands/temp_password.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import io
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from core import temp_passwords
+
+
+class Command(BaseCommand):
+    """Create a temporary password for the requested user."""
+
+    help = "Generate a temporary password for a user by username or email."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "identifier",
+            help="Username or email address identifying the user.",
+        )
+        parser.add_argument(
+            "--expires-in",
+            type=int,
+            default=int(temp_passwords.DEFAULT_EXPIRATION.total_seconds()),
+            help=(
+                "Number of seconds before the temporary password expires. "
+                "Defaults to 3600 (1 hour)."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        identifier = options["identifier"]
+        expires_in = int(options["expires_in"])
+        if expires_in <= 0:
+            raise CommandError("Expiration must be a positive number of seconds.")
+
+        User = get_user_model()
+        manager = getattr(User, "all_objects", User._default_manager)
+
+        users = self._resolve_users(manager, identifier)
+        if not users:
+            raise CommandError(f"No user found for identifier {identifier!r}.")
+        if len(users) > 1:
+            usernames = ", ".join(sorted({user.username for user in users}))
+            raise CommandError(
+                "Multiple users share this email address. Provide the username "
+                f"instead. Matches: {usernames}"
+            )
+
+        user = users[0]
+        password = temp_passwords.generate_password()
+        expires_at = timezone.now() + timedelta(seconds=expires_in)
+        entry = temp_passwords.store_temp_password(user.username, password, expires_at)
+
+        buffer = io.StringIO()
+        buffer.write(f"Temporary password for {user.username}: {password}\n")
+        buffer.write(f"Expires at: {entry.expires_at.isoformat()}\n")
+        if not user.is_active:
+            buffer.write("The account will be activated on first use.\n")
+        self.stdout.write(buffer.getvalue())
+        self.stdout.write(self.style.SUCCESS("Temporary password created."))
+
+    def _resolve_users(self, manager, identifier):
+        if "@" in identifier and not identifier.startswith("@"):
+            queryset = manager.filter(email__iexact=identifier)
+        else:
+            queryset = manager.filter(username__iexact=identifier)
+            if not queryset.exists():
+                queryset = manager.filter(email__iexact=identifier)
+        return list(queryset.order_by("username"))
+

--- a/core/temp_passwords.py
+++ b/core/temp_passwords.py
@@ -1,0 +1,169 @@
+"""Utilities for temporary password lock files."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import secrets
+import string
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from django.conf import settings
+from django.contrib.auth.hashers import check_password, make_password
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+
+DEFAULT_PASSWORD_LENGTH = 16
+DEFAULT_EXPIRATION = timedelta(hours=1)
+_SAFE_COMPONENT_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _base_lock_dir() -> Path:
+    """Return the root directory used for temporary password lock files."""
+
+    configured = getattr(settings, "TEMP_PASSWORD_LOCK_DIR", None)
+    if configured:
+        path = Path(configured)
+    else:
+        path = Path(settings.BASE_DIR) / "locks" / "temp-passwords"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _safe_component(value: str) -> str:
+    """Return a filesystem safe component derived from ``value``."""
+
+    if not value:
+        return ""
+    safe = _SAFE_COMPONENT_RE.sub("_", value)
+    safe = safe.strip("._")
+    return safe[:64]
+
+
+def _lockfile_name(username: str) -> str:
+    """Return the filename used for the provided ``username``."""
+
+    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:12]
+    safe = _safe_component(username)
+    if safe:
+        return f"{safe}-{digest}.json"
+    return f"user-{digest}.json"
+
+
+def _lockfile_path(username: str) -> Path:
+    """Return the lockfile path for ``username``."""
+
+    return _base_lock_dir() / _lockfile_name(username)
+
+
+def _parse_timestamp(value: str | None) -> Optional[datetime]:
+    """Return a timezone aware datetime parsed from ``value``."""
+
+    if not value:
+        return None
+    parsed = parse_datetime(value)
+    if parsed is None:
+        return None
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed)
+    return parsed
+
+
+@dataclass(frozen=True)
+class TempPasswordEntry:
+    """Details for a temporary password stored on disk."""
+
+    username: str
+    password_hash: str
+    expires_at: datetime
+    created_at: datetime
+    path: Path
+
+    @property
+    def is_expired(self) -> bool:
+        return timezone.now() >= self.expires_at
+
+    def check_password(self, raw_password: str) -> bool:
+        """Return ``True`` if ``raw_password`` matches this entry."""
+
+        return check_password(raw_password, self.password_hash)
+
+
+def generate_password(length: int = DEFAULT_PASSWORD_LENGTH) -> str:
+    """Return a random password composed of letters and digits."""
+
+    if length <= 0:
+        raise ValueError("length must be a positive integer")
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def store_temp_password(
+    username: str,
+    raw_password: str,
+    expires_at: Optional[datetime] = None,
+) -> TempPasswordEntry:
+    """Persist a temporary password for ``username`` and return the entry."""
+
+    if expires_at is None:
+        expires_at = timezone.now() + DEFAULT_EXPIRATION
+    if timezone.is_naive(expires_at):
+        expires_at = timezone.make_aware(expires_at)
+    created_at = timezone.now()
+    path = _lockfile_path(username)
+    data = {
+        "username": username,
+        "password_hash": make_password(raw_password),
+        "expires_at": expires_at.isoformat(),
+        "created_at": created_at.isoformat(),
+    }
+    path.write_text(json.dumps(data, indent=2, sort_keys=True))
+    return TempPasswordEntry(
+        username=username,
+        password_hash=data["password_hash"],
+        expires_at=expires_at,
+        created_at=created_at,
+        path=path,
+    )
+
+
+def load_temp_password(username: str) -> Optional[TempPasswordEntry]:
+    """Return the stored temporary password for ``username``, if any."""
+
+    path = _lockfile_path(username)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        path.unlink(missing_ok=True)
+        return None
+
+    expires_at = _parse_timestamp(data.get("expires_at"))
+    created_at = _parse_timestamp(data.get("created_at")) or timezone.now()
+    password_hash = data.get("password_hash")
+    if not expires_at or not password_hash:
+        path.unlink(missing_ok=True)
+        return None
+
+    username = data.get("username") or username
+    return TempPasswordEntry(
+        username=username,
+        password_hash=password_hash,
+        expires_at=expires_at,
+        created_at=created_at,
+        path=path,
+    )
+
+
+def discard_temp_password(username: str) -> None:
+    """Remove any stored temporary password for ``username``."""
+
+    path = _lockfile_path(username)
+    path.unlink(missing_ok=True)
+

--- a/tests/test_temp_passwords.py
+++ b/tests/test_temp_passwords.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import io
+import json
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from core import temp_passwords
+from core.backends import TempPasswordBackend
+
+
+def test_temp_password_command_creates_lockfile(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "TEMP_PASSWORD_LOCK_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(temp_passwords, "generate_password", lambda length=16: "TempPass123")
+
+    User = get_user_model()
+    user = User.objects.create_user(username="alice", email="alice@example.com", password="irrelevant")
+
+    output = io.StringIO()
+    call_command("temp_password", "alice", stdout=output)
+
+    message = output.getvalue()
+    assert "TempPass123" in message
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    data = json.loads(files[0].read_text())
+    assert data["username"] == "alice"
+    assert data["password_hash"] != "TempPass123"
+    expires_at = parse_datetime(data["expires_at"])
+    assert expires_at is not None
+    if timezone.is_naive(expires_at):
+        expires_at = timezone.make_aware(expires_at)
+    delta = expires_at - timezone.now()
+    assert timedelta(minutes=59) <= delta <= timedelta(hours=1, minutes=1)
+
+
+def test_temp_password_backend_authenticates_and_activates(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "TEMP_PASSWORD_LOCK_DIR", str(tmp_path), raising=False)
+
+    User = get_user_model()
+    user = User.objects.create_user(username="bob", password="old-password")
+    user.is_active = False
+    user.save(update_fields=["is_active"])
+
+    password = "TempPass123"
+    expires_at = timezone.now() + timedelta(minutes=10)
+    temp_passwords.store_temp_password(user.username, password, expires_at)
+
+    backend = TempPasswordBackend()
+    authenticated = backend.authenticate(None, username="bob", password=password)
+
+    assert authenticated is not None
+    assert authenticated.pk == user.pk
+    authenticated.refresh_from_db()
+    assert authenticated.is_active
+    assert not list(tmp_path.iterdir())
+
+
+def test_temp_password_backend_rejects_expired(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "TEMP_PASSWORD_LOCK_DIR", str(tmp_path), raising=False)
+
+    User = get_user_model()
+    user = User.objects.create_user(username="carol", password="old-password")
+
+    password = "TempPass123"
+    expires_at = timezone.now() - timedelta(minutes=5)
+    entry = temp_passwords.store_temp_password(user.username, password, expires_at)
+
+    backend = TempPasswordBackend()
+    result = backend.authenticate(None, username="carol", password=password)
+
+    assert result is None
+    assert not entry.path.exists()


### PR DESCRIPTION
## Summary
- add lockfile utilities and a `temp_password` management command for issuing temporary credentials
- authenticate temporary passwords through a new backend and enable it in the settings
- exercise the workflow with dedicated tests and ignore generated test databases

## Testing
- pytest tests/test_temp_passwords.py

------
https://chatgpt.com/codex/tasks/task_e_68d46c0929d08326a45101a1dfad2485