### PR TITLE
Add admin action to fetch CP configuration

### DIFF
--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -362,6 +362,87 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertEqual(charger.availability_requested_state, "Inoperative")
         await communicator.disconnect()
 
+    async def test_get_configuration_result_logged(self):
+        store.pending_calls.clear()
+        pending_key = store.pending_key("CFGRES")
+        store.clear_log(pending_key, log_type="charger")
+        log_key = store.identity_key("CFGRES", None)
+        store.clear_log(log_key, log_type="charger")
+        communicator = WebsocketCommunicator(application, "/CFGRES/")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        message_id = "cfg-result"
+        payload = {
+            "configurationKey": [
+                {
+                    "key": "AllowOfflineTxForUnknownId",
+                    "readonly": True,
+                    "value": "false",
+                }
+            ]
+        }
+        store.register_pending_call(
+            message_id,
+            {
+                "action": "GetConfiguration",
+                "charger_id": "CFGRES",
+                "connector_id": None,
+                "log_key": log_key,
+                "requested_at": timezone.now(),
+            },
+        )
+
+        await communicator.send_json_to([3, message_id, payload])
+        await asyncio.sleep(0.05)
+
+        log_entries = store.get_logs(log_key, log_type="charger")
+        self.assertTrue(
+            any("GetConfiguration result" in entry for entry in log_entries)
+        )
+        self.assertNotIn(message_id, store.pending_calls)
+
+        await communicator.disconnect()
+        store.clear_log(log_key, log_type="charger")
+        store.clear_log(pending_key, log_type="charger")
+
+    async def test_get_configuration_error_logged(self):
+        store.pending_calls.clear()
+        pending_key = store.pending_key("CFGERR")
+        store.clear_log(pending_key, log_type="charger")
+        log_key = store.identity_key("CFGERR", None)
+        store.clear_log(log_key, log_type="charger")
+        communicator = WebsocketCommunicator(application, "/CFGERR/")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        message_id = "cfg-error"
+        store.register_pending_call(
+            message_id,
+            {
+                "action": "GetConfiguration",
+                "charger_id": "CFGERR",
+                "connector_id": None,
+                "log_key": log_key,
+                "requested_at": timezone.now(),
+            },
+        )
+
+        await communicator.send_json_to(
+            [4, message_id, "InternalError", "Boom", {"detail": "nope"}]
+        )
+        await asyncio.sleep(0.05)
+
+        log_entries = store.get_logs(log_key, log_type="charger")
+        self.assertTrue(
+            any("GetConfiguration error" in entry for entry in log_entries)
+        )
+        self.assertNotIn(message_id, store.pending_calls)
+
+        await communicator.disconnect()
+        store.clear_log(log_key, log_type="charger")
+        store.clear_log(pending_key, log_type="charger")
+
     async def test_status_notification_updates_availability_state(self):
         store.pending_calls.clear()
         communicator = WebsocketCommunicator(application, "/STATAVAIL/")
@@ -1640,6 +1721,46 @@ class ChargerAdminTests(TestCase):
         )
         self.client.post(delete_url, {"post": "yes"})
         self.assertFalse(Charger.objects.filter(pk=charger.pk).exists())
+
+    def test_fetch_configuration_dispatches_request(self):
+        charger = Charger.objects.create(charger_id="CFGADMIN", connector_id=1)
+        ws = DummyWebSocket()
+        log_key = store.identity_key(charger.charger_id, charger.connector_id)
+        store.clear_log(log_key, log_type="charger")
+        pending_key = store.pending_key(charger.charger_id)
+        store.clear_log(pending_key, log_type="charger")
+        store.set_connection(charger.charger_id, charger.connector_id, ws)
+        store.pending_calls.clear()
+        try:
+            url = reverse("admin:ocpp_charger_changelist")
+            response = self.client.post(
+                url,
+                {
+                    "action": "fetch_cp_configuration",
+                    "_selected_action": [charger.pk],
+                },
+                follow=True,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(ws.sent), 1)
+            frame = json.loads(ws.sent[0])
+            self.assertEqual(frame[0], 2)
+            self.assertEqual(frame[2], "GetConfiguration")
+            self.assertIn(frame[1], store.pending_calls)
+            metadata = store.pending_calls[frame[1]]
+            self.assertEqual(metadata.get("action"), "GetConfiguration")
+            self.assertEqual(metadata.get("charger_id"), charger.charger_id)
+            self.assertEqual(metadata.get("connector_id"), charger.connector_id)
+            self.assertEqual(metadata.get("log_key"), log_key)
+            log_entries = store.get_logs(log_key, log_type="charger")
+            self.assertTrue(
+                any("GetConfiguration" in entry for entry in log_entries)
+            )
+        finally:
+            store.pop_connection(charger.charger_id, charger.connector_id)
+            store.pending_calls.clear()
+            store.clear_log(log_key, log_type="charger")
+            store.clear_log(pending_key, log_type="charger")
 
 
 class LocationAdminTests(TestCase):


### PR DESCRIPTION
## Summary
- add a charger admin action that dispatches GetConfiguration requests and tracks pending metadata
- log GetConfiguration results and errors from charge points in the CSMS consumer
- cover the new action and consumer handling with focused tests

## Testing
- python manage.py test ocpp.tests.ChargerAdminTests.test_fetch_configuration_dispatches_request ocpp.tests.CSMSConsumerTests.test_get_configuration_result_logged ocpp.tests.CSMSConsumerTests.test_get_configuration_error_logged

------
https://chatgpt.com/codex/tasks/task_e_68d7f55a4b288326aac628d987294077