### PR TITLE
Fix admin feedback form spacing and alert visibility

### DIFF
--- a/pages/templates/admin/base_site.html
+++ b/pages/templates/admin/base_site.html
@@ -567,6 +567,27 @@ body.user-story-open {
     cursor: pointer;
 }
 
+.user-story-card .mb-3 {
+    margin-bottom: 1rem;
+}
+
+.user-story-card .mt-3 {
+    margin-top: 1rem;
+}
+
+.user-story-card .w-100 {
+    width: 100%;
+}
+
+.user-story-card .py-2 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.user-story-card .d-none {
+    display: none !important;
+}
+
 .user-story-card .form-check-input:focus {
     border-color: #2563eb;
     box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.2);

--- a/pages/templates/admin/includes/user_story_feedback.html
+++ b/pages/templates/admin/includes/user_story_feedback.html
@@ -97,10 +97,10 @@
         <button type="submit" class="btn btn-primary w-100 py-2">
           {% trans 'Submit feedback' %}
         </button>
-        <div id="user-story-success" class="alert alert-success user-story-alert mt-3 d-none" role="status">
+        <div id="user-story-success" class="alert alert-success user-story-alert mt-3 d-none" role="status" hidden>
           {% trans 'Thank you! Your feedback has been sent.' %}
         </div>
-        <div id="user-story-error" class="alert alert-danger user-story-alert mt-3 d-none" role="alert"></div>
+        <div id="user-story-error" class="alert alert-danger user-story-alert mt-3 d-none" role="alert" hidden></div>
       </form>
     </div>
   </div>
@@ -132,10 +132,12 @@
     const resetAlerts = () => {
       if (successAlert) {
         successAlert.classList.add('d-none');
+        successAlert.setAttribute('hidden', '');
       }
       if (errorAlert) {
         errorAlert.classList.add('d-none');
         errorAlert.textContent = '';
+        errorAlert.setAttribute('hidden', '');
       }
     };
 
@@ -225,6 +227,7 @@
           setCharCount();
           if (successAlert) {
             successAlert.classList.remove('d-none');
+            successAlert.removeAttribute('hidden');
           }
         } else {
           const data = await response.json().catch(() => ({}));
@@ -240,12 +243,14 @@
           if (errorAlert) {
             errorAlert.textContent = message;
             errorAlert.classList.remove('d-none');
+            errorAlert.removeAttribute('hidden');
           }
         }
       } catch (error) {
         if (errorAlert) {
           errorAlert.textContent = '{% trans "Network error. Please try again." %}';
           errorAlert.classList.remove('d-none');
+          errorAlert.removeAttribute('hidden');
         }
       } finally {
         if (submitBtn) {


### PR DESCRIPTION
## Summary
- add scoped utility styles so the admin feedback form rows regain spacing and sizing
- ensure feedback success and error alerts start hidden and toggle their visibility alongside the d-none class

## Testing
- ⚠️ `python manage.py migrate` *(terminated because the command appeared to hang in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a87f0748832680a867cd31aba53f