### PR TITLE
Hide feedback toggle while dialog is displayed

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -186,6 +186,11 @@
         height: 1.75rem;
         display: block;
       }
+      body.user-story-open .user-story-toggle {
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+      }
       body.user-story-open {
         overflow: hidden;
       }


### PR DESCRIPTION
## Summary
- hide the floating feedback toggle when the feedback dialog is open to prevent it overlapping the popup

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7438f87088326b912978ccc958453