### PR TITLE
ocpp: remove apps.ocpp.forwarder shim and standardize forwarder imports

### DIFF
--- a/apps/ocpp/consumers/base/connection_flow.py
+++ b/apps/ocpp/consumers/base/connection_flow.py
@@ -11,7 +11,7 @@ from apps.features.models import Feature
 from apps.nodes.models import Node
 
 from ... import store
-from ...forwarder import forwarder
+from apps.forwarder.ocpp import forwarder
 from ...forwarder_feature import ocpp_forwarder_enabled
 from ...models import Charger, ChargingStation, Transaction
 from ..connection import RateLimitedConnectionMixin

--- a/apps/ocpp/forwarder/__init__.py
+++ b/apps/ocpp/forwarder/__init__.py
@@ -1,9 +1,0 @@
-"""Backward-compatible import shim for OCPP forwarding services."""
-
-from apps.forwarder.ocpp import Forwarder, ForwardingSession, forwarder
-
-__all__ = [
-    "Forwarder",
-    "ForwardingSession",
-    "forwarder",
-]

--- a/apps/ocpp/models/cp_forwarder.py
+++ b/apps/ocpp/models/cp_forwarder.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 def sync_forwarded_charge_points(*, refresh_forwarders: bool = True) -> int:
     """Proxy to the OCPP forwarder for testability."""
 
-    from ..forwarder import forwarder
+    from apps.forwarder.ocpp import forwarder
 
     return forwarder.sync_forwarded_charge_points(
         refresh_forwarders=refresh_forwarders
@@ -18,7 +18,7 @@ def sync_forwarded_charge_points(*, refresh_forwarders: bool = True) -> int:
 def is_target_active(target_id: int | None) -> bool:
     """Proxy to check whether a forwarding session is active."""
 
-    from ..forwarder import forwarder
+    from apps.forwarder.ocpp import forwarder
 
     return forwarder.is_target_active(target_id)
 

--- a/apps/ocpp/tests/test_forwarder_service.py
+++ b/apps/ocpp/tests/test_forwarder_service.py
@@ -147,7 +147,8 @@ def test_sync_forwarded_charge_points_respects_existing_sessions(monkeypatch):
     monkeypatch.setattr("apps.forwarder.ocpp.logger", fake_logger)
     monkeypatch.setattr("apps.forwarder.ocpp.create_connection", fake_create_connection)
 
-    from apps.ocpp import forwarder as forwarder_module, forwarding_utils
+    from apps.forwarder import ocpp as forwarder_module
+    from apps.ocpp import forwarding_utils
 
     monkeypatch.setitem(sys.modules, "apps.ocpp.models.forwarder", forwarder_module)
 

--- a/docs/development/ocpp-user-manual.md
+++ b/docs/development/ocpp-user-manual.md
@@ -100,6 +100,18 @@ If your automation still calls legacy entrypoints, update scripts to the canonic
 | `.venv/bin/python manage.py export_transactions <output.json> [--start ... --end ... --chargers ...]` | `.venv/bin/python manage.py ocpp transactions export <output.json> [--start ... --end ... --chargers ...]` |
 | `.venv/bin/python manage.py ocpp_replay <extract.json>` | `.venv/bin/python manage.py ocpp trace replay <extract.json>` |
 
+
+### Release migration notes (forwarder import path removal)
+The compatibility shim at `apps.ocpp.forwarder` has been removed.
+
+If integration code still imports the legacy path, switch to `apps.forwarder.ocpp`:
+
+```python
+# old → new
+from apps.ocpp.forwarder import Forwarder, ForwardingSession, forwarder
+from apps.forwarder.ocpp import Forwarder, ForwardingSession, forwarder
+```
+
 ### Release migration notes (simulator import path removal)
 The compatibility package at `apps.ocpp.simulator` has been removed.
 

--- a/docs/development/ocpp-user-manual.md
+++ b/docs/development/ocpp-user-manual.md
@@ -107,8 +107,7 @@ The compatibility shim at `apps.ocpp.forwarder` has been removed.
 If integration code still imports the legacy path, switch to `apps.forwarder.ocpp`:
 
 ```python
-# old → new
-from apps.ocpp.forwarder import Forwarder, ForwardingSession, forwarder
+# from apps.ocpp.forwarder import Forwarder, ForwardingSession, forwarder
 from apps.forwarder.ocpp import Forwarder, ForwardingSession, forwarder
 ```
 


### PR DESCRIPTION
### Motivation
- Remove a legacy compatibility shim and consolidate the canonical import path to reduce ambiguity and long-term maintenance.
- Ensure internal code consistently imports the forwarder implementation from the single source of truth `apps.forwarder.ocpp`.
- Provide clear upgrade guidance for external integrations that may still import the old path.

### Description
- Deleted the deprecated compatibility shim `apps/ocpp/forwarder/__init__.py` so the legacy import path is no longer provided.
- Replaced internal runtime imports to use the canonical module `apps.forwarder.ocpp` (notably in `apps/ocpp/consumers/base/connection_flow.py`).
- Updated tests to load the canonical forwarder module (`apps.forwarder.ocpp`) where the old shim had been referenced (in `apps/ocpp/tests/test_forwarder_service.py`).
- Added an upgrade note and a simple old→new import mapping snippet to `docs/development/ocpp-user-manual.md` documenting the removal.

### Testing
- Ran `./env-refresh.sh --deps-only` successfully to bootstrap the environment and dependencies.
- Installed test/dev CI deps with `.venv/bin/pip install -r requirements-ci.txt` to resolve test runner requirements (initial test run failed due to missing `pytest` until this step was performed).
- Executed `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_forwarder_service.py` which completed successfully (`11 passed`).
- Executed `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_websocket_creation.py` which completed successfully (`25 passed, 1 skipped`).
- Triggered the review notifier with `./scripts/review-notify.sh --actor Codex` as part of verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5819ad71483268e84bcd704fe4a74)