### PR TITLE
nodes: harden visitor registration proxy exception handling

### DIFF
--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -667,6 +667,50 @@ def test_register_visitor_proxy_marks_visitor_confirmation_failed_without_id(
 
 
 @pytest.mark.django_db
+def test_register_visitor_proxy_masks_unexpected_proxy_exception(
+    monkeypatch, admin_user
+):
+    factory = RequestFactory()
+    request = factory.post(
+        "/nodes/register-visitor-proxy/",
+        data=json.dumps(
+            {
+                "visitor_info_url": "https://visitor.example/nodes/info/",
+                "visitor_register_url": "https://visitor.example/nodes/register/",
+            }
+        ),
+        content_type="application/json",
+    )
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    target = SimpleNamespace(
+        url="https://visitor.example/nodes/info/",
+        server_hostname="visitor.example",
+        host_header="visitor.example",
+    )
+    monkeypatch.setattr(handlers, "is_allowed_visitor_url", lambda _: True)
+    monkeypatch.setattr(handlers, "get_public_targets", lambda _: [target])
+    monkeypatch.setattr(
+        handlers,
+        "node_info",
+        lambda _request: JsonResponse({"hostname": "host-node"}),
+    )
+    monkeypatch.setattr(
+        handlers,
+        "_try_proxy_json_request",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("internal traceback")),
+    )
+
+    response = handlers.register_visitor_proxy(request)
+
+    assert response.status_code == 502
+    data = json.loads(response.content.decode())
+    assert data["detail"] == "visitor info unavailable"
+    assert "traceback" not in data["detail"].lower()
+
+
+@pytest.mark.django_db
 def test_get_local_does_not_cache_stale_self_after_mac_conflict(monkeypatch):
     self_node = Node.objects.create(
         hostname="self-node",

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -939,15 +939,28 @@ def register_visitor_proxy(request):
     session = requests.Session()
     timeout_seconds = 45
 
-    visitor_info, visitor_info_url, last_error, info_attempt = _try_proxy_json_request(
-        session=session,
-        url=visitor_info_url,
-        timeout_seconds=timeout_seconds,
-        method="get",
-        log_prefix="Visitor registration proxy",
-        request_error_message="info request failed",
-        response_error_message="info response json parse failed",
-    )
+    try:
+        visitor_info, visitor_info_url, last_error, info_attempt = (
+            _try_proxy_json_request(
+                session=session,
+                url=visitor_info_url,
+                timeout_seconds=timeout_seconds,
+                method="get",
+                log_prefix="Visitor registration proxy",
+                request_error_message="info request failed",
+                response_error_message="info response json parse failed",
+            )
+        )
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        registration_logger.warning(
+            "Visitor registration proxy: unexpected visitor info proxy failure",
+            extra={
+                "target": redact_url_token(visitor_info_url),
+                "attempt": "visitor_info_proxy",
+                "exception_class": exc.__class__.__name__,
+            },
+        )
+        return JsonResponse({"detail": "visitor info unavailable"}, status=502)
     if visitor_info is None:
         registration_logger.warning(
             "Visitor registration proxy: unable to fetch visitor info from %s: %s",
@@ -989,18 +1002,29 @@ def register_visitor_proxy(request):
     visitor_payload = _build_registration_payload(host_info, "Upstream")
     _apply_token_signature(visitor_payload, host_info, token)
 
-    visitor_register_body, visitor_register_url, last_error, register_attempt = (
-        _try_proxy_json_request(
-            session=session,
-            url=visitor_register_url,
-            timeout_seconds=timeout_seconds,
-            method="post",
-            payload=visitor_payload,
-            log_prefix="Visitor registration proxy",
-            request_error_message="visitor notification request failed",
-            response_error_message="visitor response json parse failed",
+    try:
+        visitor_register_body, visitor_register_url, last_error, register_attempt = (
+            _try_proxy_json_request(
+                session=session,
+                url=visitor_register_url,
+                timeout_seconds=timeout_seconds,
+                method="post",
+                payload=visitor_payload,
+                log_prefix="Visitor registration proxy",
+                request_error_message="visitor notification request failed",
+                response_error_message="visitor response json parse failed",
+            )
         )
-    )
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        registration_logger.warning(
+            "Visitor registration proxy: unexpected visitor confirmation proxy failure",
+            extra={
+                "target": redact_url_token(visitor_register_url),
+                "attempt": "visitor_register_proxy",
+                "exception_class": exc.__class__.__name__,
+            },
+        )
+        return JsonResponse({"detail": "visitor confirmation failed"}, status=502)
     if visitor_register_body is None:
         registration_logger.warning(
             "Visitor registration proxy: unable to notify visitor at %s: %s",


### PR DESCRIPTION
### Motivation

- Prevent unexpected local runtime errors in the visitor registration proxy from producing traceback-bearing 500 responses or leaking exception details to callers by returning stable, sanitized 502 responses instead.

### Description

- Wrap the `visitor_info` and `visitor_register` `_try_proxy_json_request` calls in `register_visitor_proxy` with explicit `try/except` handlers that catch `AttributeError`, `RuntimeError`, `TypeError`, and `ValueError` and return sanitized error responses.
- Log a redacted, structured warning on these unexpected failures using `registration_logger.warning` with `redact_url_token(visitor_*_url)` and the exception class name to preserve server-side diagnostics without exposing internals.
- Preserve existing behavior for expected proxy failures (where `_try_proxy_json_request` returns `None` or an error) and for host registration handling, only adding defensive handling for unexpected exceptions.
- Add `test_register_visitor_proxy_masks_unexpected_proxy_exception` which forces `_try_proxy_json_request` to raise and asserts the endpoint responds with `502` and a non-sensitive detail message.

### Testing

- Bootstrapped environment dependencies with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt`, both completed successfully.
- Ran `manage.py` tests: `apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_masks_unexpected_proxy_exception` and it passed.
- Ran `apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_uses_safe_success_details` and `apps/nodes/tests/test_register_node.py::test_register_visitor_proxy_uses_safe_failure_detail` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9172cd57c8326939eefb569df852b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request hardens exception handling in the visitor registration proxy to prevent unexpected runtime errors from exposing sensitive information in HTTP responses.

### Changes to `apps/nodes/views/registration/handlers.py`

The `register_visitor_proxy` function now wraps both `_try_proxy_json_request` calls with explicit try/except handlers:

- Catches `AttributeError`, `RuntimeError`, `TypeError`, and `ValueError` during visitor info retrieval and visitor confirmation
- Returns a `JsonResponse` with HTTP 502 status and sanitized error messages (`"visitor info unavailable"` or `"visitor confirmation failed"`) instead of propagating exceptions
- Logs structured warnings via `registration_logger.warning` with:
  - Redacted target URLs using `redact_url_token()`
  - Fixed attempt labels (`visitor_info_proxy` or `visitor_register_proxy`)
  - Exception class names for server-side diagnostics
- Preserves existing behavior for expected proxy failures (where `_try_proxy_json_request` returns `None` or error responses) and for host registration handling

### Changes to `apps/nodes/tests/test_register_node.py`

Added test `test_register_visitor_proxy_masks_unexpected_proxy_exception` that:

- Configures `handlers._try_proxy_json_request` to raise an unexpected `RuntimeError`
- Verifies `handlers.register_visitor_proxy(request)` returns HTTP 502 with response detail `"visitor info unavailable"`
- Confirms exception details (including the word "traceback") are not exposed in the response

### Impact

This change prevents information leakage through exception tracebacks while maintaining diagnostic information server-side for troubleshooting unexpected failures in the visitor registration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->