### PR TITLE
Add admin action to register products from Odoo

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1931,7 +1931,7 @@ class ProductFetchWizardForm(forms.Form):
 @admin.register(Product)
 class ProductAdmin(EntityModelAdmin):
     form = ProductAdminForm
-    actions = ["fetch_odoo_product"]
+    actions = ["fetch_odoo_product", "register_from_odoo"]
 
     def _odoo_profile_admin(self):
         return self.admin_site._registry.get(OdooProfile)
@@ -2080,6 +2080,169 @@ class ProductAdmin(EntityModelAdmin):
         )
         context["media"] = self.media + form.media
         return TemplateResponse(request, "admin/core/product/fetch_odoo.html", context)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "register-from-odoo/",
+                self.admin_site.admin_view(self.register_from_odoo_view),
+                name=f"{self.opts.app_label}_{self.opts.model_name}_register_from_odoo",
+            )
+        ]
+        return custom + urls
+
+    @admin.action(description="Register from Odoo")
+    def register_from_odoo(self, request, queryset=None):  # pragma: no cover - simple redirect
+        return HttpResponseRedirect(
+            reverse(
+                f"admin:{self.opts.app_label}_{self.opts.model_name}_register_from_odoo"
+            )
+        )
+
+    def _build_register_context(self, request):
+        opts = self.model._meta
+        context = self.admin_site.each_context(request)
+        context.update(
+            {
+                "opts": opts,
+                "title": _("Register from Odoo"),
+                "has_credentials": False,
+                "profile_url": None,
+                "products": [],
+                "selected_product_id": request.POST.get("product_id", ""),
+            }
+        )
+
+        profile_admin = self._odoo_profile_admin()
+        if profile_admin is not None:
+            context["profile_url"] = profile_admin.get_my_profile_url(request)
+
+        profile = getattr(request.user, "odoo_profile", None)
+        if not profile or not profile.is_verified:
+            context["credential_error"] = _(
+                "Configure your Odoo employee credentials before registering products."
+            )
+            return context, None
+
+        try:
+            products = profile.execute(
+                "product.product",
+                "search_read",
+                [],
+                {
+                    "fields": [
+                        "name",
+                        "description_sale",
+                        "list_price",
+                        "standard_price",
+                    ],
+                    "limit": 0,
+                },
+            )
+        except Exception:
+            context["error"] = _("Unable to fetch products from Odoo.")
+            return context, []
+
+        context["has_credentials"] = True
+        simplified = []
+        for product in products:
+            simplified.append(
+                {
+                    "id": product.get("id"),
+                    "name": product.get("name", ""),
+                    "description_sale": product.get("description_sale", ""),
+                    "list_price": product.get("list_price"),
+                    "standard_price": product.get("standard_price"),
+                }
+            )
+        context["products"] = simplified
+        return context, simplified
+
+    def register_from_odoo_view(self, request):
+        context, products = self._build_register_context(request)
+        if products is None:
+            return TemplateResponse(
+                request, "admin/core/product/register_from_odoo.html", context
+            )
+
+        if request.method == "POST" and context.get("has_credentials"):
+            if not self.has_add_permission(request):
+                context["form_error"] = _(
+                    "You do not have permission to add products."
+                )
+            else:
+                product_id = request.POST.get("product_id")
+                if not product_id:
+                    context["form_error"] = _("Select a product to register.")
+                else:
+                    try:
+                        odoo_id = int(product_id)
+                    except (TypeError, ValueError):
+                        context["form_error"] = _("Invalid product selection.")
+                    else:
+                        match = next(
+                            (item for item in products if item.get("id") == odoo_id),
+                            None,
+                        )
+                        if not match:
+                            context["form_error"] = _(
+                                "The selected product was not found. Reload the page and try again."
+                            )
+                        else:
+                            existing = self.model.objects.filter(
+                                odoo_product__id=odoo_id
+                            ).first()
+                            if existing:
+                                self.message_user(
+                                    request,
+                                    _(
+                                        "Product %(name)s already imported; opening existing record."
+                                    )
+                                    % {"name": existing.name},
+                                    level=messages.WARNING,
+                                )
+                                return HttpResponseRedirect(
+                                    reverse(
+                                        "admin:%s_%s_change"
+                                        % (
+                                            existing._meta.app_label,
+                                            existing._meta.model_name,
+                                        ),
+                                        args=[existing.pk],
+                                    )
+                                )
+                            product = self.model.objects.create(
+                                name=match.get("name") or f"Odoo Product {odoo_id}",
+                                description=match.get("description_sale", "") or "",
+                                renewal_period=30,
+                                odoo_product={
+                                    "id": odoo_id,
+                                    "name": match.get("name", ""),
+                                },
+                            )
+                            self.log_addition(
+                                request, product, "Registered product from Odoo"
+                            )
+                            self.message_user(
+                                request,
+                                _("Imported %(name)s from Odoo.")
+                                % {"name": product.name},
+                            )
+                            return HttpResponseRedirect(
+                                reverse(
+                                    "admin:%s_%s_change"
+                                    % (
+                                        product._meta.app_label,
+                                        product._meta.model_name,
+                                    ),
+                                    args=[product.pk],
+                                )
+                            )
+
+        return TemplateResponse(
+            request, "admin/core/product/register_from_odoo.html", context
+        )
 
 
 class RFIDResource(resources.ModelResource):

