### PR TITLE
Add subprotocol logging test for CSMS consumer

### DIFF
--- a/ocpp/tests.py
+++ b/ocpp/tests.py
@@ -379,6 +379,70 @@ class CSMSConsumerTests(TransactionTestCase):
             store.transactions.pop(store_key, None)
         self.assertNotIn(store_key, store.transactions)
 
+    async def test_connection_logs_subprotocol(self):
+        pending_key = store.pending_key("PROT1")
+        original_connections = dict(store.connections)
+        original_ip_connections = {
+            ip: set(consumers) for ip, consumers in store.ip_connections.items()
+        }
+        original_logs = {
+            key: list(entries)
+            for key, entries in store.logs.get("charger", {}).items()
+        }
+        original_log_names = dict(store.log_names.get("charger", {}))
+        store.connections.clear()
+        store.ip_connections.clear()
+        store.clear_log(pending_key, log_type="charger")
+
+        communicator_with_protocol = ClientWebsocketCommunicator(
+            application, "/PROT1/", subprotocols=["ocpp1.6"]
+        )
+        communicator_with_protocol.scope["path"] = (
+            communicator_with_protocol.scope.get("path", "").rstrip("/")
+        )
+        communicator_without_protocol = ClientWebsocketCommunicator(
+            application, "/PROT1/"
+        )
+        communicator_without_protocol.scope["path"] = (
+            communicator_without_protocol.scope.get("path", "").rstrip("/")
+        )
+
+        try:
+            accepted, negotiated = await communicator_with_protocol.connect()
+            logs = store.get_logs(pending_key, log_type="charger")
+            self.assertTrue(accepted, negotiated)
+            self.assertEqual(negotiated, "ocpp1.6")
+            self.assertTrue(
+                any("Connected (subprotocol=ocpp1.6)" in entry for entry in logs),
+                logs,
+            )
+
+            accepted_without, negotiated_without = await communicator_without_protocol.connect()
+            logs = store.get_logs(pending_key, log_type="charger")
+            self.assertTrue(accepted_without, logs)
+            self.assertIsNone(negotiated_without)
+            self.assertTrue(
+                any("Connected (subprotocol=none)" in entry for entry in logs),
+                logs,
+            )
+        finally:
+            with suppress(Exception):
+                await communicator_without_protocol.disconnect()
+            with suppress(Exception):
+                await communicator_with_protocol.disconnect()
+            store.connections.clear()
+            store.connections.update(original_connections)
+            store.ip_connections.clear()
+            for ip, consumers in original_ip_connections.items():
+                store.ip_connections[ip] = set(consumers)
+            store.logs.setdefault("charger", {})
+            store.logs["charger"].clear()
+            for key, entries in original_logs.items():
+                store.logs["charger"][key] = list(entries)
+            store.log_names.setdefault("charger", {})
+            store.log_names["charger"].clear()
+            store.log_names["charger"].update(original_log_names)
+
     async def test_rfid_recorded(self):
         await database_sync_to_async(Charger.objects.create)(charger_id="RFIDREC")
         communicator = WebsocketCommunicator(application, "/RFIDREC/?cid=RFIDREC")


### PR DESCRIPTION
## Summary
- add an asynchronous CSMSConsumer test that exercises websocket connections with and without an offered OCPP subprotocol
- verify charger logs include the negotiated subprotocol and restore store state after the test completes

## Testing
- pytest --import-mode=importlib ocpp/tests.py -k subprotocol

------
https://chatgpt.com/codex/tasks/task_e_68e092bc215c832681a2adc7a1c89ca9