### PR TITLE
ocpp: add memory-profile benchmark for 1-4 GiB device targets

### DIFF
--- a/apps/ocpp/management/commands/benchmark_ocpp_memory.py
+++ b/apps/ocpp/management/commands/benchmark_ocpp_memory.py
@@ -156,31 +156,30 @@ class Command(BaseCommand):
                 stderr=subprocess.PIPE,
                 text=True,
             )
-            process_info = psutil.Process(process.pid)
+            process_info = None
+            try:
+                process_info = psutil.Process(process.pid)
+            except psutil.NoSuchProcess:
+                process_info = None
             peak_rss_bytes = 0
+            stdout = ""
+            stderr = ""
 
             while True:
-                if process.poll() is not None:
-                    break
+                if process_info is not None:
+                    try:
+                        rss = process_info.memory_info().rss
+                    except (psutil.AccessDenied, psutil.NoSuchProcess):
+                        rss = 0
+                    peak_rss_bytes = max(peak_rss_bytes, rss)
+
                 try:
-                    rss = process_info.memory_info().rss
-                except (
-                    psutil.AccessDenied,
-                    psutil.NoSuchProcess,
-                    psutil.ZombieProcess,
-                ):
-                    rss = 0
-                peak_rss_bytes = max(peak_rss_bytes, int(rss))
-                time.sleep(0.1)
+                    stdout, stderr = process.communicate(timeout=0.1)
+                    break
+                except subprocess.TimeoutExpired:
+                    continue
 
-            stdout, stderr = process.communicate()
             duration_seconds = time.monotonic() - start
