### PR TITLE
Add clean_release_logs management command

### DIFF
--- a/core/fixtures/todo__review_release_publish_logs_cleanup.json
+++ b/core/fixtures/todo__review_release_publish_logs_cleanup.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate release publish log cleanup command",
+      "url": "",
+      "request_details": "Run the clean_release_logs management command in production to confirm stale publish logs and lock files are cleared."
+    }
+  }
+]

--- a/core/management/commands/clean_release_logs.py
+++ b/core/management/commands/clean_release_logs.py
@@ -1,0 +1,106 @@
+"""Management command to remove release publish logs and lock files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from core.models import PackageRelease
+
+
+class Command(BaseCommand):
+    help = (
+        "Remove release publish logs and associated lock files so the flow can restart."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "releases",
+            nargs="*",
+            metavar="PACKAGE:VERSION",
+            help="Release identifier in the form <package>:<version>.",
+        )
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            dest="clean_all",
+            help="Remove all release publish logs and related lock files.",
+        )
+
+    def handle(self, *args, **options):
+        releases: list[str] = options.get("releases") or []
+        clean_all: bool = options.get("clean_all", False)
+
+        if not releases and not clean_all:
+            raise CommandError(
+                "Specify --all or at least one PACKAGE:VERSION identifier to clean."
+            )
+
+        log_dir = Path(settings.LOG_DIR)
+        lock_dir = Path("locks")
+
+        log_targets: set[Path] = set()
+        lock_targets: set[Path] = set()
+
+        if clean_all:
+            log_targets.update(log_dir.glob("pr.*.log"))
+            lock_targets.update(lock_dir.glob("release_publish_*.json"))
+            lock_targets.update(lock_dir.glob("release_publish_*.restarts"))
+
+        for spec in releases:
+            release = self._resolve_release(spec)
+            prefix = f"pr.{release.package.name}.v{release.version}"
+            log_targets.update(log_dir.glob(f"{prefix}*.log"))
+            for suffix in (".json", ".restarts"):
+                lock_targets.add(lock_dir / f"release_publish_{release.pk}{suffix}")
+
+        removed_logs = self._remove_files(log_targets)
+        removed_locks = self._remove_files(lock_targets)
+
+        if removed_logs:
+            self.stdout.write(
+                self.style.SUCCESS(f"Removed {removed_logs} release log file(s).")
+            )
+        else:
+            self.stdout.write("No release log files removed.")
+
+        if removed_locks:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Removed {removed_locks} release publish lock file(s)."
+                )
+            )
+        else:
+            self.stdout.write("No release publish lock files removed.")
+
+    def _resolve_release(self, spec: str) -> PackageRelease:
+        if ":" not in spec:
+            raise CommandError(
+                f"Release identifier '{spec}' is invalid. Use the format PACKAGE:VERSION."
+            )
+        package_name, version = [part.strip() for part in spec.split(":", 1)]
+        if not package_name or not version:
+            raise CommandError(
+                f"Release identifier '{spec}' is invalid. Use the format PACKAGE:VERSION."
+            )
+        try:
+            return PackageRelease.objects.select_related("package").get(
+                package__name=package_name, version=version
+            )
+        except PackageRelease.DoesNotExist as exc:
+            raise CommandError(
+                f"Release for package '{package_name}' and version '{version}' not found."
+            ) from exc
+
+    def _remove_files(self, paths: set[Path]) -> int:
+        removed = 0
+        for path in paths:
+            try:
+                if path.is_file():
+                    path.unlink()
+                    removed += 1
+            except OSError as exc:
+                raise CommandError(f"Failed to remove {path}: {exc}") from exc
+        return removed

--- a/tests/test_clean_release_logs_command.py
+++ b/tests/test_clean_release_logs_command.py
@@ -1,0 +1,108 @@
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import shutil
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.core.management import call_command, CommandError
+from django.test import TestCase, override_settings
+
+from core.models import Package, PackageRelease
+
+
+class CleanReleaseLogsCommandTests(TestCase):
+    def setUp(self):
+        self.package = Package.objects.create(name="pkg", is_active=True)
+        self.release = PackageRelease.objects.create(
+            package=self.package,
+            version="1.0",
+            revision="",
+        )
+        self.addCleanup(lambda: shutil.rmtree("locks", ignore_errors=True))
+
+    def test_requires_arguments(self):
+        with self.assertRaises(CommandError):
+            call_command("clean_release_logs")
+
+    def test_clean_specific_release_removes_logs_and_locks(self):
+        other_release = PackageRelease.objects.create(
+            package=self.package,
+            version="2.0",
+            revision="",
+        )
+
+        with TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            keep_file = log_dir / "server.log"
+            keep_file.write_text("keep", encoding="utf-8")
+
+            target_prefix = f"pr.{self.package.name}.v{self.release.version}"
+            log_path = log_dir / f"{target_prefix}.log"
+            extra_variant = log_dir / f"{target_prefix}.1.log"
+            log_path.write_text("entry", encoding="utf-8")
+            extra_variant.write_text("more", encoding="utf-8")
+
+            other_log = log_dir / f"pr.{self.package.name}.v{other_release.version}.log"
+            other_log.write_text("other", encoding="utf-8")
+
+            lock_dir = Path("locks")
+            lock_dir.mkdir(exist_ok=True)
+            lock_file = lock_dir / f"release_publish_{self.release.pk}.json"
+            restart_file = lock_dir / f"release_publish_{self.release.pk}.restarts"
+            other_lock = lock_dir / f"release_publish_{other_release.pk}.json"
+            lock_file.write_text("{}", encoding="utf-8")
+            restart_file.write_text("1", encoding="utf-8")
+            other_lock.write_text("{}", encoding="utf-8")
+
+            with override_settings(LOG_DIR=log_dir):
+                call_command(
+                    "clean_release_logs",
+                    f"{self.package.name}:{self.release.version}",
+                )
+
+            self.assertFalse(log_path.exists())
+            self.assertFalse(extra_variant.exists())
+            self.assertTrue(other_log.exists())
+            self.assertTrue(keep_file.exists())
+            self.assertFalse(lock_file.exists())
+            self.assertFalse(restart_file.exists())
+            self.assertTrue(other_lock.exists())
+
+    def test_clean_all_removes_all_release_logs(self):
+        release_two = PackageRelease.objects.create(
+            package=self.package,
+            version="3.0",
+            revision="",
+        )
+
+        with TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            retained = log_dir / "app.log"
+            retained.write_text("retain", encoding="utf-8")
+
+            for release in (self.release, release_two):
+                log_file = log_dir / f"pr.{self.package.name}.v{release.version}.log"
+                log_file.write_text("entry", encoding="utf-8")
+
+            lock_dir = Path("locks")
+            lock_dir.mkdir(exist_ok=True)
+            for release in (self.release, release_two):
+                (lock_dir / f"release_publish_{release.pk}.json").write_text(
+                    "{}", encoding="utf-8"
+                )
+                (lock_dir / f"release_publish_{release.pk}.restarts").write_text(
+                    "1", encoding="utf-8"
+                )
+
+            with override_settings(LOG_DIR=log_dir):
+                call_command("clean_release_logs", "--all")
+
+            self.assertTrue(retained.exists())
+            self.assertFalse(list(log_dir.glob("pr.*.log")))
+            self.assertFalse(list(lock_dir.glob("release_publish_*")))


### PR DESCRIPTION
## Summary
- add a clean_release_logs management command that removes release publish logs from the configured log directory and clears related lock files
- cover the new command with targeted tests for both single-release and full cleanup scenarios
- record a release manager TODO to validate the manual cleanup workflow

## Testing
- pytest tests/test_clean_release_logs_command.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e43e0f11208326baed167002dbb751