### PR TITLE
Restore projects RFID helper and update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 - Note: do not modify README files unless directed. Use Django's admindocs for app documentation.
   - When a README change is requested, update the translated README files in `locale/` (for example `README.es.md`, `README.fr.md`, `README.ru.md`) to keep them in sync.
   - If a requested change would make any README content inaccurate or outdated, update the README and translations accordingly even if the user did not explicitly ask for README edits.
+- Avoid creating new files or directories at the repository root unless the user specifically requests them.
 - Application documentation lives in Django's admindocs. Do not create or modify per-app README files.
 - Do not edit the changelog manually. An automated process builds it from commit
   messages.


### PR DESCRIPTION
## Summary
- restore the standalone projects RFID helper package and the unit tests that cover it
- document new guidance for agents to avoid adding unrequested files or directories at the repository root

## Testing
- pytest tests/test_projects_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68e4712c4be0832680fa63a39038419e