### PR TITLE
Ensure pre-release regenerates changelog

### DIFF
--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -342,6 +342,7 @@ class ReleaseProgressViewTests(TestCase):
                 url = reverse("release-progress", args=[self.release.pk, "publish"])
                 response = self.client.get(f"{url}?step=4")
 
+        self.assertIn(["scripts/generate-changelog.sh"], commands)
         expected_request = "Create release pkg 1.0.1"
         todo = Todo.objects.get(request=expected_request)
         self.assertTrue(todo.is_seed_data)
@@ -356,6 +357,11 @@ class ReleaseProgressViewTests(TestCase):
         )
 
         log_content = response.context["log_content"]
+        self.assertIn(
+            "Regenerated CHANGELOG.rst using scripts/generate-changelog.sh",
+            log_content,
+        )
+        self.assertIn("Staged CHANGELOG.rst for commit", log_content)
         self.assertIn(f"Added TODO: {expected_request}", log_content)
         self.assertIn(
             "Staged TODO fixture tmp_todos_pre_release/todos__create_release_pkg_1_0_1.json",
@@ -374,7 +380,11 @@ class ReleaseProgressViewTests(TestCase):
             f"Updated VERSION file to {self.release.version}", log_content
         )
         self.assertIn("Staged VERSION for commit", log_content)
-        self.assertIn("No changes detected for VERSION; skipping commit", log_content)
+        self.assertIn(
+            "No changes detected for VERSION or CHANGELOG; skipping commit",
+            log_content,
+        )
+        self.assertIn("Unstaged CHANGELOG.rst", log_content)
         self.assertIn("Unstaged VERSION file", log_content)
         self.assertIn("Pre-release actions complete", log_content)
         self.assertIn(


### PR DESCRIPTION
## Summary
- regenerate CHANGELOG.rst during the publish pre-release step and stage the result
- commit gating now considers both CHANGELOG.rst and VERSION updates
- expand the release progress test to assert the changelog script runs and logs are recorded

## Testing
- pytest tests/test_release_progress.py::ReleaseProgressViewTests::test_pre_release_commit *(fails: django.template.exceptions.TemplateSyntaxError: 'sites' is not a registered tag library)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e3d4640c8326a6793df310ff7bbc