### PR TITLE
Use pipe separator for node feature actions

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -543,7 +543,7 @@ class NodeFeatureAdmin(EntityModelAdmin):
 
         if not links:
             return "—"
-        return format_html_join("<br>", "{}", ((link,) for link in links))
+        return format_html_join(" | ", "{}", ((link,) for link in links))
 
     def _manual_enablement_message(self, feature, node):
         if node is None:


### PR DESCRIPTION
## Summary
- replace the `<br>` separator between node feature action links with a simple pipe character so actions stay on one line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89d78419483269854b9782dc19825