### PR TITLE
Stage release builds from sanitized tree to avoid runtime permissions

### DIFF
--- a/core/fixtures/todo__review_release_publish_log_dir_fallback.json
+++ b/core/fixtures/todo__review_release_publish_log_dir_fallback.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate release publish log directory fallback",
+      "url": "",
+      "request_details": "Attempt a publish in production after deploying the fallback fix to ensure release logs are written to the runtime log directory without triggering permission errors."
+    }
+  }
+]

--- a/core/fixtures/todo__review_release_publish_logs_cleanup.json
+++ b/core/fixtures/todo__review_release_publish_logs_cleanup.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate release publish log cleanup command",
+      "url": "",
+      "request_details": "Run the clean_release_logs management command in production to confirm stale publish logs and lock files are cleared."
+    }
+  }
+]

--- a/core/fixtures/todo__validate_sanitized_release_build.json
+++ b/core/fixtures/todo__validate_sanitized_release_build.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "core.todo",
+    "fields": {
+      "request": "Validate sanitized release build staging directory",
+      "url": "",
+      "request_details": "Run the publish flow on the Linux service after deploying the sanitized build staging fix to ensure the distribution step succeeds even when runtime directories under the repository tree are not readable."
+    }
+  }
+]

--- a/core/management/commands/clean_release_logs.py
+++ b/core/management/commands/clean_release_logs.py
@@ -1,0 +1,106 @@
+"""Management command to remove release publish logs and lock files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from core.models import PackageRelease
+
+
+class Command(BaseCommand):
+    help = (
+        "Remove release publish logs and associated lock files so the flow can restart."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "releases",
+            nargs="*",
+            metavar="PACKAGE:VERSION",
+            help="Release identifier in the form <package>:<version>.",
+        )
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            dest="clean_all",
+            help="Remove all release publish logs and related lock files.",
+        )
+
+    def handle(self, *args, **options):
+        releases: list[str] = options.get("releases") or []
+        clean_all: bool = options.get("clean_all", False)
+
+        if not releases and not clean_all:
+            raise CommandError(
+                "Specify --all or at least one PACKAGE:VERSION identifier to clean."
+            )
+
+        log_dir = Path(settings.LOG_DIR)
+        lock_dir = Path("locks")
+
+        log_targets: set[Path] = set()
+        lock_targets: set[Path] = set()
+
+        if clean_all:
+            log_targets.update(log_dir.glob("pr.*.log"))
+            lock_targets.update(lock_dir.glob("release_publish_*.json"))
+            lock_targets.update(lock_dir.glob("release_publish_*.restarts"))
+
+        for spec in releases:
+            release = self._resolve_release(spec)
+            prefix = f"pr.{release.package.name}.v{release.version}"
+            log_targets.update(log_dir.glob(f"{prefix}*.log"))
+            for suffix in (".json", ".restarts"):
+                lock_targets.add(lock_dir / f"release_publish_{release.pk}{suffix}")
+
+        removed_logs = self._remove_files(log_targets)
+        removed_locks = self._remove_files(lock_targets)
+
+        if removed_logs:
+            self.stdout.write(
+                self.style.SUCCESS(f"Removed {removed_logs} release log file(s).")
+            )
+        else:
+            self.stdout.write("No release log files removed.")
+
+        if removed_locks:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Removed {removed_locks} release publish lock file(s)."
+                )
+            )
+        else:
+            self.stdout.write("No release publish lock files removed.")
+
+    def _resolve_release(self, spec: str) -> PackageRelease:
+        if ":" not in spec:
+            raise CommandError(
+                f"Release identifier '{spec}' is invalid. Use the format PACKAGE:VERSION."
+            )
+        package_name, version = [part.strip() for part in spec.split(":", 1)]
+        if not package_name or not version:
+            raise CommandError(
+                f"Release identifier '{spec}' is invalid. Use the format PACKAGE:VERSION."
+            )
+        try:
+            return PackageRelease.objects.select_related("package").get(
+                package__name=package_name, version=version
+            )
+        except PackageRelease.DoesNotExist as exc:
+            raise CommandError(
+                f"Release for package '{package_name}' and version '{version}' not found."
+            ) from exc
+
+    def _remove_files(self, paths: set[Path]) -> int:
+        removed = 0
+        for path in paths:
+            try:
+                if path.is_file():
+                    path.unlink()
+                    removed += 1
+            except OSError as exc:
+                raise CommandError(f"Failed to remove {path}: {exc}") from exc
+        return removed

--- a/tests/test_clean_release_logs_command.py
+++ b/tests/test_clean_release_logs_command.py
@@ -1,0 +1,108 @@
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import shutil
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+
+django.setup()
+
+from django.core.management import call_command, CommandError
+from django.test import TestCase, override_settings
+
+from core.models import Package, PackageRelease
+
+
+class CleanReleaseLogsCommandTests(TestCase):
+    def setUp(self):
+        self.package = Package.objects.create(name="pkg", is_active=True)
+        self.release = PackageRelease.objects.create(
+            package=self.package,
+            version="1.0",
+            revision="",
+        )
+        self.addCleanup(lambda: shutil.rmtree("locks", ignore_errors=True))
+
+    def test_requires_arguments(self):
+        with self.assertRaises(CommandError):
+            call_command("clean_release_logs")
+
+    def test_clean_specific_release_removes_logs_and_locks(self):
+        other_release = PackageRelease.objects.create(
+            package=self.package,
+            version="2.0",
+            revision="",
+        )
+
+        with TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            keep_file = log_dir / "server.log"
+            keep_file.write_text("keep", encoding="utf-8")
+
+            target_prefix = f"pr.{self.package.name}.v{self.release.version}"
+            log_path = log_dir / f"{target_prefix}.log"
+            extra_variant = log_dir / f"{target_prefix}.1.log"
+            log_path.write_text("entry", encoding="utf-8")
+            extra_variant.write_text("more", encoding="utf-8")
+
+            other_log = log_dir / f"pr.{self.package.name}.v{other_release.version}.log"
+            other_log.write_text("other", encoding="utf-8")
+
+            lock_dir = Path("locks")
+            lock_dir.mkdir(exist_ok=True)
+            lock_file = lock_dir / f"release_publish_{self.release.pk}.json"
+            restart_file = lock_dir / f"release_publish_{self.release.pk}.restarts"
+            other_lock = lock_dir / f"release_publish_{other_release.pk}.json"
+            lock_file.write_text("{}", encoding="utf-8")
+            restart_file.write_text("1", encoding="utf-8")
+            other_lock.write_text("{}", encoding="utf-8")
+
+            with override_settings(LOG_DIR=log_dir):
+                call_command(
+                    "clean_release_logs",
+                    f"{self.package.name}:{self.release.version}",
+                )
+
+            self.assertFalse(log_path.exists())
+            self.assertFalse(extra_variant.exists())
+            self.assertTrue(other_log.exists())
+            self.assertTrue(keep_file.exists())
+            self.assertFalse(lock_file.exists())
+            self.assertFalse(restart_file.exists())
+            self.assertTrue(other_lock.exists())
+
+    def test_clean_all_removes_all_release_logs(self):
+        release_two = PackageRelease.objects.create(
+            package=self.package,
+            version="3.0",
+            revision="",
+        )
+
+        with TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            retained = log_dir / "app.log"
+            retained.write_text("retain", encoding="utf-8")
+
+            for release in (self.release, release_two):
+                log_file = log_dir / f"pr.{self.package.name}.v{release.version}.log"
+                log_file.write_text("entry", encoding="utf-8")
+
+            lock_dir = Path("locks")
+            lock_dir.mkdir(exist_ok=True)
+            for release in (self.release, release_two):
+                (lock_dir / f"release_publish_{release.pk}.json").write_text(
+                    "{}", encoding="utf-8"
+                )
+                (lock_dir / f"release_publish_{release.pk}.restarts").write_text(
+                    "1", encoding="utf-8"
+                )
+
+            with override_settings(LOG_DIR=log_dir):
+                call_command("clean_release_logs", "--all")
+
+            self.assertTrue(retained.exists())
+            self.assertFalse(list(log_dir.glob("pr.*.log")))
+            self.assertFalse(list(lock_dir.glob("release_publish_*")))

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import shutil
+import stat
+import sys
+import uuid
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from core import release as release_module
+
+
+@pytest.mark.django_db
+def test_build_sanitizes_runtime_directories(monkeypatch):
+    base_dir = Path(__file__).resolve().parents[1]
+    locked_dir = base_dir / "run-permission-check"
+    locked_dir.mkdir(exist_ok=True)
+    locked_dir.chmod(0)
+    dist_dir = base_dir / "dist"
+    dist_backup = None
+    if dist_dir.exists():
+        dist_backup = dist_dir.parent / f"dist.backup.{uuid.uuid4().hex}"
+        dist_dir.rename(dist_backup)
+
+    run_calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(cmd, check=True, cwd=None):
+        run_calls.append((cmd, Path(cwd) if cwd else None))
+        if cmd[:3] == [sys.executable, "-m", "build"]:
+            staging = Path(cwd)
+            assert not (staging / locked_dir.name).exists()
+            dist_dir = staging / "dist"
+            dist_dir.mkdir(parents=True, exist_ok=True)
+            (dist_dir / "artifact.whl").write_text("wheel", encoding="utf-8")
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setenv("ARTHEXIS_LOG_DIR", str(locked_dir))
+
+    try:
+        with mock.patch("core.release._run", side_effect=fake_run):
+            release_module._build_in_sanitized_tree(base_dir)
+
+        build_invocations = [
+            call for call in run_calls if call[0][:3] == [sys.executable, "-m", "build"]
+        ]
+        assert build_invocations, "Expected python -m build to run"
+        build_cwd = build_invocations[0][1]
+        assert build_cwd is not None and build_cwd != base_dir
+        assert (base_dir / "dist" / "artifact.whl").exists()
+    finally:
+        try:
+            locked_dir.chmod(stat.S_IRWXU)
+        except PermissionError:
+            pass
+        shutil.rmtree(locked_dir, ignore_errors=True)
+        if dist_dir.exists():
+            shutil.rmtree(dist_dir)
+        if dist_backup is not None:
+            if dist_dir.exists():
+                shutil.rmtree(dist_dir)
+            dist_backup.rename(dist_dir)


### PR DESCRIPTION
## Summary
- stage `python -m build` inside a temporary tree containing only tracked files so runtime log directories no longer break release packaging
- cover the sanitized staging workflow with a regression test that exercises the fallback and artifacts copy
- add a release manager TODO to validate the sanitized build staging on the Linux service

## Testing
- pytest tests/test_release_build.py tests/test_release_progress.py tests/test_clean_release_logs_command.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e43e0f11208326baed167002dbb751