### PR TITLE
Split release manager credentials sections

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -471,17 +471,24 @@ class ReleaseManagerAdmin(ProfileAdminMixin, SaveBeforeChangeAction, EntityModel
     fieldsets = (
         ("Owner", {"fields": ("user", "group")}),
         (
-            "Credentials",
+            "PyPI",
             {
                 "fields": (
                     "pypi_username",
                     "pypi_token",
                     "pypi_password",
+                    "pypi_url",
+                    "secondary_pypi_url",
+                )
+            },
+        ),
+        (
+            "GitHub",
+            {
+                "fields": (
                     "github_token",
                     "git_username",
                     "git_password",
-                    "pypi_url",
-                    "secondary_pypi_url",
                 )
             },
         ),


### PR DESCRIPTION
## Summary
- split the Release Manager admin form credentials into dedicated PyPI and GitHub sections for clearer organization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5cdeac12483268f738e903e957dad