### PR TITLE
Enable Wi-Fi leases for general AP nodes

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -699,12 +699,8 @@ class Node(Entity):
             detected_slugs.add("rpi-camera")
         if self._has_gway_runner():
             detected_slugs.add("gway-runner")
-        public_mode_lock = locks_dir / "public_wifi_mode.lck"
         if self._hosts_gelectriic_ap():
-            if public_mode_lock.exists():
-                detected_slugs.add("ap-public-wifi")
-            else:
-                detected_slugs.add("ap-router")
+            detected_slugs.add("ap-router")
         try:
             from core.notifications import supports_gui_toast
         except Exception:

--- a/nodes/tests.py
+++ b/nodes/tests.py
@@ -3130,7 +3130,7 @@ class NodeFeatureTests(TestCase):
         )
 
     @patch("nodes.models.Node._hosts_gelectriic_ap", return_value=True)
-    def test_ap_public_wifi_detection(self, mock_hosts):
+    def test_ap_router_detection_with_public_mode_lock(self, mock_hosts):
         control_role, _ = NodeRole.objects.get_or_create(name="Control")
         router = NodeFeature.objects.create(slug="ap-router", display="AP Router")
         router.roles.add(control_role)
@@ -3154,10 +3154,10 @@ class NodeFeatureTests(TestCase):
                 )
                 node.refresh_features()
         self.assertTrue(
-            NodeFeatureAssignment.objects.filter(node=node, feature=public).exists()
+            NodeFeatureAssignment.objects.filter(node=node, feature=router).exists()
         )
         self.assertFalse(
-            NodeFeatureAssignment.objects.filter(node=node, feature=router).exists()
+            NodeFeatureAssignment.objects.filter(node=node, feature=public).exists()
         )
 
     @patch("nodes.models.Node._hosts_gelectriic_ap", side_effect=[True, False])

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -502,9 +502,7 @@ class InvitationTests(TestCase):
     )
     def test_invitation_login_grants_public_wifi_access(self, mock_resolve, mock_grant):
         control_role, _ = NodeRole.objects.get_or_create(name="Control")
-        feature = NodeFeature.objects.create(
-            slug="ap-public-wifi", display="AP Public Wi-Fi"
-        )
+        feature = NodeFeature.objects.create(slug="ap-router", display="AP Router")
         feature.roles.add(control_role)
         node = Node.objects.create(
             hostname="control",

--- a/pages/views.py
+++ b/pages/views.py
@@ -862,7 +862,10 @@ def invitation_login(request, uidb64, token):
         user.is_active = True
         user.save()
         node = Node.get_local()
-        if node and node.has_feature("ap-public-wifi"):
+        if node and (
+            node.has_feature("ap-router")
+            or node.has_feature("ap-public-wifi")
+        ):
             mac_address = public_wifi.resolve_mac_address(
                 request.META.get("REMOTE_ADDR")
             )


### PR DESCRIPTION
## Summary
- issue Wi-Fi leases during invitation login whenever the AP router feature is present, without relying on the removed public mode flag
- always detect hosted access points as the shared `ap-router` feature so legacy `ap-public-wifi` assignments fall away
- update the associated unit tests to reflect the new feature flag usage

## Testing
- python manage.py test pages.tests.InvitationTests.test_invitation_login_grants_public_wifi_access nodes.tests.NodeFeatureTests.test_ap_router_detection_with_public_mode_lock

------
https://chatgpt.com/codex/tasks/task_e_68e44487abc4832696782c7299a1154b