### PR TITLE
Remove dark theme borders from seed datum controls

### DIFF
--- a/core/templates/admin/includes/seed_datum_styles.html
+++ b/core/templates/admin/includes/seed_datum_styles.html
@@ -23,13 +23,10 @@
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
     background-color: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.35);
 }
 :root[data-theme="dark"] .seed-datum-checkbox {
     opacity: 1;
-    border: 1px solid rgba(255, 255, 255, 0.6);
     background-color: rgba(255, 255, 255, 0.18);
-    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15);
 }
 :root[data-theme="dark"] .seed-datum-checkbox:checked {
     background-color: var(--link-fg, #58a6ff);


### PR DESCRIPTION
## Summary
- remove the dark theme border accents from the seed datum checkbox and label styling

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: requires unapplied migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68e05f06f17083268317dba9eb7187ff