### PR TITLE
Update OCPP 1.6 coverage badge to 46.4%

### DIFF
--- a/ocpp_coverage.svg
+++ b/ocpp_coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="ocpp 1.6: 42.9%">
-  <title>ocpp 1.6: 42.9%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="ocpp 1.6: 46.4%">
+  <title>ocpp 1.6: 46.4%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -14,6 +14,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="34.0" y="14">ocpp 1.6</text>
-    <text x="93.0" y="14">42.9%</text>
+    <text x="93.0" y="14">46.4%</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- refresh the OCPP 1.6 coverage badge to show the current 46.4% support level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74aa347ec83269b913c0bcd56ee57