### PR TITLE
Toggle RFID deep read mode without timeout

### DIFF
--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -16,7 +16,7 @@ from .constants import (
 )
 
 
-_deep_read_until: float = 0.0
+_deep_read_enabled: bool = False
 
 _HEX_RE = re.compile(r"^[0-9A-F]+$")
 
@@ -73,10 +73,20 @@ def _build_tag_response(tag, rfid: str, *, created: bool, kind: str | None = Non
     return result
 
 
-def enable_deep_read(duration: float = 60) -> None:
-    """Enable deep read mode for ``duration`` seconds."""
-    global _deep_read_until
-    _deep_read_until = time.time() + duration
+def enable_deep_read(duration: float | None = None) -> bool:
+    """Enable deep read mode until it is explicitly disabled."""
+
+    global _deep_read_enabled
+    _deep_read_enabled = True
+    return _deep_read_enabled
+
+
+def toggle_deep_read() -> bool:
+    """Toggle deep read mode and return the new state."""
+
+    global _deep_read_enabled
+    _deep_read_enabled = not _deep_read_enabled
+    return _deep_read_enabled
 
 
 def read_rfid(
@@ -143,9 +153,7 @@ def read_rfid(
                         created=created,
                         kind=kind,
                     )
-                    deep_read_active = (
-                        tag.kind == RFID.CLASSIC and time.time() < _deep_read_until
-                    )
+                    deep_read_active = tag.kind == RFID.CLASSIC and _deep_read_enabled
                     if deep_read_active:
                         keys = {}
                         if hasattr(tag, "key_a"):

--- a/ocpp/rfid/scanner.py
+++ b/ocpp/rfid/scanner.py
@@ -1,6 +1,6 @@
 from .background_reader import get_next_tag, is_configured, start, stop
 from .irq_wiring_check import check_irq_pin
-from .reader import enable_deep_read
+from .reader import toggle_deep_read
 
 
 def scan_sources(request=None):
@@ -36,8 +36,9 @@ def test_sources():
 
 
 def enable_deep_read_mode(duration: float = 60) -> dict:
-    """Put the RFID reader into deep read mode for ``duration`` seconds."""
+    """Toggle the RFID reader deep read mode and report the new state."""
     if not is_configured():
         return {"error": "no scanner available"}
-    enable_deep_read(duration)
-    return {"status": "deep read enabled", "timeout": duration}
+    enabled = toggle_deep_read()
+    status = "deep read enabled" if enabled else "deep read disabled"
+    return {"status": status, "enabled": enabled}

--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -272,6 +272,7 @@
   let lastLocalValue = null;
   let lastLocalAt = 0;
   const historyEntries = tableMode ? new Map() : null;
+  let deepReadActive = false;
 
   if(modeToggleBtn){
     const toggleTarget = modeToggleBtn.getAttribute('data-toggle-url') || modeToggleBtn.getAttribute('href');
@@ -360,6 +361,21 @@
     if(deepBlocksEl){ deepBlocksEl.innerHTML = ''; }
   }
 
+  function setDeepReadState(enabled, options){
+    const opts = Object.assign({updateStatus: true, clearDetails: true}, options || {});
+    deepReadActive = Boolean(enabled);
+    if(deepBtn){
+      deepBtn.textContent = deepReadActive ? 'Disable Deep Read' : 'Enable Deep Read';
+      deepBtn.setAttribute('aria-pressed', deepReadActive ? 'true' : 'false');
+    }
+    if(opts.updateStatus){
+      statusEl.textContent = deepReadActive ? 'Deep read enabled' : 'Deep read disabled';
+    }
+    if(!deepReadActive && opts.clearDetails){
+      clearDeepDetails();
+    }
+  }
+
   function updateDeepDetails(data){
     if(!deepDetailsEl || tableMode){
       return;
@@ -370,6 +386,9 @@
     if(!isDeep && !hasDump){
       clearDeepDetails();
       return;
+    }
+    if(isDeep){
+      setDeepReadState(true, {updateStatus: false, clearDetails: false});
     }
     deepDetailsEl.style.display = 'block';
     const keys = (data && data.keys) || {};
@@ -512,6 +531,9 @@
       configureEl.style.display = 'inline';
     }
     updateDeepDetails(data);
+    if(deepBtn && data.deep_read){
+      setDeepReadState(true, {updateStatus: false, clearDetails: false});
+    }
     const okText = data.allowed === undefined ? '' : (data.allowed ? 'OK' : 'BAD');
     const statusMsg = okText ? `RFID ${labelValue} ${okText}` : `RFID ${labelValue}`;
     statusEl.textContent = data.created ? `Created ${statusMsg}` : statusMsg;
@@ -699,6 +721,7 @@
   }
 
   if(deepBtn){
+    setDeepReadState(false, {updateStatus: false, clearDetails: false});
     deepBtn.addEventListener('click', async () => {
       const headers = {
         'Accept': 'application/json',
@@ -707,6 +730,7 @@
       if(csrf){
         headers['X-CSRFToken'] = csrf;
       }
+      deepBtn.disabled = true;
       try {
         const response = await fetch('{{ deep_read_url|default:"" }}', {
           method: 'POST',
@@ -716,14 +740,18 @@
         if(!response.ok){
           throw new Error('Request failed');
         }
-        const data = await response.json().catch(() => ({status: null}));
+        const data = await response.json().catch(() => ({}));
         if(data.error){
           throw new Error(data.error);
         }
-        const timeout = data.timeout || 60;
-        statusEl.textContent = `Deep read enabled for ${timeout} seconds`;
+        const enabled = Boolean(data.enabled);
+        setDeepReadState(enabled, {updateStatus: false});
+        statusEl.textContent = data.status || (enabled ? 'Deep read enabled' : 'Deep read disabled');
       } catch(err){
-        statusEl.textContent = 'Deep read failed';
+        const message = err && err.message ? err.message : 'Deep read failed';
+        statusEl.textContent = message;
+      } finally {
+        deepBtn.disabled = false;
       }
     });
   }

--- a/ocpp/test_rfid.py
+++ b/ocpp/test_rfid.py
@@ -607,7 +607,7 @@ class DeepReadViewTests(TestCase):
     @patch("config.middleware.get_site")
     @patch(
         "ocpp.rfid.views.enable_deep_read_mode",
-        return_value={"status": "deep", "timeout": 60},
+        return_value={"status": "deep read enabled", "enabled": True},
     )
     def test_enable_deep_read(self, mock_enable, mock_site, mock_node):
         User = get_user_model()
@@ -615,7 +615,9 @@ class DeepReadViewTests(TestCase):
         self.client.force_login(staff)
         resp = self.client.post(reverse("rfid-scan-deep"))
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), {"status": "deep", "timeout": 60})
+        self.assertEqual(
+            resp.json(), {"status": "deep read enabled", "enabled": True}
+        )
         mock_enable.assert_called_once()
 
     def test_forbidden_for_anonymous(self):

--- a/ocpp/tests/test_rfid_scanner.py
+++ b/ocpp/tests/test_rfid_scanner.py
@@ -70,16 +70,22 @@ def test_test_sources_handles_configuration(configured):
         assert result == {"error": "no scanner available"}
 
 
-@pytest.mark.parametrize("configured", [True, False])
-def test_enable_deep_read_mode(configured):
-    duration = 30
+@pytest.mark.parametrize(
+    "configured, toggled, expected",
+    [
+        (True, True, {"status": "deep read enabled", "enabled": True}),
+        (True, False, {"status": "deep read disabled", "enabled": False}),
+        (False, True, {"error": "no scanner available"}),
+    ],
+)
+def test_enable_deep_read_mode(configured, toggled, expected):
     with patch("ocpp.rfid.scanner.is_configured", return_value=configured), patch(
-        "ocpp.rfid.scanner.enable_deep_read"
-    ) as mock_enable:
-        result = scanner.enable_deep_read_mode(duration)
+        "ocpp.rfid.scanner.toggle_deep_read", return_value=toggled
+    ) as mock_toggle:
+        result = scanner.enable_deep_read_mode()
     if configured:
-        mock_enable.assert_called_once_with(duration)
-        assert result == {"status": "deep read enabled", "timeout": duration}
+        mock_toggle.assert_called_once_with()
+        assert result == expected
     else:
-        mock_enable.assert_not_called()
-        assert result == {"error": "no scanner available"}
+        mock_toggle.assert_not_called()
+        assert result == expected


### PR DESCRIPTION
## Summary
- make the RFID deep read mode stateful so it can be toggled on and off without expiring
- update the scanner interface to reflect the current deep read state and handle toggle failures
- adjust RFID scanner tests for the new toggle semantics

## Testing
- pytest ocpp/tests/test_rfid_scanner.py ocpp/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68e1df6d8128832689217e3df978811b