### PR TITLE
Fix admin access for arthexis system user

### DIFF
--- a/core/fixtures/users__arthexis.json
+++ b/core/fixtures/users__arthexis.json
@@ -6,7 +6,7 @@
       "email": "arthexis@gmail.com",
       "is_staff": true,
       "is_superuser": true,
-      "is_active": false,
+      "is_active": true,
       "password": ""
     }
   }

--- a/core/migrations/0051_ensure_system_user_staff.py
+++ b/core/migrations/0051_ensure_system_user_staff.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def ensure_system_user_staff(apps, schema_editor):
+    User = apps.get_model("core", "User")
+    manager = getattr(User, "all_objects", User._default_manager)
+    system_username = getattr(User, "SYSTEM_USERNAME", "arthexis")
+    updates = {
+        "is_staff": True,
+        "is_superuser": True,
+    }
+    if hasattr(User, "is_active"):
+        updates["is_active"] = True
+    manager.filter(username=system_username).update(**updates)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0050_emailcollector_name_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_system_user_staff, migrations.RunPython.noop),
+    ]
+


### PR DESCRIPTION
## Summary
- add a data migration that enforces staff and superuser flags for the arthexis system account
- update the arthexis user fixture so the seeded account remains active after upgrades

## Testing
- python manage.py test core.tests --verbosity 2

------
https://chatgpt.com/codex/tasks/task_e_68d74cde5b30832688601883a630ed37