### PR TITLE
Add multiple node feature actions and Raspberry Pi camera stream view

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -84,21 +84,33 @@ class NodeFeature(Entity):
 
     objects = NodeFeatureManager()
 
-    DEFAULT_ACTIONS = {
-        "rfid-scanner": NodeFeatureDefaultAction(
-            label="Scan RFIDs", url_name="admin:core_rfid_scan"
+    DEFAULT_ACTIONS: dict[str, tuple[NodeFeatureDefaultAction, ...]] = {
+        "rfid-scanner": (
+            NodeFeatureDefaultAction(
+                label="Scan RFIDs", url_name="admin:core_rfid_scan"
+            ),
         ),
-        "celery-queue": NodeFeatureDefaultAction(
-            label="Celery Report",
-            url_name="admin:nodes_nodefeature_celery_report",
+        "celery-queue": (
+            NodeFeatureDefaultAction(
+                label="Celery Report",
+                url_name="admin:nodes_nodefeature_celery_report",
+            ),
         ),
-        "screenshot-poll": NodeFeatureDefaultAction(
-            label="Take Screenshot",
-            url_name="admin:nodes_nodefeature_take_screenshot",
+        "screenshot-poll": (
+            NodeFeatureDefaultAction(
+                label="Take Screenshot",
+                url_name="admin:nodes_nodefeature_take_screenshot",
+            ),
         ),
-        "rpi-camera": NodeFeatureDefaultAction(
-            label="Take a Snapshot",
-            url_name="admin:nodes_nodefeature_take_snapshot",
+        "rpi-camera": (
+            NodeFeatureDefaultAction(
+                label="Take a Snapshot",
+                url_name="admin:nodes_nodefeature_take_snapshot",
+            ),
+            NodeFeatureDefaultAction(
+                label="View stream",
+                url_name="admin:nodes_nodefeature_view_stream",
+            ),
         ),
     }
 
@@ -141,10 +153,19 @@ class NodeFeature(Entity):
             return (base_path / "locks" / lock).exists()
         return False
 
-    def get_default_action(self) -> NodeFeatureDefaultAction | None:
-        """Return the configured default action for this feature if any."""
+    def get_default_actions(self) -> tuple[NodeFeatureDefaultAction, ...]:
+        """Return the configured default actions for this feature."""
 
-        return self.DEFAULT_ACTIONS.get(self.slug)
+        actions = self.DEFAULT_ACTIONS.get(self.slug, ())
+        if isinstance(actions, NodeFeatureDefaultAction):  # pragma: no cover - legacy
+            return (actions,)
+        return actions
+
+    def get_default_action(self) -> NodeFeatureDefaultAction | None:
+        """Return the first configured default action for this feature if any."""
+
+        actions = self.get_default_actions()
+        return actions[0] if actions else None
 
 
 def get_terminal_role():

--- a/nodes/templates/admin/nodes/nodefeature/view_stream.html
+++ b/nodes/templates/admin/nodes/nodefeature/view_stream.html
@@ -1,0 +1,47 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<div id="content-main" class="camera-stream">
+  <div class="module">
+    <h2>{% trans "Raspberry Pi Camera stream" %}</h2>
+    <p class="help">
+      {% blocktrans %}
+        The live feed below opens in an embedded frame. If the stream does not appear,
+        ensure the Raspberry Pi camera service is running and reachable.
+      {% endblocktrans %}
+    </p>
+    <div class="camera-stream__frame">
+      <iframe
+        src="{{ stream_url }}"
+        title="{% trans "Camera stream" %}"
+        allow="autoplay; fullscreen"
+        allowfullscreen
+        referrerpolicy="no-referrer"
+      ></iframe>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  .camera-stream__frame {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+    background: #000;
+  }
+
+  .camera-stream__frame iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow node features to expose multiple default actions and render them individually in the admin changelist
- add an admin view and template to open the Raspberry Pi camera stream alongside the existing snapshot action
- expand the test suite to cover the new actions, stream view access controls, and multi-action mapping

## Testing
- pytest nodes/tests.py -k "node_feature_list_shows_all_actions_for_rpi_camera or view_stream or rpi_camera_feature_has_multiple_actions" -q


------
https://chatgpt.com/codex/tasks/task_e_68d873d478448326b04a7fb9b4ea6595