### PR TITLE
Retarget seeded operator journey to Site Operator

### DIFF
--- a/apps/ops/migrations/0007_retarget_seeded_operator_journey_to_site_operator.py
+++ b/apps/ops/migrations/0007_retarget_seeded_operator_journey_to_site_operator.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+SITE_OPERATOR_GROUP_NAME = "Site Operator"
+SEEDED_JOURNEY_SLUG = "operator-node-readiness"
+
+
+def retarget_seeded_journey_to_site_operator(apps, schema_editor):
+    """Assign the seeded operator node readiness journey to Site Operator."""
+
+    SecurityGroup = apps.get_model("groups", "SecurityGroup")
+    OperatorJourney = apps.get_model("ops", "OperatorJourney")
+
+    site_operator_group, _ = SecurityGroup.objects.get_or_create(name=SITE_OPERATOR_GROUP_NAME)
+    OperatorJourney.objects.filter(
+        slug=SEEDED_JOURNEY_SLUG,
+        is_seed_data=True,
+    ).update(security_group=site_operator_group)
+
+
+def noop_reverse(apps, schema_editor):
+    """Leave journey ownership unchanged when reversing this migration."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ops", "0006_seed_operator_journey_first_step"),
+    ]
+
+    operations = [
+        migrations.RunPython(retarget_seeded_journey_to_site_operator, noop_reverse),
+    ]

--- a/apps/ops/tests/test_seeded_operator_journey.py
+++ b/apps/ops/tests/test_seeded_operator_journey.py
@@ -1,0 +1,32 @@
+"""Regression tests for seeded operator journey ownership defaults."""
+
+from importlib import import_module
+
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+from apps.groups.models import SecurityGroup
+from apps.ops.models import OperatorJourney
+
+migration_module = import_module(
+    "apps.ops.migrations.0007_retarget_seeded_operator_journey_to_site_operator"
+)
+
+
+class SeededOperatorJourneyTests(TestCase):
+    """Ensure seeded operator journey ownership retargets to Site Operator."""
+
+    def test_retarget_seeded_operator_journey_to_site_operator(self):
+        network_operator_group = SecurityGroup.objects.create(name="Network Operator")
+        OperatorJourney.objects.create(
+            name="Operator Node Readiness",
+            slug="operator-node-readiness",
+            security_group=network_operator_group,
+            is_active=True,
+            is_seed_data=True,
+        )
+
+        migration_module.retarget_seeded_journey_to_site_operator(django_apps, None)
+
+        journey = OperatorJourney.objects.get(slug="operator-node-readiness")
+        self.assertEqual(journey.security_group.name, "Site Operator")


### PR DESCRIPTION
### Motivation

- Ensure the seeded operator journey `operator-node-readiness` is owned by the "Site Operator" security group instead of its previous owner so seeded data reflects current ownership policy.

### Description

- Add migration `0007_retarget_seeded_operator_journey_to_site_operator.py` which finds the seeded `OperatorJourney` with slug `operator-node-readiness` and updates its `security_group` to the `Site Operator` `SecurityGroup` using a `RunPython` operation.
- Provide a no-op reverse function so the migration does not change ownership when reversed and declare a dependency on `0006_seed_operator_journey_first_step`.
- Add a unit test `apps.ops.tests.test_seeded_operator_journey.SeededOperatorJourneyTests.test_retarget_seeded_operator_journey_to_site_operator` that creates a `Network Operator` group and a seeded `OperatorJourney`, invokes the migration function, and asserts the journey's `security_group` is `Site Operator`.

### Testing

- Added the unit test `apps.ops.tests.test_seeded_operator_journey.SeededOperatorJourneyTests.test_retarget_seeded_operator_journey_to_site_operator` which exercises the migration function and assertion logic.
- Ran the Django test for the new case with `./manage.py test apps.ops.tests.test_seeded_operator_journey` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86b61b4888326b76d190dd6542c25)