### PR TITLE
Fix env refresh fixture loading without natural key flags

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -294,16 +294,7 @@ def run_database_tasks(*, latest: bool = False, clean: bool = False) -> None:
                 for priority in sorted(patched):
                     for fixture in patched[priority]:
                         try:
-                            try:
-                                call_command(
-                                    "loaddata",
-                                    fixture,
-                                    natural_foreign=True,
-                                    natural_primary=True,
-                                    verbosity=0,
-                                )
-                            except TypeError:
-                                call_command("loaddata", fixture, verbosity=0)
+                            call_command("loaddata", fixture, verbosity=0)
                         except DeserializationError as exc:
                             print(f"Skipping fixture {fixture} due to: {exc}")
                         else:


### PR DESCRIPTION
## Summary
- remove unsupported natural key options when calling `loaddata` so env refresh runs on Django 5
- rely on Django's default natural key handling to load fixtures without raising errors

## Testing
- python env-refresh.py database

------
https://chatgpt.com/codex/tasks/task_e_68d8560967bc8326a98a16e11e50549d