### PR TITLE
Add CSMSConsumer pending connector assignment test

### DIFF
--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -493,6 +493,63 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertTrue(message_mock.save.called)
         self.assertTrue(message_mock.propagate.called)
 
+    async def test_assign_connector_promotes_pending_connection(self):
+        serial = "ASSIGNPROMOTE"
+        path = f"/{serial}/"
+        pending_key = store.pending_key(serial)
+        new_key = store.identity_key(serial, 1)
+        aggregate_key = store.identity_key(serial, None)
+
+        store.connections.pop(pending_key, None)
+        store.connections.pop(new_key, None)
+        store.logs["charger"].pop(new_key, None)
+        store.log_names["charger"].pop(new_key, None)
+        store.log_names["charger"].pop(aggregate_key, None)
+
+        aggregate = await database_sync_to_async(Charger.objects.create)(
+            charger_id=serial,
+            connector_id=None,
+        )
+
+        consumer = CSMSConsumer()
+        consumer.scope = {"path": path, "headers": [], "client": ("127.0.0.1", 1234)}
+        consumer.charger_id = serial
+        consumer.store_key = pending_key
+        consumer.connector_value = None
+        consumer.client_ip = "127.0.0.1"
+        consumer.charger = aggregate
+        consumer.aggregate_charger = aggregate
+
+        store.connections[pending_key] = consumer
+
+        try:
+            with patch.object(Charger, "refresh_manager_node", autospec=True) as mock_refresh:
+                mock_refresh.return_value = None
+                await consumer._assign_connector(1)
+
+            self.assertEqual(consumer.store_key, new_key)
+            self.assertNotIn(pending_key, store.connections)
+
+            connector = await database_sync_to_async(Charger.objects.get)(
+                charger_id=serial,
+                connector_id=1,
+            )
+            self.assertEqual(consumer.charger.pk, connector.pk)
+            self.assertEqual(consumer.charger.connector_id, 1)
+            self.assertIsNone(consumer.aggregate_charger.connector_id)
+
+            self.assertIn(new_key, store.log_names["charger"])
+            self.assertIn(aggregate_key, store.log_names["charger"])
+
+            self.assertNotIn(pending_key, store.connections)
+        finally:
+            store.connections.pop(new_key, None)
+            store.connections.pop(pending_key, None)
+            store.logs["charger"].pop(new_key, None)
+            store.log_names["charger"].pop(new_key, None)
+            store.log_names["charger"].pop(aggregate_key, None)
+            await database_sync_to_async(Charger.objects.filter(charger_id=serial).delete)()
+
     async def test_change_availability_result_updates_model(self):
         store.pending_calls.clear()
         communicator = WebsocketCommunicator(application, "/AVAILRES/")


### PR DESCRIPTION
## Summary
- add an async regression test ensuring a pending CSMSConsumer connection is promoted to a connector-specific identity
- verify the connector-specific Charger row is created and that log name registrations occur for both connector and aggregate keys

## Testing
- python manage.py test ocpp.tests.CSMSConsumerTests.test_assign_connector_promotes_pending_connection *(fails: ModuleNotFoundError: No module named 'ocpp.tests.CSMSConsumerTests')*
- pytest --import-mode=importlib ocpp/tests.py::CSMSConsumerTests::test_assign_connector_promotes_pending_connection *(fails: ModuleNotFoundError: No module named 'tests')*


------
https://chatgpt.com/codex/tasks/task_e_68dca081d5a48326828510bdda25a4ad