### PR TITLE
Add chargeBoxId support to OCPP websocket handshake

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -174,6 +174,7 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                     "cid",
                     "chargepointid",
                     "charge_point_id",
+                    "chargeboxid",
                     "chargerid",
                 ):
                     values = normalized.get(candidate)

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -2413,6 +2413,18 @@ class SimulatorAdminTests(TransactionTestCase):
         charger = await database_sync_to_async(Charger.objects.get)(charger_id="QCHARGE")
         self.assertEqual(charger.last_path, "/")
 
+    async def test_query_string_charge_box_id_supported(self):
+        communicator = WebsocketCommunicator(
+            application, "/?chargeBoxId=QBOX"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QBOX")
+        self.assertEqual(charger.last_path, "/")
+
     async def test_query_string_cid_overrides_path_segment(self):
         communicator = WebsocketCommunicator(application, "/ocpp?cid=QSEGOVR")
         connected, _ = await communicator.connect()


### PR DESCRIPTION
## Summary
- allow the CSMS consumer to read the chargeBoxId query parameter during handshake
- add a regression test that verifies a connection using chargeBoxId is accepted

## Testing
- pytest ocpp/tests.py -k charge_box

------
https://chatgpt.com/codex/tasks/task_e_68d94ce2bd3083268c48747e101aa084