### PR TITLE
Improve seed datum visibility in dark mode

### DIFF
--- a/core/templates/admin/django_object_actions_user_datum_change_form.html
+++ b/core/templates/admin/django_object_actions_user_datum_change_form.html
@@ -1,20 +1,25 @@
 {% extends "django_object_actions/change_form.html" %}
 {% load i18n %}
 
+{% block extrahead %}
+{{ block.super }}
+{% include "admin/includes/seed_datum_styles.html" %}
+{% endblock %}
+
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>
-    <div>
+    <div style="display:flex; align-items:center; gap:1em; flex-wrap:wrap; justify-content:flex-end;">
         {% if show_user_datum %}
-        <label style="color: var(--body-quiet-color); margin-left: 1em;">
+        <label class="seed-datum-flag seed-datum-flag--user">
             <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
-            {% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]
+            <span class="seed-datum-text">{% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
         {% if show_seed_datum %}
-        <label style="color: var(--body-quiet-color); margin-left: 1em;">
-            <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
-            {% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]
+        <label class="seed-datum-flag seed-datum-flag--seed">
+            <input type="checkbox" class="seed-datum-checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
+            <span class="seed-datum-text">{% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
     </div>

--- a/core/templates/admin/includes/seed_datum_styles.html
+++ b/core/templates/admin/includes/seed_datum_styles.html
@@ -1,0 +1,38 @@
+<style>
+.seed-datum-flag {
+    color: var(--body-quiet-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.seed-datum-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.seed-datum-text a {
+    color: inherit;
+}
+.seed-datum-flag--seed .seed-datum-text {
+    font-weight: 600;
+}
+:root[data-theme="dark"] .seed-datum-flag {
+    color: var(--body-fg);
+}
+:root[data-theme="dark"] .seed-datum-flag--seed .seed-datum-text {
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+}
+:root[data-theme="dark"] .seed-datum-checkbox {
+    opacity: 1;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    background-color: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+:root[data-theme="dark"] .seed-datum-checkbox:checked {
+    background-color: var(--link-fg, #58a6ff);
+    border-color: var(--link-fg, #58a6ff);
+}
+</style>

--- a/core/templates/admin/user_datum_change_form.html
+++ b/core/templates/admin/user_datum_change_form.html
@@ -1,20 +1,25 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 
+{% block extrahead %}
+{{ block.super }}
+{% include "admin/includes/seed_datum_styles.html" %}
+{% endblock %}
+
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>
-    <div>
+    <div style="display:flex; align-items:center; gap:1em; flex-wrap:wrap; justify-content:flex-end;">
         {% if show_user_datum %}
-        <label style="color: var(--body-quiet-color); margin-left: 1em;">
+        <label class="seed-datum-flag seed-datum-flag--user">
             <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
-            {% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]
+            <span class="seed-datum-text">{% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
         {% if show_seed_datum %}
-        <label style="color: var(--body-quiet-color); margin-left: 1em;">
-            <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
-            {% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]
+        <label class="seed-datum-flag seed-datum-flag--seed">
+            <input type="checkbox" class="seed-datum-checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
+            <span class="seed-datum-text">{% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
     </div>

--- a/core/templates/admin/user_profile_change_form.html
+++ b/core/templates/admin/user_profile_change_form.html
@@ -1,19 +1,24 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
+
+{% block extrahead %}
+{{ block.super }}
+{% include "admin/includes/seed_datum_styles.html" %}
+{% endblock %}
 {% block content_title %}
 <div style="display:flex; justify-content:space-between; align-items:center;">
     <h1>{{ title }}</h1>
     <div style="display:flex; align-items:center; gap:1em; flex-wrap:wrap;">
         {% if show_user_datum %}
-        <label style="color: var(--body-quiet-color); display:flex; align-items:center; gap:0.35rem;">
+        <label class="seed-datum-flag seed-datum-flag--user">
             <input type="checkbox" name="_user_datum" form="{{ opts.model_name }}_form"{% if is_user_datum %} checked{% endif %}>
-            <span>{% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]</span>
+            <span class="seed-datum-text">{% trans "User Datum" %} [ <a href="{% url 'admin:user_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
         {% if show_seed_datum %}
-        <label style="color: var(--body-quiet-color); display:flex; align-items:center; gap:0.35rem;">
-            <input type="checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
-            <span>{% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]</span>
+        <label class="seed-datum-flag seed-datum-flag--seed">
+            <input type="checkbox" class="seed-datum-checkbox" name="_seed_datum" form="{{ opts.model_name }}_form"{% if original and original.is_seed_data %} checked{% endif %} disabled>
+            <span class="seed-datum-text">{% trans "Seed Datum" %} [ <a href="{% url 'admin:seed_data' %}">{% trans "View" %}</a> ]</span>
         </label>
         {% endif %}
         {% if operate_as_profile_url_template %}


### PR DESCRIPTION
## Summary
- add shared styling to keep the seed datum indicator legible in dark mode
- update admin change form templates to load the shared styles and align the badge layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e054b3918c8326904db610491c9653