### PR TITLE
Organize profile admin fieldsets by owner and credentials

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1350,10 +1350,8 @@ class OdooProfileAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModelAdm
     changelist_actions = ["my_profile"]
     fieldsets = (
         ("Owner", {"fields": ("user", "group")}),
-        (
-            "Configuration",
-            {"fields": ("host", "database", "username", "password")},
-        ),
+        ("Configuration", {"fields": ("host", "database")}),
+        ("Credentials", {"fields": ("username", "password")}),
         (
             "Odoo Employee",
             {"fields": ("verified_on", "odoo_uid", "name", "email")},
@@ -1443,18 +1441,10 @@ class EmailInboxAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModelAdmi
 
     fieldsets = (
         ("Owner", {"fields": ("user", "group")}),
+        ("Credentials", {"fields": ("username", "password")}),
         (
-            None,
-            {
-                "fields": (
-                    "username",
-                    "host",
-                    "port",
-                    "password",
-                    "protocol",
-                    "use_ssl",
-                )
-            },
+            "Configuration",
+            {"fields": ("host", "port", "protocol", "use_ssl")},
         ),
     )
 
@@ -1552,17 +1542,10 @@ class AssistantProfileAdmin(
     changelist_actions = ["my_profile"]
     fieldsets = (
         ("Owner", {"fields": ("user", "group")}),
+        ("Credentials", {"fields": ("user_key_hash",)}),
         (
-            None,
-            {
-                "fields": (
-                    "scopes",
-                    "is_active",
-                    "user_key_hash",
-                    "created_at",
-                    "last_used_at",
-                )
-            },
+            "Configuration",
+            {"fields": ("scopes", "is_active", "created_at", "last_used_at")},
         ),
     )
 

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -70,6 +70,24 @@ class NodeManagerAdmin(EntityModelAdmin):
         "user__username",
         "group__name",
     )
+    fieldsets = (
+        (_("Owner"), {"fields": ("user", "group")}),
+        (
+            _("Credentials"),
+            {"fields": ("api_key", "api_secret", "customer_id")},
+        ),
+        (
+            _("Configuration"),
+            {
+                "fields": (
+                    "provider",
+                    "default_domain",
+                    "use_sandbox",
+                    "is_enabled",
+                )
+            },
+        ),
+    )
 
 
 @admin.register(DNSRecord)
@@ -371,15 +389,15 @@ class EmailOutboxAdmin(EntityModelAdmin):
     )
     change_form_template = "admin/nodes/emailoutbox/change_form.html"
     fieldsets = (
-        ("Owner", {"fields": ("user", "group", "node")}),
+        ("Owner", {"fields": ("user", "group")}),
+        ("Credentials", {"fields": ("username", "password")}),
         (
             "Configuration",
             {
                 "fields": (
+                    "node",
                     "host",
                     "port",
-                    "username",
-                    "password",
                     "use_tls",
                     "use_ssl",
                     "from_email",


### PR DESCRIPTION
## Summary
- split profile admin fieldsets so owner information is isolated from credentials and configuration details
- update Odoo, email inbox/outbox, assistant, and node manager admins to provide consistent Owner, Credentials, and Configuration sections

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d7548892648326af46042f7139d31a