### PR TITLE
Ensure new RFID scans default to allowed and unreleased

### DIFF
--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -207,7 +207,7 @@ def read_rfid(
                         selected = False
                     rfid = "".join(f"{x:02X}" for x in uid_bytes)
                     kind = RFID.NTAG215 if len(uid_bytes) > 5 else RFID.CLASSIC
-                    defaults = {"kind": kind}
+                    defaults = {"kind": kind, "allowed": True, "released": False}
                     tag, created = RFID.objects.get_or_create(
                         rfid=rfid, defaults=defaults
                     )
@@ -371,7 +371,9 @@ def validate_rfid_value(value: object, *, kind: str | None = None) -> dict:
         if candidate in {choice[0] for choice in RFID.KIND_CHOICES}:
             normalized_kind = candidate
 
-    defaults = {"kind": normalized_kind} if normalized_kind else {}
+    defaults = {"allowed": True, "released": False}
+    if normalized_kind:
+        defaults["kind"] = normalized_kind
 
     try:
         tag, created = RFID.objects.get_or_create(

--- a/ocpp/test_rfid.py
+++ b/ocpp/test_rfid.py
@@ -254,7 +254,9 @@ class ValidateRfidValueTests(SimpleTestCase):
 
         result = validate_rfid_value("abcd1234")
 
-        mock_get.assert_called_once_with(rfid="ABCD1234", defaults={})
+        mock_get.assert_called_once_with(
+            rfid="ABCD1234", defaults={"allowed": True, "released": False}
+        )
         tag.save.assert_called_once_with(update_fields=["last_seen_on"])
         self.assertIs(tag.last_seen_on, fake_now)
         mock_notify.assert_called_once_with("RFID 1 OK", "ABCD1234 B")
@@ -280,7 +282,12 @@ class ValidateRfidValueTests(SimpleTestCase):
         result = validate_rfid_value("abcd", kind=RFID.NTAG215)
 
         mock_get.assert_called_once_with(
-            rfid="ABCD", defaults={"kind": RFID.NTAG215}
+            rfid="ABCD",
+            defaults={
+                "allowed": True,
+                "released": False,
+                "kind": RFID.NTAG215,
+            },
         )
         tag.save.assert_called_once_with(update_fields=["kind", "last_seen_on"])
         self.assertIs(tag.last_seen_on, fake_now)


### PR DESCRIPTION
## Summary
- default new RFID scan records to allowed and unreleased so they are immediately valid
- update RFID validation tests to reflect the new creation defaults

## Testing
- pytest ocpp/test_rfid.py::ValidateRfidValueTests::test_creates_new_tag ocpp/test_rfid.py::ValidateRfidValueTests::test_updates_existing_tag_kind

------
https://chatgpt.com/codex/tasks/task_e_68e1eb36df4c83268d2034aa6dd74628