### PR TITLE
Remove dependency-graph write permission from dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: read
-  dependency-graph: write
   id-token: write
   issues: write
 


### PR DESCRIPTION
### Motivation
- Remove unnecessary `dependency-graph: write` permission from `.github/workflows/dependency-submission.yml` to tighten workflow permissions.

### Description
- Deleted the `dependency-graph: write` entry from the `permissions` block in `dependency-submission.yml`.

### Testing
- No automated tests were executed for this permissions-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93b04b4988326935ea8f4bb8a17b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Removed dependency-graph write permission from dependency submission workflow

Removed the `dependency-graph: write` permission from the workflow-level `permissions` block in `.github/workflows/dependency-submission.yml` to tighten the workflow's permission scope. The remaining permissions (`contents: read`, `id-token: write`, and `issues: write`) are retained unchanged.

**Changes:**
- Deleted `dependency-graph: write` from `permissions` block
- 1 line removed

**Context:**
The dependency submission workflow did not require write access to the dependency graph, making this permission unnecessary and a potential security risk if the workflow were compromised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->