### PR TITLE
Add table mode to RFID scanner

### DIFF
--- a/core/fixtures/todo__validate_screen_rfid_scanner.json
+++ b/core/fixtures/todo__validate_screen_rfid_scanner.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate screen RFID Scanner",
+      "url": "/ocpp/rfid/",
+      "request_details": "Ensure both the single and table modes render correctly, record scans, and show the running total."
+    }
+  }
+]

--- a/ocpp/rfid/views.py
+++ b/ocpp/rfid/views.py
@@ -62,10 +62,29 @@ def scan_deep(_request):
 @login_required(login_url="pages:login")
 def reader(request):
     """Public page to scan RFID tags."""
+    params = request.GET.copy()
+    mode = params.get("mode")
+    table_mode = mode == "table"
+    params = params.copy()
+    params._mutable = True
+    if table_mode:
+        params.pop("mode", None)
+        toggle_label = "Switch to Single Mode"
+    else:
+        params["mode"] = "table"
+        toggle_label = "Switch to Table Mode"
+    toggle_query = params.urlencode()
+    toggle_url = request.path
+    if toggle_query:
+        toggle_url = f"{toggle_url}?{toggle_query}"
+
     context = {
         "scan_url": reverse("rfid-scan-next"),
         "restart_url": reverse("rfid-scan-restart"),
         "test_url": reverse("rfid-scan-test"),
+        "table_mode": table_mode,
+        "toggle_url": toggle_url,
+        "toggle_label": toggle_label,
     }
     if request.user.is_staff:
         context["admin_change_url_template"] = reverse(

--- a/ocpp/templates/rfid/reader.html
+++ b/ocpp/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
 {% block content %}
 <h1>RFID Scanner</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url %}
+{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label %}
 {% endblock %}

--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -1,5 +1,8 @@
 {% with prefix=prefix|default:"rfid" %}
   <div id="{{ prefix }}-scanner">
+  <div class="rfid-mode-toggle">
+    <a class="rfid-mode-button" id="{{ prefix }}-mode-toggle" href="{{ toggle_url }}">{{ toggle_label }}</a>
+  </div>
   <p id="{{ prefix }}-status">Scanner ready</p>
   <p>
     {% if request.user.is_authenticated %}
@@ -11,17 +14,59 @@
       <a id="{{ prefix }}-configure" href="#" style="display:none; margin-left:1em;"></a>
     {% endif %}
   </p>
-  <div class="field"><span class="label">Label:</span><span class="value" id="{{ prefix }}-label"></span></div>
-  <div class="field"><span class="label">Type:</span><span class="value" id="{{ prefix }}-kind"></span></div>
-  <div class="field"><span class="label">Color:</span><span class="value" id="{{ prefix }}-color"></span></div>
-  <div class="field"><span class="label">Valid:</span><span class="value" id="{{ prefix }}-allowed"></span></div>
-  {% if request.user.is_staff %}
-    <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
-    <div class="field"><span class="label">Released:</span><span class="value" id="{{ prefix }}-released"></span></div>
-    <div class="field"><span class="label">Reference:</span><span class="value" id="{{ prefix }}-reference"></span></div>
+  {% if table_mode %}
+    <div class="rfid-table-mode">
+      <table class="rfid-history" id="{{ prefix }}-history">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Label</th>
+            <th>Type</th>
+            <th>Color</th>
+            <th>Valid</th>
+            {% if request.user.is_staff %}
+              <th>RFID</th>
+              <th>Released</th>
+              <th>Reference</th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody id="{{ prefix }}-history-body"></tbody>
+      </table>
+      <p class="rfid-history-total">Total scanned: <span id="{{ prefix }}-total-count">0</span></p>
+    </div>
+  {% else %}
+    <div class="field"><span class="label">Label:</span><span class="value" id="{{ prefix }}-label"></span></div>
+    <div class="field"><span class="label">Type:</span><span class="value" id="{{ prefix }}-kind"></span></div>
+    <div class="field"><span class="label">Color:</span><span class="value" id="{{ prefix }}-color"></span></div>
+    <div class="field"><span class="label">Valid:</span><span class="value" id="{{ prefix }}-allowed"></span></div>
+    {% if request.user.is_staff %}
+      <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
+      <div class="field"><span class="label">Released:</span><span class="value" id="{{ prefix }}-released"></span></div>
+      <div class="field"><span class="label">Reference:</span><span class="value" id="{{ prefix }}-reference"></span></div>
+    {% endif %}
   {% endif %}
 </div>
 <style>
+#{{ prefix }}-scanner .rfid-mode-toggle {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1em;
+}
+#{{ prefix }}-scanner .rfid-mode-button {
+  background-color: #005a9c;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1em;
+  padding: 0.5em 1em;
+  text-decoration: none;
+}
+#{{ prefix }}-scanner .rfid-mode-button:hover,
+#{{ prefix }}-scanner .rfid-mode-button:focus {
+  background-color: #004377;
+}
 #{{ prefix }}-scanner .field {
   display: flex;
   margin: 0.5em 0;
