### PR TITLE
Stop listing Control as a feature in status output

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -87,16 +87,9 @@ if [ -f "$LOCK_DIR/lcd_screen.lck" ]; then
 else
   LCD_FEATURE=false
 fi
-if [ -f "$LOCK_DIR/control.lck" ]; then
-  CONTROL_FEATURE=true
-else
-  CONTROL_FEATURE=false
-fi
-
 echo "Features:"
 echo "  Celery: $CELERY_FEATURE"
 echo "  LCD screen: $LCD_FEATURE"
-echo "  Control: $CONTROL_FEATURE"
 
 echo "Checking running status..."
 RUNNING=false


### PR DESCRIPTION
## Summary
- remove the Control lock check from `status.sh` so the script no longer lists Control as a feature

## Testing
- ./status.sh


------
https://chatgpt.com/codex/tasks/task_e_68d89359d2a88326b42e4dfce30700a1