### PR TITLE
Split environment admin into environ and config views

### DIFF
--- a/core/environment.py
+++ b/core/environment.py
@@ -9,20 +9,33 @@ from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
 
-def _environment_view(request):
-    env_vars = sorted(os.environ.items())
-    django_settings = sorted(
+def _get_django_settings():
+    return sorted(
         [(name, getattr(settings, name)) for name in dir(settings) if name.isupper()]
     )
+
+
+def _environment_view(request):
+    env_vars = sorted(os.environ.items())
     context = admin.site.each_context(request)
     context.update(
         {
-            "title": _("Environment"),
+            "title": _("Environ"),
             "env_vars": env_vars,
-            "django_settings": django_settings,
         }
     )
     return TemplateResponse(request, "admin/environment.html", context)
+
+
+def _config_view(request):
+    context = admin.site.each_context(request)
+    context.update(
+        {
+            "title": _("Config"),
+            "django_settings": _get_django_settings(),
+        }
+    )
+    return TemplateResponse(request, "admin/config.html", context)
 
 
 def patch_admin_environment_view() -> None:
@@ -36,6 +49,11 @@ def patch_admin_environment_view() -> None:
                 "environment/",
                 admin.site.admin_view(_environment_view),
                 name="environment",
+            ),
+            path(
+                "config/",
+                admin.site.admin_view(_config_view),
+                name="config",
             ),
         ]
         return custom + urls

--- a/core/fixtures/todos__validate_screen_admin_config.json
+++ b/core/fixtures/todos__validate_screen_admin_config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Config admin",
+      "url": "/admin/config/",
+      "request_details": "Confirm configuration settings display correctly after split."
+    }
+  }
+]

--- a/core/fixtures/todos__validate_screen_admin_environ.json
+++ b/core/fixtures/todos__validate_screen_admin_environ.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Environ admin",
+      "url": "/admin/environment/",
+      "request_details": "Verify environment variables view after rename to Environ."
+    }
+  }
+]

--- a/core/sigil_builder.py
+++ b/core/sigil_builder.py
@@ -40,12 +40,12 @@ def _sigil_builder_view(request):
         {
             "prefix": "ENV",
             "url": reverse("admin:environment"),
-            "label": _("Environment"),
+            "label": _("Environ"),
         },
         {
             "prefix": "CONF",
-            "url": reverse("admin:system"),
-            "label": _("Configuration"),
+            "url": reverse("admin:config"),
+            "label": _("Config"),
         },
         {
             "prefix": "SYS",

--- a/core/templates/admin/config.html
+++ b/core/templates/admin/config.html
@@ -3,17 +3,17 @@
 
 {% block content %}
 <div id="content-main">
-  <h2>{% trans "Environment Variables" %}</h2>
-  <input type="text" id="env-vars-filter" placeholder="{% trans 'Filter' %}" />
-  <table id="env-vars-table">
+  <h2>{% trans "Configuration" %}</h2>
+  <input type="text" id="config-filter" placeholder="{% trans 'Filter' %}" />
+  <table id="config-table">
     <thead>
       <tr><th>{% trans "Name" %}</th><th>{% trans "Value" %}</th></tr>
     </thead>
     <tbody>
-    {% for key, value in env_vars %}
+    {% for key, value in django_settings %}
       <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
     {% empty %}
-      <tr><td colspan="2">{% trans "No environment variables." %}</td></tr>
+      <tr><td colspan="2">{% trans "No settings." %}</td></tr>
     {% endfor %}
     </tbody>
   </table>
@@ -31,7 +31,7 @@
     });
   }
   document.addEventListener('DOMContentLoaded', function () {
-    setupFilter('env-vars-filter', 'env-vars-table');
+    setupFilter('config-filter', 'config-table');
   });
 </script>
 {% endblock %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -142,7 +142,8 @@
     <a class="button" href="{% url 'admin:seed_data' %}">{% translate 'Seed Data' %}</a>
     <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
     <a class="button" href="{% url 'admin:system' %}">{% translate 'System' %}</a>
-    <a class="button" href="{% url 'admin:environment' %}">{% translate 'Environment' %}</a>
+    <a class="button" href="{% url 'admin:environment' %}">{% translate 'Environ' %}</a>
+    <a class="button" href="{% url 'admin:config' %}">{% translate 'Config' %}</a>
     <a class="button" href="{% url 'admin:sigil_builder' %}">{% translate 'Sigil Builder' %}</a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- rename the admin dashboard Environment button to Environ and add a new Config shortcut
- split the Django settings table into a dedicated Config admin view and template
- point built-in sigil roots to the new views and add validation TODO fixtures for both screens

## Testing
- pytest *(fails: OperationalError: no such table: core_user when running RFID authentication tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bfa10b6c8326adf54f26d4c7b13d