### PR TITLE
Allow temp password for password change

### DIFF
--- a/core/backends.py
+++ b/core/backends.py
@@ -222,7 +222,6 @@ class TempPasswordBackend(ModelBackend):
         if not entry.check_password(password):
             return None
 
-        temp_passwords.discard_temp_password(user.username)
         if not user.is_active:
             user.is_active = True
             user.save(update_fields=["is_active"])


### PR DESCRIPTION
## Summary
- keep temporary password entries available after authentication so they can be reused during the expiration window
- let the custom user model validate stored temporary passwords and discard them once a real password is set
- extend temp password tests to cover the new behaviours and removal timing

## Testing
- `pytest` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68d47beff17c8326b6518a1bba622b30