### PR TITLE
Ensure release script commits generated release artifacts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,8 +19,20 @@ echo "$VERSION" > VERSION
 
 python scripts/capture_migration_state.py "$VERSION"
 
+# Stage release metadata before committing. capture_migration_state.py adds the
+# generated files, but we explicitly stage the directory to ensure every
+# artifact (including the directory itself) is captured in the commit.
+git add VERSION "releases/${VERSION}"
+
+git commit -m "Release $VERSION"
+
+# Build the source archive from the freshly created release commit so the
+# archive reflects the published version.
 git archive --format=tar.gz -o "releases/${VERSION}/source.tar.gz" HEAD
 
-git commit -am "Release $VERSION"
+# Amend the release commit to include the generated source archive.
+git add "releases/${VERSION}/source.tar.gz"
+git commit --amend --no-edit
+
 git tag -a "v$VERSION" -m "Release $VERSION"
 git push origin main --tags


### PR DESCRIPTION
## Summary
- explicitly stage the VERSION file and release artifacts before committing
- regenerate the source archive from the release commit and amend the commit to include it

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68e32f963600832696fac52abf324d90