### PR TITLE
Auto-scroll release progress logs

### DIFF
--- a/core/templates/core/release_progress.html
+++ b/core/templates/core/release_progress.html
@@ -408,7 +408,7 @@
     <h2>{% trans 'Logs' %}</h2>
     {% if show_log %}
       {% if log_content %}
-      <pre class="log-text">{{ log_content }}</pre>
+      <pre class="log-text" id="release-log">{{ log_content }}</pre>
       {% else %}
       <p class="log-empty">{% trans 'Logs will appear here as steps progress.' %}</p>
       {% endif %}
@@ -417,5 +417,22 @@
     {% endif %}
   </div>
 </div>
+<script>
+  (function () {
+    const logEl = document.getElementById('release-log');
+    if (!logEl) {
+      return;
+    }
+
+    const scrollToBottom = () => {
+      logEl.scrollTop = logEl.scrollHeight;
+    };
+
+    scrollToBottom();
+
+    const observer = new MutationObserver(scrollToBottom);
+    observer.observe(logEl, { childList: true, characterData: true, subtree: true });
+  })();
+</script>
 {% endblock %}
 

--- a/pages/templates/core/release_progress.html
+++ b/pages/templates/core/release_progress.html
@@ -327,7 +327,7 @@
     <h2>{% trans 'Logs' %}</h2>
     {% if show_log %}
       {% if log_content %}
-      <pre class="log-text">{{ log_content }}</pre>
+      <pre class="log-text" id="release-log">{{ log_content }}</pre>
       {% else %}
       <p class="log-empty">{% trans 'Logs will appear here as steps progress.' %}</p>
       {% endif %}
@@ -336,5 +336,22 @@
     {% endif %}
   </div>
 </div>
+<script>
+  (function () {
+    const logEl = document.getElementById('release-log');
+    if (!logEl) {
+      return;
+    }
+
+    const scrollToBottom = () => {
+      logEl.scrollTop = logEl.scrollHeight;
+    };
+
+    scrollToBottom();
+
+    const observer = new MutationObserver(scrollToBottom);
+    observer.observe(logEl, { childList: true, characterData: true, subtree: true });
+  })();
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- keep the release progress log viewer pinned to the newest entries by scrolling to the bottom automatically
- observe log updates and maintain the behaviour in both admin and pages release progress templates

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e531e49c0c83269a9677b351bfffdc