### PR TITLE
Set newly detected RFIDs as allowed by default

### DIFF
--- a/ocpp/consumers.py
+++ b/ocpp/consumers.py
@@ -297,12 +297,12 @@ class CSMSConsumer(AsyncWebsocketConsumer):
             now = timezone.now()
             tag, created = CoreRFID.objects.get_or_create(
                 rfid=normalized,
-                defaults={"allowed": False, "last_seen_on": now},
+                defaults={"allowed": True, "last_seen_on": now},
             )
             if created:
                 updates = []
-                if tag.allowed:
-                    tag.allowed = False
+                if not tag.allowed:
+                    tag.allowed = True
                     updates.append("allowed")
                 if tag.last_seen_on != now:
                     tag.last_seen_on = now

--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -397,7 +397,7 @@ class CSMSConsumerTests(TransactionTestCase):
         self.assertEqual(tx.rfid, "TAG123")
 
         tag = await database_sync_to_async(RFID.objects.get)(rfid="TAG123")
-        self.assertFalse(tag.allowed)
+        self.assertTrue(tag.allowed)
         self.assertIsNotNone(tag.last_seen_on)
 
         await communicator.disconnect()


### PR DESCRIPTION
## Summary
- ensure newly created RFID records are marked as allowed when they are first seen by the CSMS consumer
- update the CSMS consumer test to expect allowed RFIDs after recording a tag

## Testing
- pytest ocpp/tests.py::CSMSConsumerTests::test_rfid_recorded --import-mode=importlib

------
https://chatgpt.com/codex/tasks/task_e_68df3ccfbddc8326bcb6976bf6499394