### PR TITLE
Add assertions for systemctl probe in LCD check tests

### DIFF
--- a/tests/test_lcd_check_command.py
+++ b/tests/test_lcd_check_command.py
@@ -2,7 +2,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -23,24 +23,38 @@ pytestmark = [
 ]
 
 
-def test_lcd_check_sends_random_string(tmp_path):
+def _create_lock_files(tmp_path):
     locks = tmp_path / "locks"
     locks.mkdir()
     (locks / "lcd_screen.lck").write_text("hello\n", encoding="utf-8")
     (locks / "service.lck").write_text("demo", encoding="utf-8")
+    return locks
+
+
+def _assert_systemctl_probe(mock_run, service_name="demo"):
+    mock_run.assert_called_once_with(
+        ["systemctl", "is-active", f"lcd-{service_name}"],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_lcd_check_sends_random_string(tmp_path):
+    _create_lock_files(tmp_path)
+
+    mock_run = Mock(return_value=SimpleNamespace(returncode=0, stdout="active\n"))
 
     with (
         patch("core.management.commands.lcd_check.CharLCD1602") as mock_lcd,
         patch("core.management.commands.lcd_check.notify") as mock_notify,
         patch("builtins.input", return_value="y"),
         patch("random.choices", return_value=list("ABC123")),
-        patch(
-            "subprocess.run",
-            return_value=SimpleNamespace(returncode=0, stdout="active\n"),
-        ),
+        patch("subprocess.run", mock_run),
         patch.object(settings, "BASE_DIR", tmp_path),
     ):
         call_command("lcd_check")
+
+    _assert_systemctl_probe(mock_run)
 
     mock_lcd.assert_called_once()
     mock_lcd.return_value.init_lcd.assert_called_once()
@@ -48,10 +62,9 @@ def test_lcd_check_sends_random_string(tmp_path):
 
 
 def test_lcd_check_advises_when_i2c_missing(tmp_path, capsys):
-    locks = tmp_path / "locks"
-    locks.mkdir()
-    (locks / "lcd_screen.lck").write_text("hello\n", encoding="utf-8")
-    (locks / "service.lck").write_text("demo", encoding="utf-8")
+    _create_lock_files(tmp_path)
+
+    mock_run = Mock(return_value=SimpleNamespace(returncode=0, stdout="active\n"))
 
     with (
         patch(
@@ -61,13 +74,12 @@ def test_lcd_check_advises_when_i2c_missing(tmp_path, capsys):
         patch("core.management.commands.lcd_check.notify"),
         patch("builtins.input", return_value="n"),
         patch("random.choices", return_value=list("ABC123")),
-        patch(
-            "subprocess.run",
-            return_value=SimpleNamespace(returncode=0, stdout="active\n"),
-        ),
+        patch("subprocess.run", mock_run),
         patch.object(settings, "BASE_DIR", tmp_path),
     ):
         call_command("lcd_check")
+
+    _assert_systemctl_probe(mock_run)
 
     out = capsys.readouterr().out
     assert "Unexpected error during LCD init" in out


### PR DESCRIPTION
## Summary
- replace the subprocess.run patches with mocks that record the invoked command
- assert the lcd_check management command probes systemctl with the expected arguments in both scenarios

## Testing
- pytest tests/test_lcd_check_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b1ca68fc83268d0c0d26d41c93d8