### PR TITLE
ocpp: move firmware inbound handlers into CSMS firmware mixin

### DIFF
--- a/apps/ocpp/consumers/base/actions_notifications.py
+++ b/apps/ocpp/consumers/base/actions_notifications.py
@@ -10,20 +10,12 @@ class NotificationActionsMixin:
     """Expose protocol-routed notification action handlers."""
 
     def _notification_handler(self) -> NotificationHandler:
-        """Return notification helper for firmware/log/security event actions."""
+        """Return notification helper for diagnostics/log/security actions."""
         handler = getattr(self, "_cached_notification_handler", None)
         if handler is None:
             handler = NotificationHandler(self)
             self._cached_notification_handler = handler
         return handler
-
-    @protocol_call("ocpp21", ProtocolCallModel.CP_TO_CSMS, "PublishFirmwareStatusNotification")
-    @protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "PublishFirmwareStatusNotification")
-    async def _handle_publish_firmware_status_notification_action(self, payload, msg_id, raw, text_data):
-        """Route firmware publish notifications through notification handler."""
-        return await self._notification_handler().handle_publish_firmware_status(
-            payload, msg_id, raw, text_data
-        )
 
     @protocol_call("ocpp16", ProtocolCallModel.CP_TO_CSMS, "DiagnosticsStatusNotification")
     async def _handle_diagnostics_status_notification_action(self, payload, msg_id, raw, text_data):
