### PR TITLE
Add admin action and dashboard link for Odoo quote report

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -139,6 +139,11 @@ urlpatterns = [
         core_views.odoo_products,
         name="odoo-products",
     ),
+    path(
+        "admin/core/odoo-quote-report/",
+        core_views.odoo_quote_report,
+        name="odoo-quote-report",
+    ),
     path("admin/", admin.site.urls),
     path("i18n/setlang/", csrf_exempt(set_language), name="set_language"),
     path("api/", include("core.workgroup_urls")),

--- a/core/admin.py
+++ b/core/admin.py
@@ -1639,7 +1639,7 @@ class OdooProfileAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModelAdm
     readonly_fields = ("verified_on", "odoo_uid", "name", "email")
     actions = ["verify_credentials"]
     change_actions = ["verify_credentials_action", "my_profile_action"]
-    changelist_actions = ["my_profile"]
+    changelist_actions = ["my_profile", "generate_quote_report"]
     fieldsets = (
         ("Owner", {"fields": ("user", "group")}),
         ("Configuration", {"fields": ("host", "database")}),
@@ -1674,6 +1674,12 @@ class OdooProfileAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModelAdm
 
     verify_credentials_action.label = "Test credentials"
     verify_credentials_action.short_description = "Test credentials"
+
+    def generate_quote_report(self, request, queryset=None):
+        return HttpResponseRedirect(reverse("odoo-quote-report"))
+
+    generate_quote_report.label = _("Generate Quote Report")
+    generate_quote_report.short_description = _("Generate Quote Report")
 
 
 @admin.register(OpenPayProfile)

--- a/core/templates/admin/core/odoo_quote_report.html
+++ b/core/templates/admin/core/odoo_quote_report.html
@@ -1,0 +1,135 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
+  {% trans 'Generate Quote Report' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+{% if error %}
+  <div class="messagelist">
+    <div class="error">
+      {{ error }}
+      {% if profile_url %}
+        <a href="{{ profile_url }}">{% trans 'Manage Odoo credentials' %}</a>
+      {% endif %}
+    </div>
+  </div>
+{% else %}
+  <div class="module">
+    <h2>{% trans 'Quote templates' %}</h2>
+    <table class="adminlist">
+      <thead>
+        <tr>
+          <th scope="col">{% trans 'Template' %}</th>
+          <th scope="col">{% trans 'Quotes' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for template in template_stats %}
+          <tr>
+            <th scope="row">{{ template.name|default:"-" }}</th>
+            <td>{{ template.quote_count }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="2">{% trans 'No templates found.' %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="module">
+    <h2>{% trans 'Recent unsent quotes' %}</h2>
+    <table class="adminlist">
+      <thead>
+        <tr>
+          <th scope="col">{% trans 'Quote' %}</th>
+          <th scope="col">{% trans 'Customer' %}</th>
+          <th scope="col">{% trans 'Total' %}</th>
+          <th scope="col">{% trans 'Activity' %}</th>
+          <th scope="col">{% trans 'Tags' %}</th>
+          <th scope="col">{% trans 'Created' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for quote in quotes %}
+          <tr>
+            <th scope="row">{{ quote.name|default:"-" }}</th>
+            <td>{{ quote.customer|default:"-" }}</td>
+            <td>{{ quote.total_display|default:"-" }}</td>
+            <td>{{ quote.activity|default:"-" }}</td>
+            <td>{{ quote.tags|join:", "|default:"-" }}</td>
+            <td>{{ quote.create_date|date:"DATETIME_FORMAT"|default:"-" }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="6">{% trans 'No matching quotes found.' %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="module">
+    <h2>{% trans 'Recently updated products' %}</h2>
+    <table class="adminlist">
+      <thead>
+        <tr>
+          <th scope="col">{% trans 'Product' %}</th>
+          <th scope="col">{% trans 'Internal reference' %}</th>
+          <th scope="col">{% trans 'Created' %}</th>
+          <th scope="col">{% trans 'Last updated' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for product in recent_products %}
+          <tr>
+            <th scope="row">{{ product.name|default:"-" }}</th>
+            <td>{{ product.default_code|default:"-" }}</td>
+            <td>{{ product.create_date|date:"DATETIME_FORMAT"|default:"-" }}</td>
+            <td>{{ product.write_date|date:"DATETIME_FORMAT"|default:"-" }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="4">{% trans 'No products found.' %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="module">
+    <h2>{% trans 'Installed modules' %}</h2>
+    <table class="adminlist">
+      <thead>
+        <tr>
+          <th scope="col">{% trans 'Module' %}</th>
+          <th scope="col">{% trans 'Description' %}</th>
+          <th scope="col">{% trans 'Version' %}</th>
+          <th scope="col">{% trans 'Author' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for module in installed_modules %}
+          <tr>
+            <th scope="row">{{ module.name|default:"-" }}</th>
+            <td>{{ module.shortdesc|default:"-" }}</td>
+            <td>{{ module.latest_version|default:"-" }}</td>
+            <td>{{ module.author|default:"-" }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="4">{% trans 'No installed modules found.' %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}
+{% endblock %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -192,6 +192,7 @@
     <a class="button" href="{% url 'admin:config' %}">{% translate 'Config' %}</a>
     <a class="button" href="{% url 'admin:sigil_builder' %}">{% translate 'Sigil Builder' %}</a>
     <a class="button" href="{% url 'admin:nodes_netmessage_send' %}">{% translate 'Send Net Message' %}</a>
+    <a class="button" href="{% url 'odoo-quote-report' %}">{% translate 'Generate Quote Report' %}</a>
   </div>
 </div>
 {% endblock %}

--- a/tests/test_odoo_quote_report.py
+++ b/tests/test_odoo_quote_report.py
@@ -1,0 +1,112 @@
+from unittest.mock import patch
+
+from django.contrib.admin.sites import site as default_site
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import OdooProfile, User
+
+
+class OdooQuoteReportViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="quote-admin", email="quote@example.com", password="pwd"
+        )
+        self.client.force_login(self.user)
+
+    def test_requires_verified_profile(self):
+        response = self.client.get(reverse("odoo-quote-report"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "Configure and verify your Odoo employee credentials",
+        )
+
+    @patch.object(OdooProfile, "execute")
+    def test_renders_report_with_data(self, mock_execute):
+        profile = OdooProfile.objects.create(
+            user=self.user,
+            host="http://odoo",
+            database="db",
+            username="api",
+            password="secret",
+            verified_on=timezone.now(),
+            odoo_uid=7,
+        )
+
+        mock_execute.side_effect = [
+            [{"id": 1, "name": "Standard"}],
+            [
+                {
+                    "sale_order_template_id": (1, "Standard"),
+                    "sale_order_template_id_count": 3,
+                }
+            ],
+            [
+                {
+                    "name": "SO001",
+                    "amount_total": 1250.5,
+                    "partner_id": (5, "Acme"),
+                    "activity_type_id": (9, "Call"),
+                    "activity_summary": "Follow up",
+                    "tag_ids": [4],
+                    "create_date": "2024-01-02 12:00:00",
+                    "currency_id": (3, "USD"),
+                }
+            ],
+            [{"id": 4, "name": "Priority"}],
+            [{"id": 3, "name": "USD", "symbol": "$"}],
+            [
+                {
+                    "name": "Widget",
+                    "default_code": "W-1",
+                    "create_date": "2023-12-31 09:00:00",
+                    "write_date": "2024-01-05 10:00:00",
+                }
+            ],
+            [
+                {
+                    "name": "sale",
+                    "shortdesc": "Sales",
+                    "latest_version": "16.0.1",
+                    "author": "Odoo",
+                }
+            ],
+        ]
+
+        response = self.client.get(reverse("odoo-quote-report"))
+        self.assertEqual(response.status_code, 200)
+        response.render()
+        context = response.context_data
+        self.assertEqual(context["template_stats"], [{"id": 1, "name": "Standard", "quote_count": 3}])
+        self.assertEqual(len(context["quotes"]), 1)
+        quote = context["quotes"][0]
+        self.assertEqual(quote["name"], "SO001")
+        self.assertEqual(quote["customer"], "Acme")
+        self.assertEqual(quote["tags"], ["Priority"])
+        self.assertEqual(quote["total_display"], "$1,250.50")
+        self.assertIsNotNone(quote["create_date"])
+        self.assertEqual(len(context["recent_products"]), 1)
+        self.assertEqual(context["recent_products"][0]["name"], "Widget")
+        self.assertEqual(len(context["installed_modules"]), 1)
+        self.assertEqual(context["installed_modules"][0]["name"], "sale")
+        self.assertEqual(mock_execute.call_count, 7)
+        profile.refresh_from_db()
+        self.assertTrue(profile.is_verified)
+
+
+class OdooQuoteReportAdminActionTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="quote-action", email="action@example.com", password="pwd"
+        )
+        self.factory = RequestFactory()
+        self.admin = default_site._registry[OdooProfile]
+
+    def test_generate_quote_report_action_redirects(self):
+        request = self.factory.get("/admin/core/odooprofile/")
+        request.user = self.user
+        response = self.admin.generate_quote_report(request, OdooProfile.objects.none())
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("odoo-quote-report"))


### PR DESCRIPTION
## Summary
- add a staff-only Odoo quote report view that aggregates template usage, unsent quotes, recent products, and installed modules data in a dedicated admin template
- expose the report from the admin dashboard header, register a URL, and provide a changelist action on Odoo employees for quick access
- cover the new view and changelist action with targeted tests exercising the Odoo RPC integration stubs

## Testing
- pytest tests/test_odoo_quote_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e1f054a0408326a6d9bd4e228d1999