### PR TITLE
Add test for NodeFeature without local node

### DIFF
--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -2475,6 +2475,13 @@ class NodeFeatureTests(TestCase):
         ):
             self.assertFalse(feature.is_enabled)
 
+    def test_feature_disabled_when_local_node_missing(self):
+        feature = NodeFeature.objects.create(slug="lcd-screen", display="LCD")
+        with patch("nodes.models.Node.get_local", return_value=None):
+            with patch("core.notifications.supports_gui_toast") as mock_toast:
+                self.assertFalse(feature.is_enabled)
+        mock_toast.assert_not_called()
+
     def test_rfid_scanner_lock(self):
         feature = NodeFeature.objects.create(slug="rfid-scanner", display="RFID")
         feature.roles.add(self.role)


### PR DESCRIPTION
## Summary
- add a regression test ensuring NodeFeature.is_enabled short-circuits when no local node is found
- verify gui toast checks remain untouched during the early return path

## Testing
- pytest nodes/tests.py::NodeFeatureTests::test_feature_disabled_when_local_node_missing

------
https://chatgpt.com/codex/tasks/task_e_68dc9aae9eac83269a2c263f291e3f68