### PR TITLE
Add visibility controls for social profile configuration sections

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1391,6 +1391,18 @@ PROFILE_INLINE_CONFIG = {
                 },
             ),
         ),
+        "fieldset_visibility": (
+            {
+                "name": _("Configuration: Bluesky"),
+                "field": "network",
+                "values": (SocialProfile.Network.BLUESKY,),
+            },
+            {
+                "name": _("Configuration: Discord"),
+                "field": "network",
+                "values": (SocialProfile.Network.DISCORD,),
+            },
+        ),
     },
     ReleaseManager: {
         "form": ReleaseManagerInlineForm,
@@ -1431,6 +1443,7 @@ def _build_profile_inline(model, owner_field):
         "verbose_name": verbose_name,
         "verbose_name_plural": verbose_name_plural,
         "template": "admin/edit_inline/profile_stacked.html",
+        "fieldset_visibility": tuple(config.get("fieldset_visibility", ())),
     }
     if "fieldsets" in config:
         attrs["fieldsets"] = config["fieldsets"]

--- a/core/templates/admin/edit_inline/profile_stacked.html
+++ b/core/templates/admin/edit_inline/profile_stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls %}
+{% load i18n admin_urls form_extras %}
 <div class="js-inline-admin-formset inline-group"
      id="{{ inline_admin_formset.formset.prefix }}-group"
      data-inline-type="stacked"
@@ -50,6 +50,14 @@
       color: inherit;
     }
 
+    [data-inline-prefix="{{ inline_admin_formset.formset.prefix }}"] .profile-fieldset-visibility {
+      display: block;
+    }
+
+    [data-inline-prefix="{{ inline_admin_formset.formset.prefix }}"] .is-hidden-by-visibility {
+      display: none !important;
+    }
+
   </style>
   {% if inline_admin_formset.is_collapsible %}<details><summary>{% endif %}
   <h2 id="{{ inline_admin_formset.formset.prefix }}-heading" class="inline-heading">
@@ -84,7 +92,17 @@
 
   {% with parent_counter=forloop.counter0 %}
     {% for fieldset in inline_admin_form %}
-      {% include "admin/includes/fieldset.html" with heading_level=4 prefix=fieldset.formset.prefix id_prefix=parent_counter id_suffix=forloop.counter0 %}
+      {% resolve_fieldset_visibility fieldset inline_admin_form.model_admin.fieldset_visibility as fieldset_visibility %}
+      {% if fieldset_visibility %}
+        <div class="profile-fieldset-visibility"
+             data-visibility-field="{{ fieldset_visibility.field }}"
+             {% if fieldset_visibility.mode %}data-visibility-mode="{{ fieldset_visibility.mode }}"{% endif %}
+             {% if fieldset_visibility.values %}data-visibility-values="{{ fieldset_visibility.values|join:' ' }}"{% endif %}>
+          {% include "admin/includes/fieldset.html" with heading_level=4 prefix=fieldset.formset.prefix id_prefix=parent_counter id_suffix=forloop.counter0 %}
+        </div>
+      {% else %}
+        {% include "admin/includes/fieldset.html" with heading_level=4 prefix=fieldset.formset.prefix id_prefix=parent_counter id_suffix=forloop.counter0 %}
+      {% endif %}
     {% endfor %}
   {% endwith %}
 
@@ -94,3 +112,134 @@
   {% if inline_admin_formset.is_collapsible %}</details>{% endif %}
 </fieldset>
 </div>
