### PR TITLE
Disable Django autoreloader for all VS runserver launches

### DIFF
--- a/tests/test_vscode_manage.py
+++ b/tests/test_vscode_manage.py
@@ -22,6 +22,7 @@ def test_wrapper_strips_debugpy(monkeypatch):
     assert "DEBUGPY_LAUNCHER_PORT" not in os.environ
     assert "/debugpy" not in os.environ["PYTHONPATH"]
     assert os.environ["DEBUG"] == "1"
+    assert sys.argv == ["manage.py", "runserver", "--noreload"]
 
 
 def test_wrapper_sets_debug_env_without_debugger(monkeypatch):
@@ -33,7 +34,21 @@ def test_wrapper_sets_debug_env_without_debugger(monkeypatch):
         runpy, "run_path", lambda path, run_name: called.setdefault("path", path)
     )
 
-    vscode_manage.main(["runserver", "--noreload"])
+    monkeypatch.setattr(sys, "argv", ["python"])
+
+    vscode_manage.main(["runserver"])
 
     assert called["path"] == "manage.py"
     assert os.environ["DEBUG"] == "0"
+    assert sys.argv == ["manage.py", "runserver", "--noreload"]
+
+
+def test_wrapper_adds_noreload_for_debug_sessions(monkeypatch):
+    monkeypatch.setenv("DEBUGPY_LAUNCHER_PORT", "1234")
+
+    monkeypatch.setattr(runpy, "run_path", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", ["python"])
+
+    vscode_manage.main(["runserver", "0.0.0.0:8000"])
+
+    assert sys.argv == ["manage.py", "runserver", "--noreload", "0.0.0.0:8000"]

--- a/vscode_manage.py
+++ b/vscode_manage.py
@@ -21,6 +21,8 @@ def main(argv=None):
     is_debug_session = "DEBUGPY_LAUNCHER_PORT" in os.environ
     if is_runserver:
         os.environ["DEBUG"] = "1" if is_debug_session else "0"
+        if "--noreload" not in argv:
+            argv.insert(1, "--noreload")
     try:
         if celery_enabled:
             worker = subprocess.Popen(


### PR DESCRIPTION
## Summary
- ensure the Visual Studio manage wrapper always injects --noreload when runserver is invoked
- expand the unit tests to assert --noreload is added for both debug and regular VS runs

## Testing
- pytest tests/test_vscode_manage.py

------
https://chatgpt.com/codex/tasks/task_e_68dacdb7da30832698ce3b7e79765473