### PR TITLE
Add release TODO during pre-release actions

### DIFF
--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from pathlib import Path
 import shutil
 import subprocess
@@ -314,6 +315,10 @@ class ReleaseProgressViewTests(TestCase):
         def fake_run(cmd, capture_output=False, text=False, check=False, **kwargs):
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
+        tmp_dir = Path("tmp_todos_pre_release")
+        tmp_dir.mkdir(exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
         session = self.client.session
         session_key = f"release_publish_{self.release.pk}"
         session[session_key] = {
@@ -323,15 +328,34 @@ class ReleaseProgressViewTests(TestCase):
         }
         session.save()
 
-        with mock.patch("core.views.subprocess.run", side_effect=fake_run):
-            url = reverse("release-progress", args=[self.release.pk, "publish"])
-            response = self.client.get(f"{url}?step=4")
+        with mock.patch("core.views.TODO_FIXTURE_DIR", tmp_dir):
+            with mock.patch("core.views.subprocess.run", side_effect=fake_run):
+                url = reverse("release-progress", args=[self.release.pk, "publish"])
+                response = self.client.get(f"{url}?step=4")
 
+        expected_request = "Create release pkg 1.0.1"
+        todo = Todo.objects.get(request=expected_request)
+        self.assertTrue(todo.is_seed_data)
+        self.assertEqual(todo.url, reverse("admin:core_packagerelease_changelist"))
+        self.assertIsNone(todo.done_on)
+        fixture_path = tmp_dir / "todos__create_release_pkg_1_0_1.json"
+        self.assertTrue(fixture_path.exists())
+        data = json.loads(fixture_path.read_text(encoding="utf-8"))
+        self.assertEqual(data[0]["fields"]["request"], expected_request)
+        self.assertEqual(
+            data[0]["fields"]["url"], reverse("admin:core_packagerelease_changelist")
+        )
+
+        log_content = response.context["log_content"]
+        self.assertIn(f"Added TODO: {expected_request}", log_content)
+        self.assertIn(
+            "Staged TODO fixture tmp_todos_pre_release/todos__create_release_pkg_1_0_1.json",
+            log_content,
+        )
         self.assertEqual(
             Path("VERSION").read_text(encoding="utf-8").strip(),
             self.release.version,
         )
-        log_content = response.context["log_content"]
         self.assertIn("Execute pre-release actions", log_content)
         self.assertIn(
             f"Updated VERSION file to {self.release.version}", log_content


### PR DESCRIPTION
## Summary
- add helper utilities to compute the next patch version and dump release TODO fixtures during pre-release actions
- ensure pre-release actions create and stage a "Create release" TODO pointing to the package release admin
- extend release progress tests to validate TODO creation, fixture writing, and log output

## Testing
- pytest tests/test_release_progress.py::ReleaseProgressViewTests::test_pre_release_commit

------
https://chatgpt.com/codex/tasks/task_e_68d4c6af6dbc8326a608f5aff0e89682