### PR TITLE
feat: enforce RFID label sequencing and copy action

### DIFF
--- a/core/templates/admin/core/rfid/copy.html
+++ b/core/templates/admin/core/rfid/copy.html
@@ -1,0 +1,50 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  {{ media.css }}
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media.js }}
+{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    <h1>{% blocktrans with label=source.label_id %}Copy RFID {{ label }}{% endblocktrans %}</h1>
+    <p class="help">{% blocktrans with rfid=source.rfid %}This will create a new RFID using the configuration from {{ rfid }}.{% endblocktrans %}</p>
+    <form method="post">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="{{ action }}">
+      <input type="hidden" name="select_across" value="0">
+      <input type="hidden" name="_selected_action" value="{{ source.pk }}">
+      {% if form.non_field_errors %}
+        <div class="errornote">
+          {% for error in form.non_field_errors %}
+            <p>{{ error }}</p>
+          {% endfor %}
+        </div>
+      {% endif %}
+      <div class="form-row">
+        {{ form.rfid.label_tag }}
+        {{ form.rfid }}
+        {% if form.rfid.errors %}
+          <div class="errors">
+            {% for error in form.rfid.errors %}
+              <p>{{ error }}</p>
+            {% endfor %}
+          </div>
+        {% endif %}
+        {% if form.rfid.help_text %}
+          <p class="help">{{ form.rfid.help_text }}</p>
+        {% endif %}
+      </div>
+      <div class="submit-row">
+        <button type="submit" name="apply" class="button default">{% trans "Copy" %}</button>
+        <a href="{% url 'admin:core_rfid_changelist' %}" class="button cancel-link">{% trans "Cancel" %}</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -469,6 +469,27 @@ class RFIDValidationTests(TestCase):
             tag.full_clean()
 
 
+class RFIDLabelSequenceTests(TestCase):
+    def test_next_scan_label_starts_at_ten(self):
+        self.assertEqual(RFID.next_scan_label(), 10)
+
+    def test_next_scan_label_skips_non_multiples(self):
+        RFID.objects.create(label_id=21, rfid="SEQTEST21")
+
+        self.assertEqual(RFID.next_scan_label(), 30)
+
+    def test_next_copy_label_increments_by_one(self):
+        source = RFID.objects.create(label_id=40, rfid="SEQTEST40")
+
+        self.assertEqual(RFID.next_copy_label(source), 41)
+
+    def test_next_copy_label_skips_existing(self):
+        source = RFID.objects.create(label_id=50, rfid="SEQTEST50")
+        RFID.objects.create(label_id=51, rfid="SEQTEST51")
+
+        self.assertEqual(RFID.next_copy_label(source), 52)
+
+
 class RFIDAssignmentTests(TestCase):
     def setUp(self):
         self.user1 = User.objects.create_user(username="user1", password="x")

--- a/ocpp/rfid/reader.py
+++ b/ocpp/rfid/reader.py
@@ -207,10 +207,7 @@ def read_rfid(
                         selected = False
                     rfid = "".join(f"{x:02X}" for x in uid_bytes)
                     kind = RFID.NTAG215 if len(uid_bytes) > 5 else RFID.CLASSIC
-                    defaults = {"kind": kind}
-                    tag, created = RFID.objects.get_or_create(
-                        rfid=rfid, defaults=defaults
-                    )
+                    tag, created = RFID.register_scan(rfid, kind=kind)
                     result = _build_tag_response(
                         tag,
                         rfid,
@@ -371,12 +368,8 @@ def validate_rfid_value(value: object, *, kind: str | None = None) -> dict:
         if candidate in {choice[0] for choice in RFID.KIND_CHOICES}:
             normalized_kind = candidate
 
-    defaults = {"kind": normalized_kind} if normalized_kind else {}
-
     try:
-        tag, created = RFID.objects.get_or_create(
-            rfid=normalized, defaults=defaults
-        )
+        tag, created = RFID.register_scan(normalized, kind=normalized_kind)
     except ValidationError as exc:
         return {"error": "; ".join(exc.messages)}
     except Exception as exc:  # pragma: no cover - defensive fallback

--- a/tests/test_rfid_admin_scan_csrf.py
+++ b/tests/test_rfid_admin_scan_csrf.py
@@ -71,3 +71,69 @@ class AdminRfidScanNextTests(TestCase):
         self.assertEqual(response.status_code, 200)
         tag = RFID.objects.get(rfid="11223344")
         self.assertIsNotNone(tag.last_seen_on)
+
+    def test_scan_assigns_labels_in_steps_of_ten(self):
+        self.post_scan({"rfid": "AA11BB22"})
+        first = RFID.objects.get(rfid="AA11BB22")
+        self.assertEqual(first.label_id, 10)
+
+        self.post_scan({"rfid": "CC33DD44"})
+        second = RFID.objects.get(rfid="CC33DD44")
+        self.assertEqual(second.label_id, 20)
+
+    def test_scan_ignores_non_multiple_labels(self):
+        RFID.objects.create(label_id=21, rfid="EE55FF66")
+
+        self.post_scan({"rfid": "1122AABB"})
+        created = RFID.objects.get(rfid="1122AABB")
+        self.assertEqual(created.label_id, 30)
+
+
+class AdminRfidCopyActionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_superuser(
+            username="copyadmin",
+            email="copyadmin@example.com",
+            password="password",
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.url = reverse("admin:core_rfid_changelist")
+
+    def _start_copy(self, tag, new_rfid):
+        response = self.client.post(
+            self.url,
+            data={"action": "copy_rfids", "_selected_action": [tag.pk]},
+        )
+        self.assertEqual(response.status_code, 200)
+        return self.client.post(
+            self.url,
+            data={
+                "action": "copy_rfids",
+                "_selected_action": [tag.pk],
+                "apply": "1",
+                "rfid": new_rfid,
+            },
+        )
+
+    def test_copy_action_increments_label_by_one(self):
+        original = RFID.objects.create(label_id=20, rfid="AABBCCDD", custom_label="Lobby")
+
+        response = self._start_copy(original, "DDCCBBAA")
+
+        self.assertEqual(response.status_code, 302)
+        copied = RFID.objects.get(rfid="DDCCBBAA")
+        self.assertEqual(copied.label_id, 21)
+        self.assertEqual(copied.custom_label, original.custom_label)
+        self.assertEqual(copied.color, original.color)
+
+    def test_copy_action_skips_existing_label(self):
+        original = RFID.objects.create(label_id=30, rfid="FACE1234")
+        RFID.objects.create(label_id=31, rfid="BEEF5678")
+
+        response = self._start_copy(original, "FEEDC0DE")
+
+        self.assertEqual(response.status_code, 302)
+        copied = RFID.objects.get(rfid="FEEDC0DE")
+        self.assertEqual(copied.label_id, 32)


### PR DESCRIPTION
## Summary
- add helper methods that generate RFID labels in steps of ten for scans and single steps for copies
- wire the new label helpers into the scanner, OCPP consumer, onboarding flow, and a new RFID copy admin action with UI
- expand the RFID admin and unit test suites to cover the new label sequencing and copy behaviour

## Testing
- pytest tests/test_rfid_admin_scan_csrf.py ocpp/test_rfid.py::ValidateRfidValueTests::test_creates_new_tag -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e01d022883269f4ec9d9710b97d3