### PR TITLE
Add database router for persistent RFID storage

### DIFF
--- a/config/data/model_databases.json
+++ b/config/data/model_databases.json
@@ -1,0 +1,3 @@
+{
+  "core.rfid": "persistent"
+}

--- a/config/database_router.py
+++ b/config/database_router.py
@@ -1,0 +1,49 @@
+"""Database router that directs selected models to named aliases."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.conf import settings
+
+
+class ModelDatabaseRouter:
+    """Route models to database aliases configured in ``settings.MODEL_DATABASES``."""
+
+    default_alias = "default"
+
+    @staticmethod
+    def _alias_for_model(model: type[Any]) -> str:
+        label = getattr(model._meta, "label_lower", None)
+        if not label:
+            return ModelDatabaseRouter.default_alias
+        alias = settings.MODEL_DATABASES.get(label)
+        if alias and alias in settings.DATABASES:
+            return alias
+        return ModelDatabaseRouter.default_alias
+
+    def db_for_read(self, model: type[Any], **hints: Any) -> str | None:
+        return self._alias_for_model(model)
+
+    def db_for_write(self, model: type[Any], **hints: Any) -> str | None:
+        return self._alias_for_model(model)
+
+    def allow_relation(self, obj1: Any, obj2: Any, **hints: Any) -> bool | None:
+        return self._alias_for_model(obj1.__class__) == self._alias_for_model(obj2.__class__)
+
+    def allow_migrate(
+        self,
+        db: str,
+        app_label: str,
+        model_name: str | None = None,
+        **hints: Any,
+    ) -> bool | None:
+        if not model_name:
+            return None
+        label = f"{app_label}.{model_name}".lower()
+        alias = settings.MODEL_DATABASES.get(label)
+        if alias and alias in settings.DATABASES:
+            return db == alias
+        if alias and alias not in settings.DATABASES:
+            return db == self.default_alias
+        return db == self.default_alias

--- a/tests/test_model_database_router.py
+++ b/tests/test_model_database_router.py
@@ -1,0 +1,60 @@
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+from config.database_router import ModelDatabaseRouter
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Overriding setting DATABASES can lead to unexpected behavior.",
+)
+
+
+class _FakeMeta:
+    def __init__(self, label_lower: str) -> None:
+        self.label_lower = label_lower
+
+
+def _fake_model(label_lower: str) -> type:
+    return type("FakeModel", (), {"_meta": _FakeMeta(label_lower)})
+
+
+def _persistent_override() -> override_settings:
+    databases = settings.DATABASES.copy()
+    databases["persistent"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+    mapping = dict(settings.MODEL_DATABASES)
+    mapping["core.rfid"] = "persistent"
+    return override_settings(DATABASES=databases, MODEL_DATABASES=mapping)
+
+
+def test_router_uses_configured_alias():
+    with _persistent_override():
+        router = ModelDatabaseRouter()
+        rfid_model = _fake_model("core.rfid")
+        assert router.db_for_read(rfid_model) == "persistent"
+        assert router.db_for_write(rfid_model) == "persistent"
+        assert router.allow_migrate("persistent", "core", "rfid") is True
+        assert router.allow_migrate("default", "core", "rfid") is False
+
+
+def test_router_defaults_when_alias_missing():
+    with override_settings(MODEL_DATABASES={"core.rfid": "persistent"}):
+        router = ModelDatabaseRouter()
+        rfid_model = _fake_model("core.rfid")
+        assert router.db_for_read(rfid_model) == "default"
+        assert router.db_for_write(rfid_model) == "default"
+        assert router.allow_migrate("default", "core", "rfid") is True
+        assert router.allow_migrate("persistent", "core", "rfid") is False
+
+
+def test_router_blocks_cross_database_relations():
+    with _persistent_override():
+        router = ModelDatabaseRouter()
+        rfid_model_class = _fake_model("core.rfid")
+        default_model_class = _fake_model("core.user")
+        rfid_obj = rfid_model_class()
+        other_obj = default_model_class()
+        assert router.allow_relation(rfid_obj, rfid_obj) is True
+        assert router.allow_relation(rfid_obj, other_obj) is False


### PR DESCRIPTION
## Summary
- keep SQLite as the default database while registering a persistent PostgreSQL alias when available
- load per-model database mappings from config/data/model_databases.json and route RFID traffic through the new database router
- update env-refresh to migrate every configured alias and add regression coverage for the router

## Testing
- pytest tests/test_model_database_router.py

------
https://chatgpt.com/codex/tasks/task_e_68dc24e5a6488326884aa19e7763426d