### PR TITLE
Fix Odoo product fetch arguments and clean header

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1941,7 +1941,7 @@ class ProductAdmin(EntityModelAdmin):
         return profile.execute(
             "product.product",
             "search_read",
-            domain,
+            [domain],
             {
                 "fields": [
                     "name",
@@ -2129,7 +2129,7 @@ class ProductAdmin(EntityModelAdmin):
             products = profile.execute(
                 "product.product",
                 "search_read",
-                [],
+                [[]],
                 {
                     "fields": [
                         "name",

--- a/core/templates/admin/core/product/register_from_odoo.html
+++ b/core/templates/admin/core/product/register_from_odoo.html
@@ -11,7 +11,6 @@
 {% endblock %}
 
 {% block content %}
-<h1>{% trans 'Register from Odoo' %}</h1>
 {% if credential_error %}
   <div class="messagelist">
     <div class="error">{{ credential_error }}

--- a/core/views.py
+++ b/core/views.py
@@ -40,7 +40,7 @@ def odoo_products(request):
         products = profile.execute(
             "product.product",
             "search_read",
-            [],
+            [[]],
             {"fields": ["name"], "limit": 50},
         )
     except Exception:

--- a/tests/test_odoo_product.py
+++ b/tests/test_odoo_product.py
@@ -34,7 +34,7 @@ class OdooProductTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [{"id": 5, "name": "Prod"}])
         mock_exec.assert_called_once_with(
-            "product.product", "search_read", [], {"fields": ["name"], "limit": 50}
+            "product.product", "search_read", [[]], {"fields": ["name"], "limit": 50}
         )
 
     def test_product_admin_form_uses_widget(self):
@@ -115,7 +115,7 @@ class ProductAdminFetchWizardTests(TestCase):
         mock_execute.assert_called_once_with(
             "product.product",
             "search_read",
-            [("name", "ilike", "Wid")],
+            [[("name", "ilike", "Wid")]],
             {
                 "fields": [
                     "name",
@@ -163,7 +163,7 @@ class ProductAdminFetchWizardTests(TestCase):
         mock_execute.assert_called_once_with(
             "product.product",
             "search_read",
-            [],
+            [[]],
             {
                 "fields": [
                     "name",
@@ -227,7 +227,7 @@ class ProductAdminRegisterFromOdooTests(TestCase):
         mock_execute.assert_called_once_with(
             "product.product",
             "search_read",
-            [],
+            [[]],
             {
                 "fields": [
                     "name",


### PR DESCRIPTION
## Summary
- send search domains to Odoo using the expected nested list in both the fetch wizard and register view
- update the product registration view and tests to align with the corrected execute arguments
- remove the duplicate heading from the register-from-odoo admin template

## Testing
- pytest tests/test_odoo_product.py

------
https://chatgpt.com/codex/tasks/task_e_68d86007aed08326b90bdbd655a7762d