### PR TITLE
Add SYS sigil root and modernize system admin view

### DIFF
--- a/core/migrations/0046_create_sys_sigil_root.py
+++ b/core/migrations/0046_create_sys_sigil_root.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+def _create_sys_root(apps, schema_editor):
+    SigilRoot = apps.get_model("core", "SigilRoot")
+    root = SigilRoot.objects.filter(prefix__iexact="SYS").first()
+    if root:
+        updates = []
+        if root.prefix != "SYS":
+            root.prefix = "SYS"
+            updates.append("prefix")
+        if root.context_type != "config":
+            root.context_type = "config"
+            updates.append("context_type")
+        if updates:
+            root.save(update_fields=updates)
+        return
+    SigilRoot.objects.create(prefix="SYS", context_type="config")
+
+
+def _remove_sys_root(apps, schema_editor):
+    SigilRoot = apps.get_model("core", "SigilRoot")
+    SigilRoot.objects.filter(prefix__iexact="SYS").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0045_invitelead_sent_via_outbox"),
+        ("core", "0045_rename_sys_sigil_root"),
+    ]
+
+    operations = [
+        migrations.RunPython(_create_sys_root, _remove_sys_root),
+    ]

--- a/core/sigil_builder.py
+++ b/core/sigil_builder.py
@@ -17,7 +17,7 @@ from .sigil_resolver import (
 def generate_model_sigils(**kwargs) -> None:
     """Ensure built-in configuration SigilRoot entries exist."""
     SigilRoot = apps.get_model("core", "SigilRoot")
-    for prefix in ["ENV", "CONF"]:
+    for prefix in ["ENV", "CONF", "SYS"]:
         # Ensure built-in configuration roots exist without violating the
         # unique ``prefix`` constraint, even if older databases already have
         # entries with a different ``context_type``.
@@ -46,6 +46,11 @@ def _sigil_builder_view(request):
             "prefix": "CONF",
             "url": reverse("admin:system"),
             "label": _("Configuration"),
+        },
+        {
+            "prefix": "SYS",
+            "url": reverse("admin:system"),
+            "label": _("System"),
         },
     ]
     for root in SigilRoot.objects.filter(

--- a/core/system.py
+++ b/core/system.py
@@ -44,10 +44,14 @@ def _database_configurations() -> list[dict[str, str]]:
     for alias, config in settings.DATABASES.items():
         engine = config.get("ENGINE", "")
         name = config.get("NAME", "")
+        if engine is None:
+            engine = ""
+        if name is None:
+            name = ""
         databases.append({
             "alias": alias,
-            "engine": engine,
-            "name": name,
+            "engine": str(engine),
+            "name": str(name),
         })
     databases.sort(key=lambda entry: entry["alias"].lower())
     return databases

--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -5,57 +5,75 @@
 <div id="content-main">
   <div>
     <h1>{{ title }}</h1>
-    <dl>
-      <dt>{% trans "Suite installed" %}</dt>
-      <dd>{{ info.installed }}</dd>
-      <dt>{% trans "Revision" %}</dt>
-      <dd>{{ info.revision }}</dd>
-      <dt>{% trans "Service" %}</dt>
-      <dd>{% if info.service %}{{ info.service }}{% else %}{% trans "not installed" %}{% endif %}</dd>
-      <dt>{% trans "Nginx mode" %}</dt>
-      <dd>{{ info.mode }} ({{ info.port }})</dd>
-      <dt>{% trans "Node role" %}</dt>
-      <dd>{{ info.role }}</dd>
-      {% if info.screen_mode %}
-      <dt>{% trans "Display mode" %}</dt>
-      <dd>{{ info.screen_mode }}</dd>
-      {% endif %}
-      <dt>{% trans "Features" %}</dt>
-      <dd>
-        {% if info.features %}
-        <ul>
-          {% for feature in info.features %}
-          <li>
-            {{ feature.display }}
-            {% if feature.expected or feature.actual %}
-              (
-              {% if feature.expected and feature.actual %}
-                {% trans "expected and actual" %}
-              {% elif feature.expected %}
-                {% trans "expected" %}
+    <table class="system-info-table table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">{% trans "System field" %}</th>
+          <th scope="col">{% trans "Sigil" %}</th>
+          <th scope="col">{% trans "Current values" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for field in system_fields %}
+        <tr>
+          <th scope="row">{{ field.label }}</th>
+          <td><code>{{ field.sigil }}</code></td>
+          <td>
+            {% if field.field_type == "boolean" %}
+              {% if field.value %}
+                {% trans "Yes" %}
               {% else %}
-                {% trans "actual" %}
+                {% trans "No" %}
               {% endif %}
-              )
+            {% elif field.field_type == "features" %}
+              {% if field.value %}
+              <ul>
+                {% for feature in field.value %}
+                <li>
+                  {{ feature.display }}
+                  {% if feature.expected or feature.actual %}
+                    (
+                    {% if feature.expected and feature.actual %}
+                      {% trans "expected and actual" %}
+                    {% elif feature.expected %}
+                      {% trans "expected" %}
+                    {% else %}
+                      {% trans "actual" %}
+                    {% endif %}
+                    )
+                  {% endif %}
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <em>{% trans "No features detected" %}</em>
+              {% endif %}
+            {% elif field.field_type == "databases" %}
+              {% if field.value %}
+              <ul>
+                {% for database in field.value %}
+                <li>
+                  <strong>{{ database.alias }}</strong>
+                  {% if database.engine %}
+                    — {{ database.engine }}
+                  {% endif %}
+                  {% if database.name %}
+                    ({{ database.name }})
+                  {% endif %}
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <em>{% trans "No databases configured" %}</em>
+              {% endif %}
+            {% else %}
+              {{ field.value|default_if_none:"" }}
             {% endif %}
-          </li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        <em>{% trans "No features detected" %}</em>
-        {% endif %}
-      </dd>
-      <dt>{% trans "Running" %}</dt>
-      <dd>{{ info.running }}</dd>
-      {% if info.service %}
-      <dt>{% trans "Service status" %}</dt>
-      <dd>{{ info.service_status }}</dd>
-      {% endif %}
-      <dt>{% trans "Hostname" %}</dt>
-      <dd>{{ info.hostname }}</dd>
-      <dt>{% trans "IP addresses" %}</dt>
-      <dd>{{ info.ip_addresses|join:" " }}</dd>
-    </dl>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 </div>
 {% endblock %}

--- a/core/test_system_info.py
+++ b/core/test_system_info.py
@@ -63,6 +63,19 @@ class SystemInfoDatabaseTests(SimpleTestCase):
         aliases = {entry["alias"] for entry in info["databases"]}
         self.assertIn("default", aliases)
 
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": Path("/tmp/db.sqlite3"),
+            }
+        }
+    )
+    def test_serializes_path_database_names(self):
+        info = _gather_info()
+        databases = info["databases"]
+        self.assertEqual(databases[0]["name"], "/tmp/db.sqlite3")
+
 
 class SystemInfoRunserverDetectionTests(SimpleTestCase):
     @patch("core.system.subprocess.run")

