### PR TITLE
Remove JavaScript-enabled feedback form check

### DIFF
--- a/apps/sites/forms.py
+++ b/apps/sites/forms.py
@@ -100,12 +100,11 @@ class UserStoryForm(forms.ModelForm):
 
     class Meta:
         model = UserStory
-        fields = ("name", "rating", "comments", "path", "messages", "contact_via_chat", "javascript_enabled")
+        fields = ("name", "rating", "comments", "path", "messages", "contact_via_chat")
         widgets = {
             "path": forms.HiddenInput(),
             "comments": forms.Textarea(attrs={"rows": 4}),
             "messages": forms.HiddenInput(),
-            "javascript_enabled": forms.HiddenInput(),
         }
 
     def __init__(self, *args, user=None, files=None, **kwargs):
@@ -290,7 +289,6 @@ class UserStoryForm(forms.ModelForm):
         if self.user is not None and self.user.is_authenticated:
             instance.user = self.user
         instance.contact_via_chat = bool(self.cleaned_data.get("contact_via_chat"))
-        instance.javascript_enabled = self.cleaned_data.get("javascript_enabled", False)
         if commit:
             instance.save()
             self.save_attachments()

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -28,7 +28,6 @@
   const copyAriaLabel = form.dataset.copyAriaLabel;
   const canCopyStaffDetails = form.dataset.copyStaffDetails === '1';
   const messageField = form.querySelector('input[name="messages"]');
-  const javascriptEnabledField = form.querySelector('input[name="javascript_enabled"]');
   let previousFocus = null;
   let copyFeedbackTimeout = null;
 
@@ -371,10 +370,6 @@
     event.preventDefault();
     resetAlerts();
     syncMessageField(getPageMessages());
-    if (javascriptEnabledField) {
-      javascriptEnabledField.value = '1';
-    }
-
     if (submitBtn) {
       submitBtn.disabled = true;
     }

--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -50,7 +50,6 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
-            <input type="hidden" name="javascript_enabled" value="0">
         {% if request.user.is_authenticated %}
           <div class="user-story-field user-story-contact-row">
             <div class="user-story-contact-name">

--- a/apps/sites/templates/pages/includes/public_feedback_widget.html
+++ b/apps/sites/templates/pages/includes/public_feedback_widget.html
@@ -51,7 +51,6 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
-        <input type="hidden" name="javascript_enabled" value="0">
       {% if request.user.is_authenticated %}
         <div class="user-story-contact-row mb-3">
           <div class="user-story-contact-name">


### PR DESCRIPTION
### Motivation

- The feedback flow no longer needs to capture or persist whether the client had JavaScript enabled, so remove the hidden field and client-side check to simplify submissions and storage.

### Description

- Remove `javascript_enabled` from the `UserStoryForm` `fields` and widget configuration and stop assigning `instance.javascript_enabled` in `save` (file: `apps/sites/forms.py`).
- Remove the hidden `javascript_enabled` input from the public and admin feedback templates (files: `apps/sites/templates/pages/includes/public_feedback_widget.html`, `apps/sites/templates/admin/includes/user_story_feedback.html`).
- Remove frontend code that located and set `javascript_enabled` before submit (file: `apps/sites/static/pages/js/user_story_feedback.js`).

### Testing

- Ran environment refresh with `./env-refresh.sh --deps-only` which completed successfully.
- Installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Ran the site public routes tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py` and observed `14 passed`.
- Executed `./scripts/review-notify.sh --actor Codex` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9660020b88326a4f936706c5cec84)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This pull request removes the `javascript_enabled` field from the feedback form submission flow across all related components. The field is no longer needed since the feedback system does not require tracking whether the client had JavaScript enabled.

### Modified Files

**apps/sites/forms.py**
- Removed `javascript_enabled` from `UserStoryForm.Meta.fields` list
- Removed the hidden widget configuration for `javascript_enabled`
- Removed assignment to `instance.javascript_enabled` in the `save()` method
- All other form behavior (attachments, contact_via_chat, user binding) remains unchanged

**apps/sites/static/pages/js/user_story_feedback.js**
- Removed retrieval and initialization of the hidden `javascript_enabled` input field
- Removed code that sets the field value to `'1'` on form submission
- All other submission flow, validation, and network request behavior remains intact

**apps/sites/templates/pages/includes/public_feedback_widget.html**
- Removed the hidden form field `<input type="hidden" name="javascript_enabled" value="0">`

**apps/sites/templates/admin/includes/user_story_feedback.html**
- Removed the hidden form field `<input type="hidden" name="javascript_enabled" value="0">`

### Testing

- Environment setup completed successfully via `./env-refresh.sh --deps-only`
- CI dependencies installed successfully
- Public routes tests passed: 14/14 tests in `apps/sites/tests/test_public_routes.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->