### PR TITLE
chore: refresh coverage badge

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">57%</text>
-        <text x="80" y="14">57%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">58%</text>
+        <text x="80" y="14">58%</text>
     </g>
 </svg>


### PR DESCRIPTION
## Summary
- regenerate the coverage badge after recomputing the suite's coverage locally

## Testing
- pytest --cov=. --cov-report=term-missing *(fails: several data fixture and settings assertions in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c18b35b08326844711ce81b0672c