### PR TITLE
Add migration number round-trip tests for PackageRelease

### DIFF
--- a/core/tests/test_package_release_model.py
+++ b/core/tests/test_package_release_model.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+
+import django
+from django.test import SimpleTestCase
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from core.models import PackageRelease
+
+
+class PackageReleaseMigrationTests(SimpleTestCase):
+    def test_version_bits_round_trip(self) -> None:
+        test_cases = [
+            "3.1.0",
+            "5.0.1",
+        ]
+
+        for version in test_cases:
+            with self.subTest(version=version):
+                release = PackageRelease(version=version)
+
+                major, minor, patch = (int(part) for part in version.split("."))
+                expected_migration = (major << 2) | (minor << 1) | patch
+
+                self.assertEqual(release.migration_number, expected_migration)
+                self.assertEqual(
+                    PackageRelease.version_from_migration(expected_migration),
+                    version,
+                )

--- a/core/tests/test_package_release_model.py
+++ b/core/tests/test_package_release_model.py
@@ -16,6 +16,7 @@ class PackageReleaseMigrationTests(SimpleTestCase):
         test_cases = [
             "3.1.0",
             "5.0.1",
+            "2.3.4",
         ]
 
         for version in test_cases:
@@ -23,7 +24,11 @@ class PackageReleaseMigrationTests(SimpleTestCase):
                 release = PackageRelease(version=version)
 
                 major, minor, patch = (int(part) for part in version.split("."))
-                expected_migration = (major << 2) | (minor << 1) | patch
+                expected_migration = (
+                    (major << PackageRelease._MAJOR_SHIFT)
+                    | (minor << PackageRelease._MINOR_SHIFT)
+                    | patch
+                )
 
                 self.assertEqual(release.migration_number, expected_migration)
                 self.assertEqual(


### PR DESCRIPTION
## Summary
- add a PackageRelease migration bit-math test covering versions 3.1.0 and 5.0.1
- assert the computed migration number and round-trip conversion via version_from_migration

## Testing
- pytest core/tests/test_package_release_model.py

------
https://chatgpt.com/codex/tasks/task_e_68dc967581688326bf1f789f80096b39