### PR TITLE
Fix release log naming and publish context capture

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1046,7 +1046,9 @@ class ReleaseProgressFixtureVisibilityTests(TestCase):
                 package=package, version=current_version
             )
         self.session_key = f"release_publish_{self.release.pk}"
-        self.log_name = f"{self.release.package.name}-{self.release.version}.log"
+        self.log_name = core_views._release_log_name(
+            self.release.package.name, self.release.version
+        )
         self.lock_path = Path("locks") / f"{self.session_key}.json"
         self.restart_path = Path("locks") / f"{self.session_key}.restarts"
         self.log_path = Path("logs") / self.log_name


### PR DESCRIPTION
## Summary
- ensure release logs are written to `logs/pr.<package>.v<version>.log` via a shared helper and update log cleanup/rename logic
- render the release progress template manually so the template_rendered signal fires and adjust tests to adopt the new log naming helper

## Testing
- pytest tests/test_release_progress.py

------
https://chatgpt.com/codex/tasks/task_e_68d86c0d4a38832683e9ccf7cb1430d7