--- a/core/templates/admin/core/product/register_from_odoo.html
+++ b/core/templates/admin/core/product/register_from_odoo.html
@@ -1,0 +1,79 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+  <a href="{% url 'admin:app_list' opts.app_label %}">{{ opts.app_config.verbose_name }}</a> ›
+  <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> ›
+  {% trans 'Register from Odoo' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{% trans 'Register from Odoo' %}</h1>
+{% if credential_error %}
+  <div class="messagelist">
+    <div class="error">{{ credential_error }}
+      {% if profile_url %}
+        <a href="{{ profile_url }}">{% trans 'Manage Odoo credentials' %}</a>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
+{% if error %}
+  <div class="messagelist">
+    <div class="error">{{ error }}</div>
+  </div>
+{% endif %}
+
+{% if form_error %}
+  <div class="messagelist">
+    <div class="error">{{ form_error }}</div>
+  </div>
+{% endif %}
+
+{% if has_credentials %}
+<form method="post">
+  {% csrf_token %}
+  <p class="help">{% trans 'Select a product from Odoo to create it in Arthexis.' %}</p>
+  <table class="adminlist">
+    <thead>
+      <tr>
+        <th>{% trans 'Select' %}</th>
+        <th>{% trans 'Name' %}</th>
+        <th>{% trans 'Sales description' %}</th>
+        <th>{% trans 'Price' %}</th>
+        <th>{% trans 'Original cost' %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for product in products %}
+        <tr>
+          <td>
+            <input
+              type="radio"
+              name="product_id"
+              value="{{ product.id }}"
+              {% if product.id|stringformat:'s' == selected_product_id %}checked{% endif %}
+            >
+          </td>
+          <td>{{ product.name }}</td>
+          <td>{{ product.description_sale }}</td>
+          <td>{{ product.list_price }}</td>
+          <td>{{ product.standard_price }}</td>
+        </tr>
+      {% empty %}
+        <tr>
+          <td colspan="5">{% trans 'No products available from Odoo.' %}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <div class="submit-row">
+    <button type="submit" class="button default">{% trans 'Register product' %}</button>
+  </div>
+</form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Product admin action that redirects to a new registration view and exposes it on the dashboard
- build the registration view to list Odoo products with pricing details and import the selected item
- extend the Odoo product tests to cover the new action, view listing, and creation flow

## Testing
- pytest tests/test_odoo_product.py

------
https://chatgpt.com/codex/tasks/task_e_68d85b3ab25083269292201d9c6a7862