### PR TITLE
ci: reuse mypy workflow path filters via YAML anchor

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   pull_request:
-    paths:
+    paths: &mypy_paths
       - '.github/workflows/mypy.yml'
       - '.pre-commit-config.yaml'
       - 'CONTRIBUTING.md'
@@ -29,25 +29,7 @@ on:
     branches:
       - main
       - 'release/**'
-    paths:
-      - '.github/workflows/mypy.yml'
-      - '.pre-commit-config.yaml'
-      - 'CONTRIBUTING.md'
-      - 'Makefile'
-      - 'docs/development/mypy-adoption-checklist.md'
-      - 'pyproject.toml'
-      - 'scripts/run_mypy.sh'
-      - 'scripts/generate_requirements.py'
-      - 'scripts/sort_pyproject_deps.py'
-      - 'apps/protocols/**'
-      - 'apps/repos/github.py'
-      - 'apps/repos/services/github.py'
-      - 'apps/repos/release_management.py'
-      - 'apps/repos/views/webhooks.py'
-      - 'apps/core/services/health.py'
-      - 'apps/core/services/health_checks.py'
-      - 'apps/core/modeling/**'
-      - 'apps/core/system_ui.py'
+    paths: *mypy_paths
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation

- Make the MyPy GitHub Actions workflow valid and maintainable by removing duplication and avoiding unsupported custom top-level workflow keys (e.g. `x-*`).

### Description

- Define the MyPy path filter list once as `pull_request.paths` with a YAML anchor `&mypy_paths` and reuse it for `push.paths` via the alias `*mypy_paths`.
- Remove the duplicated `push.paths` block so the workflow triggers and job bodies remain unchanged.

### Testing

- Parsed the workflow YAML with `python -c "import yaml; yaml.safe_load(open('.github/workflows/mypy.yml'))"` and it succeeded.
- Ran `./env-refresh.sh --deps-only` to refresh the environment and it completed successfully.
- Ran `./scripts/review-notify.sh --actor Codex` which sent the review notification via the fallback notifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f66d27ec8326bcfb73b345fc63ca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD workflow configuration efficiency.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->