### PR TITLE
Fix MCP profile instructions and proxy configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -465,7 +465,7 @@ MCP_SIGIL_SERVER = {
     "required_scopes": ["sigils:read"],
     "issuer_url": os.environ.get("MCP_SIGIL_ISSUER_URL"),
     "resource_server_url": os.environ.get("MCP_SIGIL_RESOURCE_URL"),
-    "mount_path": os.environ.get("MCP_SIGIL_MOUNT_PATH"),
+    "mount_path": os.environ.get("MCP_SIGIL_MOUNT_PATH", "/mcp"),
 }
 
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -1800,18 +1800,26 @@ class AssistantProfileAdmin(
         host = config.get("host") or "127.0.0.1"
         port = config.get("port", 8800)
         base_url, issuer_url = resolve_base_urls(config)
+        mount_path = config.get("mount_path") or "/"
+        display_base_url = base_url or f"http://{host}:{port}"
+        display_issuer_url = issuer_url or display_base_url
+        chat_endpoint = f"{display_base_url.rstrip('/')}/api/chat/"
         if isinstance(response, dict):
             response.setdefault("mcp_server_host", host)
             response.setdefault("mcp_server_port", port)
-            response.setdefault("mcp_server_base_url", base_url)
-            response.setdefault("mcp_server_issuer_url", issuer_url)
+            response.setdefault("mcp_server_base_url", display_base_url)
+            response.setdefault("mcp_server_issuer_url", display_issuer_url)
+            response.setdefault("mcp_server_mount_path", mount_path)
+            response.setdefault("mcp_server_chat_endpoint", chat_endpoint)
         else:
             context_data = getattr(response, "context_data", None)
             if context_data is not None:
                 context_data.setdefault("mcp_server_host", host)
                 context_data.setdefault("mcp_server_port", port)
-                context_data.setdefault("mcp_server_base_url", base_url)
-                context_data.setdefault("mcp_server_issuer_url", issuer_url)
+                context_data.setdefault("mcp_server_base_url", display_base_url)
+                context_data.setdefault("mcp_server_issuer_url", display_issuer_url)
+                context_data.setdefault("mcp_server_mount_path", mount_path)
+                context_data.setdefault("mcp_server_chat_endpoint", chat_endpoint)
         return response
 
     def start_server(self, request):

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -89,13 +89,17 @@ def _site_base_url(port: int) -> str | None:
     if "://" in domain:
         return domain.rstrip("/")
 
-    scheme = "https"
     normalized_domain = domain
-    if normalized_domain.startswith("localhost") or normalized_domain.startswith("127."):
-        scheme = "http"
-
     host, port_override = _split_host_port(normalized_domain)
-    port_to_use = port_override or port
+    host_for_check = host.strip("[]")
+    is_loopback = host_for_check in {"localhost", "::1"} or host_for_check.startswith("127.")
+
+    scheme = "http" if is_loopback else "https"
+    if is_loopback:
+        port_to_use = port_override or port
+    else:
+        default_port = 443 if scheme == "https" else 80
+        port_to_use = port_override or default_port
 
     return _build_url(scheme, host, port_to_use)
 

--- a/core/templates/admin/workgroupassistantprofile_change_form.html
+++ b/core/templates/admin/workgroupassistantprofile_change_form.html
@@ -11,19 +11,24 @@
 {% block form_top %}
 <p class="help">
     Use the Assistant Profiles list to start the MCP server and confirm it is
-    running before sharing credentials. Once online, open
+    running before sharing credentials. The process binds to
+    <code>{{ mcp_server_host|default:"127.0.0.1" }}:{{ mcp_server_port|default:"8800" }}</code>
+    and is published through Nginx at
+    <code>{{ mcp_server_base_url|default:"https://arthexis.com/mcp" }}</code>.
+    Once online, open
     <a href="https://platform.openai.com/docs/gpts/tools/model-context-protocol"
        target="_blank" rel="noopener">ChatGPT Developer Mode</a>
-    and register a Model Context Protocol server pointing to
-    <code>{{ mcp_server_base_url|default:"http://127.0.0.1:8800" }}</code>.
-    Requests must call <code>/api/chat/</code> and include the API key in the
-    <code>Authorization</code> header as <code>Bearer &lt;key&gt;</code>.
+    and register a Model Context Protocol server pointing to that HTTPS URL.
+    Requests must call
+    <code>{{ mcp_server_chat_endpoint|default:"https://arthexis.com/mcp/api/chat/" }}</code>
+    and include the API key in the <code>Authorization</code> header as
+    <code>Bearer &lt;key&gt;</code>.
 </p>
 <p class="help">
     ChatGPT fetches OAuth metadata from
-    <code>{{ mcp_server_issuer_url|default:"http://127.0.0.1:8800" }}</code>. If the
+    <code>{{ mcp_server_issuer_url|default:mcp_server_base_url }}</code>. If the
     connector shows <strong>Error fetching OAuth configuration</strong>, verify
-    this URL is reachable over HTTPS. Update the
+    this HTTPS endpoint is reachable. Update the
     <a href="https://docs.djangoproject.com/en/stable/ref/contrib/sites/"
        target="_blank" rel="noopener">Site domain</a>,
     or set <code>MCP_SIGIL_RESOURCE_URL</code> and

--- a/install.sh
+++ b/install.sh
@@ -349,6 +349,24 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # Model Context Protocol server (SSE)
+    location = /mcp {
+        return 301 /mcp/;
+    }
+
+    location /mcp/ {
+        proxy_pass http://127.0.0.1:MCP_PORT_PLACEHOLDER/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Cache-Control "no-cache";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600;
+    }
     #DATASETTE_START
     location /data/ {
         auth_request /datasette-auth/;
@@ -381,6 +399,24 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # Model Context Protocol server (SSE)
+    location = /mcp {
+        return 301 /mcp/;
+    }
+
+    location /mcp/ {
+        proxy_pass http://127.0.0.1:MCP_PORT_PLACEHOLDER/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Cache-Control "no-cache";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600;
+    }
     #DATASETTE_START
     location /data/ {
         auth_request /datasette-auth/;
@@ -400,6 +436,8 @@ NGINXCONF
 fi
 
 sudo sed -i "s/PORT_PLACEHOLDER/$PORT/" "$NGINX_CONF"
+MCP_PROXY_PORT="${MCP_SIGIL_PORT:-8800}"
+sudo sed -i "s/MCP_PORT_PLACEHOLDER/$MCP_PROXY_PORT/" "$NGINX_CONF"
 if [ "$ENABLE_DATASETTE" = true ]; then
     sudo sed -i "s/DATA_PORT_PLACEHOLDER/$DATASETTE_PORT/" "$NGINX_CONF"
     sudo sed -i '/#DATASETTE_START/d;/#DATASETTE_END/d' "$NGINX_CONF"

--- a/tests/test_mcp_sigil_server.py
+++ b/tests/test_mcp_sigil_server.py
@@ -148,7 +148,7 @@ class SigilResolverServerURLTests(TestCase):
         self.site.save()
         config = {"host": "0.0.0.0", "port": 8800, "api_keys": ["secret"], "required_scopes": []}
         base_url, issuer_url = resolve_base_urls(config)
-        self.assertEqual(base_url, "https://mcp.example.test:8800")
+        self.assertEqual(base_url, "https://mcp.example.test")
         self.assertEqual(issuer_url, base_url)
 
     def test_resolve_base_urls_falls_back_to_host(self) -> None:
@@ -178,5 +178,5 @@ class SigilResolverServerURLTests(TestCase):
             "mount_path": "/mcp",
         }
         base_url, issuer_url = resolve_base_urls(config)
-        self.assertEqual(base_url, "https://resolver.example.com:8800/mcp")
+        self.assertEqual(base_url, "https://resolver.example.com/mcp")
         self.assertEqual(issuer_url, base_url)


### PR DESCRIPTION
## Summary
- update the Assistant Profile help text to point to the public MCP endpoint and display the published chat URL
- derive HTTPS-friendly MCP base URLs, default the mount path, and document the new endpoint in settings and tests
- expose the MCP SSE server through nginx with a dedicated /mcp proxy and configurable port replacement

## Testing
- pytest tests/test_mcp_sigil_server.py tests/test_mcp_asgi.py

------
https://chatgpt.com/codex/tasks/task_e_68e051000f148326983f5dbf8c3c3e14