### PR TITLE
Align Spanish decimal formatting with Mexican conventions

### DIFF
--- a/config/formats/__init__.py
+++ b/config/formats/__init__.py
@@ -1,0 +1,2 @@
+"""Custom locale format definitions for the Arthexis project."""
+

--- a/config/formats/es.py
+++ b/config/formats/es.py
@@ -1,0 +1,5 @@
+"""Spanish locale customisations aligned with Mexican formatting."""
+
+DECIMAL_SEPARATOR = "."
+THOUSAND_SEPARATOR = ","
+NUMBER_GROUPING = 3

--- a/config/settings.py
+++ b/config/settings.py
@@ -567,6 +567,8 @@ LANGUAGES = [
 
 LOCALE_PATHS = [BASE_DIR / "locale"]
 
+FORMAT_MODULE_PATH = ["config.formats"]
+
 TIME_ZONE = "America/Monterrey"
 
 USE_I18N = True


### PR DESCRIPTION
## Summary
- add a project-level formats module for locale overrides
- configure the Spanish locale to use Mexican decimal and thousands separators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db42940c548326be3c8c7bba540522