### PR TITLE
Fix install health check failure in OCPP dashboard screenshot smoke test

### DIFF
--- a/apps/ocpp/tests/test_screenshot_workflows.py
+++ b/apps/ocpp/tests/test_screenshot_workflows.py
@@ -28,7 +28,10 @@ def test_dashboard_snapshot_after_simulated_session(client, settings, monkeypatc
     )
 
     user = get_user_model().objects.create_user(
-        username="snapshot-user", email="snapshots@example.com", password="pass"
+        username="snapshot-user",
+        email="snapshots@example.com",
+        password="pass",
+        is_staff=True,
     )
     client.force_login(user)
 


### PR DESCRIPTION
### Motivation
- The install health check's `Run install smoke tests` step was failing because the dashboard enforces `require_site_operator_or_staff`, and the screenshot workflow test created a non-staff user which resulted in a `403`; the test must reflect current access rules.

### Description
- Update `apps/ocpp/tests/test_screenshot_workflows.py` to create the test user with `is_staff=True` so the client can access the OCPP dashboard and capture the screenshot.

### Testing
- Ran `pytest -q apps/ocpp/tests/test_screenshot_workflows.py apps/sites/tests/test_public_routes.py::test_charge_point_views_forbid_authenticated_non_operator_users apps/sites/tests/test_public_routes.py::test_require_site_operator_or_staff_enforces_admin_operator_boundary --timeout=180` which passed; an attempt to install the full `requirements-ci.txt` failed in this environment due to an unavailable `RPi.GPIO` distribution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d951edf7808326bfb466821a0464ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Created a new test file `apps/ocpp/tests/test_screenshot_workflows.py` to capture screenshots of OCPP dashboard workflows. The key change is that the test user is created with `is_staff=True` to satisfy the `require_site_operator_or_staff` permission check enforced by the OCPP dashboard, which was previously causing 403 access denied errors during the smoke test.

## Changes

- **apps/ocpp/tests/test_screenshot_workflows.py** (new file)
  - Added `test_dashboard_snapshot_after_simulated_session()`: Creates a staff user, simulates a charger transaction, and captures a screenshot of the OCPP dashboard after verifying access is granted (200 status).
  - Added `test_evcs_public_site_snapshot_with_transactions()`: Creates a charger with meter values and captures a screenshot of the public EVCS page.

The test user is instantiated with `is_staff=True` to ensure the test client can access the dashboard and complete the screenshot workflow, aligning with the current access control requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->