### PR TITLE
Update Active Profile admin labels for user profiles

### DIFF
--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -12,6 +12,7 @@ from django.db.models import Model
 from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 from django.utils.text import capfirst
+from django.utils.translation import gettext_lazy as _
 
 from core.models import Lead, ReleaseManager, Todo
 from core.entity import Entity
@@ -79,10 +80,14 @@ def model_admin_actions(context, app_label, model_name):
         if action_name == "delete_selected" or uses_queryset(func):
             continue
         url = None
+        label = description or _name.replace("_", " ")
         if action_name == "my_profile":
             getter = getattr(model_admin, "get_my_profile_url", None)
             if callable(getter):
                 url = getter(request)
+            label_getter = getattr(model_admin, "get_my_profile_label", None)
+            if callable(label_getter):
+                label = label_getter(request)
         base = f"admin:{model_admin.opts.app_label}_{model_admin.opts.model_name}_"
         if not url:
             try:
@@ -92,7 +97,7 @@ def model_admin_actions(context, app_label, model_name):
                     url = reverse(base + action_name.split("_")[0])
                 except NoReverseMatch:
                     url = reverse(base + "changelist") + f"?action={action_name}"
-        actions.append({"url": url, "label": description or _name.replace("_", " ")})
+        actions.append({"url": url, "label": label})
     return actions
 
 

--- a/tests/test_admin_profile_link.py
+++ b/tests/test_admin_profile_link.py
@@ -12,6 +12,8 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
+from core.models import ReleaseManager
+
 
 class AdminProfileLinkTests(TestCase):
     def setUp(self):
@@ -27,4 +29,16 @@ class AdminProfileLinkTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         expected_url = reverse("admin:teams_user_change", args=[self.user.pk])
         self.assertContains(response, "Active Profile")
+        self.assertContains(response, f'href="{expected_url}"')
+
+    def test_profile_link_shows_unset_when_missing(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, "Active Profile (Unset)")
+
+    def test_profile_link_shows_profile_name_when_available(self):
+        profile = ReleaseManager.objects.create(user=self.user)
+        response = self.client.get(reverse("admin:index"))
+        expected_url = reverse("admin:teams_releasemanager_change", args=[profile.pk])
+        expected_label = f"Active Profile ({profile})"
+        self.assertContains(response, expected_label)
         self.assertContains(response, f'href="{expected_url}"')


### PR DESCRIPTION
## Summary
- compute user-specific profile info in the admin mixin and expose a dynamic Active Profile label
- adjust the admin dashboard action helper to use the new label and keep the my profile link target
- expand admin profile link tests to cover unset and named profile scenarios

## Testing
- pytest tests/test_admin_profile_link.py

------
https://chatgpt.com/codex/tasks/task_e_68e06e2354008326b054f40792149f27