### PR TITLE
Add admin shortcut to print labels for valid RFIDs

### DIFF
--- a/tests/test_rfid_admin_print_labels.py
+++ b/tests/test_rfid_admin_print_labels.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -12,6 +13,7 @@ django.setup()
 
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth import get_user_model
+from django.http import HttpResponse
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -54,3 +56,57 @@ class RFIDAdminPrintLabelsTests(TestCase):
         )
         self.assertTrue(response.content.startswith(b"%PDF"))
         self.assertGreater(len(response.content), 1000)
+
+    def test_print_valid_card_labels_returns_pdf_response(self):
+        RFID.objects.create(rfid="VALID0001", allowed=True, released=True)
+        RFID.objects.create(rfid="VALID0002", allowed=True, released=True)
+
+        response = self.client.get(
+            reverse("admin:core_rfid_print_valid_card_labels")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertTrue(
+            response["Content-Disposition"].startswith(
+                "attachment; filename=rfid-card-labels"
+            )
+        )
+        self.assertTrue(response.content.startswith(b"%PDF"))
+        self.assertGreater(len(response.content), 1000)
+
+    def test_print_valid_card_labels_filters_to_released_and_allowed(self):
+        allowed_released = RFID.objects.create(
+            rfid="VALIDONLY",
+            allowed=True,
+            released=True,
+        )
+        RFID.objects.create(rfid="ALLOWEDONLY", allowed=True, released=False)
+        RFID.objects.create(rfid="RELEASEDONLY", allowed=False, released=True)
+
+        with mock.patch(
+            "core.admin.RFIDAdmin._render_card_labels",
+            autospec=True,
+            return_value=HttpResponse(b"%PDF", content_type="application/pdf"),
+        ) as render_mock:
+            response = self.client.get(
+                reverse("admin:core_rfid_print_valid_card_labels")
+            )
+
+        self.assertEqual(response.status_code, 200)
+        args, _ = render_mock.call_args
+        queryset = args[2]
+        self.assertQuerySetEqual(
+            queryset.values_list("pk", flat=True),
+            [allowed_released.pk],
+            ordered=False,
+        )
+
+    def test_print_valid_card_labels_redirects_with_message_when_empty(self):
+        response = self.client.get(
+            reverse("admin:core_rfid_print_valid_card_labels"),
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No RFID cards marked as valid are available to print.")


### PR DESCRIPTION
## Summary
- add a helper for rendering RFID card label PDFs so different entry points share the implementation
- expose a changelist shortcut that prints labels for released and allowed RFID cards without requiring a manual selection
- cover the new shortcut with regression tests, including empty states and queryset filtering

## Testing
- pytest tests/test_rfid_admin_print_labels.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ee91f880832699288ab315dde0ad