### PR TITLE
Add CSMS dashboard link to CP simulator notice

### DIFF
--- a/ocpp/templates/ocpp/cp_simulator.html
+++ b/ocpp/templates/ocpp/cp_simulator.html
@@ -9,7 +9,14 @@
 
 {% block content %}
 <h1>OCPP Charge Point Simulator</h1>
-{% if message %}<div class="sim-msg">{{ message }}</div>{% endif %}
+{% if message %}
+<div class="sim-msg">
+  <div>{{ message }}</div>
+  {% if dashboard_link %}
+  <div>If CSMS Dashboard is running on the target, view it here: <a href="{{ dashboard_link }}">{{ dashboard_link }}</a></div>
+  {% endif %}
+</div>
+{% endif %}
 <ul class="nav nav-tabs mb-3" id="cpSimTabs" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link active" id="cp1-tab" data-bs-toggle="tab" data-bs-target="#cp1" type="button" role="tab" aria-controls="cp1" aria-selected="true">Primary CP</button>

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -464,6 +464,7 @@ def cp_simulator(request):
     default_vins = ["WP0ZZZ00000000000", "WAUZZZ00000000000"]
 
     message = ""
+    dashboard_link: str | None = None
     if request.method == "POST":
         cp_idx = int(request.POST.get("cp") or 1)
         action = request.POST.get("action")
@@ -500,6 +501,12 @@ def cp_simulator(request):
                 started, status, log_file = _start_simulator(sim_params, cp=cp_idx)
                 if started:
                     message = f"CP{cp_idx} started: {status}. Logs: {log_file}"
+                    try:
+                        dashboard_link = reverse(
+                            "charger-status", args=[sim_params["cp_path"]]
+                        )
+                    except NoReverseMatch:  # pragma: no cover - defensive
+                        dashboard_link = None
                 else:
                     message = f"CP{cp_idx} {status}. Logs: {log_file}"
             except Exception as exc:  # pragma: no cover - unexpected
@@ -526,6 +533,7 @@ def cp_simulator(request):
 
     context = {
         "message": message,
+        "dashboard_link": dashboard_link,
         "states": state_list,
         "default_host": default_host,
         "default_ws_port": default_ws_port,


### PR DESCRIPTION
## Summary
- expose a dashboard link when the simulator successfully starts
- render a follow-up notice beneath the log message that points to the CP status page

## Testing
- pytest ocpp/tests.py -k cp_simulator

------
https://chatgpt.com/codex/tasks/task_e_68d4d57294b48326b0253aab5077328a