### PR TITLE
Fix clean_release_logs lock directory resolution

### DIFF
--- a/core/management/commands/clean_release_logs.py
+++ b/core/management/commands/clean_release_logs.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             )
 
         log_dir = Path(settings.LOG_DIR)
-        lock_dir = Path("locks")
+        lock_dir = Path(settings.BASE_DIR) / "locks"
 
         log_targets: set[Path] = set()
         lock_targets: set[Path] = set()

--- a/tests/test_clean_release_logs_command.py
+++ b/tests/test_clean_release_logs_command.py
@@ -2,7 +2,6 @@ import os
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import shutil
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
@@ -24,7 +23,6 @@ class CleanReleaseLogsCommandTests(TestCase):
             version="1.0",
             revision="",
         )
-        self.addCleanup(lambda: shutil.rmtree("locks", ignore_errors=True))
 
     def test_requires_arguments(self):
         with self.assertRaises(CommandError):
@@ -37,8 +35,9 @@ class CleanReleaseLogsCommandTests(TestCase):
             revision="",
         )
 
-        with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir, TemporaryDirectory() as base_tmp:
             log_dir = Path(tmp_dir)
+            base_dir = Path(base_tmp)
             keep_file = log_dir / "server.log"
             keep_file.write_text("keep", encoding="utf-8")
 
@@ -51,7 +50,7 @@ class CleanReleaseLogsCommandTests(TestCase):
             other_log = log_dir / f"pr.{self.package.name}.v{other_release.version}.log"
             other_log.write_text("other", encoding="utf-8")
 
-            lock_dir = Path("locks")
+            lock_dir = base_dir / "locks"
             lock_dir.mkdir(exist_ok=True)
             lock_file = lock_dir / f"release_publish_{self.release.pk}.json"
             restart_file = lock_dir / f"release_publish_{self.release.pk}.restarts"
@@ -60,7 +59,7 @@ class CleanReleaseLogsCommandTests(TestCase):
             restart_file.write_text("1", encoding="utf-8")
             other_lock.write_text("{}", encoding="utf-8")
 
-            with override_settings(LOG_DIR=log_dir):
+            with override_settings(LOG_DIR=log_dir, BASE_DIR=base_dir):
                 call_command(
                     "clean_release_logs",
                     f"{self.package.name}:{self.release.version}",
@@ -81,8 +80,9 @@ class CleanReleaseLogsCommandTests(TestCase):
             revision="",
         )
 
-        with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir, TemporaryDirectory() as base_tmp:
             log_dir = Path(tmp_dir)
+            base_dir = Path(base_tmp)
             retained = log_dir / "app.log"
             retained.write_text("retain", encoding="utf-8")
 
@@ -90,7 +90,7 @@ class CleanReleaseLogsCommandTests(TestCase):
                 log_file = log_dir / f"pr.{self.package.name}.v{release.version}.log"
                 log_file.write_text("entry", encoding="utf-8")
 
-            lock_dir = Path("locks")
+            lock_dir = base_dir / "locks"
             lock_dir.mkdir(exist_ok=True)
             for release in (self.release, release_two):
                 (lock_dir / f"release_publish_{release.pk}.json").write_text(
@@ -100,7 +100,7 @@ class CleanReleaseLogsCommandTests(TestCase):
                     "1", encoding="utf-8"
                 )
 
-            with override_settings(LOG_DIR=log_dir):
+            with override_settings(LOG_DIR=log_dir, BASE_DIR=base_dir):
                 call_command("clean_release_logs", "--all")
 
             self.assertTrue(retained.exists())


### PR DESCRIPTION
## Summary
- add a clean_release_logs management command that removes release publish logs from the configured log directory and clears related lock files
- cover the new command with targeted tests for both single-release and full cleanup scenarios
- record a release manager TODO to validate the manual cleanup workflow
- resolve the clean_release_logs lock directory relative to BASE_DIR so the command succeeds regardless of the current working directory
- update the command tests to exercise the new BASE_DIR override

## Testing
- pytest tests/test_clean_release_logs_command.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e45da55a7c832690ccf42ccb5d273b