### PR TITLE
Update Experience description and hide manual application

### DIFF
--- a/pages/defaults.py
+++ b/pages/defaults.py
@@ -8,7 +8,6 @@ DEFAULT_APPLICATION_DESCRIPTIONS: Dict[str, str] = {
     "core": "Support for Business Processes and monetization.",
     "ocpp": "Compatibility with Standards and Good Practices.",
     "nodes": "System and Node-level operations,",
-    "pages": "Scheduling, Periodicity and Event Signaling,",
+    "pages": "User QA, Continuity Design and Chaos Testing.",
     "teams": "Identity, Entitlements and Access Controls.",
-    "man": "User QA, Continuity Design and Chaos Testing.",
 }

--- a/pages/fixtures/default__application_man.json
+++ b/pages/fixtures/default__application_man.json
@@ -3,7 +3,7 @@
     "model": "pages.application",
     "fields": {
       "is_seed_data": true,
-      "is_deleted": false,
+      "is_deleted": true,
       "name": "man",
       "description": "User QA, Continuity Design and Chaos Testing."
     }


### PR DESCRIPTION
## Summary
- update the Experience application description to "User QA, Continuity Design and Chaos Testing."
- mark the manual application fixture as deleted so it is no longer displayed

## Testing
- pytest tests/test_register_site_apps_command.py::RegisterSiteAppsCommandTests::test_register_site_apps_creates_entries


------
https://chatgpt.com/codex/tasks/task_e_68d7556fd464832687a0d23233e47ac7