### PR TITLE
Align quick guide list formatting

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -67,28 +67,28 @@ Die Arthexis-Konstellation wird in vier Node-Rollen ausgeliefert, die auf unters
 ### 2. Starten und Stoppen
 Terminal-Knoten können direkt mit den untenstehenden Skripten ohne Installation gestartet werden; die Rollen Control, Satellite und Constellation müssen vorher installiert werden. Beide Ansätze lauschen standardmäßig auf [`http://localhost:8000/`](http://localhost:8000/).
 
-**[VS Code](https://code.visualstudio.com/)**
-- Ordner öffnen und zum Bereich **Run and Debug** (`Ctrl+Shift+D`) wechseln.
-- Die Konfiguration **Run Server** (oder **Debug Server**) auswählen.
-- Auf den grünen Startknopf klicken. Den Server mit dem roten Quadrat (`Shift+F5`) anhalten.
+- **[VS Code](https://code.visualstudio.com/)**
+   - Ordner öffnen und zum Bereich **Run and Debug** (`Ctrl+Shift+D`) wechseln.
+   - Die Konfiguration **Run Server** (oder **Debug Server**) auswählen.
+   - Auf den grünen Startknopf klicken. Den Server mit dem roten Quadrat (`Shift+F5`) anhalten.
 
-**[Shell](https://de.wikipedia.org/wiki/Shell_(Informatik))**
-- Linux: [`./start.sh`](start.sh) ausführen und mit [`./stop.sh`](stop.sh) anhalten.
-- Windows: [`start.bat`](start.bat) ausführen und mit `Ctrl+C` beenden.
+- **[Shell](https://de.wikipedia.org/wiki/Shell_(Informatik))**
+   - Linux: [`./start.sh`](start.sh) ausführen und mit [`./stop.sh`](stop.sh) anhalten.
+   - Windows: [`start.bat`](start.bat) ausführen und mit `Ctrl+C` beenden.
 
 ### 3. Installieren und Aktualisieren
-**Linux:** [`./install.sh`](install.sh) mit einem Flag für die Node-Rolle ausführen:
-- `--terminal` – Standard, wenn nicht angegeben, und empfohlen, wenn du unsicher bist. Terminal-Knoten können auch ohne Installation über die obigen Skripte gestartet/gestoppt werden.
-- `--control` – Bereitet das Einzelgerätetest-System vor.
-- `--satellite` – Konfiguriert den Edge-Knoten zur Datenerfassung.
-- `--constellation` – Aktiviert den Multiuser-Orchestrierungsstack.
-`./install.sh --help` zeigt alle verfügbaren Optionen, falls du die Konfiguration über die Rollenvorgaben hinaus anpassen möchtest.
+- **Linux:**
+   - [`./install.sh`](install.sh) mit einem Flag für die Node-Rolle ausführen:
+     - `--terminal` – Standard, wenn nicht angegeben, und empfohlen, wenn du unsicher bist. Terminal-Knoten können auch ohne Installation über die obigen Skripte gestartet/gestoppt werden.
+     - `--control` – Bereitet das Einzelgerätetest-System vor.
+     - `--satellite` – Konfiguriert den Edge-Knoten zur Datenerfassung.
+     - `--constellation` – Aktiviert den Multiuser-Orchestrierungsstack.
+   - `./install.sh --help` zeigt alle verfügbaren Optionen, falls du die Konfiguration über die Rollenvorgaben hinaus anpassen möchtest.
+   - Aktualisieren mit [`./upgrade.sh`](upgrade.sh).
 
-Aktualisieren mit [`./upgrade.sh`](upgrade.sh).
-
-**Windows:**
-- [`install.bat`](install.bat) zur Installation (Terminal-Rolle) und [`upgrade.bat`](upgrade.bat) zum Aktualisieren ausführen.
-- Für den Start im Terminalmodus (Standard) ist keine Installation erforderlich.
+- **Windows:**
+   - [`install.bat`](install.bat) zur Installation (Terminal-Rolle) und [`upgrade.bat`](upgrade.bat) zum Aktualisieren ausführen.
+   - Für den Start im Terminalmodus (Standard) ist keine Installation erforderlich.
 
 ### 4. Administration
 [`http://localhost:8000/admin/`](http://localhost:8000/admin/) für den [Django-Admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) und [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) für die [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/) aufrufen. Verwende `--port` mit den Startskripten oder dem Installer, wenn ein anderer Port benötigt wird.

--- a/README.es.md
+++ b/README.es.md
@@ -67,28 +67,28 @@ Constelación Arthexis se distribuye en cuatro roles de nodo que adaptan la plat
 ### 2. Iniciar y detener
 Los nodos Terminal pueden iniciarse directamente con los siguientes scripts sin instalar; los roles Control, Satélite y Constelación deben instalarse primero. Ambos métodos escuchan en [`http://localhost:8000/`](http://localhost:8000/) de forma predeterminada.
 
-**[VS Code](https://code.visualstudio.com/)**
-- Abre la carpeta y ve al panel **Run and Debug** (`Ctrl+Shift+D`).
-- Selecciona la configuración **Run Server** (o **Debug Server**).
-- Presiona el botón verde de inicio. Detén el servidor con el cuadrado rojo (`Shift+F5`).
+- **[VS Code](https://code.visualstudio.com/)**
+   - Abre la carpeta y ve al panel **Run and Debug** (`Ctrl+Shift+D`).
+   - Selecciona la configuración **Run Server** (o **Debug Server**).
+   - Presiona el botón verde de inicio. Detén el servidor con el cuadrado rojo (`Shift+F5`).
 
-**[Shell](https://es.wikipedia.org/wiki/Shell_de_unidad_de_comandos)**
-- Linux: ejecuta [`./start.sh`](start.sh) y detén con [`./stop.sh`](stop.sh).
-- Windows: ejecuta [`start.bat`](start.bat) y detén con `Ctrl+C`.
+- **[Shell](https://es.wikipedia.org/wiki/Shell_de_unidad_de_comandos)**
+   - Linux: ejecuta [`./start.sh`](start.sh) y detén con [`./stop.sh`](stop.sh).
+   - Windows: ejecuta [`start.bat`](start.bat) y detén con `Ctrl+C`.
 
 ### 3. Instalar y actualizar
-**Linux:** ejecuta [`./install.sh`](install.sh) con un flag de rol de nodo:
-- `--terminal`: rol predeterminado si no se especifica y recomendado si no sabes cuál elegir. Los nodos Terminal también pueden usar los scripts anteriores para iniciar/detener sin instalar.
-- `--control`: prepara el equipo de control para pruebas de un solo dispositivo.
-- `--satellite`: configura el nodo perimetral de adquisición de datos.
-- `--constellation`: habilita la pila de orquestación multiusuario.
-Usa `./install.sh --help` para ver la lista completa de flags si necesitas personalizar el nodo más allá del rol.
+- **Linux:**
+   - Ejecuta [`./install.sh`](install.sh) con un flag de rol de nodo:
+     - `--terminal`: rol predeterminado si no se especifica y recomendado si no sabes cuál elegir. Los nodos Terminal también pueden usar los scripts anteriores para iniciar/detener sin instalar.
+     - `--control`: prepara el equipo de control para pruebas de un solo dispositivo.
+     - `--satellite`: configura el nodo perimetral de adquisición de datos.
+     - `--constellation`: habilita la pila de orquestación multiusuario.
+   - Usa `./install.sh --help` para ver la lista completa de flags si necesitas personalizar el nodo más allá del rol.
+   - Actualiza con [`./upgrade.sh`](upgrade.sh).
 
-Actualiza con [`./upgrade.sh`](upgrade.sh).
-
-**Windows:**
-- Ejecuta [`install.bat`](install.bat) para instalar (rol Terminal) y [`upgrade.bat`](upgrade.bat) para actualizar.
-- No es necesario instalar para iniciar en modo Terminal (el predeterminado).
+- **Windows:**
+   - Ejecuta [`install.bat`](install.bat) para instalar (rol Terminal) y [`upgrade.bat`](upgrade.bat) para actualizar.
+   - No es necesario instalar para iniciar en modo Terminal (el predeterminado).
 
 ### 4. Administración
 Visita [`http://localhost:8000/admin/`](http://localhost:8000/admin/) para el [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) y [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) para la [documentación de administración](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Usa `--port` con los scripts de inicio o el instalador si necesitas exponer otro puerto.

--- a/README.it.md
+++ b/README.it.md
@@ -67,28 +67,28 @@ Costellazione Arthexis è distribuita in quattro ruoli di nodo pensati per diver
 ### 2. Avvio e arresto
 I nodi Terminal possono avviarsi direttamente con gli script sottostanti senza installazione; i ruoli Control, Satellite e Constellation richiedono prima l'installazione. Entrambi i metodi ascoltano su [`http://localhost:8000/`](http://localhost:8000/) per impostazione predefinita.
 
-**[VS Code](https://code.visualstudio.com/)**
-- Apri la cartella e vai al pannello **Run and Debug** (`Ctrl+Shift+D`).
-- Seleziona la configurazione **Run Server** (o **Debug Server**).
-- Premi il pulsante verde di avvio. Arresta il server con il quadrato rosso (`Shift+F5`).
+- **[VS Code](https://code.visualstudio.com/)**
+   - Apri la cartella e vai al pannello **Run and Debug** (`Ctrl+Shift+D`).
+   - Seleziona la configurazione **Run Server** (o **Debug Server**).
+   - Premi il pulsante verde di avvio. Arresta il server con il quadrato rosso (`Shift+F5`).
 
-**[Shell](https://it.wikipedia.org/wiki/Shell_(informatica))**
-- Linux: esegui [`./start.sh`](start.sh) e arresta con [`./stop.sh`](stop.sh).
-- Windows: esegui [`start.bat`](start.bat) e interrompi con `Ctrl+C`.
+- **[Shell](https://it.wikipedia.org/wiki/Shell_(informatica))**
+   - Linux: esegui [`./start.sh`](start.sh) e arresta con [`./stop.sh`](stop.sh).
+   - Windows: esegui [`start.bat`](start.bat) e interrompi con `Ctrl+C`.
 
 ### 3. Installare e aggiornare
-**Linux:** esegui [`./install.sh`](install.sh) con un flag per il ruolo del nodo:
-- `--terminal` – impostazione predefinita se non specificato e consigliato se non sei sicuro. I nodi Terminal possono anche utilizzare gli script sopra per avviare/arrestare senza installazione.
-- `--control` – prepara l'appliance di test per singolo dispositivo.
-- `--satellite` – configura il nodo perimetrale di acquisizione dati.
-- `--constellation` – abilita lo stack di orchestrazione multiutente.
-Usa `./install.sh --help` per elencare tutte le opzioni disponibili se hai bisogno di personalizzare il nodo oltre le impostazioni del ruolo.
+- **Linux:**
+   - Esegui [`./install.sh`](install.sh) con un flag per il ruolo del nodo:
+     - `--terminal` – impostazione predefinita se non specificato e consigliato se non sei sicuro. I nodi Terminal possono anche utilizzare gli script sopra per avviare/arrestare senza installazione.
+     - `--control` – prepara l'appliance di test per singolo dispositivo.
+     - `--satellite` – configura il nodo perimetrale di acquisizione dati.
+     - `--constellation` – abilita lo stack di orchestrazione multiutente.
+   - Usa `./install.sh --help` per elencare tutte le opzioni disponibili se hai bisogno di personalizzare il nodo oltre le impostazioni del ruolo.
+   - Aggiorna con [`./upgrade.sh`](upgrade.sh).
 
-Aggiorna con [`./upgrade.sh`](upgrade.sh).
-
-**Windows:**
-- Esegui [`install.bat`](install.bat) per installare (ruolo Terminal) e [`upgrade.bat`](upgrade.bat) per aggiornare.
-- Non è necessario installare per avviare in modalità Terminal (predefinita).
+- **Windows:**
+   - Esegui [`install.bat`](install.bat) per installare (ruolo Terminal) e [`upgrade.bat`](upgrade.bat) per aggiornare.
+   - Non è necessario installare per avviare in modalità Terminal (predefinita).
 
 ### 4. Amministrazione
 Visita [`http://localhost:8000/admin/`](http://localhost:8000/admin/) per il [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) e [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) per gli [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Usa `--port` con gli script di avvio o l'installer quando devi esporre una porta diversa.

--- a/README.md
+++ b/README.md
@@ -69,28 +69,28 @@ Arthexis Constellation ships in four node roles tailored to different deployment
 ### 2. Start and stop
 Terminal nodes can start directly with the scripts below without installing; Control, Satellite, and Constellation roles require installation first. Both approaches listen on [`http://localhost:8000/`](http://localhost:8000/) by default.
 
-**[VS Code](https://code.visualstudio.com/)**
-- Open the folder and go to the **Run and Debug** panel (`Ctrl+Shift+D`).
-- Select the **Run Server** (or **Debug Server**) configuration.
-- Press the green start button. Stop the server with the red square button (`Shift+F5`).
+- **[VS Code](https://code.visualstudio.com/)**
+   - Open the folder and go to the **Run and Debug** panel (`Ctrl+Shift+D`).
+   - Select the **Run Server** (or **Debug Server**) configuration.
+   - Press the green start button. Stop the server with the red square button (`Shift+F5`).
 
-**[Shell](https://en.wikipedia.org/wiki/Shell_(computing))**
-- Linux: run [`./start.sh`](start.sh) and stop with [`./stop.sh`](stop.sh).
-- Windows: run [`start.bat`](start.bat) and stop with `Ctrl+C`.
+- **[Shell](https://en.wikipedia.org/wiki/Shell_(computing))**
+   - Linux: run [`./start.sh`](start.sh) and stop with [`./stop.sh`](stop.sh).
+   - Windows: run [`start.bat`](start.bat) and stop with `Ctrl+C`.
 
 ### 3. Install and upgrade
-**Linux:** run [`./install.sh`](install.sh) with a node role flag:
-- `--terminal` – default when unspecified and recommended if you're unsure. Terminal nodes can also use the start/stop scripts above without installing.
-- `--control` – prepares the single-device testing appliance.
-- `--satellite` – configures the edge data acquisition node.
-- `--constellation` – enables the multi-user orchestration stack.
-Use `./install.sh --help` to list every available flag if you need to customize the node beyond the role defaults.
+- **Linux:**
+   - Run [`./install.sh`](install.sh) with a node role flag:
+     - `--terminal` – default when unspecified and recommended if you're unsure. Terminal nodes can also use the start/stop scripts above without installing.
+     - `--control` – prepares the single-device testing appliance.
+     - `--satellite` – configures the edge data acquisition node.
+     - `--constellation` – enables the multi-user orchestration stack.
+   - Use `./install.sh --help` to list every available flag if you need to customize the node beyond the role defaults.
+   - Upgrade with [`./upgrade.sh`](upgrade.sh).
 
-Upgrade with [`./upgrade.sh`](upgrade.sh).
-
-**Windows:**
-- Run [`install.bat`](install.bat) to install (Terminal role) and [`upgrade.bat`](upgrade.bat) to upgrade.
-- Installation is not required to start in Terminal mode (the default).
+- **Windows:**
+   - Run [`install.bat`](install.bat) to install (Terminal role) and [`upgrade.bat`](upgrade.bat) to upgrade.
+   - Installation is not required to start in Terminal mode (the default).
 
 ### 4. Administration
 Visit [`http://localhost:8000/admin/`](http://localhost:8000/admin/) for the [Django admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/) and [`http://localhost:8000/admindocs/`](http://localhost:8000/admindocs/) for the [admindocs](https://docs.djangoproject.com/en/stable/ref/contrib/admin/admindocs/). Use `--port` with the start scripts or installer when you need to expose a different port.


### PR DESCRIPTION
## Summary
- align the "Start and stop" and "Install and upgrade" quick guide sections with nested lists in the main README
- mirror the updated list formatting across the Spanish, German, and Italian README translations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d47f1b59188326a45b040f3a4c3609