### PR TITLE
Fix admin login template and enable default debug for runserver

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -64,5 +64,6 @@ def site_and_node(request: HttpRequest):
         "badge_admin_site_name": site_name or (site.domain if site else ""),
         "badge_site_color": site_color,
         "badge_node_color": node_color,
+        "current_site_domain": site.domain if site else host,
         "TIME_ZONE": settings.TIME_ZONE,
     }

--- a/manage.py
+++ b/manage.py
@@ -12,6 +12,8 @@ def main() -> None:
     """Run administrative tasks."""
     loadenv()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    if len(sys.argv) > 1 and sys.argv[1] == "runserver":
+        os.environ.setdefault("DEBUG", "1")
 
     ver_path = Path(__file__).resolve().parent / "VERSION"
     version = ver_path.read_text().strip() if ver_path.exists() else ""

--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -1,10 +1,9 @@
 {% extends "admin/base.html" %}
-{% load i18n sites %}
+{% load i18n %}
 {% block title %}{% if title %}{{ title }} | {% endif %}{{ site_title|default:_('Django site admin') }}{% endblock %}
 {% block extrahead %}
 {{ block.super }}
-{% get_current_site as current_site %}
-{% if current_site and current_site.domain == "arthexis.com" %}
+{% if current_site_domain == "arthexis.com" %}
 <link rel="icon" href="data:image/png;base64,{% include 'admin/favicon_arthexis.txt' %}">
 {% else %}
 <link rel="icon" href="data:image/png;base64,{% include 'admin/favicon.txt' %}">

--- a/tests/test_manage_debug.py
+++ b/tests/test_manage_debug.py
@@ -1,0 +1,31 @@
+import contextlib
+import importlib
+import os
+import sys
+
+import manage
+
+
+def test_manage_runserver_enables_debug(monkeypatch):
+    """`runserver` should enable Django's debug mode by default."""
+
+    monkeypatch.delenv("DEBUG", raising=False)
+    monkeypatch.setattr(
+        "django.core.management.execute_from_command_line", lambda argv: None
+    )
+    monkeypatch.setattr(sys, "argv", ["manage.py", "runserver"])
+
+    try:
+        manage.main()
+    finally:
+        importlib.reload(
+            importlib.import_module("django.core.management.commands.runserver")
+        )
+        with contextlib.suppress(ModuleNotFoundError):
+            importlib.reload(
+                importlib.import_module(
+                    "django.contrib.staticfiles.management.commands.runserver"
+                )
+            )
+
+    assert os.environ["DEBUG"] == "1"


### PR DESCRIPTION
## Summary
- expose the current site domain via the shared context processor so templates do not rely on the deprecated `sites` tag library
- update the admin base template to choose the favicon without loading the missing `sites` library, restoring the login page
- default DEBUG to on for `runserver` sessions and cover the behavior with a regression test

## Testing
- pytest tests/test_manage_debug.py tests/test_vscode_manage.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f5e4a9408326843d7b5ef1e7bc6e