### PR TITLE
sites: honor selected language on prefixed public URLs

### DIFF
--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -36,9 +36,13 @@ class LanguagePreferenceMiddleware:
 
     def __call__(self, request):
         language_code = self._language_from_path(request.path_info)
+        preferred_language_code = ""
         if not language_code:
             raw_language_code = get_request_language_code(request)
             language_code = normalize_language_code(raw_language_code)
+        else:
+            raw_language_code = get_request_language_code(request)
+            preferred_language_code = normalize_language_code(raw_language_code)
 
         if language_code:
             activate(language_code)
@@ -46,6 +50,14 @@ class LanguagePreferenceMiddleware:
 
         request.selected_language_code = language_code
         request.selected_language = language_code
+
+        prefixed_redirect = self._prefixed_language_redirect(
+            request,
+            language_code=language_code,
+            preferred_language_code=preferred_language_code,
+        )
+        if prefixed_redirect is not None:
+            return prefixed_redirect
 
         if self._should_redirect_to_language_path(request, language_code):
             return HttpResponseRedirect(f"/{language_code}{request.get_full_path()}")
@@ -83,6 +95,47 @@ class LanguagePreferenceMiddleware:
                 return False
 
         return resolver_match.namespace in {"pages", "pages-lang"}
+
+    def _prefixed_language_redirect(
+        self,
+        request,
+        *,
+        language_code: str,
+        preferred_language_code: str,
+    ):
+        """Redirect ``/xx/...`` paths when users changed language preferences."""
+
+        if request.method.upper() not in {"GET", "HEAD"}:
+            return None
+        if not language_code or not preferred_language_code:
+            return None
+        if language_code == preferred_language_code:
+            return None
+        if request.path_info.startswith("/admin"):
+            return None
+        if request.path_info.startswith("/i18n/"):
+            return None
+
+        resolver_match = getattr(request, "resolver_match", None)
+        if resolver_match is None:
+            try:
+                resolver_match = resolve(request.path_info)
+            except Resolver404:
+                return None
+        if resolver_match.namespace not in {"pages", "pages-lang"}:
+            return None
+
+        trimmed = request.path_info.lstrip("/")
+        segments = trimmed.split("/", maxsplit=1)
+        if not segments:
+            return None
+
+        remainder = f"/{segments[1]}" if len(segments) > 1 else "/"
+        replacement = f"/{preferred_language_code}{remainder}"
+        query = request.META.get("QUERY_STRING", "")
+        if query:
+            replacement = f"{replacement}?{query}"
+        return HttpResponseRedirect(replacement)
 
 
 class ViewHistoryMiddleware:

--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -35,14 +35,12 @@ class LanguagePreferenceMiddleware:
         self._supported_language_codes = get_supported_language_codes()
 
     def __call__(self, request):
+        raw_language_code = get_request_language_code(request)
+        preferred_language_code = normalize_language_code(raw_language_code)
         language_code = self._language_from_path(request.path_info)
-        preferred_language_code = ""
         if not language_code:
-            raw_language_code = get_request_language_code(request)
-            language_code = normalize_language_code(raw_language_code)
-        else:
-            raw_language_code = get_request_language_code(request)
-            preferred_language_code = normalize_language_code(raw_language_code)
+            language_code = preferred_language_code
+            preferred_language_code = ""
 
         if language_code:
             activate(language_code)
@@ -91,6 +89,7 @@ class LanguagePreferenceMiddleware:
         if resolver_match is None:
             try:
                 resolver_match = resolve(request.path_info)
+                request.resolver_match = resolver_match
             except Resolver404:
                 return False
 
@@ -111,6 +110,8 @@ class LanguagePreferenceMiddleware:
             return None
         if language_code == preferred_language_code:
             return None
+        if preferred_language_code not in self._supported_language_codes:
+            return None
         if request.path_info.startswith("/admin"):
             return None
         if request.path_info.startswith("/i18n/"):
@@ -120,6 +121,7 @@ class LanguagePreferenceMiddleware:
         if resolver_match is None:
             try:
                 resolver_match = resolve(request.path_info)
+                request.resolver_match = resolver_match
             except Resolver404:
                 return None
         if resolver_match.namespace not in {"pages", "pages-lang"}:
@@ -127,8 +129,6 @@ class LanguagePreferenceMiddleware:
 
         trimmed = request.path_info.lstrip("/")
         segments = trimmed.split("/", maxsplit=1)
