### PR TITLE
docs: clarify explicit .venv manage.py commands in AGENTS Test Execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,8 @@ Agents must run relevant tests after code changes.
 * Execute tests and **fix errors introduced by changes**.
 * Prefer validated repository entrypoints over ad-hoc interpreter calls. Run `./env-refresh.sh --deps-only` before Django or pytest commands when the environment may be unbootstrapped.
 * Use `.venv/bin/python` (or the repo's validated wrapper/management entrypoints) instead of bare `python` when invoking `manage.py` or `pytest` directly.
-* Prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check` over raw `.venv/bin/python -m pytest` / `.venv/bin/python manage.py makemigrations --check` when those entrypoints cover the task.
+* Prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check` when those entrypoints cover the task.
+* Use `.venv/bin/python manage.py ...` for development and test workflows; use `./command.sh ...` only for operator-facing runtime actions when applicable.
 * If `.venv/bin/python` is unavailable, use the repository's validated wrapper or management entrypoint.
 * Avoid creating tests for **micro-behaviors** unless:
 


### PR DESCRIPTION
### Motivation

* Remove ambiguity around using bare `python` in the Testing Policy and align the Test Execution examples with the repository's explicit `.venv` command-style convention.

### Description

* Updated `AGENTS.md` Test Execution guidance to prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check` and removed the ambiguous reference to bare `python` usage.
* Added a concise command-style sentence recommending `Use .venv/bin/python manage.py ...` for development/test workflows and `./command.sh ...` only for operator-facing runtime actions.

### Testing

* Displayed the updated section with `nl -ba AGENTS.md | sed -n '126,140p'`, which showed the new wording as expected.
* Ran `./scripts/review-notify.sh --actor Codex`, which failed due to a missing virtual environment with the message `Virtual environment not found. Run ./install.sh first.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d860d5cb8c8326ad8a155c93768316)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and testing workflow guidelines to clarify preferred practices for development/test workflows and runtime operations, establishing clearer team standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->