### PR TITLE
sites: add language-prefixed public URL handling

### DIFF
--- a/apps/sites/checks.py
+++ b/apps/sites/checks.py
@@ -8,8 +8,9 @@ from config import urls as project_urls
 
 def _collect_checks(resolver: URLResolver, errors: list, prefix: str = ""):
     for pattern in resolver.url_patterns:
+        route_prefix = getattr(pattern.pattern, "_route", str(pattern.pattern))
         if isinstance(pattern, URLResolver):
-            _collect_checks(pattern, errors, prefix + pattern.pattern._route)
+            _collect_checks(pattern, errors, prefix + route_prefix)
         elif isinstance(pattern, URLPattern):
             view = pattern.callback
             if getattr(view, "landing", False):
@@ -36,5 +37,5 @@ def landing_views_have_no_args(app_configs, **kwargs):
     errors: list = []
     for p in project_urls.urlpatterns:
         if isinstance(p, URLResolver):
-            _collect_checks(p, errors, p.pattern._route)
+            _collect_checks(p, errors, getattr(p.pattern, "_route", str(p.pattern)))
     return errors

--- a/apps/sites/languages.py
+++ b/apps/sites/languages.py
@@ -1,0 +1,27 @@
+"""Language code helpers for public site URL handling."""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def normalize_language_code(value: str | None) -> str:
+    """Return the normalized two-letter language code when available."""
+
+    if not isinstance(value, str):
+        return ""
+
+    short_code = value.split("-", maxsplit=1)[0].lower()
+    if len(short_code) != 2:
+        return ""
+    return short_code
+
+
+def get_supported_language_codes() -> set[str]:
+    """Return the configured two-letter language prefixes used by public URLs."""
+
+    return {
+        short_code
+        for code, _label in getattr(settings, "LANGUAGES", ())
+        if (short_code := normalize_language_code(code))
+    }

--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -14,6 +14,7 @@ from django.http import HttpResponseRedirect
 from django.urls import Resolver404, resolve
 from django.utils.translation import activate
 
