### PR TITLE
Add quick send action for net messages

### DIFF
--- a/nodes/templates/admin/nodes/netmessage/change_list.html
+++ b/nodes/templates/admin/nodes/netmessage/change_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  <li>
+    <a href="{% url 'admin:nodes_netmessage_send' %}" class="addlink">{% trans "Send Net Message" %}</a>
+  </li>
+  {{ block.super }}
+{% endblock %}

--- a/nodes/templates/admin/nodes/netmessage/send.html
+++ b/nodes/templates/admin/nodes/netmessage/send.html
@@ -1,0 +1,44 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+    <a href="{% url 'admin:app_list' opts.app_label %}">{{ opts.app_config.verbose_name }}</a> ›
+    <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a> ›
+    {% trans 'Send Net Message' %}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <h1>{% trans 'Send Net Message' %}</h1>
+  <form method="post" action="">
+    {% csrf_token %}
+    {{ adminform.form.non_field_errors }}
+    {% for fieldset in adminform %}
+      <fieldset class="module aligned{% if fieldset.classes %} {{ fieldset.classes }}{% endif %}">
+        {% if fieldset.name %}<h2>{{ fieldset.name }}</h2>{% endif %}
+        {% for line in fieldset %}
+          {% for field in line %}
+            <div class="form-row{% if field.errors %} errors{% endif %}">
+              {{ field.errors }}
+              {{ field.field.label_tag }} {{ field.field }}
+              {% if field.field.help_text %}
+                <p class="help">{{ field.field.help_text }}</p>
+              {% endif %}
+            </div>
+          {% endfor %}
+        {% endfor %}
+      </fieldset>
+    {% endfor %}
+    <div class="submit-row">
+      <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">{% trans 'Cancel' %}</a>
+      <button type="submit" class="button default">{% trans 'Send message' %}</button>
+    </div>
+  </form>
+{% endblock %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -186,6 +186,7 @@
     <a class="button" href="{% url 'admin:environment' %}">{% translate 'Environ' %}</a>
     <a class="button" href="{% url 'admin:config' %}">{% translate 'Config' %}</a>
     <a class="button" href="{% url 'admin:sigil_builder' %}">{% translate 'Sigil Builder' %}</a>
+    <a class="button" href="{% url 'admin:nodes_netmessage_send' %}">{% translate 'Send Net Message' %}</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated admin view to compose and immediately send Net Messages
- expose the quick send action from the Net Message changelist and the admin dashboard for easy access

## Testing
- pytest nodes/tests.py -k net_message

------
https://chatgpt.com/codex/tasks/task_e_68e1c01825388326bdbcc2228efeadb6