### PR TITLE
core-reports: handle release validation command timeouts in publish gate

### DIFF
--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -325,6 +325,72 @@ def test_step_run_tests_executes_configured_validation_command(
     assert "tests_verified_at" in ctx
 
 
+def test_step_run_tests_passes_configured_timeout_to_subprocess_run(
+    monkeypatch, settings, tmp_path: Path
+):
+    ctx: dict[str, object] = {}
+    settings.RELEASE_PUBLISH_VALIDATION_COMMAND = "echo release tests ok"
+    settings.RELEASE_PUBLISH_VALIDATION_TIMEOUT_SECONDS = 42
+    call: dict[str, object] = {}
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command, **kwargs):
+        call["command"] = command
+        call["kwargs"] = kwargs
+        return Completed()
+
+    monkeypatch.setattr(pipeline.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        pipeline,
+        "_append_log",
+        lambda *_args, **_kwargs: None,
+    )
+
+    pipeline._step_run_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert call["command"] == ["echo", "release", "tests", "ok"]
+    assert call["kwargs"]["timeout"] == 42
+    assert ctx["tests_result"]["success"] is True
+
+
+def test_step_run_tests_records_timeout_result_and_logs_gate_failure(
+    monkeypatch, settings, tmp_path: Path
+):
+    ctx: dict[str, object] = {}
+    settings.RELEASE_PUBLISH_VALIDATION_COMMAND = "echo timeout"
+    settings.RELEASE_PUBLISH_VALIDATION_TIMEOUT_SECONDS = 15
+    logged_messages: list[str] = []
+
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=command, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(pipeline.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        pipeline,
+        "_append_log",
+        lambda _path, message: logged_messages.append(message),
+    )
+
+    with pytest.raises(PublishPending):
+        pipeline._step_run_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert ctx["paused"] is True
+    assert ctx["tests_result"] == {
+        "success": False,
+        "reason": "timeout",
+        "source": "pipeline_command",
+        "timeout_seconds": 15,
+    }
+    assert "echo timeout" in ctx["error"]
+    assert "15 seconds" in ctx["error"]
+    assert any("timeout=15s" in message for message in logged_messages)
+    assert any("timed out after 15 seconds" in message for message in logged_messages)
+
+
 def test_step_confirm_pypi_trusted_publisher_settings_validates_expected_workflow_metadata(
     monkeypatch, tmp_path: Path
 ):

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -121,6 +121,8 @@ EXPECTED_PUBLISH_WORKFLOW_FILE = "publish.yml"
 EXPECTED_PUBLISH_REF_PATTERN = "refs/tags/v*"
 EXPECTED_PUBLISH_ENVIRONMENT = "pypi"
 RELEASE_VALIDATION_COMMAND_SETTING = "RELEASE_PUBLISH_VALIDATION_COMMAND"
+RELEASE_VALIDATION_TIMEOUT_SETTING = "RELEASE_PUBLISH_VALIDATION_TIMEOUT_SECONDS"
+DEFAULT_RELEASE_VALIDATION_TIMEOUT_SECONDS = 900
 
 
 def _resolve_github_token(
@@ -1547,8 +1549,42 @@ def _step_run_tests(release, ctx, log_path: Path, *, user=None) -> None:
         )
 
     command = _normalize_validation_command(validation_command)
-    _append_log(log_path, f"Running release validation command: {shlex.join(command)}")
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    command_text = shlex.join(command)
+    configured_timeout = int(
+        getattr(
+            settings,
+            RELEASE_VALIDATION_TIMEOUT_SETTING,
+            DEFAULT_RELEASE_VALIDATION_TIMEOUT_SECONDS,
+        )
+    )
+    _append_log(
+        log_path,
+        "Running release validation command: "
+        f"{command_text} (timeout={configured_timeout}s)",
+    )
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=configured_timeout,
+        )
+    except subprocess.TimeoutExpired:
+        ctx["tests_command"] = command_text
+        ctx["tests_result"] = {
+            "success": False,
+            "reason": "timeout",
+            "source": "pipeline_command",
+            "timeout_seconds": configured_timeout,
+        }
+        _fail_release_gate(
+            ctx,
+            log_path,
+            "Release test gate failed: configured validation command "
+            f"'{command_text}' timed out after {configured_timeout} seconds. "
+            "Fix the stalled tests and rerun the step.",
+        )
     if result.stdout.strip():
         _append_log(log_path, "Validation command stdout:\n" + result.stdout.strip())
     if result.stderr.strip():
@@ -1562,7 +1598,7 @@ def _step_run_tests(release, ctx, log_path: Path, *, user=None) -> None:
         )
 
     ctx["tests_verified_at"] = timezone.now().isoformat()
-    ctx["tests_command"] = shlex.join(command)
+    ctx["tests_command"] = command_text
     ctx["tests_result"] = {
         "success": True,
         "returncode": result.returncode,


### PR DESCRIPTION
### Motivation

- Prevent the release validation step from hanging indefinitely by bounding the configured validation command with a timeout and making timeout failures auditable.

### Description

- Add `RELEASE_PUBLISH_VALIDATION_TIMEOUT_SECONDS` (setting name) and `DEFAULT_RELEASE_VALIDATION_TIMEOUT_SECONDS = 900` and read the configured timeout in `_step_run_tests`.
- Pass the configured timeout to `subprocess.run(..., timeout=...)`, include the timeout in the validation log, and use a normalized `command_text` for stored command context (`ctx["tests_command"]`).
- Catch `subprocess.TimeoutExpired` in `_step_run_tests`, fail via `_fail_release_gate(...)` with a clear message that includes the configured command and timeout, and record the timeout outcome in `ctx["tests_result"]` (for example `{"success": False, "reason": "timeout", "timeout_seconds": ...}`).
- Add/modify regression tests under `apps/core/tests/reports/` to cover timeout propagation into `subprocess.run`, timeout failure behavior, context updates, and log message expectations.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI test dependencies with `./venv/bin/pip install -r requirements-ci.txt` to enable tests.
- Ran the release-publish regression test module with `./.venv/bin/python manage.py test run -- apps/core/tests/reports/test_release_publish_regressions.py` and observed all tests in that module pass (`19 passed`).
- Ran the repository review notifier `./scripts/review-notify.sh --actor Codex` as part of the change workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86d4a04c48326822508fb5273bcab)