### PR TITLE
Add coverage for Node.normalize_relation inputs

### DIFF
--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -123,6 +123,32 @@ class NodeGetLocalDatabaseUnavailableTests(SimpleTestCase):
 
 
 class NodeGetLocalTests(TestCase):
+    def test_normalize_relation_handles_various_inputs(self):
+        self.assertEqual(
+            Node.normalize_relation(Node.Relation.UPSTREAM),
+            Node.Relation.UPSTREAM,
+        )
+        self.assertEqual(
+            Node.normalize_relation(None),
+            Node.Relation.PEER,
+        )
+        self.assertEqual(
+            Node.normalize_relation("Upstream"),
+            Node.Relation.UPSTREAM,
+        )
+        self.assertEqual(
+            Node.normalize_relation("DOWNSTREAM"),
+            Node.Relation.DOWNSTREAM,
+        )
+        self.assertEqual(
+            Node.normalize_relation("peer"),
+            Node.Relation.PEER,
+        )
+        self.assertEqual(
+            Node.normalize_relation("unexpected"),
+            Node.Relation.PEER,
+        )
+
     def test_register_current_does_not_create_release(self):
         node = None
         created = False


### PR DESCRIPTION
## Summary
- add a dedicated unit test covering Node.normalize_relation inputs including enum, None, labels, names, and unexpected strings

## Testing
- pytest nodes/tests.py -k normalize_relation

------
https://chatgpt.com/codex/tasks/task_e_68dc9aa78534832698d4b9c8ce481caf