### PR TITLE
Fix homepage 500 by loading i18n in reader QR include

### DIFF
--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <script>
   (function () {
     const qrContainer = document.getElementById("reader-qr");


### PR DESCRIPTION
### Motivation
- The public home page raised `TemplateSyntaxError: Invalid block tag ... 'trans'` because the include `apps/docs/templates/includes/reader_qr_script.html` used `{% trans %}` without loading the `i18n` tag library, causing a 500 on `/`.

### Description
- Add `'{% load i18n %}'` to the top of `apps/docs/templates/includes/reader_qr_script.html` so the template's `{% trans %}` tags are valid when the include is rendered.

### Testing
- Ran `./env-refresh.sh --deps-only` (success), ran `.venv/bin/python manage.py check` (success), verified template compilation with `.venv/bin/python manage.py shell -c "from django.template.loader import get_template; get_template('includes/reader_qr_script.html')"` (success), and attempted `.venv/bin/python manage.py test run -- apps.sites.tests` which failed to run because `pytest` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6026d9e88326a2371d99b7aabbe0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issue
The public homepage raised a `TemplateSyntaxError` on `/` because the template include `apps/docs/templates/includes/reader_qr_script.html` used `{% trans %}` translation tags (for labels like "Expand table", "Collapse table", "row", "rows", and "Table") without loading the required `i18n` template tag library.

## Solution
Added `{% load i18n %}` as the first line in `apps/docs/templates/includes/reader_qr_script.html` to make the translation tags available at render time. The file contains an embedded JavaScript module that provides QR code generation, heading navigation tracking, and table collapse/expand functionality, with translatable labels for table operations.

## Testing
- Verified environment setup with `./env-refresh.sh --deps-only`
- Confirmed template compilation with `manage.py check`
- Validated template loading directly with `manage.py shell`

## Changes
- `apps/docs/templates/includes/reader_qr_script.html`: Added `{% load i18n %}` (+1 line)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->