### PR TITLE
Adjust RFID admin scanner behavior

### DIFF
--- a/tests/test_rfid_admin_scan_csrf.py
+++ b/tests/test_rfid_admin_scan_csrf.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from pathlib import Path
@@ -10,9 +11,10 @@ import django
 
 django.setup()
 
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from core.models import RFID
 
 
 pytestmark = [pytest.mark.feature("rfid-scanner")]
@@ -32,3 +34,40 @@ class AdminRfidScanCsrfTests(TestCase):
     def test_scan_view_allows_post_without_csrf(self):
         response = self.client.post(reverse("admin:core_rfid_scan"))
         self.assertEqual(response.status_code, 200)
+
+
+class AdminRfidScanNextTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="scanadmin",
+            email="scanadmin@example.com",
+            password="password",
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.url = reverse("admin:core_rfid_scan_next")
+
+    def post_scan(self, payload):
+        return self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_scan_next_post_updates_last_seen_for_existing_tag(self):
+        tag = RFID.objects.create(rfid="ABCDEF01")
+        self.assertIsNone(tag.last_seen_on)
+
+        response = self.post_scan({"rfid": tag.rfid})
+
+        self.assertEqual(response.status_code, 200)
+        tag.refresh_from_db()
+        self.assertIsNotNone(tag.last_seen_on)
+
+    def test_scan_next_post_sets_last_seen_when_creating_tag(self):
+        response = self.post_scan({"rfid": "11223344"})
+
+        self.assertEqual(response.status_code, 200)
+        tag = RFID.objects.get(rfid="11223344")
+        self.assertIsNotNone(tag.last_seen_on)


### PR DESCRIPTION
## Summary
- rename the RFID admin list column to "Label" and hide unused energy account and added-on columns
- update the admin scanner endpoint to validate posted values so scanning records updates last-seen timestamps
- add tests covering the scanner POST workflow for existing and newly created tags

## Testing
- pytest tests/test_rfid_admin_scan_csrf.py

------
https://chatgpt.com/codex/tasks/task_e_68d8809eb7348326a34d4a4e00ca98a6