### PR TITLE
Rename SYS next version check sigil

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -119,7 +119,7 @@ def _auto_upgrade_next_check() -> str:
 
 
 def _resolve_auto_upgrade_namespace(key: str) -> str | None:
-    """Resolve sigils within the ``AUTO-UPGRADE`` namespace."""
+    """Resolve sigils within the legacy ``AUTO-UPGRADE`` namespace."""
 
     normalized = key.replace("-", "_").upper()
     if normalized == "NEXT_CHECK":
@@ -137,6 +137,9 @@ def resolve_system_namespace_value(key: str) -> str | None:
 
     if not key:
         return None
+    normalized_key = key.replace("-", "_").upper()
+    if normalized_key == "NEXT_VER_CHECK":
+        return _auto_upgrade_next_check()
     namespace, _, remainder = key.partition(".")
     if not remainder:
         return None
@@ -218,8 +221,8 @@ def _build_system_fields(info: dict[str, object]) -> list[SystemField]:
     )
 
     add_field(
-        _("Next auto-upgrade check"),
-        "AUTO-UPGRADE.NEXT-CHECK",
+        _("Next version check"),
+        "NEXT-VER-CHECK",
         info.get("auto_upgrade_next_check", ""),
     )
 

--- a/tests/test_sigil_resolution.py
+++ b/tests/test_sigil_resolution.py
@@ -161,16 +161,21 @@ class SigilResolutionTests(TestCase):
                 return_value="soon",
             ):
                 resolved = sigil_resolver._resolve_token(
-                    "SYS.AUTO-UPGRADE.NEXT-CHECK"
+                    "SYS.NEXT-VER-CHECK"
                 )
         self.assertEqual(resolved, "soon")
 
     def test_system_namespace_value_normalizes_hyphen(self):
         with mock.patch("core.system._auto_upgrade_next_check", return_value="later"):
+            result = system.resolve_system_namespace_value("next-ver-check")
+        self.assertEqual(result, "later")
+
+    def test_system_namespace_value_supports_legacy_auto_upgrade(self):
+        with mock.patch("core.system._auto_upgrade_next_check", return_value="legacy"):
             result = system.resolve_system_namespace_value(
                 "auto-upgrade.next-check"
             )
-        self.assertEqual(result, "later")
+        self.assertEqual(result, "legacy")
 
     def test_entity_sigil_hyphen_field(self):
         ct = ContentType.objects.get_for_model(OdooProfile)


### PR DESCRIPTION
## Summary
- rename the system sigil for the next version check to SYS.NEXT-VER-CHECK while keeping the legacy AUTO-UPGRADE namespace
- update the system sigil field label and tests to exercise the new and legacy spellings

## Testing
- pytest tests/test_sigil_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ae7cdab48326af180096c4b24314