-        if not segments:
-            return None
 
         remainder = f"/{segments[1]}" if len(segments) > 1 else "/"
         replacement = f"/{preferred_language_code}{remainder}"

--- a/apps/sites/tests/test_language_preference_middleware.py
+++ b/apps/sites/tests/test_language_preference_middleware.py
@@ -58,3 +58,16 @@ def test_prefixed_pages_path_redirects_to_selected_language(settings):
 
     assert response.status_code == 302
     assert response["Location"] == "/de/changelog/?v=1"
+
+
+@pytest.mark.django_db
+def test_prefixed_pages_path_ignores_unsupported_selected_language(settings):
+    settings.LANGUAGES = [("en", "English"), ("de", "German")]
+    request = RequestFactory().get("/en/changelog/?v=1")
+    request.resolver_match = resolve("/en/changelog/")
+    request.COOKIES["django_language"] = "pt"
+
+    middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
+    response = middleware(request)
+
+    assert response.status_code == 200

--- a/apps/sites/tests/test_language_preference_middleware.py
+++ b/apps/sites/tests/test_language_preference_middleware.py
@@ -44,3 +44,17 @@ def test_language_with_region_in_path_does_not_loop(settings):
 
     assert response.status_code == 200
     assert request.selected_language_code == "en"
+
+
+@pytest.mark.django_db
+def test_prefixed_pages_path_redirects_to_selected_language(settings):
+    settings.LANGUAGES = [("en-us", "English (US)"), ("de", "German")]
+    request = RequestFactory().get("/en/changelog/?v=1")
+    request.resolver_match = resolve("/en/changelog/")
+    request.COOKIES["django_language"] = "de"
+
+    middleware = LanguagePreferenceMiddleware(lambda _request: HttpResponse("ok"))
+    response = middleware(request)
+
+    assert response.status_code == 302
+    assert response["Location"] == "/de/changelog/?v=1"


### PR DESCRIPTION
### Motivation
- Public pages using language-prefixed routes (for example `/en/...`) ignored a newly selected language preference, so changing the language selector had no visible effect for prefixed URLs and confused users. 

### Description
- Update `LanguagePreferenceMiddleware` to compute the current request's `preferred_language_code` and add a `_prefixed_language_redirect` helper that redirects `/xx/...` public paths to the newly selected language prefix while preserving the remainder of the path and query string. 
- The new redirect only runs for `GET`/`HEAD` requests, is scoped to the public pages namespaces (`pages`, `pages-lang`), and explicitly skips `/admin` and `/i18n/` endpoints to avoid unintended behavior. 
- Add a unit test `test_prefixed_pages_path_redirects_to_selected_language` in `apps/sites/tests/test_language_preference_middleware.py` to cover the flow of `/en/changelog/?v=1` with `django_language=de` redirecting to `/de/changelog/?v=1`. 

### Testing
- Ran the focused middleware tests with `./.venv/bin/python manage.py test run -- apps/sites/tests/test_language_preference_middleware.py` and the suite for that module completed successfully (4 passed). 
- Executed the repository review notifier via `./scripts/review-notify.sh --actor Codex` to surface the change for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9758f181c832695a5681ceeff82db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Motivation:** Public pages using language-prefixed URLs (e.g., `/en/...`) ignored newly selected language preferences, making the language selector ineffective for these routes.

**Implementation:**

The `LanguagePreferenceMiddleware` was enhanced to detect and redirect prefixed paths when the user's language preference changes:

1. **Separated language tracking**: The middleware now distinguishes between `language_code` (extracted from the URL path) and `preferred_language_code` (from user preferences). When a URL is already language-prefixed, the path-derived value is used as `language_code` while the user's selected preference is captured separately as `preferred_language_code`.

2. **New redirect method**: Added `_prefixed_language_redirect()` that:
   - Only processes GET/HEAD requests
   - Redirects when the URL language prefix differs from the user's preference
   - Applies only to public pages (`pages` and `pages-lang` namespaces)
   - Explicitly excludes `/admin` and `/i18n/` paths
   - Preserves the path remainder and query string in the redirect URL

The new redirect step executes before the existing unprefixed-to-prefixed redirect logic.

**Test Coverage:**

Added `test_prefixed_pages_path_redirects_to_selected_language()` in the test suite, which verifies that a request to `/en/changelog/?v=1` with a `de` language preference redirects to `/de/changelog/?v=1`, correctly rewriting the language prefix while preserving the query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->