### PR TITLE
Hide redundant revision in footer when matching release

### DIFF
--- a/core/templatetags/ref_tags.py
+++ b/core/templatetags/ref_tags.py
@@ -57,15 +57,24 @@ def render_footer(context):
     if ver_path.exists():
         version = ver_path.read_text().strip()
 
-    revision_value = revision.get_revision()
-    rev_short = revision_value[-6:] if revision_value else ""
+    revision_value = (revision.get_revision() or "").strip()
     release_name = DEFAULT_PACKAGE.name
     release_url = None
+    release = None
+    release_revision = ""
+    if version:
+        release = PackageRelease.objects.filter(version=version).first()
+        if release and release.revision:
+            release_revision = release.revision.strip()
+
+    rev_short = ""
+    if revision_value and revision_value != release_revision:
+        rev_short = revision_value[-6:]
+
     if version:
         release_name = f"{release_name}-{version}"
         if rev_short:
             release_name = f"{release_name}-{rev_short}"
-        release = PackageRelease.objects.filter(version=version).first()
         if release:
             release_url = reverse("admin:core_packagerelease_change", args=[release.pk])
 

--- a/tests/test_footer_no_references.py
+++ b/tests/test_footer_no_references.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from django.test import TestCase
 from django.urls import reverse
 
-from core.models import Reference
+from core.models import PackageRelease, Reference
 from core.release import DEFAULT_PACKAGE
 from utils import revision
 
@@ -14,7 +14,15 @@ class FooterNoReferencesTests(TestCase):
         response = self.client.get(reverse("pages:login"))
         self.assertContains(response, "<footer", html=False)
         version = Path("VERSION").read_text().strip()
-        rev_short = revision.get_revision()[-6:]
+        revision_value = (revision.get_revision() or "").strip()
+        release = PackageRelease.objects.filter(version=version).first()
+        release_revision = ""
+        if release and release.revision:
+            release_revision = release.revision.strip()
+        rev_short = ""
+        if revision_value and revision_value != release_revision:
+            rev_short = revision_value[-6:]
+
         release_name = f"{DEFAULT_PACKAGE.name}-{version}"
         if rev_short:
             release_name = f"{release_name}-{rev_short}"

--- a/tests/test_footer_render.py
+++ b/tests/test_footer_render.py
@@ -15,7 +15,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from unittest.mock import patch, PropertyMock
 
-from core.models import Reference
+from core.models import PackageRelease, Reference
 from core.release import DEFAULT_PACKAGE
 from utils import revision
 from nodes.models import (
@@ -45,7 +45,15 @@ class FooterRenderTests(TestCase):
         self.assertContains(response, "Example")
         self.assertContains(response, "https://example.com")
         version = Path("VERSION").read_text().strip()
-        rev_short = revision.get_revision()[-6:]
+        revision_value = (revision.get_revision() or "").strip()
+        release = PackageRelease.objects.filter(version=version).first()
+        release_revision = ""
+        if release and release.revision:
+            release_revision = release.revision.strip()
+        rev_short = ""
+        if revision_value and revision_value != release_revision:
+            rev_short = revision_value[-6:]
+
         release_name = f"{DEFAULT_PACKAGE.name}-{version}"
         if rev_short:
             release_name = f"{release_name}-{rev_short}"


### PR DESCRIPTION
## Summary
- avoid displaying the footer revision when it matches the stored release revision
- adjust footer-related tests to reflect the conditional revision display logic

## Testing
- pytest tests/test_footer_render.py tests/test_footer_no_references.py

------
https://chatgpt.com/codex/tasks/task_e_68e54e9ebb40832686d3cd8541b62073