### PR TITLE
Exclude dotfiles from admin log viewer

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -619,7 +619,11 @@ def log_viewer(request):
     available_logs = []
     if logs_exist:
         available_logs = sorted(
-            [entry.name for entry in logs_dir.iterdir() if entry.is_file()],
+            [
+                entry.name
+                for entry in logs_dir.iterdir()
+                if entry.is_file() and not entry.name.startswith(".")
+            ],
             key=str.lower,
         )
 

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -982,6 +982,14 @@ class LogViewerAdminTests(SimpleTestCase):
         self.assertIn("root.log", response.context_data["available_logs"])
         self.assertNotIn("hidden.log", response.context_data["available_logs"])
 
+    def test_log_viewer_ignores_hidden_files(self):
+        hidden_log = self.logs_dir / ".hidden.log"
+        hidden_log.write_text("secret", encoding="utf-8")
+        self._create_log("visible.log", "visible")
+        response = self._render()
+        self.assertIn("visible.log", response.context_data["available_logs"])
+        self.assertNotIn(".hidden.log", response.context_data["available_logs"])
+
 class AdminModelStatusTests(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
## Summary
- filter admin log viewer entries to exclude hidden dotfiles from the logs directory
- add a regression test ensuring the log viewer omits hidden files while still showing visible logs

## Testing
- pytest pages/tests.py -k LogViewerTests -q

------
https://chatgpt.com/codex/tasks/task_e_68e587563d048326b6c2541fd488c911