### PR TITLE
Fix spacing between admin action links

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -66,7 +66,7 @@
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
                 <td class="actions">
                   {% for action in extra_actions %}
-                    {% if not forloop.first %}, {% endif %}<a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>
+                    <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>{% if not forloop.last %}, {% endif %}
                   {% endfor %}
                 </td>
               {% else %}


### PR DESCRIPTION
## Summary
- adjust the admin model action list template so commas follow the preceding link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a3ed4c988326a9fb8597ca83b870