### PR TITLE
Compact pip output for satisfied requirements

### DIFF
--- a/env-refresh.bat
+++ b/env-refresh.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 set "SCRIPT_DIR=%~dp0"
+set "PIP_HELPER=%SCRIPT_DIR%scripts\helpers\pip_install.py"
 set "BACKUP_DIR=%SCRIPT_DIR%backups"
 if /I "%SCRIPT_DIR%"=="%SYSTEMDRIVE%\\" (
     echo Refusing to run from drive root.
@@ -60,7 +61,11 @@ if exist "%SCRIPT_DIR%\requirements.txt" (
         set /p STORED_HASH=<"%SCRIPT_DIR%\requirements.md5"
     )
     if /I not "%REQ_HASH%"=="%STORED_HASH%" (
-        "%VENV%\Scripts\python.exe" -m pip install -r "%SCRIPT_DIR%\requirements.txt"
+        if exist "%PIP_HELPER%" (
+            "%VENV%\Scripts\python.exe" "%PIP_HELPER%" -r "%SCRIPT_DIR%\requirements.txt"
+        ) else (
+            "%VENV%\Scripts\python.exe" -m pip install -r "%SCRIPT_DIR%\requirements.txt"
+        )
         echo %REQ_HASH%>"%SCRIPT_DIR%\requirements.md5"
     )
 )

--- a/install.bat
+++ b/install.bat
@@ -1,5 +1,6 @@
 @echo off
 set "SCRIPT_DIR=%~dp0"
+set "PIP_HELPER=%SCRIPT_DIR%scripts\helpers\pip_install.py"
 if /I "%SCRIPT_DIR%"=="%SYSTEMDRIVE%\\" (
     echo Refusing to run from drive root.
     exit /b 1
@@ -10,7 +11,11 @@ if not exist "%VENV%\Scripts\python.exe" (
     python -m venv "%VENV%"
 )
 "%VENV%\Scripts\python.exe" -m pip install -U pip
-"%VENV%\Scripts\python.exe" -m pip install -r "%SCRIPT_DIR%\requirements.txt"
+if exist "%PIP_HELPER%" (
+    "%VENV%\Scripts\python.exe" "%PIP_HELPER%" -r "%SCRIPT_DIR%\requirements.txt"
+) else (
+    "%VENV%\Scripts\python.exe" -m pip install -r "%SCRIPT_DIR%\requirements.txt"
+)
 "%VENV%\Scripts\python.exe" manage.py migrate --noinput
 call "%SCRIPT_DIR%\env-refresh.bat" --latest
 popd >nul

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PIP_INSTALL_HELPER="$SCRIPT_DIR/scripts/helpers/pip_install.py"
 # shellcheck source=scripts/helpers/logging.sh
 . "$SCRIPT_DIR/scripts/helpers/logging.sh"
 arthexis_resolve_log_dir "$SCRIPT_DIR" LOG_DIR || exit 1
@@ -421,14 +422,22 @@ NEW_HASH=$(md5sum "$REQ_FILE" | awk '{print $1}')
 STORED_HASH=""
 [ -f "$MD5_FILE" ] && STORED_HASH=$(cat "$MD5_FILE")
 if [ "$NEW_HASH" != "$STORED_HASH" ]; then
-    pip install -r "$REQ_FILE"
+    if [ -f "$PIP_INSTALL_HELPER" ] && command -v python >/dev/null 2>&1; then
+        python "$PIP_INSTALL_HELPER" -r "$REQ_FILE"
+    else
+        pip install -r "$REQ_FILE"
+    fi
     echo "$NEW_HASH" > "$MD5_FILE"
 else
     echo "Requirements unchanged. Skipping installation."
 fi
 
 if [ "$ENABLE_DATASETTE" = true ]; then
-    pip install datasette
+    if [ -f "$PIP_INSTALL_HELPER" ] && command -v python >/dev/null 2>&1; then
+        python "$PIP_INSTALL_HELPER" datasette
+    else
+        pip install datasette
+    fi
 fi
 
 if [ "$ENABLE_CONTROL" = true ]; then

--- a/scripts/helpers/pip_install.py
+++ b/scripts/helpers/pip_install.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run ``pip install`` with compact output for satisfied requirements."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Iterable
+
+
+def _iter_pip_output(cmd: Iterable[str]) -> int:
+    """Stream pip output while replacing satisfied requirement lines with dots."""
+    process = subprocess.Popen(
+        list(cmd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    assert process.stdout is not None
+
+    printed_dot = False
+    try:
+        for raw_line in process.stdout:
+            line = raw_line.rstrip("\r\n")
+            if "Requirement already satisfied" in line:
+                sys.stdout.write(".")
+                sys.stdout.flush()
+                printed_dot = True
+                continue
+
+            if printed_dot:
+                sys.stdout.write("\n")
+                printed_dot = False
+
+            sys.stdout.write(raw_line)
+        return_code = process.wait()
+    finally:
+        if printed_dot:
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+
+    return return_code
+
+
+def main() -> int:
+    pip_args = sys.argv[1:]
+    cmd = [sys.executable, "-m", "pip", "install", *pip_args]
+    return _iter_pip_output(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/upgrade.bat
+++ b/upgrade.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
 set "BASE_DIR=%~dp0"
+set "PIP_HELPER=%BASE_DIR%scripts\helpers\pip_install.py"
 set "BACKUP_DIR=%BASE_DIR%backups"
 cd /d "%BASE_DIR%"
 
@@ -43,7 +44,11 @@ if exist %MD5% (
     set /p STORED_HASH=<%MD5%
 )
 if /I not "%NEW_HASH%"=="%STORED_HASH%" (
-    %VENV%\Scripts\python.exe -m pip install -r %REQ%
+    if exist "%PIP_HELPER%" (
+        %VENV%\Scripts\python.exe "%PIP_HELPER%" -r %REQ%
+    ) else (
+        %VENV%\Scripts\python.exe -m pip install -r %REQ%
+    )
     echo %NEW_HASH%>%MD5%
 ) else (
     echo Requirements unchanged. Skipping installation.


### PR DESCRIPTION
## Summary
- add a helper that streams pip install output while collapsing "Requirement already satisfied" messages to single dots
- update installation and refresh scripts on Linux and Windows to use the new helper when installing requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d474484c948326ba150df2191c8779