### PR TITLE
Use non-breaking space between admin model actions

### DIFF
--- a/pages/templates/admin/app_list.html
+++ b/pages/templates/admin/app_list.html
@@ -66,7 +66,7 @@
                 {% model_admin_actions app.app_label model.object_name as extra_actions %}
                 <td class="actions">
                   {% for action in extra_actions %}
-                    <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>{% if not forloop.last %}, {% endif %}
+                    <a href="{{ action.url }}" class="actionlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{{ action.label }}</a>{% if not forloop.last %}&nbsp;{% endif %}
                   {% endfor %}
                 </td>
               {% else %}


### PR DESCRIPTION
## Summary
- replace the comma between admin model extra actions with a non-breaking space so the links are separated without punctuation

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2bd870de48326a9ae69a5ea0ae996