### PR TITLE
Add GitHub repository creation helper

### DIFF
--- a/core/github_repos.py
+++ b/core/github_repos.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+
+import requests
+
+from .github_issues import REQUEST_TIMEOUT, get_github_token
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_repository_payload(
+    repo: str,
+    visibility: str,
+    description: str | None,
+) -> Mapping[str, object]:
+    payload: dict[str, object] = {"name": repo, "visibility": visibility}
+
+    if description is not None:
+        payload["description"] = description
+
+    return payload
+
+
+def create_repository(
+    owner: str | None,
+    repo: str,
+    *,
+    visibility: str = "private",
+    description: str | None = None,
+) -> requests.Response:
+    """Create a GitHub repository for the authenticated user or organisation."""
+
+    token = get_github_token()
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {token}",
+        "User-Agent": "arthexis-runtime-reporter",
+    }
+
+    if owner:
+        url = f"https://api.github.com/orgs/{owner}/repos"
+    else:
+        url = "https://api.github.com/user/repos"
+
+    payload = _build_repository_payload(repo, visibility, description)
+
+    response = requests.post(
+        url,
+        json=payload,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+    )
+
+    if not (200 <= response.status_code < 300):
+        logger.error(
+            "GitHub repository creation failed with status %s: %s",
+            response.status_code,
+            response.text,
+        )
+        response.raise_for_status()
+
+    logger.info(
+        "GitHub repository created for %s with status %s",
+        owner or "authenticated user",
+        response.status_code,
+    )
+
+    return response

--- a/core/tests/test_github_repos.py
+++ b/core/tests/test_github_repos.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+
+import django
+import requests
+from django.test import TestCase
+from unittest import mock
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from core import github_repos
+
+
+class CreateRepositoryTests(TestCase):
+    def test_successful_creation_for_organisation(self) -> None:
+        response = mock.Mock()
+        response.status_code = 201
+
+        with mock.patch(
+            "core.github_repos.get_github_token", return_value="token"
+        ) as get_token:
+            with mock.patch("requests.post", return_value=response) as post:
+                with self.assertLogs("core.github_repos", level="INFO") as logs:
+                    result = github_repos.create_repository(
+                        owner="example-org",
+                        repo="demo",
+                        visibility="public",
+                        description="Demo repository",
+                    )
+
+        self.assertIs(result, response)
+        get_token.assert_called_once_with()
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], "https://api.github.com/orgs/example-org/repos")
+        self.assertEqual(kwargs["timeout"], github_repos.REQUEST_TIMEOUT)
+        self.assertEqual(kwargs["json"], {
+            "name": "demo",
+            "visibility": "public",
+            "description": "Demo repository",
+        })
+        self.assertEqual(kwargs["headers"]["Authorization"], "token token")
+        self.assertTrue(
+            any("GitHub repository created" in message for message in logs.output)
+        )
+
+    def test_user_repository_creation_uses_user_endpoint(self) -> None:
+        response = mock.Mock()
+        response.status_code = 201
+
+        with mock.patch("core.github_repos.get_github_token", return_value="token"):
+            with mock.patch("requests.post", return_value=response) as post:
+                github_repos.create_repository(
+                    owner=None,
+                    repo="demo",
+                    visibility="private",
+                    description=None,
+                )
+
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], "https://api.github.com/user/repos")
+        self.assertNotIn("description", kwargs["json"])
+
+    def test_failure_logs_and_raises(self) -> None:
+        response = mock.Mock()
+        response.status_code = 422
+        response.text = "invalid"
+        response.raise_for_status.side_effect = requests.HTTPError("invalid")
+
+        with mock.patch("core.github_repos.get_github_token", return_value="token"):
+            with mock.patch("requests.post", return_value=response):
+                with self.assertLogs("core.github_repos", level="ERROR") as logs:
+                    with self.assertRaises(requests.HTTPError):
+                        github_repos.create_repository(
+                            owner="example-org",
+                            repo="demo",
+                            visibility="private",
+                        )
+
+        self.assertTrue(
+            any("GitHub repository creation failed" in message for message in logs.output)
+        )


### PR DESCRIPTION
## Summary
- add a GitHub repository creation helper that reuses the existing token lookup and request configuration
- cover the helper with unit tests for success, user endpoint selection, and failure handling

## Testing
- pytest core/tests/test_github_repos.py

------
https://chatgpt.com/codex/tasks/task_e_68e02cc07e10832691d35d23b2efe733