### PR TITLE
Update OCPP 1.6 coverage badge and summary

### DIFF
--- a/ocpp/coverage.json
+++ b/ocpp/coverage.json
@@ -1,0 +1,119 @@
+{
+  "coverage": {
+    "cp_to_csms": {
+      "count": 10,
+      "percent": 100.0,
+      "supported": [
+        "Authorize",
+        "BootNotification",
+        "DataTransfer",
+        "DiagnosticsStatusNotification",
+        "FirmwareStatusNotification",
+        "Heartbeat",
+        "MeterValues",
+        "StartTransaction",
+        "StatusNotification",
+        "StopTransaction"
+      ],
+      "total": 10
+    },
+    "csms_to_cp": {
+      "count": 6,
+      "percent": 31.58,
+      "supported": [
+        "ChangeAvailability",
+        "DataTransfer",
+        "RemoteStartTransaction",
+        "RemoteStopTransaction",
+        "Reset",
+        "TriggerMessage"
+      ],
+      "total": 19
+    },
+    "overall": {
+      "count": 16,
+      "percent": 57.14,
+      "supported": [
+        "Authorize",
+        "BootNotification",
+        "ChangeAvailability",
+        "DataTransfer",
+        "DiagnosticsStatusNotification",
+        "FirmwareStatusNotification",
+        "GetConfiguration",
+        "Heartbeat",
+        "MeterValues",
+        "RemoteStartTransaction",
+        "RemoteStopTransaction",
+        "Reset",
+        "StartTransaction",
+        "StatusNotification",
+        "StopTransaction",
+        "TriggerMessage"
+      ],
+      "total": 28
+    }
+  },
+  "implemented": {
+    "cp_to_csms": [
+      "Authorize",
+      "BootNotification",
+      "DataTransfer",
+      "DiagnosticsStatusNotification",
+      "FirmwareStatusNotification",
+      "GetConfiguration",
+      "Heartbeat",
+      "MeterValues",
+      "RemoteStartTransaction",
+      "RemoteStopTransaction",
+      "Reset",
+      "StartTransaction",
+      "StatusNotification",
+      "StopTransaction",
+      "TriggerMessage"
+    ],
+    "csms_to_cp": [
+      "ChangeAvailability",
+      "DataTransfer",
+      "RemoteStartTransaction",
+      "RemoteStopTransaction",
+      "Reset",
+      "TriggerMessage"
+    ]
+  },
+  "spec": {
+    "cp_to_csms": [
+      "Authorize",
+      "BootNotification",
+      "DataTransfer",
+      "DiagnosticsStatusNotification",
+      "FirmwareStatusNotification",
+      "Heartbeat",
+      "MeterValues",
+      "StartTransaction",
+      "StatusNotification",
+      "StopTransaction"
+    ],
+    "csms_to_cp": [
+      "CancelReservation",
+      "ChangeAvailability",
+      "ChangeConfiguration",
+      "ClearCache",
+      "ClearChargingProfile",
+      "DataTransfer",
+      "GetCompositeSchedule",
+      "GetConfiguration",
+      "GetDiagnostics",
+      "GetLocalListVersion",
+      "RemoteStartTransaction",
+      "RemoteStopTransaction",
+      "ReserveNow",
+      "Reset",
+      "SendLocalList",
+      "SetChargingProfile",
+      "TriggerMessage",
+      "UnlockConnector",
+      "UpdateFirmware"
+    ]
+  }
+}

--- a/ocpp_coverage.svg
+++ b/ocpp_coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="ocpp 1.6: 46.4%">
-  <title>ocpp 1.6: 46.4%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20" role="img" aria-label="ocpp 1.6: 57.1%">
+  <title>ocpp 1.6: 57.1%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -14,6 +14,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="34.0" y="14">ocpp 1.6</text>
-    <text x="93.0" y="14">46.4%</text>
+    <text x="93.0" y="14">57.1%</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- regenerate the OCPP 1.6 coverage badge to reflect the latest implemented handlers
- publish the recalculated coverage breakdown in ocpp/coverage.json for future reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c0bd71688326b7108d94344d6371