### PR TITLE
Prevent placeholder charger IDs from being persisted

### DIFF
--- a/ocpp/migrations/0019_remove_placeholder_chargers.py
+++ b/ocpp/migrations/0019_remove_placeholder_chargers.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def remove_placeholder_chargers(apps, schema_editor):
+    Charger = apps.get_model("ocpp", "Charger")
+    Location = apps.get_model("ocpp", "Location")
+
+    placeholder_ids = list(
+        Charger.objects.filter(
+            charger_id__startswith="<", charger_id__endswith=">"
+        ).values_list("pk", flat=True)
+    )
+    if placeholder_ids:
+        Charger.objects.filter(pk__in=placeholder_ids).delete()
+    Location.objects.filter(
+        name__startswith="<", name__endswith=">", chargers__isnull=True
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ocpp", "0018_charger_availability_request_details_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_placeholder_chargers, migrations.RunPython.noop),
+    ]

--- a/ocpp/views.py
+++ b/ocpp/views.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _, gettext, ngettext
 from django.urls import NoReverseMatch, reverse
 from django.conf import settings
 from django.utils import translation, timezone
+from django.core.exceptions import ValidationError
 
 from utils.api import api_login_required
 
@@ -58,6 +59,10 @@ def _reverse_connector_url(name: str, serial: str, connector_slug: str) -> str:
 def _get_charger(serial: str, connector_slug: str | None) -> tuple[Charger, str]:
     """Return charger for the requested identity, creating if necessary."""
 
+    try:
+        serial = Charger.validate_serial(serial)
+    except ValidationError as exc:
+        raise Http404("Charger not found") from exc
     connector_value, normalized_slug = _normalize_connector_slug(connector_slug)
     if connector_value is None:
         charger, _ = Charger.objects.get_or_create(


### PR DESCRIPTION
## Summary
- validate charger serial numbers and guard websocket/API entry points against placeholder `<charger_id>` values
- skip invalid charger IDs during transaction imports and remove existing placeholder records via migration
- cover the regression with new charger landing tests

## Testing
- pytest ocpp/tests.py::ChargerLandingTests::test_placeholder_serial_not_created_from_status_view ocpp/tests.py::ChargerLandingTests::test_placeholder_serial_rejected

------
https://chatgpt.com/codex/tasks/task_e_68d72ecc559c8326b6130bced03def5e