### PR TITLE
Add RPI camera stream port to firewall validation

### DIFF
--- a/network-setup.sh
+++ b/network-setup.sh
@@ -576,7 +576,7 @@ if [[ $RUN_PACKAGES == true ]]; then
 fi
 
 if [[ $RUN_FIREWALL == true ]]; then
-    PORTS=(22 21114)
+    PORTS=(22 21114 8554)
     MODE="internal"
     if [ -f "$LOCK_DIR/nginx_mode.lck" ]; then
         MODE="$(cat "$LOCK_DIR/nginx_mode.lck")"

--- a/tests/test_network_setup_interactive.py
+++ b/tests/test_network_setup_interactive.py
@@ -20,4 +20,12 @@ def test_network_setup_help_includes_flags() -> None:
     assert "--interactive" in result.stdout
     assert "--unsafe" in result.stdout
     assert "--no-watchdog" in result.stdout
-    assert "--public" in result.stdout
+    assert "--subnet" in result.stdout
+
+
+def test_network_setup_firewall_ports_include_camera_stream() -> None:
+    """Ensure the firewall validation checks the camera stream port."""
+
+    script = REPO_ROOT / "network-setup.sh"
+    script_contents = script.read_text()
+    assert "PORTS=(22 21114 8554)" in script_contents


### PR DESCRIPTION
## Summary
- include the Raspberry Pi camera stream port in the network setup firewall validation
- update the network setup interactive test to cover the camera stream port and reflect the current flag list

## Testing
- pytest tests/test_network_setup_interactive.py

------
https://chatgpt.com/codex/tasks/task_e_68e47ee66ce083268ba95d4af7cf09b8