### PR TITLE
Set Constellation and Control node badge colors

### DIFF
--- a/nodes/migrations/0013_node_role_badge_colors.py
+++ b/nodes/migrations/0013_node_role_badge_colors.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+ROLE_BADGE_COLORS = {
+    "Constellation": "#daa520",
+    "Control": "#673ab7",
+}
+DEFAULT_BADGE_COLOR = "#28a745"
+
+
+def apply_role_badge_colors(apps, schema_editor):
+    Node = apps.get_model("nodes", "Node")
+    for role_name, color in ROLE_BADGE_COLORS.items():
+        Node.objects.filter(
+            role__name=role_name,
+            badge_color__in=["", DEFAULT_BADGE_COLOR],
+        ).update(badge_color=color)
+
+
+def revert_role_badge_colors(apps, schema_editor):
+    Node = apps.get_model("nodes", "Node")
+    for role_name, color in ROLE_BADGE_COLORS.items():
+        Node.objects.filter(role__name=role_name, badge_color=color).update(
+            badge_color=DEFAULT_BADGE_COLOR
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0012_remove_postgres_nodefeature"),
+    ]
+
+    operations = [
+        migrations.RunPython(apply_role_badge_colors, revert_role_badge_colors),
+    ]

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -63,6 +63,43 @@ from cryptography.hazmat.primitives import serialization, hashes
 from core.models import PackageRelease, SecurityGroup
 
 
+class NodeBadgeColorTests(TestCase):
+    def setUp(self):
+        self.constellation, _ = NodeRole.objects.get_or_create(name="Constellation")
+        self.control, _ = NodeRole.objects.get_or_create(name="Control")
+
+    def test_constellation_role_defaults_to_goldenrod(self):
+        node = Node.objects.create(
+            hostname="constellation",
+            address="10.1.0.1",
+            port=8000,
+            mac_address="00:aa:bb:cc:dd:01",
+            role=self.constellation,
+        )
+        self.assertEqual(node.badge_color, "#daa520")
+
+    def test_control_role_defaults_to_deep_purple(self):
+        node = Node.objects.create(
+            hostname="control",
+            address="10.1.0.2",
+            port=8001,
+            mac_address="00:aa:bb:cc:dd:02",
+            role=self.control,
+        )
+        self.assertEqual(node.badge_color, "#673ab7")
+
+    def test_custom_badge_color_is_preserved(self):
+        node = Node.objects.create(
+            hostname="custom",
+            address="10.1.0.3",
+            port=8002,
+            mac_address="00:aa:bb:cc:dd:03",
+            role=self.constellation,
+            badge_color="#123456",
+        )
+        self.assertEqual(node.badge_color, "#123456")
+
+
 class NodeTests(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
## Summary
- align node badge colors with role-specific defaults for Constellation and Control while preserving custom overrides
- backfill existing node records with the new badge colors via a data migration
- add unit tests covering the default and custom badge color behaviors

## Testing
- pytest nodes/tests.py::NodeBadgeColorTests -q

------
https://chatgpt.com/codex/tasks/task_e_68d85c343b7c8326a538b398ec59f8a4