### PR TITLE
Fix release TODO version when VERSION already bumped

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -868,7 +868,7 @@ class ReleaseProcessTests(TestCase):
         sync_main.assert_called_once_with(Path("rel.log"))
         run.assert_any_call(["git", "add", "CHANGELOG.rst"], check=True)
         run.assert_any_call(["git", "add", "VERSION"], check=True)
-        ensure_todo.assert_called_once()
+        ensure_todo.assert_called_once_with(self.release, previous_version=mock.ANY)
 
     @mock.patch("core.views.subprocess.run")
     @mock.patch("core.views.PackageRelease.dump_fixture")

--- a/tests/test_release_progress.py
+++ b/tests/test_release_progress.py
@@ -411,6 +411,24 @@ class ReleaseProgressViewTests(TestCase):
         self.release.refresh_from_db()
         self.assertEqual(self.release.changelog, "- pending change")
 
+    def test_ensure_release_todo_uses_release_version_when_bumped(self):
+        self.release.version = "0.9.1"
+        self.release.save(update_fields=["version"])
+
+        tmp_dir = Path("tmp_todos_version_bumped")
+        tmp_dir.mkdir(exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
+        with mock.patch("core.views.TODO_FIXTURE_DIR", tmp_dir):
+            todo, fixture_path = core_views._ensure_release_todo(
+                self.release, previous_version="0.9.0"
+            )
+
+        expected_request = "Create release pkg 0.9.1"
+        self.assertEqual(todo.request, expected_request)
+        data = json.loads(fixture_path.read_text(encoding="utf-8"))
+        self.assertEqual(data[0]["fields"]["request"], expected_request)
+
     @mock.patch("core.views.release_utils._git_clean", return_value=True)
     @mock.patch("core.views.release_utils.network_available", return_value=False)
     def test_pre_release_python_fallback(self, net, git_clean):

--- a/tests/test_release_progress_pre_release_integration.py
+++ b/tests/test_release_progress_pre_release_integration.py
@@ -137,6 +137,9 @@ EOF
         check=True,
     )
 
+    core_views._step_check_todos(release, {"todos_ack": True}, log_path)
+    commands.clear()
+
     release.version = "1.2.1"
     release.save(update_fields=["version"])
 
@@ -152,7 +155,7 @@ EOF
     changelog_text = Path("CHANGELOG.rst").read_text(encoding="utf-8")
     assert "Fix fallback integration coverage (#42)" in changelog_text
 
-    fixture_two = todo_fixture_dir / "todos__create_release_pkg_1_2_2.json"
+    fixture_two = todo_fixture_dir / "todos__create_release_pkg_1_2_1.json"
     assert fixture_two.exists()
 
     second_diff = subprocess.run(


### PR DESCRIPTION
## Summary
- ensure release TODO generation reuses the release version when the VERSION file has already been advanced
- capture the repository version before syncing and pass it through pre-release actions
- add regression coverage for the TODO helper and integration flow when the VERSION bump happens early

## Testing
- pytest tests/test_release_progress.py tests/test_release_progress_pre_release_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e1daafcf648326967f24f96c133fd4