### PR TITLE
Improve RFID deep read key verification

### DIFF
--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -19,6 +19,70 @@ from .constants import (
 _deep_read_enabled: bool = False
 
 _HEX_RE = re.compile(r"^[0-9A-F]+$")
+_KEY_RE = re.compile(r"^[0-9A-F]{12}$")
+
+COMMON_MIFARE_CLASSIC_KEYS = (
+    "FFFFFFFFFFFF",
+    "A0A1A2A3A4A5",
+    "B0B1B2B3B4B5",
+    "000000000000",
+    "D3F7D3F7D3F7",
+    "AABBCCDDEEFF",
+    "1A2B3C4D5E6F",
+    "4D3A99C351DD",
+    "123456789ABC",
+    "ABCDEF123456",
+)
+
+
+def _normalize_key(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().upper()
+    if not candidate:
+        return None
+    if not _KEY_RE.fullmatch(candidate):
+        return None
+    return candidate
+
+
+def _key_to_bytes(value: str) -> list[int] | None:
+    if not _KEY_RE.fullmatch(value):
+        return None
+    try:
+        return [int(value[i : i + 2], 16) for i in range(0, 12, 2)]
+    except ValueError:  # pragma: no cover - defensive guard
+        return None
+
+
+def _build_key_candidates(tag, key_attr: str, verified_attr: str) -> list[tuple[str, list[int]]]:
+    candidates: list[tuple[str, list[int]]] = []
+    seen: set[str] = set()
+
+    normalized = _normalize_key(getattr(tag, key_attr, ""))
+    if normalized:
+        bytes_key = _key_to_bytes(normalized)
+        if bytes_key is not None:
+            candidates.append((normalized, bytes_key))
+            seen.add(normalized)
+
+    if not bool(getattr(tag, verified_attr, False)):
+        for key in COMMON_MIFARE_CLASSIC_KEYS:
+            if key in seen:
+                continue
+            bytes_key = _key_to_bytes(key)
+            if bytes_key is None:
+                continue
+            candidates.append((key, bytes_key))
+            seen.add(key)
+
+    if not candidates:
+        fallback = COMMON_MIFARE_CLASSIC_KEYS[0]
+        bytes_key = _key_to_bytes(fallback)
+        if bytes_key is not None:
+            candidates.append((fallback, bytes_key))
+
+    return candidates
 
 
 def _build_tag_response(tag, rfid: str, *, created: bool, kind: str | None = None) -> dict:
@@ -155,36 +219,61 @@ def read_rfid(
                     )
                     deep_read_active = tag.kind == RFID.CLASSIC and _deep_read_enabled
                     if deep_read_active:
-                        keys = {}
+                        keys: dict[str, object] = {}
                         if hasattr(tag, "key_a"):
-                            keys["a"] = getattr(tag, "key_a") or ""
+                            key_a_value = _normalize_key(getattr(tag, "key_a", ""))
+                            keys["a"] = key_a_value or (getattr(tag, "key_a", "") or "")
                             keys["a_verified"] = bool(
                                 getattr(tag, "key_a_verified", False)
                             )
                         if hasattr(tag, "key_b"):
-                            keys["b"] = getattr(tag, "key_b") or ""
+                            key_b_value = _normalize_key(getattr(tag, "key_b", ""))
+                            keys["b"] = key_b_value or (getattr(tag, "key_b", "") or "")
                             keys["b_verified"] = bool(
                                 getattr(tag, "key_b_verified", False)
                             )
-                        if keys:
-                            result["keys"] = keys
+
+                        result["keys"] = keys
                         result["deep_read"] = True
+
                         dump = []
-                        default_key = [0xFF] * 6
+                        pending_updates: set[str] = set()
+                        key_candidates = {
+                            "A": _build_key_candidates(tag, "key_a", "key_a_verified"),
+                            "B": _build_key_candidates(tag, "key_b", "key_b_verified"),
+                        }
+
                         for block in range(64):
                             try:
                                 used_key = None
-                                status = mfrc.MFRC522_Auth(
-                                    mfrc.PICC_AUTHENT1A, block, default_key, uid
-                                )
-                                if status == mfrc.MI_OK:
-                                    used_key = "A"
-                                if status != mfrc.MI_OK:
+                                used_value = None
+                                used_bytes: list[int] | None = None
+                                status = mfrc.MI_ERR
+
+                                for key_value, key_bytes in key_candidates["A"]:
                                     status = mfrc.MFRC522_Auth(
-                                        mfrc.PICC_AUTHENT1B, block, default_key, uid
+                                        mfrc.PICC_AUTHENT1A, block, key_bytes, uid
                                     )
                                     if status == mfrc.MI_OK:
-                                        used_key = "B"
+                                        used_key = "A"
+                                        used_value = key_value
+                                        used_bytes = key_bytes
+                                        break
+
+                                if status != mfrc.MI_OK:
+                                    for key_value, key_bytes in key_candidates["B"]:
+                                        status = mfrc.MFRC522_Auth(
+                                            mfrc.PICC_AUTHENT1B,
+                                            block,
+                                            key_bytes,
+                                            uid,
+                                        )
+                                        if status == mfrc.MI_OK:
+                                            used_key = "B"
+                                            used_value = key_value
+                                            used_bytes = key_bytes
+                                            break
+
                                 if status == mfrc.MI_OK:
                                     read_status = mfrc.MFRC522_Read(block)
                                     if isinstance(read_status, tuple):
@@ -196,8 +285,44 @@ def read_rfid(
                                         if used_key:
                                             entry["key"] = used_key
                                         dump.append(entry)
+
+                                        if used_key == "A" and used_value:
+                                            if used_value != keys.get("a"):
+                                                keys["a"] = used_value
+                                            if not keys.get("a_verified"):
+                                                keys["a_verified"] = True
+                                            if not getattr(tag, "key_a_verified", False) or getattr(
+                                                tag, "key_a", ""
+                                            ).upper() != used_value:
+                                                setattr(tag, "key_a", used_value)
+                                                setattr(tag, "key_a_verified", True)
+                                                pending_updates.update(
+                                                    {"key_a", "key_a_verified"}
+                                                )
+                                            if used_bytes is not None:
+                                                key_candidates["A"] = [(used_value, used_bytes)]
+
+                                        if used_key == "B" and used_value:
+                                            if used_value != keys.get("b"):
+                                                keys["b"] = used_value
+                                            if not keys.get("b_verified"):
+                                                keys["b_verified"] = True
+                                            if not getattr(tag, "key_b_verified", False) or getattr(
+                                                tag, "key_b", ""
+                                            ).upper() != used_value:
+                                                setattr(tag, "key_b", used_value)
+                                                setattr(tag, "key_b_verified", True)
+                                                pending_updates.update(
+                                                    {"key_b", "key_b_verified"}
+                                                )
+                                            if used_bytes is not None:
+                                                key_candidates["B"] = [(used_value, used_bytes)]
                             except Exception:
                                 continue
+
+                        if pending_updates:
+                            tag.save(update_fields=sorted(pending_updates))
+
                         result["dump"] = dump
                     return result
             if not use_irq and poll_interval:


### PR DESCRIPTION
## Summary
- add heuristics for common MIFARE keys so deep reads can authenticate unverified tags
- persist newly verified RFID keys and expose the updated key metadata in scanner responses
- extend deep read tests to cover verification of heuristic keys

## Testing
- pytest ocpp/test_rfid.py::DeepReadAuthTests


------
https://chatgpt.com/codex/tasks/task_e_68e1e716c0e88326a499427e6641b8c3