### PR TITLE
ci: capture install-hourly junit artifacts for failure investigation

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -143,13 +143,15 @@ jobs:
           set -Eeuo pipefail
           source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
-          pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 -m "not critical and not slow and not integration" | tee pytest.log
+          pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 --junitxml=pytest-junit.xml -m "not critical and not slow and not integration" | tee pytest.log
       - name: Upload pytest log
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: install-hourly-pytest-log-${{ matrix.role }}
-          path: pytest.log
+          name: install-hourly-pytest-results-${{ matrix.role }}
+          path: |
+            pytest.log
+            pytest-junit.xml
           if-no-files-found: warn
 
   notify_failure:


### PR DESCRIPTION
### Motivation
- The `install (satellite)` matrix job failed in the hourly Install Health Check and the run metadata alone was insufficient to triage the failure because Actions log/artifact downloads require elevated permissions, so structured JUnit output is needed for testcase-level debugging.

### Description
- Add `--junitxml=pytest-junit.xml` to the `Run install smoke tests` step in `.github/workflows/install-hourly.yml` and upload both `pytest.log` and `pytest-junit.xml` as a per-role artifact named `install-hourly-pytest-results-${{ matrix.role }}` without changing which tests are selected.

### Testing
- Inspected the failing run and jobs via the GitHub Actions API, installed required pytest plugins (`pytest-xdist`, `pytest-timeout`, `pytest-django`, `pytest-asyncio`), reproduced the install smoke invocation locally under `ARTHEXIS_ROLE_PRESET=satellite` and confirmed the smoke tests passed (`998 passed, 4 skipped`), and ran `./scripts/review-notify.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83ad0a794832692b1aa692d2e59fa)