### PR TITLE
Follow-up: fix Install Health Check pyproject ordering validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ preview = [
   "selenium==4.41.0",
 ]
 qa = [
-  "pytest-asyncio==1.3.0",  # pytest>=9 compatible series
+  "pytest-asyncio==1.3.0",
   "pytest-django==4.12.0",
   "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ preview = [
   "selenium==4.41.0",
 ]
 qa = [
+  # pytest>=9 compatible series
   "pytest-asyncio==1.3.0",
   "pytest-django==4.12.0",
   "pytest-timeout==2.4.0",


### PR DESCRIPTION
### Motivation
- The Install Health Check jobs repeatedly failed at the CI `Validate pyproject dependency ordering` step because an inline comment in the `qa` dependency entry prevented the repository dependency-ordering check from passing.  

### Description
- Remove the inline comment from the `pytest-asyncio` entry in `pyproject.toml`'s `qa` optional-dependencies so `scripts/sort_pyproject_deps.py --check` accepts the file while keeping dependency versions unchanged.  

### Testing
- Ran validation and CI-related checks which all succeeded: `curl` to inspect failing workflow jobs, `./env-refresh.sh --deps-only`, `python scripts/sort_pyproject_deps.py --check`, `python scripts/generate_requirements.py --check`, and `./scripts/review-notify.sh --actor Codex`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f62cf8488326be9f429362ee6c4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary comments from project configuration to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->