### PR TITLE
Follow-up: correct permissions for dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -16,8 +16,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  id-token: write
+  contents: write
   issues: write
 
 jobs:


### PR DESCRIPTION
### Motivation
- Dependency snapshot submissions were failing after retries likely due to insufficient repository token scope for the component-detection action, so the workflow needs `contents: write` and removal of an unused `id-token` permission.

### Description
- Update `.github/workflows/dependency-submission.yml` to set `permissions: contents: write` and remove the `id-token: write` entry.

### Testing
- Ran `git diff --check` and it completed with no errors.
- Executed `./scripts/review-notify.sh --actor Codex` which succeeded using the fallback notification path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d951fbf49c83269fa97e38aeecaa12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This is a follow-up fix to address dependency snapshot submission failures caused by insufficient repository token permissions in the GitHub Actions workflow. The `component-detection-dependency-submission-action` requires write access to repository contents to successfully submit dependency snapshots.

## Changes
Updated `.github/workflows/dependency-submission.yml` permissions configuration:
- Changed `permissions.contents` from `read` to `write` to grant the required authorization for dependency submission
- Removed the unused `permissions.id-token: write` entry

The workflow retains `permissions.issues: write` for tracking persistent submission failures via GitHub issues.

## Testing
- Validated syntax with `git diff --check` (no errors)
- Executed `./scripts/review-notify.sh --actor Codex` successfully using the fallback notification path

## Impact
Enables the dependency submission workflow to successfully submit dependency snapshots to GitHub's Dependency Graph after retries, while maintaining the existing failure tracking and non-blocking behavior for transient GitHub Dependency Graph API outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->