### PR TITLE
Add notice for Django autoreloader preparation

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -21,6 +21,8 @@ def main() -> None:
     if rev_short:
         msg += f" r{rev_short}"
     print(msg)
+    if os.environ.get("RUN_MAIN") != "true":
+        print("Preparing Django auto-reloader...")
     try:
         from django.core.management import execute_from_command_line
         from daphne.management.commands.runserver import (


### PR DESCRIPTION
## Summary
- print a notice when the initial manage.py process is preparing the Django auto-reloader

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f635e42883268ef24b6b17f44e88