### PR TITLE
Log GetConfiguration timeouts in admin action

### DIFF
--- a/ocpp/admin.py
+++ b/ocpp/admin.py
@@ -367,6 +367,16 @@ class ChargerAdmin(LogViewAdminMixin, EntityModelAdmin):
                     "requested_at": timezone.now(),
                 },
             )
+            store.schedule_call_timeout(
+                message_id,
+                timeout=5.0,
+                action="GetConfiguration",
+                log_key=log_key,
+                message=(
+                    "GetConfiguration timed out: charger did not respond"
+                    " (operation may not be supported)"
+                ),
+            )
             fetched += 1
         if fetched:
             self.message_user(


### PR DESCRIPTION
## Summary
- log a timeout message when admin-triggered GetConfiguration requests remain unanswered
- add a store utility to schedule pending-call timeout notices and cover the behavior with tests

## Testing
- pytest ocpp/tests.py::ChargerAdminTests::test_fetch_configuration_timeout_logged -q

------
https://chatgpt.com/codex/tasks/task_e_68d867f111508326876bfbef82ca6331