### PR TITLE
Normalize nginx mode when resolving auto-upgrade service URL

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -115,9 +115,11 @@ def _resolve_service_url(base_dir: Path) -> str:
     mode = "internal"
     if mode_file.exists():
         try:
-            mode = mode_file.read_text().strip() or "internal"
+            value = mode_file.read_text(encoding="utf-8").strip()
         except OSError:
-            mode = "internal"
+            value = ""
+        if value:
+            mode = value.lower()
     port = 8000 if mode == "public" else 8888
     return f"http://127.0.0.1:{port}/"
 

--- a/core/tests/test_tasks.py
+++ b/core/tests/test_tasks.py
@@ -66,3 +66,18 @@ def test_check_github_updates_handles_mode_read_error(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks.subprocess, "check_output", fake_check_output)
 
     tasks.check_github_updates()
+
+
+def test_resolve_service_url_handles_case_insensitive_mode(tmp_path):
+    """Public mode should be detected regardless of the file's casing."""
+
+    from core import tasks
+
+    base_dir = tmp_path
+    lock_dir = base_dir / "locks"
+    lock_dir.mkdir()
+    (lock_dir / "nginx_mode.lck").write_text("PUBLIC\n", encoding="utf-8")
+
+    url = tasks._resolve_service_url(base_dir)
+
+    assert url == "http://127.0.0.1:8000/"


### PR DESCRIPTION
## Summary
- normalize the nginx mode lockfile value before resolving the auto-upgrade health-check port
- add a regression test covering case-insensitive public mode detection

## Testing
- pytest core/tests/test_tasks.py::test_resolve_service_url_handles_case_insensitive_mode -q

------
https://chatgpt.com/codex/tasks/task_e_68e57fcffa6083269a8f89d767c6767d