### PR TITLE
Handle unreadable auto-upgrade mode lockfile

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -129,7 +129,12 @@ def check_github_updates() -> None:
     mode_file = base_dir / "locks" / "auto_upgrade.lck"
     mode = "version"
     if mode_file.exists():
-        mode = mode_file.read_text().strip()
+        try:
+            mode = mode_file.read_text().strip() or "version"
+        except (OSError, UnicodeDecodeError):
+            logger.warning(
+                "Failed to read auto-upgrade mode lockfile", exc_info=True
+            )
 
     branch = "main"
     subprocess.run(["git", "fetch", "origin", branch], cwd=base_dir, check=True)

--- a/core/tests/test_tasks.py
+++ b/core/tests/test_tasks.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+from types import SimpleNamespace
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+
+def test_check_github_updates_handles_mode_read_error(monkeypatch, tmp_path):
+    """The auto-upgrade task should ignore unreadable mode lock files."""
+
+    from core import tasks
+
+    base_dir = Path(tasks.__file__).resolve().parent.parent
+    mode_path = base_dir / "locks" / "auto_upgrade.lck"
+
+    original_exists = Path.exists
+    original_read_text = Path.read_text
+
+    def fake_exists(self: Path) -> bool:
+        if self == mode_path:
+            return True
+        return original_exists(self)
+
+    def fake_read_text(self: Path, *args, **kwargs) -> str:
+        if self == mode_path:
+            raise OSError("permission denied")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", fake_exists, raising=False)
+    monkeypatch.setattr(Path, "read_text", fake_read_text, raising=False)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "core.notifications",
+        SimpleNamespace(notify=lambda *args, **kwargs: None),
+    )
+
+    import nodes.apps as nodes_apps
+
+    monkeypatch.setattr(nodes_apps, "_startup_notification", lambda: None)
+
+    log_path = tmp_path / "auto-upgrade.log"
+    monkeypatch.setattr(tasks, "_auto_upgrade_log_path", lambda base: log_path)
+    monkeypatch.setattr(tasks, "_append_auto_upgrade_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "_schedule_health_check", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "_load_skipped_revisions", lambda base: set())
+
+    monkeypatch.setattr(tasks.shutil, "which", lambda command: None)
+
+    def fake_run(command, *args, **kwargs):
+        return CompletedProcess(command, 0)
+
+    def fake_check_output(command, *args, **kwargs):
+        if "show" in command:
+            return b"v9.9.9"
+        return b"abcdef123456"
+
+    monkeypatch.setattr(tasks.subprocess, "run", fake_run)
+    monkeypatch.setattr(tasks.subprocess, "check_output", fake_check_output)
+
+    tasks.check_github_updates()


### PR DESCRIPTION
## Summary
- guard check_github_updates against unreadable auto-upgrade mode lockfiles by falling back to the default mode
- add a regression test that simulates a permission error when the lockfile cannot be read

## Testing
- pytest core/tests/test_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68e56c48ce3c8326935a5d1ef27b65cc