### PR TITLE
ci: include main public homepage in screenshot CI paths

### DIFF
--- a/.github/screenshot-paths.public.txt
+++ b/.github/screenshot-paths.public.txt
@@ -2,3 +2,4 @@
 # One path per line. Comments and blank lines are ignored.
 # Example:
 # /status/
+/


### PR DESCRIPTION
### Motivation
- Ensure Screenshot CI captures the site's root page (`/`) alongside other public screenshots so the main public homepage is previewed in the same environment.

### Description
- Added the root route (`/`) to `.github/screenshot-paths.public.txt`; change is minimal and limited to CI screenshot configuration.

### Testing
- Ran the review notification hook `./scripts/review-notify.sh --actor Codex` which completed successfully; no code or unit tests were required for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da60570c408326809e402cdc99378c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the site root route (`/`) to `.github/screenshot-paths.public.txt` to ensure the main public homepage is included in the Screenshot CI workflow alongside other public screenshots.

## Changes

- **`.github/screenshot-paths.public.txt`**: Added one entry for the root path (`/`)

The change is limited to CI configuration with no modifications to application code or tests. The author confirmed the change by running the review notification hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->