### PR TITLE
Adjust eth0 default prefix to /16 for EVCS reachability

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -30,7 +30,7 @@ Usage: $0 [--password] [--ap NAME] [--no-firewall] [--unsafe] [--public] [--inte
   --no-watchdog   Skip installing the WiFi watchdog service.
   --vnc           Require validating that a VNC service is enabled.
   --no-vnc        Skip validating that a VNC service is enabled (default).
-  --subnet N[/P]  Configure eth0 on the 192.168.N.0/24 subnet (default: 129/24).
+  --subnet N[/P]  Configure eth0 on the 192.168.N.0/P subnet (default: 129/16).
                   Accepts prefix lengths of 16 or 24.
 USAGE
 }
@@ -49,7 +49,7 @@ AP_SPECIFIED=false
 AP_NAME_LOWER=""
 SKIP_AP=false
 ETH0_SUBNET=129
-ETH0_PREFIX=24
+ETH0_PREFIX=16
 validate_subnet_value() {
     local value="$1"
     if [[ ! "$value" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- widen the default eth0 subnet configured by `network-setup.sh` to /16 so the controller can reach devices on both 192.168.0.x and 192.168.129.x
- update the usage text to reflect the new default prefix

## Testing
- `pytest tests/test_csrf_origin_subnet.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5b3819a608326aeef4835ef8411b3