### PR TITLE
Add upgrade report to system admin page

### DIFF
--- a/core/templates/admin/system.html
+++ b/core/templates/admin/system.html
@@ -18,6 +18,157 @@
       <p class="help">{% trans "Celery support is not enabled on this node." %}</p>
     {% endif %}
   </div>
+  <div class="module upgrade-report">
+    <h2>{% trans "Upgrade Report" %}</h2>
+    {% with report=auto_upgrade_report %}
+    <div class="upgrade-report-section">
+      <h3>{% trans "Settings" %}</h3>
+      <dl>
+        <dt>{% trans "Auto-upgrade status" %}</dt>
+        <dd>
+          {% if report.settings.enabled %}
+            {% if report.settings.is_latest %}
+              {% trans "Enabled (tracking the latest available revision)" %}
+            {% else %}
+              {% trans "Enabled (tracking release versions)" %}
+            {% endif %}
+          {% else %}
+            {% if report.settings.lock_exists %}
+              {% trans "Disabled (mode file present but unreadable)" %}
+            {% else %}
+              {% trans "Disabled" %}
+            {% endif %}
+          {% endif %}
+        </dd>
+        <dt>{% trans "Mode" %}</dt>
+        <dd><code>{{ report.settings.mode }}</code></dd>
+        <dt>{% trans "Task" %}</dt>
+        <dd>
+          <code>{{ report.settings.task_name }}</code>
+          {% if report.settings.task_path %}
+            — <code>{{ report.settings.task_path }}</code>
+          {% endif %}
+        </dd>
+        <dt>{% trans "Log file" %}</dt>
+        <dd><code>{{ report.settings.log_path }}</code></dd>
+        <dt>{% trans "Blocked revisions" %}</dt>
+        <dd>
+          {% if report.settings.skip_revisions %}
+          <ul>
+            {% for revision in report.settings.skip_revisions %}
+            <li><code>{{ revision }}</code></li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <em>{% trans "No revisions are currently blocked." %}</em>
+          {% endif %}
+        </dd>
+      </dl>
+      {% if report.settings.read_error %}
+        <p class="errornote">{% trans "The auto-upgrade mode could not be read; verify the lock file permissions." %}</p>
+      {% endif %}
+    </div>
+    <div class="upgrade-report-section">
+      <h3>{% trans "Schedule" %}</h3>
+      {% if report.schedule.available %}
+        {% if report.schedule.configured %}
+        <table class="table table-striped">
+          <tbody>
+            <tr>
+              <th scope="row">{% trans "Enabled" %}</th>
+              <td>
+                {% if report.schedule.enabled %}
+                  {% trans "Yes" %}
+                {% else %}
+                  {% trans "No" %}
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "One-off" %}</th>
+              <td>
+                {% if report.schedule.one_off %}
+                  {% trans "Yes" %}
+                {% else %}
+                  {% trans "No" %}
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Queue" %}</th>
+              <td>{{ report.schedule.queue|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Schedule" %}</th>
+              <td>{{ report.schedule.schedule|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Next run" %}</th>
+              <td>{{ report.schedule.next_run|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Last run" %}</th>
+              <td>{{ report.schedule.last_run_at|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Start time" %}</th>
+              <td>{{ report.schedule.start_time|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Expires" %}</th>
+              <td>{{ report.schedule.expires|default:"" }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{% trans "Run count" %}</th>
+              <td>{{ report.schedule.total_run_count }}</td>
+            </tr>
+            {% if report.schedule.description %}
+            <tr>
+              <th scope="row">{% trans "Description" %}</th>
+              <td>{{ report.schedule.description }}</td>
+            </tr>
+            {% endif %}
+          </tbody>
+        </table>
+        {% else %}
+          <p class="help">{% trans "The auto-upgrade periodic task has not been created yet." %}</p>
+        {% endif %}
+      {% else %}
+        {% if report.schedule.error %}
+          <p class="help">{{ report.schedule.error }}</p>
+        {% else %}
+          <p class="help">{% trans "Scheduling information is unavailable." %}</p>
+        {% endif %}
+      {% endif %}
+    </div>
+    <div class="upgrade-report-section">
+      <h3>{% trans "Recent activity" %}</h3>
+      {% if report.log_entries %}
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th scope="col">{% trans "Timestamp" %}</th>
+            <th scope="col">{% trans "Message" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in report.log_entries %}
+          <tr>
+            <td>{{ entry.timestamp|default:"" }}</td>
+            <td><code>{{ entry.message }}</code></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+        <p class="help">{% trans "No auto-upgrade activity has been recorded yet." %}</p>
+      {% endif %}
+      {% if report.log_error %}
+        <p class="errornote">{{ report.log_error }}</p>
+      {% endif %}
+    </div>
+    {% endwith %}
+  </div>
   <div>
     <table class="system-info-table table table-striped">
       <thead>

--- a/tests/test_upgrade_report.py
+++ b/tests/test_upgrade_report.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
+
+from core import system
+
+
+class UpgradeReportTests(SimpleTestCase):
+    def test_build_auto_upgrade_report_reads_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            locks_dir = base / "locks"
+            logs_dir = base / "logs"
+            locks_dir.mkdir()
+            logs_dir.mkdir()
+
+            (locks_dir / "auto_upgrade.lck").write_text("latest", encoding="utf-8")
+            (locks_dir / "auto_upgrade_skip_revisions.lck").write_text(
+                "abc123\n\nxyz789\n",
+                encoding="utf-8",
+            )
+            (logs_dir / "auto-upgrade.log").write_text(
+                "2024-01-01T00:00:00+00:00 first run\n"
+                "2024-01-01T01:00:00+00:00 second run\n",
+                encoding="utf-8",
+            )
+
+            schedule_stub = {
+                "available": False,
+                "configured": False,
+                "enabled": False,
+                "one_off": False,
+                "queue": "",
+                "schedule": "",
+                "start_time": "",
+                "last_run_at": "",
+                "next_run": "",
+                "total_run_count": 0,
+                "description": "",
+                "expires": "",
+                "task": "",
+                "name": system.AUTO_UPGRADE_TASK_NAME,
+                "error": "",
+            }
+
+            with override_settings(BASE_DIR=str(base)):
+                with mock.patch(
+                    "core.system._load_auto_upgrade_schedule",
+                    return_value=schedule_stub,
+                ):
+                    report = system._build_auto_upgrade_report(limit=10)
+
+        self.assertTrue(report["settings"]["enabled"])
+        self.assertTrue(report["settings"]["is_latest"])
+        self.assertEqual(report["settings"]["mode"], "latest")
+        self.assertEqual(
+            report["settings"]["skip_revisions"],
+            ["abc123", "xyz789"],
+        )
+        self.assertEqual(
+            [entry["message"] for entry in report["log_entries"]],
+            ["first run", "second run"],
+        )
+        self.assertFalse(report["log_error"])
+        self.assertTrue(report["settings"]["log_path"].endswith("auto-upgrade.log"))
+
+    def test_load_auto_upgrade_schedule_uses_task_metadata(self):
+        class DummySchedule:
+            def __str__(self) -> str:
+                return "every 5 minutes"
+
+        class DummyTask:
+            def __init__(self):
+                self.enabled = True
+                self.one_off = False
+                self.queue = "default"
+                self.total_run_count = 7
+                self.description = "Auto-upgrade"
+                self.task = "core.tasks.check_github_updates"
+                self.name = system.AUTO_UPGRADE_TASK_NAME
+                self.start_time = timezone.now()
+                self.last_run_at = timezone.now()
+                self.expires = None
+                self._schedule = DummySchedule()
+
+            @property
+            def schedule(self):
+                return self._schedule
+
+        dummy_task = DummyTask()
+        expected_start = system._format_timestamp(dummy_task.start_time)
+        expected_last_run = system._format_timestamp(dummy_task.last_run_at)
+
+        with mock.patch(
+            "core.system._get_auto_upgrade_periodic_task",
+            return_value=(dummy_task, True, ""),
+        ), mock.patch(
+            "core.system._auto_upgrade_next_check",
+            return_value="Soon",
+        ):
+            info = system._load_auto_upgrade_schedule()
+
+        self.assertTrue(info["available"])
+        self.assertTrue(info["configured"])
+        self.assertTrue(info["enabled"])
+        self.assertEqual(info["schedule"], "every 5 minutes")
+        self.assertEqual(info["next_run"], "Soon")
+        self.assertEqual(info["total_run_count"], 7)
+        self.assertEqual(info["task"], dummy_task.task)
+        self.assertEqual(info["name"], dummy_task.name)
+        self.assertEqual(info["start_time"], expected_start)
+        self.assertEqual(info["last_run_at"], expected_last_run)


### PR DESCRIPTION
## Summary
- collect auto-upgrade configuration, schedule, and log details for the system admin view
- surface the upgrade report in the admin template with settings, schedule, and recent activity tables
- add tests covering the upgrade report helpers and schedule handling

## Testing
- pytest tests/test_upgrade_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e04c7b087c8326bb54290e8ac57ce7