### PR TITLE
imager: block private redirect targets in download probe

### DIFF
--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -4,8 +4,8 @@ from ipaddress import ip_address
 from pathlib import Path
 from socket import getaddrinfo
 from urllib.error import HTTPError, URLError
-from urllib.parse import unquote, urlparse
-from urllib.request import Request, urlopen
+from urllib.parse import unquote, urljoin, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from django import forms
 from django.conf import settings
@@ -22,51 +22,68 @@ from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.services import ImagerBuildError, build_rpi4b_image
 
 
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Disable automatic redirects so each target can be validated."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def _probe_download_url(download_url: str) -> tuple[bool, str]:
     """Check whether an artifact download URL appears reachable."""
 
-    parsed_url = urlparse(download_url)
-    hostname = parsed_url.hostname
-    if parsed_url.scheme not in {"http", "https"} or not hostname:
-        return False, _("Unsupported download URL.")
-
     blocked_message = _("Refusing to probe local or private addresses.")
-    if hostname == "localhost":
-        return False, blocked_message
-
-    try:
-        ip_candidate = ip_address(hostname)
-    except ValueError:
-        ip_candidate = None
-
     blocked_flags = ("is_link_local", "is_loopback", "is_multicast", "is_private", "is_unspecified")
-    if ip_candidate is not None:
-        if any(getattr(ip_candidate, flag) for flag in blocked_flags):
+    redirect_codes = {301, 302, 303, 307, 308}
+    opener = build_opener(_NoRedirectHandler())
+    current_url = download_url
+
+    for _redirect_count in range(5):
+        parsed_url = urlparse(current_url)
+        hostname = parsed_url.hostname
+        if parsed_url.scheme not in {"http", "https"} or not hostname:
+            return False, _("Unsupported download URL.")
+        if hostname == "localhost":
             return False, blocked_message
-    else:
+
         try:
-            resolved_hosts = {
-                ip_address(record[4][0]) for record in getaddrinfo(hostname, None, type=0)
-            }
-        except OSError as exc:
-            reason = getattr(exc, "strerror", str(exc))
+            ip_candidate = ip_address(hostname)
+        except ValueError:
+            ip_candidate = None
+
+        if ip_candidate is not None:
+            if any(getattr(ip_candidate, flag) for flag in blocked_flags):
+                return False, blocked_message
+        else:
+            try:
+                resolved_hosts = {
+                    ip_address(record[4][0]) for record in getaddrinfo(hostname, None, type=0)
+                }
+            except OSError as exc:
+                reason = getattr(exc, "strerror", str(exc))
+                return False, str(reason)
+            if any(any(getattr(ip_value, flag) for flag in blocked_flags) for ip_value in resolved_hosts):
+                return False, blocked_message
+
+        request = Request(current_url, method="HEAD")
+        try:
+            with opener.open(request, timeout=10) as response:  # noqa: S310 - staff-triggered verification flow
+                status = response.getcode()
+        except HTTPError as exc:
+            location = exc.headers.get("Location")
+            if exc.code in redirect_codes and location:
+                current_url = urljoin(current_url, location)
+                continue
+            status = exc.code
+        except (URLError, ValueError) as exc:
+            reason = getattr(exc, "reason", str(exc))
             return False, str(reason)
-        if any(any(getattr(ip_value, flag) for flag in blocked_flags) for ip_value in resolved_hosts):
-            return False, blocked_message
 
-    request = Request(download_url, method="HEAD")
-    try:
-        with urlopen(request, timeout=10) as response:  # noqa: S310 - staff-triggered verification flow
-            status = response.getcode()
-    except HTTPError as exc:
-        status = exc.code
-    except (URLError, ValueError) as exc:
-        reason = getattr(exc, "reason", str(exc))
-        return False, str(reason)
+        if 200 <= status < 400:
+            return True, f"HTTP {status}"
+        return False, f"HTTP {status}"
 
-    if 200 <= status < 400:
-        return True, f"HTTP {status}"
-    return False, f"HTTP {status}"
+    return False, _("Too many redirects.")
 
 
 class RaspberryPiImageBuildForm(forms.Form):

--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -1,7 +1,9 @@
 """Admin integration for Raspberry Pi image artifacts."""
 
+from contextlib import contextmanager, nullcontext
 from ipaddress import ip_address
 from pathlib import Path
+import socket
 from socket import getaddrinfo
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlparse
@@ -21,6 +23,16 @@ from django_object_actions import DjangoObjectActions
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.services import ImagerBuildError, build_rpi4b_image
 
