### PR TITLE
ci: fix dependency submission workflow permission key

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -16,8 +16,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  dependency-graph: write
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
### Motivation
- GitHub Actions fails to parse the dependency submission workflow due to an unsupported `dependency-graph` permission key, so the workflow permissions must be adjusted to be accepted by the runner.

### Description
- Replace `dependency-graph: write` and the prior `contents: read` with a single `contents: write` entry in `.github/workflows/dependency-submission.yml`, preserving the existing job steps and retry logic.

### Testing
- Executed `./env-refresh.sh --deps-only`, `./scripts/review-notify.sh --actor Codex`, and parsed the workflow with `./.venv/bin/python -c "import pathlib,yaml; yaml.safe_load(pathlib.Path('.github/workflows/dependency-submission.yml').read_text()); print('ok')"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d2193d1883269aadc16fd6bc9bc0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->