### PR TITLE
docs: standardize Test Execution interpreter examples in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@ Agents must run relevant tests after code changes.
 * Execute tests and **fix errors introduced by changes**.
 * Prefer validated repository entrypoints over ad-hoc interpreter calls. Run `./env-refresh.sh --deps-only` before Django or pytest commands when the environment may be unbootstrapped.
 * Use `.venv/bin/python` (or the repo's validated wrapper/management entrypoints) instead of bare `python` when invoking `manage.py` or `pytest` directly.
-* Prefer `python manage.py test run -- ...` and `python manage.py migrations check` over raw `python -m pytest` / `makemigrations --check` when those entrypoints cover the task.
+* Prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check` over raw `.venv/bin/python -m pytest` / `.venv/bin/python manage.py makemigrations --check` when those entrypoints cover the task.
+* If `.venv/bin/python` is unavailable, use the repository's validated wrapper or management entrypoint.
 * Avoid creating tests for **micro-behaviors** unless:
 
   * they are security-relevant, or


### PR DESCRIPTION
### Motivation

* Ensure Test Execution examples consistently recommend the repository interpreter wrapper and remove bare-`python` examples in favor of the canonical `.venv/bin/python` form.

### Description

* Updated the **Testing Policy → Test Execution** guidance to prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check`, and added a short fallback note to use the repository's validated wrapper when `.venv/bin/python` is unavailable.

### Testing

* Ran `rg -n "python manage.py|python -m pytest" AGENTS.md` to verify the examples were updated successfully (succeeded).; attempted `./scripts/review-notify.sh --actor Codex` to trigger review notification but it failed with `Virtual environment not found. Run ./install.sh first.` (expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85429640883268b4c0d66fc1be821)