### PR TITLE
Harden chargeBoxId handshake parsing

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -174,11 +174,19 @@ class CSMSConsumer(AsyncWebsocketConsumer):
                     "cid",
                     "chargepointid",
                     "charge_point_id",
+                    "chargeboxid",
+                    "charge_box_id",
                     "chargerid",
                 ):
                     values = normalized.get(candidate)
-                    if values:
-                        return values[0]
+                    if not values:
+                        continue
+                    for value in values:
+                        if not value:
+                            continue
+                        trimmed = value.strip()
+                        if trimmed:
+                            return trimmed
 
         return self.scope["url_route"]["kwargs"].get("cid", "")
 

--- a/ocpp/templates/ocpp/dashboard.html
+++ b/ocpp/templates/ocpp/dashboard.html
@@ -18,6 +18,9 @@
   <p class="mb-1">{% blocktrans with limit=ws_rate_limit %}Rate limiting applies (maximum {{ limit }} simultaneous connections per IP).{% endblocktrans %}</p>
   <p class="mb-0">{% blocktrans %}Use the following WebSocket URL format, replacing &lt;CHARGE_POINT_ID&gt; with your charge point identifier:{% endblocktrans %}</p>
   <pre class="mb-0"><code>{{ demo_ws_url }}</code></pre>
+  <p class="mb-0 mt-2">
+    {% blocktrans trimmed %}You may also provide the identifier as a query parameter using any of the following names: <code>cid</code>, <code>chargePointId</code>, <code>charge_point_id</code>, <code>chargeBoxId</code>, or <code>chargerId</code>.{% endblocktrans %}
+  </p>
 </div>
 <script>
   (function () {

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -2413,6 +2413,46 @@ class SimulatorAdminTests(TransactionTestCase):
         charger = await database_sync_to_async(Charger.objects.get)(charger_id="QCHARGE")
         self.assertEqual(charger.last_path, "/")
 
+    async def test_query_string_charge_box_id_supported(self):
+        communicator = WebsocketCommunicator(
+            application, "/?chargeBoxId=QBOX"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(charger_id="QBOX")
+        self.assertEqual(charger.last_path, "/")
+
+    async def test_query_string_charge_box_id_case_insensitive(self):
+        communicator = WebsocketCommunicator(
+            application, "/?CHARGEBOXID=CaseSense"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(
+            charger_id="CaseSense"
+        )
+        self.assertEqual(charger.last_path, "/")
+
+    async def test_query_string_charge_box_id_strips_whitespace(self):
+        communicator = WebsocketCommunicator(
+            application, "/?chargeBoxId=%20Trimmed%20Value%20"
+        )
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+        charger = await database_sync_to_async(Charger.objects.get)(
+            charger_id="Trimmed Value"
+        )
+        self.assertEqual(charger.last_path, "/")
+
     async def test_query_string_cid_overrides_path_segment(self):
         communicator = WebsocketCommunicator(application, "/ocpp?cid=QSEGOVR")
         connected, _ = await communicator.connect()


### PR DESCRIPTION
## Summary
- ensure the CSMS handshake honors chargeBoxId/charge_box_id query parameters and ignores empty values
- add regression coverage for case-insensitive and whitespace-trimmed chargeBoxId handshakes
- document the supported query parameter names on the OCPP dashboard demo notice

## Testing
- pytest ocpp/tests.py -k "charge_box"

------
https://chatgpt.com/codex/tasks/task_e_68d94ce2bd3083268c48747e101aa084