### PR TITLE
Keep admin dashboard actions inline with comma separators

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -66,7 +66,7 @@
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
                 <td class="actions">
                   {% for action in extra_actions %}
-                    <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
+                    {% if not forloop.first %}, {% endif %}<a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
                   {% endfor %}
                 </td>
               {% else %}

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -73,9 +73,7 @@
         white-space: nowrap;
     }
     .dashboard-main td.actions .actionlink {
-        margin-left: 16px;
-    }
-    .dashboard-main td.actions .actionlink:first-child {
+        display: inline;
         margin-left: 0;
     }
     .dashboard-main .module table {


### PR DESCRIPTION
## Summary
- render multiple model actions inline on the admin dashboard using comma separators
- ensure dashboard action links use inline display so rows stay consistent in height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29ad1635c8326b5bd9f4ca1d534f5