### PR TITLE
Remove unused autoreloader banner

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -21,8 +21,6 @@ def main() -> None:
     if rev_short:
         msg += f" r{rev_short}"
     print(msg)
-    if os.environ.get("RUN_MAIN") != "true":
-        print("Preparing Django auto-reloader...")
     try:
         from django.core.management import execute_from_command_line
         from daphne.management.commands.runserver import (


### PR DESCRIPTION
## Summary
- remove the custom autoreloader banner from manage.py so runserver --noreload stays quiet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadec2d1fc83268a7951d8eaa1429b