### PR TITLE
Fix Odoo product registration RPC kwargs handling

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2391,15 +2391,13 @@ class ProductAdmin(EntityModelAdmin):
             "product.product",
             "search_read",
             [domain],
-            {
-                "fields": [
-                    "name",
-                    "default_code",
-                    "barcode",
-                    "description_sale",
-                ],
-                "limit": 50,
-            },
+            fields=[
+                "name",
+                "default_code",
+                "barcode",
+                "description_sale",
+            ],
+            limit=50,
         )
 
     @admin.action(description="Fetch Odoo Product")
@@ -2586,15 +2584,13 @@ class ProductAdmin(EntityModelAdmin):
                 "product.product",
                 "search_read",
                 [[]],
-                {
-                    "fields": [
-                        "name",
-                        "description_sale",
-                        "list_price",
-                        "standard_price",
-                    ],
-                    "limit": 0,
-                },
+                fields=[
+                    "name",
+                    "description_sale",
+                    "list_price",
+                    "standard_price",
+                ],
+                limit=0,
             )
         except Exception:
             context["error"] = _("Unable to fetch products from Odoo.")

--- a/core/models.py
+++ b/core/models.py
@@ -642,14 +642,16 @@ class OdooProfile(Profile):
         """Execute an Odoo RPC call, invalidating credentials on failure."""
         try:
             client = xmlrpc_client.ServerProxy(f"{self.host}/xmlrpc/2/object")
+            call_args = list(args)
+            call_kwargs = dict(kwargs)
             return client.execute_kw(
                 self.database,
                 self.odoo_uid,
                 self.password,
                 model,
                 method,
-                args,
-                kwargs,
+                call_args,
+                call_kwargs,
             )
         except Exception:
             logger.exception(

--- a/core/views.py
+++ b/core/views.py
@@ -51,7 +51,8 @@ def odoo_products(request):
             "product.product",
             "search_read",
             [[]],
-            {"fields": ["name"], "limit": 50},
+            fields=["name"],
+            limit=50,
         )
     except Exception:
         logger.exception(
@@ -129,14 +130,15 @@ def odoo_quote_report(request):
             "sale.order.template",
             "search_read",
             [[]],
-            {"fields": ["name"], "order": "name asc"},
+            fields=["name"],
+            order="name asc",
         )
         template_usage = profile.execute(
             "sale.order",
             "read_group",
             [[("sale_order_template_id", "!=", False)]],
             ["sale_order_template_id"],
-            {"lazy": False},
+            lazy=False,
         )
 
         usage_map = {}
@@ -169,19 +171,17 @@ def odoo_quote_report(request):
                     ("quote_sent", "=", False),
                 ]
             ],
-            {
-                "fields": [
-                    "name",
-                    "amount_total",
-                    "partner_id",
-                    "activity_type_id",
-                    "activity_summary",
-                    "tag_ids",
-                    "create_date",
-                    "currency_id",
-                ],
-                "order": "create_date desc",
-            },
+            fields=[
+                "name",
+                "amount_total",
+                "partner_id",
+                "activity_type_id",
+                "activity_summary",
+                "tag_ids",
+                "create_date",
+                "currency_id",
+            ],
+            order="create_date desc",
         )
 
         tag_ids = set()
@@ -202,7 +202,7 @@ def odoo_quote_report(request):
                 "sale.order.tag",
                 "read",
                 list(tag_ids),
-                {"fields": ["name"]},
+                fields=["name"],
             )
             for tag in tag_records:
                 tag_id = tag.get("id")
@@ -215,7 +215,7 @@ def odoo_quote_report(request):
                 "res.currency",
                 "read",
                 list(currency_ids),
-                {"fields": ["name", "symbol"]},
+                fields=["name", "symbol"],
             )
             for currency in currency_records:
                 currency_id = currency.get("id")
@@ -280,11 +280,9 @@ def odoo_quote_report(request):
             "product.product",
             "search_read",
             [[]],
-            {
-                "fields": ["name", "default_code", "write_date", "create_date"],
-                "limit": 10,
-                "order": "write_date desc, create_date desc",
-            },
+            fields=["name", "default_code", "write_date", "create_date"],
+            limit=10,
+            order="write_date desc, create_date desc",
         )
         context["recent_products"] = [
             {
@@ -300,10 +298,8 @@ def odoo_quote_report(request):
             "ir.module.module",
             "search_read",
             [[("state", "=", "installed")]],
-            {
-                "fields": ["name", "shortdesc", "latest_version", "author"],
-                "order": "name asc",
-            },
+            fields=["name", "shortdesc", "latest_version", "author"],
+            order="name asc",
         )
         context["installed_modules"] = [
             {

--- a/tests/test_odoo_product.py
+++ b/tests/test_odoo_product.py
@@ -34,7 +34,11 @@ class OdooProductTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [{"id": 5, "name": "Prod"}])
         mock_exec.assert_called_once_with(
-            "product.product", "search_read", [[]], {"fields": ["name"], "limit": 50}
+            "product.product",
+            "search_read",
+            [[]],
+            fields=["name"],
+            limit=50,
         )
 
     def test_product_admin_form_uses_widget(self):
@@ -116,15 +120,13 @@ class ProductAdminFetchWizardTests(TestCase):
             "product.product",
             "search_read",
             [[("name", "ilike", "Wid")]],
-            {
-                "fields": [
-                    "name",
-                    "default_code",
-                    "barcode",
-                    "description_sale",
-                ],
-                "limit": 50,
-            },
+            fields=[
+                "name",
+                "default_code",
+                "barcode",
+                "description_sale",
+            ],
+            limit=50,
         )
         content = response.render().content.decode()
         self.assertIn("Widget", content)
@@ -164,15 +166,13 @@ class ProductAdminFetchWizardTests(TestCase):
             "product.product",
             "search_read",
             [[]],
-            {
-                "fields": [
-                    "name",
-                    "default_code",
-                    "barcode",
-                    "description_sale",
-                ],
-                "limit": 50,
-            },
+            fields=[
+                "name",
+                "default_code",
+                "barcode",
+                "description_sale",
+            ],
+            limit=50,
         )
         product = Product.objects.get()
         self.assertEqual(product.name, "Imported")
@@ -228,15 +228,13 @@ class ProductAdminRegisterFromOdooTests(TestCase):
             "product.product",
             "search_read",
             [[]],
-            {
-                "fields": [
-                    "name",
-                    "description_sale",
-                    "list_price",
-                    "standard_price",
-                ],
-                "limit": 0,
-            },
+            fields=[
+                "name",
+                "description_sale",
+                "list_price",
+                "standard_price",
+            ],
+            limit=0,
         )
 
     @patch.object(OdooProfile, "execute")


### PR DESCRIPTION
## Summary
- ensure Odoo RPC calls forward positional and keyword arguments correctly
- update product admin and quote report integrations to send search options as keyword args
- extend Odoo integration tests to cover the new parameter handling

## Testing
- pytest tests/test_odoo_product.py tests/test_odoo_profile.py tests/test_odoo_quote_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e33065c75c8326b7c526ae0e019791