### PR TITLE
Add per-plugin SQLite databases and router for external apps

### DIFF
--- a/apps/core/checks/apps_registry.py
+++ b/apps/core/checks/apps_registry.py
@@ -9,6 +9,8 @@ from django.core.exceptions import ImproperlyConfigured
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+from config.settings.external_dbs import external_app_module
+
 
 APPS_REGISTRY_ENTRY_NOT_IMPORTABLE_ID = "core.E001"
 APPS_REGISTRY_UNLISTED_LOCAL_APP_ID = "core.E002"
@@ -61,12 +63,7 @@ def _resolve_class(import_path: str) -> type:
 def _get_base_module(app_path: str) -> str:
     """Return the module path that should be importable for a settings app entry."""
 
-    has_app_config_class = app_path.rsplit(".", maxsplit=1)[-1][:1].isupper()
-    if ".apps." in app_path:
-        return app_path.rsplit(".apps.", maxsplit=1)[0]
-    if has_app_config_class:
-        return app_path.rsplit(".", maxsplit=1)[0]
-    return app_path
+    return external_app_module(app_path)
 
 
 def _get_external_app_compatibility_errors(external_apps: list[str]) -> list[Error]:

--- a/apps/core/dbrouters.py
+++ b/apps/core/dbrouters.py
@@ -1,0 +1,45 @@
+"""Database router for external app SQLite databases."""
+
+from django.conf import settings
+
+from config.settings.external_dbs import external_app_database_alias, external_app_module
+
+
+class ExternalAppDatabaseRouter:
+    """Route external-app models to dedicated SQLite databases in ``work/dbs``."""
+
+    def _external_alias_for_model(self, model) -> str | None:
+        module_name = getattr(model, "__module__", "")
+        for index, app_path in enumerate(
+            list(getattr(settings, "ARTHEXIS_EXTERNAL_APPS", [])),
+            start=1,
+        ):
+            module_root = external_app_module(app_path)
+            if module_name == module_root or module_name.startswith(f"{module_root}."):
+                return external_app_database_alias(app_path, fallback_index=index)
+        return None
+
+    def db_for_read(self, model, **hints):
+        return self._external_alias_for_model(model)
+
+    def db_for_write(self, model, **hints):
+        return self._external_alias_for_model(model)
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        del app_label, model_name
+
+        model = hints.get("model")
+        if model is None:
+            return None
+
+        external_alias = self._external_alias_for_model(model)
+        if external_alias is None:
+            return None
+
+        if db == external_alias:
+            return True
+
+        if db == "default":
+            return False
+
+        return None

--- a/apps/core/dbrouters.py
+++ b/apps/core/dbrouters.py
@@ -2,31 +2,58 @@
 
 from django.conf import settings
 
-from config.settings.external_dbs import external_app_database_alias, external_app_module
+from config.settings.external_dbs import external_app_database_alias_mapping
 
 
 class ExternalAppDatabaseRouter:
     """Route external-app models to dedicated SQLite databases in ``work/dbs``."""
 
+    _external_app_aliases: tuple[str, ...] = ()
+    _module_alias_mapping: dict[str, str] = {}
+
+    @classmethod
+    def _get_module_alias_mapping(cls) -> dict[str, str]:
+        """Return and cache module-root to alias mapping for configured plugins."""
+
+        external_apps = tuple(getattr(settings, "ARTHEXIS_EXTERNAL_APPS", []))
+        if external_apps != cls._external_app_aliases:
+            cls._external_app_aliases = external_apps
+            cls._module_alias_mapping = external_app_database_alias_mapping(
+                list(external_apps)
+            )
+        return cls._module_alias_mapping
+
     def _external_alias_for_model(self, model) -> str | None:
+        """Return the plugin database alias for a model, if it is external."""
+
         module_name = getattr(model, "__module__", "")
-        for index, app_path in enumerate(
-            list(getattr(settings, "ARTHEXIS_EXTERNAL_APPS", [])),
-            start=1,
-        ):
-            module_root = external_app_module(app_path)
+        for module_root, alias in self._get_module_alias_mapping().items():
             if module_name == module_root or module_name.startswith(f"{module_root}."):
-                return external_app_database_alias(app_path, fallback_index=index)
+                return alias
         return None
 
     def db_for_read(self, model, **hints):
+        """Route read operations for external models to their plugin database."""
+
+        del hints
         return self._external_alias_for_model(model)
 
     def db_for_write(self, model, **hints):
+        """Route write operations for external models to their plugin database."""
+
+        del hints
         return self._external_alias_for_model(model)
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """Allow migrations only on each model's assigned database."""
+
         del app_label, model_name
