### PR TITLE
Improve OCPP handshake serial extraction

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -157,11 +157,13 @@ class CSMSConsumer(AsyncWebsocketConsumer):
     def _extract_serial_identifier(self) -> str:
         """Return the charge point serial from the query string or path."""
 
+        self.serial_source = None
         query_bytes = self.scope.get("query_string") or b""
+        self._raw_query_string = query_bytes.decode("utf-8", "ignore") if query_bytes else ""
         if query_bytes:
             try:
                 parsed = parse_qs(
-                    query_bytes.decode("utf-8", "ignore"),
+                    self._raw_query_string,
                     keep_blank_values=False,
                 )
             except Exception:
@@ -175,13 +177,21 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                     "chargepointid",
                     "charge_point_id",
                     "chargeboxid",
+                    "chargeboxidentity",
+                    "chargepointidentity",
                     "chargerid",
                 ):
                     values = normalized.get(candidate)
                     if values:
+                        self.serial_source = f"query:{candidate}"
                         return values[0]
 
-        return self.scope["url_route"]["kwargs"].get("cid", "")
+        value = self.scope["url_route"]["kwargs"].get("cid", "")
+        if value:
+            self.serial_source = "path"
+        elif self.serial_source is None:
+            self.serial_source = "path:empty"
+        return value
 
     @requires_network
     async def connect(self):
@@ -192,6 +202,13 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             serial = Charger.normalize_serial(raw_serial)
             store_key = store.pending_key(serial)
             message = exc.messages[0] if exc.messages else "Invalid Serial Number"
+            details: list[str] = []
+            if getattr(self, "serial_source", None):
+                details.append(f"serial_source={self.serial_source}")
+            if getattr(self, "_raw_query_string", ""):
+                details.append(f"query_string={self._raw_query_string!r}")
+            if details:
+                message = f"{message} ({'; '.join(details)})"
             store.add_log(
                 store_key,
                 f"Rejected connection: {message}",

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -2425,6 +2425,18 @@ class SimulatorAdminTests(TransactionTestCase):
         charger = await database_sync_to_async(Charger.objects.get)(charger_id="QBOX")
         self.assertEqual(charger.last_path, "/")
 
+    async def test_query_string_charge_box_identity_supported(self):
+        communicator = WebsocketCommunicator(
+            application, "/?chargeBoxIdentity=QIDENT"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QIDENT")
+        self.assertEqual(charger.last_path, "/")
+
     async def test_query_string_cid_overrides_path_segment(self):
         communicator = WebsocketCommunicator(application, "/ocpp?cid=QSEGOVR")
         connected, _ = await communicator.connect()


### PR DESCRIPTION
## Summary
- allow the CSMS consumer to recognise additional OCPP query parameter names such as chargeBoxIdentity and chargePointIdentity when extracting charger serials
- record the query string and source used when a connection is rejected for an invalid serial to aid troubleshooting
- cover the new handshake parameter in SimulatorAdmin websocket tests

## Testing
- pytest ocpp/tests.py -k "charge_box_identity" -q

------
https://chatgpt.com/codex/tasks/task_e_68d94989778883269de63ac708dd5229