### PR TITLE
Show related models on admin changelist and change form

### DIFF
--- a/pages/templates/admin/change_form.html
+++ b/pages/templates/admin/change_form.html
@@ -16,50 +16,8 @@
     .inline-heading {
       scroll-margin-top: 80px;
     }
-
-    .related-models {
-      margin-top: 2rem;
-    }
-
-    .related-models__title {
-      font-size: 1.5rem;
-      font-weight: 700;
-      margin: 0 0 0.75rem;
-    }
-
-    .related-models__list {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-
-    .related-models__item {
-      margin: 0;
-      list-style: none;
-    }
-
-    .related-models__link {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.35rem 0.75rem;
-      border-radius: 9999px;
-      border: 1px solid var(--border-color);
-      text-decoration: none;
-      font-weight: 600;
-      color: var(--body-fg);
-      transition: color 0.2s ease, border-color 0.2s ease;
-    }
-
-    .related-models__link:hover,
-    .related-models__link:focus {
-      color: var(--link-fg);
-      border-color: var(--link-fg);
-      outline: none;
-    }
   </style>
+  {% include "admin/includes/related_models_styles.html" %}
 {% endblock %}
 
 {% block coltype %}colM{% endblock %}
@@ -118,18 +76,7 @@
 {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
 
 {% related_admin_models opts as related_models %}
-{% if related_models %}
-  <section class="related-models" aria-labelledby="related-models-title">
-    <h2 id="related-models-title" class="related-models__title">{% translate "Related Models" %}</h2>
-    <ul class="related-models__list">
-      {% for related in related_models %}
-        <li class="related-models__item">
-          <a class="related-models__link" href="{{ related.url }}">{{ related.label }}</a>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
-{% endif %}
+{% include "admin/includes/related_models_section.html" %}
 
 {% block admin_change_form_document_ready %}
     <script id="django-admin-form-add-constants"

--- a/pages/templates/admin/change_list.html
+++ b/pages/templates/admin/change_list.html
@@ -1,0 +1,96 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_list admin_extras %}
+
+{% block title %}{% if cl.formset and cl.formset.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}">
+  {% if cl.formset %}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+  {% endif %}
+  {% if cl.formset or action_form %}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+  {% endif %}
+  {{ media.css }}
+  {% if not actions_on_top and not actions_on_bottom %}
+    <style>
+      #changelist table thead th:first-child {width: inherit}
+    </style>
+  {% endif %}
+  {% include "admin/includes/related_models_styles.html" %}
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+{{ media.js }}
+<script src="{% static 'admin/js/filters.js' %}" defer></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+&rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block coltype %}{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    {% block object-tools %}
+        <ul class="object-tools">
+          {% block object-tools-items %}
+            {% change_list_object_tools %}
+          {% endblock %}
+        </ul>
+    {% endblock %}
+    {% if cl.formset and cl.formset.errors %}
+        <p class="errornote">
+        {% blocktranslate count counter=cl.formset.total_error_count %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+        </p>
+        {{ cl.formset.non_form_errors }}
+    {% endif %}
+    <div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
+      <div class="changelist-form-container">
+        {% block search %}{% search_form cl %}{% endblock %}
+        {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
+
+        <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>{% csrf_token %}
+        {% if cl.formset %}
+          <div>{{ cl.formset.management_form }}</div>
+        {% endif %}
+
+        {% block result_list %}
+          {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+          {% result_list cl %}
+          {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+        {% endblock %}
+        {% block pagination %}{% pagination cl %}{% endblock %}
+        </form>
+      </div>
+      {% block filters %}
+        {% if cl.has_filters %}
+          <nav id="changelist-filter" aria-labelledby="changelist-filter-header">
+            <h2 id="changelist-filter-header">{% translate 'Filter' %}</h2>
+            {% if cl.is_facets_optional or cl.has_active_filters %}<div id="changelist-filter-extra-actions">
+              {% if cl.is_facets_optional %}<h3>
+                {% if cl.add_facets %}<a href="{{ cl.remove_facet_link }}" class="hidelink">{% translate "Hide counts" %}</a>{% else %}<a href="{{ cl.add_facet_link }}" class="viewlink">{% translate "Show counts" %}</a>{% endif %}
+              </h3>{% endif %}
+              {% if cl.has_active_filters %}<h3>
+                <a href="{{ cl.clear_all_filters_qs }}">&#10006; {% translate "Clear all filters" %}</a>
+              </h3>{% endif %}
+            </div>{% endif %}
+            {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
+          </nav>
+        {% endif %}
+      {% endblock %}
+    </div>
+    {% related_admin_models cl.opts as related_models %}
+    {% include "admin/includes/related_models_section.html" %}
+  </div>
+{% endblock %}

--- a/pages/templates/admin/includes/related_models_section.html
+++ b/pages/templates/admin/includes/related_models_section.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% if related_models %}
+  <section class="related-models" aria-labelledby="related-models-title">
+    <h2 id="related-models-title" class="related-models__title">{% translate "Related Models" %}</h2>
+    <ul class="related-models__list">
+      {% for related in related_models %}
+        <li class="related-models__item">
+          <a class="related-models__link" href="{{ related.url }}">{{ related.label }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/pages/templates/admin/includes/related_models_styles.html
+++ b/pages/templates/admin/includes/related_models_styles.html
@@ -1,0 +1,44 @@
+<style>
+  .related-models {
+    margin-top: 2rem;
+  }
+
+  .related-models__title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 0.75rem;
+  }
+
+  .related-models__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .related-models__item {
+    margin: 0;
+    list-style: none;
+  }
+
+  .related-models__link {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    border: 1px solid var(--border-color);
+    text-decoration: none;
+    font-weight: 600;
+    color: var(--body-fg);
+    transition: color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .related-models__link:hover,
+  .related-models__link:focus {
+    color: var(--link-fg);
+    border-color: var(--link-fg);
+    outline: none;
+  }
+</style>


### PR DESCRIPTION
## Summary
- reuse a shared template fragment for rendering the Related Models footer
- add the related models footer and styles to the admin changelist template

## Testing
- pytest tests/test_admin_index_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68d5dd14b1cc83268f960216af398433