### PR TITLE
ocpp: preserve simulator backend when JS is disabled

### DIFF
--- a/apps/ocpp/templates/ocpp/cp_simulator.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator.html
@@ -24,6 +24,7 @@
       <option value="{{ value }}" {% if value == selected_backend %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
     </select>
+    <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
     {% if not backends_available %}<small class="text-warning ms-2">No simulator backends are enabled.</small>{% endif %}
   </form>
 </div>

--- a/apps/ocpp/templates/ocpp/cp_simulator.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator.html
@@ -24,7 +24,9 @@
       <option value="{{ value }}" {% if value == selected_backend %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
     </select>
-    <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+    <noscript>
+      <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+    </noscript>
     {% if not backends_available %}<small class="text-warning ms-2">No simulator backends are enabled.</small>{% endif %}
   </form>
 </div>

--- a/apps/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator_block.html
@@ -6,6 +6,7 @@
           hx-swap="outerHTML">
       {% csrf_token %}
       <input type="hidden" name="simulator_slot" value="{{ idx }}">
+      <input type="hidden" name="simulator_backend" value="{{ selected_backend }}">
       <div class="row g-3 align-items-start simulator-layout">
         <div class="col-12 col-xl-6">
           <div class="row g-2">

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -49,10 +49,13 @@ def test_cp_simulator_start_posts_selected_backend(
     "apps.ocpp.views.simulator.get_simulator_backend_choices",
     return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
 )
-def test_cp_simulator_backend_selector_has_no_js_fallback(_backend_choices, admin_client):
+def test_cp_simulator_backend_selector_has_noscript_apply_fallback(
+    _backend_choices, admin_client
+):
     response = admin_client.get(reverse("ocpp:cp-simulator"))
 
     assert response.status_code == 200
     content = response.content.decode("utf-8")
     assert 'name="simulator_backend" value="mobilityhouse"' in content
-    assert "Apply" in content
+    assert "<noscript>" in content
+    assert '<button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>' in content

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@patch("apps.ocpp.views.simulator._start_simulator")
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
+)
+def test_cp_simulator_start_posts_selected_backend(
+    _backend_choices,
+    start_simulator,
+    admin_client,
+):
+    response = admin_client.post(
+        reverse("ocpp:cp-simulator"),
+        {
+            "action": "start",
+            "host": "localhost:8888",
+            "cp_path": "CP2",
+            "serial_number": "CP2",
+            "connector_id": "1",
+            "rfid": "FFFFFFFF",
+            "vin": "WP0ZZZ00000000000",
+            "duration": "600",
+            "interval": "5",
+            "pre_charge_delay": "0",
+            "average_kwh": "60",
+            "amperage": "90",
+            "repeat": "False",
+            "simulator_backend": "arthexis",
+        },
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    start_simulator.assert_called_once()
+    sim_params = start_simulator.call_args.args[0]
+    assert sim_params["simulator_backend"] == "arthexis"
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
+)
+def test_cp_simulator_backend_selector_has_no_js_fallback(_backend_choices, admin_client):
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert 'name="simulator_backend" value="mobilityhouse"' in content
+    assert "Apply" in content


### PR DESCRIPTION
### Motivation

- Ensure the operator-selected simulator backend is preserved when JavaScript is disabled so Start requests use the intended runtime and do not silently fall back to a different backend.

### Description

- Add a non-JS fallback `Apply` button to the simulator backend selector in `apps/ocpp/templates/ocpp/cp_simulator.html` so backend changes can be submitted without JavaScript. 
- Include a hidden `simulator_backend` field in the start/stop simulator form in `apps/ocpp/templates/ocpp/cp_simulator_block.html` so backend selection is propagated on normal form submits. 
- Add `apps/ocpp/tests/test_cp_simulator_view.py` with regression tests validating backend propagation on start POST and that the no-JS fallback rendering contains the hidden backend value and the `Apply` control.

### Testing

- Ran environment refresh and dependency install with `./env-refresh.sh --deps-only` and ` .venv/bin/pip install -r requirements-ci.txt` successfully. 
- Executed the new view tests with `.venv/bin/python manage.py test run -- apps.ocpp/tests/test_cp_simulator_view.py` and `2 passed` was reported. 
- Ran ` .venv/bin/python manage.py migrations check` and it reported `No changes detected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d965ef4a4c832688e748693206b6b4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix: Preserve simulator backend selection when JavaScript is disabled

**Motivation:**
Ensure an operator-selected simulator backend is preserved when JavaScript is disabled so Start requests use the intended runtime and do not silently fall back to a different backend.

**Changes:**

1. apps/ocpp/templates/ocpp/cp_simulator.html
   - Added a <noscript>-scoped "Apply" submit button so backend selection can be submitted without JavaScript while preserving the existing auto-submit behavior when JS is enabled.

2. apps/ocpp/templates/ocpp/cp_simulator_block.html
   - Added a hidden `simulator_backend` form field to propagate the selected backend value on normal form submits (start/stop).

3. apps/ocpp/tests/test_cp_simulator_view.py
   - Added two regression tests:
     - `test_cp_simulator_start_posts_selected_backend`: Verifies a start POST includes and uses the selected `simulator_backend`.
     - `test_cp_simulator_backend_selector_has_noscript_apply_fallback`: Verifies the backend selector rendering includes the hidden backend value and a `<noscript>` "Apply" control.

**Testing:**
- Ran dependency setup and test runner; new tests pass (2 passed).
- Ran Django migrations check (no changes detected).

**Notes:**
- Commit scopes the non-JS fallback to <noscript> so the "Apply" control only appears when JavaScript is disabled.
- A test author comment notes the test detected JS as disabled in one environment; this may indicate the test's JS-detection logic is worth reviewing if issues arise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->