### PR TITLE
Automate upgrade recovery for supervisory nodes

### DIFF
--- a/docs/git-conflict-resolution.rst
+++ b/docs/git-conflict-resolution.rst
@@ -1,0 +1,39 @@
+Resolving Detached HEAD Merge Conflicts
+=======================================
+
+If you find yourself detached from a branch with unfinished merge conflicts, use
+this workflow to recover safely:
+
+1. Inspect your repository status to see the in-progress operation and the
+   conflicted files::
+
+      git status
+
+2. Either finish the operation by resolving the conflicts or abort it entirely.
+
+   * To finish, edit each conflicted file to the desired content, stage it with
+     ``git add`` and continue the operation (for example ``git rebase
+     --continue``).
+   * To abort the operation, run the matching ``git <operation> --abort`` command
+     (``git rebase --abort``, ``git merge --abort``, etc.).
+
+3. Once the working tree is clean and ``git status`` reports no pending
+   operations, switch back to the branch that tracks ``origin``::
+
+      git switch <branch>
+
+   Re-running ``./upgrade.sh --latest`` works as well because it calls
+   ``git switch`` under the hood.
+
+4. Only after the tree is clean should you use ``git stash`` or any other
+   commands that assume a completed merge; otherwise Git will refuse to proceed
+   until conflicts are resolved.
+
+Following these steps ensures you do not lose work while recovering from an
+interrupted upgrade.
+
+Control and Constellation nodes now automate this recovery during
+``./upgrade.sh`` by aborting incomplete rebases/merges and realigning to the
+latest ``origin/<branch>`` commit before pulling. The manual steps above remain
+helpful for Terminal nodes or when running Git commands outside the upgrade
+script.


### PR DESCRIPTION
## Summary
- add git recovery helpers in `upgrade.sh` that abort interrupted operations and realign Control/Constellation nodes with their tracked branch before pulling
- capture the latest failover branch name so discarded commits remain discoverable after cleanup
- document the automated behavior in the detached HEAD conflict guide

## Testing
- not run (shellcheck unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5900e29588326b0b5e28c153cbe7b