### PR TITLE
Add email collector naming and preview features (fix default name)

### DIFF
--- a/core/migrations/0050_emailcollector_name_and_more.py
+++ b/core/migrations/0050_emailcollector_name_and_more.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
             name="name",
             field=models.CharField(
                 blank=True,
+                default="",
                 help_text="Optional label to identify this collector.",
                 max_length=255,
             ),


### PR DESCRIPTION
## Summary
- set the new EmailCollector.name field to default to an empty string so existing rows migrate cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e569f63c832692403afcbf85302d