### PR TITLE
Follow-up: fix Install Health Check smoke-test async execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ preview = [
   "selenium==4.41.0",
 ]
 qa = [
-  "pytest-asyncio==1.3.0",
+  "pytest-asyncio==1.3.0",  # pytest>=9 compatible series
   "pytest-django==4.12.0",
   "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ preview = [
   "selenium==4.41.0",
 ]
 qa = [
+  "pytest-asyncio==1.3.0",
   "pytest-django==4.12.0",
   "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 DJANGO_SETTINGS_MODULE = config.settings
 python_files = tests.py test_*.py *_tests.py
 addopts = --import-mode=importlib
+asyncio_mode = auto
 norecursedirs =
     *.egg
     .*

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -61,6 +61,7 @@ psycopg==3.3.3
 pycparser==3.0
 pyOpenSSL==26.0.0
 PySocks==1.7.1
+pytest-asyncio==1.3.0
 pytest-django==4.12.0
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0


### PR DESCRIPTION
### Motivation

- The scheduled Install Health Check workflow failed in all matrix roles during the `Run install smoke tests` step because pytest encountered `async def` tests without an async plugin available, causing test-run aborts rather than role-specific install failures.

### Description

- Add `pytest-asyncio==1.3.0` to the `qa` dependency group in `pyproject.toml` so CI installs include an async pytest plugin. 
- Regenerate `requirements-ci.txt` so CI picks up `pytest-asyncio` during the `Install CI dependencies` step. 
- Enable automatic async handling by adding `asyncio_mode = auto` to `pytest.ini` so `async def` tests run under `pytest==9` without per-test marker changes. 

### Testing

- Queried the failing workflow via the GitHub API to confirm failures were in the smoke-test step; the job metadata showed `Run install smoke tests` failing for all roles. 
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and regenerated/validated requirements with `python scripts/generate_requirements.py --check`. 
- Verified the previously failing async test with `pytest -q apps/ocpp/tests/test_ocpp201_actions.py::test_boot_notification_normalizes_ocpp2x_payload --timeout=180`, which passed. 
- Ran the install-smoke test command shape used by CI (`pytest -n auto --dist loadfile --maxfail=1 --disable-warnings -q --timeout=180 -m "not critical and not slow and not integration"`) and observed the suite succeed (`963 passed, 4 skipped, 14 subtests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d478c1bb2c8326bb22d1405ee374c9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for asynchronous test execution across the project.
  * CI/test tooling updated to include async test runner support.
* **Tests**
  * Test configuration adjusted to enable automatic asyncio handling for async tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->