### PR TITLE
ci: make install-hourly venv cache key role-specific

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -64,7 +64,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
+          key: venv-${{ runner.os }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
+          restore-keys: |
+            venv-${{ runner.os }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-
       - name: Validate pyproject dependency ordering
         run: |
           python "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check


### PR DESCRIPTION
### Motivation
- Prevent role-dependent dependencies from leaking between matrix jobs by making the `.venv` cache key role-specific while preserving existing OS, Python version, and dependency-hash inputs.

### Description
- Update `.github/workflows/install-hourly.yml` in the `Cache virtualenv` step to include `${{ matrix.role }}` in the `key` and add a role-scoped `restore-keys` prefix so partial reuse is possible within the same role/Python combination.

### Testing
- Ran `git diff --check` (success) and attempted `./scripts/review-notify.sh --actor Codex` which failed due to missing `.venv` in this environment; the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f33c858083269648550902c0d0e8)