### PR TITLE
Clarify AWG ground option labels

### DIFF
--- a/awg/templates/awg/calculator.html
+++ b/awg/templates/awg/calculator.html
@@ -71,9 +71,9 @@
         <label class="form-label" for="ground">{% trans "Ground:" %}</label>
         <select id="ground" name="ground" class="form-select">
           <option value="" {% if not form.ground %}selected{% endif %}></option>
-          <option value="[1]" {% if form.ground == "[1]" %}selected{% endif %}>[1]</option>
-          <option value="1" {% if form.ground == "1" %}selected{% endif %}>1</option>
-          <option value="0" {% if form.ground == "0" %}selected{% endif %}>0</option>
+          <option value="[1]" {% if form.ground == "[1]" %}selected{% endif %}>[1] ({% trans "Maybe" %})</option>
+          <option value="1" {% if form.ground == "1" %}selected{% endif %}>1 ({% trans "Yes" %})</option>
+          <option value="0" {% if form.ground == "0" %}selected{% endif %}>0 ({% trans "No" %})</option>
         </select>
       </div>
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- clarify the displayed text for AWG calculator ground options to explain what each value represents
- localize the clarifying text so the translated interface shows the intended prefixes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7390d18ac8326975ec252bb6d8d5f