### PR TITLE
Ensure dry run publish builds artifacts when missing

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1247,6 +1247,27 @@ def _step_publish(release, ctx, log_path: Path) -> None:
             verify_availability=False,
         )
         label = target.repository_url or target.name
+        dist_path = Path("dist")
+        if not dist_path.exists():
+            _append_log(log_path, "Dry run: building distribution artifacts")
+            try:
+                release_utils.build(
+                    package=release.to_package(),
+                    version=release.version,
+                    creds=release.to_credentials(),
+                    dist=True,
+                    tests=False,
+                    twine=False,
+                    git=False,
+                    tag=False,
+                    stash=True,
+                )
+            except release_utils.ReleaseError as exc:
+                _append_log(
+                    log_path,
+                    f"Dry run: failed to prepare distribution artifacts ({exc})",
+                )
+                raise
         _append_log(log_path, f"Dry run: uploading distribution to {label}")
         release_utils.publish(
             package=release.to_package(),


### PR DESCRIPTION
## Summary
- build distribution artifacts during dry-run publish when the dist directory is absent
- log the artifact preparation step and surface failures before attempting the upload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58c2f90848326a8d0404373f77c33