### PR TITLE
Fix SiteBadge manager usage in favicon migration

### DIFF
--- a/pages/migrations/0008_arthexis_favicon.py
+++ b/pages/migrations/0008_arthexis_favicon.py
@@ -25,13 +25,13 @@ def _manager(model, name):
 def apply_arthexis_favicon(apps, schema_editor):
     Site = apps.get_model("sites", "Site")
     SiteBadge = apps.get_model("pages", "SiteBadge")
-    badge_manager = _manager(SiteBadge, "all_objects")
-
     site = Site.objects.filter(domain="arthexis.com").first()
     if not site:
         return
-      
-    badge, created = SiteBadge.all_objects.get_or_create(site=site)
+
+    badge_manager = _manager(SiteBadge, "all_objects")
+
+    badge, created = badge_manager.get_or_create(site=site)
 
     if not created and (badge.is_user_data or badge.favicon):
         return


### PR DESCRIPTION
## Summary
- ensure the RunPython migration for the Arthexis favicon uses the available manager when creating SiteBadge records

## Testing
- poetry run python manage.py makemigrations --check *(fails: ModuleNotFoundError: No module named 'celery')*


------
https://chatgpt.com/codex/tasks/task_e_68d5e7a8a8648326baaa3cd9b0c2d02f