### PR TITLE
ocpp: restrict dashboard and simulator to site operators and staff

### DIFF
--- a/apps/ocpp/views/common.py
+++ b/apps/ocpp/views/common.py
@@ -52,7 +52,7 @@ from apps.simulators.evcs import (
     _stop_simulator,
     get_simulator_state,
 )
-from apps.sites.utils import landing
+from apps.sites.utils import landing, user_in_site_operator_group
 from utils.api import api_login_required
 
 from .. import store
@@ -427,6 +427,20 @@ def _landing_visibility_params(*, request, landing) -> dict[str, object]:
 
     user = getattr(request, "user", None)
     return {"user_id": getattr(user, "pk", "anon") or "anon"}
+
+
+def _landing_requires_site_operator_or_staff(*, request, landing, **kwargs) -> bool:
+    """Return ``True`` when the user is a site operator or a staff member."""
+
+    user = getattr(request, "user", None)
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_superuser", False) or getattr(user, "is_staff", False):
+        return True
+    try:
+        return user_in_site_operator_group(user)
+    except (OperationalError, ProgrammingError):
+        return False
 
 
 def _charger_last_seen(charger: Charger | object):

--- a/apps/ocpp/views/dashboard.py
+++ b/apps/ocpp/views/dashboard.py
@@ -11,7 +11,11 @@ from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from apps.nodes.models import Node
-from apps.sites.utils import landing
+from apps.sites.utils import (
+    landing,
+    module_pill_link_validation,
+    require_site_operator_or_staff,
+)
 from config.request_utils import is_https_request
 
 from .. import store
@@ -20,12 +24,21 @@ from ..status_display import STATUS_BADGE_MAP
 from . import common as view_common
 from .common import (_charger_last_seen, _charger_state,
                      _charging_limit_details, _clear_stale_statuses_for_view,
+                     _landing_requires_site_operator_or_staff,
+                     _landing_visibility_params,
                      _has_active_session, _reverse_connector_url)
 
 
 @landing("CPMS Online Dashboard")
+@module_pill_link_validation(
+    _landing_requires_site_operator_or_staff,
+    parameter_getter=_landing_visibility_params,
+)
 def dashboard(request):
     """Landing page listing all known chargers and their status."""
+    auth_response = require_site_operator_or_staff(request)
+    if auth_response is not None:
+        return auth_response
     is_htmx = request.headers.get("HX-Request") == "true"
     node = Node.get_local()
     role = node.role if node else None

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -1,16 +1,23 @@
 from datetime import timedelta
 import ipaddress
 
-from django.contrib.auth.views import redirect_to_login
-from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from ..utils import resolve_ws_scheme
 from apps.core.notifications import LcdChannel
 from apps.screens.startup_notifications import format_lcd_lines
+from apps.sites.utils import (
+    landing,
+    module_pill_link_validation,
+    require_site_operator_or_staff,
+)
 
 from .common import *  # noqa: F401,F403
