### PR TITLE
Add test coverage for RFID backend authentication

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "feature(slug): mark test as requiring a node feature"
     )
+    config.addinivalue_line(
+        "markers", "django_db: mark test as requiring database access"
+    )
 
 
 def _env_flag(name: str) -> bool:

--- a/tests/test_rfid_backend.py
+++ b/tests/test_rfid_backend.py
@@ -1,0 +1,63 @@
+"""Tests for the RFID authentication backend."""
+
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from core.backends import RFIDBackend
+from core.models import EnergyAccount, RFID
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def backend():
+    return RFIDBackend()
+
+
+@pytest.fixture
+def user():
+    User = get_user_model()
+    return User.objects.create_user(
+        username=f"rfid-user-{uuid4()}",
+        email="rfid@example.com",
+        password="test-password",
+    )
+
+
+def test_authenticate_returns_user_for_allowed_rfid(backend, user):
+    account = EnergyAccount.objects.create(name="Test Account", user=user)
+    rfid = RFID.objects.create(rfid="ABC123")
+    account.rfids.add(rfid)
+
+    authenticated = backend.authenticate(request=None, rfid="abc123")
+
+    assert authenticated == user
+
+
+def test_authenticate_returns_none_when_rfid_missing(backend):
+    assert backend.authenticate(request=None, rfid=None) is None
+    assert backend.authenticate(request=None, rfid="") is None
+
+
+def test_authenticate_returns_none_when_rfid_not_allowed(backend, user):
+    account = EnergyAccount.objects.create(name="Disallowed Account", user=user)
+    rfid = RFID.objects.create(rfid="DEF456", allowed=False)
+    account.rfids.add(rfid)
+
+    assert backend.authenticate(request=None, rfid="def456") is None
+
+
+def test_authenticate_returns_none_when_account_has_no_user(backend):
+    account = EnergyAccount.objects.create(name="Unassigned Account")
+    rfid = RFID.objects.create(rfid="FED654")
+    account.rfids.add(rfid)
+
+    assert backend.authenticate(request=None, rfid="fed654") is None
+
+
+def test_get_user(backend, user):
+    assert backend.get_user(user.pk) == user
+    assert backend.get_user(999999) is None


### PR DESCRIPTION
## Summary
- add unit tests for RFIDBackend covering allowed and disallowed RFID scenarios
- register the django_db marker so pytest recognizes database-dependent tests

## Testing
- pytest tests/test_rfid_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9dace21883269619d53a214dcda7