### PR TITLE
Update public RFID scanner display and validity rules

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2374,6 +2374,7 @@ class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
         )
         context["title"] = _("Scan RFIDs")
         context["opts"] = self.model._meta
+        context["show_release_info"] = True
         return render(request, "admin/core/rfid/scan.html", context)
 
     def scan_next(self, request):

--- a/core/templates/admin/core/rfid/scan.html
+++ b/core/templates/admin/core/rfid/scan.html
@@ -12,5 +12,5 @@
 
 {% block content %}
 <h1>{% trans "RFID Scanner" %}</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url prefix="admin" %}
+{% include "rfid/scanner.html" with scan_url=scan_url prefix="admin" show_release_info=show_release_info %}
 {% endblock %}

--- a/ocpp/rfid/views.py
+++ b/ocpp/rfid/views.py
@@ -85,6 +85,7 @@ def reader(request):
         "table_mode": table_mode,
         "toggle_url": toggle_url,
         "toggle_label": toggle_label,
+        "show_release_info": False,
     }
     if request.user.is_staff:
         context["admin_change_url_template"] = reverse(

--- a/ocpp/templates/rfid/reader.html
+++ b/ocpp/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
 {% block content %}
 <h1>RFID Scanner</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label %}
+{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label show_release_info=show_release_info %}
 {% endblock %}

--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -28,6 +28,8 @@
             <th>Valid</th>
             {% if request.user.is_staff %}
               <th>RFID</th>
+            {% endif %}
+            {% if show_release_info %}
               <th>Released</th>
               <th>Reference</th>
             {% endif %}
@@ -44,6 +46,8 @@
     <div class="field"><span class="label">Valid:</span><span class="value" id="{{ prefix }}-allowed"></span></div>
     {% if request.user.is_staff %}
       <div class="field"><span class="label">RFID:</span><span class="value" id="{{ prefix }}-rfid"></span></div>
+    {% endif %}
+    {% if show_release_info %}
       <div class="field"><span class="label">Released:</span><span class="value" id="{{ prefix }}-released"></span></div>
       <div class="field"><span class="label">Reference:</span><span class="value" id="{{ prefix }}-reference"></span></div>
     {% endif %}
@@ -114,6 +118,7 @@
   const historyBody = tableMode ? document.getElementById('{{ prefix }}-history-body') : null;
   const totalCountEl = tableMode ? document.getElementById('{{ prefix }}-total-count') : null;
   const isStaff = {{ request.user.is_staff|yesno:"true,false" }};
+  const showReleaseInfo = {{ show_release_info|yesno:"true,false" }};
 
   let historyCount = 0;
   let localPort = null;
@@ -139,6 +144,13 @@
     return value ? 'Yes' : 'No';
   }
 
+  function validText(data){
+    if(data.allowed === undefined || data.allowed === null){
+      return '';
+    }
+    return data.allowed && data.released ? 'Yes' : 'No';
+  }
+
   function appendHistoryRow(data, labelValue){
     if(!historyBody){
       return;
@@ -149,10 +161,12 @@
       labelValue,
       data.kind || '',
       data.color || '',
-      booleanText(data.allowed),
+      validText(data),
     ];
     if(isStaff){
       cells.push(data.rfid || '');
+    }
+    if(showReleaseInfo){
       cells.push(booleanText(data.released));
       cells.push(data.reference || '');
     }
@@ -193,14 +207,14 @@
     if(kindEl){ kindEl.textContent = data.kind || ''; }
     if(rfidEl){ rfidEl.textContent = data.rfid || ''; }
     if(colorEl){ colorEl.textContent = data.color || ''; }
-    if(allowedEl){ allowedEl.textContent = booleanText(data.allowed); }
+    if(allowedEl){ allowedEl.textContent = validText(data); }
     if(releasedEl){ releasedEl.textContent = booleanText(data.released); }
     if(referenceEl){ referenceEl.textContent = data.reference || ''; }
     const hasReferenceLink = data.reference && /^https?:\/\//i.test(data.reference);
     if(referenceEl && hasReferenceLink){
       const w = window.open(data.reference, '_blank');
       if(w){ w.focus(); }
-    } else if(!referenceEl && tableMode && isStaff && hasReferenceLink){
+    } else if(!referenceEl && tableMode && showReleaseInfo && hasReferenceLink){
       const w = window.open(data.reference, '_blank');
       if(w){ w.focus(); }
     }


### PR DESCRIPTION
## Summary
- hide Released and Reference details on the public RFID scanner while keeping them available in the admin scanner
- thread a show_release_info flag into the shared scanner template and history rows to match the selected context
- only display "Yes" for Valid when both the allowed and released flags are true

## Testing
- pytest tests/test_rfid_admin_reference_clear.py

------
https://chatgpt.com/codex/tasks/task_e_68dc94960fb483269fc098df88adb66d