### PR TITLE
Ensure scanned RFIDs default to allowed and unreleased

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1977,7 +1977,12 @@ class RFID(Entity):
         while attempts < max_attempts:
             attempts += 1
             label_id = cls.next_scan_label()
-            create_kwargs = {"label_id": label_id, "rfid": normalized}
+            create_kwargs = {
+                "label_id": label_id,
+                "rfid": normalized,
+                "allowed": True,
+                "released": False,
+            }
             if kind:
                 create_kwargs["kind"] = kind
             try:

--- a/tests/test_rfid_admin_scan_csrf.py
+++ b/tests/test_rfid_admin_scan_csrf.py
@@ -88,6 +88,13 @@ class AdminRfidScanNextTests(TestCase):
         created = RFID.objects.get(rfid="1122AABB")
         self.assertEqual(created.label_id, 30)
 
+    def test_scan_defaults_to_allowed_and_unreleased(self):
+        self.post_scan({"rfid": "A1B2C3D4"})
+
+        tag = RFID.objects.get(rfid="A1B2C3D4")
+        self.assertTrue(tag.allowed)
+        self.assertFalse(tag.released)
+
 
 class AdminRfidCopyActionTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- force `RFID.register_scan` to persist newly scanned tags as allowed and unreleased
- add an admin scan test that verifies the created tag defaults

## Testing
- pytest tests/test_rfid_admin_scan_csrf.py::AdminRfidScanNextTests::test_scan_defaults_to_allowed_and_unreleased

------
https://chatgpt.com/codex/tasks/task_e_68e2e8a3e6f48326b2b084e1033d1bf8