### PR TITLE
style: reduce admin dashboard badge vertical padding

### DIFF
--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -90,9 +90,8 @@
         align-items: center;
         justify-content: center;
         margin-left: 8px;
-        padding: 0 8px;
+        padding: 0.125rem 0.5rem;
         min-width: 1.5rem;
-        height: 1.5rem;
         font-size: 0.75rem;
         font-weight: 600;
         line-height: 1;
@@ -113,8 +112,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 0 8px;
-        min-height: 1.5rem;
+        padding: 0.125rem 0.5rem;
         border-radius: 999px;
         background-color: var(--darkened-bg);
         color: var(--body-fg);


### PR DESCRIPTION
## Summary
- reduce the admin dashboard lead and RFID badges' vertical padding so their rows match the standard height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1af7516588326913402f719b9d1be