### PR TITLE
docs: clarify new-app scaffold and structure policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,20 @@ curl https://api.github.com/repos/<org>/<repo>/issues
 When new apps are created:
 
 * Always create the **admin configuration** for the app using suite commands.
+* Use the canonical scaffold commands:
+
+  * `.venv/bin/python manage.py create app <app_name>`
+  * `.venv/bin/python manage.py create app <app_name> --backend-only`
+* Every new app must include `manifest.py`.
+* Backend-only apps that intentionally omit `views.py`, `urls.py`, and `routes.py` must include this marker comment:
+
+  * `# APP_STRUCTURE: backend-only (intentionally omits views.py, urls.py, and routes.py)`
+* Web-capable apps should include `views.py`, `urls.py`, and `routes.py` unless they are intentionally backend-only.
 * Prefer short application names, ideally a single word whenever possible.
+* Follow and keep this policy aligned with:
+
+  * `docs/development/create-local-app.md`
+  * `docs/development/app-structure-policy.md`
 
 ## Retiring legacy apps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ curl https://api.github.com/repos/<org>/<repo>/issues
 When new apps are created:
 
 * Always create the **admin configuration** for the app using suite commands.
+* Prefer short application names, ideally a single word whenever possible.
 * Use the canonical scaffold commands:
 
   * `.venv/bin/python manage.py create app <app_name>`
@@ -60,7 +61,6 @@ When new apps are created:
 
   * `# APP_STRUCTURE: backend-only (intentionally omits views.py, urls.py, and routes.py)`
 * Web-capable apps should include `views.py`, `urls.py`, and `routes.py` unless they are intentionally backend-only.
-* Prefer short application names, ideally a single word whenever possible.
 * Follow and keep this policy aligned with:
 
   * `docs/development/create-local-app.md`


### PR DESCRIPTION
### Motivation

* Make the repository's expectations for creating new Django apps explicit so agents and developers follow the same scaffold and app-structure conventions.
* Reduce drift between automated agent behavior and the suite's actual app-generation workflow by codifying the canonical commands and required artifacts.
* Prevent accidental omission of important files by requiring `manifest.py` and an explicit marker for backend-only apps.

### Description

* Added the canonical scaffold commands for app creation: `.venv/bin/python manage.py create app <app_name>` and `.venv/bin/python manage.py create app <app_name> --backend-only`.
* Require `manifest.py` to be present in every new app and require the backend-only marker comment when `views.py`, `urls.py`, and `routes.py` are intentionally omitted.
* Specified the exact marker comment: `# APP_STRUCTURE: backend-only (intentionally omits views.py, urls.py, and routes.py)`.
* Clarified that web-capable apps should include `views.py`, `urls.py`, and `routes.py` unless intentionally backend-only, and linked the policy to `docs/development/create-local-app.md` and `docs/development/app-structure-policy.md`.

### Testing

* Ran the repository review notifier `./scripts/review-notify.sh --actor Codex`, which failed due to a missing virtual environment (`Virtual environment not found. Run ./install.sh first.`).
* No additional automated tests (pytest or Django test/migrations checks) were executed in this rollout due to the missing environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d854b5f9d8832697550cb26b86842c)