### PR TITLE
Improve TOTP admin calibration token input spacing

### DIFF
--- a/teams/forms.py
+++ b/teams/forms.py
@@ -61,7 +61,7 @@ class TOTPDeviceAdminForm(forms.ModelForm):
 
 class TOTPDeviceCalibrationActionForm(ActionForm):
     token = forms.CharField(
-        label=_("One-time password"),
+        label=_("OTP"),
         required=False,
         help_text=_(
             "Enter the current authenticator code when running the"
@@ -69,10 +69,26 @@ class TOTPDeviceCalibrationActionForm(ActionForm):
         ),
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        token_field = self.fields["token"]
+        token_field.widget.attrs.setdefault(
+            "title", _("Enter your one-time password for testing")
+        )
+        existing_classes = token_field.widget.attrs.get("class", "")
+        spacing_class = "totp-token-spacing"
+        if spacing_class not in existing_classes.split():
+            token_field.widget.attrs["class"] = (existing_classes + " " + spacing_class).strip()
+
     def clean(self):
         cleaned_data = super().clean()
         token = cleaned_data.get("token")
         if token is not None:
             cleaned_data["token"] = token.strip()
         return cleaned_data
+
+    class Media:
+        css = {
+            "all": ("teams/css/totp_admin.css",)
+        }
 

--- a/teams/static/teams/css/totp_admin.css
+++ b/teams/static/teams/css/totp_admin.css
@@ -1,0 +1,8 @@
+.actions select + .totp-token-spacing {
+  margin-left: 0.75rem;
+}
+
+td .totp-token-spacing {
+  margin-left: 0.75rem;
+}
+


### PR DESCRIPTION
## Summary
- rename the calibration action token field to "OTP" and add a tooltip for testing guidance
- include admin CSS to space the OTP input from the action select

## Testing
- python -m compileall teams/forms.py

------
https://chatgpt.com/codex/tasks/task_e_68e1a6ceb70c83269d979463f30c4cfd