### PR TITLE
Fix deep read button CSRF handling on RFID scanner

### DIFF
--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -700,9 +700,28 @@
 
   if(deepBtn){
     deepBtn.addEventListener('click', async () => {
+      const headers = {
+        'Accept': 'application/json',
+      };
+      const csrf = getCookie('csrftoken');
+      if(csrf){
+        headers['X-CSRFToken'] = csrf;
+      }
       try {
-        await fetch('{{ deep_read_url|default:"" }}', {method: 'POST'});
-        statusEl.textContent = 'Deep read enabled for 60 seconds';
+        const response = await fetch('{{ deep_read_url|default:"" }}', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers,
+        });
+        if(!response.ok){
+          throw new Error('Request failed');
+        }
+        const data = await response.json().catch(() => ({status: null}));
+        if(data.error){
+          throw new Error(data.error);
+        }
+        const timeout = data.timeout || 60;
+        statusEl.textContent = `Deep read enabled for ${timeout} seconds`;
       } catch(err){
         statusEl.textContent = 'Deep read failed';
       }


### PR DESCRIPTION
## Summary
- ensure the RFID scanner deep read request includes CSRF protection and same-origin credentials
- handle API responses to surface backend errors and keep the status message accurate

## Testing
- pytest ocpp/tests/test_rfid_scanner.py::test_enable_deep_read_mode -q

------
https://chatgpt.com/codex/tasks/task_e_68e1c7f252088326be84fcfeed2ed545