### PR TITLE
Ensure node role updates from lock file

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -252,23 +252,27 @@ class Node(Entity):
             "mac_address": mac,
             "current_relation": cls.Relation.SELF,
         }
+        role_lock = Path(settings.BASE_DIR) / "locks" / "role.lck"
+        role_name = role_lock.read_text().strip() if role_lock.exists() else "Terminal"
+        desired_role = NodeRole.objects.filter(name=role_name).first()
+
         if node:
+            update_fields = []
             for field, value in defaults.items():
-                setattr(node, field, value)
-            update_fields = list(defaults.keys())
-            node.save(update_fields=update_fields)
+                if getattr(node, field) != value:
+                    setattr(node, field, value)
+                    update_fields.append(field)
+            if desired_role and node.role_id != desired_role.id:
+                node.role = desired_role
+                update_fields.append("role")
+            if update_fields:
+                node.save(update_fields=update_fields)
             created = False
         else:
             node = cls.objects.create(**defaults)
             created = True
-            # assign role from installation lock file
-            role_lock = Path(settings.BASE_DIR) / "locks" / "role.lck"
-            role_name = (
-                role_lock.read_text().strip() if role_lock.exists() else "Terminal"
-            )
-            role = NodeRole.objects.filter(name=role_name).first()
-            if role:
-                node.role = role
+            if desired_role:
+                node.role = desired_role
                 node.save(update_fields=["role"])
         if created and node.role is None:
             terminal = NodeRole.objects.filter(name="Terminal").first()

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -101,6 +101,54 @@ class NodeGetLocalTests(TestCase):
         self.assertTrue(created)
         self.assertEqual(node.current_relation, Node.Relation.SELF)
 
+    def test_register_current_updates_role_from_lock_file(self):
+        NodeRole.objects.get_or_create(name="Terminal")
+        NodeRole.objects.get_or_create(name="Constellation")
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            lock_dir = base / "locks"
+            lock_dir.mkdir(parents=True, exist_ok=True)
+            role_file = lock_dir / "role.lck"
+            role_file.write_text("Terminal")
+            with override_settings(BASE_DIR=base):
+                with (
+                    patch(
+                        "nodes.models.Node.get_current_mac",
+                        return_value="00:aa:bb:cc:dd:ee",
+                    ),
+                    patch("nodes.models.socket.gethostname", return_value="role-host"),
+                    patch(
+                        "nodes.models.socket.gethostbyname", return_value="127.0.0.1"
+                    ),
+                    patch("nodes.models.revision.get_revision", return_value="rev"),
+                    patch.object(Node, "ensure_keys"),
+                    patch.object(Node, "notify_peers_of_update"),
+                ):
+                    node, created = Node.register_current()
+            self.assertTrue(created)
+            self.assertEqual(node.role.name, "Terminal")
+
+            role_file.write_text("Constellation")
+            with override_settings(BASE_DIR=base):
+                with (
+                    patch(
+                        "nodes.models.Node.get_current_mac",
+                        return_value="00:aa:bb:cc:dd:ee",
+                    ),
+                    patch("nodes.models.socket.gethostname", return_value="role-host"),
+                    patch(
+                        "nodes.models.socket.gethostbyname", return_value="127.0.0.1"
+                    ),
+                    patch("nodes.models.revision.get_revision", return_value="rev"),
+                    patch.object(Node, "ensure_keys"),
+                    patch.object(Node, "notify_peers_of_update"),
+                ):
+                    _, created_again = Node.register_current()
+
+            self.assertFalse(created_again)
+            node.refresh_from_db()
+            self.assertEqual(node.role.name, "Constellation")
+
     def test_register_and_list_node(self):
         response = self.client.post(
             reverse("register-node"),


### PR DESCRIPTION
## Summary
- update `Node.register_current` to apply the current role lock to existing nodes
- add a regression test covering role changes driven by `locks/role.lck`

## Testing
- python manage.py test nodes.tests.NodeGetLocalTests.test_register_current_updates_role_from_lock_file


------
https://chatgpt.com/codex/tasks/task_e_68d6b1d22f5c832696d2ec476a9b3147