### PR TITLE
Prioritize query string charger IDs for OCPP connections

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import asyncio
 import inspect
 import json
+from urllib.parse import parse_qs
 from django.utils import timezone
 from core.models import EnergyAccount, Reference, RFID as CoreRFID
 from nodes.models import NetMessage
@@ -153,9 +154,37 @@ class CSMSConsumer(AsyncWebsocketConsumer):
 
     consumption_update_interval = 300
 
+    def _extract_serial_identifier(self) -> str:
+        """Return the charge point serial from the query string or path."""
+
+        query_bytes = self.scope.get("query_string") or b""
+        if query_bytes:
+            try:
+                parsed = parse_qs(
+                    query_bytes.decode("utf-8", "ignore"),
+                    keep_blank_values=False,
+                )
+            except Exception:
+                parsed = {}
+            if parsed:
+                normalized = {
+                    key.lower(): values for key, values in parsed.items() if values
+                }
+                for candidate in (
+                    "cid",
+                    "chargepointid",
+                    "charge_point_id",
+                    "chargerid",
+                ):
+                    values = normalized.get(candidate)
+                    if values:
+                        return values[0]
+
+        return self.scope["url_route"]["kwargs"].get("cid", "")
+
     @requires_network
     async def connect(self):
-        raw_serial = self.scope["url_route"]["kwargs"].get("cid", "")
+        raw_serial = self._extract_serial_identifier()
         try:
             self.charger_id = Charger.validate_serial(raw_serial)
         except ValidationError as exc:

--- a/ocpp/routing.py
+++ b/ocpp/routing.py
@@ -4,6 +4,8 @@ from . import consumers
 
 websocket_urlpatterns = [
     re_path(r"^ws/sink/$", consumers.SinkConsumer.as_asgi()),
-    # Accept connections at any path; the last segment is the charger ID
-    re_path(r"^(?:.*/)?(?P<cid>[^/]+)/?$", consumers.CSMSConsumer.as_asgi()),
+    # Accept connections at any path; the last segment is the charger ID.
+    # Some charge points omit the final segment and only provide the
+    # identifier via query parameters, so allow an empty match here.
+    re_path(r"^(?:.*/)?(?P<cid>[^/]*)/?$", consumers.CSMSConsumer.as_asgi()),
 ]

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -2396,6 +2396,50 @@ class SimulatorAdminTests(TransactionTestCase):
 
         await communicator.disconnect()
 
+    async def test_query_string_cid_supported(self):
+        communicator = WebsocketCommunicator(application, "/?cid=QSERIAL")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QSERIAL")
+        self.assertEqual(charger.last_path, "/")
+
+    async def test_query_string_charge_point_id_supported(self):
+        communicator = WebsocketCommunicator(
+            application, "/?chargePointId=QCHARGE"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QCHARGE")
+        self.assertEqual(charger.last_path, "/")
+
+    async def test_query_string_cid_overrides_path_segment(self):
+        communicator = WebsocketCommunicator(application, "/ocpp?cid=QSEGOVR")
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QSEGOVR")
+        self.assertEqual(charger.last_path, "/ocpp")
+
+    async def test_query_string_charge_point_id_overrides_path_segment(self):
+        communicator = WebsocketCommunicator(
+            application, "/ocpp?chargePointId=QPSEG"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QPSEG")
+        self.assertEqual(charger.last_path, "/ocpp")
+
     async def test_nested_path_accepted_and_recorded(self):
         communicator = WebsocketCommunicator(application, "/foo/NEST/")
         connected, _ = await communicator.connect()


### PR DESCRIPTION
## Summary
- update the CSMS consumer to prefer query string identifiers before path segments when deriving charger serial numbers
- extend simulator WebSocket tests to cover query string overrides for base paths like /ocpp

## Testing
- pytest ocpp/tests.py -k "query_string"


------
https://chatgpt.com/codex/tasks/task_e_68d885ba51ec8326ba24be13162f314d