### PR TITLE
Show Django command list when command scripts run without arguments

### DIFF
--- a/command.bat
+++ b/command.bat
@@ -5,8 +5,11 @@ if not exist %VENV%\Scripts\python.exe (
     exit /b 1
 )
 if "%~1"=="" (
-    echo Usage: %0 ^<command^> [args...]
-    exit /b 1
+    echo Available Django management commands:
+    %VENV%\Scripts\python.exe manage.py help --commands
+    echo.
+    echo Usage: %~nx0 ^<command^> [args...]
+    exit /b 0
 )
 set COMMAND=%1
 set COMMAND=%COMMAND:-=_%

--- a/command.sh
+++ b/command.sh
@@ -17,8 +17,11 @@ fi
 source .venv/bin/activate
 
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 <command> [args...]" >&2
-  exit 1
+  echo "Available Django management commands:"
+  python manage.py help --commands
+  echo
+  echo "Usage: $0 <command> [args...]"
+  exit 0
 fi
 
 COMMAND="${1//-/_}"


### PR DESCRIPTION
## Summary
- show the available Django management commands when `command.sh` is invoked without arguments
- mirror the same behavior in `command.bat` and keep the usage hint after the command list

## Testing
- ./command.sh *(fails: Virtual environment not found. Run ./install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b8593ad083268aeaae49eff63390