### PR TITLE
Add admin/public view toggles and refresh RFID scanner styles

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -35,6 +35,7 @@ import calendar
 import re
 from django_object_actions import DjangoObjectActions
 from ocpp.models import Transaction
+from ocpp.rfid.utils import build_mode_toggle
 from nodes.models import EmailOutbox
 from .models import (
     User,
@@ -2368,12 +2369,24 @@ class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
 
     def scan_view(self, request):
         context = self.admin_site.each_context(request)
-        context["scan_url"] = reverse("admin:core_rfid_scan_next")
-        context["admin_change_url_template"] = reverse(
-            "admin:core_rfid_change", args=[0]
+        table_mode, toggle_url, toggle_label = build_mode_toggle(request)
+        public_view_url = reverse("rfid-reader")
+        if table_mode:
+            public_view_url = f"{public_view_url}?mode=table"
+        context.update(
+            {
+                "scan_url": reverse("admin:core_rfid_scan_next"),
+                "admin_change_url_template": reverse(
+                    "admin:core_rfid_change", args=[0]
+                ),
+                "title": _("Scan RFIDs"),
+                "opts": self.model._meta,
+                "table_mode": table_mode,
+                "toggle_url": toggle_url,
+                "toggle_label": toggle_label,
+                "public_view_url": public_view_url,
+            }
         )
-        context["title"] = _("Scan RFIDs")
-        context["opts"] = self.model._meta
         return render(request, "admin/core/rfid/scan.html", context)
 
     def scan_next(self, request):

--- a/core/templates/admin/core/rfid/scan.html
+++ b/core/templates/admin/core/rfid/scan.html
@@ -12,5 +12,5 @@
 
 {% block content %}
 <h1>{% trans "RFID Scanner" %}</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url prefix="admin" %}
+{% include "rfid/scanner.html" with scan_url=scan_url prefix="admin" table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label public_view_url=public_view_url %}
 {% endblock %}

--- a/ocpp/rfid/utils.py
+++ b/ocpp/rfid/utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from django.http import HttpRequest
+
+
+def build_mode_toggle(
+    request: HttpRequest, *, base_path: str | None = None
+) -> Tuple[bool, str, str]:
+    """Return table mode flag and toggle details for the RFID views."""
+
+    params = request.GET.copy()
+    mode = params.get("mode")
+    table_mode = mode == "table"
+
+    params = params.copy()
+    params._mutable = True
+    if table_mode:
+        params.pop("mode", None)
+        toggle_label = "Switch to Single Mode"
+    else:
+        params["mode"] = "table"
+        toggle_label = "Switch to Table Mode"
+
+    toggle_url = base_path or request.path
+    toggle_query = params.urlencode()
+    if toggle_query:
+        toggle_url = f"{toggle_url}?{toggle_query}"
+
+    return table_mode, toggle_url, toggle_label

--- a/ocpp/rfid/views.py
+++ b/ocpp/rfid/views.py
@@ -10,6 +10,7 @@ from pages.utils import landing
 
 from .scanner import scan_sources, restart_sources, test_sources, enable_deep_read_mode
 from .reader import validate_rfid_value
+from .utils import build_mode_toggle
 
 
 @login_required(login_url="pages:login")
@@ -62,21 +63,7 @@ def scan_deep(_request):
 @login_required(login_url="pages:login")
 def reader(request):
     """Public page to scan RFID tags."""
-    params = request.GET.copy()
-    mode = params.get("mode")
-    table_mode = mode == "table"
-    params = params.copy()
-    params._mutable = True
-    if table_mode:
-        params.pop("mode", None)
-        toggle_label = "Switch to Single Mode"
-    else:
-        params["mode"] = "table"
-        toggle_label = "Switch to Table Mode"
-    toggle_query = params.urlencode()
-    toggle_url = request.path
-    if toggle_query:
-        toggle_url = f"{toggle_url}?{toggle_query}"
+    table_mode, toggle_url, toggle_label = build_mode_toggle(request)
 
     context = {
         "scan_url": reverse("rfid-scan-next"),
@@ -85,10 +72,12 @@ def reader(request):
         "table_mode": table_mode,
         "toggle_url": toggle_url,
         "toggle_label": toggle_label,
+        "admin_view_url": None,
     }
     if request.user.is_staff:
         context["admin_change_url_template"] = reverse(
             "admin:core_rfid_change", args=[0]
         )
         context["deep_read_url"] = reverse("rfid-scan-deep")
+        context["admin_view_url"] = reverse("admin:core_rfid_scan")
     return render(request, "rfid/reader.html", context)

--- a/ocpp/templates/rfid/reader.html
+++ b/ocpp/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
 {% block content %}
 <h1>RFID Scanner</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label %}
+{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label admin_view_url=admin_view_url public_view_url=None %}
 {% endblock %}

--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -1,8 +1,15 @@
 {% with prefix=prefix|default:"rfid" %}
   <div id="{{ prefix }}-scanner">
-    {% if toggle_url %}
+    {% if toggle_url or admin_view_url or public_view_url %}
       <div class="rfid-mode-toggle">
