### PR TITLE
Add editable text register to RFID data widget

### DIFF
--- a/core/static/core/rfid_data_widget.css
+++ b/core/static/core/rfid_data_widget.css
@@ -8,13 +8,24 @@
   gap: 1rem;
 }
 
+.rfid-data-widget__sector-wrapper {
+  display: grid;
+  gap: 0.75rem;
+}
+
 @media (min-width: 768px) {
   .rfid-data-widget__grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(520px, 1fr));
+  }
+
+  .rfid-data-widget__sector-wrapper {
+    grid-template-columns: minmax(320px, 1fr) minmax(180px, 0.6fr);
+    align-items: start;
   }
 }
 
-.rfid-data-widget__sector {
+.rfid-data-widget__sector,
+.rfid-data-widget__text {
   border-collapse: collapse;
   width: 100%;
   font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -32,7 +43,8 @@
   background: var(--darkened-bg, rgba(0, 0, 0, 0.05));
 }
 
-.rfid-data-widget__sector thead th {
+.rfid-data-widget__sector thead th,
+.rfid-data-widget__text thead th {
   position: sticky;
   top: 0;
   background: var(--body-bg);
@@ -44,7 +56,9 @@
 }
 
 .rfid-data-widget__sector th,
-.rfid-data-widget__sector td {
+.rfid-data-widget__sector td,
+.rfid-data-widget__text th,
+.rfid-data-widget__text td {
   border-bottom: 1px solid var(--hairline-color);
   border-right: 1px solid var(--hairline-color);
   padding: 0.35rem 0.5rem;
@@ -52,19 +66,28 @@
   white-space: nowrap;
 }
 
-.rfid-data-widget__sector tbody th {
+.rfid-data-widget__sector tbody th,
+.rfid-data-widget__text tbody th {
   font-weight: 600;
   text-align: left;
 }
 
 .rfid-data-widget__sector tbody tr:last-child th,
-.rfid-data-widget__sector tbody tr:last-child td {
+.rfid-data-widget__sector tbody tr:last-child td,
+.rfid-data-widget__text tbody tr:last-child th,
+.rfid-data-widget__text tbody tr:last-child td {
   border-bottom: none;
 }
 
 .rfid-data-widget__sector thead tr th:last-child,
-.rfid-data-widget__sector tbody tr td:last-child {
+.rfid-data-widget__sector tbody tr td:last-child,
+.rfid-data-widget__text thead tr th:last-child,
+.rfid-data-widget__text tbody tr td:last-child {
   border-right: none;
+}
+
+.rfid-data-widget__text td {
+  text-align: left;
 }
 
 .rfid-data-widget__key {
@@ -105,4 +128,21 @@
 .rfid-data-widget__input {
   width: 100%;
   font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.rfid-data-widget__text-input {
+  width: 100%;
+  min-height: 2rem;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+  padding: 0.25rem 0.35rem;
+  border: 1px solid var(--hairline-color);
+  border-radius: 0.25rem;
+  background-color: var(--darkened-bg, rgba(0, 0, 0, 0.02));
+  color: inherit;
+}
+
+.rfid-data-widget__text-input:focus {
+  outline: 2px solid var(--selected-row, rgba(60, 118, 244, 0.35));
+  outline-offset: 1px;
 }

--- a/core/static/core/rfid_data_widget.js
+++ b/core/static/core/rfid_data_widget.js
@@ -1,0 +1,174 @@
+(function () {
+  "use strict";
+
+  function normalizeByte(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return Math.min(Math.max(Math.trunc(value), 0), 255);
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+      return 0;
+    }
+    return Math.min(Math.max(parsed, 0), 255);
+  }
+
+  function formatBytesToText(bytes) {
+    const chars = [];
+    for (let index = 0; index < 16; index += 1) {
+      const byte = normalizeByte(bytes[index]);
+      if (byte >= 32 && byte <= 126) {
+        chars.push(String.fromCharCode(byte));
+      } else {
+        chars.push("·");
+      }
+    }
+    return chars.join("");
+  }
+
+  function updateHexRow(row, bytes) {
+    if (!row) {
+      return;
+    }
+    const cells = row.querySelectorAll("td[data-byte-index]");
+    cells.forEach((cell, index) => {
+      const hasValue = index < bytes.length;
+      if (!hasValue) {
+        cell.textContent = "--";
+        return;
+      }
+      const byte = normalizeByte(bytes[index]);
+      cell.textContent = byte.toString(16).toUpperCase().padStart(2, "0");
+    });
+  }
+
+  function parseRawEntries(rawValue) {
+    let parsed;
+    try {
+      parsed = JSON.parse(rawValue || "[]");
+    } catch (error) {
+      parsed = [];
+    }
+    if (!Array.isArray(parsed)) {
+      parsed = [];
+    }
+
+    const entries = parsed.map((entry) => {
+      if (entry && typeof entry === "object") {
+        return { ...entry };
+      }
+      return {};
+    });
+
+    const map = new Map();
+    entries.forEach((entry, index) => {
+      if (typeof entry.block !== "number") {
+        return;
+      }
+      const data = Array.isArray(entry.data) ? entry.data : [];
+      const normalized = [];
+      for (let position = 0; position < 16; position += 1) {
+        const value = position < data.length ? normalizeByte(data[position]) : 0;
+        normalized.push(value);
+      }
+      entry.data = normalized;
+      map.set(entry.block, { entry, index });
+    });
+    return { entries, map };
+  }
+
+  function syncRawInput(rawInput, state) {
+    rawInput.value = JSON.stringify(state.entries, null, 2);
+  }
+
+  function initWidget(widgetEl) {
+    const rawInput = widgetEl.querySelector(".rfid-data-widget__input");
+    if (!rawInput) {
+      return;
+    }
+
+    let state = parseRawEntries(rawInput.value);
+
+    const blockRows = new Map();
+    widgetEl.querySelectorAll(".rfid-data-widget__block[data-block]").forEach((row) => {
+      const blockNumber = Number.parseInt(row.dataset.block || "", 10);
+      if (!Number.isNaN(blockNumber)) {
+        blockRows.set(blockNumber, row);
+      }
+    });
+
+    const textInputs = widgetEl.querySelectorAll(".rfid-data-widget__text-input");
+
+    function refreshFromState() {
+      textInputs.forEach((input) => {
+        const blockNumber = Number.parseInt(input.dataset.block || "", 10);
+        if (Number.isNaN(blockNumber)) {
+          input.value = "";
+          return;
+        }
+        const info = state.map.get(blockNumber);
+        if (!info) {
+          input.value = "";
+          updateHexRow(blockRows.get(blockNumber), []);
+          return;
+        }
+        input.value = formatBytesToText(info.entry.data);
+        updateHexRow(blockRows.get(blockNumber), info.entry.data);
+      });
+    }
+
+    textInputs.forEach((input) => {
+      const blockNumber = Number.parseInt(input.dataset.block || "", 10);
+      if (Number.isNaN(blockNumber)) {
+        return;
+      }
+      const info = state.map.get(blockNumber);
+      if (info) {
+        input.value = formatBytesToText(info.entry.data);
+        updateHexRow(blockRows.get(blockNumber), info.entry.data);
+      }
+
+      input.addEventListener("input", () => {
+        const current = state.map.get(blockNumber);
+        if (!current) {
+          return;
+        }
+        const existingBytes = current.entry.data.slice();
+        const characters = Array.from(input.value).slice(0, 16);
+        while (characters.length < 16) {
+          characters.push("·");
+        }
+        const updatedBytes = characters.map((character, index) => {
+          if (character === "·") {
+            return existingBytes[index] ?? 0;
+          }
+          const codePoint = character.codePointAt(0);
+          if (typeof codePoint !== "number") {
+            return existingBytes[index] ?? 0;
+          }
+          return normalizeByte(codePoint);
+        });
+        current.entry.data = updatedBytes;
+        state.entries[current.index] = current.entry;
+        input.value = formatBytesToText(updatedBytes);
+        updateHexRow(blockRows.get(blockNumber), updatedBytes);
+        syncRawInput(rawInput, state);
+      });
+    });
+
+    function handleRawInputChange() {
+      state = parseRawEntries(rawInput.value);
+      refreshFromState();
+    }
+
+    rawInput.addEventListener("change", handleRawInputChange);
+    rawInput.addEventListener("input", handleRawInputChange);
+
+    refreshFromState();
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".rfid-data-widget").forEach((widgetEl) => {
+      initWidget(widgetEl);
+    });
+  });
+})();

--- a/core/templates/admin/core/widgets/rfid_data_widget.html
+++ b/core/templates/admin/core/widgets/rfid_data_widget.html
@@ -3,31 +3,60 @@
   <div class="rfid-data-widget__grid">
     {% if widget.sectors %}
       {% for sector in widget.sectors %}
-        <table class="rfid-data-widget__sector" aria-label="{% blocktrans %}Sector {{ sector.sector }}{% endblocktrans %}">
-          <caption class="rfid-data-widget__sector-title">
-            {% blocktrans with number=sector.sector %}Sector {{ number }}{% endblocktrans %}
-          </caption>
-          <thead>
-            <tr>
-              <th scope="col">{% translate "Block" %}</th>
-              <th scope="col">{% translate "Key" %}</th>
-              {% for header in widget.byte_headers %}
-                <th scope="col">{{ header }}</th>
-              {% endfor %}
-            </tr>
-          </thead>
-          <tbody>
-            {% for block in sector.blocks %}
-              <tr class="rfid-data-widget__block{% if block.is_trailer %} rfid-data-widget__block--trailer{% endif %}">
-                <th scope="row">{{ block.block }}</th>
-                <td class="rfid-data-widget__key">{% if block.key %}{{ block.key }}{% else %}&mdash;{% endif %}</td>
-                {% for byte in block.bytes %}
-                  <td>{{ byte }}</td>
+        <div class="rfid-data-widget__sector-wrapper">
+          <table class="rfid-data-widget__sector" aria-label="{% blocktrans %}Sector {{ sector.sector }}{% endblocktrans %}">
+            <caption class="rfid-data-widget__sector-title">
+              {% blocktrans with number=sector.sector %}Sector {{ number }}{% endblocktrans %}
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Block" %}</th>
+                <th scope="col">{% translate "Key" %}</th>
+                {% for header in widget.byte_headers %}
+                  <th scope="col">{{ header }}</th>
                 {% endfor %}
               </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {% for block in sector.blocks %}
+                <tr class="rfid-data-widget__block{% if block.is_trailer %} rfid-data-widget__block--trailer{% endif %}" data-block="{{ block.block }}">
+                  <th scope="row">{{ block.block }}</th>
+                  <td class="rfid-data-widget__key">{% if block.key %}{{ block.key }}{% else %}&mdash;{% endif %}</td>
+                  {% for byte in block.bytes %}
+                    <td data-byte-index="{{ forloop.counter0 }}">{{ byte }}</td>
+                  {% endfor %}
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          <table class="rfid-data-widget__text" aria-label="{% blocktrans %}Sector {{ sector.sector }} text register{% endblocktrans %}">
+            <caption class="rfid-data-widget__sector-title">
+              {% blocktrans with number=sector.sector %}Sector {{ number }} text{% endblocktrans %}
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Block" %}</th>
+                <th scope="col">{% translate "Text" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for block in sector.blocks %}
+                <tr>
+                  <th scope="row">{{ block.block }}</th>
+                  <td>
+                    <textarea
+                      class="rfid-data-widget__text-input"
+                      data-block="{{ block.block }}"
+                      maxlength="16"
+                      rows="1"
+                      spellcheck="false"
+                    >{% firstof block.text_value '' %}</textarea>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       {% endfor %}
     {% else %}
       <p class="rfid-data-widget__empty{% if widget.has_parse_error %} rfid-data-widget__empty--error{% endif %}">


### PR DESCRIPTION
## Summary
- add a companion text register table next to each RFID sector grid and style the layout for the narrower column
- expose printable text derived from each block in the widget context and load a controller script
- synchronize edits between the text register, hex cells, and raw JSON through a dedicated JavaScript module

## Testing
- python -m compileall core/widgets.py

------
https://chatgpt.com/codex/tasks/task_e_68e302e22f888326a13c4c6176f00bd8