### PR TITLE
Normalize pyproject dependency ordering for Install CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ preview = [
   "selenium==4.41.0",
 ]
 qa = [
-  # pytest>=9 compatible series
   "pytest-asyncio==1.3.0",
   "pytest-django==4.12.0",
   "pytest-timeout==2.4.0",


### PR DESCRIPTION
### Motivation
- The Install CI check failed because `pyproject.toml` dependency arrays were not normalized and the repo uses a normalization script to enforce a stable ordering.

### Description
- Ran `scripts/sort_pyproject_deps.py` to rewrite the `project.dependencies` and `project.optional-dependencies` arrays in `pyproject.toml`, which normalized ordering and removed an inline comment in the `qa` optional group as part of the rewrite.

### Testing
- Ran `python scripts/sort_pyproject_deps.py --check`, `./env-refresh.sh --deps-only`, and `./scripts/review-notify.sh --actor Codex`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a1bb0f4c8326983c96b2844d9216)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Minor configuration file cleanup with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->