### PR TITLE
Harden souls registration flow against account enumeration

### DIFF
--- a/apps/souls/tests/test_registration_views.py
+++ b/apps/souls/tests/test_registration_views.py
@@ -13,7 +13,30 @@ from apps.survey.models import Survey, SurveyAnswer, SurveyOption, SurveyQuestio
 class SoulRegistrationViewsTests(TestCase):
     def test_register_start_uses_same_redirect_for_existing_and_new_email(self):
         user_model = get_user_model()
-        user_model.objects.create_user(username="existing-user", email="existing@example.com", password="x")
+        user = user_model.objects.create_user(username="existing-user", email="existing@example.com", password="x")
+        offering = OfferingSoul.objects.create(
+            core_hash="a" * 64,
+            package={
+                "schema_version": "1.0",
+                "core_hash": "a" * 64,
+                "issuance_marker": "start",
+                "metadata": {"size_bytes": 2},
+                "traits": {"structural": {}, "type_aware": {}},
+            },
+            structural_traits={},
+            type_traits={},
+        )
+        survey = Survey.objects.create(title="Soul Registration", is_active=True)
+        response = SurveyResponse.objects.create(survey=survey, participant_token="existing-token")
+        Soul.objects.create(
+            user=user,
+            offering_soul=offering,
+            survey_response=response,
+            soul_id="existing-soul-id",
+            survey_digest="digest",
+            package={"schema_version": "1.0"},
+            email_hash="hash",
+        )
 
         existing_response = self.client.post(
             reverse("souls:register_start"),
@@ -82,13 +105,59 @@ class SoulRegistrationViewsTests(TestCase):
             email_hash="hash",
         )
 
-        self.client.get(reverse("souls:register_complete"))
         verify_response = self.client.get(
             reverse("souls:register_verify", kwargs={"session_id": registration.id, "token": token})
         )
 
-        self.assertRedirects(verify_response, reverse("souls:register_complete"), fetch_redirect_response=False)
+        self.assertRedirects(verify_response, reverse("souls:register_landing"), fetch_redirect_response=False)
         self.assertFalse(verify_response.wsgi_request.user.is_authenticated)
+        registration.refresh_from_db()
+        self.assertEqual(registration.state, SoulRegistrationSession.State.EMAIL_SENT)
+
+    def test_register_verify_blocks_claim_when_email_matches_multiple_users(self):
+        user_model = get_user_model()
+        first_user = user_model.objects.create_user(username="dupe-a", email="dupe@example.com", password="x")
+        user_model.objects.create_user(username="dupe-b", email="dupe@example.com", password="x")
+        survey = Survey.objects.create(title="Soul Registration", is_active=True)
+        question = SurveyQuestion.objects.create(
+            survey=survey,
+            prompt="Axis",
+            allow_multiple=False,
+            display_order=1,
+        )
+        option = SurveyOption.objects.create(question=question, label="As Above", display_order=1)
+        response = SurveyResponse.objects.create(survey=survey, participant_token="token-dup")
+        answer = SurveyAnswer.objects.create(response=response, question=question)
+        answer.selected_options.set([option])
+        offering = OfferingSoul.objects.create(
+            core_hash="e" * 64,
+            package={
+                "schema_version": "1.0",
+                "core_hash": "e" * 64,
+                "issuance_marker": "dupe",
+                "metadata": {"size_bytes": 2},
+                "traits": {"structural": {}, "type_aware": {}},
+            },
+            structural_traits={},
+            type_traits={},
+        )
+        registration = SoulRegistrationSession.objects.create(
+            email=first_user.email,
+            offering_soul=offering,
+            survey_response=response,
+            state=SoulRegistrationSession.State.EMAIL_SENT,
+        )
+        token = "valid-token-dup"
+        registration.verification_token_hash = SoulRegistrationSession.digest_value(token)
+        registration.save(update_fields=["verification_token_hash"])
+
+        verify_response = self.client.get(
+            reverse("souls:register_verify", kwargs={"session_id": registration.id, "token": token})
+        )
+
+        self.assertRedirects(verify_response, reverse("souls:register_landing"), fetch_redirect_response=False)
+        self.assertFalse(verify_response.wsgi_request.user.is_authenticated)
+        self.assertFalse(Soul.objects.filter(user__email__iexact=registration.email).exists())
         registration.refresh_from_db()
         self.assertEqual(registration.state, SoulRegistrationSession.State.EMAIL_SENT)
 

