### PR TITLE
ci: serialize publish workflow and preflight PyPI version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -128,6 +132,50 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
+      - name: Preflight PyPI version availability
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from urllib.error import HTTPError, URLError
+          from urllib.request import urlopen
+
+          package_name = "arthexis"
+          package_version = Path("VERSION").read_text(encoding="utf-8").strip()
+          pypi_url = f"https://pypi.org/pypi/{package_name}/json"
+
+          try:
+              with urlopen(pypi_url, timeout=15) as response:
+                  payload = json.load(response)
+          except HTTPError as exc:
+              if exc.code == 404:
+                  payload = {"releases": {}}
+              else:
+                  raise SystemExit(
+                      "Release publish blocked: unable to verify existing PyPI versions "
+                      f"(HTTP {exc.code} from {pypi_url}). "
+                      "Check Arthexis release UI/headless logs, then rerun intentionally."
+                  ) from exc
+          except URLError as exc:
+              raise SystemExit(
+                  "Release publish blocked: network failure while checking PyPI for an existing release "
+                  f"({exc.reason}). Check Arthexis release UI/headless logs, then rerun intentionally."
+              ) from exc
+
+          releases = payload.get("releases", {})
+          if package_version in releases:
+              raise SystemExit(
+                  f"Release publish blocked: {package_name} {package_version} is already available on PyPI. "
+                  "Use a new VERSION/tag before publishing again, and confirm the rerun intent in "
+                  "Arthexis release UI/headless logs for traceability."
+              )
+
+          print(
+              f"Preflight passed: {package_name} {package_version} is not yet published on PyPI; "
+              "continuing with build and publish workflow."
+          )
+          PY
 
       - name: Install build backend
         run: |


### PR DESCRIPTION
### Motivation
- Prevent concurrent/competing publish runs for the same tag/ref and enforce deterministic serialization of release workflows. 
- Fail fast when a release `VERSION` is already present on PyPI to avoid wasted build/publish work and confusing duplicate publishes. 
- Give operators an actionable, traceable failure message that points them back to Arthexis release UI/headless logs so reruns are intentional.

### Description
- Added workflow-level `concurrency` to `.github/workflows/publish.yml` with group key `${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: false` to serialize publish runs. 
- Inserted a `Preflight PyPI version availability` step in the `build` job that reads `VERSION`, queries `https://pypi.org/pypi/<package>/json`, and fails early if the version already exists. 
- Adjusted failure messages to explicitly reference checking Arthexis release UI/headless logs to confirm rerun intent and to provide clearer operator guidance.

### Testing
- Loaded `.github/workflows/publish.yml` with PyYAML using `python` and `yaml.safe_load` and confirmed the top-level `concurrency` key is present (pass). 
- Ran `./scripts/review-notify.sh --actor Codex` as required by repository policy and observed it report `Virtual environment not found. Run ./install.sh first.`, which prevented notification (informational failure). 
- Verified the new `Preflight PyPI version availability` step is present before the build steps in `build` job by inspecting the updated workflow file (manual inspection via repository tools succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86d59c59c83268a78f211a5aea463)