### PR TITLE
Handle duplicate node public endpoints during registration

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -451,7 +451,46 @@ class Node(Entity):
         """Determine if this node represents the current host."""
         return self.mac_address == self.get_current_mac()
 
+    @classmethod
+    def _generate_unique_public_endpoint(
+        cls, value: str | None, *, exclude_pk: int | None = None
+    ) -> str:
+        """Return a unique public endpoint slug for ``value``."""
+
+        field = cls._meta.get_field("public_endpoint")
+        max_length = getattr(field, "max_length", None) or 50
+        base_slug = slugify(value or "") or "node"
+        if len(base_slug) > max_length:
+            base_slug = base_slug[:max_length]
+        slug = base_slug
+        queryset = cls.objects.all()
+        if exclude_pk is not None:
+            queryset = queryset.exclude(pk=exclude_pk)
+        counter = 2
+        while queryset.filter(public_endpoint=slug).exists():
+            suffix = f"-{counter}"
+            available = max_length - len(suffix)
+            if available <= 0:
+                slug = suffix[-max_length:]
+            else:
+                slug = f"{base_slug[:available]}{suffix}"
+            counter += 1
+        return slug
+
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+
+        def include_update_field(field: str):
+            nonlocal update_fields
+            if update_fields is None:
+                return
+            fields = set(update_fields)
+            if field in fields:
+                return
+            fields.add(field)
+            update_fields = tuple(fields)
+            kwargs["update_fields"] = update_fields
+
         role_name = None
         role = getattr(self, "role", None)
         if role and getattr(role, "name", None):
@@ -468,17 +507,28 @@ class Node(Entity):
             not self.badge_color or self.badge_color == self.DEFAULT_BADGE_COLOR
         ):
             self.badge_color = role_color
-            update_fields = kwargs.get("update_fields")
-            if update_fields:
-                fields = set(update_fields)
-                if "badge_color" not in fields:
-                    fields.add("badge_color")
-                    kwargs["update_fields"] = tuple(fields)
+            include_update_field("badge_color")
 
         if self.mac_address:
             self.mac_address = self.mac_address.lower()
-        if not self.public_endpoint:
-            self.public_endpoint = slugify(self.hostname)
+        endpoint_value = slugify(self.public_endpoint or "")
+        if not endpoint_value:
+            endpoint_value = self._generate_unique_public_endpoint(
+                self.hostname, exclude_pk=self.pk
+            )
+        else:
+            queryset = (
+                self.__class__.objects.exclude(pk=self.pk)
+                if self.pk
+                else self.__class__.objects.all()
+            )
+            if queryset.filter(public_endpoint=endpoint_value).exists():
+                endpoint_value = self._generate_unique_public_endpoint(
+                    self.hostname or endpoint_value, exclude_pk=self.pk
+                )
+        if self.public_endpoint != endpoint_value:
+            self.public_endpoint = endpoint_value
+            include_update_field("public_endpoint")
         super().save(*args, **kwargs)
         if self.pk:
             self.refresh_features()

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -245,6 +245,41 @@ class NodeGetLocalTests(TestCase):
         hostnames = {n["hostname"] for n in data["nodes"]}
         self.assertEqual(hostnames, {"dup", "local2"})
 
+    def test_register_node_generates_unique_public_endpoint(self):
+        url = reverse("register-node")
+        User = get_user_model()
+        user = User.objects.create_user(username="registrar", password="pwd")
+        self.client.force_login(user)
+        first = self.client.post(
+            url,
+            data={
+                "hostname": "duplicate-host",
+                "address": "10.0.0.10",
+                "port": 8080,
+                "mac_address": "00:11:22:33:aa:bb",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(first.status_code, 200)
+        node_one = Node.objects.get(mac_address="00:11:22:33:aa:bb")
+        self.assertEqual(node_one.public_endpoint, "duplicate-host")
+
+        second = self.client.post(
+            url,
+            data={
+                "hostname": "duplicate-host",
+                "address": "10.0.0.11",
+                "port": 8081,
+                "mac_address": "00:11:22:33:aa:cc",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(second.status_code, 200)
+        node_two = Node.objects.get(mac_address="00:11:22:33:aa:cc")
+
+        self.assertNotEqual(node_one.public_endpoint, node_two.public_endpoint)
+        self.assertTrue(node_two.public_endpoint.startswith("duplicate-host-"))
+
     def test_register_node_feature_toggle(self):
         NodeFeature.objects.get_or_create(
             slug="clipboard-poll", defaults={"display": "Clipboard Poll"}


### PR DESCRIPTION
## Summary
- ensure Node.save generates a unique `public_endpoint` slug when hostnames collide
- normalize endpoint updates when saving to avoid unique constraint errors
- cover duplicate-hostname registration with a regression test

## Testing
- pytest nodes/tests.py::NodeGetLocalTests::test_register_node_generates_unique_public_endpoint

------
https://chatgpt.com/codex/tasks/task_e_68d871e3b4fc8326aa1220a246f96382