### PR TITLE
docs(release): align release package options with current models

### DIFF
--- a/docs/development/release-package-options.md
+++ b/docs/development/release-package-options.md
@@ -1,20 +1,37 @@
 # Release Package Configuration
 
-The release workflow reads package metadata from `apps.core.release.Package` instances.
-Administrators can override the default behavior through the `apps.core.Package`
-model, which now exposes additional optional fields:
+The release workflow reads package metadata from `apps.release.models.Package`
+instances and converts them to the runtime release dataclass
+`apps.release.services.models.Package` via `Package.to_package()`.
+Administrators can override the default behavior through the
+`apps.release.models.Package` model fields:
 
 - **Version path** – relative path to the version file that should be updated
-  during a build. When left blank the release process uses the repository root
-  `VERSION` file.
+  during a build (`version_path`). When left blank, the release process uses the
+  repository root `VERSION` file.
 - **Dependencies path** – relative path to the requirements file used while
-  generating the temporary `pyproject.toml`. Defaults to `requirements.txt`
-  when the field is empty.
-- **Test command** – custom command executed when the `build` helper runs the
-  test suite. The command is parsed with `shlex.split` and executed via
-  `subprocess.run`. When unset, the workflow runs `.venv/bin/python manage.py test`.
+  generating the temporary `pyproject.toml` (`dependencies_path`). Defaults to
+  `requirements.txt` when the field is empty.
+- **Test command** – custom command executed when the release build runs the
+  test suite (`test_command`). The command is parsed with `shlex.split` and
+  executed via `subprocess.run`. When unset, the workflow runs
+  `.venv/bin/python manage.py test`.
 
 These settings allow packaging projects with non-standard layouts without
 modifying the release tooling. Every value is optional, so existing packages
 continue to behave exactly as before. To update the settings, edit the package
 record in the Django admin and provide the appropriate paths or command.
+
+## Where this is used
+
+- `apps/release/management/commands/release.py`:
+  `release build` resolves a package selection and passes the package to the
+  release build pipeline.
+- `apps/release/services/builder.py`:
+  `build()` reads `package.version_path`, `package.dependencies_path`, and
+  `package.test_command` to perform version updates, dependency loading, and
+  test execution.
+- `apps/release/models/package.py`:
+  `Package.to_package()` maps Django model fields to the runtime
+  `apps.release.services.models.Package` object consumed by the build/publish
+  workflow.

--- a/docs/development/release-package-options.md
+++ b/docs/development/release-package-options.md
@@ -15,7 +15,7 @@ Administrators can override the default behavior through the
 - **Test command** – custom command executed when the release build runs the
   test suite (`test_command`). The command is parsed with `shlex.split` and
   executed via `subprocess.run`. When unset, the workflow runs
-  `.venv/bin/python manage.py test`.
+  `python manage.py test` using the current Python interpreter.
 
 These settings allow packaging projects with non-standard layouts without
 modifying the release tooling. Every value is optional, so existing packages


### PR DESCRIPTION
### Motivation

- Replace stale `apps.core.*` references in release docs with the actual runtime model paths and ensure documentation matches the current release build code.
- Make the document explicit about the exact model fields used by the build/publish pipeline so administrators can reliably configure package records.

### Description

- Updated `docs/development/release-package-options.md` to reference `apps.release.models.Package` and the runtime dataclass `apps.release.services.models.Package` and to state the conversion through `Package.to_package()`.
- Documented the exact field names used by the release pipeline: `version_path`, `dependencies_path`, and `test_command`, and clarified their default behaviors.
- Added a short "Where this is used" section pointing to `apps/release/management/commands/release.py`, `apps/release/services/builder.py`, and `apps/release/models/package.py` for traceability.

### Testing

- Reviewed relevant implementation files with `rg`/`sed` to confirm the fields and code paths (`apps/release/models/package.py`, `apps/release/services/models.py`, and `apps/release/services/builder.py`) and found matching names and behavior (success).
- Ran repository checks `git diff --check` and `git status` and committed the documentation change (success).
- Attempted to run the review notifier `./scripts/review-notify.sh --actor Codex`, but it failed due to a missing virtual environment (`Virtual environment not found. Run ./install.sh first.`), so no virtualenv-backed CI hooks were executed (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86d6053208326a22f98a068e032e6)