### PR TITLE
Refactor admin badges to use fixed color palette

### DIFF
--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -5,13 +5,19 @@ from django.http import HttpRequest
 from django.conf import settings
 
 
+DEFAULT_BADGE_COLOR = "#28a745"
+UNKNOWN_BADGE_COLOR = "#6c757d"
+
+
 def site_and_node(request: HttpRequest):
     """Provide current Site and Node based on request host.
 
     Returns a dict with keys ``badge_site`` and ``badge_node``.
     ``badge_site`` is a ``Site`` instance or ``None`` if no match.
     ``badge_node`` is a ``Node`` instance or ``None`` if no match.
-    ``badge_site_color`` and ``badge_node_color`` provide the configured colors.
+    ``badge_site_color`` and ``badge_node_color`` report the palette color used
+    for the corresponding badge. Badges always use green when the entity is
+    known and grey when the value cannot be determined.
     """
     host = request.get_host().split(":")[0]
     site = Site.objects.filter(domain__iexact=host).first()
@@ -42,16 +48,8 @@ def site_and_node(request: HttpRequest):
     except Exception:
         node = None
 
-    site_color = "#28a745"
-    if site:
-        try:
-            site_color = site.badge.badge_color
-        except Exception:
-            pass
-
-    node_color = "#28a745"
-    if node:
-        node_color = node.badge_color
+    site_color = DEFAULT_BADGE_COLOR if site else UNKNOWN_BADGE_COLOR
+    node_color = DEFAULT_BADGE_COLOR if node else UNKNOWN_BADGE_COLOR
 
     site_name = site.name if site else ""
     node_role_name = node.role.name if node and node.role else ""

--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -5,7 +5,6 @@ from django.template.response import TemplateResponse
 from django.utils.html import format_html, format_html_join
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from core.widgets import CopyColorWidget
 from django.db.models import Count
 from django.conf import settings
 from pathlib import Path
@@ -55,8 +54,7 @@ from core.user_data import EntityModelAdmin
 class NodeAdminForm(forms.ModelForm):
     class Meta:
         model = Node
-        fields = "__all__"
-        widgets = {"badge_color": CopyColorWidget()}
+        exclude = ("badge_color",)
 
 
 class NodeFeatureAssignmentInline(admin.TabularInline):

--- a/pages/admin.py
+++ b/pages/admin.py
@@ -4,8 +4,6 @@ from django.contrib import admin, messages
 from django.contrib.sites.admin import SiteAdmin as DjangoSiteAdmin
 from django.contrib.sites.models import Site
 from django import forms
-from django.db import models
-from core.widgets import CopyColorWidget
 from django.shortcuts import redirect, render, get_object_or_404
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -58,8 +56,7 @@ class SiteBadgeInline(admin.StackedInline):
     model = SiteBadge
     can_delete = False
     extra = 0
-    formfield_overrides = {models.CharField: {"widget": CopyColorWidget}}
-    fields = ("badge_color", "favicon", "landing_override")
+    fields = ("favicon", "landing_override")
 
 
 class SiteForm(forms.ModelForm):

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -611,6 +611,20 @@ class AdminBadgesTests(TestCase):
         self.assertContains(resp, f'href="{node_list}"')
         self.assertContains(resp, f'href="{node_change}"')
 
+    def test_badge_colors_use_standard_palette(self):
+        site = Site.objects.get(pk=1)
+        badge, _ = SiteBadge.objects.get_or_create(site=site)
+        badge.badge_color = "#ff0000"
+        badge.save(update_fields=["badge_color"])
+        self.node.badge_color = "#123456"
+        self.node.save(update_fields=["badge_color"])
+
+        resp = self.client.get(reverse("admin:index"))
+
+        self.assertNotContains(resp, "#ff0000")
+        self.assertNotContains(resp, "#123456")
+        self.assertContains(resp, 'style="background-color: #28a745;"', 2)
+
 
 class AdminDashboardAppListTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- enforce the admin badge palette to green for known entities and grey when unknown
- remove badge color controls from the site and node admin interfaces
- add a regression test to ensure custom colors no longer affect admin badges

## Testing
- python manage.py test pages.tests.AdminBadgesTests --verbosity 2

------
https://chatgpt.com/codex/tasks/task_e_68e04f034f188326929803dcae7af419