### PR TITLE
Keep deep read data visible between scans

### DIFF
--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -273,6 +273,7 @@
   let lastLocalAt = 0;
   const historyEntries = tableMode ? new Map() : null;
   let deepReadActive = false;
+  let lastDeepDetailsRfid = null;
 
   if(modeToggleBtn){
     const toggleTarget = modeToggleBtn.getAttribute('data-toggle-url') || modeToggleBtn.getAttribute('href');
@@ -351,6 +352,7 @@
   }
 
   function clearDeepDetails(){
+    lastDeepDetailsRfid = null;
     if(!deepDetailsEl){
       return;
     }
@@ -376,21 +378,35 @@
     }
   }
 
-  function updateDeepDetails(data){
+  function normalizeRfidValue(value){
+    if(value === undefined || value === null){
+      return null;
+    }
+    const text = String(value);
+    return text ? text : null;
+  }
+
+  function updateDeepDetails(data, rfidValue){
     if(!deepDetailsEl || tableMode){
       return;
     }
+    const normalizedRfid = normalizeRfidValue(rfidValue);
     const dumpEntries = Array.isArray(data && data.dump) ? data.dump : [];
     const hasDump = dumpEntries.length > 0;
     const isDeep = Boolean(data && data.deep_read);
     if(!isDeep && !hasDump){
-      clearDeepDetails();
+      if(normalizedRfid && lastDeepDetailsRfid && normalizedRfid !== lastDeepDetailsRfid){
+        clearDeepDetails();
+      }
       return;
     }
     if(isDeep){
       setDeepReadState(true, {updateStatus: false, clearDetails: false});
     }
     deepDetailsEl.style.display = 'block';
+    if(normalizedRfid){
+      lastDeepDetailsRfid = normalizedRfid;
+    }
     const keys = (data && data.keys) || {};
     if(keyAEl){
       const keyAValue = keys.a !== undefined ? keys.a : keys.key_a;
@@ -506,9 +522,12 @@
       return;
     }
     if(!data.rfid){
-      clearDeepDetails();
+      if(typeof data.status === 'string' && data.status){
+        statusEl.textContent = data.status;
+      }
       return;
     }
+    const rfidValue = normalizeRfidValue(data.rfid);
     const labelValue = data.label_id === undefined || data.label_id === null ? '' : data.label_id;
     if(labelEl){ labelEl.textContent = labelValue; }
     if(kindEl){ kindEl.textContent = data.kind || ''; }
@@ -530,7 +549,7 @@
       configureEl.href = adminTemplate ? adminTemplate.replace('0', labelValue) : '#';
       configureEl.style.display = 'inline';
     }
-    updateDeepDetails(data);
+    updateDeepDetails(data, rfidValue);
     if(deepBtn && data.deep_read){
       setDeepReadState(true, {updateStatus: false, clearDetails: false});
     }


### PR DESCRIPTION
## Summary
- preserve deep read details on the RFID scanner until the user disables deep read or scans a different card
- normalize RFID values so repeated polls without data do not clear previously shown deep read information

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e493eee48326b647cfbf80a11ceb