### PR TITLE
Auto-start MCP server when assistant profiles are active

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -347,3 +347,10 @@ class CoreConfig(AppConfig):
             dispatch_uid="core.github_issue_reporter",
             weak=False,
         )
+
+        try:
+            from .mcp.auto_start import schedule_auto_start
+
+            schedule_auto_start()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("Failed to schedule MCP auto-start")

--- a/core/mcp/auto_start.py
+++ b/core/mcp/auto_start.py
@@ -1,0 +1,190 @@
+"""Auto-start helpers for the MCP sigil resolver server."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+
+from django.conf import settings
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.utils import DatabaseError, OperationalError, ProgrammingError
+
+from . import process as mcp_process
+
+__all__ = ["schedule_auto_start"]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DELAY_SECONDS = 2.0
+
+# Management commands that should never trigger the MCP auto-start workflow.
+_SKIP_MANAGEMENT_COMMANDS: set[str] = {
+    "changepassword",
+    "check",
+    "collectstatic",
+    "compilemessages",
+    "createsuperuser",
+    "dbshell",
+    "dumpdata",
+    "flush",
+    "loaddata",
+    "makemessages",
+    "makemigrations",
+    "migrate",
+    "shell",
+    "shell_plus",
+    "sqlflush",
+    "test",
+}
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _management_command_name(argv: list[str]) -> str | None:
+    if not argv:
+        return None
+    if argv[0].endswith("manage.py") and len(argv) > 1:
+        return argv[1]
+    return None
+
+
+def _should_schedule_auto_start() -> bool:
+    """Return ``True`` when the current process should schedule auto-start."""
+
+    if _is_truthy(os.environ.get("MCP_AUTO_START_DISABLED")):
+        return False
+
+    # pytest sets this environment variable for each running test. When the
+    # value is truthy we avoid mutating the test process state by starting
+    # background timers or subprocesses.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+
+    argv = list(sys.argv or [])
+    management_command = _management_command_name(argv)
+    if management_command is not None:
+        if management_command == "runserver":
+            if "--noreload" in argv[2:]:
+                return True
+            return os.environ.get("RUN_MAIN") == "true"
+        if management_command in _SKIP_MANAGEMENT_COMMANDS:
+            return False
+        # Assume all other management commands run in a foreground process
+        # where starting background services is acceptable.
+        return True
+
+    if not argv:
+        return True
+
+    command = argv[0].lower()
+    if "pytest" in command or "py.test" in command:
+        return False
+    if command.endswith("celery") or command.startswith("celery"):
+        return False
+    if "celery" in command:
+        return False
+
+    return True
+
+
+def _has_active_assistant_profile() -> bool:
+    """Return ``True`` when at least one active Assistant Profile exists."""
+
+    try:
+        connection = connections[DEFAULT_DB_ALIAS]
+    except Exception:  # pragma: no cover - defensive fallback
+        return False
+
+    if not connection.settings_dict:
+        return False
+
+    try:
+        if not connection.is_usable():  # pragma: no cover - best effort
+            return False
+    except Exception:
+        # Some database backends do not implement ``is_usable``. Continue and
+        # rely on the query to raise an OperationalError when unavailable.
+        pass
+
+    try:
+        from core.models import AssistantProfile
+
+        return AssistantProfile.objects.filter(is_active=True).exists()
+    except (OperationalError, ProgrammingError, DatabaseError):
+        return False
+
+
+def _resolve_delay_seconds(delay: float | None = None) -> float:
+    if delay is not None:
+        try:
+            return max(float(delay), 0.0)
+        except (TypeError, ValueError):
+            return DEFAULT_DELAY_SECONDS
+
+    config = dict(getattr(settings, "MCP_SIGIL_SERVER", {}))
+    configured_delay = config.get("auto_start_delay")
+    if configured_delay is not None:
+        try:
+            return max(float(configured_delay), 0.0)
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_DELAY_SECONDS
+
+
+def _start_server_if_needed() -> bool:
+    """Start the MCP server when required.
+
+    Returns ``True`` when a start was attempted, ``False`` otherwise.
+    """
+
+    if not _has_active_assistant_profile():
+        return False
+
+    try:
+        status = mcp_process.get_status()
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Unable to determine MCP server status for auto-start")
+        return False
+
+    if status.get("running"):
+        return False
+
+    try:
+        pid = mcp_process.start_server()
+    except mcp_process.ServerAlreadyRunningError:
+        return False
+    except mcp_process.ServerStartError:
+        logger.exception("Unable to auto-start MCP server")
+        return False
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Unexpected error auto-starting MCP server")
+        return False
+
+    logger.info("Auto-started MCP server because an active Assistant Profile is present (PID %s).", pid)
+    return True
+
+
+def schedule_auto_start(*, delay: float | None = None) -> bool:
+    """Schedule the MCP server auto-start if the environment requires it.
+
+    Returns ``True`` when the timer has been scheduled, ``False`` otherwise.
+    """
+
+    if not _should_schedule_auto_start():
+        return False
+
+    if not _has_active_assistant_profile():
+        return False
+
+    delay_seconds = _resolve_delay_seconds(delay)
+
+    timer = threading.Timer(delay_seconds, _start_server_if_needed)
+    timer.daemon = True
+    timer.start()
+    return True

--- a/tests/test_mcp_auto_start.py
+++ b/tests/test_mcp_auto_start.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase
+
+from core.mcp import auto_start
+from core.models import AssistantProfile, hash_key
+
+
+class ShouldScheduleAutoStartTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        # Ensure the pytest guard does not short-circuit the logic during tests.
+        self.pytest_patch = mock.patch.dict(
+            auto_start.os.environ, {"PYTEST_CURRENT_TEST": ""}, clear=False
+        )
+        self.pytest_patch.start()
+
+    def tearDown(self):
+        self.pytest_patch.stop()
+        super().tearDown()
+
+    def test_runserver_child_process_schedules(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["manage.py", "runserver"]):
+            with mock.patch.dict(
+                auto_start.os.environ, {"RUN_MAIN": "true"}, clear=False
+            ):
+                self.assertTrue(auto_start._should_schedule_auto_start())
+
+    def test_runserver_parent_process_skipped(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["manage.py", "runserver"]):
+            with mock.patch.dict(
+                auto_start.os.environ, {"RUN_MAIN": "false"}, clear=False
+            ):
+                self.assertFalse(auto_start._should_schedule_auto_start())
+
+    def test_runserver_no_reload_schedules(self):
+        argv = ["manage.py", "runserver", "--noreload"]
+        with mock.patch("core.mcp.auto_start.sys.argv", argv):
+            self.assertTrue(auto_start._should_schedule_auto_start())
+
+    def test_management_command_skip(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["manage.py", "migrate"]):
+            self.assertFalse(auto_start._should_schedule_auto_start())
+
+    def test_pytest_command_skipped(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["pytest"]):
+            with mock.patch.dict(
+                auto_start.os.environ, {"PYTEST_CURRENT_TEST": "running"}, clear=False
+            ):
+                self.assertFalse(auto_start._should_schedule_auto_start())
+
+    def test_celery_command_skipped(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["celery", "worker"]):
+            self.assertFalse(auto_start._should_schedule_auto_start())
+
+    def test_generic_process_allows_auto_start(self):
+        with mock.patch("core.mcp.auto_start.sys.argv", ["gunicorn", "config.wsgi"]):
+            self.assertTrue(auto_start._should_schedule_auto_start())
+
+
+class HasActiveAssistantProfileTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(
+            username="assistant-test-user", password="password"
+        )
+
+    def test_returns_true_when_active_profile_exists(self):
+        AssistantProfile.objects.create(
+            user=self.user,
+            user_key_hash=hash_key("active"),
+            scopes=["chat"],
+            is_active=True,
+        )
+        self.assertTrue(auto_start._has_active_assistant_profile())
+
+    def test_returns_false_when_all_profiles_inactive(self):
+        AssistantProfile.objects.create(
+            user=self.user,
+            user_key_hash=hash_key("inactive"),
+            scopes=["chat"],
+            is_active=False,
+        )
+        self.assertFalse(auto_start._has_active_assistant_profile())
+
+
+class ScheduleAutoStartTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(
+            username="assistant-schedule-user", password="password"
+        )
+        self.profile = AssistantProfile.objects.create(
+            user=self.user,
+            user_key_hash=hash_key("schedule"),
+            scopes=["chat"],
+            is_active=True,
+        )
+        self.pytest_patch = mock.patch.dict(
+            auto_start.os.environ, {"PYTEST_CURRENT_TEST": ""}, clear=False
+        )
+        self.pytest_patch.start()
+        self.argv_patch = mock.patch(
+            "core.mcp.auto_start.sys.argv", ["manage.py", "runserver", "--noreload"]
+        )
+        self.argv_patch.start()
+
+    def tearDown(self):
+        self.pytest_patch.stop()
+        self.argv_patch.stop()
+        super().tearDown()
+
+    @mock.patch("core.mcp.auto_start.threading.Timer")
+    def test_schedule_auto_start_creates_timer(self, timer_mock):
+        timer_instance = timer_mock.return_value
+        result = auto_start.schedule_auto_start(delay=1.5)
+        self.assertTrue(result)
+        timer_mock.assert_called_once()
+        args, kwargs = timer_mock.call_args
+        self.assertAlmostEqual(args[0], 1.5)
+        callback = args[1]
+        self.assertTrue(callable(callback))
+        self.assertTrue(timer_instance.daemon)
+        timer_instance.start.assert_called_once()
+
+    @mock.patch("core.mcp.auto_start.threading.Timer")
+    def test_schedule_auto_start_skips_when_no_active_profile(self, timer_mock):
+        AssistantProfile.objects.update(is_active=False)
+        result = auto_start.schedule_auto_start(delay=1.0)
+        self.assertFalse(result)
+        timer_mock.assert_not_called()
+
+    @mock.patch("core.mcp.auto_start.mcp_process")
+    def test_start_server_if_needed_starts_when_inactive(self, process_mock):
+        process_mock.get_status.return_value = {"running": False}
+        with mock.patch("core.mcp.auto_start._has_active_assistant_profile", return_value=True):
+            self.assertTrue(auto_start._start_server_if_needed())
+        process_mock.start_server.assert_called_once()
+
+    @mock.patch("core.mcp.auto_start.mcp_process")
+    def test_start_server_if_needed_skips_when_running(self, process_mock):
+        process_mock.get_status.return_value = {"running": True}
+        with mock.patch("core.mcp.auto_start._has_active_assistant_profile", return_value=True):
+            self.assertFalse(auto_start._start_server_if_needed())
+        process_mock.start_server.assert_not_called()
+
+    @mock.patch("core.mcp.auto_start.mcp_process")
+    def test_start_server_if_needed_handles_errors(self, process_mock):
+        process_mock.get_status.side_effect = RuntimeError("boom")
+        with mock.patch("core.mcp.auto_start._has_active_assistant_profile", return_value=True):
+            self.assertFalse(auto_start._start_server_if_needed())
+        process_mock.start_server.assert_not_called()


### PR DESCRIPTION
## Summary
- add an auto-start helper that launches the MCP server when an active assistant profile exists
- schedule the helper during application startup and cover it with environment-aware unit tests

## Testing
- pytest tests/test_mcp_auto_start.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e788dac08326950c029dfdd102df