### PR TITLE
Remove restart/test scanner controls from RFID interface

### DIFF
--- a/ocpp/rfid/urls.py
+++ b/ocpp/rfid/urls.py
@@ -4,7 +4,5 @@ from . import views
 urlpatterns = [
     path("", views.reader, name="rfid-reader"),
     path("scan/next/", views.scan_next, name="rfid-scan-next"),
-    path("scan/restart/", views.scan_restart, name="rfid-scan-restart"),
-    path("scan/test/", views.scan_test, name="rfid-scan-test"),
     path("scan/deep/", views.scan_deep, name="rfid-scan-deep"),
 ]

--- a/ocpp/templates/rfid/reader.html
+++ b/ocpp/templates/rfid/reader.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
 {% block content %}
 <h1>RFID Scanner</h1>
-{% include "rfid/scanner.html" with scan_url=scan_url restart_url=restart_url test_url=test_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label show_release_info=show_release_info %}
+{% include "rfid/scanner.html" with scan_url=scan_url deep_read_url=deep_read_url table_mode=table_mode toggle_url=toggle_url toggle_label=toggle_label show_release_info=show_release_info %}
 {% endblock %}

--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -14,11 +14,8 @@
     {% endif %}
   <p id="{{ prefix }}-status">Scanner ready</p>
   <p>
-    {% if request.user.is_authenticated %}
-      <button id="{{ prefix }}-connect-local">Connect Local Scanner</button>
-    {% endif %}
-    <button id="{{ prefix }}-restart-test">Restart &amp; Test Scanner</button>
     {% if request.user.is_staff %}
+      <button id="{{ prefix }}-connect-local">Connect Local Scanner</button>
       <button id="{{ prefix }}-deep-read">Enable Deep Read</button>
       <a id="{{ prefix }}-configure" href="#" style="display:none; margin-left:1em;"></a>
     {% endif %}
@@ -187,7 +184,6 @@
   const releasedEl = document.getElementById('{{ prefix }}-released');
   const referenceEl = document.getElementById('{{ prefix }}-reference');
   const connectBtn = document.getElementById('{{ prefix }}-connect-local');
-  const restartTestBtn = document.getElementById('{{ prefix }}-restart-test');
   const deepBtn = document.getElementById('{{ prefix }}-deep-read');
   const configureEl = document.getElementById('{{ prefix }}-configure');
   const modeToggleBtn = document.getElementById('{{ prefix }}-mode-toggle');
@@ -283,7 +279,7 @@
 
   function showError(message){
     console.error(message);
-    const defaultMsg = 'RFID reader not detected. Please connect the reader and press Restart & Test Scanner.';
+    const defaultMsg = 'RFID reader not detected. Please connect the reader.';
     if(typeof message === 'string' && message){
       statusEl.textContent = message;
     } else {
@@ -508,23 +504,6 @@
     }
   }
 
-  restartTestBtn.addEventListener('click', async () => {
-    try {
-      await fetch('{{ restart_url }}', {method: 'POST'});
-      const resp = await fetch('{{ test_url }}');
-      const data = await resp.json();
-      let msg = '';
-      if(data.error){
-        msg = 'No local scanner detected.';
-      } else if(data.irq_pin !== undefined){
-        msg = `IRQ pin ${data.irq_pin}.`;
-      }
-      statusEl.textContent = msg || 'Test completed';
-      poll();
-    } catch(err) {
-      statusEl.textContent = 'Test failed';
-    }
-  });
   if(deepBtn){
     deepBtn.addEventListener('click', async () => {
       try {


### PR DESCRIPTION
## Summary
- remove the restart/test scanner controls from the shared RFID scanner template and adjust default error messaging
- drop the unused restart/test views and URLs while restricting local scanner actions to staff-only and surfacing release fields to staff
- update RFID scanner tests to cover the revised authentication handling and absence of the restart/test button

## Testing
- pytest ocpp/tests/test_rfid_scanner.py
- python manage.py test ocpp.test_rfid.ScanNextViewTests ocpp.test_rfid.ScannerTemplateTests

------
https://chatgpt.com/codex/tasks/task_e_68df3c5d04608326bdcab65012dc6f17