@@ -37,15 +29,6 @@ class NotificationActionsMixin:
     async def _handle_log_status_notification_action(self, payload, msg_id, raw, text_data):
         """Route log notifications through notification handler."""
         return await self._notification_handler().handle_log_status(
-            payload, msg_id, raw, text_data
-        )
-
-    @protocol_call("ocpp16", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
-    @protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
-    @protocol_call("ocpp21", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
-    async def _handle_firmware_status_notification_action(self, payload, msg_id, raw, text_data):
-        """Route firmware status notifications through notification handler."""
-        return await self._notification_handler().handle_firmware_status(
             payload, msg_id, raw, text_data
         )
 

--- a/apps/ocpp/consumers/base/notifications.py
+++ b/apps/ocpp/consumers/base/notifications.py
@@ -1,8 +1,8 @@
-"""Notification handlers for status, diagnostics, firmware, and security.
+"""Notification handlers for diagnostics, log, and security events.
 
 These adapters group OCPP 1.6/2.x notification actions whose legacy handlers
-perform DB side effects such as firmware deployment state updates, log request
-updates, and security event persistence.
+perform DB side effects such as log request updates and security event
+persistence.
 """
 
 from typing import Protocol
@@ -11,19 +11,11 @@ from apps.ocpp.payload_types import HandlerPayload, HandlerResponse
 
 
 class NotificationConsumer(Protocol):
-    async def _handle_publish_firmware_status_notification_action_legacy(
-        self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
-    ) -> HandlerResponse: ...
-
     async def _handle_diagnostics_status_notification_action_legacy(
         self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
     ) -> HandlerResponse: ...
 
     async def _handle_log_status_notification_action_legacy(
-        self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
-    ) -> HandlerResponse: ...
-
-    async def _handle_firmware_status_notification_action_legacy(
         self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
     ) -> HandlerResponse: ...
 
@@ -37,15 +29,6 @@ class NotificationHandler:
 
     def __init__(self, consumer: NotificationConsumer) -> None:
         self.consumer = consumer
-
-    async def handle_publish_firmware_status(
-        self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
-    ) -> HandlerResponse:
-        """Handle OCPP 2.x firmware publish notifications with DB updates."""
-
-        return await self.consumer._handle_publish_firmware_status_notification_action_legacy(
-            payload, msg_id, raw, text_data
-        )
 
     async def handle_diagnostics_status(
         self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
@@ -62,15 +45,6 @@ class NotificationHandler:
         """Handle log status notifications and persist log delivery progress."""
 
         return await self.consumer._handle_log_status_notification_action_legacy(
-            payload, msg_id, raw, text_data
-        )
-
-    async def handle_firmware_status(
-        self, payload: HandlerPayload, msg_id: str, raw: str | None, text_data: str | None
-    ) -> HandlerResponse:
-        """Handle OCPP 1.6 firmware status notifications with deployment writes."""
-
-        return await self.consumer._handle_firmware_status_notification_action_legacy(
             payload, msg_id, raw, text_data
         )
 

--- a/apps/ocpp/consumers/csms/consumer.py
+++ b/apps/ocpp/consumers/csms/consumer.py
@@ -1,73 +1,49 @@
-from datetime import datetime, timedelta, timezone as dt_timezone
 import asyncio
-from collections import deque
-from dataclasses import dataclass
 import inspect
 import json
 import logging
 import re
 import uuid
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from decimal import Decimal, InvalidOperation
 
+from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
-from apps.energy.models import CustomerAccount
-from apps.links.models import Reference
-from apps.cards.models import RFID as CoreRFID, RFIDAttempt
-from apps.core.notifications import LcdChannel
-from apps.nodes.models import NetMessage
-from apps.protocols.decorators import protocol_call
-from apps.protocols.models import ProtocolCall as ProtocolCallModel
-
-from channels.generic.websocket import AsyncWebsocketConsumer
-from channels.db import database_sync_to_async
-from asgiref.sync import sync_to_async
-from apps.rates.mixins import RateLimitedConsumerMixin
-from config.offline import requires_network
-
-from decimal import Decimal, InvalidOperation
 from django.utils.dateparse import parse_datetime
-from apps.ocpp import store
+
+from apps.cards.models import RFID as CoreRFID
+from apps.cards.models import RFIDAttempt
+from apps.core.notifications import LcdChannel
+from apps.energy.models import CustomerAccount
 from apps.forwarder.ocpp import forwarder
-from apps.ocpp.status_resets import STATUS_RESET_UPDATES, clear_cached_statuses
-from apps.ocpp.models import (
-    Transaction,
-    Charger,
-    ChargingStation,
-    ChargerConfiguration,
-    MeterValue,
-    CostUpdate,
-    DataTransferMessage,
-    CPReservation,
-    CPFirmware,
-    CPFirmwareDeployment,
-    CPFirmwareRequest,
-    SecurityEvent,
-    ChargerLogRequest,
-    PowerProjection,
-    ChargingProfile,
-    ChargingSchedule,
-    Variable,
-    MonitoringRule,
-    MonitoringReport,
-    DeviceInventorySnapshot,
-    DeviceInventoryItem,
-    CustomerInformationRequest,
-    CustomerInformationChunk,
-    DisplayMessageNotification,
-    DisplayMessage,
-    ClearedChargingLimitEvent,
-)
+from apps.links.models import Reference
 from apps.links.reference_utils import host_is_local_loopback
-from apps.screens.startup_notifications import format_lcd_lines
-from apps.ocpp.evcs_discovery import (
-    DEFAULT_CONSOLE_PORT,
-    HTTPS_PORTS,
-    build_console_url,
-    prioritise_ports,
-    scan_open_ports,
+from apps.nodes.models import NetMessage
+from apps.ocpp import store
+from apps.ocpp.consumers.base.actions_metering import MeteringActionsMixin
+from apps.ocpp.consumers.base.actions_notifications import NotificationActionsMixin
+from apps.ocpp.consumers.base.actions_transactions import TransactionActionsMixin
+from apps.ocpp.consumers.base.certificates import CertificatesMixin
+from apps.ocpp.consumers.base.connection import ConnectionHandler
+from apps.ocpp.consumers.base.connection_flow import ConnectionFlowMixin
+from apps.ocpp.consumers.base.dispatch import DispatchMixin
+from apps.ocpp.consumers.base.forwarding import ForwardingHandler
+from apps.ocpp.consumers.base.identity import (
+    IdentityMixin,
+    _extract_vehicle_identifier,
+    _register_log_names_for_identity,
+    _resolve_client_ip,
 )
+from apps.ocpp.consumers.base.legacy_transactions import LegacyTransactionHandlersMixin
+from apps.ocpp.consumers.base.rfid import RfidMixin
 from apps.ocpp.consumers.connection import (
     RateLimitedConnectionMixin,
     SubprotocolConnectionMixin,
@@ -77,33 +53,58 @@ from apps.ocpp.consumers.constants import (
     OCPP_CONNECT_RATE_LIMIT_FALLBACK,
     OCPP_CONNECT_RATE_LIMIT_WINDOW_SECONDS,
     OCPP_VERSION_16,
-    OCPP_VERSION_201,
     OCPP_VERSION_21,
+    OCPP_VERSION_201,
 )
-from apps.ocpp.consumers.base.certificates import CertificatesMixin
-from apps.ocpp.consumers.base.dispatch import DispatchMixin
-from apps.ocpp.consumers.base.identity import (
-    IdentityMixin,
-    _extract_vehicle_identifier,
-    _register_log_names_for_identity,
-    _resolve_client_ip,
-)
-from apps.ocpp.utils import _parse_ocpp_timestamp
-from apps.ocpp.consumers.base.actions_metering import MeteringActionsMixin
-from apps.ocpp.consumers.base.actions_notifications import NotificationActionsMixin
-from apps.ocpp.consumers.base.actions_transactions import TransactionActionsMixin
-from apps.ocpp.consumers.base.connection_flow import ConnectionFlowMixin
-from apps.ocpp.consumers.base.legacy_transactions import LegacyTransactionHandlersMixin
-from apps.ocpp.consumers.base.rfid import RfidMixin
-from apps.ocpp.consumers.base.connection import ConnectionHandler
-from apps.ocpp.consumers.base.forwarding import ForwardingHandler
+from apps.ocpp.consumers.csms.actions import build_action_handlers
+from apps.ocpp.consumers.csms.handlers.firmware import FirmwareHandlersMixin
 from apps.ocpp.consumers.csms.handlers.metering import MeteringHandlersMixin
 from apps.ocpp.consumers.csms.handlers.notifications import (
     NotificationHandlersMixin as CsmsNotificationHandlersMixin,
 )
 from apps.ocpp.consumers.csms.handlers.status import StatusHandlersMixin
 from apps.ocpp.consumers.csms.transport import CSMSTransportMixin
-from apps.ocpp.consumers.csms.actions import build_action_handlers
+from apps.ocpp.evcs_discovery import (
+    DEFAULT_CONSOLE_PORT,
+    HTTPS_PORTS,
+    build_console_url,
+    prioritise_ports,
+    scan_open_ports,
+)
+from apps.ocpp.models import (
+    Charger,
+    ChargerConfiguration,
+    ChargerLogRequest,
+    ChargingProfile,
+    ChargingSchedule,
+    ChargingStation,
+    ClearedChargingLimitEvent,
+    CostUpdate,
+    CPFirmware,
+    CPFirmwareRequest,
+    CPReservation,
+    CustomerInformationChunk,
+    CustomerInformationRequest,
+    DataTransferMessage,
+    DeviceInventoryItem,
+    DeviceInventorySnapshot,
+    DisplayMessage,
+    DisplayMessageNotification,
+    MeterValue,
+    MonitoringReport,
+    MonitoringRule,
+    PowerProjection,
+    SecurityEvent,
+    Transaction,
+    Variable,
+)
+from apps.ocpp.status_resets import STATUS_RESET_UPDATES, clear_cached_statuses
+from apps.ocpp.utils import _parse_ocpp_timestamp
+from apps.protocols.decorators import protocol_call
+from apps.protocols.models import ProtocolCall as ProtocolCallModel
+from apps.rates.mixins import RateLimitedConsumerMixin
+from apps.screens.startup_notifications import format_lcd_lines
+from config.offline import requires_network
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,7 @@ class SinkConsumer(AsyncWebsocketConsumer):
 class CSMSConsumer(
     CSMSTransportMixin,
     StatusHandlersMixin,
+    FirmwareHandlersMixin,
     MeteringHandlersMixin,
     CsmsNotificationHandlersMixin,
     ConnectionFlowMixin,
@@ -586,56 +588,6 @@ class CSMSConsumer(
             await database_sync_to_async(self.charger.save)(
                 update_fields=["temperature", "temperature_unit"]
             )
-
-    async def _update_firmware_state(
-        self, status: str, status_info: str, timestamp: datetime | None
-    ) -> None:
-        """Persist firmware status fields for the active charger identities."""
-
-        targets: list[Charger] = []
-        seen_ids: set[int] = set()
-        for charger in (self.charger, self.aggregate_charger):
-            if not charger or charger.pk is None:
-                continue
-            if charger.pk in seen_ids:
-                continue
-            targets.append(charger)
-            seen_ids.add(charger.pk)
-
-        if not targets:
-            return
-
-        def _persist(ids: list[int]) -> None:
-            Charger.objects.filter(pk__in=ids).update(
-                firmware_status=status,
-                firmware_status_info=status_info,
-                firmware_timestamp=timestamp,
-            )
-
-        await database_sync_to_async(_persist)([target.pk for target in targets])
-        for target in targets:
-            target.firmware_status = status
-            target.firmware_status_info = status_info
-            target.firmware_timestamp = timestamp
-
-        def _update_deployments(ids: list[int]) -> None:
-            deployments = list(
-                CPFirmwareDeployment.objects.filter(
-                    charger_id__in=ids, completed_at__isnull=True
-                )
-            )
-            payload = {"status": status, "statusInfo": status_info}
-            for deployment in deployments:
-                deployment.mark_status(
-                    status,
-                    status_info,
-                    timestamp,
-                    response=payload,
-                )
-
-        await database_sync_to_async(_update_deployments)(
-            [target.pk for target in targets]
-        )
 
     async def _cancel_consumption_message(self) -> None:
         """Stop any scheduled consumption message updates."""
@@ -2479,65 +2431,6 @@ class CSMSConsumer(
             payload, msg_id, raw, text_data
         )
 
-    @protocol_call(
-        "ocpp21",
-        ProtocolCallModel.CP_TO_CSMS,
-        "PublishFirmwareStatusNotification",
-    )
-    @protocol_call(
-        "ocpp201",
-        ProtocolCallModel.CP_TO_CSMS,
-        "PublishFirmwareStatusNotification",
-    )
-    async def _handle_publish_firmware_status_notification_action_legacy(
-        self, payload, msg_id, raw, text_data
-    ):
-        status_raw = payload.get("status")
-        status_value = str(status_raw or "").strip()
-        info_value = payload.get("statusInfo")
-        if not isinstance(info_value, str):
-            info_value = payload.get("info")
-        status_info = str(info_value or "").strip()
-        request_id_value = payload.get("requestId")
-        timestamp_value = _parse_ocpp_timestamp(payload.get("publishTimestamp"))
-        if timestamp_value is None:
-            timestamp_value = _parse_ocpp_timestamp(payload.get("timestamp"))
-        if timestamp_value is None:
-            timestamp_value = timezone.now()
-
-        def _persist_status():
-            deployment = None
-            try:
-                deployment_pk = int(request_id_value)
-            except (TypeError, ValueError, OverflowError):
-                deployment_pk = None
-            if deployment_pk:
-                deployment = CPFirmwareDeployment.objects.filter(
-                    pk=deployment_pk
-                ).first()
-            if deployment is None and self.charger:
-                deployment = (
-                    CPFirmwareDeployment.objects.filter(
-                        charger=self.charger, completed_at__isnull=True
-                    )
-                    .order_by("-requested_at")
-                    .first()
-                )
-            if deployment is None:
-                return
-            if status_value == "Downloaded" and deployment.downloaded_at is None:
-                deployment.downloaded_at = timestamp_value
-            deployment.mark_status(
-                status_value,
-                status_info,
-                timestamp_value,
-                response=payload,
-            )
-
-        await database_sync_to_async(_persist_status)()
-        self._log_ocpp201_notification("PublishFirmwareStatusNotification", payload)
-        return {}
-
     @protocol_call("ocpp21", ProtocolCallModel.CP_TO_CSMS, "ReportChargingProfiles")
     @protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "ReportChargingProfiles")
     async def _handle_report_charging_profiles_action(
@@ -2779,42 +2672,4 @@ class CSMSConsumer(
             "idle",
         }:
             store.finalize_log_capture(session_capture)
-        return {}
-
-    async def _handle_firmware_status_notification_action_legacy(
-        self, payload, msg_id, raw, text_data
-    ):
-        status_raw = payload.get("status")
-        status = str(status_raw or "").strip()
-        info_value = payload.get("statusInfo")
-        if not isinstance(info_value, str):
-            info_value = payload.get("info")
-        status_info = str(info_value or "").strip()
-        timestamp_raw = payload.get("timestamp")
-        timestamp_value = None
-        if timestamp_raw:
-            timestamp_value = parse_datetime(str(timestamp_raw))
-            if timestamp_value and timezone.is_naive(timestamp_value):
-                timestamp_value = timezone.make_aware(
-                    timestamp_value, timezone.get_current_timezone()
-                )
-        if timestamp_value is None:
-            timestamp_value = timezone.now()
-        await self._update_firmware_state(status, status_info, timestamp_value)
-        store.add_log(
-            self.store_key,
-            "FirmwareStatusNotification: " + json.dumps(payload, separators=(",", ":")),
-            log_type="charger",
-        )
-        if self.aggregate_charger and self.aggregate_charger.connector_id is None:
-            aggregate_key = store.identity_key(
-                self.charger_id, self.aggregate_charger.connector_id
-            )
-            if aggregate_key != self.store_key:
-                store.add_log(
-                    aggregate_key,
-                    "FirmwareStatusNotification: "
-                    + json.dumps(payload, separators=(",", ":")),
-                    log_type="charger",
-                )
         return {}

--- a/apps/ocpp/consumers/csms/handlers/firmware.py
+++ b/apps/ocpp/consumers/csms/handlers/firmware.py
@@ -1,6 +1,167 @@
-"""Firmware-related handler grouping for CSMS consumer."""
+"""Firmware-related inbound handlers for the CSMS consumer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from channels.db import database_sync_to_async
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from apps.ocpp import store
+from apps.ocpp.models import Charger, CPFirmwareDeployment
+from apps.ocpp.utils import _parse_ocpp_timestamp
+from apps.protocols.decorators import protocol_call
+from apps.protocols.models import ProtocolCall as ProtocolCallModel
+
 
 class FirmwareHandlersMixin:
-    """Placeholder mixin to host firmware action handlers."""
+    """Handle inbound firmware status notifications and side effects."""
 
-    pass
+    async def _update_firmware_state(
+        self, status: str, status_info: str, timestamp: datetime | None
+    ) -> None:
+        """Persist firmware status fields for the active charger identities."""
+
+        targets: list[Charger] = []
+        seen_ids: set[int] = set()
+        for charger in (self.charger, self.aggregate_charger):
+            if not charger or charger.pk is None:
+                continue
+            if charger.pk in seen_ids:
+                continue
+            targets.append(charger)
+            seen_ids.add(charger.pk)
+
+        if not targets:
+            return
+
+        def _persist(ids: list[int]) -> None:
+            Charger.objects.filter(pk__in=ids).update(
+                firmware_status=status,
+                firmware_status_info=status_info,
+                firmware_timestamp=timestamp,
+            )
+
+        await database_sync_to_async(_persist)([target.pk for target in targets])
+        for target in targets:
+            target.firmware_status = status
+            target.firmware_status_info = status_info
+            target.firmware_timestamp = timestamp
+
+        def _update_deployments(ids: list[int]) -> None:
+            deployments = list(
+                CPFirmwareDeployment.objects.filter(
+                    charger_id__in=ids, completed_at__isnull=True
+                )
+            )
+            payload = {"status": status, "statusInfo": status_info}
+            for deployment in deployments:
+                deployment.mark_status(
+                    status,
+                    status_info,
+                    timestamp,
+                    response=payload,
+                )
+
+        await database_sync_to_async(_update_deployments)([target.pk for target in targets])
+
+    @protocol_call(
+        "ocpp21",
+        ProtocolCallModel.CP_TO_CSMS,
+        "PublishFirmwareStatusNotification",
+    )
+    @protocol_call(
+        "ocpp201",
+        ProtocolCallModel.CP_TO_CSMS,
+        "PublishFirmwareStatusNotification",
+    )
+    async def _handle_publish_firmware_status_notification_action(
+        self, payload, msg_id, raw, text_data
+    ):
+        status_raw = payload.get("status")
+        status_value = str(status_raw or "").strip()
+        info_value = payload.get("statusInfo")
+        if not isinstance(info_value, str):
+            info_value = payload.get("info")
+        status_info = str(info_value or "").strip()
+        request_id_value = payload.get("requestId")
+        timestamp_value = _parse_ocpp_timestamp(payload.get("publishTimestamp"))
+        if timestamp_value is None:
+            timestamp_value = _parse_ocpp_timestamp(payload.get("timestamp"))
+        if timestamp_value is None:
+            timestamp_value = timezone.now()
+
+        def _persist_status():
+            deployment = None
+            try:
+                deployment_pk = int(request_id_value)
+            except (TypeError, ValueError, OverflowError):
+                deployment_pk = None
+            if deployment_pk:
+                deployment = CPFirmwareDeployment.objects.filter(pk=deployment_pk).first()
+            if deployment is None and self.charger:
+                deployment = (
+                    CPFirmwareDeployment.objects.filter(
+                        charger=self.charger,
+                        completed_at__isnull=True,
+                    )
+                    .order_by("-requested_at")
+                    .first()
+                )
+            if deployment is None:
+                return
+            if status_value == "Downloaded" and deployment.downloaded_at is None:
+                deployment.downloaded_at = timestamp_value
+            deployment.mark_status(
+                status_value,
+                status_info,
+                timestamp_value,
+                response=payload,
+            )
+
+        await database_sync_to_async(_persist_status)()
+        self._log_ocpp201_notification("PublishFirmwareStatusNotification", payload)
+        return {}
+
+    @protocol_call("ocpp16", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
+    @protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
+    @protocol_call("ocpp21", ProtocolCallModel.CP_TO_CSMS, "FirmwareStatusNotification")
+    async def _handle_firmware_status_notification_action(
+        self, payload, msg_id, raw, text_data
+    ):
+        status_raw = payload.get("status")
+        status = str(status_raw or "").strip()
+        info_value = payload.get("statusInfo")
+        if not isinstance(info_value, str):
+            info_value = payload.get("info")
+        status_info = str(info_value or "").strip()
+        timestamp_raw = payload.get("timestamp")
+        timestamp_value = None
+        if timestamp_raw:
+            timestamp_value = parse_datetime(str(timestamp_raw))
+            if timestamp_value and timezone.is_naive(timestamp_value):
+                timestamp_value = timezone.make_aware(
+                    timestamp_value, timezone.get_current_timezone()
+                )
+        if timestamp_value is None:
+            timestamp_value = timezone.now()
+        await self._update_firmware_state(status, status_info, timestamp_value)
+        store.add_log(
+            self.store_key,
+            "FirmwareStatusNotification: " + json.dumps(payload, separators=(",", ":")),
+            log_type="charger",
+        )
+        if self.aggregate_charger and self.aggregate_charger.connector_id is None:
+            aggregate_key = store.identity_key(
+                self.charger_id, self.aggregate_charger.connector_id
+            )
+            if aggregate_key != self.store_key:
+                store.add_log(
+                    aggregate_key,
+                    "FirmwareStatusNotification: "
+                    + json.dumps(payload, separators=(",", ":")),
+                    log_type="charger",
+                )
+        return {}

--- a/apps/ocpp/tests/test_consumer_routing.py
+++ b/apps/ocpp/tests/test_consumer_routing.py
@@ -34,6 +34,10 @@ async def test_action_router_resolves_transaction_and_notification_handlers():
         router.resolve("PublishFirmwareStatusNotification")
         == consumer._handle_publish_firmware_status_notification_action
     )
+    assert (
+        router.resolve("FirmwareStatusNotification")
+        == consumer._handle_firmware_status_notification_action
+    )
 
 @pytest.mark.anyio
 async def test_dispatch_routes_via_registry_for_transaction_event():
@@ -68,6 +72,7 @@ async def test_ocpp21_cp_to_csms_actions_resolve_to_concrete_handlers():
         "Heartbeat": consumer._handle_heartbeat_action,
         "LogStatusNotification": consumer._handle_log_status_notification_action,
         "MeterValues": consumer._handle_meter_values_action,
+        "FirmwareStatusNotification": consumer._handle_firmware_status_notification_action,
         "NotifyChargingLimit": consumer._action_handler("NotifyChargingLimit").handle,
         "NotifyCustomerInformation": consumer._handle_notify_customer_information_action,
         "NotifyDisplayMessages": consumer._action_handler("NotifyDisplayMessages").handle,

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -1,5 +1,6 @@
 import json
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime
+from datetime import timezone as dt_timezone
 from functools import partial
 from unittest.mock import AsyncMock
 
@@ -8,40 +9,40 @@ import pytest
 from channels.db import database_sync_to_async
 from django.test import override_settings
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 
-from apps.ocpp import store, call_error_handlers, call_result_handlers
+from apps.flows.models import Transition
+from apps.ocpp import call_error_handlers, call_result_handlers, store
 from apps.ocpp.consumers import CSMSConsumer
 from apps.ocpp.consumers import base as consumers_base
-from apps.flows.models import Transition
-from apps.ocpp.views import actions
-from apps.ocpp.views.common import ActionContext
 from apps.ocpp.models import (
-    Charger,
-    CPReservation,
-    CertificateRequest,
     CertificateOperation,
+    CertificateRequest,
     CertificateStatusCheck,
-    InstalledCertificate,
-    CostUpdate,
+    Charger,
     ChargingProfile,
     ChargingSchedule,
-    Transaction,
-    Variable,
-    MonitoringRule,
-    MonitoringReport,
-    DeviceInventorySnapshot,
-    DeviceInventoryItem,
-    CustomerInformationRequest,
-    CustomerInformationChunk,
-    DisplayMessageNotification,
-    DisplayMessage,
     ClearedChargingLimitEvent,
+    CostUpdate,
     CPFirmware,
     CPFirmwareDeployment,
+    CPReservation,
+    CustomerInformationChunk,
+    CustomerInformationRequest,
+    DeviceInventoryItem,
+    DeviceInventorySnapshot,
+    DisplayMessage,
+    DisplayMessageNotification,
+    InstalledCertificate,
+    MonitoringReport,
+    MonitoringRule,
+    Transaction,
+    Variable,
 )
-from apps.protocols.models import ProtocolCall as ProtocolCallModel
 from apps.ocpp.models.location import Location
-from django.utils.dateparse import parse_datetime
+from apps.ocpp.views import actions
+from apps.ocpp.views.common import ActionContext
+from apps.protocols.models import ProtocolCall as ProtocolCallModel
 
 
 @pytest.fixture(autouse=True)
@@ -636,6 +637,49 @@ async def test_publish_firmware_status_updates_deployment():
     )
     assert deployment.status == "Published"
     assert deployment.completed_at is not None
+
+
+@pytest.mark.anyio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.integration
+async def test_firmware_status_notification_updates_chargers_and_logs():
+    aggregate = await database_sync_to_async(Charger.objects.create)(
+        charger_id="FW-16",
+        connector_id=None,
+    )
+    connector = await database_sync_to_async(Charger.objects.create)(
+        charger_id="FW-16",
+        connector_id=1,
+    )
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    consumer.charger_id = "FW-16"
+    consumer.store_key = store.identity_key("FW-16", 1)
+    consumer.charger = connector
+    consumer.aggregate_charger = aggregate
+
+    payload = {
+        "status": "Downloaded",
+        "statusInfo": "checksum-ok",
+        "timestamp": "2024-01-01T03:00:00Z",
+    }
+    result = await consumer._handle_firmware_status_notification_action(
+        payload, "msg-fw", "", ""
+    )
+
+    assert result == {}
+    connector = await database_sync_to_async(Charger.objects.get)(pk=connector.pk)
+    aggregate = await database_sync_to_async(Charger.objects.get)(pk=aggregate.pk)
+    assert connector.firmware_status == "Downloaded"
+    assert aggregate.firmware_status == "Downloaded"
+    assert connector.firmware_status_info == "checksum-ok"
+    assert aggregate.firmware_status_info == "checksum-ok"
+    assert connector.firmware_timestamp.isoformat() == "2024-01-01T03:00:00+00:00"
+    assert aggregate.firmware_timestamp.isoformat() == "2024-01-01T03:00:00+00:00"
+
+    connector_logs = list(store.logs["charger"].get(store.identity_key("FW-16", 1), []))
+    aggregate_logs = list(store.logs["charger"].get(store.identity_key("FW-16", None), []))
+    assert any("FirmwareStatusNotification:" in entry for entry in connector_logs)
+    assert any("FirmwareStatusNotification:" in entry for entry in aggregate_logs)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation

- Centralise real inbound firmware logic into a dedicated CSMS mixin to avoid placeholder fallthroughs and keep protocol-decorated handlers colocated with their side effects.
- Preserve existing routing and behaviour so OCPP action names continue to resolve to the same handler names used by the dispatch layer.
- Reduce duplicated legacy bridge code in the main consumer and keep the notification adapter focused on diagnostics/log/security responsibilities.

### Description

- Implemented `FirmwareHandlersMixin` in `apps/ocpp/consumers/csms/handlers/firmware.py` with concrete handlers for `PublishFirmwareStatusNotification` and `FirmwareStatusNotification`, including protocol decorators, deployment updates, charger firmware field persistence, and logging side effects.
- Removed firmware routes from the notification adapter by trimming `NotificationActionsMixin` / `NotificationHandler` to diagnostics/log/security only and moved firmware handling into the new mixin boundary.
- Wired `FirmwareHandlersMixin` into `CSMSConsumer` inheritance and removed the legacy firmware bridge methods and helper from `CSMSConsumer` so methods are now sourced from the dedicated firmware mixin while keeping the same handler names for the dispatch registry.
- Kept action routing stable in `apps/ocpp/consumers/csms/dispatch.py` and updated tests in `apps/ocpp/tests/test_consumer_routing.py` and `apps/ocpp/tests/test_ocpp_handlers.py` to cover routing and firmware persistence/log side effects, and applied import sorting fixes flagged by `ruff`.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed test deps via `.venv/bin/pip install -r requirements-ci.txt` with no errors.
- Ran targeted handler tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp_handlers.py -k firmware` and observed `2 passed`.
- Ran routing tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_consumer_routing.py::test_action_router_resolves_transaction_and_notification_handlers apps/ocpp/tests/test_consumer_routing.py::test_ocpp21_cp_to_csms_actions_resolve_to_concrete_handlers` and observed `2 passed`.
- Ran the combined targeted test selections used during development and all selected tests passed; linter autofixes (`ruff` I001) were applied and no test regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c04cb0e883269fe04d4f6cb0e2eb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized firmware status notification handling to improve code structure and maintainability.

* **Tests**
  * Added test coverage for firmware status notification processing to validate system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->