--- a/apps/souls/tests/test_registration_views.py
+++ b/apps/souls/tests/test_registration_views.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.cards.models import OfferingSoul
+from apps.souls.models import Soul, SoulRegistrationSession
+from apps.souls.services import build_soul_package
+from apps.survey.models import Survey, SurveyAnswer, SurveyOption, SurveyQuestion, SurveyResponse
+
+
+class SoulRegistrationViewsTests(TestCase):
+    def test_register_start_uses_same_redirect_for_existing_and_new_email(self):
+        user_model = get_user_model()
+        user_model.objects.create_user(username="existing-user", email="existing@example.com", password="x")
+
+        existing_response = self.client.post(
+            reverse("souls:register_start"),
+            data={"email": "existing@example.com"},
+        )
+        new_response = self.client.post(
+            reverse("souls:register_start"),
+            data={"email": "new@example.com"},
+        )
+
+        self.assertRedirects(existing_response, reverse("souls:register_offering"), fetch_redirect_response=False)
+        self.assertRedirects(new_response, reverse("souls:register_offering"), fetch_redirect_response=False)
+        self.assertEqual(
+            SoulRegistrationSession.objects.filter(email="existing@example.com").count(),
+            1,
+        )
+        self.assertEqual(
+            SoulRegistrationSession.objects.filter(email="new@example.com").count(),
+            1,
+        )
+
+    def test_register_verify_blocks_claim_when_existing_soul_id_differs(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(username="claimed-user", email="claimed@example.com", password="x")
+        survey = Survey.objects.create(title="Soul Registration", is_active=True)
+        question = SurveyQuestion.objects.create(
+            survey=survey,
+            prompt="Axis",
+            allow_multiple=False,
+            display_order=1,
+        )
+        option = SurveyOption.objects.create(question=question, label="As Above", display_order=1)
+        response = SurveyResponse.objects.create(survey=survey, participant_token="token-verify")
+        answer = SurveyAnswer.objects.create(response=response, question=question)
+        answer.selected_options.set([option])
+        offering = OfferingSoul.objects.create(
+            core_hash="c" * 64,
+            package={
+                "schema_version": "1.0",
+                "core_hash": "c" * 64,
+                "issuance_marker": "one",
+                "metadata": {"size_bytes": 2},
+                "traits": {"structural": {}, "type_aware": {}},
+            },
+            structural_traits={},
+            type_traits={},
+        )
+        registration = SoulRegistrationSession.objects.create(
+            email=user.email,
+            offering_soul=offering,
+            survey_response=response,
+            state=SoulRegistrationSession.State.EMAIL_SENT,
+        )
+
+        token = "valid-token"
+        registration.verification_token_hash = SoulRegistrationSession.digest_value(token)
+        registration.save(update_fields=["verification_token_hash"])
+
+        Soul.objects.create(
+            user=user,
+            offering_soul=offering,
+            survey_response=response,
+            soul_id="different-soul-id",
+            survey_digest="digest",
+            package={"schema_version": "1.0"},
+            email_hash="hash",
+        )
+
+        self.client.get(reverse("souls:register_complete"))
+        verify_response = self.client.get(
+            reverse("souls:register_verify", kwargs={"session_id": registration.id, "token": token})
+        )
+
+        self.assertRedirects(verify_response, reverse("souls:register_complete"), fetch_redirect_response=False)
+        self.assertFalse(verify_response.wsgi_request.user.is_authenticated)
+        registration.refresh_from_db()
+        self.assertEqual(registration.state, SoulRegistrationSession.State.EMAIL_SENT)
+
+    def test_register_verify_allows_claim_when_existing_soul_id_matches(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(username="matching-user", email="matching@example.com", password="x")
+        survey = Survey.objects.create(title="Soul Registration", is_active=True)
+        question = SurveyQuestion.objects.create(
+            survey=survey,
+            prompt="Axis",
+            allow_multiple=False,
+            display_order=1,
+        )
+        option = SurveyOption.objects.create(question=question, label="As Above", display_order=1)
+        response = SurveyResponse.objects.create(survey=survey, participant_token="token-match")
+        answer = SurveyAnswer.objects.create(response=response, question=question)
+        answer.selected_options.set([option])
+        offering = OfferingSoul.objects.create(
+            core_hash="d" * 64,
+            package={
+                "schema_version": "1.0",
+                "core_hash": "d" * 64,
+                "issuance_marker": "same",
+                "metadata": {"size_bytes": 2},
+                "traits": {"structural": {}, "type_aware": {}},
+            },
+            structural_traits={},
+            type_traits={},
+        )
+        registration = SoulRegistrationSession.objects.create(
+            email=user.email,
+            offering_soul=offering,
+            survey_response=response,
+            state=SoulRegistrationSession.State.EMAIL_SENT,
+        )
+
+        package, soul_id, survey_digest, email_hash = build_soul_package(registration_session=registration, user=user)
+        Soul.objects.create(
+            user=user,
+            offering_soul=offering,
+            survey_response=response,
+            soul_id=soul_id,
+            survey_digest=survey_digest,
+            package=package,
+            email_hash=email_hash,
+        )
+
+        token = "valid-token-match"
+        registration.verification_token_hash = SoulRegistrationSession.digest_value(token)
+        registration.save(update_fields=["verification_token_hash"])
+
+        verify_response = self.client.get(
+            reverse("souls:register_verify", kwargs={"session_id": registration.id, "token": token})
+        )
+
+        self.assertRedirects(verify_response, reverse("souls:me"), fetch_redirect_response=False)
+        self.assertTrue(verify_response.wsgi_request.user.is_authenticated)
+        registration.refresh_from_db()
+        self.assertEqual(registration.state, SoulRegistrationSession.State.COMPLETED)

--- a/apps/souls/views.py
+++ b/apps/souls/views.py
@@ -204,7 +204,14 @@ def register_verify(request: HttpRequest, session_id: int, token: str) -> HttpRe
 
     user_model = get_user_model()
     with transaction.atomic():
-        user = user_model.objects.filter(email__iexact=registration.email).first()
+        matching_users = list(
+            user_model.objects.select_related("soul").filter(email__iexact=registration.email).order_by("id")[:2]
+        )
+        if len(matching_users) > 1:
+            messages.error(request, "Registration could not be completed for this email address.")
+            return redirect("souls:register_landing")
+
+        user = matching_users[0] if matching_users else None
         if user is None:
             username = registration.email.split("@", 1)[0]
             candidate = username
@@ -222,11 +229,10 @@ def register_verify(request: HttpRequest, session_id: int, token: str) -> HttpRe
             registration_session=registration,
             user=user,
         )
-        existing_soul = Soul.objects.filter(user=user).first()
+        existing_soul = getattr(user, "soul", None)
         if existing_soul and existing_soul.soul_id != soul_id:
             messages.error(request, "Registration could not be completed for this submission.")
-            request.session.pop(REG_SESSION_KEY, None)
-            return redirect("souls:register_complete")
+            return redirect("souls:register_landing")
 
         soul_defaults = {
             "offering_soul": registration.offering_soul,
@@ -238,12 +244,7 @@ def register_verify(request: HttpRequest, session_id: int, token: str) -> HttpRe
             "email_hash": email_hash,
             "email_verified_at": timezone.now(),
         }
-        if existing_soul:
-            for field, value in soul_defaults.items():
-                setattr(existing_soul, field, value)
-            existing_soul.save(update_fields=list(soul_defaults.keys()))
-        else:
-            Soul.objects.create(user=user, **soul_defaults)
+        Soul.objects.update_or_create(user=user, defaults=soul_defaults)
         registration.state = SoulRegistrationSession.State.COMPLETED
         registration.save(update_fields=["state"])
 

--- a/apps/souls/views.py
+++ b/apps/souls/views.py
@@ -45,11 +45,6 @@ def register_start(request: HttpRequest) -> HttpResponse:
         return redirect("souls:register_landing")
 
     email = form.cleaned_data["email"].strip().lower()
-    user_model = get_user_model()
-    if user_model.objects.filter(email__iexact=email).exists():
-        messages.error(request, "That email already has an account. Please sign in.")
-        return redirect("pages:login")
-
     ip = request.META.get("REMOTE_ADDR", "")
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     session = SoulRegistrationSession.objects.create(
@@ -82,7 +77,7 @@ def register_offering(request: HttpRequest) -> HttpResponse:
         offering_soul = OfferingSoul.create_from_upload(offering_file)
         registration.offering_soul = offering_soul
         registration.state = SoulRegistrationSession.State.OFFERING_DONE
-        registration.save(update_fields=["offering_soul", "state", "updated_at"])
+        registration.save(update_fields=["offering_soul", "state"])
         return redirect("souls:register_survey")
 
     return render(request, "souls/register_offering.html", {"form": form, "registration": registration})
@@ -104,7 +99,7 @@ def register_survey(request: HttpRequest) -> HttpResponse:
     participant_token = registration.participant_token or uuid4().hex
     if registration.participant_token != participant_token:
         registration.participant_token = participant_token
-        registration.save(update_fields=["participant_token", "updated_at"])
+        registration.save(update_fields=["participant_token"])
 
     existing = registration.survey_response or SurveyResponse.objects.filter(
         survey=survey,
@@ -114,7 +109,7 @@ def register_survey(request: HttpRequest) -> HttpResponse:
         if existing:
             registration.survey_response = existing
             registration.state = SoulRegistrationSession.State.SURVEY_DONE
-            registration.save(update_fields=["survey_response", "state", "updated_at"])
+            registration.save(update_fields=["survey_response", "state"])
             _send_verification_email(request, registration)
             return redirect("souls:register_complete")
         form = SurveySubmissionForm(survey=survey)
@@ -140,7 +135,7 @@ def register_survey(request: HttpRequest) -> HttpResponse:
 
         registration.survey_response = response
         registration.state = SoulRegistrationSession.State.SURVEY_DONE
-        registration.save(update_fields=["survey_response", "state", "updated_at"])
+        registration.save(update_fields=["survey_response", "state"])
 
     _send_verification_email(request, registration)
     return redirect("souls:register_complete")
@@ -159,7 +154,6 @@ def _send_verification_email(request: HttpRequest, registration: SoulRegistratio
             "verification_token_hash",
             "verification_sent_at",
             "state",
-            "updated_at",
         ]
     )
 
@@ -228,21 +222,30 @@ def register_verify(request: HttpRequest, session_id: int, token: str) -> HttpRe
             registration_session=registration,
             user=user,
         )
-        soul, _ = Soul.objects.update_or_create(
-            user=user,
-            defaults={
-                "offering_soul": registration.offering_soul,
-                "survey_response": registration.survey_response,
-                "soul_id": soul_id,
-                "survey_digest": survey_digest,
-                "package": package,
-                "package_bytes": None,
-                "email_hash": email_hash,
-                "email_verified_at": timezone.now(),
-            },
-        )
+        existing_soul = Soul.objects.filter(user=user).first()
+        if existing_soul and existing_soul.soul_id != soul_id:
+            messages.error(request, "Registration could not be completed for this submission.")
+            request.session.pop(REG_SESSION_KEY, None)
+            return redirect("souls:register_complete")
+
+        soul_defaults = {
+            "offering_soul": registration.offering_soul,
+            "survey_response": registration.survey_response,
+            "soul_id": soul_id,
+            "survey_digest": survey_digest,
+            "package": package,
+            "package_bytes": None,
+            "email_hash": email_hash,
+            "email_verified_at": timezone.now(),
+        }
+        if existing_soul:
+            for field, value in soul_defaults.items():
+                setattr(existing_soul, field, value)
+            existing_soul.save(update_fields=list(soul_defaults.keys()))
+        else:
+            Soul.objects.create(user=user, **soul_defaults)
         registration.state = SoulRegistrationSession.State.COMPLETED
-        registration.save(update_fields=["state", "updated_at"])
+        registration.save(update_fields=["state"])
 
     backend = _registration_auth_backend()
     if backend:


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated actors from inferring account existence from the registration start response by removing distinct behavior for already-registered emails. 
- Allow legitimate existing-account reclaiming of a matching soul while preventing completion when the submission would claim a different soul, matching the intent to defer confirmation until the end of the flow.

### Description
- Removed the early `email` existence branch in `register_start` so both new and existing emails create a `SoulRegistrationSession` and redirect to `souls:register_offering` instead of emitting a distinct error/redirect.
- Updated `register_verify` to compute the `soul_id` and then: block completion and avoid login when an existing `Soul` for the user has a different `soul_id`, and otherwise update the existing `Soul` (or create a new one) and complete the registration.
- Replaced `update_or_create` with explicit create/update logic so mismatched claims can be detected and rejected.
- Removed non-existent `updated_at` entries from `update_fields` calls to avoid runtime save errors.

### Testing
- Refreshed the environment and installed CI dependencies with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt`, both of which succeeded.
- Executed the targeted test run with `.venv/bin/python manage.py test run -- apps.souls/tests/test_registration_views.py apps/souls/tests/test_services.py` and all tests passed (`6 passed`).
- Ran the review notifier with `./scripts/review-notify.sh --actor Codex`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91890066c832698770bea96691951)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Hardens the souls registration flow against account enumeration and mismatched soul claims by ensuring register_start treats existing and new emails identically, deferring identity validation to verification time, and rejecting verification attempts that would claim a different soul.

## Changes

### Test Coverage (apps/souls/tests/test_registration_views.py)
Adds `SoulRegistrationViewsTests` covering key registration scenarios:

1. **Email-agnostic register_start** — Confirms both existing and new emails are redirected to `souls:register_offering` and that a single `SoulRegistrationSession` is created per submitted email, preventing response-based account enumeration.

2. **Block on soul_id mismatch** — When verification would assign a soul_id that differs from an existing Soul for the matched user, verification redirects to `souls:register_landing`, does not authenticate the user, and leaves the `SoulRegistrationSession` in `EMAIL_SENT` state.

3. **Block on duplicate-email users** — When multiple users match the registration email (case-insensitive), verification redirects to `souls:register_landing`, does not authenticate, and does not create a Soul for that email; session remains `EMAIL_SENT`.

4. **Allow matching soul_id claim** — When the computed soul_id matches the user's existing Soul, verification completes: user is authenticated, and the `SoulRegistrationSession` advances to `COMPLETED`.

### Registration Flow Logic (apps/souls/views.py)
- **register_start**: Removed early user/email existence branching. Always creates a `SoulRegistrationSession`, stores its id in the session, and redirects to `souls:register_offering`.

- **register_verify**:
  - Loads up to two users by case-insensitive email to detect duplicates; redirects to `register_landing` if multiple matches exist.
  - Creates a new user only when no matching user exists.
  - Computes package and soul_id via `build_soul_package`.
  - If the matched user already has an associated `Soul` with a differing `soul_id`, aborts verification and redirects to `register_landing` (prevents reassigning a different soul).
  - Otherwise proceeds to create or update the Soul using the computed values and completes the registration.

- **Field persistence**: Removed `updated_at` from `update_fields` in session save calls (in register_offering, register_survey, _send_verification_email, and register_verify) to avoid runtime save errors when that field is not explicitly modified; targeted update_fields now include only the domain fields being changed.

## Security Impact
- Eliminates a response-based vector for email/account enumeration at registration start.
- Prevents unauthorized reassignment of an existing user's soul by validating computed soul_id against the user's current Soul.
- Ensures email verification remains the gate for completing registration and claiming souls.

## Test Status
Targeted tests (6) pass locally, covering enumeration prevention, duplicate-email handling, soul_id mismatch blocking, and successful matching claim completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->