### PR TITLE
Tag releases during publish

### DIFF
--- a/core/release.py
+++ b/core/release.py
@@ -344,3 +344,7 @@ def publish(
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         raise ReleaseError(proc.stdout + proc.stderr)
+
+    tag_name = f"v{version}"
+    _run(["git", "tag", tag_name])
+    _run(["git", "push", "origin", tag_name])

--- a/tests/test_pypi_token.py
+++ b/tests/test_pypi_token.py
@@ -24,10 +24,13 @@ class PyPITokenTests(TestCase):
             run.return_value.stdout = ""
             run.return_value.stderr = ""
             release.publish(version="0.1.1", creds=creds)
-        cmd = run.call_args[0][0]
-        assert "__token__" in cmd
-        assert "pypi-token" in cmd
-        assert "ignored" not in cmd
+        commands = [call.args[0] for call in run.call_args_list]
+        twine_cmd = next(cmd for cmd in commands if "twine" in cmd)
+        assert "__token__" in twine_cmd
+        assert "pypi-token" in twine_cmd
+        assert "ignored" not in twine_cmd
+        assert ["git", "tag", "v0.1.1"] in commands
+        assert ["git", "push", "origin", "v0.1.1"] in commands
 
     def test_publish_prefers_profile_over_env(self):
         profile = release.Credentials(token="profile-token")
@@ -50,9 +53,12 @@ class PyPITokenTests(TestCase):
             run.return_value.stdout = ""
             run.return_value.stderr = ""
             release.publish(version="0.1.1")
-        cmd = run.call_args[0][0]
-        assert "__token__" in cmd
-        assert "profile-token" in cmd
-        assert "env-user" not in cmd
-        assert "env-pass" not in cmd
-        assert "env-token" not in cmd
+        commands = [call.args[0] for call in run.call_args_list]
+        twine_cmd = next(cmd for cmd in commands if "twine" in cmd)
+        assert "__token__" in twine_cmd
+        assert "profile-token" in twine_cmd
+        assert "env-user" not in twine_cmd
+        assert "env-pass" not in twine_cmd
+        assert "env-token" not in twine_cmd
+        assert ["git", "tag", "v0.1.1"] in commands
+        assert ["git", "push", "origin", "v0.1.1"] in commands


### PR DESCRIPTION
## Summary
- ensure the publish step creates and pushes a version tag so the release workflow runs
- update the PyPI publish tests to look for the new git tag and push commands while keeping credential checks

## Testing
- pytest tests/test_pypi_token.py

------
https://chatgpt.com/codex/tasks/task_e_68d72c01ed9883268b8e3d5b58180bcc