### PR TITLE
Fix navbar light theme defaults

### DIFF
--- a/pages/templates/pages/base.html
+++ b/pages/templates/pages/base.html
@@ -363,7 +363,7 @@
                   {% endfor %}
                 </select>
               </form>
-              <a class="btn btn-sm btn-outline-light position-relative user-info-trigger" href="{% if request.user.is_authenticated %}{% url 'admin:index' %}{% else %}{% url 'pages:login' %}{% endif %}" aria-label="{% if request.user.is_authenticated %}{% trans "Admin" %}{% else %}{% trans "Login" %}{% endif %}">
+              <a class="btn btn-sm btn-outline-dark position-relative user-info-trigger" href="{% if request.user.is_authenticated %}{% url 'admin:index' %}{% else %}{% url 'pages:login' %}{% endif %}" aria-label="{% if request.user.is_authenticated %}{% trans "Admin" %}{% else %}{% trans "Login" %}{% endif %}">
                 <svg aria-hidden="true" width="1.5rem" height="1.5rem">
                   <use href="#icon-person"></use>
                 </svg>
@@ -373,7 +373,7 @@
                 </div>
                 {% endif %}
               </a>
-              <button id="share-button" class="btn btn-sm btn-outline-light ms-2" type="button" aria-label="{% trans 'Share' %}">
+              <button id="share-button" class="btn btn-sm btn-outline-dark ms-2" type="button" aria-label="{% trans 'Share' %}">
                 <svg aria-hidden="true" width="1.5rem" height="1.5rem">
                   <use href="#icon-share"></use>
                 </svg>


### PR DESCRIPTION
## Summary
- default the navigation bar to the light theme so first load matches the page background
- update theme toggle logic so the light theme uses the body background color
- default toolbar button outlines to the dark variant so they remain visible before theme initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76518877883269fd8ed9dddc4a74c