### PR TITLE
Store RFID deep read dump on tag records

### DIFF
--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -192,13 +192,16 @@ def read_rfid(
                                     else:
                                         r, data = (mfrc.MI_OK, read_status)
                                     if r == mfrc.MI_OK and data is not None:
-                                        entry = {"block": block, "data": data}
+                                        entry = {"block": block, "data": list(data)}
                                         if used_key:
                                             entry["key"] = used_key
                                         dump.append(entry)
                             except Exception:
                                 continue
                         result["dump"] = dump
+                        if getattr(tag, "data", None) != dump:
+                            tag.data = [dict(entry) for entry in dump]
+                            tag.save(update_fields=["data"])
                     return result
             if not use_irq and poll_interval:
                 time.sleep(poll_interval)

--- a/ocpp/test_rfid.py
+++ b/ocpp/test_rfid.py
@@ -664,6 +664,8 @@ class DeepReadAuthTests(TestCase):
         tag.key_b = "B1B2B3B4B5B6"
         tag.key_a_verified = True
         tag.key_b_verified = False
+        tag.data = []
+        tag.save = MagicMock()
         mock_get.return_value = (tag, False)
         reader = self.MockReader()
         enable_deep_read(60)
@@ -677,6 +679,13 @@ class DeepReadAuthTests(TestCase):
         self.assertEqual(result["keys"].get("a"), "A1A2A3A4A5A6")
         self.assertFalse(result["keys"].get("b_verified"))
         self.assertTrue(any(entry.get("key") == "B" for entry in result["dump"]))
+        self.assertEqual(tag.data, result["dump"])
+        self.assertTrue(
+            any(
+                "data" in set(kwargs.get("update_fields", []) or [])
+                for _args, kwargs in tag.save.call_args_list
+            )
+        )
 
 
 class RFIDWiringConfigTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- persist RFID deep read sector dumps onto the tag record when scanning
- serialize block data for JSON storage and extend tests to cover persistence

## Testing
- pytest ocpp/test_rfid.py::DeepReadAuthTests::test_auth_tries_key_a_then_b

------
https://chatgpt.com/codex/tasks/task_e_68e1e69547008326b4bb366c78ff5981