### PR TITLE
sites: fix install smoke failure from missing resolver imports

### DIFF
--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError
+from django.urls import Resolver404, resolve
 
 from .models import Landing, LandingLead, ViewHistory
 from .utils import (


### PR DESCRIPTION
### Motivation
- Fix a runtime `NameError` in `ViewHistoryMiddleware._resolve_view_name` where `resolve` and `Resolver404` were referenced but not imported, which caused install smoke tests to fail.

### Description
- Add `from django.urls import Resolver404, resolve` to `apps/sites/middleware.py` to restore correct URL resolver behavior.

### Testing
- Ran `pytest apps/sites/tests/test_view_history_middleware.py::test_view_history_database_failure_does_not_break_response` (passed), `pytest apps/ocpp/tests/test_ocpp201_actions.py::test_boot_notification_normalizes_ocpp2x_payload` (passed), and the install-smoke selection `pytest -n auto --dist loadfile -m "not critical and not slow and not integration"` which completed successfully (`1063 passed, 4 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5e6ac4188326883b40b574d61b53)