### PR TITLE
Preserve Path type when falling back to release log directory

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -426,7 +426,7 @@ def _resolve_release_log_dir(preferred: Path) -> tuple[Path, str | None]:
             f"Release log directory {fallback} is not writable"
         )
 
-    settings.LOG_DIR = str(fallback)
+    settings.LOG_DIR = fallback
     warning = (
         f"Release log directory {preferred} is not writable; using {fallback}"
     )


### PR DESCRIPTION
## Summary
- keep `settings.LOG_DIR` as a `Path` when falling back to a writable release log directory

## Testing
- pytest tests/test_release_progress.py tests/test_clean_release_logs_command.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4603bf2c88326becad996996dce8f