### PR TITLE
Rename OCPP CSMS link to CPMS Online Dashboard

### DIFF
--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -413,7 +413,7 @@ def charger_detail(request, cid, connector=None):
     return JsonResponse(payload)
 
 
-@landing("OCPP CSMS Dashboard")
+@landing("CPMS Online Dashboard")
 @live_update()
 def dashboard(request):
     """Landing page listing all known chargers and their status."""

--- a/pages/fixtures/constellation__landing_ocpp_dashboard.json
+++ b/pages/fixtures/constellation__landing_ocpp_dashboard.json
@@ -7,7 +7,7 @@
       "is_deleted": false,
       "module": ["Constellation", "/ocpp/"],
       "path": "/ocpp/",
-      "label": "OCPP CSMS Dashboard",
+      "label": "CPMS Online Dashboard",
       "enabled": true,
       "description": ""
     }

--- a/pages/fixtures/localhost__landing_ocpp_dashboard.json
+++ b/pages/fixtures/localhost__landing_ocpp_dashboard.json
@@ -7,7 +7,7 @@
       "is_deleted": false,
       "module": ["Terminal", "/ocpp/"],
       "path": "/ocpp/",
-      "label": "OCPP CSMS Dashboard",
+      "label": "CPMS Online Dashboard",
       "enabled": true,
       "description": ""
     }

--- a/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
+++ b/pages/fixtures/satellite_box__landing_ocpp_dashboard.json
@@ -7,7 +7,7 @@
       "is_deleted": false,
       "module": ["Satellite", "/ocpp/"],
       "path": "/ocpp/",
-      "label": "OCPP CSMS Dashboard",
+      "label": "CPMS Online Dashboard",
       "enabled": true,
       "description": ""
     }


### PR DESCRIPTION
## Summary
- update the OCPP dashboard landing label to "CPMS Online Dashboard" so navigation matches the requested wording
- synchronize seed fixtures so each environment displays the updated label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fff9a4d483269d6cc28528c90b9e