### PR TITLE
Expose Odoo quote report tool on the dashboard

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1742,8 +1742,8 @@ class OdooProfileAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModelAdm
     def generate_quote_report(self, request, queryset=None):
         return HttpResponseRedirect(reverse("odoo-quote-report"))
 
-    generate_quote_report.label = _("Generate Quote Report")
-    generate_quote_report.short_description = _("Generate Quote Report")
+    generate_quote_report.label = _("Quote Report")
+    generate_quote_report.short_description = _("Quote Report")
 
 
 @admin.register(OpenPayProfile)

--- a/core/templates/admin/core/odoo_quote_report.html
+++ b/core/templates/admin/core/odoo_quote_report.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> ›
-  {% trans 'Generate Quote Report' %}
+  {% trans 'Quote Report' %}
 </div>
 {% endblock %}
 

--- a/core/views.py
+++ b/core/views.py
@@ -72,7 +72,7 @@ def odoo_quote_report(request):
 
     profile = getattr(request.user, "odoo_profile", None)
     context = {
-        "title": _("Generate Quote Report"),
+        "title": _("Quote Report"),
         "profile": profile,
         "error": None,
         "template_stats": [],

--- a/pages/templatetags/admin_extras.py
+++ b/pages/templatetags/admin_extras.py
@@ -132,6 +132,17 @@ def model_admin_actions(context, app_label, model_name):
             )
             url = None
             tools_view_name = getattr(model_admin, "tools_view_name", None)
+            if not tools_view_name:
+                initializer = getattr(model_admin, "_get_action_urls", None)
+                if callable(initializer):
+                    try:
+                        initializer()
+                    except Exception:  # pragma: no cover - defensive
+                        tools_view_name = None
+                    else:
+                        tools_view_name = getattr(
+                            model_admin, "tools_view_name", None
+                        )
             if tools_view_name:
                 try:
                     url = reverse(tools_view_name, kwargs={"tool": action_name})

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -2105,7 +2105,7 @@ class AdminActionListTests(TestCase):
                 labels = {action["label"] for action in actions}
                 self.assertIn("Active Profile", labels)
 
-    def test_generate_quote_report_link_available(self):
+    def test_quote_report_link_available(self):
         from pages.templatetags.admin_extras import model_admin_actions
 
         request = self.factory.get("/")
@@ -2114,11 +2114,11 @@ class AdminActionListTests(TestCase):
 
         actions = model_admin_actions(context, "core", "OdooProfile")
         labels = {action["label"] for action in actions}
-        self.assertIn("Generate Quote Report", labels)
+        self.assertIn("Quote Report", labels)
         url = next(
             action["url"]
             for action in actions
-            if action["label"] == "Generate Quote Report"
+            if action["label"] == "Quote Report"
         )
         self.assertEqual(
             url,

--- a/tests/test_odoo_quote_report.py
+++ b/tests/test_odoo_quote_report.py
@@ -104,7 +104,7 @@ class OdooQuoteReportAdminActionTests(TestCase):
         self.factory = RequestFactory()
         self.admin = default_site._registry[OdooProfile]
 
-    def test_generate_quote_report_action_redirects(self):
+    def test_quote_report_action_redirects(self):
         request = self.factory.get("/admin/core/odooprofile/")
         request.user = self.user
         response = self.admin.generate_quote_report(request, OdooProfile.objects.none())


### PR DESCRIPTION
## Summary
- rename the Generate Quote Report action to Quote Report throughout the admin, view, and template
- ensure changelist tools expose their actions URL so the Quote Report link appears in the Odoo Employee dashboard row

## Testing
- pytest pages/tests.py::AdminActionListTests::test_quote_report_link_available tests/test_odoo_quote_report.py::OdooQuoteReportAdminActionTests::test_quote_report_action_redirects

------
https://chatgpt.com/codex/tasks/task_e_68e2e80f20388326b5a91ee65bc2eac0