### PR TITLE
Set Constellation role badge color to red

### DIFF
--- a/nodes/migrations/0016_update_constellation_badge_color.py
+++ b/nodes/migrations/0016_update_constellation_badge_color.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+NEW_COLOR = "#dc3545"
+OLD_COLORS = ["#daa520"]
+DEFAULT_BADGE_COLOR = "#28a745"
+
+
+def apply_constellation_badge_color(apps, schema_editor):
+    Node = apps.get_model("nodes", "Node")
+    Node.objects.filter(
+        role__name="Constellation",
+        badge_color__in=OLD_COLORS + ["", DEFAULT_BADGE_COLOR],
+    ).update(badge_color=NEW_COLOR)
+
+
+def revert_constellation_badge_color(apps, schema_editor):
+    Node = apps.get_model("nodes", "Node")
+    Node.objects.filter(
+        role__name="Constellation",
+        badge_color=NEW_COLOR,
+    ).update(badge_color=OLD_COLORS[0])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0015_netmessage_target_limit"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            apply_constellation_badge_color,
+            revert_constellation_badge_color,
+        ),
+    ]

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -180,7 +180,7 @@ class Node(Entity):
 
     DEFAULT_BADGE_COLOR = "#28a745"
     ROLE_BADGE_COLORS = {
-        "Constellation": "#daa520",  # goldenrod
+        "Constellation": "#dc3545",  # red
         "Control": "#673ab7",  # deep purple
     }
 

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -69,7 +69,7 @@ class NodeBadgeColorTests(TestCase):
         self.constellation, _ = NodeRole.objects.get_or_create(name="Constellation")
         self.control, _ = NodeRole.objects.get_or_create(name="Control")
 
-    def test_constellation_role_defaults_to_goldenrod(self):
+    def test_constellation_role_defaults_to_red(self):
         node = Node.objects.create(
             hostname="constellation",
             address="10.1.0.1",
@@ -77,7 +77,7 @@ class NodeBadgeColorTests(TestCase):
             mac_address="00:aa:bb:cc:dd:01",
             role=self.constellation,
         )
-        self.assertEqual(node.badge_color, "#daa520")
+        self.assertEqual(node.badge_color, "#dc3545")
 
     def test_control_role_defaults_to_deep_purple(self):
         node = Node.objects.create(


### PR DESCRIPTION
## Summary
- update the Constellation node role badge color to red
- add a data migration to swap existing Constellation badges to the new color
- adjust tests to validate the new default color

## Testing
- pytest nodes/tests.py::NodeBadgeColorTests -q

------
https://chatgpt.com/codex/tasks/task_e_68e04bb3e20083269528927ddb1d2816