### PR TITLE
config: remove unused autodiscovered_urlpatterns alias from URL config

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -30,9 +30,6 @@ urlpatterns += [
     path("admindocs/", include("django.contrib.admindocs.urls")),
 ]
 
-# Backward-compatible alias expected by legacy tests/imports.
-autodiscovered_urlpatterns = autodiscovered_route_patterns
-
 if settings.DEBUG:
     if settings.HAS_DEBUG_TOOLBAR:
         urlpatterns = [


### PR DESCRIPTION
### Motivation

- Remove a legacy alias that is no longer imported by maintained code to reduce cruft and potential confusion while keeping URL assembly behavior unchanged.

### Description

- Deleted the backward-compatible alias `autodiscovered_urlpatterns = autodiscovered_route_patterns` from `config/urls.py` and left direct calls to `autodiscovered_route_patterns()` in place.
- Verified there are no remaining references to `autodiscovered_urlpatterns` in the maintained repository before removal.

### Testing

- Ran the editable-install import check with `./.venv/bin/python scripts/check_editable_install_import.py`, which completed successfully.
- Executed the site test suite with `./.venv/bin/python manage.py test run -- apps/sites/tests`, with `35 passed` and no failures observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d581a0e5e083268e52b5bf2c0aed88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated backward-compatible URL configuration alias. Applications depending on the old alias require code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->