### PR TITLE
Add auto-detected gway runner feature

### DIFF
--- a/nodes/fixtures/node_features__nodefeature_gway_runner.json
+++ b/nodes/fixtures/node_features__nodefeature_gway_runner.json
@@ -1,0 +1,12 @@
+[
+  {
+    "model": "nodes.nodefeature",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "slug": "gway-runner",
+      "display": "gway Runner",
+      "roles": []
+    }
+  }
+]

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -2699,6 +2699,17 @@ class NodeFeatureTests(TestCase):
         ):
             self.assertTrue(feature.is_enabled)
 
+    @patch("nodes.models.Node._has_gway_runner", return_value=True)
+    def test_gway_runner_enabled_when_command_available(self, mock_has_runner):
+        feature = NodeFeature.objects.create(
+            slug="gway-runner", display="gway Runner"
+        )
+        with patch(
+            "nodes.models.Node.get_current_mac", return_value="00:11:22:33:44:55"
+        ):
+            self.assertTrue(feature.is_enabled)
+        mock_has_runner.assert_called_once_with()
+
     @patch("nodes.models.Node._has_rpi_camera", return_value=True)
     def test_rpi_camera_detection(self, mock_camera):
         feature = NodeFeature.objects.create(
@@ -2736,6 +2747,49 @@ class NodeFeatureTests(TestCase):
                 node=self.node, feature=feature
             ).exists()
         )
+
+    @patch("nodes.models.Node._find_gway_runner_command", return_value="/usr/bin/gway")
+    def test_gway_runner_detection(self, mock_find_command):
+        feature = NodeFeature.objects.create(
+            slug="gway-runner", display="gway Runner"
+        )
+        feature.roles.add(self.role)
+        with patch(
+            "nodes.models.Node.get_current_mac", return_value="00:11:22:33:44:55"
+        ):
+            self.node.refresh_features()
+        self.assertTrue(
+            NodeFeatureAssignment.objects.filter(
+                node=self.node, feature=feature
+            ).exists()
+        )
+        mock_find_command.assert_called_with()
+
+    @patch(
+        "nodes.models.Node._find_gway_runner_command",
+        side_effect=["/usr/bin/gway", None],
+    )
+    def test_gway_runner_removed_when_command_missing(self, mock_find_command):
+        feature = NodeFeature.objects.create(
+            slug="gway-runner", display="gway Runner"
+        )
+        feature.roles.add(self.role)
+        with patch(
+            "nodes.models.Node.get_current_mac", return_value="00:11:22:33:44:55"
+        ):
+            self.node.refresh_features()
+            self.assertTrue(
+                NodeFeatureAssignment.objects.filter(
+                    node=self.node, feature=feature
+                ).exists()
+            )
+            self.node.refresh_features()
+        self.assertFalse(
+            NodeFeatureAssignment.objects.filter(
+                node=self.node, feature=feature
+            ).exists()
+        )
+        self.assertEqual(mock_find_command.call_count, 2)
 
     @patch("nodes.models.Node._hosts_gelectriic_ap", return_value=True)
     def test_ap_router_detection(self, mock_hosts):


### PR DESCRIPTION
## Summary
- add a gway-runner node feature fixture that is not assigned to any roles by default
- auto-detect the gway command to manage the gway-runner feature on local nodes
- cover the new feature detection and enablement behaviour with targeted tests

## Testing
- pytest nodes/tests.py::NodeFeatureTests -k gway -q

------
https://chatgpt.com/codex/tasks/task_e_68e02206310483268f395da47af5d989