### PR TITLE
Ensure release script validates clean repo before bumping version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,12 @@ fi
 
 VERSION="$1"
 
+# Ensure the repository is clean before making any changes.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree or index is dirty; please commit or stash changes before releasing." >&2
+  exit 1
+fi
+
 echo "$VERSION" > VERSION
 
 python scripts/capture_migration_state.py "$VERSION"


### PR DESCRIPTION
## Summary
- add a clean working tree check to the release helper script so validation occurs before the VERSION file is updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09ab0781483268f98c09c1f4c0202