### PR TITLE
sites: allow dashboard top-right actions to extend left

### DIFF
--- a/apps/core/static/core/admin_ui_framework.css
+++ b/apps/core/static/core/admin_ui_framework.css
@@ -1,6 +1,8 @@
 :root {
     --admin-ui-radius-sm: 0.375rem;
     --admin-ui-radius-md: 0.5rem;
+    --admin-ui-dashboard-net-message-max-width: 30rem;
+    --admin-ui-dashboard-net-message-min-width: 18rem;
     --admin-ui-space-1: 0.25rem;
     --admin-ui-space-2: 0.5rem;
     --admin-ui-space-3: 0.75rem;

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -6,7 +6,7 @@
     }
     #admin-home-header {
         display: grid;
-        grid-template-columns: auto minmax(14rem, 30%) minmax(0, 1fr);
+        grid-template-columns: auto minmax(var(--admin-ui-dashboard-net-message-min-width, 18rem), 30%) minmax(0, 1fr);
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.25rem;
@@ -27,8 +27,8 @@
         color: var(--body-fg);
         --net-message-text-color: #3f3f3f;
         min-height: 2.25rem;
-        min-width: min(18rem, 100%);
-        max-width: min(30vw, 30rem);
+        min-width: min(var(--admin-ui-dashboard-net-message-min-width, 18rem), 100%);
+        max-width: var(--admin-ui-dashboard-net-message-max-width, 30rem);
         width: 100%;
         box-sizing: border-box;
     }

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -6,7 +6,7 @@
     }
     #admin-home-header {
         display: grid;
-        grid-template-columns: auto minmax(24rem, 1fr) auto;
+        grid-template-columns: auto minmax(14rem, 30%) minmax(0, 1fr);
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.25rem;
@@ -27,7 +27,9 @@
         color: var(--body-fg);
         --net-message-text-color: #3f3f3f;
         min-height: 2.25rem;
-        min-width: min(34rem, 100%);
+        min-width: min(18rem, 100%);
+        max-width: min(30vw, 30rem);
+        width: 100%;
         box-sizing: border-box;
     }
     .admin-home-net-message__icon {
@@ -83,8 +85,9 @@
         justify-content: flex-end;
         gap: 8px;
         flex-wrap: wrap;
-        width: min(30rem, 100%);
-        max-width: 30rem;
+        justify-self: end;
+        width: 100%;
+        max-width: none;
     }
     .admin-home-actions .button {
         white-space: nowrap;
@@ -130,7 +133,7 @@
     }
     @media (max-width: 1240px) {
         #admin-home-header {
-            grid-template-columns: auto minmax(22rem, 1fr);
+            grid-template-columns: auto minmax(18rem, 1fr);
             row-gap: 0.75rem;
         }
         .admin-home-actions {


### PR DESCRIPTION
### Motivation
- Let the admin dashboard top-right action buttons grow leftward by reducing the horizontal footprint of the net message box so buttons can fit without wrapping prematurely, keeping the net-message area to ~30% (or less) of the viewport.

### Description
- Tweak admin dashboard CSS (`apps/sites/static/sites/css/admin/dashboard.css`) to change the header grid to `auto | minmax(14rem, 30%) | minmax(0, 1fr)`, reduce the net-message `min-width`, add a `max-width: min(30vw, 30rem)` and `width: 100%`, and remove the fixed `30rem` cap on the actions container so action buttons may extend further left before wrapping.

### Testing
- Ran dependency refresh and CI deps installation, then `./manage.py check` which succeeded, and attempted `./manage.py test run -- apps.sites.tests` which failed because the test path `apps.sites.tests` is not present in this repository (no repository tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57e3b0f808326822576f739ee502a)