--- a/core/test_system_info.py
+++ b/core/test_system_info.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -11,9 +12,9 @@ import django
 django.setup()
 
 from django.conf import settings
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, override_settings
 from nodes.models import Node, NodeFeature, NodeRole
-from core.system import _gather_info
+from core.system import _gather_info, get_system_sigil_values
 
 
 class SystemInfoRoleTests(SimpleTestCase):
@@ -55,6 +56,14 @@ class SystemInfoRevisionTests(SimpleTestCase):
         mock_revision.assert_called_once()
 
 
+class SystemInfoDatabaseTests(SimpleTestCase):
+    def test_collects_database_definitions(self):
+        info = _gather_info()
+        self.assertIn("databases", info)
+        aliases = {entry["alias"] for entry in info["databases"]}
+        self.assertIn("default", aliases)
+
+
 class SystemInfoRunserverDetectionTests(SimpleTestCase):
     @patch("core.system.subprocess.run")
     def test_detects_runserver_process_port(self, mock_run):
@@ -76,4 +85,42 @@ class SystemInfoRunserverDetectionTests(SimpleTestCase):
 
         self.assertTrue(info["running"])
         self.assertEqual(info["port"], 8000)
+
+
+class SystemSigilValueTests(SimpleTestCase):
+    def test_exports_values_for_sigil_resolution(self):
+        sample_info = {
+            "installed": True,
+            "revision": "abcdef",
+            "service": "gunicorn",
+            "mode": "internal",
+            "port": 8888,
+            "role": "Terminal",
+            "screen_mode": "",
+            "features": [
+                {"display": "Feature", "expected": True, "actual": False, "slug": "feature"}
+            ],
+            "running": True,
+            "service_status": "active",
+            "hostname": "example.local",
+            "ip_addresses": ["127.0.0.1"],
+            "databases": [
+                {
+                    "alias": "default",
+                    "engine": "django.db.backends.sqlite3",
+                    "name": "db.sqlite3",
+                }
+            ],
+        }
+        with patch("core.system._gather_info", return_value=sample_info):
+            values = get_system_sigil_values()
+
+        self.assertEqual(values["REVISION"], "abcdef")
+        self.assertEqual(values["RUNNING"], "True")
+        self.assertEqual(values["NGINX_MODE"], "internal (8888)")
+        self.assertEqual(values["IP_ADDRESSES"], "127.0.0.1")
+        features = json.loads(values["FEATURES"])
+        self.assertEqual(features[0]["display"], "Feature")
+        databases = json.loads(values["DATABASES"])
+        self.assertEqual(databases[0]["alias"], "default")
 

--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -77,6 +77,13 @@ class SigilResolutionTests(TestCase):
                 "content_type": None,
             },
         )
+        SigilRoot.objects.update_or_create(
+            prefix="SYS",
+            defaults={
+                "context_type": SigilRoot.Context.CONFIG,
+                "content_type": None,
+            },
+        )
 
     def test_unknown_root_sigil_left_intact(self):
         profile = OdooProfile.objects.create(
@@ -127,6 +134,22 @@ class SigilResolutionTests(TestCase):
         )
         resolved = sigil_resolver._resolve_token("CONF.LEGACY_SIGIL_VALUE")
         self.assertEqual(resolved, "legacy")
+
+    def test_sys_sigil_resolution(self):
+        with mock.patch(
+            "core.sigil_resolver.get_system_sigil_values",
+            return_value={"REVISION": "123456"},
+        ):
+            resolved = sigil_resolver._resolve_token("SYS.REVISION")
+        self.assertEqual(resolved, "123456")
+
+    def test_sys_sigil_case_insensitive(self):
+        with mock.patch(
+            "core.sigil_resolver.get_system_sigil_values",
+            return_value={"RUNNING": "True"},
+        ):
+            resolved = resolve_sigils_in_text("[sys.running]")
+        self.assertEqual(resolved, "True")
 
     def test_entity_sigil_hyphen_field(self):
         ct = ContentType.objects.get_for_model(OdooProfile)


### PR DESCRIPTION
## Summary
- render the system admin view as a table with sigils and database details
- expose structured system information for the new SYS sigil root
- ensure the SYS sigil root exists and extend tests for the new behaviour

## Testing
- pytest core/test_system_info.py tests/test_sigil_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68d47cc01e608326a06e99c9b5771119