### PR TITLE
Fallback to system Python3 in scripts/review-notify.sh when virtualenv missing

### DIFF
--- a/scripts/review-notify.sh
+++ b/scripts/review-notify.sh
@@ -8,6 +8,9 @@ cd "$BASE_DIR"
 PYTHON_BIN="$BASE_DIR/.venv/bin/python"
 if [ ! -x "$PYTHON_BIN" ]; then
   PYTHON_BIN="$(command -v python3 || true)"
+  if [ -n "$PYTHON_BIN" ] && ! "$PYTHON_BIN" -c "import sys; import django; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
+    PYTHON_BIN=""
+  fi
 fi
 
 if [ -z "$PYTHON_BIN" ]; then

--- a/scripts/review-notify.sh
+++ b/scripts/review-notify.sh
@@ -5,9 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$BASE_DIR"
 
-if [ ! -x "$BASE_DIR/.venv/bin/python" ]; then
-  echo "Virtual environment not found. Run ./install.sh first." >&2
+PYTHON_BIN="$BASE_DIR/.venv/bin/python"
+if [ ! -x "$PYTHON_BIN" ]; then
+  PYTHON_BIN="$(command -v python3 || true)"
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
+  echo "Python runtime not found. Install Python 3 or run ./install.sh first." >&2
   exit 1
 fi
 
-exec "$BASE_DIR/.venv/bin/python" manage.py review_notify "$@"
+exec "$PYTHON_BIN" manage.py review_notify "$@"


### PR DESCRIPTION
### Motivation
- Ensure `scripts/review-notify.sh` can run when the project's virtualenv is not available by falling back to a system `python3` interpreter.

### Description
- Introduce `PYTHON_BIN` to reference the virtualenv python and fall back to `python3` via `command -v`, update the error message to mention installing Python 3 or running `./install.sh`, and call `manage.py review_notify` with `exec "$PYTHON_BIN"`.

### Testing
- No automated tests were run or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8704ea28083268e379f3b164fc6d4)