### PR TITLE
Add PyPI connectivity checks before publishing

### DIFF
--- a/core/management/commands/check_pypi.py
+++ b/core/management/commands/check_pypi.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from ...models import PackageRelease
+from ... import release as release_utils
+
+
+class Command(BaseCommand):
+    help = "Check PyPI connectivity and credentials for a package release."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "release",
+            nargs="?",
+            help=(
+                "Release primary key or version to check. "
+                "Defaults to the latest release for the active package."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        release_obj = self._resolve_release(options.get("release"))
+        self.stdout.write(self.style.MIGRATE_HEADING(f"Checking {release_obj}"))
+        result = release_utils.check_pypi_readiness(release=release_obj)
+        level_styles = {
+            "success": self.style.SUCCESS,
+            "warning": self.style.WARNING,
+            "error": self.style.ERROR,
+        }
+        for level, message in result.messages:
+            style = level_styles.get(level, str)
+            if level == "error":
+                self.stderr.write(style(message))
+            else:
+                self.stdout.write(style(message))
+        if result.ok:
+            self.stdout.write(self.style.SUCCESS("PyPI connectivity check passed"))
+            return
+        self.stderr.write(self.style.ERROR("PyPI connectivity check failed"))
+        raise CommandError("PyPI connectivity check failed")
+
+    def _resolve_release(self, identifier):
+        queryset = PackageRelease.objects.select_related(
+            "package", "release_manager", "package__release_manager"
+        )
+        if identifier:
+            try:
+                return queryset.get(pk=int(identifier))
+            except (ValueError, PackageRelease.DoesNotExist):
+                active_match = queryset.filter(
+                    package__is_active=True, version=identifier
+                ).first()
+                if active_match:
+                    return active_match
+                try:
+                    return queryset.get(version=identifier)
+                except PackageRelease.DoesNotExist as exc:
+                    raise CommandError(f"Release '{identifier}' not found") from exc
+        release = queryset.filter(package__is_active=True).order_by("-pk").first()
+        if release:
+            return release
+        release = queryset.order_by("-pk").first()
+        if release:
+            return release
+        raise CommandError("No releases available to check")
+

--- a/tests/test_check_pypi_command.py
+++ b/tests/test_check_pypi_command.py
@@ -1,0 +1,87 @@
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django  # noqa: E402
+
+
+django.setup()  # noqa: E402
+
+from django.core.management import call_command, CommandError  # noqa: E402
+from django.test import TestCase  # noqa: E402
+
+from core.models import Package, PackageRelease, ReleaseManager, User  # noqa: E402
+
+
+class CheckPyPICommandTests(TestCase):
+    def setUp(self) -> None:
+        Package.objects.all().delete()
+        self.user = User.objects.create_superuser("manager", "manager@example.com", "pw")
+        self.manager = ReleaseManager.objects.create(user=self.user, pypi_token="token")
+        self.package = Package.objects.create(
+            name="pkg-cmd",
+            release_manager=self.manager,
+            is_active=True,
+        )
+        self.release = PackageRelease.objects.create(
+            package=self.package,
+            release_manager=self.manager,
+            version="1.0.1",
+        )
+
+    def _result(self, ok=True, messages=None):
+        if messages is None:
+            messages = [("success", "All good")]
+        return SimpleNamespace(ok=ok, messages=messages)
+
+    @mock.patch("core.management.commands.check_pypi.release_utils.check_pypi_readiness")
+    def test_command_uses_release_identifier(self, check):
+        check.return_value = self._result()
+        out = mock.Mock()
+        err = mock.Mock()
+
+        call_command("check_pypi", str(self.release.pk), stdout=out, stderr=err)
+
+        check.assert_called_once_with(release=self.release)
+        out.write.assert_any_call(mock.ANY)
+
+    @mock.patch("core.management.commands.check_pypi.release_utils.check_pypi_readiness")
+    def test_command_accepts_version(self, check):
+        check.return_value = self._result()
+        out = mock.Mock()
+        err = mock.Mock()
+
+        call_command("check_pypi", self.release.version, stdout=out, stderr=err)
+
+        check.assert_called_once_with(release=self.release)
+
+    @mock.patch("core.management.commands.check_pypi.release_utils.check_pypi_readiness")
+    def test_command_without_identifier_uses_active_release(self, check):
+        check.return_value = self._result()
+        out = mock.Mock()
+        err = mock.Mock()
+
+        call_command("check_pypi", stdout=out, stderr=err)
+
+        check.assert_called_once_with(release=self.release)
+
+    @mock.patch("core.management.commands.check_pypi.release_utils.check_pypi_readiness")
+    def test_command_reports_errors_in_exit_code(self, check):
+        check.return_value = self._result(ok=False, messages=[("error", "Missing token")])
+        out = mock.Mock()
+        err = mock.Mock()
+
+        with self.assertRaises(CommandError):
+            call_command("check_pypi", str(self.release.pk), stdout=out, stderr=err)
+
+        err.write.assert_any_call(mock.ANY)
+
+    def test_missing_release_raises_error(self):
+        with self.assertRaises(CommandError):
+            call_command("check_pypi", "unknown")
+

--- a/tests/test_pypi_check.py
+++ b/tests/test_pypi_check.py
@@ -1,0 +1,121 @@
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django  # noqa: E402
+
+
+django.setup()  # noqa: E402
+
+from django.test import TestCase  # noqa: E402
+
+from core.models import Package, PackageRelease, ReleaseManager, User  # noqa: E402
+from core import release as release_utils  # noqa: E402
+
+
+class PyPICheckReadinessTests(TestCase):
+    def setUp(self) -> None:
+        Package.objects.all().delete()
+        User.objects.filter(username="manager").delete()
+        self.user = User.objects.create_superuser(
+            "manager", "manager@example.com", "pw"
+        )
+        self.manager = ReleaseManager.objects.create(
+            user=self.user,
+            pypi_token="token-value",
+        )
+        self.package = Package.objects.create(
+            name="pkg-check",
+            release_manager=self.manager,
+            is_active=True,
+        )
+        self.release = PackageRelease.objects.create(
+            package=self.package,
+            release_manager=self.manager,
+            version="1.2.3",
+        )
+
+    @mock.patch("core.release.requests.get")
+    @mock.patch("core.release.subprocess.run")
+    @mock.patch("core.release.network_available", return_value=True)
+    def test_successful_check(self, network_available, run, get):
+        run.return_value = SimpleNamespace(stdout="twine version 6.1.0", stderr="")
+        api_response = SimpleNamespace(ok=True, status_code=200)
+        api_response.json = lambda: {"releases": {}}
+        upload_response = SimpleNamespace(ok=True, status_code=200)
+        get.side_effect = [api_response, upload_response]
+
+        result = release_utils.check_pypi_readiness(release=self.release)
+
+        self.assertTrue(result.ok)
+        levels = {message for level, message in result.messages if level == "success"}
+        self.assertTrue(any("Twine" in message for message in levels))
+        self.assertTrue(
+            any("PyPI JSON API reachable" in message for message in levels)
+        )
+        self.assertEqual(get.call_count, 2)
+
+    @mock.patch("core.release.requests.get")
+    @mock.patch("core.release.subprocess.run")
+    @mock.patch("core.release.network_available", return_value=True)
+    def test_missing_credentials_reports_error(self, network_available, run, get):
+        self.manager.pypi_token = ""
+        self.manager.save(update_fields=["pypi_token"])
+        run.return_value = SimpleNamespace(stdout="twine version 6.1.0", stderr="")
+        api_response = SimpleNamespace(ok=True, status_code=200)
+        api_response.json = lambda: {"releases": {}}
+        upload_response = SimpleNamespace(ok=True, status_code=200)
+        get.side_effect = [api_response, upload_response]
+
+        result = release_utils.check_pypi_readiness(release=self.release)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(level == "error" and "Missing PyPI credentials" in message for level, message in result.messages)
+        )
+
+    @mock.patch("core.release.requests.get")
+    @mock.patch("core.release.subprocess.run")
+    @mock.patch("core.release.network_available", return_value=True)
+    def test_environment_credentials_used_when_available(
+        self, network_available, run, get
+    ):
+        self.manager.pypi_token = ""
+        self.manager.save(update_fields=["pypi_token"])
+        run.return_value = SimpleNamespace(stdout="twine version 6.1.0", stderr="")
+        api_response = SimpleNamespace(ok=True, status_code=200)
+        api_response.json = lambda: {"releases": {}}
+        upload_response = SimpleNamespace(ok=True, status_code=200)
+        get.side_effect = [api_response, upload_response]
+
+        with mock.patch.dict(os.environ, {"PYPI_API_TOKEN": "env-token"}, clear=False):
+            result = release_utils.check_pypi_readiness(release=self.release)
+
+        self.assertTrue(result.ok)
+        self.assertTrue(
+            any(
+                level == "success" and "environment variables" in message
+                for level, message in result.messages
+            )
+        )
+
+    @mock.patch("core.release.subprocess.run")
+    @mock.patch("core.release.network_available", return_value=False)
+    def test_offline_mode_skips_network_checks(self, network_available, run):
+        run.return_value = SimpleNamespace(stdout="twine version 6.1.0", stderr="")
+
+        result = release_utils.check_pypi_readiness(release=self.release)
+
+        self.assertTrue(result.ok)
+        self.assertTrue(
+            any(
+                level == "warning" and "Offline mode" in message
+                for level, message in result.messages
+            )
+        )
+


### PR DESCRIPTION
## Summary
- add a reusable release utility that checks for PyPI credentials, twine availability, and network access
- expose the connectivity check from the package release admin and provide a new `check_pypi` management command
- cover the new command and admin action with targeted tests

## Testing
- pytest tests/test_pypi_check.py tests/test_check_pypi_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e3caf1819483269f4c8bfc5efde54c