### PR TITLE
ocpp: stabilize charger session search smoke assertions

### DIFF
--- a/apps/ocpp/tests/test_charger_session_search.py
+++ b/apps/ocpp/tests/test_charger_session_search.py
@@ -47,9 +47,9 @@ def test_charger_session_search_quick_range_filters_and_summary(client):
     )
 
     assert response.status_code == 200
+    assert response.context["filtered_count"] == 2
+    assert response.context["filtered_total_kw"] == pytest.approx(4.0)
     body = response.content.decode("utf-8")
-    assert "2</strong> sessions" in body
-    assert "4.00</strong> kWh" in body
     assert "Last 7 days" in body
 
 
@@ -81,13 +81,12 @@ def test_charger_session_search_date_filter_still_supported(client):
 
     response = client.get(
         reverse("ocpp:charger-session-search-connector", args=[charger.charger_id, "1"]),
-        {"date": target.date().isoformat()},
+        {"date": timezone.localtime(target).date().isoformat()},
     )
 
     assert response.status_code == 200
-    body = response.content.decode("utf-8")
-    assert "1</strong> sessions" in body
-    assert "1.00</strong> kWh" in body
+    assert response.context["filtered_count"] == 1
+    assert response.context["filtered_total_kw"] == pytest.approx(1.0)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- The install health-check smoke path was intermittently failing due to a timezone boundary sensitivity and brittle HTML-based assertions in the charger session search tests.
- Tests should align with the view logic (which uses local timezone day boundaries) and assert stable, semantic values rather than fragile rendered HTML fragments.

### Description
- Updated `apps/ocpp/tests/test_charger_session_search.py` to query the view with `timezone.localtime(target).date().isoformat()` so the test uses a local-date value that matches the view behavior.
- Replaced fragile HTML substring assertions with direct assertions against `response.context["filtered_count"]` and `response.context["filtered_total_kw"]` to validate the same aggregates more robustly.
- No production code behavior was changed; this PR only adjusts test expectations to be timezone-consistent and less brittle.

### Testing
- Reproduced the failure locally where `test_charger_session_search_date_filter_still_supported` initially failed with `filtered_count == 0` when using a naive date string.
- Ran `pytest apps/ocpp/tests/test_charger_session_search.py -q` after the change and observed the tests pass (file-level run: all tests in the file passed).
- Executed the repository review notifier script (`./scripts/review-notify.sh --actor Codex`) to surface the change to reviewers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d465b53b3083268e2c5639d6450f17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated charger session search tests to validate summary metrics more reliably, improving test robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->