### PR TITLE
Set auto-upgrade interval to five minutes for all modes

### DIFF
--- a/core/auto_upgrade.py
+++ b/core/auto_upgrade.py
@@ -39,8 +39,8 @@ def ensure_auto_upgrade_periodic_task(
     except Exception:
         return
 
-    mode = mode_file.read_text().strip() or "version"
-    interval_minutes = 5 if mode == "latest" else 10
+    _mode = mode_file.read_text().strip() or "version"
+    interval_minutes = 5
 
     try:
         schedule, _ = IntervalSchedule.objects.get_or_create(

--- a/tests/test_auto_upgrade_scheduler.py
+++ b/tests/test_auto_upgrade_scheduler.py
@@ -11,7 +11,7 @@ def test_ensure_auto_upgrade_task_skips_without_lock(tmp_path):
     assert not PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).exists()
 
 
-def test_ensure_auto_upgrade_task_uses_latest_interval(tmp_path):
+def test_ensure_auto_upgrade_task_uses_five_minute_interval_for_latest(tmp_path):
     PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
 
     locks_dir = tmp_path / "locks"
@@ -26,7 +26,7 @@ def test_ensure_auto_upgrade_task_uses_latest_interval(tmp_path):
     assert task.interval.period == IntervalSchedule.MINUTES
 
 
-def test_ensure_auto_upgrade_task_uses_version_interval(tmp_path):
+def test_ensure_auto_upgrade_task_uses_five_minute_interval_for_version(tmp_path):
     PeriodicTask.objects.filter(name=AUTO_UPGRADE_TASK_NAME).delete()
 
     locks_dir = tmp_path / "locks"
@@ -37,5 +37,5 @@ def test_ensure_auto_upgrade_task_uses_version_interval(tmp_path):
 
     task = PeriodicTask.objects.get(name=AUTO_UPGRADE_TASK_NAME)
     assert task.task == AUTO_UPGRADE_TASK_PATH
-    assert task.interval.every == 10
+    assert task.interval.every == 5
     assert task.interval.period == IntervalSchedule.MINUTES


### PR DESCRIPTION
## Summary
- update the auto-upgrade scheduler to always schedule checks every five minutes
- refresh the auto-upgrade scheduler tests to reflect the consistent interval

## Testing
- pytest tests/test_auto_upgrade_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68d86f521e34832696705c234ddf108f