### PR TITLE
Explain skipped requirements before dot output

### DIFF
--- a/scripts/helpers/pip_install.py
+++ b/scripts/helpers/pip_install.py
@@ -20,6 +20,9 @@ def _iter_pip_output(cmd: Iterable[str]) -> int:
         for raw_line in process.stdout:
             line = raw_line.rstrip("\r\n")
             if "Requirement already satisfied" in line:
+                if not printed_dot:
+                    sys.stdout.write("Skipping requirements without updates\n")
+                    sys.stdout.flush()
                 sys.stdout.write(".")
                 sys.stdout.flush()
                 printed_dot = True


### PR DESCRIPTION
## Summary
- announce when pip output skips already satisfied requirements before printing dots
- keep the dot-based compact output behavior unchanged for satisfied requirements

## Testing
- python -m compileall scripts/helpers/pip_install.py

------
https://chatgpt.com/codex/tasks/task_e_68d478f17dac8326b0c8a9267b5e5c8a