### PR TITLE
nodes: harden visitor proxy JSON parsing to avoid exception leakage

### DIFF
--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.db import IntegrityError
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.test import RequestFactory
 
 from apps.nodes.models import Node, NodeRole
@@ -426,6 +426,44 @@ def test_register_visitor_proxy_returns_400_when_host_id_missing(
 
 
 @pytest.mark.django_db
+def test_register_visitor_proxy_returns_502_when_host_info_is_not_json(
+    monkeypatch, admin_user
+):
+    factory = RequestFactory()
+    request = factory.post(
+        "/nodes/register-visitor-proxy/",
+        data=json.dumps(
+            {
+                "visitor_info_url": "https://visitor.example/nodes/info/",
+                "visitor_register_url": "https://visitor.example/nodes/register/",
+            }
+        ),
+        content_type="application/json",
+    )
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    target = SimpleNamespace(
+        url="https://visitor.example/nodes/info/",
+        server_hostname="visitor.example",
+        host_header="visitor.example",
+    )
+    monkeypatch.setattr(handlers, "is_allowed_visitor_url", lambda _: True)
+    monkeypatch.setattr(handlers, "get_public_targets", lambda _: [target])
+    monkeypatch.setattr(
+        handlers,
+        "node_info",
+        lambda _request: HttpResponse("not-json", content_type="text/plain"),
+    )
+
+    response = handlers.register_visitor_proxy(request)
+
+    assert response.status_code == 502
+    data = json.loads(response.content.decode())
+    assert data["detail"] == "host info unavailable"
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("host_status", [200, 201, 204])
 def test_register_visitor_proxy_coerces_2xx_to_400_when_host_id_missing(
     monkeypatch, admin_user, host_status
@@ -484,6 +522,68 @@ def test_register_visitor_proxy_coerces_2xx_to_400_when_host_id_missing(
     response = handlers.register_visitor_proxy(request)
 
     assert response.status_code == 400
+    data = json.loads(response.content.decode())
+    assert data["detail"] == "host registration failed"
+
+
+@pytest.mark.django_db
+def test_register_visitor_proxy_returns_502_when_host_register_body_is_not_json(
+    monkeypatch, admin_user
+):
+    factory = RequestFactory()
+    request = factory.post(
+        "/nodes/register-visitor-proxy/",
+        data=json.dumps(
+            {
+                "visitor_info_url": "https://visitor.example/nodes/info/",
+                "visitor_register_url": "https://visitor.example/nodes/register/",
+            }
+        ),
+        content_type="application/json",
+    )
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    target = SimpleNamespace(
+        url="https://visitor.example/nodes/info/",
+        server_hostname="visitor.example",
+        host_header="visitor.example",
+    )
+    monkeypatch.setattr(handlers, "is_allowed_visitor_url", lambda _: True)
+    monkeypatch.setattr(handlers, "get_public_targets", lambda _: [target])
+    monkeypatch.setattr(
+        handlers,
+        "node_info",
+        lambda _request: JsonResponse({"hostname": "host-node"}),
+    )
+    monkeypatch.setattr(
+        handlers,
+        "register_node",
+        lambda _request: HttpResponse("not-json", content_type="text/plain"),
+    )
+    monkeypatch.setattr(
+        handlers,
+        "_try_proxy_json_request",
+        lambda *, method, **_kwargs: (
+            (
+                {
+                    "hostname": "visitor-node",
+                    "address": "198.51.100.6",
+                    "port": 8888,
+                    "mac_address": "00:11:22:33:44:66",
+                },
+                "https://visitor.example/nodes/info/",
+                None,
+                1,
+            )
+            if method == "get"
+            else ({"id": 11}, "https://visitor.example/nodes/register/", None, 2)
+        ),
+    )
+
+    response = handlers.register_visitor_proxy(request)
+
+    assert response.status_code == 502
     data = json.loads(response.content.decode())
     assert data["detail"] == "host registration failed"
 

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -78,6 +78,15 @@ def _extract_response_detail(response) -> str:
     return decoded_body
 
 
+def _parse_json_response_mapping(response) -> Mapping[str, object]:
+    """Parse a JSON response body as a mapping."""
+
+    payload = json.loads(response.content.decode() or "{}")
+    if not isinstance(payload, Mapping):
+        raise ValueError("expected JSON object")
+    return payload
+
+
 def _sign_token_for_node(data: dict[str, object], node: Node, token: str):
     """Attach token signature to node info payload when signing succeeds."""
 
@@ -922,7 +931,10 @@ def register_visitor_proxy(request):
     host_info_request = factory.get("/nodes/info/", {"token": token} if token else {})
     host_info_request.user = request.user
     host_info_request._cached_user = request.user
-    host_info = json.loads(node_info(host_info_request).content.decode() or "{}")
+    try:
+        host_info = _parse_json_response_mapping(node_info(host_info_request))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return JsonResponse({"detail": "host info unavailable"}, status=502)
 
     session = requests.Session()
     timeout_seconds = 45
@@ -961,7 +973,10 @@ def register_visitor_proxy(request):
     host_register_request.user = request.user
     host_register_request._cached_user = request.user
     host_register_response = register_node(host_register_request)
-    host_register_body = json.loads(host_register_response.content.decode() or "{}")
+    try:
+        host_register_body = _parse_json_response_mapping(host_register_response)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return JsonResponse({"detail": "host registration failed"}, status=502)
     if host_register_response.status_code != 200 or not host_register_body.get("id"):
         status_code = host_register_response.status_code or 400
         if 200 <= status_code < 300:


### PR DESCRIPTION
### Motivation

- The `register_visitor_proxy` flow parsed internal response bodies from `node_info` and `register_node` without guarding for non-JSON or non-object responses, which could allow parsing exceptions to bubble and expose internal details.

### Description

- Add `_parse_json_response_mapping` helper in `apps/nodes/views/registration/handlers.py` to parse response bodies as JSON mappings and validate the result.
- Use the helper to safely parse `node_info(...)` and `register_node(...)` responses and return sanitized `JsonResponse` errors (`"host info unavailable"` / `"host registration failed"` with status `502`) when parsing fails.
- Add tests in `apps/nodes/tests/test_register_node.py` covering malformed host info and malformed host registration responses and import `HttpResponse` for test helpers.

### Testing

- Ran environment refresh and test deps via `./env-refresh.sh --deps-only` and installing `requirements-ci.txt` successfully.
- Executed `./.venv/bin/python manage.py test run -- apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_returns_502_when_host_info_is_not_json apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_returns_502_when_host_register_body_is_not_json apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_uses_safe_success_details` and all 3 tests passed.
- Ran `./scripts/review-notify.sh --actor Codex` to publish a review notification (fallback) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d470fe49fc8326a3ab732683659b12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting during node registration when invalid responses are received. Registration now returns appropriate HTTP 502 errors with specific details indicating whether failure occurred during host information retrieval or registration.

* **Tests**
  * Added test coverage for invalid response handling during the registration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->