### PR TITLE
Enable feedback submissions in the admin

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -394,6 +394,294 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
 .selector-chosen {
     order: 2;
 }
+
+.user-story-toggle {
+    position: fixed;
+    right: 1.75rem;
+    bottom: 1.75rem;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: 0;
+    background: linear-gradient(135deg, #facc15, #fb923c);
+    color: #1f2937;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    z-index: 1080;
+}
+
+.user-story-toggle:hover,
+.user-story-toggle:focus-visible {
+    transform: translateY(-2px) scale(1.02);
+    box-shadow: 0 1.75rem 3rem rgba(15, 23, 42, 0.45);
+}
+
+.user-story-toggle svg {
+    width: 1.75rem;
+    height: 1.75rem;
+    display: block;
+}
+
+body.user-story-open .user-story-toggle {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.user-story-open {
+    overflow: hidden;
+}
+
+.user-story-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 1.5rem;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 1070;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.user-story-overlay.show {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.user-story-card {
+    width: min(28rem, 100%);
+    border-radius: 1rem;
+    box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.45);
+    background: var(--body-bg, #ffffff);
+    color: var(--body-fg, #212529);
+    transform: translateY(1rem);
+    transition: transform 0.25s ease;
+}
+
+.user-story-card .card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 1.25rem 0.75rem;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.user-story-card .card-body {
+    padding: 1rem 1.25rem 1.5rem;
+}
+
+.user-story-card .card-title {
+    margin-bottom: 0.25rem;
+}
+
+.user-story-card .card-subtitle {
+    margin-bottom: 0;
+}
+
+.user-story-card .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.65rem 1rem;
+    border: none;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background: linear-gradient(135deg, #2563eb, #0ea5e9);
+    color: #ffffff;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.user-story-card .btn:hover,
+.user-story-card .btn:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 1rem 2rem rgba(14, 165, 233, 0.35);
+    text-decoration: none;
+}
+
+.user-story-card .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.user-story-card .btn-close {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.user-story-card .btn-close::before {
+    content: "\00d7";
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.user-story-card .btn-close:hover,
+.user-story-card .btn-close:focus-visible {
+    background-color: rgba(15, 23, 42, 0.08);
+}
+
+.user-story-card .form-control,
+.user-story-card textarea {
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(15, 23, 42, 0.15);
+    padding: 0.5rem 0.75rem;
+    background: var(--body-bg, #ffffff);
+    color: inherit;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    resize: vertical;
+}
+
+.user-story-card .form-control:focus,
+.user-story-card textarea:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.2);
+    outline: none;
+}
+
+.user-story-card .form-check-input {
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 0.35rem;
+    border: 1px solid rgba(15, 23, 42, 0.25);
+    cursor: pointer;
+}
+
+.user-story-card .form-check-input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.2);
+}
+
+.user-story-overlay.show .user-story-card {
+    transform: translateY(0);
+}
+
+.user-story-rating {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    gap: 0.35rem;
+}
+
+.user-story-feedback-options {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.user-story-card .form-label,
+.user-story-card .form-text,
+.user-story-card .form-check-label {
+    display: block;
+}
+
+.user-story-card .form-text {
+    color: rgba(15, 23, 42, 0.6);
+    font-size: 0.85rem;
+    margin-top: 0.3rem;
+}
+
+.user-story-screenshot {
+    margin: 0;
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.user-story-screenshot .form-check-input {
+    margin-top: 0;
+}
+
+.user-story-rating input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.user-story-rating label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.75rem;
+    color: rgba(148, 163, 184, 0.7);
+    cursor: pointer;
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.user-story-rating label:hover,
+.user-story-rating label:focus-visible,
+.user-story-rating label:hover ~ label {
+    color: #fbbf24;
+}
+
+.user-story-rating input:checked ~ label {
+    color: #f59e0b;
+}
+
+.user-story-rating label:active {
+    transform: scale(0.95);
+}
+
+.user-story-alert {
+    transition: opacity 0.2s ease;
+}
+
+.user-story-card .alert {
+    margin-bottom: 0;
+    border-radius: 0.75rem;
+    border: 1px solid transparent;
+    padding: 0.75rem 1rem;
+}
+
+.user-story-card .alert-success {
+    background-color: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.35);
+    color: #047857;
+}
+
+.user-story-card .alert-danger {
+    background-color: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.35);
+    color: #b91c1c;
+}
+
+@media (max-width: 767.98px) {
+    .user-story-toggle {
+        right: 1.25rem;
+        bottom: 1.25rem;
+    }
+
+    .user-story-overlay {
+        align-items: stretch;
+        padding: 1rem;
+    }
+
+    .user-story-card {
+        width: 100%;
+        border-radius: 1rem;
+    }
+}
 </style>
 {% endblock %}
 {% block branding %}
@@ -478,4 +766,8 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
 {% block nav-global %}{% endblock %}
 {% block messages %}
   {% include "admin/includes/messages.html" %}
+{% endblock %}
+{% block footer %}
+  {{ block.super }}
+  {% include "admin/includes/user_story_feedback.html" %}
 {% endblock %}

--- a/pages/templates/admin/includes/user_story_feedback.html
+++ b/pages/templates/admin/includes/user_story_feedback.html
@@ -1,0 +1,257 @@
+{% load i18n %}
+<button
+  type="button"
+  id="user-story-toggle"
+  class="user-story-toggle"
+  aria-haspopup="dialog"
+  aria-controls="user-story-overlay"
+  aria-expanded="false"
+  aria-label="{% trans 'Share your feedback' %}"
+>
+  <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+    <path
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M11.049 2.927a1 1 0 011.902 0l1.563 4.813a1 1 0 00.95.69h5.063c.969 0 1.371 1.24.588 1.81l-4.096 2.977a1 1 0 00-.364 1.118l1.563 4.813c.3.921-.755 1.688-1.54 1.118l-4.096-2.977a1 1 0 00-1.175 0l-4.096 2.977c-.784.57-1.838-.197-1.539-1.118l1.563-4.813a1 1 0 00-.364-1.118L2.445 10.24c-.783-.57-.38-1.81.588-1.81h5.063a1 1 0 00.95-.69l1.563-4.813z"
+      clip-rule="evenodd"
+    ></path>
+  </svg>
+  <span class="visually-hidden">{% trans 'Share your feedback' %}</span>
+</button>
+<div
+  id="user-story-overlay"
+  class="user-story-overlay"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="user-story-title"
+  hidden
+>
+  <div class="user-story-card card" tabindex="-1">
+    <div class="card-header d-flex justify-content-between align-items-start">
+      <div>
+        <h5 class="card-title mb-1" id="user-story-title">{% trans 'Please provide feedback!' %}</h5>
+        <p class="card-subtitle text-muted small mb-0">{% trans 'Tell us how this page worked for you.' %}</p>
+      </div>
+      <button type="button" class="btn-close" aria-label="{% trans 'Close' %}" data-feedback-close></button>
+    </div>
+    <div class="card-body">
+      <form id="user-story-form" method="post" action="{% url 'pages:user-story-submit' %}">
+        {% csrf_token %}
+        <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
+        <div class="mb-3">
+          <label for="user-story-name" class="form-label">{% trans 'Name (email or pseudonym)' %}</label>
+          <input
+            type="text"
+            class="form-control"
+            id="user-story-name"
+            name="name"
+            maxlength="40"
+            value="{% if request.user.is_authenticated %}{{ request.user.username|slice:':40' }}{% endif %}"
+            placeholder="{% trans 'Share how we should address you' %}"
+          >
+          <div class="form-text">{% trans 'Leave blank to submit anonymously.' %}</div>
+        </div>
+        <div class="mb-3">
+          <span class="form-label d-block">{% trans 'Your experience on this page' %}</span>
+          <div class="user-story-feedback-options">
+            <div class="user-story-rating" role="radiogroup" aria-labelledby="user-story-title">
+              <input type="radio" id="user-story-rating-5" name="rating" value="5" required>
+              <label for="user-story-rating-5" title="{% trans 'Excellent' %}" aria-label="{% trans '5 stars' %}">★</label>
+              <input type="radio" id="user-story-rating-4" name="rating" value="4">
+              <label for="user-story-rating-4" title="{% trans 'Great' %}" aria-label="{% trans '4 stars' %}">★</label>
+              <input type="radio" id="user-story-rating-3" name="rating" value="3">
+              <label for="user-story-rating-3" title="{% trans 'Good' %}" aria-label="{% trans '3 stars' %}">★</label>
+              <input type="radio" id="user-story-rating-2" name="rating" value="2">
+              <label for="user-story-rating-2" title="{% trans 'Okay' %}" aria-label="{% trans '2 stars' %}">★</label>
+              <input type="radio" id="user-story-rating-1" name="rating" value="1">
+              <label for="user-story-rating-1" title="{% trans 'Needs improvement' %}" aria-label="{% trans '1 star' %}">★</label>
+            </div>
+            <div class="form-check user-story-screenshot">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="user-story-take-screenshot"
+                name="take_screenshot"
+                value="1"
+                checked
+              >
+              <label class="form-check-label" for="user-story-take-screenshot">{% trans 'Take a screenshot' %}</label>
+            </div>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label for="user-story-comments" class="form-label">{% trans 'Detailed comments / feedback' %}</label>
+          <textarea
+            class="form-control"
+            id="user-story-comments"
+            name="comments"
+            rows="4"
+            maxlength="400"
+            placeholder="{% trans 'Share details about your experience (max 400 characters)' %}"
+            required
+          ></textarea>
+          <div class="form-text">
+            <span id="user-story-char-count">0</span>/400
+          </div>
+        </div>
+        <button type="submit" class="btn btn-primary w-100 py-2">
+          {% trans 'Submit feedback' %}
+        </button>
+        <div id="user-story-success" class="alert alert-success user-story-alert mt-3 d-none" role="status">
+          {% trans 'Thank you! Your feedback has been sent.' %}
+        </div>
+        <div id="user-story-error" class="alert alert-danger user-story-alert mt-3 d-none" role="alert"></div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+  (function() {
+    const toggle = document.getElementById('user-story-toggle');
+    const overlay = document.getElementById('user-story-overlay');
+    const form = document.getElementById('user-story-form');
+    if (!toggle || !overlay || !form) {
+      return;
+    }
+
+    const closeBtn = overlay.querySelector('[data-feedback-close]');
+    const card = overlay.querySelector('.user-story-card');
+    const successAlert = document.getElementById('user-story-success');
+    const errorAlert = document.getElementById('user-story-error');
+    const commentField = document.getElementById('user-story-comments');
+    const counter = document.getElementById('user-story-char-count');
+    const submitBtn = form.querySelector('button[type="submit"]');
+    let previousFocus = null;
+
+    const setCharCount = () => {
+      if (counter && commentField) {
+        counter.textContent = commentField.value.length;
+      }
+    };
+
+    const resetAlerts = () => {
+      if (successAlert) {
+        successAlert.classList.add('d-none');
+      }
+      if (errorAlert) {
+        errorAlert.classList.add('d-none');
+        errorAlert.textContent = '';
+      }
+    };
+
+    const openOverlay = () => {
+      if (!overlay.hasAttribute('hidden')) {
+        return;
+      }
+      previousFocus = document.activeElement;
+      overlay.removeAttribute('hidden');
+      requestAnimationFrame(() => {
+        overlay.classList.add('show');
+        document.body.classList.add('user-story-open');
+        toggle.setAttribute('aria-expanded', 'true');
+        if (card) {
+          card.focus();
+        }
+      });
+    };
+
+    const closeOverlay = () => {
+      if (overlay.hasAttribute('hidden')) {
+        return;
+      }
+      overlay.classList.remove('show');
+      document.body.classList.remove('user-story-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      setTimeout(() => {
+        overlay.setAttribute('hidden', '');
+        resetAlerts();
+        form.reset();
+        setCharCount();
+        if (previousFocus) {
+          previousFocus.focus();
+        }
+      }, 200);
+    };
+
+    toggle.addEventListener('click', () => {
+      if (overlay.hasAttribute('hidden')) {
+        openOverlay();
+      } else {
+        closeOverlay();
+      }
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeOverlay);
+    }
+
+    overlay.addEventListener('click', event => {
+      if (event.target === overlay) {
+        closeOverlay();
+      }
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !overlay.hasAttribute('hidden')) {
+        closeOverlay();
+      }
+    });
+
+    if (commentField) {
+      commentField.addEventListener('input', setCharCount);
+      setCharCount();
+    }
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      resetAlerts();
+
+      if (submitBtn) {
+        submitBtn.disabled = true;
+      }
+
+      const formData = new FormData(form);
+      try {
+        const response = await fetch(form.action, {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: formData,
+        });
+
+        if (response.ok) {
+          form.reset();
+          setCharCount();
+          if (successAlert) {
+            successAlert.classList.remove('d-none');
+          }
+        } else {
+          const data = await response.json().catch(() => ({}));
+          let message = '';
+          if (data && data.errors) {
+            message = Object.values(data.errors)
+              .flat()
+              .join(' ');
+          }
+          if (!message) {
+            message = '{% trans "We could not submit your feedback. Please try again." %}';
+          }
+          if (errorAlert) {
+            errorAlert.textContent = message;
+            errorAlert.classList.remove('d-none');
+          }
+        }
+      } catch (error) {
+        if (errorAlert) {
+          errorAlert.textContent = '{% trans "Network error. Please try again." %}';
+          errorAlert.classList.remove('d-none');
+        }
+      } finally {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+        }
+      }
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary
- add the user-story feedback overlay markup and script to the Django admin base template
- style the feedback widget so it matches the admin theme and remains accessible across viewport sizes

## Testing
- python manage.py test pages.tests.UserStorySubmissionTests

------
https://chatgpt.com/codex/tasks/task_e_68e5a3073e808326ae0fa4df2fa16799