### PR TITLE
Ensure simulator redirect reaches the member login notice

### DIFF
--- a/core/fixtures/todo__validate_screen_charge_point_simulator.json
+++ b/core/fixtures/todo__validate_screen_charge_point_simulator.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen Charge Point Simulator",
+      "url": "/ocpp/simulator/",
+      "request_details": "Ensure the member-only notice appears when unauthenticated users are redirected to log in."
+    }
+  }
+]

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -1306,6 +1306,12 @@ class SimulatorLandingTests(TestCase):
         self.assertContains(resp, "/ocpp/")
         self.assertContains(resp, "/ocpp/simulator/")
 
+    def test_cp_simulator_redirects_to_login(self):
+        response = self.client.get(reverse("cp-simulator"))
+        login_url = reverse("pages:login")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(login_url, response.url)
+
 
 class ChargerAdminTests(TestCase):
     def setUp(self):

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -447,7 +447,7 @@ def dashboard(request):
     return render(request, "ocpp/dashboard.html", context)
 
 
-@login_required
+@login_required(login_url="pages:login")
 @landing("Charge Point Simulator")
 @live_update()
 def cp_simulator(request):

--- a/pages/templates/pages/login.html
+++ b/pages/templates/pages/login.html
@@ -7,6 +7,11 @@
 <div class="d-flex justify-content-center">
   <div class="card p-4" style="max-width: 400px; width: 100%;">
     <h1 class="text-center mb-4">{% trans "Login" %}</h1>
+    {% if restricted_notice %}
+    <div class="alert alert-info" role="alert">
+      {{ restricted_notice }}
+    </div>
+    {% endif %}
     {% with current_method=form.auth_method.value|default:'password' %}
     <form method="post" novalidate data-auth-form>
       {% csrf_token %}

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -84,6 +84,14 @@ class LoginViewTests(TestCase):
         resp = self.client.get(reverse("pages:login"))
         self.assertContains(resp, "Use Authenticator app")
 
+    def test_cp_simulator_redirect_shows_restricted_message(self):
+        simulator_path = reverse("cp-simulator")
+        resp = self.client.get(f"{reverse('pages:login')}?next={simulator_path}")
+        self.assertContains(
+            resp,
+            "This page is reserved for members only. Please log in to continue.",
+        )
+
     def test_staff_login_redirects_admin(self):
         resp = self.client.post(
             reverse("pages:login"),


### PR DESCRIPTION
## Summary
- add a member-only notice when the charging station simulator redirects anonymous visitors to the login screen
- expose the notice in the login template so the message appears above the form
- cover the new behavior with a regression test for the login view
- route the simulator through the `pages:login` view so unauthenticated users land on the member-only login notice instead of a server error
- add a regression test for the simulator redirect and a TODO reminder to manually validate the updated screen

## Testing
- python manage.py test pages.tests.LoginViewTests.test_cp_simulator_redirect_shows_restricted_message ocpp.tests.SimulatorLandingTests.test_cp_simulator_redirects_to_login

------
https://chatgpt.com/codex/tasks/task_e_68d6c9aae6208326b220d59aa58e89cb