### PR TITLE
Avoid duplicating EmailOutbox host in name

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -814,6 +814,8 @@ class EmailOutbox(Profile):
         username = (self.username or "").strip()
         host = (self.host or "").strip()
         if username and host:
+            if "@" in username:
+                return username
             return f"{username}@{host}"
         if username:
             return username

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -1452,6 +1452,16 @@ class EmailOutboxTests(TestCase):
 
         self.assertEqual(str(outbox), "mailer@smtp.example.com")
 
+    def test_string_representation_does_not_duplicate_email_hostname(self):
+        outbox = EmailOutbox.objects.create(
+            host="smtp.example.com",
+            port=587,
+            username="mailer@example.com",
+            password="secret",
+        )
+
+        self.assertEqual(str(outbox), "mailer@example.com")
+
     def test_unattached_outbox_used_as_fallback(self):
         EmailOutbox.objects.create(
             group=SecurityGroup.objects.create(name="Attached"),


### PR DESCRIPTION
## Summary
- prevent EmailOutbox.__str__ from appending the host when the username already contains an @
- add a regression test covering the non-duplication scenario for EmailOutbox string representation

## Testing
- pytest nodes/tests.py::EmailOutboxTests::test_string_representation_does_not_duplicate_email_hostname *(fails: missing database tables because migrations cannot run due to existing conflicts)*
- pytest nodes/tests.py::EmailOutboxTests::test_string_representation_prefers_username_over_owner *(fails: missing database tables because migrations cannot run due to existing conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d4877cd5e48326a6553f9be2899a13