### PR TITLE
release: harden promote to stage only release metadata

### DIFF
--- a/apps/release/services/builder.py
+++ b/apps/release/services/builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import shlex
 import shutil
@@ -24,6 +25,14 @@ ARG_LICENSE_NAMES = (
     "Arthexis Reciprocity License 1.0",
 )
 ARG_LICENSE_REF = "LicenseRef-ARG-1.0"
+RELEASE_METADATA_PATHS = (
+    Path("VERSION"),
+    Path("pyproject.toml"),
+)
+RELEASE_FIXTURE_ROOT = Path("apps/core/fixtures")
+RELEASE_FIXTURE_PREFIX = "releases__"
+
+logger = logging.getLogger(__name__)
 
 
 class TestsFailed(ReleaseError):
@@ -211,6 +220,62 @@ def _git_has_staged_changes() -> bool:
     """Return True if there are staged changes ready to commit."""
     proc = subprocess.run(["git", "diff", "--cached", "--quiet"])
     return proc.returncode != 0
+
+
+def _git_staged_paths() -> list[Path]:
+    """Return staged file paths in the current repository."""
+
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(line.strip()) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _git_modified_paths() -> set[Path]:
+    """Return modified or untracked working-tree paths from porcelain output."""
+
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths: set[Path] = set()
+    for line in proc.stdout.splitlines():
+        if not line or line.startswith("##"):
+            continue
+        entry = line[3:].split(" -> ", 1)[-1].strip()
+        if entry:
+            paths.add(Path(entry))
+    return paths
+
+
+def _is_release_metadata_path(path: Path) -> bool:
+    """Return True when ``path`` should be staged for release promotion."""
+
+    if path in RELEASE_METADATA_PATHS:
+        return True
+    try:
+        relative = path.relative_to(RELEASE_FIXTURE_ROOT)
+    except ValueError:
+        return False
+    return (
+        relative.suffix == ".json"
+        and relative.parent == Path(".")
+        and relative.name.startswith(RELEASE_FIXTURE_PREFIX)
+    )
+
+
+def _release_metadata_paths_for_promote() -> tuple[list[Path], list[Path]]:
+    """Return expected and unexpected modified paths for ``promote`` commits."""
+
+    modified = _git_modified_paths()
+    expected = sorted(path for path in modified if _is_release_metadata_path(path))
+    unexpected = sorted(path for path in modified if not _is_release_metadata_path(path))
+    return expected, unexpected
 
 
 def run_tests(
@@ -489,7 +554,21 @@ def promote(
             tag=False,
             stash=stash,
         )
-        _run(["git", "add", "."])  # add all changes
+        expected_paths, unexpected_paths = _release_metadata_paths_for_promote()
+        if unexpected_paths:
+            unexpected = "\n".join(f"- {path.as_posix()}" for path in unexpected_paths)
+            raise ReleaseError(
+                "Unexpected modified files detected during promotion:\n"
+                f"{unexpected}\n"
+                "Clean, commit, or stash these files separately before promoting."
+            )
+
+        if expected_paths:
+            _run(["git", "add", *(path.as_posix() for path in expected_paths)])
+
+        staged_paths = _git_staged_paths()
+        staged_display = ", ".join(path.as_posix() for path in staged_paths) or "(none)"
+        logger.info("Promotion staged files: %s", staged_display)
         if _git_has_staged_changes():
             _run(["git", "commit", "-m", f"Release v{version}"])
     finally:

--- a/apps/release/services/builder.py
+++ b/apps/release/services/builder.py
@@ -237,26 +237,41 @@ def _git_staged_paths() -> list[Path]:
 def _git_modified_paths() -> set[Path]:
     """Return modified or untracked working-tree paths from porcelain output."""
 
+    base_dir = Path.cwd().resolve()
+    ignored_paths = _ignored_working_tree_paths(base_dir)
     proc = subprocess.run(
-        ["git", "status", "--porcelain"],
+        ["git", "status", "--porcelain", "-z"],
         capture_output=True,
-        text=True,
         check=True,
     )
     paths: set[Path] = set()
-    for line in proc.stdout.splitlines():
-        if not line or line.startswith("##"):
+    entries = iter(proc.stdout.split(b"\0"))
+    for entry in entries:
+        if not entry:
             continue
-        entry = line[3:].split(" -> ", 1)[-1].strip()
-        if entry:
-            paths.add(Path(entry))
+        status = entry[:2]
+        path_bytes = entry[3:]
+        if status.startswith((b"R", b"C")):
+            path_bytes = next(entries, b"")
+        if not path_bytes:
+            continue
+
+        path = Path(path_bytes.decode("utf-8", errors="surrogateescape"))
+        with contextlib.suppress(OSError):
+            resolved = (base_dir / path).resolve()
+            if any(
+                resolved == ignored or resolved.is_relative_to(ignored)
+                for ignored in ignored_paths
+            ):
+                continue
+        paths.add(path)
     return paths
 
 
-def _is_release_metadata_path(path: Path) -> bool:
+def _is_release_metadata_path(path: Path, *, metadata_paths: set[Path]) -> bool:
     """Return True when ``path`` should be staged for release promotion."""
 
-    if path in RELEASE_METADATA_PATHS:
+    if path in metadata_paths:
         return True
     try:
         relative = path.relative_to(RELEASE_FIXTURE_ROOT)
@@ -269,12 +284,26 @@ def _is_release_metadata_path(path: Path) -> bool:
     )
 
 
