### PR TITLE
screens: handle missing I2C device without startup traceback

### DIFF
--- a/apps/screens/lcd.py
+++ b/apps/screens/lcd.py
@@ -45,7 +45,7 @@ class _BusWrapper:
             raise LCDUnavailableError(SMBUS_HINT)
         try:
             return smbus.SMBus(self.channel)
-        except FileNotFoundError as exc:
+        except OSError as exc:
             raise LCDUnavailableError(
                 f"I2C bus device for channel {self.channel} is unavailable"
             ) from exc
@@ -54,15 +54,19 @@ class _BusWrapper:
         self, addr: int, data: int
     ) -> None:  # pragma: no cover - thin wrapper
         bus = self._open_bus()
-        bus.write_byte(addr, data)
-        bus.close()
+        try:
+            bus.write_byte(addr, data)
+        finally:
+            bus.close()
 
     def write_byte_data(
         self, addr: int, cmd: int, data: int
     ) -> None:  # pragma: no cover - thin wrapper
         bus = self._open_bus()
-        bus.write_byte_data(addr, cmd, data)
-        bus.close()
+        try:
+            bus.write_byte_data(addr, cmd, data)
+        finally:
+            bus.close()
 
 
 @dataclass

--- a/apps/screens/lcd.py
+++ b/apps/screens/lcd.py
@@ -40,21 +40,27 @@ class _BusWrapper:
 
     channel: int
 
+    def _open_bus(self):
+        if smbus is None:
+            raise LCDUnavailableError(SMBUS_HINT)
+        try:
+            return smbus.SMBus(self.channel)
+        except FileNotFoundError as exc:
+            raise LCDUnavailableError(
+                f"I2C bus device for channel {self.channel} is unavailable"
+            ) from exc
+
     def write_byte(
         self, addr: int, data: int
     ) -> None:  # pragma: no cover - thin wrapper
-        if smbus is None:
-            raise LCDUnavailableError(SMBUS_HINT)
-        bus = smbus.SMBus(self.channel)
+        bus = self._open_bus()
         bus.write_byte(addr, data)
         bus.close()
 
     def write_byte_data(
         self, addr: int, cmd: int, data: int
     ) -> None:  # pragma: no cover - thin wrapper
-        if smbus is None:
-            raise LCDUnavailableError(SMBUS_HINT)
-        bus = smbus.SMBus(self.channel)
+        bus = self._open_bus()
         bus.write_byte_data(addr, cmd, data)
         bus.close()
 

--- a/apps/screens/tests/test_lcd_bus_wrapper.py
+++ b/apps/screens/tests/test_lcd_bus_wrapper.py
@@ -10,6 +10,22 @@ class _RaisingBus:
         raise FileNotFoundError("/dev/i2c-1")
 
 
+class _PermissionDeniedBus:
+    def __init__(self, _channel: int) -> None:
+        raise PermissionError("denied")
+
+
+class _WriteErrorBus:
+    def __init__(self, _channel: int) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def write_byte(self, _addr: int, _data: int) -> None:
+        raise OSError("remote i/o error")
+
+
 def test_bus_wrapper_raises_lcd_unavailable_when_i2c_device_missing(monkeypatch):
     monkeypatch.setattr("apps.screens.lcd.smbus", SimpleNamespace(SMBus=_RaisingBus))
 
@@ -20,3 +36,29 @@ def test_bus_wrapper_raises_lcd_unavailable_when_i2c_device_missing(monkeypatch)
 
     assert "I2C bus device for channel 1 is unavailable" in str(exc.value)
     assert isinstance(exc.value.__cause__, FileNotFoundError)
+
+
+def test_bus_wrapper_raises_lcd_unavailable_when_i2c_bus_access_denied(monkeypatch):
+    monkeypatch.setattr(
+        "apps.screens.lcd.smbus", SimpleNamespace(SMBus=_PermissionDeniedBus)
+    )
+
+    wrapper = _BusWrapper(channel=1)
+
+    with pytest.raises(LCDUnavailableError) as exc:
+        wrapper.write_byte(0x27, 0x00)
+
+    assert "I2C bus device for channel 1 is unavailable" in str(exc.value)
+    assert isinstance(exc.value.__cause__, PermissionError)
+
+
+def test_bus_wrapper_closes_bus_when_write_byte_raises(monkeypatch):
+    bus = _WriteErrorBus(1)
+    monkeypatch.setattr("apps.screens.lcd.smbus", SimpleNamespace(SMBus=lambda _: bus))
+
+    wrapper = _BusWrapper(channel=1)
+
+    with pytest.raises(OSError):
+        wrapper.write_byte(0x27, 0x00)
+
+    assert bus.closed is True

--- a/apps/screens/tests/test_lcd_bus_wrapper.py
+++ b/apps/screens/tests/test_lcd_bus_wrapper.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.screens.lcd import LCDUnavailableError, _BusWrapper
+
+
+class _RaisingBus:
+    def __init__(self, _channel: int) -> None:
+        raise FileNotFoundError("/dev/i2c-1")
+
+
+def test_bus_wrapper_raises_lcd_unavailable_when_i2c_device_missing(monkeypatch):
+    monkeypatch.setattr("apps.screens.lcd.smbus", SimpleNamespace(SMBus=_RaisingBus))
+
+    wrapper = _BusWrapper(channel=1)
+
+    with pytest.raises(LCDUnavailableError) as exc:
+        wrapper.write_byte(0x27, 0x00)
+
+    assert "I2C bus device for channel 1 is unavailable" in str(exc.value)
+    assert isinstance(exc.value.__cause__, FileNotFoundError)


### PR DESCRIPTION
### Motivation

- Startup of the LCD service could surface a raw `FileNotFoundError` when opening the SMBus (e.g. `/dev/i2c-1`) on systems without I2C, producing noisy tracebacks even though i2c is not required. 
- Treating missing I2C as the existing LCD-unavailable condition keeps the service startup clean and consistent with the service fallback flow.

### Description

- Add `_open_bus()` on `apps.screens.lcd._BusWrapper` to centralize opening `smbus.SMBus` and translate `FileNotFoundError` into `LCDUnavailableError` with the original exception chained. 
- Update `write_byte()` and `write_byte_data()` to use `_open_bus()` instead of calling `smbus.SMBus(...)` directly. 
- Add a focused regression test `apps/screens/tests/test_lcd_bus_wrapper.py` that mocks a failing SMBus constructor and asserts `_BusWrapper.write_byte()` raises `LCDUnavailableError` and preserves the original `FileNotFoundError` as the cause.

### Testing

- Bootstrapped environment with `./env-refresh.sh --deps-only` and installed test deps with `.venv/bin/pip install -r requirements-ci.txt`. 
- Ran the new test with `.venv/bin/python manage.py test run -- apps/screens/tests/test_lcd_bus_wrapper.py` and it passed (`1 passed`). 
- Review notification script `./scripts/review-notify.sh --actor Codex` was executed as part of the change workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5731dbf8c83268f197100bf4b07a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for LCD I2C device unavailability with clearer, more actionable error messages.
  * Enhanced validation when initializing hardware components.

* **Tests**
  * Added comprehensive test coverage for LCD hardware device error conditions and error messaging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->