### PR TITLE
Fix quick send redirect target in admin

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -1237,8 +1237,7 @@ class NetMessageAdmin(EntityModelAdmin):
                     level=messages.SUCCESS,
                 )
                 changelist_url = reverse(
-                    f"admin:{self.model._meta.app_label}_"
-                    f"{self.model._meta.model_name}_changelist"
+                    f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_changelist"
                 )
                 return redirect(changelist_url)
         else:


### PR DESCRIPTION
## Summary
- build the Net Message quick-send changelist redirect using a single reverse name to avoid ModuleNotFound errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1c23d3ba48326bfe4e7bda02d2b10