### PR TITLE
sites: remove public-facing module pill styling from navbar

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -104,29 +104,6 @@ nav.toc a:hover {
 }
 
 
-.navbar .module-pill-nav {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.35rem 0.3rem;
-}
-
-.module-pill-nav .nav-item {
-  flex: 0 0 auto;
-}
-
-.module-pill-nav .nav-link {
-  display: inline-flex;
-  align-items: center;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.module-pill-nav .badge {
-  display: inline-flex;
-}
-
 @media (min-width: 992px) {
   .reader-sidebar {
     position: sticky;

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -103,6 +103,10 @@ nav.toc a:hover {
   display: none;
 }
 
+.navbar-nav-wrap {
+  flex-wrap: wrap;
+  gap: 0.35rem 0.3rem;
+}
 
 @media (min-width: 992px) {
   .reader-sidebar {

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -36,7 +36,7 @@
             <span class="visually-hidden">{% trans "Toggle navigation" %}</span>
           </button>
           <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav module-pill-nav me-auto mb-2 mb-lg-0">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
               {% if nav_modules %}
                 {% for module in nav_modules %}
                   {% with landings=module.enabled_landings %}
@@ -44,7 +44,7 @@
                       {% if module.enabled_landings_all_invalid %}
                         <li class="nav-item dropdown">
                           <a class="nav-link" href="#" role="button">
-                            <span class="badge rounded-pill text-bg-secondary">{{ module.menu_label|upper }}</span>
+                            {{ module.menu_label|upper }}
                             {% include "pages/_agent_notes.html" with notes=module.agent_notes role="module" %}
                           </a>
                           <ul class="dropdown-menu">
@@ -80,7 +80,7 @@
                       {% else %}
                         <li class="nav-item">
                           <a class="nav-link" href="{{ landings.0.path }}">
-                            <span class="badge rounded-pill text-bg-secondary">{{ module.menu_label|upper }}</span>
+                            {{ module.menu_label|upper }}
                             {% include "pages/_agent_notes.html" with notes=module.agent_notes role="module" %}
                             {% include "pages/_agent_notes.html" with notes=landings.0.agent_notes role="landing" %}
                           </a>
@@ -89,7 +89,7 @@
                     {% else %}
                       <li class="nav-item dropdown">
                         <a class="nav-link" href="#" role="button">
-                          <span class="badge rounded-pill text-bg-secondary">{{ module.menu_label|upper }}</span>
+                          {{ module.menu_label|upper }}
                           {% include "pages/_agent_notes.html" with notes=module.agent_notes role="module" %}
                         </a>
                         <ul class="dropdown-menu">
@@ -129,7 +129,7 @@
               {% if header_references %}
                 <li class="nav-item dropdown">
                   <a class="nav-link" href="#" role="button">
-                    <span class="badge rounded-pill text-bg-secondary">CONSOLES</span>
+                    CONSOLES
                   </a>
                   <ul class="dropdown-menu">
                     {% for reference in header_references %}

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -36,7 +36,7 @@
             <span class="visually-hidden">{% trans "Toggle navigation" %}</span>
           </button>
           <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <ul class="navbar-nav navbar-nav-wrap me-auto mb-2 mb-lg-0">
               {% if nav_modules %}
                 {% for module in nav_modules %}
                   {% with landings=module.enabled_landings %}
@@ -129,7 +129,8 @@
               {% if header_references %}
                 <li class="nav-item dropdown">
                   <a class="nav-link" href="#" role="button">
-                    CONSOLES
+                    {% trans "Consoles" as consoles_label %}
+                    {{ consoles_label|upper }}
                   </a>
                   <ul class="dropdown-menu">
                     {% for reference in header_references %}


### PR DESCRIPTION
### Motivation
- Public-facing navigation used pill-shaped badges for module labels which should be plain text for a consistent public docs appearance.

### Description
- Removed the `module-pill-nav` class from the public navbar list in `apps/sites/templates/pages/base.html` and replaced badge markup with plain `{{ module.menu_label|upper }}` and `CONSOLES` text.
- Deleted the corresponding unused `.module-pill-nav` CSS rules from `apps/sites/static/pages/css/base.css` so layout no longer relies on pill-specific styles.
- Changes only affect the public site navbar presentation and preserve existing navigation behavior and accessibility markers.

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` which completed successfully.
- Installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` to provide test tooling.
- Executed ` .venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py` and all tests passed (`8 passed`).
- Ran the repository review notifier `./scripts/review-notify.sh --actor Codex` which executed via fallback notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7af7ab19c8326a026588aa793ec70)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified navigation bar styling by removing badge pill styling from navigation items. Navigation labels now display as plain text instead of styled badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->