### PR TITLE
Add console handler for error logging

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -685,10 +685,15 @@ LOGGING = {
             "backupCount": 7,
             "encoding": "utf-8",
             "formatter": "standard",
-        }
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "ERROR",
+            "formatter": "standard",
+        },
     },
     "root": {
-        "handlers": ["file"],
+        "handlers": ["file", "console"],
         "level": "DEBUG",
     },
 }


### PR DESCRIPTION
## Summary
- ensure the root logger also streams to the console so runtime errors are visible without reading log files

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d85bb83cd48326a8d989857ab81557