### PR TITLE
sites: remove feedback JS checkbox and persist JS flag server-side

### DIFF
--- a/apps/sites/forms.py
+++ b/apps/sites/forms.py
@@ -100,12 +100,11 @@ class UserStoryForm(forms.ModelForm):
 
     class Meta:
         model = UserStory
-        fields = ("name", "rating", "comments", "path", "messages", "contact_via_chat", "javascript_enabled")
+        fields = ("name", "rating", "comments", "path", "messages", "contact_via_chat")
         widgets = {
             "path": forms.HiddenInput(),
             "comments": forms.Textarea(attrs={"rows": 4}),
             "messages": forms.HiddenInput(),
-            "javascript_enabled": forms.HiddenInput(),
         }
 
     def __init__(self, *args, user=None, files=None, **kwargs):
@@ -290,7 +289,7 @@ class UserStoryForm(forms.ModelForm):
         if self.user is not None and self.user.is_authenticated:
             instance.user = self.user
         instance.contact_via_chat = bool(self.cleaned_data.get("contact_via_chat"))
-        instance.javascript_enabled = self.cleaned_data.get("javascript_enabled", False)
+        instance.javascript_enabled = True
         if commit:
             instance.save()
             self.save_attachments()

--- a/apps/sites/models/user_story.py
+++ b/apps/sites/models/user_story.py
@@ -115,7 +115,6 @@ class UserStory(Lead):
             f"**Rating:** {self.rating}/5",
             f"**Name:** {name}",
             f"**Contact via chat:** {'Yes' if self.contact_via_chat else 'No'}",
-            f"**JavaScript enabled:** {'Yes' if self.javascript_enabled else 'No'}",
         ]
         if self.screenshot:
             lines.append("**Screenshot:** Provided (see admin attachments).")

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -28,7 +28,6 @@
   const copyAriaLabel = form.dataset.copyAriaLabel;
   const canCopyStaffDetails = form.dataset.copyStaffDetails === '1';
   const messageField = form.querySelector('input[name="messages"]');
-  const javascriptEnabledField = form.querySelector('input[name="javascript_enabled"]');
   let previousFocus = null;
   let copyFeedbackTimeout = null;
 
@@ -371,10 +370,6 @@
     event.preventDefault();
     resetAlerts();
     syncMessageField(getPageMessages());
-    if (javascriptEnabledField) {
-      javascriptEnabledField.value = '1';
-    }
-
     if (submitBtn) {
       submitBtn.disabled = true;
     }

--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -50,7 +50,6 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
-            <input type="hidden" name="javascript_enabled" value="0">
         {% if request.user.is_authenticated %}
           <div class="user-story-field user-story-contact-row">
             <div class="user-story-contact-name">
@@ -89,7 +88,7 @@
         <div class="user-story-field">
           <div class="user-story-rating-row">
             <span class="user-story-label" id="user-story-rating-group-label">
-              {% if request.user.is_authenticated %}
+          {% if request.user.is_authenticated %}
                 {% blocktrans trimmed with link_start='<a href="#" class="user-story-copy-link" data-feedback-copy role="button">'|safe link_end='</a>'|safe %}
                   Please rate {{ link_start }}this page{{ link_end }}
                 {% endblocktrans %}

--- a/apps/sites/templates/pages/includes/public_feedback_widget.html
+++ b/apps/sites/templates/pages/includes/public_feedback_widget.html
@@ -51,7 +51,6 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
-        <input type="hidden" name="javascript_enabled" value="0">
       {% if request.user.is_authenticated %}
         <div class="user-story-contact-row mb-3">
           <div class="user-story-contact-name">

--- a/apps/sites/tests/test_user_story_feedback_form.py
+++ b/apps/sites/tests/test_user_story_feedback_form.py
@@ -1,0 +1,40 @@
+import pytest
+
+from apps.sites.forms import UserStoryForm
+from apps.sites.models import UserStory
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_user_story_form_persists_javascript_enabled_as_true():
+    form = UserStoryForm(
+        data={
+            "name": "feedback@example.com",
+            "rating": 4,
+            "comments": "Needs a few improvements.",
+            "path": "/admin/",
+            "messages": "",
+        }
+    )
+
+    assert form.is_valid(), form.errors
+
+    story = form.save()
+
+    assert story.javascript_enabled is True
+
+
+def test_user_story_issue_body_omits_javascript_enabled_line():
+    story = UserStory.objects.create(
+        name="feedback@example.com",
+        rating=3,
+        comments="Flow felt confusing.",
+        path="/dashboard/",
+        contact_via_chat=True,
+        javascript_enabled=True,
+    )
+
+    issue_body = story.build_github_issue_body()
+
+    assert "**Contact via chat:** Yes" in issue_body
+    assert "JavaScript enabled" not in issue_body


### PR DESCRIPTION
### Motivation

- The feedback forms had an explicit "JavaScript enabled" hidden field and frontend plumbing that is redundant because the form requires JS; record the flag server-side unconditionally and stop exposing it in copied/issue text.

### Description

- Remove `javascript_enabled` from `UserStoryForm` fields and widget and delete the hidden input from the public and admin feedback templates so the client no longer submits a separate JS flag.  
- Stop mutating the hidden field in `apps/sites/static/pages/js/user_story_feedback.js` by removing the lookup and write logic.  
- Persist `javascript_enabled = True` in `UserStoryForm.save()` so submissions always record JavaScript as enabled server-side.  
- Remove the “JavaScript enabled” line from `UserStory.build_github_issue_body()` and add tests verifying the server-side default and that the issue body omits the JavaScript line.

### Testing

- Ran `./env-refresh.sh --deps-only` to prepare the environment and it completed successfully.  
- Ran `./.venv/bin/python manage.py migrations check` with no changes detected.  
- Ran the feedback and public-route test suites with `./.venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py apps/sites/tests/test_public_routes.py` and all tests passed (`16 passed`).  
- Review notification was emitted via the repository notifier as part of the change workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97245237083269f93df7d027bc009)