### PR TITLE
ci: scope stale workflow token permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Limit the stale PR workflow's GitHub token to the minimal scopes required so the automation can close PRs and post comments without granting broad write access.

### Description
- Add a top-level `permissions` block to `.github/workflows/stale.yml` granting only `pull-requests: write`, `issues: write`, and `contents: read`.

### Testing
- Ran `./env-refresh.sh --deps-only`, `git diff --check`, and `./scripts/review-notify.sh --actor Codex`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f32997748326bd8e6f4f794502c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable automated issue and pull request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->