### PR TITLE
Improve MCP resolver URLs and admin guidance

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -76,6 +76,7 @@ from .user_data import (
 )
 from .widgets import OdooProductWidget
 from .mcp import process as mcp_process
+from .mcp.server import resolve_base_urls
 
 
 admin.site.unregister(Group)
@@ -1636,14 +1637,19 @@ class AssistantProfileAdmin(
         config = dict(getattr(settings, "MCP_SIGIL_SERVER", {}))
         host = config.get("host") or "127.0.0.1"
         port = config.get("port", 8800)
+        base_url, issuer_url = resolve_base_urls(config)
         if isinstance(response, dict):
             response.setdefault("mcp_server_host", host)
             response.setdefault("mcp_server_port", port)
+            response.setdefault("mcp_server_base_url", base_url)
+            response.setdefault("mcp_server_issuer_url", issuer_url)
         else:
             context_data = getattr(response, "context_data", None)
             if context_data is not None:
                 context_data.setdefault("mcp_server_host", host)
                 context_data.setdefault("mcp_server_port", port)
+                context_data.setdefault("mcp_server_base_url", base_url)
+                context_data.setdefault("mcp_server_issuer_url", issuer_url)
         return response
 
     def start_server(self, request):

--- a/core/templates/admin/workgroupassistantprofile_change_form.html
+++ b/core/templates/admin/workgroupassistantprofile_change_form.html
@@ -15,8 +15,18 @@
     <a href="https://platform.openai.com/docs/gpts/tools/model-context-protocol"
        target="_blank" rel="noopener">ChatGPT Developer Mode</a>
     and register a Model Context Protocol server pointing to
-    <code>http://{{ mcp_server_host|default:"127.0.0.1" }}:{{ mcp_server_port|default:"8800" }}</code>.
+    <code>{{ mcp_server_base_url|default:"http://127.0.0.1:8800" }}</code>.
     Requests must call <code>/api/chat/</code> and include the API key in the
     <code>Authorization</code> header as <code>Bearer &lt;key&gt;</code>.
+</p>
+<p class="help">
+    ChatGPT fetches OAuth metadata from
+    <code>{{ mcp_server_issuer_url|default:"http://127.0.0.1:8800" }}</code>. If the
+    connector shows <strong>Error fetching OAuth configuration</strong>, verify
+    this URL is reachable over HTTPS. Update the
+    <a href="https://docs.djangoproject.com/en/stable/ref/contrib/sites/"
+       target="_blank" rel="noopener">Site domain</a>,
+    or set <code>MCP_SIGIL_RESOURCE_URL</code> and
+    <code>MCP_SIGIL_ISSUER_URL</code> to override the advertised URLs.
 </p>
 {% endblock %}

--- a/tests/test_assistant_profile_admin.py
+++ b/tests/test_assistant_profile_admin.py
@@ -41,6 +41,8 @@ class AssistantProfileAdminTests(TestCase):
         self.assertContains(response, "Authorization")
         self.assertContains(response, "ChatGPT Developer Mode")
         self.assertContains(response, "Assistant Profiles list")
+        self.assertContains(response, "Error fetching OAuth configuration")
+        self.assertContains(response, "MCP_SIGIL_RESOURCE_URL")
 
     def test_generate_key_button(self):
         url = reverse(
@@ -49,7 +51,8 @@ class AssistantProfileAdminTests(TestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        key = response.context["user_key"]
+        context = getattr(response, "context_data", None) or response.context
+        key = context["user_key"]
         self.assertTrue(key)
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.user_key_hash, hash_key(key))


### PR DESCRIPTION
## Summary
- derive the MCP resolver base and issuer URLs from the Django Site configuration when no explicit settings are provided
- surface the computed URLs and troubleshooting guidance in the assistant profile admin form to clarify the "Error fetching OAuth configuration" message
- extend the MCP resolver and admin tests to cover the new URL logic and helper text

## Testing
- pytest tests/test_mcp_sigil_server.py tests/test_assistant_profile_admin.py


------
https://chatgpt.com/codex/tasks/task_e_68d85dc83dcc8326986be662f2d4a2af