-        <a id="{{ prefix }}-mode-toggle" class="button" href="{{ toggle_url }}" data-toggle-url="{{ toggle_url }}">{{ toggle_label }}</a>
+        {% if toggle_url %}
+          <a id="{{ prefix }}-mode-toggle" class="button" href="{{ toggle_url }}" data-toggle-url="{{ toggle_url }}">{{ toggle_label }}</a>
+        {% endif %}
+        {% if request.user.is_staff and admin_view_url %}
+          <a class="button secondary" href="{{ admin_view_url }}">Admin View</a>
+        {% elif request.user.is_staff and public_view_url %}
+          <a class="button secondary" href="{{ public_view_url }}">Public View</a>
+        {% endif %}
       </div>
     {% endif %}
   <p id="{{ prefix }}-status">Scanner ready</p>
@@ -50,10 +57,58 @@
   {% endif %}
 </div>
 <style>
+#{{ prefix }}-scanner {
+  --rfid-table-border: #d0d5dd;
+  --rfid-header-bg: #f1f5f9;
+  --rfid-header-text: #1f2937;
+  --rfid-row-bg: #ffffff;
+  --rfid-row-alt-bg: #f8fafc;
+  --rfid-row-text: #111827;
+  --rfid-row-hover-bg: #e0f2fe;
+}
+
+@media (prefers-color-scheme: dark) {
+  #{{ prefix }}-scanner {
+    --rfid-table-border: rgba(255, 255, 255, 0.24);
+    --rfid-header-bg: rgba(255, 255, 255, 0.08);
+    --rfid-header-text: #f9fafb;
+    --rfid-row-bg: rgba(17, 24, 39, 0.7);
+    --rfid-row-alt-bg: rgba(17, 24, 39, 0.55);
+    --rfid-row-text: #e5e7eb;
+    --rfid-row-hover-bg: rgba(59, 130, 246, 0.3);
+  }
+}
+
 #{{ prefix }}-scanner .rfid-mode-toggle {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75em;
   margin-bottom: 1em;
+}
+
+#{{ prefix }}-scanner .rfid-mode-toggle .button {
+  text-decoration: none;
+  padding: 0.35em 0.9em;
+  border-radius: 9999px;
+  font-weight: 600;
+  background: var(--rfid-header-bg);
+  color: var(--rfid-header-text);
+  border: 1px solid var(--rfid-table-border);
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+#{{ prefix }}-scanner .rfid-mode-toggle .button:hover {
+  background: var(--rfid-row-hover-bg);
+}
+
+#{{ prefix }}-scanner .rfid-mode-toggle .button.secondary {
+  background: transparent;
+  color: inherit;
+}
+
+#{{ prefix }}-scanner .rfid-mode-toggle .button.secondary:hover {
+  background: var(--rfid-header-bg);
 }
 
 #{{ prefix }}-scanner .field {
@@ -72,21 +127,45 @@
   margin-top: 1em;
 }
 #{{ prefix }}-scanner .rfid-history {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
+  border: 1px solid var(--rfid-table-border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background-color: var(--rfid-row-bg);
+  color: var(--rfid-row-text);
 }
 #{{ prefix }}-scanner .rfid-history th,
 #{{ prefix }}-scanner .rfid-history td {
-  border: 1px solid #ccc;
-  padding: 0.5em;
+  padding: 0.5em 0.75em;
   text-align: left;
+  border-right: 1px solid var(--rfid-table-border);
 }
-#{{ prefix }}-scanner .rfid-history thead {
-  background-color: #f5f5f5;
+#{{ prefix }}-scanner .rfid-history th:last-child,
+#{{ prefix }}-scanner .rfid-history td:last-child {
+  border-right: none;
+}
+#{{ prefix }}-scanner .rfid-history thead th {
+  background-color: var(--rfid-header-bg);
+  color: var(--rfid-header-text);
+  font-weight: 600;
+  border-bottom: 1px solid var(--rfid-table-border);
+}
+#{{ prefix }}-scanner .rfid-history tbody tr {
+  background-color: var(--rfid-row-bg);
+  transition: background-color 0.2s ease-in-out;
+}
+#{{ prefix }}-scanner .rfid-history tbody tr:nth-child(odd) {
+  background-color: var(--rfid-row-alt-bg);
+}
+#{{ prefix }}-scanner .rfid-history tbody tr:hover {
+  background-color: var(--rfid-row-hover-bg);
 }
 #{{ prefix }}-scanner .rfid-history-total {
   font-weight: bold;
   margin-top: 0.75em;
+  color: var(--rfid-row-text);
 }
 #{{ prefix }}-status {
   font-size: 1.2em;


### PR DESCRIPTION
## Summary
- add a shared helper to generate RFID scanner mode toggle links and reuse it in public and admin views
- expose the mode toggle in the admin scanner, add admin/public view shortcuts, and pass the new context values to templates
- refresh the RFID scanner table styling for light and dark themes with CSS variables and hover states

## Testing
- pytest tests/test_rfid_admin_scan_csrf.py

------
https://chatgpt.com/codex/tasks/task_e_68dc92e9713083268e08b9f60b9f5984