### PR TITLE
Add RFID release badge to admin dashboard

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -38,6 +38,19 @@
                 {% else %}
                   {{ fav.custom_label|default:model.name }}
                 {% endif %}
+                {% if model.object_name == 'RFID' %}
+                  {% rfid_release_stats as rfid_stats %}
+                  {% if rfid_stats %}
+                    {% blocktranslate with released=rfid_stats.released registered=rfid_stats.total asvar rfid_badge_label trimmed %}
+                      {{ released }} released RFIDs out of {{ registered }} registered RFIDs
+                    {% endblocktranslate %}
+                    <span class="rfid-release-stats" aria-label="{{ rfid_badge_label }}" title="{{ rfid_badge_label }}">
+                      <span class="rfid-release-badge">[{{ rfid_stats.released }} {% translate 'Released' %}]</span>
+                      <span class="rfid-release-separator" aria-hidden="true">/</span>
+                      <span class="rfid-release-badge">[{{ rfid_stats.total }} {% translate 'Registered' %}]</span>
+                    </span>
+                  {% endif %}
+                {% endif %}
                 {% lead_open_count app.app_label model.object_name as lead_open_count %}
                 {% if lead_open_count is not None %}
                   {% blocktranslate count open_count=lead_open_count asvar lead_open_label trimmed %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -100,6 +100,30 @@
         background-color: var(--button-bg, #0d6efd);
         color: var(--button-fg, #fff);
     }
+    .dashboard-main .rfid-release-stats {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        margin-left: 8px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--body-quiet-color);
+    }
+    .dashboard-main .rfid-release-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 8px;
+        min-height: 1.5rem;
+        border-radius: 999px;
+        background-color: var(--darkened-bg);
+        color: var(--body-fg);
+        border: 1px solid var(--hairline-color);
+    }
+    .dashboard-main .rfid-release-separator {
+        font-weight: 700;
+        color: var(--body-quiet-color);
+    }
     .dashboard-main .app-caption .section {
         display: block;
         width: 100%;

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -45,6 +45,7 @@ from core.models import (
     InviteLead,
     Package,
     Reference,
+    RFID,
     ReleaseManager,
     Todo,
     TOTPDeviceSettings,
@@ -71,6 +72,7 @@ from datetime import (
 from django.core import mail
 from django.utils import timezone
 from django.utils.text import slugify
+from django.utils.translation import gettext
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.oath import TOTP
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -1669,6 +1671,18 @@ class FavoriteTests(TestCase):
         self.assertIn('class="lead-open-badge"', content)
         self.assertIn('title="2 open leads"', content)
         self.assertIn('aria-label="2 open leads"', content)
+
+    def test_dashboard_shows_rfid_release_badge(self):
+        RFID.objects.create(rfid="RFID0001", released=True)
+        RFID.objects.create(rfid="RFID0002", released=False)
+
+        resp = self.client.get(reverse("admin:index"))
+
+        released_label = gettext("Released")
+        registered_label = gettext("Registered")
+        expected = f"[1 {released_label}] / [2 {registered_label}]"
+
+        self.assertContains(resp, expected)
 
     def test_dashboard_limits_future_actions_to_top_four(self):
         from pages.templatetags.admin_extras import future_action_items


### PR DESCRIPTION
## Summary
- add a reusable template tag to expose released vs registered RFID counts
- render a styled RFID badge on the admin dashboard app list and adjust styles
- cover the badge with a regression test for the admin dashboard

## Testing
- python manage.py test pages.tests.AdminDashboardAppListTests

------
https://chatgpt.com/codex/tasks/task_e_68e06c3eb304832687f402edec81e459