### PR TITLE
Avoid overwriting custom arthexis favicon in migration

### DIFF
--- a/pages/migrations/0008_arthexis_favicon.py
+++ b/pages/migrations/0008_arthexis_favicon.py
@@ -23,7 +23,11 @@ def apply_arthexis_favicon(apps, schema_editor):
     if not site:
         return
 
-    badge, _ = SiteBadge.all_objects.get_or_create(site=site)
+    badge, created = SiteBadge.all_objects.get_or_create(site=site)
+
+    if not created and (badge.is_user_data or badge.favicon):
+        return
+
     badge.badge_color = badge.badge_color or "#28a745"
     badge.is_seed_data = True
     badge.is_user_data = False


### PR DESCRIPTION
## Summary
- stop the arthexis favicon migration when a badge already contains user-provided data

## Testing
- python manage.py test pages.tests.FaviconTests

------
https://chatgpt.com/codex/tasks/task_e_68d5e2cdbf5c8326a3503cc07ff1070b