### PR TITLE
docs-sites: collapse markdown tables behind toggle headings

### DIFF
--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -1,11 +1,17 @@
 <script>
   (function () {
     const qrContainer = document.getElementById("reader-qr");
+    const readerContent = document.getElementById("reader-content");
 
     const baseUrlString = (qrContainer && qrContainer.dataset.url) || window.location.href;
     let lastQrUrl = "";
     let activeHeadingId = window.location.hash.replace(/^#/, "");
     let allowImplicitHashUpdates = Boolean(activeHeadingId);
+    const collapseLabel = "{% trans 'Expand table' %}";
+    const expandLabel = "{% trans 'Collapse table' %}";
+    const rowLabelSingular = "{% trans 'row' %}";
+    const rowLabelPlural = "{% trans 'rows' %}";
+    const tableLabel = "{% trans 'Table' %}";
 
     const buildQrUrl = () => {
       try {
@@ -121,8 +127,74 @@
       requestAnimationFrame(selectActiveHeading);
     };
 
+    const getBodyRows = (table) => {
+      const tbody = table.tBodies[0];
+      if (tbody && tbody.rows.length) {
+        return tbody.rows.length;
+      }
+
+      if (table.rows.length > 1) {
+        return table.rows.length - 1;
+      }
+
+      return table.rows.length;
+    };
+
+    const buildTableToggleLabel = (table, rowCount) => {
+      const captionText = table.caption ? table.caption.textContent.trim() : "";
+      const tableName = captionText || tableLabel;
+      const rowLabel = rowCount === 1 ? rowLabelSingular : rowLabelPlural;
+      return `${tableName} (${rowCount} ${rowLabel})`;
+    };
+
+    const enhanceReaderTables = () => {
+      if (!readerContent) {
+        return;
+      }
+
+      const tables = Array.from(readerContent.querySelectorAll("table"));
+      tables.forEach((table, index) => {
+        if (table.dataset.tableToggleReady === "true") {
+          return;
+        }
+
+        const rowCount = getBodyRows(table);
+        const headingButton = document.createElement("button");
+        const tableId = table.id || `reader-table-${index + 1}`;
+        const headingText = buildTableToggleLabel(table, rowCount);
+
+        table.id = tableId;
+        table.classList.add("reader-collapsible-table");
+        table.setAttribute("hidden", "");
+        table.dataset.tableToggleReady = "true";
+
+        headingButton.type = "button";
+        headingButton.className = "reader-table-toggle";
+        headingButton.setAttribute("aria-expanded", "false");
+        headingButton.setAttribute("aria-controls", tableId);
+        headingButton.setAttribute("title", collapseLabel);
+        headingButton.innerHTML = `<span class="reader-table-toggle-text">${headingText}</span><span class="reader-table-toggle-icon" aria-hidden="true">▸</span>`;
+
+        headingButton.addEventListener("click", () => {
+          const expanded = headingButton.getAttribute("aria-expanded") === "true";
+          const nextExpanded = !expanded;
+          headingButton.setAttribute("aria-expanded", String(nextExpanded));
+          headingButton.setAttribute("title", nextExpanded ? expandLabel : collapseLabel);
+
+          if (nextExpanded) {
+            table.removeAttribute("hidden");
+          } else {
+            table.setAttribute("hidden", "");
+          }
+        });
+
+        table.parentNode.insertBefore(headingButton, table);
+      });
+    };
+
     const onReady = () => {
       observeHeadings();
+      enhanceReaderTables();
 
       if (typeof window.QRCode === "undefined") {
         if (qrContainer) {

--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -1,7 +1,6 @@
 <script>
   (function () {
     const qrContainer = document.getElementById("reader-qr");
-    const readerContent = document.getElementById("reader-content");
 
     const baseUrlString = (qrContainer && qrContainer.dataset.url) || window.location.href;
     let lastQrUrl = "";
@@ -129,15 +128,11 @@
 
     const getBodyRows = (table) => {
       const tbody = table.tBodies[0];
-      if (tbody && tbody.rows.length) {
+      if (tbody) {
         return tbody.rows.length;
       }
 
-      if (table.rows.length > 1) {
-        return table.rows.length - 1;
-      }
-
-      return table.rows.length;
+      return Math.max(0, table.rows.length - 1);
     };
 
     const buildTableToggleLabel = (table, rowCount) => {
@@ -148,11 +143,12 @@
     };
 
     const enhanceReaderTables = () => {
-      if (!readerContent) {
+      const container = document.getElementById("reader-content");
+      if (!container) {
         return;
       }
 
-      const tables = Array.from(readerContent.querySelectorAll("table"));
+      const tables = Array.from(container.querySelectorAll("table"));
       tables.forEach((table, index) => {
         if (table.dataset.tableToggleReady === "true") {
           return;
@@ -195,6 +191,20 @@
     const onReady = () => {
       observeHeadings();
       enhanceReaderTables();
+      document.body.addEventListener("htmx:afterSwap", (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+          return;
+        }
+
+        if (
+          target.id === "reader-content" ||
+          target.closest("#reader-content") ||
+          target.querySelector("#reader-content")
+        ) {
+          enhanceReaderTables();
+        }
+      });
 
       if (typeof window.QRCode === "undefined") {
         if (qrContainer) {

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -331,6 +331,47 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
   font-weight: 500;
 }
 
+.markdown-body .reader-collapsible-table[hidden] {
+  display: none !important;
+}
+
+.markdown-body .reader-table-toggle {
+  width: 100%;
+  border: 1px solid var(--bs-border-color-translucent, rgba(108, 117, 125, 0.25));
+  border-radius: 0.85rem;
+  background: var(--bs-body-bg);
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0.25rem 0 0.85rem;
+  padding: 0.65rem 0.9rem;
+  text-align: left;
+}
+
+.markdown-body .reader-table-toggle[aria-expanded='true'] {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body .reader-table-toggle-icon {
+  font-size: 0.9rem;
+  transition: transform 0.2s ease;
+}
+
+.markdown-body .reader-table-toggle[aria-expanded='true'] .reader-table-toggle-icon {
+  transform: rotate(90deg);
+}
+
+.markdown-body .reader-table-toggle[aria-expanded='true'] + .reader-collapsible-table {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 @media (max-width: 991.98px) {
   .markdown-body table {
     display: block;


### PR DESCRIPTION
### Motivation

- Improve the markdown reader UX by collapsing long tables by default and exposing a concise, clickable heading that shows the table row count and expands/collapses the table on demand.

### Description

- Add client-side enhancement in `apps/docs/templates/includes/reader_qr_script.html` that finds markdown-rendered `table` elements, computes a row count, inserts a per-table toggle `button` with `aria-expanded` and `aria-controls`, and leaves each table collapsed (`hidden`) by default while avoiding duplicate work on fragment reloads.
- Compute accessible labels including caption fallback and singular/plural row labels and update button title/expanded state on click to toggle the table display.
- Add styling in `apps/sites/static/pages/css/base.css` for `.reader-table-toggle` and `.reader-collapsible-table[hidden]` to present the toggle control, animate the icon rotation, and preserve table visual appearance when expanded.
- Keep existing QR/heading-observer behavior intact and ensure the enhancement is safe for pages loaded in fragments.

### Testing

- Ran environment setup with `./env-refresh.sh --deps-only` and dependency install with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed the docs test suite with `.venv/bin/python manage.py test run -- apps/docs/tests` and received `2 passed` (all tests passed).
- Ran `./scripts/review-notify.sh --actor Codex` as required by repository review workflow which completed (fallback notification used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83e3bab308326b5d7f6490cee1d34)