### PR TITLE
Ensure optional RFID tags are tracked and flagged

### DIFF
--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -293,7 +293,7 @@ class CSMSConsumerTests(TransactionTestCase):
 
     async def test_rfid_recorded(self):
         await database_sync_to_async(Charger.objects.create)(charger_id="RFIDREC")
-        communicator = WebsocketCommunicator(application, "/RFIDREC/")
+        communicator = WebsocketCommunicator(application, "/RFIDREC/?cid=RFIDREC")
         connected, _ = await communicator.connect()
         self.assertTrue(connected)
 
@@ -307,6 +307,10 @@ class CSMSConsumerTests(TransactionTestCase):
             pk=tx_id, charger__charger_id="RFIDREC"
         )
         self.assertEqual(tx.rfid, "TAG123")
+
+        tag = await database_sync_to_async(RFID.objects.get)(rfid="TAG123")
+        self.assertFalse(tag.allowed)
+        self.assertIsNotNone(tag.last_seen_on)
 
         await communicator.disconnect()
 


### PR DESCRIPTION
## Summary
- ensure optional RFID tags are persisted with a helper that records last-seen timestamps and defaults them to disallowed
- update the Authorize and StartTransaction flows to invoke the helper when RFID authorization is disabled
- extend the StartTransaction test to assert new tags are created as disallowed and reachable via query-string serials

## Testing
- pytest ocpp/tests.py::DispatchActionTests::test_trigger_message_registers_pending_call -q
- pytest ocpp/tests.py::CSMSConsumerTests::test_rfid_recorded -q

------
https://chatgpt.com/codex/tasks/task_e_68db452fa5088326a08584a46246d685