### PR TITLE
Allow subnet zero in network setup

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -49,11 +49,11 @@ ETH0_SUBNET=129
 validate_subnet() {
     local value="$1"
     if [[ ! "$value" =~ ^[0-9]+$ ]]; then
-        echo "Error: --subnet requires an integer between 1 and 254." >&2
+        echo "Error: --subnet requires an integer between 0 and 254." >&2
         exit 1
     fi
-    if (( value < 1 || value > 254 )); then
-        echo "Error: --subnet requires an integer between 1 and 254." >&2
+    if (( value < 0 || value > 254 )); then
+        echo "Error: --subnet requires an integer between 0 and 254." >&2
         exit 1
     fi
 }


### PR DESCRIPTION
## Summary
- expand the subnet validator to accept 0 so 192.168.0.0/24 can be configured
- update the validation error message to reflect the new valid range

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d58a8fe7188326bff1d7b452f6f895