### PR TITLE
Update CP simulator demo notice terminology

### DIFF
--- a/ocpp/templates/ocpp/dashboard.html
+++ b/ocpp/templates/ocpp/dashboard.html
@@ -13,7 +13,7 @@
     data-demo-notice-dismiss
     aria-label="{% trans "Dismiss demo notice" %}"
   ></button>
-  <h2 class="h5 mb-2">{% trans "Demo OCPP 1.6 CSMS" %}</h2>
+  <h2 class="h5 mb-2">{% trans "Demo OCPP 1.6 CPMS (Charge Point Management System)" %}</h2>
   <p class="mb-1">{% trans "Everyone is welcome to use this demo to test their charge points." %}</p>
   <p class="mb-1">{% blocktrans with limit=ws_rate_limit %}Rate limiting applies (maximum {{ limit }} simultaneous connections per IP).{% endblocktrans %}</p>
   <p class="mb-0">{% blocktrans %}Use the following WebSocket URL format, replacing &lt;CHARGE_POINT_ID&gt; with your charge point identifier:{% endblocktrans %}</p>


### PR DESCRIPTION
## Summary
- update the charge point simulator notice headline to refer to CPMS and spell out Charge Point Management System

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d709e7929c8326940e375528fb18b0