### PR TITLE
Rename social profile verbose names to social identity

### DIFF
--- a/core/migrations/0048_rename_socialprofile_verbose.py
+++ b/core/migrations/0048_rename_socialprofile_verbose.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0047_socialprofile"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="socialprofile",
+            options={
+                "verbose_name": "Social Identity",
+                "verbose_name_plural": "Social Identities",
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("network", "handle"),
+                        name="socialprofile_network_handle",
+                    ),
+                    models.UniqueConstraint(
+                        fields=("network", "domain"),
+                        name="socialprofile_network_domain",
+                    ),
+                    models.CheckConstraint(
+                        condition=models.Q(
+                            models.Q(("user__isnull", False), ("group__isnull", True)),
+                            models.Q(("user__isnull", True), ("group__isnull", False)),
+                            _connector="OR",
+                        ),
+                        name="socialprofile_requires_owner",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -851,8 +851,8 @@ class SocialProfile(Profile):
         return f"{owner} – {label}" if owner else label
 
     class Meta:
-        verbose_name = _("Social Profile")
-        verbose_name_plural = _("Social Profiles")
+        verbose_name = _("Social Identity")
+        verbose_name_plural = _("Social Identities")
         constraints = [
             models.UniqueConstraint(
                 fields=["network", "handle"], name="socialprofile_network_handle"


### PR DESCRIPTION
## Summary
- rename the SocialProfile model's verbose names to Social Identity/Identities
- add a follow-up migration that updates the model options accordingly

## Testing
- python manage.py test core.tests.test_social_profile


------
https://chatgpt.com/codex/tasks/task_e_68d4c0bb93748326bd6f7b022d2c8fe8