### PR TITLE
Ensure staff users get default operator group so admin journeys surface without explicit group

### DIFF
--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from django.contrib.auth.models import AbstractBaseUser
 from django.urls import reverse
 
+from apps.groups.security import ensure_default_staff_groups
+
 from .models import OperatorJourneyStep, OperatorJourneyStepCompletion
 
 
@@ -30,7 +32,7 @@ def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
         OperatorJourneyStep.objects.filter(
             is_active=True,
             journey__is_active=True,
-            journey__security_group__in=user.groups.all(),
+            journey__security_group__in=_active_security_groups_for_user(user),
         )
         .exclude(completions__user=user)
         .select_related("journey")
@@ -56,13 +58,13 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
     if not user.is_authenticated:
         return OperatorJourneyStatus(has_journey=False, is_complete=True, message="", url="")
 
-    group_ids = list(user.groups.values_list("id", flat=True))
-    has_journey = OperatorJourneyStep.objects.filter(
+    has_journey_steps = OperatorJourneyStep.objects.filter(
         is_active=True,
         journey__is_active=True,
-        journey__security_group_id__in=group_ids,
-    ).exists()
-    if not has_journey:
+        journey__security_group__in=_active_security_groups_for_user(user),
+    )
+
+    if not has_journey_steps.exists():
         return OperatorJourneyStatus(has_journey=False, is_complete=True, message="", url="")
 
     next_step = next_step_for_user(user=user)
@@ -80,3 +82,9 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
         message=f"Next Operator task: {next_step.title}",
         url=reverse("ops:operator-journey-step", args=[next_step.pk]),
     )
+
+
+def _active_security_groups_for_user(user: AbstractBaseUser):
+    if user.is_staff:
+        ensure_default_staff_groups(user)
+    return user.groups.all()

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
+from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
 from apps.groups.models import SecurityGroup
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
@@ -139,3 +140,34 @@ class OperatorJourneyViewTests(TestCase):
             dashboard_response,
             "All Operator tasks completed to date. Keep coming back for more.",
         )
+
+    def test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment(self):
+        site_operator_group = SecurityGroup.objects.create(name=SITE_OPERATOR_GROUP_NAME)
+        admin_user = get_user_model().objects.create_user(
+            username="admin",
+            password="x",
+            is_staff=True,
+            is_superuser=True,
+        )
+        admin_user.groups.clear()
+
+        admin_journey = OperatorJourney.objects.create(
+            name="Admin Journey",
+            slug="admin-journey",
+            security_group=site_operator_group,
+            is_active=True,
+        )
+        OperatorJourneyStep.objects.create(
+            journey=admin_journey,
+            title="Run admin setup",
+            slug="run-admin-setup",
+            instruction="Run setup.",
+            iframe_url="/admin/",
+            order=1,
+        )
+
+        self.client.force_login(admin_user)
+        response = self.client.get(reverse("admin:index"))
+
+        self.assertContains(response, "Next Operator task: Run admin setup")
+        self.assertTrue(admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists())


### PR DESCRIPTION
### Motivation

- Staff users who lack explicit security group assignments should still see operator journeys intended for site operators, and completing the default assignment should surface journey steps for admin users.

### Description

- Add `_active_security_groups_for_user` helper to centralize retrieval of a user's active security groups and ensure default staff groups when `user.is_staff` by calling `ensure_default_staff_groups`.
- Update `next_step_for_user` and `status_for_user` to filter journeys using the new helper via `journey__security_group__in=_active_security_groups_for_user(user)`.
- Fix a variable/exists usage by renaming `has_journey` to `has_journey_steps` and calling `.exists()` for the presence check.
- Import `SITE_OPERATOR_GROUP_NAME` in tests and add `test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment` to validate default group assignment and dashboard surfacing for admin users.

### Testing

- Ran the operator journey tests with `python manage.py test apps.ops.tests.test_operator_journey`, and the suite passed.  
- The new test `test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment` passed and verifies the default staff group is assigned and the dashboard shows the next task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9730e7b0483268c27f95752e87683)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Ensures staff users automatically receive a default operator security group assignment, allowing admin users to see operator journeys without explicit group membership.

## Changes

**apps/ops/operator_journey.py**
- Added `_active_security_groups_for_user(user)` helper function that automatically calls `ensure_default_staff_groups(user)` for staff users, then returns their current security groups
- Updated `next_step_for_user()` and `status_for_user()` to use the new helper instead of directly accessing `user.groups.all()` when filtering eligible journey steps
- Fixed a presence-check bug by renaming `has_journey` to `has_journey_steps` and changing the conditional to use `.exists()` rather than comparing group counts

**apps/ops/tests/test_operator_journey.py**
- Added import of `SITE_OPERATOR_GROUP_NAME`
- Added `test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment()` to verify that:
  - An admin user without explicit operator group membership is assigned the default `SITE_OPERATOR_GROUP_NAME` group when accessing the dashboard
  - The operator journey step appears on the admin dashboard for that user

## Testing

Operator journey test suite passes, including the new regression test validating default group assignment and dashboard visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->