### PR TITLE
Handle RequestSite in reference filtering

### DIFF
--- a/core/reference_utils.py
+++ b/core/reference_utils.py
@@ -30,7 +30,7 @@ def filter_visible_references(
         if host:
             site = Site.objects.filter(domain__iexact=host).first()
 
-    site_id = site.pk if site else None
+    site_id = getattr(site, "pk", None)
 
     if node is None:
         try:


### PR DESCRIPTION
## Summary
- avoid AttributeError when `filter_visible_references` receives a `RequestSite`

## Testing
- pytest tests/test_footer_render.py tests/test_sites_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d858ef96808326ba44521d2fd60af4