@@ -33,6 +78,26 @@
 }
 #{{ prefix }}-scanner .value {
   flex: 1;
+}
+#{{ prefix }}-scanner .rfid-table-mode {
+  margin-top: 1em;
+}
+#{{ prefix }}-scanner .rfid-history {
+  border-collapse: collapse;
+  width: 100%;
+}
+#{{ prefix }}-scanner .rfid-history th,
+#{{ prefix }}-scanner .rfid-history td {
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  text-align: left;
+}
+#{{ prefix }}-scanner .rfid-history thead {
+  background-color: #f5f5f5;
+}
+#{{ prefix }}-scanner .rfid-history-total {
+  font-weight: bold;
+  margin-top: 0.75em;
 }
 #{{ prefix }}-status {
   font-size: 1.2em;
@@ -54,12 +119,53 @@
   const deepBtn = document.getElementById('{{ prefix }}-deep-read');
   const configureEl = document.getElementById('{{ prefix }}-configure');
   const adminTemplate = '{{ admin_change_url_template|default:""|escapejs }}';
+  const tableMode = {{ table_mode|yesno:"true,false" }};
+  const historyBody = tableMode ? document.getElementById('{{ prefix }}-history-body') : null;
+  const totalCountEl = tableMode ? document.getElementById('{{ prefix }}-total-count') : null;
+  const isStaff = {{ request.user.is_staff|yesno:"true,false" }};
 
+  let historyCount = 0;
   let localPort = null;
   let localReader = null;
   let localConnected = false;
   let lastLocalValue = null;
   let lastLocalAt = 0;
+
+  function booleanText(value){
+    if(value === undefined || value === null){
+      return '';
+    }
+    return value ? 'Yes' : 'No';
+  }
+
+  function appendHistoryRow(data, labelValue){
+    if(!historyBody){
+      return;
+    }
+    const row = document.createElement('tr');
+    const cells = [
+      new Date().toLocaleTimeString(),
+      labelValue,
+      data.kind || '',
+      data.color || '',
+      booleanText(data.allowed),
+    ];
+    if(isStaff){
+      cells.push(data.rfid || '');
+      cells.push(booleanText(data.released));
+      cells.push(data.reference || '');
+    }
+    cells.forEach((value) => {
+      const cell = document.createElement('td');
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+    historyBody.insertBefore(row, historyBody.firstChild);
+    historyCount += 1;
+    if(totalCountEl){
+      totalCountEl.textContent = String(historyCount);
+    }
+  }
 
   function showError(message){
     console.error(message);
@@ -82,14 +188,18 @@
       return;
     }
     const labelValue = data.label_id === undefined || data.label_id === null ? '' : data.label_id;
-    labelEl.textContent = labelValue;
+    if(labelEl){ labelEl.textContent = labelValue; }
     if(kindEl){ kindEl.textContent = data.kind || ''; }
     if(rfidEl){ rfidEl.textContent = data.rfid || ''; }
-    colorEl.textContent = data.color || '';
-    allowedEl.textContent = data.allowed === undefined ? '' : (data.allowed ? 'Yes' : 'No');
-    if(releasedEl){ releasedEl.textContent = data.released === undefined ? '' : (data.released ? 'Yes' : 'No'); }
+    if(colorEl){ colorEl.textContent = data.color || ''; }
+    if(allowedEl){ allowedEl.textContent = booleanText(data.allowed); }
+    if(releasedEl){ releasedEl.textContent = booleanText(data.released); }
     if(referenceEl){ referenceEl.textContent = data.reference || ''; }
-    if(referenceEl && data.reference && /^https?:\/\//i.test(data.reference)){
+    const hasReferenceLink = data.reference && /^https?:\/\//i.test(data.reference);
+    if(referenceEl && hasReferenceLink){
+      const w = window.open(data.reference, '_blank');
+      if(w){ w.focus(); }
+    } else if(!referenceEl && tableMode && isStaff && hasReferenceLink){
       const w = window.open(data.reference, '_blank');
       if(w){ w.focus(); }
     }
@@ -101,6 +211,9 @@
     const okText = data.allowed === undefined ? '' : (data.allowed ? 'OK' : 'BAD');
     const statusMsg = okText ? `RFID ${labelValue} ${okText}` : `RFID ${labelValue}`;
     statusEl.textContent = data.created ? `Created ${statusMsg}` : statusMsg;
+    if(tableMode){
+      appendHistoryRow(data, labelValue);
+    }
   }
 
   async function poll(){


### PR DESCRIPTION
## Summary
- add query parameter handling to toggle the RFID scanner between single and table modes
- render a table-mode interface that keeps a visible RFID scan history with a running total
- add a release-manager TODO to validate the updated RFID scanner screen

## Testing
- python -m compileall ocpp/rfid/views.py ocpp/templates/rfid/reader.html ocpp/templates/rfid/scanner.html

------
https://chatgpt.com/codex/tasks/task_e_68dac5020b94832681accd7a08c029e0