+<script>
+  (function () {
+    const group = document.getElementById("{{ inline_admin_formset.formset.prefix }}-group");
+    if (!group || group.dataset.visibilityInitialized === "true") {
+      return;
+    }
+    group.dataset.visibilityInitialized = "true";
+
+    const HIDDEN_CLASS = "is-hidden-by-visibility";
+
+    function parseValues(valueAttr) {
+      if (!valueAttr) {
+        return [];
+      }
+      return valueAttr.split(/\s+/).filter(Boolean);
+    }
+
+    function getInputs(container, fieldName) {
+      const selector = `[name$="-${fieldName}"]`;
+      const matches = Array.from(container.querySelectorAll(selector));
+      if (!matches.length) {
+        return [];
+      }
+      if (matches[0].type === "radio") {
+        return matches;
+      }
+      return [matches[0]];
+    }
+
+    function currentValue(inputs) {
+      if (!inputs.length) {
+        return "";
+      }
+      const input = inputs[0];
+      if (input.tagName === "SELECT") {
+        return input.value;
+      }
+      if (input.type === "radio") {
+        const checked = inputs.find((node) => node.checked);
+        return checked ? checked.value : "";
+      }
+      if (input.type === "checkbox") {
+        return input.checked ? "true" : "false";
+      }
+      return input.value;
+    }
+
+    function attachController(inline, fieldName, wrappers) {
+      const inputs = getInputs(inline, fieldName);
+      if (!inputs.length) {
+        return;
+      }
+
+      const update = () => {
+        const value = currentValue(inputs);
+        wrappers.forEach((wrapper) => {
+          const values = parseValues(wrapper.dataset.visibilityValues || "");
+          const mode = (wrapper.dataset.visibilityMode || "show").toLowerCase();
+          const matches = !values.length || values.includes(value);
+          const shouldShow = mode === "hide" ? !matches : matches;
+          wrapper.classList.toggle(HIDDEN_CLASS, !shouldShow);
+        });
+      };
+
+      inputs.forEach((input) => {
+        const handler = () => update();
+        input.addEventListener("change", handler);
+        if (
+          input.tagName !== "SELECT" &&
+          input.type !== "radio" &&
+          input.type !== "checkbox"
+        ) {
+          input.addEventListener("input", handler);
+        }
+      });
+
+      update();
+    }
+
+    function initializeInline(inline) {
+      if (!inline || inline.dataset.visibilityInitialized === "true") {
+        return;
+      }
+
+      const wrappers = Array.from(
+        inline.querySelectorAll("[data-visibility-field]")
+      );
+
+      if (!wrappers.length) {
+        inline.dataset.visibilityInitialized = "true";
+        return;
+      }
+
+      const grouped = new Map();
+
+      wrappers.forEach((wrapper) => {
+        const fieldName = wrapper.dataset.visibilityField;
+        if (!fieldName) {
+          return;
+        }
+        if (!grouped.has(fieldName)) {
+          grouped.set(fieldName, []);
+        }
+        grouped.get(fieldName).push(wrapper);
+      });
+
+      grouped.forEach((wrapperList, fieldName) => {
+        attachController(inline, fieldName, wrapperList);
+      });
+
+      inline.dataset.visibilityInitialized = "true";
+    }
+
+    group.querySelectorAll(".inline-related").forEach((inline) => {
+      initializeInline(inline);
+    });
+
+    document.addEventListener("formset:added", (event) => {
+      if (
+        !event.detail ||
+        event.detail.formsetName !== "{{ inline_admin_formset.formset.prefix }}"
+      ) {
+        return;
+      }
+      const row = event.target;
+      if (row && group.contains(row)) {
+        initializeInline(row);
+      }
+    });
+  })();
+</script>

--- a/core/templatetags/form_extras.py
+++ b/core/templatetags/form_extras.py
@@ -9,3 +9,30 @@ def get_field(form, name):
         return form[name]
     except Exception:
         return None
+
+
+@register.simple_tag
+def resolve_fieldset_visibility(fieldset, controls):
+    """Return the visibility configuration for the given ``fieldset``."""
+
+    if not controls:
+        return None
+
+    name = getattr(fieldset, "name", None)
+    fields = getattr(fieldset, "fields", tuple())
+
+    for control in controls:
+        if not isinstance(control, dict):
+            continue
+
+        control_name = control.get("name")
+        if control_name is not None and name is not None:
+            if str(control_name) == str(name):
+                return control
+
+        control_fields = control.get("fields")
+        if control_fields:
+            if all(field in fields for field in control_fields):
+                return control
+
+    return None


### PR DESCRIPTION
## Summary
- add a `fieldset_visibility` configuration hook for profile inlines and enable it on social profiles
- wrap inline fieldsets with visibility metadata and add JavaScript to toggle sections based on field values
- expose a template tag that resolves the matching visibility rule for each rendered fieldset

## Testing
- pytest core/tests/test_social_profile.py *(fails: Apps aren't loaded yet; pytest-django not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dbedc5908326bcf98a4cd05a0978