### PR TITLE
Move Release Manager admin entry to Workgroup section

### DIFF
--- a/teams/admin.py
+++ b/teams/admin.py
@@ -44,6 +44,12 @@ from .models import (
 )
 
 
+try:
+    admin.site.unregister(CoreReleaseManager)
+except NotRegistered:
+    pass
+
+
 @admin.register(InviteLead)
 class InviteLeadAdminProxy(InviteLeadAdmin):
     pass


### PR DESCRIPTION
## Summary
- unregister the core Release Manager admin so only the teams proxy is exposed, placing the model in the "6. Workgroup" admin group
- update the Release Manager admin tests to exercise the teams proxy and expect the new admin URL namespace

## Testing
- pytest tests/test_release_manager_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d4c06f5f208326b233f830c9beb1ef