### PR TITLE
Handle admin crash when node table missing

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from django.db import models
+from django.db.utils import DatabaseError
 from django.db.models.signals import post_delete
 from django.dispatch import Signal, receiver
 from core.entity import Entity
@@ -215,7 +216,11 @@ class Node(Entity):
     def get_local(cls):
         """Return the node representing the current host if it exists."""
         mac = cls.get_current_mac()
-        return cls.objects.filter(mac_address=mac).first()
+        try:
+            return cls.objects.filter(mac_address=mac).first()
+        except DatabaseError:
+            logger.debug("nodes.Node.get_local skipped: database unavailable", exc_info=True)
+            return None
 
     @classmethod
     def register_current(cls):


### PR DESCRIPTION
## Summary
- guard `Node.get_local` against database errors so the admin works before migrations run
- log the skipped lookup and add a regression test covering the database-unavailable scenario

## Testing
- pytest nodes/tests.py::NodeGetLocalTests::test_get_local_handles_database_errors

------
https://chatgpt.com/codex/tasks/task_e_68d5eb0786488326804a3198506b6421