### PR TITLE
Cache is_seed_data detection during env refresh

### DIFF
--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -22,6 +22,7 @@ from teams.models import OdooProfile, SecurityGroup
 from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.core.management import call_command
 import socket
 from core.models import Brand, Todo, WMICode
@@ -204,7 +205,12 @@ class EnvRefreshFixtureTests(TestCase):
                         "model": "nodes.noderole",
                         "pk": 999,
                         "fields": {"name": "Fixture Role"},
-                    }
+                    },
+                    {
+                        "model": "auth.group",
+                        "pk": 777,
+                        "fields": {"name": "Fixture Group"},
+                    },
                 ]
             )
         )
@@ -229,6 +235,8 @@ class EnvRefreshFixtureTests(TestCase):
         output = buf.getvalue()
         role = NodeRole.all_objects.get(pk=999)
         self.assertTrue(role.is_seed_data)
+        group = Group.objects.get(pk=777)
+        self.assertFalse(hasattr(group, "is_seed_data"))
         self.assertIn(".", output)
         self.assertIn("nodes.NodeRole: 1", output)
         shutil.rmtree(tmp_dir)


### PR DESCRIPTION
## Summary
- add a cached helper to detect the is_seed_data field when patching fixtures in env-refresh
- reuse the cached result for each model to avoid repeated field scans and handle dynamic models safely
- extend the env refresh fixture test to cover models with and without the seed flag

## Testing
- pytest tests/test_seed_data.py::EnvRefreshFixtureTests::test_env_refresh_marks_seed_data

------
https://chatgpt.com/codex/tasks/task_e_68e092613af08326b5700d165074a8df