### PR TITLE
links: shorten footer reference labels

### DIFF
--- a/apps/links/fixtures/references__reference_11.json
+++ b/apps/links/fixtures/references__reference_11.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://github.com/arthexis/arthexis/blob/main/LICENSE",
-      "alt_text": "ARG 1.0 (The Arthexis Reciprocity License)",
+      "alt_text": "ARG License 1.0",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/fixtures/references__reference_21.json
+++ b/apps/links/fixtures/references__reference_21.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://company.wizards.com/",
-      "alt_text": "Wizards of the Coast",
+      "alt_text": "The Wizards",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/fixtures/references__reference_4.json
+++ b/apps/links/fixtures/references__reference_4.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://www.python.org/",
-      "alt_text": "The Python Foundation",
+      "alt_text": "The Foundation",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/fixtures/references__reference_6.json
+++ b/apps/links/fixtures/references__reference_6.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://openchargealliance.org/protocols/open-charge-point-protocol/",
-      "alt_text": "Open Charge Point Protocol",
+      "alt_text": "Open CP Protocol",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/fixtures/references__reference_8.json
+++ b/apps/links/fixtures/references__reference_8.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://github.com/orgs/arthexis/repositories",
-      "alt_text": "Github repos",
+      "alt_text": "GitHub Repos",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/fixtures/references__reference_8.json
+++ b/apps/links/fixtures/references__reference_8.json
@@ -3,7 +3,7 @@
     "model": "links.reference",
     "fields": {
       "value": "https://github.com/orgs/arthexis/repositories",
-      "alt_text": "GitHub Repositories",
+      "alt_text": "Github repos",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/migrations/0004_shorten_footer_reference_labels.py
+++ b/apps/links/migrations/0004_shorten_footer_reference_labels.py
@@ -17,7 +17,7 @@ FOOTER_REFERENCE_LABEL_RENAMES = [
     (
         "GitHub Repositories",
         "https://github.com/orgs/arthexis/repositories",
-        "Github repos",
+        "GitHub Repos",
     ),
     (
         "ARG 1.0 (The Arthexis Reciprocity License)",
@@ -36,35 +36,37 @@ def shorten_footer_seed_reference_labels(apps, schema_editor) -> None:
     Reference = apps.get_model("links", "Reference")
 
     for old_alt, value, new_alt in FOOTER_REFERENCE_LABEL_RENAMES:
-        old_rows = list(
+        old_seed_rows = list(
             Reference.objects.filter(
                 alt_text=old_alt,
                 value=value,
                 is_seed_data=True,
             ).order_by("pk")
         )
-        new_rows = list(
+        target_rows = list(
             Reference.objects.filter(
                 alt_text=new_alt,
                 value=value,
-                is_seed_data=True,
             ).order_by("pk")
         )
-        if not old_rows and not new_rows:
+        if not old_seed_rows and not target_rows:
             continue
 
-        keep = old_rows[0] if old_rows else new_rows[0]
+        keep = next((row for row in target_rows if not row.is_seed_data), None)
+        if keep is None and old_seed_rows:
+            keep = old_seed_rows[0]
+        if keep is None:
+            keep = target_rows[0]
 
-        duplicate_pks = [row.pk for row in old_rows[1:] + new_rows]
-        if keep.pk in duplicate_pks:
-            duplicate_pks.remove(keep.pk)
+        duplicate_pks = [row.pk for row in old_seed_rows + target_rows if row.pk != keep.pk]
         if duplicate_pks:
             Reference.all_objects.filter(pk__in=duplicate_pks)._raw_delete(
                 schema_editor.connection.alias
             )
 
-        keep.alt_text = new_alt
-        keep.save(update_fields=["alt_text"])
+        if keep.alt_text != new_alt:
+            keep.alt_text = new_alt
+            keep.save(update_fields=["alt_text"])
 
 
 def noop_reverse(apps, schema_editor) -> None:

--- a/apps/links/migrations/0004_shorten_footer_reference_labels.py
+++ b/apps/links/migrations/0004_shorten_footer_reference_labels.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+FOOTER_REFERENCE_LABEL_RENAMES = [
+    (
+        "The Python Foundation",
+        "https://www.python.org/",
+        "The Foundation",
+    ),
+    (
+        "Open Charge Point Protocol",
+        "https://openchargealliance.org/protocols/open-charge-point-protocol/",
+        "Open CP Protocol",
+    ),
+    (
+        "GitHub Repositories",
+        "https://github.com/orgs/arthexis/repositories",
+        "Github repos",
+    ),
+    (
+        "ARG 1.0 (The Arthexis Reciprocity License)",
+        "https://github.com/arthexis/arthexis/blob/main/LICENSE",
+        "ARG License 1.0",
+    ),
+    (
+        "Wizards of the Coast",
+        "https://company.wizards.com/",
+        "The Wizards",
+    ),
+]
+
+
+def shorten_footer_seed_reference_labels(apps, schema_editor) -> None:
+    Reference = apps.get_model("links", "Reference")
+
+    for old_alt, value, new_alt in FOOTER_REFERENCE_LABEL_RENAMES:
+        old_rows = list(
+            Reference.objects.filter(
+                alt_text=old_alt,
+                value=value,
+                is_seed_data=True,
+            ).order_by("pk")
+        )
+        new_rows = list(
+            Reference.objects.filter(
+                alt_text=new_alt,
+                value=value,
+                is_seed_data=True,
+            ).order_by("pk")
+        )
+        if not old_rows and not new_rows:
+            continue
+
+        keep = old_rows[0] if old_rows else new_rows[0]
+
+        duplicate_pks = [row.pk for row in old_rows[1:] + new_rows]
+        if keep.pk in duplicate_pks:
+            duplicate_pks.remove(keep.pk)
+        if duplicate_pks:
+            Reference.all_objects.filter(pk__in=duplicate_pks)._raw_delete(
+                schema_editor.connection.alias
+            )
+
+        keep.alt_text = new_alt
+        keep.save(update_fields=["alt_text"])
+
+
+def noop_reverse(apps, schema_editor) -> None:
+    return None
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("links", "0003_update_footer_reference_seed_keys"),
+    ]
+
+    operations = [
+        migrations.RunPython(shorten_footer_seed_reference_labels, noop_reverse),
+    ]

--- a/apps/links/tests/test_footer_seed_reference_label_migration.py
+++ b/apps/links/tests/test_footer_seed_reference_label_migration.py
@@ -1,0 +1,70 @@
+"""Tests for footer seed reference label shortening migration."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from apps.links.models import Reference
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    ("old_alt_text", "value", "new_alt_text"),
+    [
+        ("The Python Foundation", "https://www.python.org/", "The Foundation"),
+        (
+            "Open Charge Point Protocol",
+            "https://openchargealliance.org/protocols/open-charge-point-protocol/",
+            "Open CP Protocol",
+        ),
+        (
+            "GitHub Repositories",
+            "https://github.com/orgs/arthexis/repositories",
+            "Github repos",
+        ),
+        (
+            "ARG 1.0 (The Arthexis Reciprocity License)",
+            "https://github.com/arthexis/arthexis/blob/main/LICENSE",
+            "ARG License 1.0",
+        ),
+        ("Wizards of the Coast", "https://company.wizards.com/", "The Wizards"),
+    ],
+)
+def test_footer_seed_reference_label_migration_updates_existing_seed_rows(
+    old_alt_text: str,
+    value: str,
+    new_alt_text: str,
+) -> None:
+    migration = importlib.import_module(
+        "apps.links.migrations.0004_shorten_footer_reference_labels"
+    )
+
+    stale = Reference.objects.create(
+        alt_text=old_alt_text,
+        value=value,
+        include_in_footer=True,
+        is_seed_data=True,
+        method="link",
+    )
+    duplicate = Reference.objects.create(
+        alt_text=new_alt_text,
+        value=value,
+        include_in_footer=True,
+        is_seed_data=True,
+        method="link",
+    )
+
+    migration.shorten_footer_seed_reference_labels(
+        apps=type("Apps", (), {"get_model": staticmethod(lambda *_: Reference)}),
+        schema_editor=SimpleNamespace(connection=SimpleNamespace(alias="default")),
+    )
+
+    stale.refresh_from_db()
+    assert stale.alt_text == new_alt_text
+    assert stale.value == value
+    assert not Reference.objects.filter(pk=duplicate.pk).exists()

--- a/apps/links/tests/test_footer_seed_reference_label_migration.py
+++ b/apps/links/tests/test_footer_seed_reference_label_migration.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.django_db
         (
             "GitHub Repositories",
             "https://github.com/orgs/arthexis/repositories",
-            "Github repos",
+            "GitHub Repos",
         ),
         (
             "ARG 1.0 (The Arthexis Reciprocity License)",
@@ -68,3 +68,33 @@ def test_footer_seed_reference_label_migration_updates_existing_seed_rows(
     assert stale.alt_text == new_alt_text
     assert stale.value == value
     assert not Reference.objects.filter(pk=duplicate.pk).exists()
+
+
+def test_footer_seed_reference_label_migration_handles_existing_non_seed_short_label() -> None:
+    migration = importlib.import_module(
+        "apps.links.migrations.0004_shorten_footer_reference_labels"
+    )
+
+    stale_seed = Reference.objects.create(
+        alt_text="GitHub Repositories",
+        value="https://github.com/orgs/arthexis/repositories",
+        include_in_footer=True,
+        is_seed_data=True,
+        method="link",
+    )
+    existing_non_seed = Reference.objects.create(
+        alt_text="GitHub Repos",
+        value="https://github.com/orgs/arthexis/repositories",
+        include_in_footer=True,
+        is_seed_data=False,
+        method="link",
+    )
+
+    migration.shorten_footer_seed_reference_labels(
+        apps=type("Apps", (), {"get_model": staticmethod(lambda *_: Reference)}),
+        schema_editor=SimpleNamespace(connection=SimpleNamespace(alias="default")),
+    )
+
+    assert not Reference.objects.filter(pk=stale_seed.pk).exists()
+    existing_non_seed.refresh_from_db()
+    assert existing_non_seed.alt_text == "GitHub Repos"


### PR DESCRIPTION
### Motivation
- Shorten a set of footer reference labels to more concise wording used in the site footer.
- Ensure existing installations update seeded `links.Reference` rows safely to the new shorter labels and avoid duplicate seed rows.

### Description
- Updated five seed fixtures to use the shorter `alt_text` values for the Python, OCPP, GitHub, ARG license, and Wizards links (fixtures: `references__reference_4.json`, `6.json`, `8.json`, `11.json`, `21.json`).
- Added a data migration `apps/links/migrations/0004_shorten_footer_reference_labels.py` that renames seed rows in-place and deduplicates when both old and new labels exist for the same URL.
- Added tests `apps/links/tests/test_footer_seed_reference_label_migration.py` to verify each rename and the duplicate-cleanup behavior.

### Testing
- Bootstrapped environment dependencies with `./env-refresh.sh --deps-only` and installed CI test requirements with `.venv/bin/pip install -r requirements-ci.txt` (succeeded).
- Ran the migration tests with `.venv/bin/python manage.py test run -- apps/links/tests/test_footer_seed_reference_migration.py apps/links/tests/test_footer_seed_reference_label_migration.py` which completed with all tests passing (`6 passed`).
- Ran the new test file standalone with `.venv/bin/python manage.py test run -- apps/links/tests/test_footer_seed_reference_label_migration.py` which also passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83f0459408326abb77e8648f254b4)