### PR TITLE
Add Datasette shortcut to admin dashboard when enabled

### DIFF
--- a/pages/context_processors.py
+++ b/pages/context_processors.py
@@ -48,6 +48,7 @@ def nav_links(request):
         modules = []
 
     valid_modules = []
+    datasette_enabled = False
     current_module = None
     for module in modules:
         landings = []
@@ -82,6 +83,7 @@ def nav_links(request):
 
     datasette_lock = Path(settings.BASE_DIR) / "locks" / "datasette.lck"
     if datasette_lock.exists():
+        datasette_enabled = True
         datasette_module = SimpleNamespace(
             menu_label="Data",
             path="/data/",
@@ -121,4 +123,5 @@ def nav_links(request):
         "nav_modules": valid_modules,
         "favicon_url": favicon_url,
         "header_references": header_references,
+        "datasette_enabled": datasette_enabled,
     }

--- a/pages/templates/admin/AGENTS.md
+++ b/pages/templates/admin/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Guidelines
+
+- Do not add new buttons to the Home row of `index.html` unless explicitly requested by the user.

--- a/pages/templates/admin/index.html
+++ b/pages/templates/admin/index.html
@@ -189,6 +189,9 @@
     <a class="button" href="{% url 'admin:environment' %}">{% translate 'Environ' %}</a>
     <a class="button" href="{% url 'admin:config' %}">{% translate 'Config' %}</a>
     <a class="button" href="{% url 'admin:sigil_builder' %}">{% translate 'Sigil Builder' %}</a>
+    {% if datasette_enabled %}
+      <a class="button" href="/data/">{% translate 'Datasette' %}</a>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -2189,6 +2189,22 @@ class DatasetteTests(TestCase):
         finally:
             lock_file.unlink(missing_ok=True)
 
+    def test_admin_home_includes_datasette_button_when_enabled(self):
+        lock_dir = Path(settings.BASE_DIR) / "locks"
+        lock_dir.mkdir(exist_ok=True)
+        lock_file = lock_dir / "datasette.lck"
+        try:
+            lock_file.touch()
+            self.user.is_staff = True
+            self.user.is_superuser = True
+            self.user.save()
+            self.client.force_login(self.user)
+            resp = self.client.get(reverse("admin:index"))
+            self.assertContains(resp, 'href="/data/"')
+            self.assertContains(resp, ">Datasette<")
+        finally:
+            lock_file.unlink(missing_ok=True)
+
 
 class UserStorySubmissionTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- show a Datasette shortcut in the admin Home header when the Datasette service is enabled
- expose a context flag for Datasette availability so templates can conditionally render the link
- document agent guidance about adding Home row buttons and cover the new behaviour with tests

## Testing
- python manage.py test pages.tests.DatasetteTests

------
https://chatgpt.com/codex/tasks/task_e_68e2e2cb8e88832695a6357ac15e7016