### PR TITLE
Improve RFID admin data field readability

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -92,7 +92,7 @@ from .user_data import (
     _resolve_fixture_user,
     _user_allows_user_data,
 )
-from .widgets import OdooProductWidget
+from .widgets import OdooProductWidget, RFIDDataWidget
 from .mcp import process as mcp_process
 from .mcp.server import resolve_base_urls
 
@@ -2666,6 +2666,7 @@ class RFIDForm(forms.ModelForm):
             can_change_related=True,
             can_view_related=True,
         )
+        self.fields["data"].widget = RFIDDataWidget()
 
 
 @admin.register(RFID)

--- a/core/static/core/rfid_data_widget.css
+++ b/core/static/core/rfid_data_widget.css
@@ -1,0 +1,108 @@
+.rfid-data-widget {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rfid-data-widget__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .rfid-data-widget__grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
+.rfid-data-widget__sector {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+  background-color: var(--body-bg);
+  color: var(--body-fg);
+  border: 1px solid var(--hairline-color);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.rfid-data-widget__sector-title {
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  background: var(--darkened-bg, rgba(0, 0, 0, 0.05));
+}
+
+.rfid-data-widget__sector thead th {
+  position: sticky;
+  top: 0;
+  background: var(--body-bg);
+  border-bottom: 1px solid var(--hairline-color);
+  padding: 0.35rem 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.rfid-data-widget__sector th,
+.rfid-data-widget__sector td {
+  border-bottom: 1px solid var(--hairline-color);
+  border-right: 1px solid var(--hairline-color);
+  padding: 0.35rem 0.5rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.rfid-data-widget__sector tbody th {
+  font-weight: 600;
+  text-align: left;
+}
+
+.rfid-data-widget__sector tbody tr:last-child th,
+.rfid-data-widget__sector tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.rfid-data-widget__sector thead tr th:last-child,
+.rfid-data-widget__sector tbody tr td:last-child {
+  border-right: none;
+}
+
+.rfid-data-widget__key {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.rfid-data-widget__block--trailer {
+  font-weight: 600;
+}
+
+.rfid-data-widget__empty {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--hairline-color);
+  border-radius: 0.5rem;
+  font-style: italic;
+  color: var(--body-quiet-color);
+}
+
+.rfid-data-widget__empty--error {
+  border-style: solid;
+  color: var(--error-fg, #ba2121);
+}
+
+.rfid-data-widget__raw {
+  border: 1px solid var(--hairline-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem 0.75rem;
+}
+
+.rfid-data-widget__raw > summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.rfid-data-widget__input {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+}

--- a/core/templates/admin/core/widgets/rfid_data_widget.html
+++ b/core/templates/admin/core/widgets/rfid_data_widget.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+<div class="rfid-data-widget">
+  <div class="rfid-data-widget__grid">
+    {% if widget.sectors %}
+      {% for sector in widget.sectors %}
+        <table class="rfid-data-widget__sector" aria-label="{% blocktrans %}Sector {{ sector.sector }}{% endblocktrans %}">
+          <caption class="rfid-data-widget__sector-title">
+            {% blocktrans with number=sector.sector %}Sector {{ number }}{% endblocktrans %}
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Block" %}</th>
+              <th scope="col">{% translate "Key" %}</th>
+              {% for header in widget.byte_headers %}
+                <th scope="col">{{ header }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for block in sector.blocks %}
+              <tr class="rfid-data-widget__block{% if block.is_trailer %} rfid-data-widget__block--trailer{% endif %}">
+                <th scope="row">{{ block.block }}</th>
+                <td class="rfid-data-widget__key">{% if block.key %}{{ block.key }}{% else %}&mdash;{% endif %}</td>
+                {% for byte in block.bytes %}
+                  <td>{{ byte }}</td>
+                {% endfor %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endfor %}
+    {% else %}
+      <p class="rfid-data-widget__empty{% if widget.has_parse_error %} rfid-data-widget__empty--error{% endif %}">
+        {% if widget.has_parse_error %}
+          {% translate "Unable to display block data. Showing raw JSON below." %}
+        {% else %}
+          {% translate "No block data available." %}
+        {% endif %}
+      </p>
+    {% endif %}
+  </div>
+  <details class="rfid-data-widget__raw"{% if widget.has_parse_error %} open{% endif %}>
+    <summary>{% translate "Raw data" %}</summary>
+    <textarea name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.value|default_if_none:'' }}</textarea>
+  </details>
+</div>


### PR DESCRIPTION
## Summary
- add a custom RFID data widget that formats block dumps into sector tables
- style the widget with dedicated template and CSS for easier visualization
- use the new widget on the RFID admin form instead of the raw JSON textarea

## Testing
- pytest tests/test_rfid_admin_reference_clear.py

------
https://chatgpt.com/codex/tasks/task_e_68e1eb8d61e883269ade148aceb4905d