### PR TITLE
Rename Register Visitor admin action label

### DIFF
--- a/nodes/admin.py
+++ b/nodes/admin.py
@@ -326,7 +326,7 @@ class NodeAdmin(EntityModelAdmin):
         }
         return render(request, "admin/nodes/node/register_remote.html", context)
 
-    @admin.action(description="Register Visitor Node")
+    @admin.action(description="Register Visitor")
     def register_visitor(self, request, queryset=None):
         return self.register_visitor_view(request)
 
@@ -575,7 +575,7 @@ class NodeAdmin(EntityModelAdmin):
         context = {
             **self.admin_site.each_context(request),
             "opts": self.model._meta,
-            "title": _("Register Visitor Node"),
+            "title": _("Register Visitor"),
             "token": token,
             "info_url": reverse("node-info"),
             "register_url": reverse("register-node"),

--- a/nodes/templates/admin/nodes/node/register_visitor.html
+++ b/nodes/templates/admin/nodes/node/register_visitor.html
@@ -7,7 +7,7 @@
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
   &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name|capfirst }}</a>
   &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-  &rsaquo; {% trans "Register Visitor Node" %}
+  &rsaquo; {% trans "Register Visitor" %}
 </div>
 {% endif %}
 {% endblock %}

--- a/tests/test_admin_index_actions.py
+++ b/tests/test_admin_index_actions.py
@@ -27,7 +27,7 @@ class AdminIndexActionLinkTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         self.assertContains(response, "Scan RFIDs")
         self.assertContains(response, f'href="{reverse("admin:core_rfid_scan")}"')
-        self.assertContains(response, "Register Visitor Node")
+        self.assertContains(response, "Register Visitor")
         self.assertContains(
             response, f'href="{reverse("admin:nodes_node_register_visitor")}"'
         )
@@ -41,7 +41,7 @@ class AdminIndexActionLinkTests(TestCase):
         row_html = row_match.group(1)
         # Actions column should still precede the Add and Change links
         pattern = re.compile(
-            r'<td class="actions">\s*</td>\s*'
+            r'<td class="actions">.*?</td>\s*'
             r'<td>\s*<a[^>]*class="addlink"[^<]*</a>\s*</td>\s*'
             r'<td>\s*(?:<[^>]+>\s*)*<a[^>]*class="changelink"',
             re.DOTALL,


### PR DESCRIPTION
## Summary
- rename the register visitor admin action and page title to "Register Visitor"
- update the register visitor template breadcrumb text
- refresh the admin index action test expectation and make the order check resilient to rendered action links

## Testing
- pytest tests/test_admin_index_actions.py::AdminIndexActionLinkTests::test_custom_action_links_display

------
https://chatgpt.com/codex/tasks/task_e_68e32b56fe408326a6c649656b2aacef