### PR TITLE
Mark non-release revisions in status announcements

### DIFF
--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -31,6 +31,21 @@ def _startup_notification() -> None:
     rev_short = revision_value[-6:] if revision_value else ""
 
     body = version
+    if body:
+        normalized = body.lstrip("vV") or body
+        base_version = normalized.rstrip("+")
+        needs_marker = False
+        if base_version and revision_value:
+            try:  # pragma: no cover - defensive guard
+                from core.models import PackageRelease
+
+                needs_marker = not PackageRelease.matches_revision(
+                    base_version, revision_value
+                )
+            except Exception:
+                logger.debug("Startup release comparison failed", exc_info=True)
+        if needs_marker and not normalized.endswith("+"):
+            body = f"{body}+"
     if rev_short:
         body = f"{body} r{rev_short}" if body else f"r{rev_short}"
 

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -7,7 +7,7 @@ from django.db.utils import DatabaseError
 from django.db.models.signals import post_delete
 from django.dispatch import Signal, receiver
 from core.entity import Entity
-from core.models import Profile
+from core.models import PackageRelease, Profile
 from core.fields import SigilLongAutoField, SigilShortAutoField
 import re
 import json
@@ -755,7 +755,16 @@ def _format_upgrade_body(version: str, revision: str) -> str:
     parts: list[str] = []
     if version:
         normalized = version.lstrip("vV") or version
-        parts.append(f"v{normalized}")
+        base_version = normalized.rstrip("+")
+        display_version = normalized
+        if (
+            base_version
+            and revision
+            and not PackageRelease.matches_revision(base_version, revision)
+            and not normalized.endswith("+")
+        ):
+            display_version = f"{display_version}+"
+        parts.append(f"v{display_version}")
     if revision:
         rev_clean = re.sub(r"[^0-9A-Za-z]", "", revision)
         rev_short = (rev_clean[-6:] if rev_clean else revision[-6:])


### PR DESCRIPTION
## Summary
- add a helper on PackageRelease to detect whether a revision matches the published release
- include a '+' suffix on startup net messages and peer notifications when running non-release commits
- cover the new behavior with startup and node registration tests

## Testing
- pytest nodes/tests.py::StartupNotificationTests::test_startup_notification_marks_nonrelease_version
- pytest nodes/tests.py::NodeGetLocalTests::test_register_node_marks_nonrelease_version

------
https://chatgpt.com/codex/tasks/task_e_68dc0c5c6a7883268605ba9646d3c499