### PR TITLE
Run gway upgrade after suite updates

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 import urllib.error
@@ -217,6 +218,9 @@ def check_github_updates() -> None:
         )
 
     subprocess.run(args, cwd=base_dir, check=True)
+
+    if shutil.which("gway"):
+        subprocess.run(["gway", "upgrade"], check=True)
 
     service_file = base_dir / "locks/service.lck"
     if service_file.exists():

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -220,7 +220,10 @@ def check_github_updates() -> None:
     subprocess.run(args, cwd=base_dir, check=True)
 
     if shutil.which("gway"):
-        subprocess.run(["gway", "upgrade"], check=True)
+        try:
+            subprocess.run(["gway", "upgrade"], check=True)
+        except subprocess.CalledProcessError:
+            logger.warning("gway upgrade failed; continuing anyway", exc_info=True)
 
     service_file = base_dir / "locks/service.lck"
     if service_file.exists():

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -410,5 +410,7 @@ fi
 
 if command -v gway >/dev/null 2>&1; then
   echo "Detected gway command; running gway upgrade..."
-  gway upgrade
+  if ! gway upgrade; then
+    echo "gway upgrade failed; continuing with suite upgrade" >&2
+  fi
 fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -407,3 +407,8 @@ if [[ $NO_RESTART -eq 0 ]]; then
   nohup ./start.sh >/dev/null 2>&1 &
   echo "Services restart triggered"
 fi
+
+if command -v gway >/dev/null 2>&1; then
+  echo "Detected gway command; running gway upgrade..."
+  gway upgrade
+fi


### PR DESCRIPTION
## Summary
- trigger a follow-up `gway upgrade` from the shell script when manual upgrades finish
- extend the auto-upgrade task to invoke `gway upgrade` when the command is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df4a472be08326bf5c1e88420bcdc7