### PR TITLE
Filter single-word commits from changelog generation

### DIFF
--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -26,7 +26,8 @@ fi
   echo "Unreleased"
   echo "----------"
   echo
-  git log $range --no-merges --pretty=format:"- %h %s"
+  # Filter out commit subjects that are a single word to keep the changelog informative.
+  git log $range --no-merges --pretty=format:"- %h %s" | awk 'NF > 3'
   if [ -n "$previous" ]; then
     echo
     echo "$previous"


### PR DESCRIPTION
## Summary
- skip single-word commit subjects when generating the changelog so that entries stay informative

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60096c99083269e3b21676bd6c755