### PR TITLE
Default Datasette enablement with opt-out flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,11 +22,11 @@ CLEAN=false
 ENABLE_CONTROL=false
 NODE_ROLE="Terminal"
 REQUIRES_REDIS=false
-ENABLE_DATASETTE=false
+ENABLE_DATASETTE=true
 START_SERVICES=false
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--public|--internal] [--port PORT] [--upgrade] [--auto-upgrade] [--latest] [--satellite] [--terminal] [--control] [--constellation] [--celery] [--lcd-screen|--no-lcd-screen] [--datasette] [--clean] [--start]" >&2
+    echo "Usage: $0 [--service NAME] [--public|--internal] [--port PORT] [--upgrade] [--auto-upgrade] [--latest] [--satellite] [--terminal] [--control] [--constellation] [--celery] [--lcd-screen|--no-lcd-screen] [--datasette|--no-datasette] [--clean] [--start]" >&2
     exit 1
 }
 
@@ -162,6 +162,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --datasette)
             ENABLE_DATASETTE=true
+            shift
+            ;;
+        --no-datasette)
+            ENABLE_DATASETTE=false
             shift
             ;;
         --lcd-screen)

--- a/switch-role.sh
+++ b/switch-role.sh
@@ -18,7 +18,7 @@ REQUIRES_REDIS=false
 UPDATE=false
 CLEAN=false
 LATEST=false
-ENABLE_DATASETTE=false
+ENABLE_DATASETTE=true
 CHECK=false
 AUTO_UPGRADE_MODE=""
 
@@ -26,7 +26,7 @@ BASE_DIR="$SCRIPT_DIR"
 LOCK_DIR="$BASE_DIR/locks"
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--update] [--latest] [--clean] [--datasette] [--check] [--auto-upgrade|--no-auto-upgrade] [--satellite|--terminal|--control|--constellation]" >&2
+    echo "Usage: $0 [--service NAME] [--update] [--latest] [--clean] [--datasette|--no-datasette] [--check] [--auto-upgrade|--no-auto-upgrade] [--satellite|--terminal|--control|--constellation]" >&2
     exit 1
 }
 
@@ -108,6 +108,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --datasette)
             ENABLE_DATASETTE=true
+            shift
+            ;;
+        --no-datasette)
+            ENABLE_DATASETTE=false
             shift
             ;;
         --check)


### PR DESCRIPTION
## Summary
- enable Datasette by default in install and switch-role scripts
- add a --no-datasette flag to opt out and update usage help accordingly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e034faf083269fef56f6968d6427