### PR TITLE
Improve RFID deep read feedback

### DIFF
--- a/ocpp/templates/rfid/scanner.html
+++ b/ocpp/templates/rfid/scanner.html
@@ -568,17 +568,25 @@
     }
   }
 
-  async function poll(){
+  async function requestScanData(){
     try {
       const resp = await fetch('{{ scan_url }}');
       const data = await resp.json();
       if(data.error){
         showError(data.error);
-      } else {
-        updateFromData(data);
+        return null;
       }
+      updateFromData(data);
+      return data;
     } catch(err){
       showError(err);
+    }
+    return null;
+  }
+
+  async function poll(){
+    try {
+      await requestScanData();
     } finally {
       setTimeout(poll, 200);
     }
@@ -749,6 +757,7 @@
   if(deepBtn){
     setDeepReadState(false, {updateStatus: false, clearDetails: false});
     deepBtn.addEventListener('click', async () => {
+      const enabling = !deepReadActive;
       const headers = {
         'Accept': 'application/json',
       };
@@ -758,6 +767,19 @@
       }
       deepBtn.disabled = true;
       try {
+        let detectionData = null;
+        if(enabling){
+          statusEl.textContent = 'Detecting RFID before deep read...';
+          detectionData = await requestScanData();
+          if(detectionData && detectionData.rfid){
+            const hasLabelId = detectionData.label_id !== undefined && detectionData.label_id !== null && detectionData.label_id !== '';
+            const detectedId = hasLabelId ? detectionData.label_id : detectionData.rfid;
+            const labelText = detectedId ? ` ${detectedId}` : '';
+            statusEl.textContent = `RFID${labelText} detected. Keep holding the card steady for deep read.`;
+          } else {
+            statusEl.textContent = 'Deep read enabled. Hold the card on the reader a bit longer to complete the read.';
+          }
+        }
         const response = await fetch('{{ deep_read_url|default:"" }}', {
           method: 'POST',
           credentials: 'same-origin',
@@ -772,7 +794,11 @@
         }
         const enabled = Boolean(data.enabled);
         setDeepReadState(enabled, {updateStatus: false});
-        statusEl.textContent = data.status || deepReadStatusText(enabled);
+        if(!enabling || !enabled){
+          statusEl.textContent = data.status || deepReadStatusText(enabled);
+        } else if(!detectionData || !detectionData.rfid){
+          statusEl.textContent = data.status || deepReadStatusText(enabled);
+        }
       } catch(err){
         const message = err && err.message ? err.message : 'Deep read failed';
         statusEl.textContent = message;


### PR DESCRIPTION
## Summary
- add a reusable requestScanData helper so the deep read button can trigger an immediate poll
- prefetch a normal scan before enabling deep read to update the status message while the read completes

## Testing
- pytest ocpp/tests/test_rfid_scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68e1eb0080948326a49142341fac015c