### PR TITLE
Align coverage workflow with automated badge updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,7 +68,8 @@ jobs:
 
       - name: Generate coverage badge
         if: steps.coverage-data.outputs.has_data == 'true'
-        uses: tj-actions/coverage-badge-py@v2
+        run: |
+          coverage-badge -f -o coverage.svg
 
       - name: Verify coverage badge changes
         if: steps.coverage-data.outputs.has_data == 'true'
@@ -96,8 +97,10 @@ jobs:
         if: steps.coverage-data.outputs.has_data == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-xml
-          path: coverage.xml
+          name: coverage-reports
+          path: |
+            coverage.xml
+            coverage-report.txt
 
       - name: Fail if tests failed
         if: steps.pytest.outputs.exit_code != '0'


### PR DESCRIPTION
## Summary
- switch the coverage workflow to generate the badge via the coverage-badge CLI so it matches the documented automation plan
- bundle both the XML and text coverage reports as workflow artifacts to aid review

## Testing
- not run (GitHub Actions workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa9ed65483269f03c98c571c5f4f