### PR TITLE
Remove duplicate admin page titles

### DIFF
--- a/core/templates/admin/environment.html
+++ b/core/templates/admin/environment.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 <div id="content-main">
-  <h1>{{ title }}</h1>
   <h2>{% trans "Environment Variables" %}</h2>
   <input type="text" id="env-vars-filter" placeholder="{% trans 'Filter' %}" />
   <table id="env-vars-table">

--- a/core/templates/admin/sigil_builder.html
+++ b/core/templates/admin/sigil_builder.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 <div id="content-main">
-  <h1>{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" style="margin-bottom:1em;">
     {% csrf_token %}
     {% if show_sigils_input %}

--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -4,7 +4,6 @@
 {% block content %}
 <div id="content-main">
   <div>
-    <h1>{{ title }}</h1>
     <table class="system-info-table table table-striped">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- remove redundant `<h1>` elements from the Environment, System, and Sigil Builder admin templates so the base template supplies the page title once

## Testing
- `pytest tests/test_sigil_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d492845578832693144575d11b1efe