### PR TITLE
Add configuration section to EmailOutbox admin

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -245,7 +245,7 @@ class EmailOutboxAdmin(EntityModelAdmin):
     fieldsets = (
         ("Owner", {"fields": ("user", "group", "node")}),
         (
-            None,
+            "Configuration",
             {
                 "fields": (
                     "host",


### PR DESCRIPTION
## Summary
- label the Email Outbox connection fields under a "Configuration" fieldset in the Django admin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48afbf044832688cbd1235761af4b