+
+        module_alias_mapping = self._get_module_alias_mapping()
+        external_aliases = set(module_alias_mapping.values())
+
+        if db in external_aliases and hints.get("model") is None:
+            return False
 
         model = hints.get("model")
         if model is None:
@@ -34,6 +61,8 @@ class ExternalAppDatabaseRouter:
 
         external_alias = self._external_alias_for_model(model)
         if external_alias is None:
+            if db in external_aliases:
+                return False
             return None
 
         if db == external_alias:

--- a/config/settings/database.py
+++ b/config/settings/database.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .apps import ARTHEXIS_EXTERNAL_APPS
 from .base import BASE_DIR
-from .external_dbs import external_app_database_alias
+from .external_dbs import external_app_database_alias_mapping
 
 
 def build_external_sqlite_databases(external_apps: list[str]) -> dict[str, dict[str, Path | str]]:
@@ -18,12 +18,7 @@ def build_external_sqlite_databases(external_apps: list[str]) -> dict[str, dict[
     external_dbs_dir.mkdir(parents=True, exist_ok=True)
 
     configs: dict[str, dict[str, Path | str]] = {}
-    seen_aliases: set[str] = set()
-    for index, app_path in enumerate(external_apps, start=1):
-        alias = external_app_database_alias(app_path, fallback_index=index)
-        while alias in seen_aliases:
-            alias = f"{alias}_{index}"
-        seen_aliases.add(alias)
+    for alias in external_app_database_alias_mapping(external_apps).values():
         configs[alias] = {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": external_dbs_dir / f"{alias}.sqlite3",

--- a/config/settings/database.py
+++ b/config/settings/database.py
@@ -6,7 +6,31 @@ from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 
+from .apps import ARTHEXIS_EXTERNAL_APPS
 from .base import BASE_DIR
+from .external_dbs import external_app_database_alias
+
+
+def build_external_sqlite_databases(external_apps: list[str]) -> dict[str, dict[str, Path | str]]:
+    """Return external-app SQLite database entries rooted in ``work/dbs``."""
+
+    external_dbs_dir = BASE_DIR / "work" / "dbs"
+    external_dbs_dir.mkdir(parents=True, exist_ok=True)
+
+    configs: dict[str, dict[str, Path | str]] = {}
+    seen_aliases: set[str] = set()
+    for index, app_path in enumerate(external_apps, start=1):
+        alias = external_app_database_alias(app_path, fallback_index=index)
+        while alias in seen_aliases:
+            alias = f"{alias}_{index}"
+        seen_aliases.add(alias)
+        configs[alias] = {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": external_dbs_dir / f"{alias}.sqlite3",
+            "OPTIONS": {"timeout": 60},
+        }
+
+    return configs
 
 FORCED_DB_BACKEND = os.environ.get("ARTHEXIS_DB_BACKEND", "").strip().lower()
 if FORCED_DB_BACKEND and FORCED_DB_BACKEND not in {"sqlite", "postgres"}:
@@ -36,6 +60,7 @@ if _use_postgres:
             },
         }
     }
+    DATABASES.update(build_external_sqlite_databases(list(ARTHEXIS_EXTERNAL_APPS)))
 else:
     _sqlite_override = os.environ.get("ARTHEXIS_SQLITE_PATH")
     if _sqlite_override:
@@ -77,3 +102,6 @@ else:
             "TEST": {"NAME": SQLITE_TEST_DB_PATH},
         }
     }
+    DATABASES.update(build_external_sqlite_databases(list(ARTHEXIS_EXTERNAL_APPS)))
+
+DATABASE_ROUTERS = ["apps.core.dbrouters.ExternalAppDatabaseRouter"]

--- a/config/settings/external_dbs.py
+++ b/config/settings/external_dbs.py
@@ -1,0 +1,27 @@
+"""Helpers for external-app SQLite database naming."""
+
+import re
+
+
+def external_app_module(external_app_path: str) -> str:
+    """Return import module path for an external app settings entry."""
+
+    if ".apps." in external_app_path:
+        return external_app_path.rsplit(".apps.", maxsplit=1)[0]
+
+    token = external_app_path.rsplit(".", maxsplit=1)[-1]
+    if token[:1].isupper() and "." in external_app_path:
+        return external_app_path.rsplit(".", maxsplit=1)[0]
+
+    return external_app_path
+
+
+def external_app_database_alias(external_app_path: str, *, fallback_index: int) -> str:
+    """Return deterministic database alias for an external app."""
+
+    module_path = external_app_module(external_app_path)
+    suffix = module_path.rsplit(".", maxsplit=1)[-1].strip().lower()
+    suffix = re.sub(r"[^a-z0-9]+", "_", suffix).strip("_")
+    if not suffix:
+        suffix = f"app_{fallback_index}"
+    return f"external_{suffix}"

