### PR TITLE
feat: add admin reply shortcut for net messages

### DIFF
--- a/nodes/templates/admin/nodes/netmessage/change_form.html
+++ b/nodes/templates/admin/nodes/netmessage/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/user_datum_change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {% if original %}
+    <li>
+      <a class="addlink" href="{% url opts|admin_urlname:'add' %}?reply_to={{ original.pk }}">{% trans "Reply Message" %}</a>
+    </li>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -1503,6 +1503,27 @@ class NetMessageAdminTests(TransactionTestCase):
         self.assertEqual(response.status_code, 302)
         mock_propagate.assert_called_once()
 
+    def test_reply_action_prefills_initial_data(self):
+        role = NodeRole.objects.get(name="Terminal")
+        node = Node.objects.create(
+            hostname="remote",
+            address="10.0.0.10",
+            port=8100,
+            mac_address="00:11:22:33:44:55",
+            role=role,
+        )
+        original = NetMessage.objects.create(
+            subject="Ping",
+            body="Hello",
+            node_origin=node,
+        )
+        url = f"{reverse('admin:nodes_netmessage_add')}?reply_to={original.pk}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["adminform"].form
+        self.assertEqual(form["subject"].value(), "Re: Ping")
+        self.assertEqual(str(form["reach"].value()), str(role.pk))
+
 
 class LastNetMessageViewTests(TestCase):
     def setUp(self):
@@ -1511,10 +1532,19 @@ class LastNetMessageViewTests(TestCase):
 
     def test_returns_latest_message(self):
         NetMessage.objects.create(subject="old", body="msg1")
-        NetMessage.objects.create(subject="new", body="msg2")
+        latest = NetMessage.objects.create(subject="new", body="msg2")
         resp = self.client.get(reverse("last-net-message"))
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), {"subject": "new", "body": "msg2"})
+        self.assertEqual(
+            resp.json(),
+            {
+                "subject": "new",
+                "body": "msg2",
+                "admin_url": reverse(
+                    "admin:nodes_netmessage_change", args=[latest.pk]
+                ),
+            },
+        )
 
 
 class NetMessageReachTests(TestCase):

--- a/nodes/views.py
+++ b/nodes/views.py
@@ -8,6 +8,7 @@ from django.http.request import split_domain_port
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
 from django.conf import settings
+from django.urls import reverse
 from pathlib import Path
 from django.utils.cache import patch_vary_headers
 
@@ -536,5 +537,11 @@ def last_net_message(request):
 
     msg = NetMessage.objects.order_by("-created").first()
     if not msg:
-        return JsonResponse({"subject": "", "body": ""})
-    return JsonResponse({"subject": msg.subject, "body": msg.body})
+        return JsonResponse({"subject": "", "body": "", "admin_url": ""})
+    return JsonResponse(
+        {
+            "subject": msg.subject,
+            "body": msg.body,
+            "admin_url": reverse("admin:nodes_netmessage_change", args=[msg.pk]),
+        }
+    )

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -138,7 +138,11 @@
 <div id="admin-home-header" style="display:flex; justify-content:space-between; align-items:center;">
   <h1>Home</h1>
   <div style="display:flex; align-items:center; gap:8px;">
-    <span id="last-netmessage" style="display:none; font-family:monospace; white-space:nowrap; margin-right:8px;"></span>
+    <a
+      id="last-netmessage"
+      href="#"
+      style="display:none; font-family:monospace; white-space:nowrap; margin-right:8px; color:#fff; text-decoration:none;"
+    ></a>
     <a class="button" href="{% url 'admin:seed_data' %}">{% translate 'Seed Data' %}</a>
     <a class="button" href="{% url 'admin:user_data' %}">{% translate 'User Data' %}</a>
     <a class="button" href="{% url 'admin:system' %}">{% translate 'System' %}</a>
@@ -237,17 +241,31 @@
     window.addEventListener('DOMContentLoaded', () => {
       const label = document.getElementById('last-netmessage');
       if (!label) return;
-      let last = '';
+      let lastKey = '';
       async function fetchMessage() {
         try {
           const resp = await fetch('{% url 'last-net-message' %}');
           if (!resp.ok) return;
           const data = await resp.json();
           const text = `${data.subject || ''} - ${data.body || ''}`.replace(/[\r\n]+/g, ' ').trim();
-          if (text && text !== last) {
+          const adminUrl = data.admin_url || '';
+          const key = `${text}\u0000${adminUrl}`;
+          if (text && key !== lastKey) {
             label.textContent = text;
+            if (adminUrl) {
+              label.href = adminUrl;
+              label.style.pointerEvents = 'auto';
+            } else {
+              label.removeAttribute('href');
+              label.style.pointerEvents = 'none';
+            }
             label.style.display = 'inline';
-            last = text;
+            lastKey = key;
+          } else if (!text) {
+            label.style.display = 'none';
+            label.removeAttribute('href');
+            label.style.pointerEvents = 'none';
+            lastKey = '';
           }
         } catch (e) {
           // ignore errors


### PR DESCRIPTION
## Summary
- make the admin dashboard's latest net message display as a link to its change form
- add a Reply Message object tool on NetMessage admin that prefills the add form for replies
- include the change-form URL in the last-net-message endpoint and cover the workflow with tests

## Testing
- pytest nodes/tests.py::NetMessageAdminTests::test_reply_action_prefills_initial_data nodes/tests.py::LastNetMessageViewTests::test_returns_latest_message

------
https://chatgpt.com/codex/tasks/task_e_68dc212ef9d48326bf09cfbb226ed3be