### PR TITLE
Simplify RFID admin badge counts

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -41,13 +41,11 @@
                 {% if model.object_name == 'RFID' %}
                   {% rfid_release_stats as rfid_stats %}
                   {% if rfid_stats %}
-                    {% blocktranslate with released=rfid_stats.released registered=rfid_stats.total asvar rfid_badge_label trimmed %}
-                      {{ released }} released RFIDs out of {{ registered }} registered RFIDs
+                    {% blocktranslate with released_allowed=rfid_stats.released_allowed registered=rfid_stats.total asvar rfid_badge_label trimmed %}
+                      {{ released_allowed }} released and allowed RFIDs out of {{ registered }} registered RFIDs
                     {% endblocktranslate %}
-                    <span class="rfid-release-stats" aria-label="{{ rfid_badge_label }}" title="{{ rfid_badge_label }}">
-                      <span class="rfid-release-badge">[{{ rfid_stats.released }} {% translate 'Released' %}]</span>
-                      <span class="rfid-release-separator" aria-hidden="true">/</span>
-                      <span class="rfid-release-badge">[{{ rfid_stats.total }} {% translate 'Registered' %}]</span>
+                    <span class="rfid-release-badge" aria-label="{{ rfid_badge_label }}" title="{{ rfid_badge_label }}">
+                      {{ rfid_stats.released_allowed }} / {{ rfid_stats.total }}
                     </span>
                   {% endif %}
                 {% endif %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -112,11 +112,16 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        margin-left: 8px;
         padding: 0.125rem 0.5rem;
+        min-width: 1.5rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1;
         border-radius: 999px;
-        background-color: var(--darkened-bg);
-        color: var(--body-fg);
-        border: 1px solid var(--hairline-color);
+        background-color: var(--button-bg, #0d6efd);
+        color: var(--button-fg, #fff);
+        border: none;
     }
     .dashboard-main .rfid-release-separator {
         font-weight: 700;

--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -248,10 +248,12 @@ def rfid_release_stats(context):
     if stats is None:
         counts = RFID.objects.aggregate(
             total=Count("pk"),
-            released=Count("pk", filter=Q(released=True)),
+            released_allowed=Count(
+                "pk", filter=Q(released=True, allowed=True)
+            ),
         )
         stats = {
-            "released": counts.get("released") or 0,
+            "released_allowed": counts.get("released_allowed") or 0,
             "total": counts.get("total") or 0,
         }
         context[cache_key] = stats

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1736,16 +1736,19 @@ class FavoriteTests(TestCase):
         self.assertIn('aria-label="2 open leads"', content)
 
     def test_dashboard_shows_rfid_release_badge(self):
-        RFID.objects.create(rfid="RFID0001", released=True)
-        RFID.objects.create(rfid="RFID0002", released=False)
+        RFID.objects.create(rfid="RFID0001", released=True, allowed=True)
+        RFID.objects.create(rfid="RFID0002", released=True, allowed=False)
 
         resp = self.client.get(reverse("admin:index"))
 
-        released_label = gettext("Released")
-        registered_label = gettext("Registered")
-        expected = f"[1 {released_label}] / [2 {registered_label}]"
+        expected = "1 / 2"
+        badge_label = gettext(
+            "%(released_allowed)s released and allowed RFIDs out of %(registered)s registered RFIDs"
+        ) % {"released_allowed": 1, "registered": 2}
 
         self.assertContains(resp, expected)
+        self.assertContains(resp, f'title="{badge_label}"')
+        self.assertContains(resp, f'aria-label="{badge_label}"')
 
     def test_dashboard_limits_future_actions_to_top_four(self):
         from pages.templatetags.admin_extras import future_action_items


### PR DESCRIPTION
## Summary
- update the admin dashboard RFID badge to display released-and-allowed credentials against the total registered count
- adjust the RFID release stats helper to aggregate cards that are both released and allowed
- refresh the dashboard test to cover the new badge layout and accessibility label

## Testing
- python manage.py migrate --noinput
- pytest pages/tests.py::FavoriteTests::test_dashboard_shows_rfid_release_badge


------
https://chatgpt.com/codex/tasks/task_e_68e1cb2558848326b7bb58aeb259ea09