### PR TITLE
Remove duplicate Celery report header

### DIFF
--- a/nodes/templates/admin/nodes/nodefeature/celery_report.html
+++ b/nodes/templates/admin/nodes/nodefeature/celery_report.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 <div id="content-main" class="celery-report">
-  <h1>{{ title }}</h1>
   <div class="module celery-report__period">
     <h2 class="celery-report__period-title">{% trans "Reporting window" %}</h2>
     <p class="celery-report__period-options">


### PR DESCRIPTION
## Summary
- remove the redundant heading from the Celery report admin template so only the standard admin title renders

## Testing
- pytest nodes/tests.py::CeleryReportAdminViewTests::test_report_includes_tasks_and_logs

------
https://chatgpt.com/codex/tasks/task_e_68d82188b2a08326a2ae8f2ded5b5a54