### PR TITLE
Add nginx maintenance fallback page

### DIFF
--- a/config/data/nginx/maintenance/index.html
+++ b/config/data/nginx/maintenance/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Arthexis Maintenance</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at top, #f5f7fa, #e4ebf5);
+        color: #1f2933;
+        padding: 2rem;
+      }
+      body.dark {
+        background: radial-gradient(circle at top, #1f2933, #0b101a);
+        color: #f9fafb;
+      }
+      main {
+        max-width: 480px;
+        text-align: center;
+        background: rgba(255, 255, 255, 0.85);
+        padding: 2.5rem 2rem;
+        border-radius: 18px;
+        box-shadow: 0 20px 40px rgba(31, 41, 51, 0.18);
+        backdrop-filter: blur(4px);
+      }
+      body.dark main {
+        background: rgba(15, 23, 32, 0.85);
+        box-shadow: 0 18px 38px rgba(0, 0, 0, 0.6);
+      }
+      h1 {
+        font-size: clamp(2.2rem, 4vw, 2.8rem);
+        margin-bottom: 1rem;
+      }
+      p {
+        font-size: 1.1rem;
+        line-height: 1.6;
+        margin: 0 auto 1.75rem;
+      }
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: #2563eb;
+        color: #fff;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      body.dark .status-chip {
+        background: #60a5fa;
+        color: #0b101a;
+      }
+      footer {
+        font-size: 0.95rem;
+        color: rgba(31, 41, 51, 0.7);
+      }
+      body.dark footer {
+        color: rgba(249, 250, 251, 0.75);
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: radial-gradient(circle at top, #1f2933, #0b101a);
+          color: #f9fafb;
+        }
+        main {
+          background: rgba(15, 23, 32, 0.85);
+          box-shadow: 0 18px 38px rgba(0, 0, 0, 0.6);
+        }
+        footer {
+          color: rgba(249, 250, 251, 0.75);
+        }
+        .status-chip {
+          background: #60a5fa;
+          color: #0b101a;
+        }
+      }
+    </style>
+    <script>
+      (function detectDarkMode() {
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (prefersDark) {
+          document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add('dark');
+          });
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <main>
+      <div class="status-chip" aria-live="polite">Scheduled maintenance</div>
+      <h1>We&rsquo;ll be right back</h1>
+      <p>
+        Arthexis is applying an update at the moment. All services will be available again as soon as the upgrade completes. Thank you for your patience.
+      </p>
+      <footer>
+        This page refreshes automatically. You can also try again in a few minutes.
+      </footer>
+    </main>
+    <script>
+      setTimeout(function () {
+        window.location.reload();
+      }, 30000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- copy a branded maintenance page into place during install so nginx can serve it
- configure both public and internal nginx server blocks to surface the static fallback instead of proxy 502 errors

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1ebd1ebac8326bd0ae4435fedd046