### PR TITLE
Fix OCPP coverage badge links

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,6 +1,6 @@
 # Arthexis-Konstellation
 
-[![Testabdeckung](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![OCPP 1.6-Abdeckung](./ocpp_coverage.svg)](./ocpp_coverage.svg)
+[![Testabdeckung](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![OCPP 1.6-Abdeckung](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)
 
 ## Zweck
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,6 +1,6 @@
 # Constelación Arthexis
 
-[![Cobertura](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![Cobertura OCPP 1.6](./ocpp_coverage.svg)](./ocpp_coverage.svg)
+[![Cobertura](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![Cobertura OCPP 1.6](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)
 
 ## Propósito
 

--- a/README.it.md
+++ b/README.it.md
@@ -1,6 +1,6 @@
 # Costellazione Arthexis
 
-[![Copertura](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![Copertura OCPP 1.6](./ocpp_coverage.svg)](./ocpp_coverage.svg)
+[![Copertura](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![Copertura OCPP 1.6](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)
 
 ## Scopo
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arthexis Constellation
 
-[![Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![OCPP 1.6 Coverage](./ocpp_coverage.svg)](./ocpp_coverage.svg)
+[![Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/coverage.svg)](https://github.com/arthexis/arthexis/actions/workflows/coverage.yml) [![OCPP 1.6 Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)](https://raw.githubusercontent.com/arthexis/arthexis/main/ocpp_coverage.svg)
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- point the OCPP coverage badge in the main README to the hosted SVG on GitHub so it renders in the UI
- update the localized README variants to use the same hosted badge URL for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ead205648326b21140c1eb02d939