### PR TITLE
Hide dashboard badges in admin sidebar

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -38,25 +38,27 @@
                 {% else %}
                   {{ fav.custom_label|default:model.name }}
                 {% endif %}
-                {% if model.object_name == 'RFID' %}
-                  {% rfid_release_stats as rfid_stats %}
-                  {% if rfid_stats %}
-                    {% blocktranslate with released_allowed=rfid_stats.released_allowed registered=rfid_stats.total asvar rfid_badge_label trimmed %}
-                      {{ released_allowed }} released and allowed RFIDs out of {{ registered }} registered RFIDs
-                    {% endblocktranslate %}
-                    <span class="rfid-release-badge" aria-label="{{ rfid_badge_label }}" title="{{ rfid_badge_label }}">
-                      {{ rfid_stats.released_allowed }} / {{ rfid_stats.total }}
-                    </span>
+                {% if show_model_badges %}
+                  {% if model.object_name == 'RFID' %}
+                    {% rfid_release_stats as rfid_stats %}
+                    {% if rfid_stats %}
+                      {% blocktranslate with released_allowed=rfid_stats.released_allowed registered=rfid_stats.total asvar rfid_badge_label trimmed %}
+                        {{ released_allowed }} released and allowed RFIDs out of {{ registered }} registered RFIDs
+                      {% endblocktranslate %}
+                      <span class="rfid-release-badge" aria-label="{{ rfid_badge_label }}" title="{{ rfid_badge_label }}">
+                        {{ rfid_stats.released_allowed }} / {{ rfid_stats.total }}
+                      </span>
+                    {% endif %}
                   {% endif %}
-                {% endif %}
-                {% lead_open_count app.app_label model.object_name as lead_open_count %}
-                {% if lead_open_count is not None %}
-                  {% blocktranslate count open_count=lead_open_count asvar lead_open_label trimmed %}
-                    {{ open_count }} open lead
-                  {% plural %}
-                    {{ open_count }} open leads
-                  {% endblocktranslate %}
-                  <span class="lead-open-badge" aria-label="{{ lead_open_label }}" title="{{ lead_open_label }}">{{ lead_open_count }}</span>
+                  {% lead_open_count app.app_label model.object_name as lead_open_count %}
+                  {% if lead_open_count is not None %}
+                    {% blocktranslate count open_count=lead_open_count asvar lead_open_label trimmed %}
+                      {{ open_count }} open lead
+                    {% plural %}
+                      {{ open_count }} open leads
+                    {% endblocktranslate %}
+                    <span class="lead-open-badge" aria-label="{{ lead_open_label }}" title="{{ lead_open_label }}">{{ lead_open_count }}</span>
+                  {% endif %}
                 {% endif %}
               </th>
 

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -202,7 +202,7 @@
 {% block content %}
 <div class="dashboard" id="admin-dashboard">
   <div id="content-main" class="dashboard-main">
-    {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+    {% include "admin/app_list.html" with app_list=app_list show_changelinks=True show_model_badges=True %}
   </div>
 <div class="dashboard-side" id="recent-boxes">
     <div class="module" id="future-actions-module">

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1796,6 +1796,15 @@ class FavoriteTests(TestCase):
         self.assertContains(resp, f'title="{badge_label}"')
         self.assertContains(resp, f'aria-label="{badge_label}"')
 
+    def test_nav_sidebar_hides_dashboard_badges(self):
+        InviteLead.objects.create(email="open@example.com")
+        RFID.objects.create(rfid="RFID0003", released=True, allowed=True)
+
+        resp = self.client.get(reverse("admin:teams_invitelead_changelist"))
+
+        self.assertNotContains(resp, "lead-open-badge")
+        self.assertNotContains(resp, "rfid-release-badge")
+
     def test_dashboard_limits_future_actions_to_top_four(self):
         from pages.templatetags.admin_extras import future_action_items
 


### PR DESCRIPTION
## Summary
- gate the RFID and lead badges behind a new `show_model_badges` flag in the shared admin app list template
- enable badges only on the dashboard include while keeping the navigation sidebar clean
- add a regression test to ensure the sidebar no longer renders the dashboard-only badges

## Testing
- python manage.py test pages.tests.FavoriteTests.test_nav_sidebar_hides_dashboard_badges
- python manage.py test pages.tests.FavoriteTests.test_dashboard_shows_rfid_release_badge

------
https://chatgpt.com/codex/tasks/task_e_68e1f16c48e48326aaec20fd74b90413