### PR TITLE
Improve Raspberry Pi camera stream embedding

### DIFF
--- a/nodes/templates/admin/nodes/nodefeature/view_stream.html
+++ b/nodes/templates/admin/nodes/nodefeature/view_stream.html
@@ -12,14 +12,36 @@
       {% endblocktrans %}
     </p>
     <div class="camera-stream__frame">
-      <iframe
-        src="{{ stream_url }}"
-        title="{% trans "Camera stream" %}"
-        allow="autoplay; fullscreen"
-        allowfullscreen
-        referrerpolicy="no-referrer"
-      ></iframe>
+      {% if stream_embed == "mjpeg" %}
+        <img
+          src="{{ stream_url }}"
+          alt="{% trans "Live camera stream" %}"
+          loading="lazy"
+        />
+      {% elif stream_embed == "iframe" %}
+        <iframe
+          src="{{ stream_url }}"
+          title="{% trans "Camera stream" %}"
+          allow="autoplay; fullscreen"
+          allowfullscreen
+          referrerpolicy="no-referrer"
+        ></iframe>
+      {% else %}
+        <div class="camera-stream__unsupported" role="alert">
+          <p>
+            {% blocktrans %}
+              This stream uses a protocol that cannot be embedded in the browser. Use the
+              button below to open it in an external viewer.
+            {% endblocktrans %}
+          </p>
+        </div>
+      {% endif %}
     </div>
+    <p class="camera-stream__actions">
+      <a class="button" href="{{ stream_url }}" target="_blank" rel="noopener">
+        {% trans "Open stream in new window" %}
+      </a>
+    </p>
   </div>
 </div>
 {% endblock %}
@@ -35,13 +57,59 @@
     background: #000;
   }
 
-  .camera-stream__frame iframe {
+  .camera-stream__frame iframe,
+  .camera-stream__frame video {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     border: 0;
+  }
+
+  .camera-stream__frame img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    object-fit: contain;
+    display: block;
+    background: #000;
+  }
+
+  .camera-stream__frame .camera-stream__unsupported {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    text-align: center;
+    padding: 1.5rem;
+  }
+
+  .camera-stream__actions {
+    margin-top: 1rem;
+  }
+
+  .camera-stream__actions .button {
+    display: inline-block;
+    padding: 0.5em 1em;
+    background: #0c4b33;
+    color: #fff;
+    border-radius: 4px;
+    text-decoration: none;
+  }
+
+  .camera-stream__actions .button:hover,
+  .camera-stream__actions .button:focus {
+    background: #0f5c3f;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- detect common Raspberry Pi camera stream types and choose an embed mode
- update the admin stream template with MJPEG support, an external link, and messaging for unsupported protocols
- cover the new logic with targeted admin view tests

## Testing
- pytest nodes/tests.py::NodeAdminTests::test_view_stream_renders_when_feature_enabled
- pytest nodes/tests.py::NodeAdminTests::test_view_stream_detects_mjpeg_stream nodes/tests.py::NodeAdminTests::test_view_stream_marks_rtsp_stream_as_unsupported

------
https://chatgpt.com/codex/tasks/task_e_68e44a8e98b483268f9b5e64e1671474