--- a/config/settings/external_dbs.py
+++ b/config/settings/external_dbs.py
@@ -16,6 +16,25 @@ def external_app_module(external_app_path: str) -> str:
     return external_app_path
 
 
+def external_app_database_alias_mapping(external_apps: list[str]) -> dict[str, str]:
+    """Return a collision-safe mapping of module roots to database aliases."""
+
+    mapping: dict[str, str] = {}
+    seen_aliases: set[str] = set()
+    for index, app_path in enumerate(external_apps, start=1):
+        module_root = external_app_module(app_path)
+        alias = external_app_database_alias(app_path, fallback_index=index)
+        base_alias = alias
+        suffix_index = 2
+        while alias in seen_aliases:
+            alias = f"{base_alias}_{suffix_index}"
+            suffix_index += 1
+        seen_aliases.add(alias)
+        mapping[module_root] = alias
+
+    return mapping
+
+
 def external_app_database_alias(external_app_path: str, *, fallback_index: int) -> str:
     """Return deterministic database alias for an external app."""
 

--- a/docs/development/external-app-plugins.md
+++ b/docs/development/external-app-plugins.md
@@ -15,6 +15,10 @@ ARTHEXIS_EXTERNAL_APPS = [
 
 Arthexis app settings append `ARTHEXIS_EXTERNAL_APPS` to `INSTALLED_APPS` during startup, so external plugins boot with the rest of the suite.
 
+When external plugins are configured, Arthexis also provisions one SQLite
+database alias per plugin under `work/dbs/` using the naming pattern
+`external_<app>.sqlite3`.
+
 ## Compatibility contract
 
 Each plugin `AppConfig` must declare:
@@ -69,6 +73,7 @@ A reference standalone package is included in `examples/external_plugin_referenc
 
 ```bash
 .venv/bin/python manage.py migrate
+.venv/bin/python manage.py migrate --database external_<plugin>
 ```
 
 4. Validate startup checks:

--- a/docs/development/external-app-plugins.md
+++ b/docs/development/external-app-plugins.md
@@ -17,7 +17,11 @@ Arthexis app settings append `ARTHEXIS_EXTERNAL_APPS` to `INSTALLED_APPS` during
 
 When external plugins are configured, Arthexis also provisions one SQLite
 database alias per plugin under `work/dbs/` using the naming pattern
-`external_<app>.sqlite3`.
+`external_<module_last_segment>.sqlite3`, where `<module_last_segment>` is
+derived from the plugin module path. For
+`arthexis_plugin_sample.apps.ArthexisPluginSampleConfig`, the alias and file
+name are `external_arthexis_plugin_sample` and
+`external_arthexis_plugin_sample.sqlite3`.
 
 ## Compatibility contract
 
@@ -73,7 +77,7 @@ A reference standalone package is included in `examples/external_plugin_referenc
 
 ```bash
 .venv/bin/python manage.py migrate
-.venv/bin/python manage.py migrate --database external_<plugin>
+.venv/bin/python manage.py migrate --database external_arthexis_plugin_sample
 ```
 
 4. Validate startup checks:

--- a/tests/test_external_app_databases.py
+++ b/tests/test_external_app_databases.py
@@ -4,7 +4,7 @@ from config.settings.database import build_external_sqlite_databases
 from config.settings.external_dbs import external_app_database_alias
 
 
-def test_build_external_sqlite_databases_uses_work_dbs_dir(settings):
+def test_build_external_sqlite_databases_uses_work_dbs_dir():
     configs = build_external_sqlite_databases(
         [
             "arthexis_plugin_sample.apps.ArthexisPluginSampleConfig",
@@ -53,3 +53,40 @@ def test_external_router_routes_external_model(settings):
         )
         is True
     )
+
+
+def test_external_router_uses_collision_safe_aliases(settings):
+    settings.ARTHEXIS_EXTERNAL_APPS = [
+        "foo_bar.apps.FooBarConfig",
+        "foo-bar.apps.FooDashBarConfig",
+    ]
+
+    from apps.core.dbrouters import ExternalAppDatabaseRouter
+
+    class FirstPluginModel:
+        __module__ = "foo_bar.models"
+
+    class SecondPluginModel:
+        __module__ = "foo-bar.models"
+
+    router = ExternalAppDatabaseRouter()
+
+    assert router.db_for_read(FirstPluginModel) == "external_foo_bar"
+    assert router.db_for_read(SecondPluginModel) == "external_foo_bar_2"
+
+
+def test_external_router_ignores_non_external_model(settings):
+    settings.ARTHEXIS_EXTERNAL_APPS = [
+        "arthexis_plugin_sample.apps.ArthexisPluginSampleConfig"
+    ]
+
+    from apps.core.dbrouters import ExternalAppDatabaseRouter
+
+    class CoreModel:
+        __module__ = "apps.core.models"
+
+    router = ExternalAppDatabaseRouter()
+
+    assert router.db_for_read(CoreModel) is None
+    assert router.db_for_write(CoreModel) is None
+    assert router.allow_migrate("external_arthexis_plugin_sample", "core", model=CoreModel) is False

--- a/tests/test_external_app_databases.py
+++ b/tests/test_external_app_databases.py
@@ -1,0 +1,55 @@
+"""Tests for external app database wiring."""
+
+from config.settings.database import build_external_sqlite_databases
+from config.settings.external_dbs import external_app_database_alias
+
+
+def test_build_external_sqlite_databases_uses_work_dbs_dir(settings):
+    configs = build_external_sqlite_databases(
+        [
+            "arthexis_plugin_sample.apps.ArthexisPluginSampleConfig",
+            "vendor.sync.apps.SyncConfig",
+        ]
+    )
+
+    assert sorted(configs.keys()) == [
+        "external_arthexis_plugin_sample",
+        "external_sync",
+    ]
+    assert str(configs["external_arthexis_plugin_sample"]["NAME"]).endswith(
+        "work/dbs/external_arthexis_plugin_sample.sqlite3"
+    )
+    assert str(configs["external_sync"]["NAME"]).endswith(
+        "work/dbs/external_sync.sqlite3"
+    )
+
+
+def test_external_alias_falls_back_when_path_has_no_suffix_token():
+    alias = external_app_database_alias("...", fallback_index=4)
+
+    assert alias == "external_app_4"
+
+
+def test_external_router_routes_external_model(settings):
+    settings.ARTHEXIS_EXTERNAL_APPS = [
+        "arthexis_plugin_sample.apps.ArthexisPluginSampleConfig"
+    ]
+
+    from apps.core.dbrouters import ExternalAppDatabaseRouter
+
+    class PluginModel:
+        __module__ = "arthexis_plugin_sample.models"
+
+    router = ExternalAppDatabaseRouter()
+
+    assert router.db_for_read(PluginModel) == "external_arthexis_plugin_sample"
+    assert router.db_for_write(PluginModel) == "external_arthexis_plugin_sample"
+    assert router.allow_migrate("default", "sample", model=PluginModel) is False
+    assert (
+        router.allow_migrate(
+            "external_arthexis_plugin_sample",
+            "sample",
+            model=PluginModel,
+        )
+        is True
+    )


### PR DESCRIPTION
### Motivation

- Support isolating external plugin Django apps into their own SQLite databases stored under `work/dbs` so plugins can manage migrations and data separately.
- Provide deterministic, filesystem-safe database aliases and names for each configured external plugin.

### Description

- Add `config/settings/external_dbs.py` with `external_app_module` and `external_app_database_alias` helpers to derive module roots and deterministic `external_<name>` aliases.
- Add `build_external_sqlite_databases` to `config/settings/database.py` and wire it into both SQLite and Postgres flows to provision per-plugin SQLite DB entries in `DATABASES`, and register `apps.core.dbrouters.ExternalAppDatabaseRouter` in `DATABASE_ROUTERS`.
- Implement `apps/core/dbrouters.py` with `ExternalAppDatabaseRouter` that routes reads/writes and migration allowances for models belonging to configured `ARTHEXIS_EXTERNAL_APPS` to their dedicated database aliases.
- Update docs `docs/development/external-app-plugins.md` to document the per-plugin database behavior and migration invocation, and add unit tests in `tests/test_external_app_databases.py` covering database filename generation, alias fallback, and router behavior.

### Testing

- Added unit tests in `tests/test_external_app_databases.py` and ran them with `pytest` (targeting the new tests); they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5335c7ad48326b9f9ea2f0335b2cb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External plugins now each receive a dedicated SQLite database for improved data isolation and independent migrations.

* **Documentation**
  * Updated external plugin setup and migration instructions to reflect new per-plugin database aliases.

* **Tests**
  * Added test coverage for external database routing and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->