### PR TITLE
Throttle boot prestart upgrade checks for unchanged revisions

### DIFF
--- a/docs/auto-upgrade.md
+++ b/docs/auto-upgrade.md
@@ -18,6 +18,11 @@ delegated systemd unit is launched, and what to check if something fails.
 - Stable auto-upgrades run once per week on Thursday mornings before 5:00 AM,
   while latest runs daily at the same hour unless overridden with
   `ARTHEXIS_UPGRADE_FREQ`.
+- Boot-time prestart checks (`scripts/boot-upgrade-prestart.sh`) keep a per-service
+  recency lock at `.locks/<service>-boot-upgrade-last-check.lck` after a
+  successful run. If the local revision is unchanged and the recency TTL has
+  not expired, startup skips launching `upgrade.sh` to reduce repeated no-op
+  checks on already-current nodes.
 
 ## How delegation works
 
@@ -52,6 +57,21 @@ You can also request the Celery task:
 from apps.core.tasks.auto_upgrade import check_github_updates
 check_github_updates.delay()
 ```
+
+## Boot-time throttle knobs
+
+Boot-time prestart upgrades still honor failure backoff in
+`.locks/<service>-boot-upgrade-backoff-until.lck`, and now also support a
+lightweight success recency throttle:
+
+- `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS` (default `300`) sets how long a
+  successful boot-time check can be reused when the local revision is unchanged.
+  Set to `0` to disable throttle reuse.
+- `ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK=1` bypasses recency throttle and forces a
+  fresh `upgrade.sh` invocation (unless failure backoff is active).
+
+The throttle is bypassed automatically when the revision changes or the TTL
+expires.
 
 ## Observing progress
 

--- a/docs/startup-sequence.md
+++ b/docs/startup-sequence.md
@@ -45,6 +45,26 @@ upgrade.
 7. Launch the Django server on `0.0.0.0:<port>`, using `--noreload` unless
    `--reload` was requested.
 
+## Boot upgrade prestart throttle (`scripts/boot-upgrade-prestart.sh`)
+
+Systemd-managed service starts can run the boot upgrade prestart helper before
+`service-start.sh`. The helper keeps startup fast on already-current nodes:
+
+1. Check the existing failure backoff lock
+   `.locks/<service>-boot-upgrade-backoff-until.lck`; when active, skip
+   `upgrade.sh`.
+2. Resolve the current local git revision and compare it with
+   `.locks/<service>-boot-upgrade-last-check.lck` (`<epoch>|<revision>`).
+3. If the last successful check is recent (within
+   `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS`, default `300`) and the revision is
+   unchanged, skip invoking `upgrade.sh`.
+4. Otherwise invoke `upgrade.sh` (stable/latest channel rules unchanged). On
+   success, refresh the recency lock; on failure, preserve existing behavior by
+   writing backoff to `.locks/<service>-boot-upgrade-backoff-until.lck`.
+
+Set `ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK=1` to bypass recency throttle and force
+a fresh check (while still honoring active failure backoff).
+
 ## Startup orchestration (`manage.py startup_orchestrate`)
 1. Evaluate lock/feature state for service mode, Celery units, and LCD feature
    enablement.

--- a/scripts/boot-upgrade-prestart.sh
+++ b/scripts/boot-upgrade-prestart.sh
@@ -87,10 +87,7 @@ if [ -f "$BASE_DIR/$LOCK_SUBDIR/auto_upgrade.lck" ]; then
   fi
 fi
 
-local_revision=""
-if local_revision="$(resolve_local_revision)"; then
-  :
-fi
+local_revision="$(resolve_local_revision)" || local_revision=""
 
 if [ "$FORCE_CHECK_ENABLED" -ne 1 ] && [ "$CHECK_TTL_SECONDS" -gt 0 ] && [ -n "$local_revision" ] && [ -f "$RECENCY_LOCK" ]; then
   recency_epoch=""
@@ -109,6 +106,7 @@ fi
 echo "Attempting boot upgrade for ${SERVICE_NAME} (${channel_flag#--} channel)."
 if "$BASE_DIR/upgrade.sh" "$channel_flag" --no-start --no-warn; then
   rm -f "$BACKOFF_LOCK"
+  local_revision="$(resolve_local_revision)" || local_revision=""
   if [ -n "$local_revision" ]; then
     printf '%s|%s\n' "$now_epoch" "$local_revision" > "$RECENCY_LOCK"
   fi
@@ -117,6 +115,7 @@ if "$BASE_DIR/upgrade.sh" "$channel_flag" --no-start --no-warn; then
 fi
 
 backoff_until=$((now_epoch + BACKOFF_SECONDS))
+rm -f "$RECENCY_LOCK"
 printf '%s\n' "$backoff_until" > "$BACKOFF_LOCK"
 echo "Boot upgrade failed for ${SERVICE_NAME}; backing off until $(date -d "@$backoff_until" -u +'%Y-%m-%dT%H:%M:%SZ')."
 exit 0

--- a/scripts/boot-upgrade-prestart.sh
+++ b/scripts/boot-upgrade-prestart.sh
@@ -108,7 +108,8 @@ if "$BASE_DIR/upgrade.sh" "$channel_flag" --no-start --no-warn; then
   rm -f "$BACKOFF_LOCK"
   local_revision="$(resolve_local_revision)" || local_revision=""
   if [ -n "$local_revision" ]; then
-    printf '%s|%s\n' "$now_epoch" "$local_revision" > "$RECENCY_LOCK"
+    completion_epoch="$(date +%s)"
+    printf '%s|%s\n' "$completion_epoch" "$local_revision" > "$RECENCY_LOCK"
   fi
   echo "Boot upgrade completed for ${SERVICE_NAME}."
   exit 0

--- a/scripts/boot-upgrade-prestart.sh
+++ b/scripts/boot-upgrade-prestart.sh
@@ -4,8 +4,12 @@ set -u
 BASE_DIR=""
 SERVICE_NAME=""
 BACKOFF_SECONDS="${ARTHEXIS_BOOT_UPGRADE_BACKOFF_SECONDS:-1800}"
+CHECK_TTL_SECONDS="${ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS:-300}"
+FORCE_CHECK="${ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK:-0}"
 LOCK_SUBDIR=".locks"
 BACKOFF_LOCK=""
+RECENCY_LOCK=""
+FORCE_CHECK_ENABLED=0
 
 usage() {
   echo "Usage: $0 --base-dir PATH --service NAME" >&2
@@ -34,9 +38,18 @@ if [ -z "$BASE_DIR" ] || [ -z "$SERVICE_NAME" ]; then
 fi
 
 BACKOFF_LOCK="$BASE_DIR/$LOCK_SUBDIR/${SERVICE_NAME}-boot-upgrade-backoff-until.lck"
+RECENCY_LOCK="$BASE_DIR/$LOCK_SUBDIR/${SERVICE_NAME}-boot-upgrade-last-check.lck"
 mkdir -p "$BASE_DIR/$LOCK_SUBDIR"
 
 now_epoch="$(date +%s)"
+if ! [[ "$CHECK_TTL_SECONDS" =~ ^[0-9]+$ ]]; then
+  CHECK_TTL_SECONDS=300
+fi
+case "${FORCE_CHECK,,}" in
+  1|true|yes|on)
+    FORCE_CHECK_ENABLED=1
+    ;;
+esac
 if [ -f "$BACKOFF_LOCK" ]; then
   backoff_until="$(tr -d '\r\n\t ' < "$BACKOFF_LOCK")"
   if [[ "$backoff_until" =~ ^[0-9]+$ ]] && [ "$now_epoch" -lt "$backoff_until" ]; then
@@ -44,6 +57,22 @@ if [ -f "$BACKOFF_LOCK" ]; then
     exit 0
   fi
 fi
+
+resolve_local_revision() {
+  local revision
+
+  revision="$(
+    cd "$BASE_DIR" 2>/dev/null \
+      && git rev-parse HEAD 2>/dev/null
+  )" || return 1
+
+  if [[ "$revision" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    printf '%s\n' "$revision"
+    return 0
+  fi
+
+  return 1
+}
 
 if [ ! -x "$BASE_DIR/upgrade.sh" ]; then
   echo "Boot upgrade skipped for ${SERVICE_NAME}; upgrade.sh is unavailable."
@@ -58,9 +87,31 @@ if [ -f "$BASE_DIR/$LOCK_SUBDIR/auto_upgrade.lck" ]; then
   fi
 fi
 
+local_revision=""
+if local_revision="$(resolve_local_revision)"; then
+  :
+fi
+
+if [ "$FORCE_CHECK_ENABLED" -ne 1 ] && [ "$CHECK_TTL_SECONDS" -gt 0 ] && [ -n "$local_revision" ] && [ -f "$RECENCY_LOCK" ]; then
+  recency_epoch=""
+  recency_revision=""
+  if IFS='|' read -r recency_epoch recency_revision < "$RECENCY_LOCK"; then
+    if [[ "$recency_epoch" =~ ^[0-9]+$ ]] && [ -n "$recency_revision" ]; then
+      recency_deadline=$((recency_epoch + CHECK_TTL_SECONDS))
+      if [ "$now_epoch" -lt "$recency_deadline" ] && [ "$local_revision" = "$recency_revision" ]; then
+        echo "Boot upgrade skipped for ${SERVICE_NAME}; recent successful no-op check still valid (TTL ${CHECK_TTL_SECONDS}s)."
+        exit 0
+      fi
+    fi
+  fi
+fi
+
 echo "Attempting boot upgrade for ${SERVICE_NAME} (${channel_flag#--} channel)."
 if "$BASE_DIR/upgrade.sh" "$channel_flag" --no-start --no-warn; then
   rm -f "$BACKOFF_LOCK"
+  if [ -n "$local_revision" ]; then
+    printf '%s|%s\n' "$now_epoch" "$local_revision" > "$RECENCY_LOCK"
+  fi
   echo "Boot upgrade completed for ${SERVICE_NAME}."
   exit 0
 fi


### PR DESCRIPTION
### Motivation

- Reduce startup latency on nodes that are already up-to-date by avoiding repeated no-op runs of `upgrade.sh` during service start.  
- Provide a lightweight, local-only throttle that is safe to use on systemd-managed starts and does not change existing backoff semantics for failures.  
- Expose simple, configurable knobs so operators can tune or override the throttle behavior per-host.  

### Description

- Add a per-service recency lock file written at `.locks/<service>-boot-upgrade-last-check.lck` that records successful no-op checks as `<epoch>|<revision>`.  
- Implement TTL/force behavior in `scripts/boot-upgrade-prestart.sh` driven by `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS` (default `300`) and `ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK` (`1|true|yes|on` to force).  
- Resolve the local git revision and skip invoking `upgrade.sh` when the recency lock is recent and the revision is unchanged, while preserving the existing failure backoff lock `.locks/<service>-boot-upgrade-backoff-until.lck`.  
- Document the new throttle behavior and knobs in `docs/auto-upgrade.md` and `docs/startup-sequence.md`.  

### Testing

- Ran `bash -n scripts/boot-upgrade-prestart.sh` to validate script syntax and it returned OK.  
- Performed a local temp-git-repo simulation calling `scripts/boot-upgrade-prestart.sh` twice and verified a single `upgrade.sh` run within the TTL and that `.locks/<service>-boot-upgrade-last-check.lck` contains `<epoch>|<revision>`.  
- Verified `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS=0` disables reuse and `ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK=1` forces a fresh check in manual simulations.  
- Attempted `./scripts/review-notify.sh --actor Codex` as required by review workflow and it exited due to a missing virtual environment in this environment (non-fatal, environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4731df4a48326963c6814aaa797b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boot-time upgrade check throttling prevents repeated no-op upgrade checks when systems are already current, significantly reducing startup time.
  * Configurable throttle controls via `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS` (default 300 seconds) and `ARTHEXIS_BOOT_UPGRADE_FORCE_CHECK` environment variables.
  * Maintains existing failure backoff behavior while allowing manual override of recency checks.

* **Documentation**
  * Added comprehensive documentation for the new boot-upgrade prestart mechanism and throttle controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->