### PR TITLE
Enforce wlan1 access controls for Wi-Fi leases

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -474,6 +474,8 @@ if [[ $RUN_AP == true ]]; then
             while iptables -C FORWARD -i wlan0 -j DROP 2>/dev/null; do
                 iptables -D FORWARD -i wlan0 -j DROP
             done
+            iptables -C FORWARD -i wlan0 -o wlan1 -j DROP 2>/dev/null || \
+                iptables -A FORWARD -i wlan0 -o wlan1 -j DROP
         fi
         if ! nmcli -t -f NAME connection show --active | grep -Fxq "$AP_NAME"; then
             echo "Access point $AP_NAME failed to start." >&2


### PR DESCRIPTION
## Summary
- ensure the public Wi-Fi helper programs a drop rule that blocks wlan1 forwarding for unleased clients
- teach the network setup script to append the wlan0→wlan1 drop rule after cleaning legacy entries
- extend the Wi-Fi utilities test suite to verify the firewall allow/deny behavior

## Testing
- python manage.py test core.tests.PublicWifiUtilitiesTests --verbosity 2 *(fails: Django cannot import `core.tests.PublicWifiUtilitiesTests` because `core.tests` is an installed package)*

------
https://chatgpt.com/codex/tasks/task_e_68e3052802dc8326a75b3eb87f2cfed8