### PR TITLE
ci: track persistent dependency submission failures without blocking transient outages

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -18,12 +18,17 @@ on:
 permissions:
   contents: write
   id-token: write
+  issues: write
 
 jobs:
   dependency-submission:
     name: Submit dependencies
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      DEPENDENCY_DETECTOR_ARGS: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff,Poetry=EnableIfDefaultOff,UvLock=EnableIfDefaultOff
+      DEPENDENCY_SUBMISSION_FAIL_AFTER: '0'
+      DEPENDENCY_SUBMISSION_TRACKING_LABEL: dependency-submission-failure
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -35,7 +40,7 @@ jobs:
         continue-on-error: true
         uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
         with:
-          detectorArgs: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff,Poetry=EnableIfDefaultOff,UvLock=EnableIfDefaultOff
+          detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
       - name: Backoff before retry
         if: steps.submit_snapshot_attempt_1.outcome == 'failure'
@@ -47,7 +52,7 @@ jobs:
         continue-on-error: true
         uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
         with:
-          detectorArgs: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff,Poetry=EnableIfDefaultOff,UvLock=EnableIfDefaultOff
+          detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
       - name: Backoff before final retry
         if: steps.submit_snapshot_attempt_2.outcome == 'failure'
@@ -59,12 +64,114 @@ jobs:
         continue-on-error: true
         uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
         with:
-          detectorArgs: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff,Poetry=EnableIfDefaultOff,UvLock=EnableIfDefaultOff
+          detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
-      - name: Report non-blocking submission failure
+      - name: Track persistent submission failures
         if: steps.submit_snapshot_attempt_3.outcome == 'failure'
-        run: |
-          echo "::warning title=Dependency submission failed after retries::GitHub dependency snapshot submission appears to be temporarily unavailable; continuing without blocking this workflow."
+        uses: actions/github-script@v8
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const label = process.env.DEPENDENCY_SUBMISSION_TRACKING_LABEL;
+            const failAfter = Number.parseInt(process.env.DEPENDENCY_SUBMISSION_FAIL_AFTER || '0', 10);
+            const runUrl = process.env.RUN_URL;
+            const detectorArgs = process.env.DEPENDENCY_DETECTOR_ARGS;
+            const branchRef = process.env.GITHUB_REF;
+            const workflowName = process.env.GITHUB_WORKFLOW;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const title = 'Dependency submission failures need attention';
+            const searchLabel = `${owner}:${label}`;
+            const issueList = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            });
+            const trackingIssue = issueList.find((issue) => issue.title === title && !issue.pull_request);
+
+            const markerRegex = /<!-- failure-count: (\d+) -->/;
+            let failureCount = 1;
+
+            if (!trackingIssue) {
+              const body = [
+                'Dependency snapshot submission failed after all retries.',
+                '',
+                `- Workflow: \`${workflowName}\``,
+                `- Branch/ref: \`${branchRef}\``,
+                `- Detector args: \`${detectorArgs}\``,
+                `- Run URL: ${runUrl}`,
+                '',
+                'Actionable remediation:',
+                '1. Re-run this workflow to rule out transient Dependency Graph API outages.',
+                '2. Check GitHub status and Actions logs for upstream service interruptions.',
+                '3. Verify token permissions and detector arguments are still valid.',
+                '',
+                '<!-- failure-count: 1 -->',
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                labels: [label],
+                body,
+              });
+            } else {
+              const issueBody = trackingIssue.body || '';
+              const markerMatch = issueBody.match(markerRegex);
+              const currentCount = markerMatch ? Number.parseInt(markerMatch[1], 10) : 0;
+              failureCount = currentCount + 1;
+
+              const nextBody = markerMatch
+                ? issueBody.replace(markerRegex, `<!-- failure-count: ${failureCount} -->`)
+                : `${issueBody}\n<!-- failure-count: ${failureCount} -->`;
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: trackingIssue.number,
+                body: nextBody,
+              });
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: trackingIssue.number,
+                body: [
+                  'Another dependency submission failure was detected after all retries.',
+                  '',
+                  `- Branch/ref: \`${branchRef}\``,
+                  `- Detector args: \`${detectorArgs}\``,
+                  `- Run URL: ${runUrl}`,
+                ].join('\n'),
+              });
+            }
+
+            const summaryLines = [
+              '### Dependency submission retry exhaustion',
+              '',
+              'Dependency snapshot submission failed after all retries. This workflow remains non-blocking for transient outages.',
+              '',
+              `- Branch/ref: \`${branchRef}\``,
+              `- Detector args: \`${detectorArgs}\``,
+              `- Run URL: ${runUrl}`,
+              '',
+              'Actionable remediation:',
+              '1. Re-run this workflow to confirm whether the outage is transient.',
+              '2. Review the action logs and GitHub status for Dependency Graph/API incidents.',
+              '3. Validate detector arguments and repository permissions.',
+            ];
+
+            await core.summary.addRaw(summaryLines.join('\n')).write();
+            core.warning(`Dependency submission failed after retries for ${branchRef}. Run: ${runUrl}`);
+
+            if (failAfter > 0 && failureCount >= failAfter) {
+              core.setFailed(`Dependency submission failed ${failureCount} times (threshold ${failAfter}). See tracking issue label ${searchLabel}.`);
+            }
 
       - name: Confirm non-blocking outcome
         if: always()


### PR DESCRIPTION
### Motivation
- Preserve the workflow's non-blocking retry behavior for transient Dependency Graph/API outages while adding persistent visibility when retries exhaust. 
- Surface actionable context (run URL, branch/ref, detector args) so operators can triage repeated failures without noise. 
- Provide an optional escalation threshold to enable stronger enforcement only after repeated failures.

### Description
- Added `issues: write` permission and job `env` variables `DEPENDENCY_DETECTOR_ARGS`, `DEPENDENCY_SUBMISSION_FAIL_AFTER`, and `DEPENDENCY_SUBMISSION_TRACKING_LABEL` to centralize configuration. 
- Kept the three-attempt submit + backoff flow and replaced the single final warning step with an `actions/github-script@v8` step that creates or updates a labeled tracking issue, maintains a hidden `<!-- failure-count: N -->` marker, appends comments for subsequent failures, and includes `workflow`, `branch/ref`, `detector args`, and `run URL` in issue/comment content. 
- Adds a job summary and workflow annotation for the failure, and optionally calls `core.setFailed(...)` when `DEPENDENCY_SUBMISSION_FAIL_AFTER > 0` and the failure-count threshold is reached.

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` and dependency installation succeeded. 
- Validated YAML syntax with `.venv/bin/python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/dependency-submission.yml').read_text()); print('ok')"` which printed `ok`. 
- Ran `git diff --check` and the repository review notification script `./scripts/review-notify.sh --actor Codex`, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f336fc008326a5989536a43b39d5)