### PR TITLE
Fix changelog generator range when HEAD is tagged

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -169,14 +169,7 @@ def _should_use_python_changelog(exc: OSError) -> bool:
 def _generate_changelog_with_python(log_path: Path) -> None:
     _append_log(log_path, "Falling back to Python changelog generator")
     changelog_path = Path("CHANGELOG.rst")
-    describe = subprocess.run(
-        ["git", "describe", "--tags", "--abbrev=0"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    start_tag = describe.stdout.strip() if describe.returncode == 0 else ""
-    range_spec = f"{start_tag}..HEAD" if start_tag else "HEAD"
+    range_spec = changelog_utils.determine_range_spec()
     previous = changelog_path.read_text(encoding="utf-8") if changelog_path.exists() else None
     sections = changelog_utils.collect_sections(range_spec=range_spec, previous_text=previous)
     content = changelog_utils.render_changelog(sections)

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -3,24 +3,19 @@ set -euo pipefail
 
 # Generate CHANGELOG.rst from commit messages.
 # Usage: scripts/generate-changelog.sh [starting-tag]
-# If starting-tag is omitted, the last tag is used.
+# If starting-tag is omitted, the last release tag is used.
 
-start_tag="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo '')}"
+start_tag="${1:-}"
 
-if [ -n "$start_tag" ]; then
-  range="$start_tag..HEAD"
-else
-  range="HEAD"
-fi
-
-python3 - "$range" <<'PY'
+python3 - "$start_tag" <<'PY'
 import sys
 from pathlib import Path
 
 from core import changelog
 
 
-range_spec = sys.argv[1] if len(sys.argv) > 1 else "HEAD"
+start_tag = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
+range_spec = changelog.determine_range_spec(start_tag)
 path = Path("CHANGELOG.rst")
 previous = path.read_text(encoding="utf-8") if path.exists() else None
 sections = changelog.collect_sections(range_spec=range_spec, previous_text=previous)

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -435,7 +435,12 @@ class ReleaseProgressViewTests(TestCase):
                 err = OSError(193, "%1 is not a valid Win32 application")
                 err.winerror = 193  # type: ignore[attr-defined]
                 raise err
-            if cmd[:3] == ["git", "describe", "--tags"]:
+            if cmd[:4] == ["git", "describe", "--tags", "--exact-match"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            if (
+                len(cmd) >= 4
+                and cmd[:4] == ["git", "describe", "--tags", "--abbrev=0"]
+            ):
                 return subprocess.CompletedProcess(cmd, 0, stdout="0.1.10\n", stderr="")
             if (
                 len(cmd) >= 4


### PR DESCRIPTION
## Summary
- resolve changelog range selection to include the previous tag when the release commit is tagged at HEAD
- update the Python fallback and shell script to share the new range detection helper
- extend tests to cover the revised range detection logic and fallback behaviour

## Testing
- pytest tests/test_changelog_builder.py tests/test_release_progress.py::ReleaseProgressViewTests::test_pre_release_python_fallback

------
https://chatgpt.com/codex/tasks/task_e_68e1411121788326a88dd6082d58d8ca