+BLOCKED_ADDRESS_FLAGS = (
+    "is_link_local",
+    "is_loopback",
+    "is_multicast",
+    "is_private",
+    "is_reserved",
+    "is_unspecified",
+)
+MAX_DOWNLOAD_PROBE_REDIRECTS = 5
+
 
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Disable automatic redirects so each target can be validated."""
@@ -29,16 +41,32 @@ class _NoRedirectHandler(HTTPRedirectHandler):
         return None
 
 
+@contextmanager
+def _pin_hostname_resolution(hostname: str, resolved_ip: str):
+    original_getaddrinfo = socket.getaddrinfo
+
+    def _pinned_getaddrinfo(host, *args, **kwargs):
+        if host == hostname:
+            return original_getaddrinfo(resolved_ip, *args, **kwargs)
+        return original_getaddrinfo(host, *args, **kwargs)
+
+    socket.getaddrinfo = _pinned_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
+
 def _probe_download_url(download_url: str) -> tuple[bool, str]:
     """Check whether an artifact download URL appears reachable."""
 
     blocked_message = _("Refusing to probe local or private addresses.")
-    blocked_flags = ("is_link_local", "is_loopback", "is_multicast", "is_private", "is_unspecified")
     redirect_codes = {301, 302, 303, 307, 308}
     opener = build_opener(_NoRedirectHandler())
     current_url = download_url
+    redirects_followed = 0
 
-    for _redirect_count in range(5):
+    while True:
         parsed_url = urlparse(current_url)
         hostname = parsed_url.hostname
         if parsed_url.scheme not in {"http", "https"} or not hostname:
@@ -52,8 +80,9 @@ def _probe_download_url(download_url: str) -> tuple[bool, str]:
             ip_candidate = None
 
         if ip_candidate is not None:
-            if any(getattr(ip_candidate, flag) for flag in blocked_flags):
+            if any(getattr(ip_candidate, flag) for flag in BLOCKED_ADDRESS_FLAGS):
                 return False, blocked_message
+            resolution_context = nullcontext()
         else:
             try:
                 resolved_hosts = {
@@ -62,28 +91,35 @@ def _probe_download_url(download_url: str) -> tuple[bool, str]:
             except OSError as exc:
                 reason = getattr(exc, "strerror", str(exc))
                 return False, str(reason)
-            if any(any(getattr(ip_value, flag) for flag in blocked_flags) for ip_value in resolved_hosts):
+            if any(any(getattr(ip_value, flag) for flag in BLOCKED_ADDRESS_FLAGS) for ip_value in resolved_hosts):
                 return False, blocked_message
+            selected_ip = sorted(str(ip_value) for ip_value in resolved_hosts)[0]
+            resolution_context = _pin_hostname_resolution(hostname, selected_ip)
 
         request = Request(current_url, method="HEAD")
         try:
-            with opener.open(request, timeout=10) as response:  # noqa: S310 - staff-triggered verification flow
-                status = response.getcode()
+            with resolution_context:
+                with opener.open(request, timeout=10) as response:  # noqa: S310 - staff-triggered verification flow
+                    status = response.getcode()
+                    location = response.headers.get("Location")
         except HTTPError as exc:
             location = exc.headers.get("Location")
-            if exc.code in redirect_codes and location:
-                current_url = urljoin(current_url, location)
-                continue
             status = exc.code
         except (URLError, ValueError) as exc:
             reason = getattr(exc, "reason", str(exc))
             return False, str(reason)
 
-        if 200 <= status < 400:
+        if status in redirect_codes:
+            if not location:
+                return False, f"HTTP {status}"
+            if redirects_followed >= MAX_DOWNLOAD_PROBE_REDIRECTS:
+                return False, _("Too many redirects.")
+            redirects_followed += 1
+            current_url = urljoin(current_url, location)
+            continue
+        if 200 <= status < 300:
             return True, f"HTTP {status}"
         return False, f"HTTP {status}"
-
-    return False, _("Too many redirects.")
 
 
 class RaspberryPiImageBuildForm(forms.Form):

--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -7,7 +7,7 @@ import socket
 from socket import getaddrinfo
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlparse
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 from django import forms
 from django.conf import settings
@@ -62,7 +62,7 @@ def _probe_download_url(download_url: str) -> tuple[bool, str]:
 
     blocked_message = _("Refusing to probe local or private addresses.")
     redirect_codes = {301, 302, 303, 307, 308}
-    opener = build_opener(_NoRedirectHandler())
+    opener = build_opener(ProxyHandler({}), _NoRedirectHandler())
     current_url = download_url
     redirects_followed = 0
 

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -11,6 +11,20 @@ from apps.imager.admin import _probe_download_url
 from apps.imager.models import RaspberryPiImageArtifact
 
 
+class _ProbeResponse:
+    headers: dict[str, str] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return None
+
+    @staticmethod
+    def getcode():
+        return 200
+
+
 @pytest.mark.django_db
 @pytest.mark.integration
 @override_settings(
@@ -162,6 +176,41 @@ def test_probe_download_url_revalidates_redirect_targets(build_opener_mock, _get
 
     assert reachable is False
     assert result == "Refusing to probe local or private addresses."
+
+
+@patch("apps.imager.admin.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 443))])
+@patch("apps.imager.admin.build_opener")
+def test_probe_download_url_allows_five_redirect_hops(build_opener_mock, _getaddrinfo_mock):
+    """Regression: redirect limit should allow five redirects before failing."""
+
+    build_opener_mock.return_value.open.side_effect = [
+        HTTPError("https://cdn.example.com/images/stable.img", 302, "Found", {"Location": "/hop-1"}, None),
+        HTTPError("https://cdn.example.com/hop-1", 302, "Found", {"Location": "/hop-2"}, None),
+        HTTPError("https://cdn.example.com/hop-2", 302, "Found", {"Location": "/hop-3"}, None),
+        HTTPError("https://cdn.example.com/hop-3", 302, "Found", {"Location": "/hop-4"}, None),
+        HTTPError("https://cdn.example.com/hop-4", 302, "Found", {"Location": "/hop-5"}, None),
+        _ProbeResponse(),
+    ]
+
+    reachable, result = _probe_download_url("https://cdn.example.com/images/stable.img")
+
+    assert reachable is True
+    assert result == "HTTP 200"
+
+
+@patch("apps.imager.admin.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 443))])
+@patch("apps.imager.admin.build_opener")
+def test_probe_download_url_fails_redirect_without_location(build_opener_mock, _getaddrinfo_mock):
+    """Regression: redirects without Location should fail probing."""
+
+    build_opener_mock.return_value.open.side_effect = [
+        HTTPError("https://cdn.example.com/images/stable.img", 302, "Found", {}, None),
+    ]
+
+    reachable, result = _probe_download_url("https://cdn.example.com/images/stable.img")
+
+    assert reachable is False
+    assert result == "HTTP 302"
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -200,6 +200,26 @@ def test_probe_download_url_allows_five_redirect_hops(build_opener_mock, _getadd
 
 @patch("apps.imager.admin.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 443))])
 @patch("apps.imager.admin.build_opener")
+def test_probe_download_url_fails_after_sixth_redirect(build_opener_mock, _getaddrinfo_mock):
+    """Regression: sixth redirect hop should fail with an explicit limit error."""
+
+    build_opener_mock.return_value.open.side_effect = [
+        HTTPError("https://cdn.example.com/images/stable.img", 302, "Found", {"Location": "/hop-1"}, None),
+        HTTPError("https://cdn.example.com/hop-1", 302, "Found", {"Location": "/hop-2"}, None),
+        HTTPError("https://cdn.example.com/hop-2", 302, "Found", {"Location": "/hop-3"}, None),
+        HTTPError("https://cdn.example.com/hop-3", 302, "Found", {"Location": "/hop-4"}, None),
+        HTTPError("https://cdn.example.com/hop-4", 302, "Found", {"Location": "/hop-5"}, None),
+        HTTPError("https://cdn.example.com/hop-5", 302, "Found", {"Location": "/hop-6"}, None),
+    ]
+
+    reachable, result = _probe_download_url("https://cdn.example.com/images/stable.img")
+
+    assert reachable is False
+    assert result == "Too many redirects."
+
+
+@patch("apps.imager.admin.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 443))])
+@patch("apps.imager.admin.build_opener")
 def test_probe_download_url_fails_redirect_without_location(build_opener_mock, _getaddrinfo_mock):
     """Regression: redirects without Location should fail probing."""
 

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -1,6 +1,7 @@
 """Regression tests for Raspberry Pi imager admin UI actions."""
 
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 import pytest
 from django.test import override_settings
@@ -140,6 +141,27 @@ def test_probe_download_url_blocks_unsafe_targets(download_url, expected_message
     reachable, result = _probe_download_url(download_url)
     assert reachable is False
     assert result == expected_message
+
+
+@patch("apps.imager.admin.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 443))])
+@patch("apps.imager.admin.build_opener")
+def test_probe_download_url_revalidates_redirect_targets(build_opener_mock, _getaddrinfo_mock):
+    """Regression: redirect responses must not allow probes to private hosts."""
+
+    build_opener_mock.return_value.open.side_effect = [
+        HTTPError(
+            "https://cdn.example.com/images/stable-rpi-4b.img",
+            302,
+            "Found",
+            {"Location": "http://127.0.0.1/secret"},
+            None,
+        )
+    ]
+
+    reachable, result = _probe_download_url("https://cdn.example.com/images/stable-rpi-4b.img")
+
+    assert reachable is False
+    assert result == "Refusing to probe local or private addresses."
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- The existing `_probe_download_url` validated only the initial hostname but used `urlopen()` which follows redirects, allowing SSRF via redirect or DNS rebinding to internal addresses.
- The admin wizard exposes a staff-triggered URL test that calls the probe, so redirect-based SSRF was reachable by authenticated staff and needed hardening.

### Description
- Add a `_NoRedirectHandler` and use `build_opener` to disable automatic redirect following so each hop can be validated manually in `_probe_download_url`.
- Re-validate scheme/hostname and check for link-local/loopback/private/unspecified/multicast addresses on every redirect hop before issuing the next `HEAD` probe, and resolve DNS for non-literal hosts via `getaddrinfo` as before.
- Cap redirect processing to 5 hops and return a clear `Too many redirects.` error if exceeded.
- Add a regression test `test_probe_download_url_revalidates_redirect_targets` that simulates a 302 redirect from a public host to `127.0.0.1` and asserts the probe rejects the redirect target.

### Testing
- Installed CI test deps with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt` to prepare the test environment.
- Ran the imager admin tests with `.venv/bin/python manage.py test run -- apps/imager/tests/test_admin.py` which completed successfully (`8 passed`).
- Also invoked the review notifier script `./scripts/review-notify.sh --actor Codex` as part of the change workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d487c7445c8326b266e8c2e3677336)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR hardens SSRF protection in the imager admin download URL probing mechanism by disabling automatic HTTP redirect following and implementing manual per-hop validation, plus disabling proxy inheritance for probe requests.

## Changes

**apps/imager/admin.py**

- Refactored _probe_download_url() to:
  - Use build_opener(ProxyHandler({}), _NoRedirectHandler()) to disable redirects and prevent proxy inheritance for probe requests.
  - Add a manual redirect-handling loop that:
    - Validates scheme and hostname on each hop (only http/https allowed; rejects "localhost").
    - Rejects literal IPs or resolved IPs with any of BLOCKED_ADDRESS_FLAGS: is_link_local, is_loopback, is_multicast, is_private, is_reserved, is_unspecified.
    - Resolves non-literal hostnames via getaddrinfo and pins hostname resolution to a chosen IP for the duration of the request using _pin_hostname_resolution() to mitigate DNS rebinding.
    - Detects redirect status codes {301,302,303,307,308}, follows up to MAX_DOWNLOAD_PROBE_REDIRECTS (5) hops, and returns _("Too many redirects.") if exceeded.
    - Treats success strictly as HTTP 2xx responses (previously accepted 2xx–3xx).
- Added constants: BLOCKED_ADDRESS_FLAGS, MAX_DOWNLOAD_PROBE_REDIRECTS.
- Added class: _NoRedirectHandler(HTTPRedirectHandler) to disable automatic redirects.
- Added context manager: _pin_hostname_resolution(hostname, resolved_ip) to temporarily monkey-patch socket.getaddrinfo.

**apps/imager/tests/test_admin.py**

- Added regression tests that mock build_opener and getaddrinfo:
  - test_probe_download_url_revalidates_redirect_targets: ensures a 302 redirect to 127.0.0.1 is rejected with "Refusing to probe local or private addresses."
  - test_probe_download_url_allows_five_redirect_hops: verifies a chain of five redirects followed by HTTP 200 succeeds.
  - test_probe_download_url_fails_after_sixth_redirect: verifies a sixth redirect fails with "Too many redirects."
  - test_probe_download_url_fails_redirect_without_location: verifies redirects missing Location fail with "HTTP 302".
- Introduced _ProbeResponse test stub to simulate a successful response.

## Testing

- CI/test environment prep noted in PR (env-refresh, pip install requirements-ci).
- Locally ran imager admin tests (8 passed in reported run).
- Tests use mocks to avoid network access and cover redirect revalidation, hop limits, and malformed redirects.

## Impact

The admin wizard's staff-triggered URL test now validates each redirect hop, blocks probes to private/reserved addresses even when reached via redirects, prevents proxy inheritance, and enforces a redirect hop limit to mitigate redirect-based SSRF and DNS rebinding vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->