### PR TITLE
Add Register from Odoo toolbar link to Product admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2270,6 +2270,7 @@ class ProductFetchWizardForm(forms.Form):
 class ProductAdmin(EntityModelAdmin):
     form = ProductAdminForm
     actions = ["fetch_odoo_product", "register_from_odoo"]
+    change_list_template = "admin/core/product/change_list.html"
 
     def _odoo_profile_admin(self):
         return self.admin_site._registry.get(OdooProfile)

--- a/core/templates/admin/core/product/change_list.html
+++ b/core/templates/admin/core/product/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if has_add_permission %}
+    <li><a href="{% url 'admin:core_product_register_from_odoo' %}" class="addlink">{% translate "Register from Odoo" %}</a></li>
+  {% else %}
+    <li><a href="{% url 'admin:core_product_register_from_odoo' %}">{% translate "Register from Odoo" %}</a></li>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a product change list template that injects a Register from Odoo link into the object tools toolbar
- wire ProductAdmin to use the new change list template so the link is visible even when no products exist

## Testing
- python manage.py migrate --noinput

------
https://chatgpt.com/codex/tasks/task_e_68e05ec6183c83268c8a2df78f77e2f9