+from .languages import get_supported_language_codes, normalize_language_code
 from .models import Landing, LandingLead, ViewHistory
 from .utils import (
     cache_original_referer,
@@ -31,18 +32,14 @@ class LanguagePreferenceMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self._supported_language_codes = {
-            str(code).split("-", maxsplit=1)[0].lower()
-            for code, _label in getattr(settings, "LANGUAGES", ())
-            if isinstance(code, str) and len(str(code).split("-", maxsplit=1)[0]) == 2
-        }
+        self._supported_language_codes = get_supported_language_codes()
 
     def __call__(self, request):
         language_code = self._language_from_path(request.path_info)
         if not language_code:
-            language_code = get_request_language_code(request)
+            raw_language_code = get_request_language_code(request)
+            language_code = normalize_language_code(raw_language_code)
 
-        language_code = (language_code or "").lower()
         if language_code:
             activate(language_code)
             request.LANGUAGE_CODE = language_code

--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -10,7 +10,9 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError
+from django.http import HttpResponseRedirect
 from django.urls import Resolver404, resolve
+from django.utils.translation import activate
 
 from .models import Landing, LandingLead, ViewHistory
 from .utils import (
@@ -29,12 +31,61 @@ class LanguagePreferenceMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
+        self._supported_language_codes = {
+            str(code).split("-", maxsplit=1)[0].lower()
+            for code, _label in getattr(settings, "LANGUAGES", ())
+            if isinstance(code, str) and len(str(code).split("-", maxsplit=1)[0]) == 2
+        }
 
     def __call__(self, request):
-        language_code = get_request_language_code(request)
+        language_code = self._language_from_path(request.path_info)
+        if not language_code:
+            language_code = get_request_language_code(request)
+
+        language_code = (language_code or "").lower()
+        if language_code:
+            activate(language_code)
+            request.LANGUAGE_CODE = language_code
+
         request.selected_language_code = language_code
         request.selected_language = language_code
+
+        if self._should_redirect_to_language_path(request, language_code):
+            return HttpResponseRedirect(f"/{language_code}{request.get_full_path()}")
+
         return self.get_response(request)
+
+    def _language_from_path(self, path_info: str) -> str:
+        """Return a two-letter language code extracted from ``path_info``."""
+
+        stripped = (path_info or "").lstrip("/")
+        first_segment = stripped.split("/", maxsplit=1)[0].lower()
+        if first_segment in self._supported_language_codes:
+            return first_segment
+        return ""
+
+    def _should_redirect_to_language_path(self, request, language_code: str) -> bool:
+        """Redirect unprefixed public pages so public URLs are language-scoped."""
+
+        if not language_code:
+            return False
+        if request.method.upper() not in {"GET", "HEAD"}:
+            return False
+        if request.path_info.startswith("/admin"):
+            return False
+        if request.path_info.startswith("/i18n/"):
+            return False
+        if self._language_from_path(request.path_info):
+            return False
+
+        resolver_match = getattr(request, "resolver_match", None)
+        if resolver_match is None:
+            try:
+                resolver_match = resolve(request.path_info)
+            except Resolver404:
+                return False
+
+        return resolver_match.namespace in {"pages", "pages-lang"}
 
 
 class ViewHistoryMiddleware:

--- a/apps/sites/routes.py
+++ b/apps/sites/routes.py
@@ -1,24 +1,18 @@
 """Root route provider for public site and site-specific admin tools."""
 
-from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
 
 from config.admin_urls import admin_route
 
+from apps.sites.languages import get_supported_language_codes
 from apps.sites import views as pages_views
 
 
 def _supported_language_prefix_regex() -> str:
     """Return a strict two-letter regex for configured public languages."""
 
-    language_codes = sorted(
-        {
-            str(code).split("-", maxsplit=1)[0].lower()
-            for code, _label in getattr(settings, "LANGUAGES", ())
-            if isinstance(code, str) and len(str(code).split("-", maxsplit=1)[0]) == 2
-        }
-    )
+    language_codes = sorted(get_supported_language_codes())
     if not language_codes:
         return "en"
     return "|".join(language_codes)

--- a/apps/sites/routes.py
+++ b/apps/sites/routes.py
@@ -1,11 +1,30 @@
 """Root route provider for public site and site-specific admin tools."""
 
+from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 
 from config.admin_urls import admin_route
 
 from apps.sites import views as pages_views
+
+
+def _supported_language_prefix_regex() -> str:
+    """Return a strict two-letter regex for configured public languages."""
+
+    language_codes = sorted(
+        {
+            str(code).split("-", maxsplit=1)[0].lower()
+            for code, _label in getattr(settings, "LANGUAGES", ())
+            if isinstance(code, str) and len(str(code).split("-", maxsplit=1)[0]) == 2
+        }
+    )
+    if not language_codes:
+        return "en"
+    return "|".join(language_codes)
+
+
+PUBLIC_LANGUAGE_PREFIX_REGEX = _supported_language_prefix_regex()
 
 ROOT_URLPATTERNS = [
     path(
@@ -17,6 +36,10 @@ ROOT_URLPATTERNS = [
         admin_route("model-graph/<str:app_label>/"),
         admin.site.admin_view(pages_views.admin_model_graph),
         name="admin-model-graph",
+    ),
+    re_path(
+        rf"^(?:{PUBLIC_LANGUAGE_PREFIX_REGEX})/",
+        include(("apps.sites.urls", "pages"), namespace="pages-lang"),
     ),
     path("", include("apps.sites.urls")),
 ]

--- a/apps/sites/tests/test_language_preference_middleware.py
+++ b/apps/sites/tests/test_language_preference_middleware.py
@@ -1,0 +1,33 @@
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.urls import resolve
+
+from apps.sites.middleware import LanguagePreferenceMiddleware
+
+
+@pytest.mark.django_db
+def test_language_prefix_sets_active_language(settings):
+    settings.LANGUAGES = [("en", "English"), ("de", "German")]
+    request = RequestFactory().get("/en/")
+    request.resolver_match = resolve("/en/")
+
+    middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert request.LANGUAGE_CODE == "en"
+    assert request.selected_language_code == "en"
+
+
+@pytest.mark.django_db
+def test_pages_requests_without_prefix_redirect_to_language_path(settings):
+    settings.LANGUAGES = [("en", "English"), ("fr", "French")]
+    request = RequestFactory().get("/")
+    request.resolver_match = resolve("/")
+
+    middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
+    response = middleware(request)
+
+    assert response.status_code == 302
+    assert response["Location"] == "/en/"

--- a/apps/sites/tests/test_language_preference_middleware.py
+++ b/apps/sites/tests/test_language_preference_middleware.py
@@ -22,12 +22,25 @@ def test_language_prefix_sets_active_language(settings):
 
 @pytest.mark.django_db
 def test_pages_requests_without_prefix_redirect_to_language_path(settings):
-    settings.LANGUAGES = [("en", "English"), ("fr", "French")]
+    settings.LANGUAGES = [("en-us", "English (US)"), ("fr", "French")]
     request = RequestFactory().get("/")
     request.resolver_match = resolve("/")
+    request.COOKIES["django_language"] = "en-us"
 
     middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
     response = middleware(request)
 
     assert response.status_code == 302
     assert response["Location"] == "/en/"
+
+
+@pytest.mark.django_db
+def test_language_with_region_in_path_does_not_loop(settings):
+    settings.LANGUAGES = [("en-us", "English (US)"), ("fr", "French")]
+    request = RequestFactory().get("/en-us/")
+
+    middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert request.selected_language_code == "en"

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -46,19 +46,19 @@ def test_client_report_download_enforces_login_and_ownership(client, monkeypatch
     assert client.get(download_url).status_code == 302
 
     client.force_login(other_user)
-    assert client.get(download_url).status_code == 403
+    assert client.get(download_url, follow=True).status_code == 403
 
     pdf_file = tmp_path / "report.pdf"
     pdf_file.write_bytes(b"%PDF-1.4\n%EOF")
     monkeypatch.setattr(ClientReport, "ensure_pdf", lambda self: Path(pdf_file))
 
     client.force_login(owner)
-    owner_response = client.get(download_url)
+    owner_response = client.get(download_url, follow=True)
     assert owner_response.status_code == 200
     assert owner_response["Content-Type"] == "application/pdf"
 
     client.force_login(staff_user)
-    staff_response = client.get(download_url)
+    staff_response = client.get(download_url, follow=True)
     assert staff_response.status_code == 200
     assert staff_response["Content-Type"] == "application/pdf"
 
@@ -71,13 +71,14 @@ def test_invitation_login_invalid_tokens_are_handled_safely(client):
     uid = urlsafe_base64_encode(force_bytes(user.pk))
 
     invalid_token_response = client.get(
-        reverse("pages:invitation-login", args=[uid, "bad-token"])
+        reverse("pages:invitation-login", args=[uid, "bad-token"]), follow=True
     )
     assert invalid_token_response.status_code == 400
     assert "Invalid invitation link" in invalid_token_response.content.decode()
 
     malformed_uid_response = client.get(
-        reverse("pages:invitation-login", args=["!!invalid!!", "bad-token"])
+        reverse("pages:invitation-login", args=["!!invalid!!", "bad-token"]),
+        follow=True,
     )
     assert malformed_uid_response.status_code == 400
 
@@ -86,7 +87,8 @@ def test_invitation_login_invalid_tokens_are_handled_safely(client):
 def test_whatsapp_webhook_requires_post_and_feature_flag(client, settings):
     url = reverse("pages:whatsapp-webhook")
 
-    assert client.get(url).status_code == 405
+    assert client.get(url).status_code == 302
+    assert client.get(f"/en{url}").status_code == 405
 
     settings.PAGES_WHATSAPP_ENABLED = False
     disabled = client.post(
@@ -142,7 +144,7 @@ def test_operator_site_interface_blocks_unsafe_redirect_targets(client):
         defaults={"interface_landing": landing},
     )
 
-    response = client.get(reverse("pages:index"))
+    response = client.get(reverse("pages:index"), follow=True)
 
     assert response.status_code == 200
     assert 'id="operator-interface-title"' in response.content.decode()


### PR DESCRIPTION
### Motivation
- Public site pages must be served with a stable two-letter language fragment (for example `/en/`) so the correct translations and language-specific templates are shown. 
- Prefer canonical language-scoped public URLs while keeping unprefixed routes available and redirecting browser GET/HEAD requests to the canonical prefixed path.

### Description
- Mount `apps.sites.urls` under a two-letter language prefix driven by `settings.LANGUAGES`, adding a regex-based prefix mount for the public site (file: `apps/sites/routes.py`).
- Update `LanguagePreferenceMiddleware` to extract the language from the URL path, call `activate(...)`, set `request.LANGUAGE_CODE`, and redirect unprefixed public `GET`/`HEAD` requests to `/<lang>/...` for canonical URLs (file: `apps/sites/middleware.py`).
- Make the landing-view system check resilient to regex-backed URL patterns by falling back to `str(pattern.pattern)` when `_route` is not present (file: `apps/sites/checks.py`).
- Add middleware unit tests and adjust public-route tests to follow the canonical language redirects (files: `apps/sites/tests/test_language_preference_middleware.py` and updates to `apps/sites/tests/test_public_routes.py`).

### Testing
- Bootstrapped and refreshed test environment with `./env-refresh.sh --deps-only` and `/.venv/bin/pip install -r requirements-ci.txt`, which completed successfully.
- Ran the targeted test suite with `.venv/bin/python manage.py test run -- apps/sites/tests/test_language_preference_middleware.py apps/sites/tests/test_public_routes.py` and all tests passed (`10 passed`).
- Sent the review notification with `./scripts/review-notify.sh --actor Codex` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d872d281d08326934e606862d5a66c)