### PR TITLE
Follow-up: normalize support trust icon to remove hidden ZWJ

### DIFF
--- a/apps/energy/templates/energy/public_connector_page.html
+++ b/apps/energy/templates/energy/public_connector_page.html
@@ -91,7 +91,7 @@
                   <div class="trust-row d-grid gap-2 gap-sm-3 mt-2">
                     <span class="trust-item"><span class="me-1" aria-hidden="true">🔒</span>{% trans "Secure account setup" %}</span>
                     <span class="trust-item"><span class="me-1" aria-hidden="true">🛡️</span>{% trans "Privacy-safe scan logging" %}</span>
-                    <span class="trust-item"><span class="me-1" aria-hidden="true">🧑‍💬</span>{% trans "Support is available when needed" %}</span>
+                    <span class="trust-item"><span class="me-1" aria-hidden="true">💬</span>{% trans "Support is available when needed" %}</span>
                   </div>
                 </div>
               </form>


### PR DESCRIPTION
### Motivation
- Remove a hidden ZERO WIDTH JOINER (U+200D) in the support trust-row emoji that caused mojibake and failed the invisible-character check.

### Description
- Replace the ZWJ-composed sequence `🧑‍💬` with the normalized visible `💬` in `apps/energy/templates/energy/public_connector_page.html` so the template renders without hidden characters.

### Testing
- Ran `python scripts/check_invisible_characters.py` and it now reports no invisible characters detected.
- Attempted `./scripts/review-notify.sh --actor Codex` but it failed due to a missing virtual environment with the message: `Virtual environment not found. Run ./install.sh first.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f622af3c83269efba179f4ee8c0f)