-
-            try:
-                rss = process_info.memory_info().rss
-            except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
-                rss = 0
-            peak_rss_bytes = max(peak_rss_bytes, int(rss))
 
             return BenchmarkRun(
                 version=version,

--- a/apps/ocpp/management/commands/benchmark_ocpp_memory.py
+++ b/apps/ocpp/management/commands/benchmark_ocpp_memory.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - handled in command execution
+    psutil = None  # type: ignore[assignment]
+
+
+DEFAULT_DEVICE_MEMORY_GB = (1, 2, 3, 4)
+DEFAULT_VERSIONS = ("1.6J", "2.0.1", "2.1")
+
+
+@dataclass
+class BenchmarkRun:
+    device_memory_gb: int
+    duration_seconds: float
+    peak_rss_bytes: int
+    rc: int
+    stderr: str
+    stdout: str
+    version: str
+
+    @property
+    def device_memory_bytes(self) -> int:
+        return self.device_memory_gb * 1024**3
+
+    @property
+    def peak_utilization_percent(self) -> float:
+        if self.device_memory_bytes <= 0:
+            return 0.0
+        return (self.peak_rss_bytes / self.device_memory_bytes) * 100.0
+
+    @property
+    def within_budget(self) -> bool:
+        return self.peak_rss_bytes <= self.device_memory_bytes
+
+    def to_dict(self) -> dict:
+        return {
+            "version": self.version,
+            "device_memory_gb": self.device_memory_gb,
+            "device_memory_bytes": self.device_memory_bytes,
+            "duration_seconds": self.duration_seconds,
+            "peak_rss_bytes": self.peak_rss_bytes,
+            "peak_utilization_percent": self.peak_utilization_percent,
+            "within_budget": self.within_budget,
+            "return_code": self.rc,
+        }
+
+
+class Command(BaseCommand):
+    help = "Benchmark OCPP feature operations under assumed maximum device memory profiles."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--memory-gb",
+            nargs="+",
+            type=int,
+            default=list(DEFAULT_DEVICE_MEMORY_GB),
+            help="Device total memory profiles in GiB (default: 1 2 3 4).",
+        )
+        parser.add_argument(
+            "--versions",
+            nargs="+",
+            default=list(DEFAULT_VERSIONS),
+            choices=("1.6J", "1.6", "2.0.1", "2.1"),
+            help="OCPP coverage versions to benchmark (default: 1.6J 2.0.1 2.1).",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit JSON summary output.",
+        )
+
+    def handle(self, *args, **options):
+        if psutil is None:
+            raise CommandError(
+                "The 'psutil' package is required to run this benchmark."
+            )
+
+        memory_profiles = sorted(set(options["memory_gb"]))
+        if any(value <= 0 for value in memory_profiles):
+            raise CommandError("--memory-gb values must be greater than zero.")
+
+        versions = [
+            "1.6J" if version == "1.6" else version for version in options["versions"]
+        ]
+
+        results: list[BenchmarkRun] = []
+        for version in versions:
+            for memory_gb in memory_profiles:
+                result = self._run_single(version=version, memory_gb=memory_gb)
+                results.append(result)
+
+        payload = {
+            "profiles_gb": memory_profiles,
+            "versions": versions,
+            "runs": [result.to_dict() for result in results],
+        }
+
+        if options["json"]:
+            self.stdout.write(json.dumps(payload, indent=2))
+            return
+
+        self.stdout.write("OCPP memory profile benchmark summary:")
+        for result in results:
+            budget_state = "PASS" if result.within_budget and result.rc == 0 else "FAIL"
+            self.stdout.write(
+                "  "
+                f"version {result.version} @ {result.device_memory_gb} GiB: "
+                f"duration {result.duration_seconds:.2f}s, "
+                f"peak RSS {self._format_bytes(result.peak_rss_bytes)} "
+                f"({result.peak_utilization_percent:.1f}% of device memory) [{budget_state}]"
+            )
+            if result.rc != 0 and result.stderr:
+                self.stdout.write(
+                    self.style.WARNING(f"    stderr: {result.stderr.strip()}")
+                )
+
+    def _run_single(self, *, version: str, memory_gb: int) -> BenchmarkRun:
+        repo_root = Path(settings.BASE_DIR)
+        manage_py = repo_root / "manage.py"
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".json") as json_file,
+            tempfile.NamedTemporaryFile(suffix=".svg") as badge_file,
+        ):
+            command = [
+                sys.executable,
+                str(manage_py),
+                "ocpp",
+                "coverage",
+                "--version",
+                version,
+                "--json-path",
+                json_file.name,
+                "--badge-path",
+                badge_file.name,
+            ]
+
+            start = time.monotonic()
+            process = subprocess.Popen(
+                command,
+                cwd=repo_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            process_info = psutil.Process(process.pid)
+            peak_rss_bytes = 0
+
+            while True:
+                if process.poll() is not None:
+                    break
+                try:
+                    rss = process_info.memory_info().rss
+                except (
+                    psutil.AccessDenied,
+                    psutil.NoSuchProcess,
+                    psutil.ZombieProcess,
+                ):
+                    rss = 0
+                peak_rss_bytes = max(peak_rss_bytes, int(rss))
+                time.sleep(0.1)
+
+            stdout, stderr = process.communicate()
+            duration_seconds = time.monotonic() - start
+
+            try:
+                rss = process_info.memory_info().rss
+            except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+                rss = 0
+            peak_rss_bytes = max(peak_rss_bytes, int(rss))
+
+            return BenchmarkRun(
+                version=version,
+                device_memory_gb=memory_gb,
+                duration_seconds=duration_seconds,
+                peak_rss_bytes=peak_rss_bytes,
+                rc=process.returncode,
+                stderr=stderr,
+                stdout=stdout,
+            )
+
+    def _format_bytes(self, value: int) -> str:
+        if value <= 0:
+            return "0 B"
+        units = ["B", "KiB", "MiB", "GiB", "TiB"]
+        size = float(value)
+        index = 0
+        while size >= 1024 and index < len(units) - 1:
+            size /= 1024
+            index += 1
+        if units[index] == "B":
+            return f"{int(size)} {units[index]}"
+        return f"{size:.1f} {units[index]}"

--- a/apps/ocpp/tests/test_benchmark_ocpp_memory_command.py
+++ b/apps/ocpp/tests/test_benchmark_ocpp_memory_command.py
@@ -1,0 +1,74 @@
+import io
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.ocpp.management.commands import benchmark_ocpp_memory
+from apps.ocpp.management.commands.benchmark_ocpp_memory import BenchmarkRun, Command
+
+
+@pytest.mark.django_db(databases=[])
+def test_benchmark_ocpp_memory_json_output(monkeypatch):
+    run = BenchmarkRun(
+        version="1.6J",
+        device_memory_gb=1,
+        duration_seconds=1.25,
+        peak_rss_bytes=256 * 1024**2,
+        rc=0,
+        stderr="",
+        stdout="ok",
+    )
+
+    def fake_run_single(self, *, version, memory_gb):
+        assert version == "1.6J"
+        assert memory_gb == 1
+        return run
+
+    monkeypatch.setattr(Command, "_run_single", fake_run_single)
+
+    stdout = io.StringIO()
+    call_command(
+        "benchmark_ocpp_memory",
+        "--memory-gb",
+        "1",
+        "--versions",
+        "1.6J",
+        "--json",
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert '"version": "1.6J"' in output
+    assert '"within_budget": true' in output
+
+
+@pytest.mark.django_db(databases=[])
+def test_benchmark_ocpp_memory_rejects_non_positive_profile():
+    with pytest.raises(CommandError):
+        call_command("benchmark_ocpp_memory", "--memory-gb", "0")
+
+
+@pytest.mark.django_db(databases=[])
+def test_benchmark_run_budget_helpers():
+    run = BenchmarkRun(
+        version="2.1",
+        device_memory_gb=2,
+        duration_seconds=2.0,
+        peak_rss_bytes=1024**3,
+        rc=0,
+        stderr="",
+        stdout="",
+    )
+
+    assert run.device_memory_bytes == 2 * 1024**3
+    assert round(run.peak_utilization_percent, 1) == 50.0
+    assert run.within_budget
+
+
+@pytest.mark.django_db(databases=[])
+def test_command_requires_psutil(monkeypatch):
+    monkeypatch.setattr(benchmark_ocpp_memory, "psutil", None)
+
+    with pytest.raises(CommandError):
+        call_command("benchmark_ocpp_memory")

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -17,3 +17,20 @@ The helper script at `scripts/benchmark-suite.sh` runs the full install, start, 
 ```
 
 Each run writes a tab-separated summary to `work/suite-benchmark-<run_id>.log` and echoes a human-readable summary to the terminal. The run ID also flows through to the existing timing instrumentation in `install.sh` and `upgrade.sh` when present, making it easier to correlate detailed timings across files.
+
+## OCPP memory-profile benchmark
+
+Use `benchmark_ocpp_memory` to compare OCPP feature-operation performance against maximum device memory profiles.
+
+```bash
+# Human-readable summary for the default 1/2/3/4 GiB profiles
+.venv/bin/python manage.py benchmark_ocpp_memory
+
+# JSON output for automation pipelines
+.venv/bin/python manage.py benchmark_ocpp_memory \
+  --memory-gb 1 2 3 4 \
+  --versions 1.6J 2.0.1 2.1 \
+  --json
+```
+
+The command runs OCPP coverage operations for each selected version/profile pair, records elapsed runtime and peak RSS, and reports memory utilization as a percentage of each device-memory profile. This models devices where the listed memory value is total system RAM (not dedicated to Arthexis).


### PR DESCRIPTION
### Motivation
- Provide a reproducible benchmark to evaluate OCPP feature performance when the device has limited total RAM (1, 2, 3, and 4 GiB) so operators can validate runtime and peak memory against realistic device constraints. 
- Produce both human-readable and machine-friendly results and avoid mutating repo artifacts during runs by writing coverage outputs to temporary files.

### Description
- Add a new management command `apps/ocpp/management/commands/benchmark_ocpp_memory.py` that runs `manage.py ocpp coverage` as a subprocess while sampling peak RSS with `psutil` and recording elapsed time per (version, device-memory) pair. 
- Command accepts `--memory-gb` (default `1 2 3 4`), `--versions` (default `1.6J 2.0.1 2.1` with `1.6` aliased to `1.6J`), and `--json` to emit structured output, and measures utilization as a percentage of the provided device memory. 
- The implementation uses temporary files for `--json-path` and `--badge-path` to avoid changing repository artifacts during benchmarking and exposes per-run details via a `BenchmarkRun` dataclass with helper properties (`device_memory_bytes`, `peak_utilization_percent`, `within_budget`). 
- Add focused tests in `apps/ocpp/tests/test_benchmark_ocpp_memory_command.py` covering JSON output, validation of non-positive memory profiles, budget math helpers, and missing-`psutil` handling, and document usage in `docs/benchmarking.md`.

### Testing
- Installed dependencies with `./env-refresh.sh --deps-only` and `./.venv/bin/pip install -r requirements-ci.txt` and formatted code with `./.venv/bin/black`. 
- Ran the new tests with `./.venv/bin/python manage.py test run -- apps/ocpp/tests/test_benchmark_ocpp_memory_command.py` which completed successfully (`4 passed`). 
- Executed the command end-to-end with `./.venv/bin/python manage.py benchmark_ocpp_memory --memory-gb 1 --versions 1.6J --json` and verified JSON output was produced and contained expected fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83f778d448326841436258c96f539)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OCPP memory-profile benchmark command that runs coverage across selectable versions and device memory profiles, measures runtime and peak memory, and reports JSON or human-readable summaries with PASS/FAIL per run.

* **Tests**
  * Added tests for output structure, input validation, derived metrics, and behavior when the runtime monitoring dependency is unavailable.

* **Documentation**
  * Added docs with usage examples and CLI options for profiles and versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->