### PR TITLE
Add package admin GitHub repository creation workflow

### DIFF
--- a/core/github_helper.py
+++ b/core/github_helper.py
@@ -1,14 +1,30 @@
-"""Helpers for reporting exceptions to GitHub."""
+"""Helpers for reporting exceptions to GitHub and managing repositories."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 from celery import shared_task
+import requests
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .models import Package
 
 
 logger = logging.getLogger(__name__)
+
+
+GITHUB_API_ROOT = "https://api.github.com"
+REQUEST_TIMEOUT = 10
+
+
+class GitHubRepositoryError(RuntimeError):
+    """Raised when a GitHub repository operation fails."""
+
 
 
 @shared_task
@@ -23,3 +39,145 @@ def report_exception_to_github(payload: dict[str, Any]) -> None:
     logger.info(
         "Queued GitHub issue report for %s", payload.get("fingerprint", "<unknown>")
     )
+
+
+def _resolve_github_token(package: Package | None) -> str:
+    """Return the GitHub token for ``package``.
+
+    Preference is given to the release manager associated with the package.
+    When unavailable, fall back to the ``GITHUB_TOKEN`` environment variable.
+    """
+
+    if package:
+        manager = getattr(package, "release_manager", None)
+        if manager and getattr(manager, "github_token", None):
+            return manager.github_token
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise GitHubRepositoryError("GitHub token is not configured")
+    return token
+
+
+def _build_headers(token: str) -> Mapping[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {token}",
+        "User-Agent": "arthexis-admin",
+    }
+
+
+def _build_payload(repo: str, *, private: bool, description: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"name": repo, "private": private}
+    if description:
+        payload["description"] = description
+    return payload
+
+
+def _extract_error_message(response: requests.Response) -> str:
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+
+    message = data.get("message") or response.text or "GitHub repository request failed"
+    errors = data.get("errors")
+    details: list[str] = []
+    if isinstance(errors, list):
+        for entry in errors:
+            if isinstance(entry, str):
+                details.append(entry)
+            elif isinstance(entry, Mapping):
+                text = entry.get("message") or entry.get("code")
+                if text:
+                    details.append(str(text))
+
+    if details:
+        message = f"{message} ({'; '.join(details)})"
+
+    return message
+
+
+def _safe_json(response: requests.Response) -> dict[str, Any]:
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    return data
+
+
+def create_repository_for_package(
+    package: Package,
+    *,
+    owner: str,
+    repo: str,
+    private: bool = False,
+    description: str | None = None,
+) -> str:
+    """Create a GitHub repository and return its canonical URL.
+
+    The helper attempts to create the repository under ``owner`` when provided.
+    If the authenticated token lacks access to the organization, the helper
+    falls back to creating the repository for the authenticated user. On
+    success, the GitHub HTML URL for the repository is returned.
+    """
+
+    token = _resolve_github_token(package)
+    headers = _build_headers(token)
+    payload = _build_payload(repo, private=private, description=description)
+
+    endpoints: list[str] = []
+    owner = owner.strip()
+    if owner:
+        endpoints.append(f"{GITHUB_API_ROOT}/orgs/{owner}/repos")
+    endpoints.append(f"{GITHUB_API_ROOT}/user/repos")
+
+    last_error: str | None = None
+
+    for index, endpoint in enumerate(endpoints):
+        try:
+            response = requests.post(
+                endpoint,
+                json=payload,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            logger.exception(
+                "GitHub repository creation request failed for %s/%s", owner, repo
+            )
+            raise GitHubRepositoryError(str(exc)) from exc
+
+        if 200 <= response.status_code < 300:
+            data = _safe_json(response)
+            html_url = data.get("html_url")
+            if html_url:
+                return html_url
+
+            resolved_owner = (
+                data.get("owner", {}).get("login")
+                if isinstance(data.get("owner"), Mapping)
+                else owner
+            )
+            resolved_owner = (resolved_owner or owner).strip("/")
+            return f"https://github.com/{resolved_owner}/{repo}"
+
+        message = _extract_error_message(response)
+        logger.error(
+            "GitHub repository creation failed for %s/%s (%s): %s",
+            owner or "<user>",
+            repo,
+            response.status_code,
+            message,
+        )
+        last_error = message
+
+        # If we're attempting to create within an organization and receive a
+        # not found or forbidden error, fall back to creating for the
+        # authenticated user.
+        if index == 0 and owner and response.status_code in {403, 404}:
+            continue
+
+        break
+
+    raise GitHubRepositoryError(last_error or "GitHub repository creation failed")

--- a/core/templates/admin/core/package/create_repository.html
+++ b/core/templates/admin/core/package/create_repository.html
@@ -1,0 +1,35 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block extrahead %}{{ block.super }}{{ media }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+  <a href="{% url 'admin:app_list' opts.app_label %}">{{ opts.app_config.verbose_name }}</a> ›
+  <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> ›
+  <a href="{% url opts|admin_urlname:'change' original.pk %}">{{ original }}</a> ›
+  {% trans 'Create GitHub repository' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{% trans 'Create GitHub repository' %}</h1>
+<form method="post" action="">
+  {% csrf_token %}
+  <fieldset class="module aligned">
+    {{ form.non_field_errors }}
+    {% for field in form %}
+      <div class="form-row{% if field.errors %} errors{% endif %}">
+        {{ field.errors }}
+        {{ field.label_tag }} {{ field }}
+        {% if field.help_text %}<p class="help">{{ field.help_text }}</p>{% endif %}
+      </div>
+    {% endfor %}
+  </fieldset>
+  <div class="submit-row">
+    <a href="{% url opts|admin_urlname:'change' original.pk %}" class="button cancel-link">{% trans 'Cancel' %}</a>
+    <button type="submit" class="button default">{% trans 'Create repository' %}</button>
+  </div>
+</form>
+{% endblock %}

--- a/core/tests/test_package_admin_repository.py
+++ b/core/tests/test_package_admin_repository.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Package
+
+
+class PackageAdminRepositoryTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+        self.client.force_login(self.user)
+        self.package = Package.objects.create(name="pkg")
+
+    def test_repository_creation_updates_package(self):
+        url = reverse("admin:core_package_create_repository", args=[self.package.pk])
+        with mock.patch(
+            "core.admin.create_repository_for_package",
+            return_value="https://github.com/example/pkg",
+        ) as create_repo:
+            response = self.client.post(
+                url,
+                {
+                    "owner_repo": "example/pkg",
+                    "description": "Example package",
+                },
+                follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.package.refresh_from_db()
+        self.assertEqual(self.package.repository_url, "https://github.com/example/pkg")
+
+        args, kwargs = create_repo.call_args
+        self.assertEqual(args[0], self.package)
+        self.assertEqual(kwargs["owner"], "example")
+        self.assertEqual(kwargs["repo"], "pkg")
+        self.assertFalse(kwargs["private"])
+        self.assertEqual(kwargs["description"], "Example package")
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(
+            any("GitHub repository created" in str(message) for message in messages)
+        )
+
+    def test_repository_errors_surface_message(self):
+        original_url = self.package.repository_url
+        url = reverse("admin:core_package_create_repository", args=[self.package.pk])
+        with mock.patch(
+            "core.admin.create_repository_for_package",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = self.client.post(
+                url,
+                {
+                    "owner_repo": "example/pkg",
+                    "description": "Broken",
+                },
+                follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.package.refresh_from_db()
+        self.assertEqual(self.package.repository_url, original_url)
+
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(
+            any("GitHub repository creation failed" in str(message) for message in messages)
+        )


### PR DESCRIPTION
## Summary
- add a GitHub repository helper with token resolution and API handling
- extend the package admin with a change action and template for creating repositories
- add admin tests that cover successful creation and error handling

## Testing
- pytest core/tests/test_package_admin_repository.py tests/test_package_admin_next_release.py

------
https://chatgpt.com/codex/tasks/task_e_68e02cd0bf588326aa01c48033e2ad4c