### PR TITLE
Add tests for staff_required decorator

### DIFF
--- a/tests/test_staff_required_decorator.py
+++ b/tests/test_staff_required_decorator.py
@@ -1,0 +1,57 @@
+import pytest
+from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.urls import reverse
+
+from utils.decorators import staff_required
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def decorated_view():
+    @staff_required
+    def sample_view(request):
+        return HttpResponse("ok")
+
+    return sample_view
+
+
+def test_staff_required_redirects_non_staff_user(decorated_view):
+    rf = RequestFactory()
+    request = rf.get("/protected/")
+    request.user = get_user_model().objects.create_user(
+        "regular",
+        "regular@example.com",
+        "password",
+    )
+
+    response = decorated_view(request)
+
+    assert response.status_code == 302
+    login_url = reverse("admin:login")
+    expected_redirect = f"{login_url}?{REDIRECT_FIELD_NAME}=/protected/"
+    assert response.url == expected_redirect
+
+
+def test_staff_required_allows_staff_user(decorated_view):
+    rf = RequestFactory()
+    request = rf.get("/protected/")
+    request.user = get_user_model().objects.create_user(
+        "staff",
+        "staff@example.com",
+        "password",
+        is_staff=True,
+    )
+
+    response = decorated_view(request)
+
+    assert response.status_code == 200
+    assert response.content == b"ok"
+
+
+def test_staff_required_marks_view_with_attributes(decorated_view):
+    assert getattr(decorated_view, "login_required") is True
+    assert getattr(decorated_view, "staff_required") is True


### PR DESCRIPTION
## Summary
- add coverage for the staff_required decorator with pytest
- verify non-staff requests are redirected to the admin login
- confirm staff requests receive the underlying response and attributes are exposed

## Testing
- pytest tests/test_staff_required_decorator.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9de6fb908326beb93077ad9c5f4e