### PR TITLE
Normalize Seed Datum label weight

### DIFF
--- a/core/templates/admin/includes/seed_datum_styles.html
+++ b/core/templates/admin/includes/seed_datum_styles.html
@@ -14,7 +14,7 @@
     color: inherit;
 }
 .seed-datum-flag--seed .seed-datum-text {
-    font-weight: 600;
+    font-weight: normal;
 }
 :root[data-theme="dark"] .seed-datum-flag {
     color: var(--body-fg);


### PR DESCRIPTION
## Summary
- remove the extra semibold styling from the Seed Datum checkbox label to match adjacent labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ddc51aa88326b4c247cdf14b3bbb