### PR TITLE
Add missing translations for charger status screen

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -29,3 +29,11 @@ msgstr "Italienisch"
 msgid "German"
 msgstr "Deutsch"
 
+#: ocpp/views.py:747 ocpp/views.py:934
+msgid "Charger timestamps"
+msgstr "Zeitstempel der Ladestation"
+
+#: ocpp/templates/ocpp/charger_status.html:132
+msgid "Select a connector to view live chart data."
+msgstr "Wählen Sie einen Anschluss aus, um Live-Diagrammdaten anzuzeigen."
+

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -692,3 +692,11 @@ msgstr "Disponible"
 #: ocpp/views.py:29
 msgid "Offline"
 msgstr "Sin conexión"
+
+#: ocpp/views.py:747 ocpp/views.py:934
+msgid "Charger timestamps"
+msgstr "Marcas de tiempo del cargador"
+
+#: ocpp/templates/ocpp/charger_status.html:132
+msgid "Select a connector to view live chart data."
+msgstr "Seleccione un conector para ver los datos de la gráfica en vivo."

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -29,3 +29,11 @@ msgstr "Italiano"
 msgid "German"
 msgstr "Tedesco"
 
+#: ocpp/views.py:747 ocpp/views.py:934
+msgid "Charger timestamps"
+msgstr "Timestamp del caricatore"
+
+#: ocpp/templates/ocpp/charger_status.html:132
+msgid "Select a connector to view live chart data."
+msgstr "Seleziona un connettore per visualizzare i dati del grafico in tempo reale."
+


### PR DESCRIPTION
## Summary
- add German, Italian, and Spanish translations for the charger status timestamps label
- translate the charger connector selection helper text in all supported locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db38e17370832696d207e5f0e10064