### PR TITLE
ci: enrich scheduled Install CI failure issue details

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -171,6 +171,7 @@ jobs:
             let runData = null;
             let failedSteps = '';
             let failedRoles = '';
+            let failedJobCount = 0;
 
             try {
               const { data: fetchedRunData } = await github.rest.actions.getWorkflowRun({
@@ -196,13 +197,18 @@ jobs:
                 }
               });
               failedRoles = Array.from(failedRoleSet).sort().join(', ');
+              failedJobCount = failedJobs.length;
               failedSteps = failedJobs
                 .map((job) => {
                   const failedStep = (job.steps || []).find((step) => step.conclusion === 'failure');
+                  const jobUrl = job.html_url ? ` [job logs](${job.html_url})` : '';
+                  const timing = job.started_at && job.completed_at
+                    ? ` (started: ${job.started_at}, completed: ${job.completed_at})`
+                    : '';
                   if (!failedStep) {
-                    return `- ${job.name}`;
+                    return `- ${job.name}${jobUrl}${timing}`;
                   }
-                  return `- ${job.name}: ${failedStep.name}`;
+                  return `- ${job.name}: ${failedStep.name}${jobUrl}${timing}`;
                 })
                 .join('\n');
             } catch (error) {
@@ -219,14 +225,15 @@ jobs:
               `- Branch/ref: ${context.ref}`,
               `- Commit: ${context.sha}`,
               `- Triggered by: ${runData?.event ?? context.eventName}`,
+              `- Run attempt: ${runData?.run_attempt ?? 1}`,
+              `- Actor: ${runData?.actor?.login ?? context.actor}`,
               '',
               '## Failure details',
               '',
               failedRoles ? `- Failed roles: ${failedRoles}` : '- Failed roles: Unable to determine failed roles from workflow metadata.',
+              failedJobCount ? `- Failed jobs: ${failedJobCount}` : '- Failed jobs: Unable to determine failed jobs from workflow metadata.',
               '',
               failedSteps ? failedSteps : '- Unable to identify failed steps from workflow metadata.',
-              '',
-              'Please investigate and close this issue once resolved.'
             ].join('\n');
 
             const openIssues = await github.paginate(github.rest.issues.listForRepo, {
@@ -247,8 +254,10 @@ jobs:
                   '',
                   `- Workflow run: ${runUrl}`,
                   `- Commit: ${context.sha}`,
+                  `- Run attempt: ${runData?.run_attempt ?? 1}`,
                   '',
                   failedRoles ? `### Failed roles\n- ${failedRoles}` : '### Failed roles\n- Unable to determine failed roles from workflow metadata.',
+                  failedJobCount ? `### Failed jobs\n- ${failedJobCount}` : '### Failed jobs\n- Unable to determine failed jobs from workflow metadata.',
                   '',
                   failedSteps ? '### Failed steps\n' + failedSteps : '### Failed steps\n- Unable to identify failed steps from workflow metadata.'
                 ].join('\n')


### PR DESCRIPTION
### Motivation

- Make the hourly Install CI failure issue more actionable by removing the closing instruction sentence and including additional failure metadata when available.

### Description

- Remove the sentence "Please investigate and close this issue once resolved." from the body of newly-created install failure issues.
- Add `run attempt`, `actor` and `failed jobs` summary fields to the issue body when those values are available from the Actions API.
- Include per-job log links and timing (`started_at` / `completed_at`) and surface failed step names in the failure details list.
- Mirror the key additions (`run attempt` and failed job count) in the follow-up comment created on an existing open failure issue.

### Testing

- Parsed `.github/workflows/install-hourly.yml` with `python3` and `yaml.safe_load` which succeeded.
- Ran `./scripts/review-notify.sh --actor Codex` which failed due to a missing virtual environment (`Run ./install.sh first.`), so the review notification step could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d478f180c483269d566fa31610caef)