### PR TITLE
ci: validate PR security scan target before running ZAP

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,9 +24,45 @@ permissions:
   issues: write
 
 jobs:
+  validate-pr-security-scan-target:
+    name: Validate PR Security Scan Target
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      target_configured: ${{ steps.validate.outputs.target_configured }}
+    steps:
+      - name: Validate PR scan target configuration
+        id: validate
+        env:
+          TARGET_URL: ${{ vars.PR_SECURITY_SCAN_TARGET }}
+        run: |
+          set -euo pipefail
+
+          trimmed_target=$(printf '%s' "${TARGET_URL}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+          if [ -z "${trimmed_target}" ]; then
+            echo "target_configured=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### PR security scan configuration is missing"
+              echo ""
+              echo "Set repository variable \`PR_SECURITY_SCAN_TARGET\` (Settings → Secrets and variables → Actions → Variables) to a safe non-production URL, such as \`https://staging.example.com\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "PR_SECURITY_SCAN_TARGET is missing or empty." >&2
+            exit 1
+          fi
+
+          echo "target_configured=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "### PR security scan configuration detected"
+            echo ""
+            echo "\`PR_SECURITY_SCAN_TARGET\` is configured. To update it, use Settings → Secrets and variables → Actions → Variables."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   zap-baseline-pr:
     name: OWASP ZAP Baseline Scan
-    if: github.event_name == 'pull_request' && vars.PR_SECURITY_SCAN_TARGET != ''
+    needs:
+      - validate-pr-security-scan-target
+    if: github.event_name == 'pull_request' && needs.validate-pr-security-scan-target.outputs.target_configured == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_configured: ${{ steps.validate.outputs.target_configured }}
+      validated_target: ${{ steps.validate.outputs.validated_target }}
     steps:
       - name: Validate PR scan target configuration
         id: validate
@@ -53,6 +54,11 @@ jobs:
 
           echo "target_configured=true" >> "$GITHUB_OUTPUT"
           {
+            echo "validated_target<<EOF"
+            echo "${trimmed_target}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
             echo "### PR security scan configuration detected"
             echo ""
             echo "\`PR_SECURITY_SCAN_TARGET\` is configured. To update it, use Settings → Secrets and variables → Actions → Variables."
@@ -74,7 +80,7 @@ jobs:
 
       - name: Validate PR scan target
         env:
-          TARGET_URL: ${{ vars.PR_SECURITY_SCAN_TARGET }}
+          TARGET_URL: ${{ needs.validate-pr-security-scan-target.outputs.validated_target }}
         run: |
           set -euo pipefail
 
@@ -96,7 +102,7 @@ jobs:
         id: zap_scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
-          target: ${{ vars.PR_SECURITY_SCAN_TARGET }}
+          target: ${{ needs.validate-pr-security-scan-target.outputs.validated_target }}
           cmd_options: >-
             -m 5
             -J zap-pr-report.json


### PR DESCRIPTION
### Motivation
- Ensure PR scans do not silently skip when `PR_SECURITY_SCAN_TARGET` is missing and surface a clear failing check with actionable guidance. 
- Make the missing configuration visible in GitHub Checks and provide a short summary that shows how to set `PR_SECURITY_SCAN_TARGET`.

### Description
- Add a new `validate-pr-security-scan-target` job that runs on every `pull_request` event and fails when `PR_SECURITY_SCAN_TARGET` is missing or empty, writing a concise summary to the job step (`$GITHUB_STEP_SUMMARY`).
- Export `target_configured` from the validator and gate `zap-baseline-pr` using `needs` and `needs.validate-pr-security-scan-target.outputs.target_configured == 'true'` so missing config appears as a failed validation check instead of silently skipping.
- Trim whitespace from the variable when validating, and keep the existing PR-time safety check in `zap-baseline-pr` that refuses production targets.
- Update `.github/workflows/security-scan.yml` with the new job and gating logic.

### Testing
- `git diff --check` completed successfully.
- YAML parse check using `python3` (`yaml.safe_load`) on `.github/workflows/security-scan.yml` succeeded.
- `./env-refresh.sh --deps-only` completed successfully to ensure environment tooling availability.
- `./scripts/review-notify.sh --actor Codex` ran and returned (skipped notification due to no reviewable changes) successfully.
- `actionlint .github/workflows/security-scan.yml` was attempted but `actionlint` is not installed in the environment, so that check could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f32e8a1c8326a2b6679680367865)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request security scan workflow validation with improved error detection and guidance when configuration requirements are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->