### PR TITLE
Add logging around Odoo product fetch failures

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -16,6 +16,7 @@ from django.contrib.auth.admin import (
     GroupAdmin as DjangoGroupAdmin,
     UserAdmin as DjangoUserAdmin,
 )
+import logging
 from import_export import resources, fields
 from import_export.admin import ImportExportModelAdmin
 from import_export.widgets import ForeignKeyWidget
@@ -77,6 +78,8 @@ from .user_data import (
 from .widgets import OdooProductWidget
 from .mcp import process as mcp_process
 from .mcp.server import resolve_base_urls
+
+logger = logging.getLogger(__name__)
 
 
 admin.site.unregister(Group)
@@ -1998,6 +2001,13 @@ class ProductAdmin(EntityModelAdmin):
             try:
                 results = self._search_odoo_products(profile, form)
             except Exception:
+                logger.exception(
+                    "Failed to fetch Odoo products for user %s (profile_id=%s, host=%s, database=%s)",
+                    getattr(getattr(request, "user", None), "pk", None),
+                    getattr(profile, "pk", None),
+                    getattr(profile, "host", None),
+                    getattr(profile, "database", None),
+                )
                 form.add_error(None, _("Unable to fetch products from Odoo."))
                 results = []
             else:

--- a/core/models.py
+++ b/core/models.py
@@ -16,6 +16,7 @@ from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 from django.views.decorators.debug import sensitive_variables
 from datetime import time as datetime_time, timedelta
+import logging
 from django.contrib.contenttypes.models import ContentType
 import hashlib
 import os
@@ -36,6 +37,8 @@ from defusedxml import xmlrpc as defused_xmlrpc
 
 defused_xmlrpc.monkey_patch()
 xmlrpc_client = defused_xmlrpc.xmlrpc_client
+
+logger = logging.getLogger(__name__)
 
 from .entity import Entity, EntityUserManager, EntityManager
 from .release import Package as ReleasePackage, Credentials, DEFAULT_PACKAGE
@@ -593,6 +596,15 @@ class OdooProfile(Profile):
                 kwargs,
             )
         except Exception:
+            logger.exception(
+                "Odoo RPC %s.%s failed for profile %s (host=%s, database=%s, username=%s)",
+                model,
+                method,
+                self.pk,
+                self.host,
+                self.database,
+                self.username,
+            )
             self._clear_verification()
             self.save(update_fields=["verified_on"])
             raise

--- a/core/views.py
+++ b/core/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import shutil
 from datetime import timedelta
 
@@ -28,6 +29,8 @@ from django.test import signals
 from utils import revision
 from utils.api import api_login_required
 
+logger = logging.getLogger(__name__)
+
 from .models import Product, EnergyAccount, PackageRelease, Todo
 from .models import RFID
 
@@ -47,6 +50,13 @@ def odoo_products(request):
             {"fields": ["name"], "limit": 50},
         )
     except Exception:
+        logger.exception(
+            "Failed to fetch Odoo products via API for user %s (profile_id=%s, host=%s, database=%s)",
+            getattr(request.user, "pk", None),
+            getattr(profile, "pk", None),
+            getattr(profile, "host", None),
+            getattr(profile, "database", None),
+        )
         return JsonResponse({"detail": "Unable to fetch products"}, status=502)
     items = [{"id": p.get("id"), "name": p.get("name", "")} for p in products]
     return JsonResponse(items, safe=False)


### PR DESCRIPTION
## Summary
- add logging to OdooProfile.execute so RPC failures emit host, database, and profile context
- emit admin-side logging when product fetch attempts fail to help triage credential issues
- log API fetch failures to capture information for support follow-up

## Testing
- pytest tests/test_odoo_profile.py tests/test_odoo_profile_admin.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8827477588326b48e47ade8e6923d