### PR TITLE
Add default application descriptions to admin list

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -153,7 +153,7 @@ class ApplicationModuleInline(admin.TabularInline):
 @admin.register(Application)
 class ApplicationAdmin(EntityModelAdmin):
     form = ApplicationForm
-    list_display = ("name", "app_verbose_name", "installed")
+    list_display = ("name", "app_verbose_name", "description", "installed")
     readonly_fields = ("installed",)
     inlines = [ApplicationModuleInline]
 

--- a/pages/defaults.py
+++ b/pages/defaults.py
@@ -1,0 +1,14 @@
+"""Default configuration for the pages application."""
+from __future__ import annotations
+
+from typing import Dict
+
+DEFAULT_APPLICATION_DESCRIPTIONS: Dict[str, str] = {
+    "awg": "Power, Energy and Cost calculations.",
+    "core": "Support for Business Processes and monetization.",
+    "ocpp": "Compatibility with Standards and Good Practices.",
+    "nodes": "System and Node-level operations,",
+    "pages": "Scheduling, Periodicity and Event Signaling,",
+    "teams": "Identity, Entitlements and Access Controls.",
+    "man": "User QA, Continuity Design and Chaos Testing.",
+}

--- a/pages/fixtures/default__application_awg.json
+++ b/pages/fixtures/default__application_awg.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "awg",
+      "description": "Power, Energy and Cost calculations."
     }
   }
 ]

--- a/pages/fixtures/default__application_core.json
+++ b/pages/fixtures/default__application_core.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "core",
+      "description": "Support for Business Processes and monetization."
     }
   }
 ]

--- a/pages/fixtures/default__application_man.json
+++ b/pages/fixtures/default__application_man.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "man",
+      "description": "User QA, Continuity Design and Chaos Testing."
     }
   }
 ]

--- a/pages/fixtures/default__application_nodes.json
+++ b/pages/fixtures/default__application_nodes.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "nodes",
+      "description": "System and Node-level operations,"
     }
   }
 ]

--- a/pages/fixtures/default__application_pages.json
+++ b/pages/fixtures/default__application_pages.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "pages",
+      "description": "Scheduling, Periodicity and Event Signaling,"
     }
   }
 ]

--- a/pages/fixtures/default__application_teams.json
+++ b/pages/fixtures/default__application_teams.json
@@ -4,8 +4,8 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "name": "ocpp",
-      "description": "Compatibility with Standards and Good Practices."
+      "name": "teams",
+      "description": "Identity, Entitlements and Access Controls."
     }
   }
 ]

--- a/pages/fixtures/localhost__application_ocpp.json
+++ b/pages/fixtures/localhost__application_ocpp.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "ocpp",
-      "description": ""
+      "description": "Compatibility with Standards and Good Practices."
     }
   }
 ]

--- a/pages/fixtures/satellite_box__application_ocpp.json
+++ b/pages/fixtures/satellite_box__application_ocpp.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "ocpp",
-      "description": ""
+      "description": "Compatibility with Standards and Good Practices."
     }
   }
 ]

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1163,6 +1163,13 @@ class ApplicationAdminDisplayTests(TestCase):
         config = django_apps.get_app_config("ocpp")
         self.assertContains(resp, config.verbose_name)
 
+    def test_changelist_shows_description(self):
+        Application.objects.create(
+            name="awg", description="Power, Energy and Cost calculations."
+        )
+        resp = self.client.get(reverse("admin:pages_application_changelist"))
+        self.assertContains(resp, "Power, Energy and Cost calculations.")
+
 
 class LandingCreationTests(TestCase):
     def setUp(self):

--- a/tests/test_register_site_apps_command.py
+++ b/tests/test_register_site_apps_command.py
@@ -16,6 +16,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from pages.models import Application, Module
+from pages.defaults import DEFAULT_APPLICATION_DESCRIPTIONS
 from nodes.models import Node, NodeRole
 
 
@@ -45,6 +46,11 @@ class RegisterSiteAppsCommandTests(TestCase):
                 continue
             self.assertTrue(Application.objects.filter(name=config.label).exists())
             app = Application.objects.get(name=config.label)
+            expected_description = DEFAULT_APPLICATION_DESCRIPTIONS.get(
+                config.label, ""
+            )
+            if expected_description:
+                self.assertEqual(app.description, expected_description)
             self.assertTrue(
                 Module.objects.filter(node_role=role, application=app).exists()
             )


### PR DESCRIPTION
## Summary
- show application descriptions in the admin changelist
- seed the default app descriptions and ensure the registration command applies them
- cover the new behaviour with targeted admin and management command tests

## Testing
- pytest pages/tests.py::ApplicationAdminDisplayTests tests/test_register_site_apps_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d4d1af94f88326aa9ad7b2951bbff0