### PR TITLE
Remove VS Code live server configuration options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,37 +32,6 @@
             ],
             "subProcess": true,
             "preLaunchTask": "Dev: collectstatic"
-        },
-        {
-            "name": "Run Live Server",
-            "type": "python",
-            "request": "launch",
-            "python": "${workspaceFolder}/.venv/bin/python",
-            "windows": {
-                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-            },
-            "program": "${workspaceFolder}/vscode_manage.py",
-            "args": [
-                "runserver"
-            ],
-            "django": true,
-            "noDebug": true,
-            "preLaunchTask": "Dev: prepare live server"
-        },
-        {
-            "name": "Debug Live Server",
-            "type": "python",
-            "request": "launch",
-            "python": "${workspaceFolder}/.venv/bin/python",
-            "windows": {
-                "python": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-            },
-            "program": "${workspaceFolder}/vscode_manage.py",
-            "args": [
-                "runserver"
-            ],
-            "subProcess": true,
-            "preLaunchTask": "Dev: prepare live server"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,19 +61,6 @@
             "detail": "Stop Django development server processes"
         },
         {
-            "label": "Dev: prepare live server",
-            "type": "shell",
-            "command": "${workspaceFolder}/scripts/live-server-update.sh",
-            "options": {
-                "cwd": "${workspaceFolder}"
-            },
-            "windows": {
-                "command": "${workspaceFolder}\\scripts\\live-server-update.bat"
-            },
-            "problemMatcher": [],
-            "detail": "Stop the development server, sync with the upstream remote, and refresh the environment before launch"
-        },
-        {
             "label": "Dev: manage",
             "type": "shell",
             "command": "${workspaceFolder}/manage.sh",


### PR DESCRIPTION
## Summary
- remove the Live Server launch configurations from the VS Code workspace
- drop the associated Dev: prepare live server task now that it is unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f59b7c308326b11b978669b62a2d