### PR TITLE
Handle blank package repository URLs

### DIFF
--- a/core/github_issues.py
+++ b/core/github_issues.py
@@ -25,11 +25,17 @@ def resolve_repository() -> tuple[str, str]:
     """Return the ``(owner, repo)`` tuple for the active package."""
 
     package = Package.objects.filter(is_active=True).first()
-    repository_url = (
-        package.repository_url
-        if package and package.repository_url
-        else DEFAULT_PACKAGE.repository_url
-    )
+
+    repository_url: str
+    if package is not None:
+        raw_url = getattr(package, "repository_url", "")
+        if raw_url is None:
+            cleaned_url = ""
+        else:
+            cleaned_url = str(raw_url).strip()
+        repository_url = cleaned_url or DEFAULT_PACKAGE.repository_url
+    else:
+        repository_url = DEFAULT_PACKAGE.repository_url
 
     owner: str
     repo: str

--- a/core/tests/test_github_issues.py
+++ b/core/tests/test_github_issues.py
@@ -37,6 +37,18 @@ class ResolveRepositoryTests(TestCase):
         self.assertEqual(owner, "arthexis")
         self.assertEqual(repo, "arthexis")
 
+    def test_whitespace_repository_url_falls_back_to_default(self) -> None:
+        Package.objects.create(
+            name="custom",
+            repository_url="   ",
+            is_active=True,
+        )
+
+        owner, repo = github_issues.resolve_repository()
+
+        self.assertEqual(owner, "arthexis")
+        self.assertEqual(repo, "arthexis")
+
 
 class TokenLookupTests(TestCase):
     def test_token_comes_from_latest_release(self) -> None:


### PR DESCRIPTION
## Summary
- strip whitespace from the active package repository URL before parsing
- fall back to the default repository when no usable URL remains
- add a regression test covering whitespace-only repository URLs

## Testing
- python manage.py test core.tests.test_github_issues.ResolveRepositoryTests.test_whitespace_repository_url_falls_back_to_default


------
https://chatgpt.com/codex/tasks/task_e_68e469a8da108326a721c95f25871303