### PR TITLE
Stop binding internal nginx to port 80

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -369,6 +369,7 @@ else
     sudo tee "$NGINX_CONF" > /dev/null <<'NGINXCONF'
 server {
     listen 8000;
+    listen 8080;
     server_name _;
     location / {
         proxy_pass http://127.0.0.1:PORT_PLACEHOLDER;

--- a/network-setup.sh
+++ b/network-setup.sh
@@ -599,7 +599,7 @@ if [[ $RUN_FIREWALL == true ]]; then
     if [ "$MODE" = "public" ]; then
         PORTS+=(80 443 8000)
     else
-        PORTS+=(8000 8888)
+        PORTS+=(8000 8080 8888)
     fi
 
     if command -v ufw >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- update the internal nginx configuration to listen on ports 8000 and 8080 while proxying traffic to the application on 8888
- adjust the network setup firewall expectations to allow the updated internal nginx ports

## Testing
- pytest tests/test_install_script.py

------
https://chatgpt.com/codex/tasks/task_e_68db47ab243c832682accf9502eb279e