### PR TITLE
Add DataTransfer audit trail and CSMS integration

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -20,6 +20,7 @@ from .models import (
     MeterValue,
     Transaction,
     Location,
+    DataTransferMessage,
 )
 from .simulator import ChargePointSimulator
 from . import store
@@ -109,6 +110,44 @@ class LocationAdmin(EntityModelAdmin):
     form = LocationAdminForm
     list_display = ("name", "latitude", "longitude")
     change_form_template = "admin/ocpp/location/change_form.html"
+
+
+@admin.register(DataTransferMessage)
+class DataTransferMessageAdmin(admin.ModelAdmin):
+    list_display = (
+        "charger",
+        "connector_id",
+        "direction",
+        "vendor_id",
+        "message_id",
+        "status",
+        "created_at",
+        "responded_at",
+    )
+    list_filter = ("direction", "status")
+    search_fields = (
+        "charger__charger_id",
+        "ocpp_message_id",
+        "vendor_id",
+        "message_id",
+    )
+    readonly_fields = (
+        "charger",
+        "connector_id",
+        "direction",
+        "ocpp_message_id",
+        "vendor_id",
+        "message_id",
+        "payload",
+        "status",
+        "response_data",
+        "error_code",
+        "error_description",
+        "error_details",
+        "responded_at",
+        "created_at",
+        "updated_at",
+    )
 
 
 @admin.register(Charger)

--- a/ocpp/migrations/0020_datatransfermessage.py
+++ b/ocpp/migrations/0020_datatransfermessage.py
@@ -1,0 +1,63 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ocpp", "0019_remove_placeholder_chargers"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DataTransferMessage",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False, auto_created=True, verbose_name="ID")),
+                ("connector_id", models.PositiveIntegerField(null=True, blank=True)),
+                (
+                    "direction",
+                    models.CharField(
+                        max_length=16,
+                        choices=[
+                            ("cp_to_csms", "Charge Point → CSMS"),
+                            ("csms_to_cp", "CSMS → Charge Point"),
+                        ],
+                    ),
+                ),
+                ("ocpp_message_id", models.CharField(max_length=64)),
+                ("vendor_id", models.CharField(max_length=255, blank=True)),
+                ("message_id", models.CharField(max_length=255, blank=True)),
+                ("payload", models.JSONField(default=dict, blank=True)),
+                ("status", models.CharField(max_length=64, blank=True)),
+                ("response_data", models.JSONField(null=True, blank=True)),
+                ("error_code", models.CharField(max_length=64, blank=True)),
+                ("error_description", models.TextField(blank=True)),
+                ("error_details", models.JSONField(null=True, blank=True)),
+                ("responded_at", models.DateTimeField(null=True, blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "charger",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="data_transfer_messages",
+                        to="ocpp.charger",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.AddIndex(
+            model_name="datatransfermessage",
+            index=models.Index(
+                fields=["ocpp_message_id"],
+                name="ocpp_datatr_ocpp_me_70d17f_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="datatransfermessage",
+            index=models.Index(
+                fields=["vendor_id"], name="ocpp_datatr_vendor__59e1c7_idx"
+            ),
+        ),
+    ]

--- a/ocpp/models.py
+++ b/ocpp/models.py
@@ -215,6 +215,7 @@ class Charger(Entity):
             ),
         ]
 
+
     @classmethod
     def normalize_serial(cls, value: str | None) -> str:
         """Return ``value`` trimmed for consistent comparisons."""
@@ -761,6 +762,52 @@ class Simulator(Entity):
         if self.ws_port:
             return f"ws://{self.host}:{self.ws_port}/{path}"
         return f"ws://{self.host}/{path}"
+
+
+class DataTransferMessage(models.Model):
+    """Persisted record of OCPP DataTransfer exchanges."""
+
+    DIRECTION_CP_TO_CSMS = "cp_to_csms"
+    DIRECTION_CSMS_TO_CP = "csms_to_cp"
+    DIRECTION_CHOICES = (
+        (DIRECTION_CP_TO_CSMS, _("Charge Point → CSMS")),
+        (DIRECTION_CSMS_TO_CP, _("CSMS → Charge Point")),
+    )
+
+    charger = models.ForeignKey(
+        "Charger",
+        on_delete=models.CASCADE,
+        related_name="data_transfer_messages",
+    )
+    connector_id = models.PositiveIntegerField(null=True, blank=True)
+    direction = models.CharField(max_length=16, choices=DIRECTION_CHOICES)
+    ocpp_message_id = models.CharField(max_length=64)
+    vendor_id = models.CharField(max_length=255, blank=True)
+    message_id = models.CharField(max_length=255, blank=True)
+    payload = models.JSONField(default=dict, blank=True)
+    status = models.CharField(max_length=64, blank=True)
+    response_data = models.JSONField(null=True, blank=True)
+    error_code = models.CharField(max_length=64, blank=True)
+    error_description = models.TextField(blank=True)
+    error_details = models.JSONField(null=True, blank=True)
+    responded_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["ocpp_message_id"],
+                name="ocpp_datatr_ocpp_me_70d17f_idx",
+            ),
+            models.Index(
+                fields=["vendor_id"], name="ocpp_datatr_vendor__59e1c7_idx"
+            ),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.get_direction_display()} {self.vendor_id or 'DataTransfer'}"
 
 
 class RFID(CoreRFID):


### PR DESCRIPTION
## Summary
- add a DataTransferMessage model with migration and admin listing to persist transfer payloads
- route DataTransfer calls through the CSMS consumer and HTTP control endpoint so responses update the audit trail
- extend documentation and automated tests to cover charge point initiated and CSMS initiated transfers

## Testing
- python manage.py test ocpp.tests.CSMSConsumerTests.test_data_transfer_inbound_persists_message --verbosity 2
- python manage.py test ocpp.tests.CSMSConsumerTests.test_data_transfer_action_round_trip --verbosity 2

------
https://chatgpt.com/codex/tasks/task_e_68d74b48af9c8326aa875c2e8da13652