### PR TITLE
Add tests covering release promote staged commit behavior

### DIFF
--- a/tests/test_release_build_flow.py
+++ b/tests/test_release_build_flow.py
@@ -54,7 +54,7 @@ def test_build_raises_when_tests_fail(monkeypatch, release_sandbox):
             self.stdout = "tests stdout\n"
             self.stderr = "tests stderr\n"
 
-    def fake_run_tests(*, log_path: Path):
+    def fake_run_tests(*, log_path: Path, command=None):
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text("log", encoding="utf-8")
         return FakeProc()
@@ -66,3 +66,49 @@ def test_build_raises_when_tests_fail(monkeypatch, release_sandbox):
 
     assert excinfo.value.output == "tests stdout\ntests stderr\n"
     assert excinfo.value.log_path == Path("logs/test.log")
+
+
+def test_promote_commits_only_with_staged_changes(monkeypatch, release_sandbox):
+    monkeypatch.setattr(release, "_git_clean", lambda: True)
+
+    build_calls: list[dict[str, object]] = []
+
+    def fake_build(**kwargs):
+        build_calls.append(kwargs)
+
+    monkeypatch.setattr(release, "build", fake_build)
+
+    def run_promote(has_staged: bool) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        monkeypatch.setattr(release, "_git_has_staged_changes", lambda: has_staged)
+
+        def fake_run(cmd, check=True):
+            calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(release, "_run", fake_run)
+        release.promote(version="1.2.3")
+        return calls
+
+    calls_with_commit = run_promote(has_staged=True)
+    calls_without_commit = run_promote(has_staged=False)
+
+    assert calls_with_commit == [
+        ["git", "add", "."],
+        ["git", "commit", "-m", "Release v1.2.3"],
+    ]
+    assert calls_without_commit == [["git", "add", "."]]
+
+    for kwargs in build_calls:
+        assert kwargs["dist"] is True
+        assert kwargs["git"] is False
+        assert kwargs["tag"] is False
+        assert kwargs["stash"] is False
+
+
+def test_promote_requires_clean_repo(monkeypatch, release_sandbox):
+    monkeypatch.setattr(release, "_git_clean", lambda: False)
+
+    with pytest.raises(release.ReleaseError):
+        release.promote(version="1.2.3")


### PR DESCRIPTION
## Summary
- add unit test ensuring release.promote only commits when staged changes exist
- assert release.build receives the expected dist/git/tag/stash flags during promotion
- verify release.promote raises a ReleaseError when the repository is dirty

## Testing
- pytest tests/test_release_build_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e06ca2a388832685dce294ad136874