### PR TITLE
Fix breadcrumbs for admin system reports

### DIFF
--- a/core/templates/admin/system_upgrade_report.html
+++ b/core/templates/admin/system_upgrade_report.html
@@ -1,6 +1,14 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:system' %}">{% trans 'System' %}</a>
+  &rsaquo; {% trans "Upgrade Report" %}
+</div>
+{% endblock %}
+
 {% block content %}
 <div id="content-main">
   <div class="module upgrade-report">

--- a/nodes/templates/admin/nodes/nodefeature/celery_report.html
+++ b/nodes/templates/admin/nodes/nodefeature/celery_report.html
@@ -1,6 +1,14 @@
 {% extends "admin/base_site.html" %}
 {% load i18n tz %}
 
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:system' %}">{% trans 'System' %}</a>
+  &rsaquo; {% trans "Celery Report" %}
+</div>
+{% endblock %}
+
 {% block content %}
 <div id="content-main" class="celery-report">
   <div class="module celery-report__period">


### PR DESCRIPTION
## Summary
- add breadcrumbs to the Celery Report so it links back through the System page
- add breadcrumbs to the Upgrade Report to show the full navigation path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b0c544688326b8e67d917b248691