-def _release_metadata_paths_for_promote() -> tuple[list[Path], list[Path]]:
+def _release_metadata_paths_for_promote(package: Package) -> tuple[list[Path], list[Path]]:
     """Return expected and unexpected modified paths for ``promote`` commits."""
 
+    version_path = (
+        Path(package.version_path)
+        if package.version_path
+        else Path("VERSION")
+    )
+    metadata_paths = {*RELEASE_METADATA_PATHS, version_path}
     modified = _git_modified_paths()
-    expected = sorted(path for path in modified if _is_release_metadata_path(path))
-    unexpected = sorted(path for path in modified if not _is_release_metadata_path(path))
+    expected = sorted(
+        path
+        for path in modified
+        if _is_release_metadata_path(path, metadata_paths=metadata_paths)
+    )
+    unexpected = sorted(
+        path
+        for path in modified
+        if not _is_release_metadata_path(path, metadata_paths=metadata_paths)
+    )
     return expected, unexpected
 
 
@@ -554,7 +583,7 @@ def promote(
             tag=False,
             stash=stash,
         )
-        expected_paths, unexpected_paths = _release_metadata_paths_for_promote()
+        expected_paths, unexpected_paths = _release_metadata_paths_for_promote(package)
         if unexpected_paths:
             unexpected = "\n".join(f"- {path.as_posix()}" for path in unexpected_paths)
             raise ReleaseError(

--- a/apps/release/tests/test_release_command.py
+++ b/apps/release/tests/test_release_command.py
@@ -8,7 +8,13 @@ from types import SimpleNamespace
 import pytest
 
 from apps.release import DEFAULT_PACKAGE
-from apps.release.services.builder import _pep639_license_metadata, build, promote
+from apps.release.services.builder import (
+    _git_modified_paths,
+    _pep639_license_metadata,
+    _release_metadata_paths_for_promote,
+    build,
+    promote,
+)
 from apps.release.services.models import Credentials, ReleaseError
 
 
@@ -107,7 +113,7 @@ def test_promote_stages_only_release_metadata_files(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr("apps.release.services.builder.build", lambda **kwargs: None)
     monkeypatch.setattr(
         "apps.release.services.builder._release_metadata_paths_for_promote",
-        lambda: (metadata_paths, []),
+        lambda package: (metadata_paths, []),
     )
     monkeypatch.setattr(
         "apps.release.services.builder._git_staged_paths",
@@ -142,7 +148,7 @@ def test_promote_fails_when_unexpected_modified_files_exist(
     monkeypatch.setattr("apps.release.services.builder.build", lambda **kwargs: None)
     monkeypatch.setattr(
         "apps.release.services.builder._release_metadata_paths_for_promote",
-        lambda: ([Path("VERSION")], [Path("README.tmp"), Path("apps/release/tests/test_x.py")]),
+        lambda package: ([Path("VERSION")], [Path("README.tmp"), Path("apps/release/tests/test_x.py")]),
     )
     monkeypatch.setattr(
         "apps.release.services.builder._run",
@@ -158,3 +164,41 @@ def test_promote_fails_when_unexpected_modified_files_exist(
     assert "- apps/release/tests/test_x.py" in message
     assert "Clean, commit, or stash these files separately before promoting." in message
     assert ("git", "add", "VERSION") not in commands
+
+
+def test_release_metadata_paths_for_promote_uses_package_version_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promotion metadata should include package-specific version files."""
+
+    package = SimpleNamespace(version_path="apps/pkg/VERSION")
+    modified = {Path("apps/pkg/VERSION"), Path("pyproject.toml"), Path("README.md")}
+    monkeypatch.setattr("apps.release.services.builder._git_modified_paths", lambda: modified)
+
+    expected, unexpected = _release_metadata_paths_for_promote(package)
+
+    assert expected == [Path("apps/pkg/VERSION"), Path("pyproject.toml")]
+    assert unexpected == [Path("README.md")]
+
+
+def test_git_modified_paths_handles_rename_and_ignored_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Modified path detection should parse NUL porcelain and ignore runtime artifacts."""
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ARTHEXIS_LOG_DIR", str(tmp_path / "runtime-logs"))
+    stdout = (
+        b" M pyproject.toml\0"
+        b"R  old/name.txt\0new/name -> value.txt\0"
+        b"?? runtime-logs/app.log\0"
+        b"?? logs/release.log\0"
+    )
+
+    def fake_run(cmd, capture_output=True, check=True):
+        assert cmd == ["git", "status", "--porcelain", "-z"]
+        return SimpleNamespace(stdout=stdout)
+
+    monkeypatch.setattr("apps.release.services.builder.subprocess.run", fake_run)
+
+    assert _git_modified_paths() == {Path("pyproject.toml"), Path("new/name -> value.txt")}

--- a/apps/release/tests/test_release_command.py
+++ b/apps/release/tests/test_release_command.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from apps.release import DEFAULT_PACKAGE
-from apps.release.services.builder import _pep639_license_metadata, build
-from apps.release.services.models import Credentials
+from apps.release.services.builder import _pep639_license_metadata, build, promote
+from apps.release.services.models import Credentials, ReleaseError
 
 
 def test_builder_release_uploads_before_pushing_git_state(
@@ -90,3 +91,70 @@ def test_pep639_license_metadata_handles_current_and_legacy_arg_names(
         assert metadata["license-files"] == ["LICENSE"]
     else:
         assert "license-files" not in metadata
+
+
+def test_promote_stages_only_release_metadata_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Promotion should stage known metadata paths and avoid blanket staging."""
+
+    commands: list[tuple[str, ...]] = []
+    metadata_paths = [
+        Path("VERSION"),
+        Path("apps/core/fixtures/releases__packagerelease_1_2_3.json"),
+        Path("pyproject.toml"),
+    ]
+
+    monkeypatch.setattr("apps.release.services.builder._git_clean", lambda: True)
+    monkeypatch.setattr("apps.release.services.builder.build", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "apps.release.services.builder._release_metadata_paths_for_promote",
+        lambda: (metadata_paths, []),
+    )
+    monkeypatch.setattr(
+        "apps.release.services.builder._git_staged_paths",
+        lambda: metadata_paths,
+    )
+    monkeypatch.setattr("apps.release.services.builder._git_has_staged_changes", lambda: True)
+    monkeypatch.setattr(
+        "apps.release.services.builder._run",
+        lambda cmd, check=True, cwd=None: commands.append(tuple(cmd)) or SimpleNamespace(),
+    )
+
+    promote(version="1.2.3")
+
+    assert ("git", "add", ".") not in commands
+    assert (
+        "git",
+        "add",
+        "VERSION",
+        "apps/core/fixtures/releases__packagerelease_1_2_3.json",
+        "pyproject.toml",
+    ) in commands
+
+
+def test_promote_fails_when_unexpected_modified_files_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promotion should fail when unrelated working-tree edits are present."""
+
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr("apps.release.services.builder._git_clean", lambda: True)
+    monkeypatch.setattr("apps.release.services.builder.build", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "apps.release.services.builder._release_metadata_paths_for_promote",
+        lambda: ([Path("VERSION")], [Path("README.tmp"), Path("apps/release/tests/test_x.py")]),
+    )
+    monkeypatch.setattr(
+        "apps.release.services.builder._run",
+        lambda cmd, check=True, cwd=None: commands.append(tuple(cmd)) or SimpleNamespace(),
+    )
+
+    with pytest.raises(ReleaseError) as exc_info:
+        promote(version="1.2.3")
+
+    message = str(exc_info.value)
+    assert "Unexpected modified files detected during promotion:" in message
+    assert "- README.tmp" in message
+    assert "- apps/release/tests/test_x.py" in message
+    assert "Clean, commit, or stash these files separately before promoting." in message
+    assert ("git", "add", "VERSION") not in commands


### PR DESCRIPTION
### Motivation

- Avoid a blanket `git add .` in `promote()` which can accidentally stage unrelated working-tree edits.  
- Ensure release commits only include explicit release metadata (VERSION, `pyproject.toml`, and release fixtures) so release history is auditable.  
- Fail early with a clear message when unexpected modified files are present so callers can clean/stash/commit unrelated changes separately.

### Description

- Introduce release metadata constants and helpers: `RELEASE_METADATA_PATHS`, `RELEASE_FIXTURE_ROOT`, `_git_staged_paths()`, `_git_modified_paths()`, `_is_release_metadata_path()` and `_release_metadata_paths_for_promote()` to classify modified files for promotion.  
- Replace the blanket staging in `promote()` with explicit staging of the computed expected metadata files, log the exact staged file list via `logger.info(...)`, and raise `ReleaseError` if unexpected modified files exist.  
- Preserve existing stash/pop behavior when `stash=True` and only commit when there are staged changes.  
- Add regression tests in `apps/release/tests/test_release_command.py` to verify that `promote()` only stages release metadata and that it fails when unrelated modified files are present.

### Testing

- Prepared environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`.  
- Ran the targeted test module with `.venv/bin/python manage.py test run -- apps/release/tests/test_release_command.py`.  
- Result: tests passed (`6 passed`), and the new promotion tests verified the intended behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d850558dc083268efc30765e355767)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion now stages only specific release metadata files instead of all changes, reducing risk of unintended commits.
  * Added validation to detect unexpected modified files during promotion and raise an error with affected file details.
  * Improved commit behavior to only proceed when staged changes exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->