### PR TITLE
Gracefully handle missing ContentSample admin URL

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -585,7 +585,18 @@ class NodeFeatureAdmin(EntityModelAdmin):
         self.message_user(
             request, f"Screenshot saved to {sample.path}", level=messages.SUCCESS
         )
-        return redirect("admin:nodes_contentsample_change", sample.pk)
+        try:
+            change_url = reverse(
+                "admin:nodes_contentsample_change", args=[sample.pk]
+            )
+        except NoReverseMatch:  # pragma: no cover - admin URL always registered
+            self.message_user(
+                request,
+                "Screenshot saved but the admin page could not be resolved.",
+                level=messages.WARNING,
+            )
+            return redirect("..")
+        return redirect(change_url)
 
     def take_snapshot(self, request):
         feature = self._ensure_feature_enabled(
@@ -608,7 +619,18 @@ class NodeFeatureAdmin(EntityModelAdmin):
         self.message_user(
             request, f"Snapshot saved to {sample.path}", level=messages.SUCCESS
         )
-        return redirect("admin:nodes_contentsample_change", sample.pk)
+        try:
+            change_url = reverse(
+                "admin:nodes_contentsample_change", args=[sample.pk]
+            )
+        except NoReverseMatch:  # pragma: no cover - admin URL always registered
+            self.message_user(
+                request,
+                "Snapshot saved but the admin page could not be resolved.",
+                level=messages.WARNING,
+            )
+            return redirect("..")
+        return redirect(change_url)
 
 
 @admin.register(ContentSample)


### PR DESCRIPTION
## Summary
- guard the ContentSample redirect in node feature admin actions
- fall back to the admin changelist with a warning if the change view URL cannot be resolved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81287afdc8326bac692354a2b0f2d