### PR TITLE
Handle missing TODO when marking done

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1330,6 +1330,14 @@ class TodoDoneTests(TestCase):
         self.assertIsNotNone(todo.done_on)
         self.assertFalse(todo.is_deleted)
 
+    def test_mark_done_missing_task_refreshes(self):
+        todo = Todo.objects.create(request="Task", is_seed_data=True)
+        todo.delete()
+        resp = self.client.post(reverse("todo-done", args=[todo.pk]))
+        self.assertRedirects(resp, reverse("admin:index"))
+        messages = [m.message for m in get_messages(resp.wsgi_request)]
+        self.assertFalse(messages)
+
     def test_mark_done_condition_failure_shows_message(self):
         todo = Todo.objects.create(
             request="Task",

--- a/core/views.py
+++ b/core/views.py
@@ -1403,8 +1403,11 @@ def todo_focus(request, pk: int):
 @staff_member_required
 @require_POST
 def todo_done(request, pk: int):
-    todo = get_object_or_404(Todo, pk=pk, is_deleted=False, done_on__isnull=True)
     redirect_to = _get_return_url(request)
+    try:
+        todo = Todo.objects.get(pk=pk, is_deleted=False, done_on__isnull=True)
+    except Todo.DoesNotExist:
+        return redirect(redirect_to)
     result = todo.check_on_done_condition()
     if not result.passed:
         messages.error(request, _format_condition_failure(todo, result))


### PR DESCRIPTION
## Summary
- redirect back to the dashboard when a TODO no longer exists instead of showing an error
- add a regression test ensuring missing TODOs refresh the page without messages

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=config.settings pytest core/tests.py::TodoDoneTests::test_mark_done_missing_task_refreshes -q --import-mode=importlib


------
https://chatgpt.com/codex/tasks/task_e_68db3db9d94083269249518d8687c65f