+from .common import (
+    _landing_requires_site_operator_or_staff,
+    _landing_visibility_params,
+)
 from apps.simulators.evcs import _start_simulator, _stop_simulator, parse_repeat
 from apps.simulators.simulator_runtime import (
     ARTHEXIS_BACKEND,
@@ -29,11 +36,16 @@ REPEAT_TRUE_STRINGS = {
 }
 
 @landing("OCPP Simulator")
+@module_pill_link_validation(
+    _landing_requires_site_operator_or_staff,
+    parameter_getter=_landing_visibility_params,
+)
 def cp_simulator(request):
-    """Public landing page to control the OCPP charge point simulator."""
-    user = getattr(request, "user", None)
-    if not getattr(user, "is_authenticated", False):
-        return redirect_to_login(request.get_full_path(), resolve_url("pages:login"))
+    """Landing page to control the OCPP charge point simulator."""
+    auth_response = require_site_operator_or_staff(request)
+    if auth_response is not None:
+        return auth_response
+    user = request.user
     if request.method == "POST" and not getattr(user, "is_staff", False):
         return HttpResponse("Forbidden", status=403)
 

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -179,13 +179,28 @@ def test_require_site_operator_or_staff_enforces_admin_operator_boundary(rf):
     assert require_site_operator_or_staff(request) is None
 
 
-def test_public_charge_point_dashboard_is_available_to_anonymous_users(client):
+def test_public_charge_point_dashboard_redirects_anonymous_users_to_login(client):
     response = client.get(reverse("ocpp:ocpp-dashboard"))
 
-    assert response.status_code == 200
+    assert response.status_code == 302
+    assert response.url.startswith(f"{reverse('pages:login')}?next=")
 
 
-def test_charge_points_module_shows_dashboard_and_simulator_links_to_anonymous_users():
+@pytest.mark.parametrize("path_name", ["ocpp:ocpp-dashboard", "ocpp:cp-simulator"])
+def test_charge_point_views_forbid_authenticated_non_operator_users(client, path_name):
+    user = get_user_model().objects.create_user(
+        username=f"charge-point-regular-{path_name.split(':')[-1]}",
+        email=f"{path_name.split(':')[-1]}@example.com",
+        password="secret",
+    )
+    client.force_login(user)
+
+    response = client.get(reverse(path_name))
+
+    assert response.status_code == 403
+
+
+def test_charge_points_module_hides_dashboard_and_simulator_links_from_anonymous_users():
     module = Module.objects.create(path="/charge-points/", menu="Charge Points")
     Landing.objects.create(
         module=module,
@@ -199,6 +214,32 @@ def test_charge_points_module_shows_dashboard_and_simulator_links_to_anonymous_u
     )
     request = RequestFactory().get("/")
     request.user = AnonymousUser()
+
+    nav_context = context_processors.nav_links(request)
+    nav_modules = nav_context["nav_modules"]
+    assert not any(module.path == "/charge-points/" for module in nav_modules)
+
+
+def test_charge_points_module_shows_dashboard_and_simulator_links_to_site_operators():
+    module = Module.objects.create(path="/charge-points/", menu="Charge Points")
+    Landing.objects.create(
+        module=module,
+        path=reverse("ocpp:ocpp-dashboard"),
+        label="Charging Station Dashboards",
+    )
+    Landing.objects.create(
+        module=module,
+        path=reverse("ocpp:cp-simulator"),
+        label="EVCS Online Simulator",
+    )
+    operator = get_user_model().objects.create_user(
+        username="charge-points-operator",
+        email="charge-points-operator@example.com",
+        password="secret",
+    )
+    Group.objects.get_or_create(name=SITE_OPERATOR_GROUP_NAME)[0].user_set.add(operator)
+    request = RequestFactory().get("/")
+    request.user = operator
 
     nav_context = context_processors.nav_links(request)
     nav_modules = nav_context["nav_modules"]


### PR DESCRIPTION
### Motivation
- Fix an information disclosure where the CPMS dashboard and simulator were reachable by anonymous users by restoring a site-operator/staff access boundary so only staff or site operators can view these pages.

### Description
- Add ` _landing_requires_site_operator_or_staff` to `apps/ocpp/views/common.py` to centralize landing visibility logic for charge-point landings. 
- Enforce `require_site_operator_or_staff` and attach `module_pill_link_validation` to the CPMS dashboard in `apps/ocpp/views/dashboard.py` so the view and the navigation pill are only visible to staff or site-operator users. 
- Apply the same access control and module-pill validator to the OCPP simulator in `apps/ocpp/views/simulator.py` and simplify the simulator landing docstring. 
- Update tests in `apps/sites/tests/test_public_routes.py` to assert anonymous requests are redirected to login, authenticated non-operator users receive `403`, and that nav-module visibility hides the charge-points module for anonymous users but shows it to site operators.

### Testing
- Ran environment refresh with `./env-refresh.sh --deps-only` to bootstrap the venv and dependencies. 
- Installed CI test dependencies via `.venv/bin/pip install -r requirements-ci.txt` to provide `pytest` and friends after an initial test-run discovered it was missing. 
- Executed the targeted test file with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py`, and all tests passed (`14 passed`). 
- Ran `./scripts/review-notify.sh --actor Codex` to emit the review notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91814a7148326971518a24fbfea07)