### PR TITLE
ocpp-simulator: surface queued cpsim requests and websocket target in simulator UI

### DIFF
--- a/apps/ocpp/cpsim_service.py
+++ b/apps/ocpp/cpsim_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timezone as dt_timezone
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
@@ -84,3 +85,28 @@ def get_cpsim_feature():
     except (ImportError, RuntimeError):
         return None
     return Feature.objects.filter(slug=CPSIM_FEATURE_SLUG).first()
+
+
+def get_cpsim_request_metadata(*, base_dir: Path | None = None) -> dict[str, Any]:
+    """Return lock-file metadata for the queued cpsim service request."""
+
+    lock_path = _lock_path(base_dir=base_dir)
+    if not lock_path.exists():
+        return {"queued": False, "lock_path": str(lock_path)}
+
+    queued_at = timezone.now()
+    try:
+        queued_at = timezone.datetime.fromtimestamp(
+            lock_path.stat().st_mtime,
+            tz=dt_timezone.utc,
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
+    age_seconds = max((timezone.now() - queued_at).total_seconds(), 0.0)
+    return {
+        "queued": True,
+        "lock_path": str(lock_path),
+        "queued_at": queued_at,
+        "age_seconds": age_seconds,
+    }

--- a/apps/ocpp/cpsim_service.py
+++ b/apps/ocpp/cpsim_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from datetime import timezone as dt_timezone
 from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone as dt_timezone
 from pathlib import Path
 from typing import Any
 
@@ -26,10 +26,11 @@ def _serialize_params(params: Any) -> dict[str, Any]:
     return {"value": params}
 
 
-def _lock_path(*, base_dir: Path | None = None) -> Path:
+def _lock_path(*, base_dir: Path | None = None, ensure_dir: bool = True) -> Path:
     base = Path(base_dir or settings.BASE_DIR)
     lock_dir = base / ".locks"
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    if ensure_dir:
+        lock_dir.mkdir(parents=True, exist_ok=True)
     return lock_dir / CPSIM_REQUEST_LOCK_NAME
 
 
@@ -52,7 +53,7 @@ def queue_cpsim_request(
         "source": source,
         "params": _serialize_params(params),
     }
-    lock_path = _lock_path(base_dir=base_dir)
+    lock_path = _lock_path(base_dir=base_dir, ensure_dir=True)
     lock_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return lock_path
 
@@ -90,13 +91,16 @@ def get_cpsim_feature():
 def get_cpsim_request_metadata(*, base_dir: Path | None = None) -> dict[str, Any]:
     """Return lock-file metadata for the queued cpsim service request."""
 
-    lock_path = _lock_path(base_dir=base_dir)
-    if not lock_path.exists():
+    lock_path = _lock_path(base_dir=base_dir, ensure_dir=False)
+    try:
+        if not lock_path.exists():
+            return {"queued": False, "lock_path": str(lock_path)}
+    except OSError:
         return {"queued": False, "lock_path": str(lock_path)}
 
     queued_at = timezone.now()
     try:
-        queued_at = timezone.datetime.fromtimestamp(
+        queued_at = datetime.fromtimestamp(
             lock_path.stat().st_mtime,
             tz=dt_timezone.utc,
         )

--- a/apps/ocpp/static/ocpp/evcs/cp_simulator.css
+++ b/apps/ocpp/static/ocpp/evcs/cp_simulator.css
@@ -11,6 +11,9 @@
 .simulator-details .stat { font-family: monospace; }
 .sim-msg { margin-bottom: 1em; color: #333; }
 .error { color: #b00020; }
+.simulator-service-alert code {
+  font-size: 0.85em;
+}
 
 .simulator-page-header {
   display: flex;

--- a/apps/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator_block.html
@@ -115,7 +115,19 @@
               <label>Last Command:</label> <span class="stat">{{ cp.last_command|default:"-" }}</span>
               <label>Started:</label> <span class="stat">{{ cp.start_time|default:"-" }}</span>
               <label>Stopped:</label> <span class="stat">{{ cp.stop_time|default:"-" }}</span>
+              <label>Target:</label> <span class="stat">{{ target_ws_url|default:"-" }}</span>
             </div>
+            {% if is_service_queued %}
+            <div class="alert alert-warning simulator-service-alert mb-0" role="alert">
+              <div class="fw-semibold">Start request queued for cpsim-service.</div>
+              {% if cpsim_request.queued %}
+              <div class="small">
+                Queue age: {{ cpsim_request.age_seconds|floatformat:0 }}s · Lock file: <code>{{ cpsim_request.lock_path }}</code>
+              </div>
+              {% endif %}
+              <div class="small mb-0">If this stays in Service phase, start or restart the cpsim worker and check simulator logs.</div>
+            </div>
+            {% endif %}
             {% if cp.last_error %}
             <div class="error"><b>Error:</b><pre>{{ cp.last_error }}</pre></div>
             {% endif %}

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -71,6 +71,38 @@ def test_cp_simulator_backend_selector_has_noscript_apply_fallback(
 
 
 @pytest.mark.django_db
+@patch("apps.ocpp.views.simulator.get_cpsim_request_metadata")
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": False,
+        "last_status": "",
+        "last_command": "",
+        "last_error": "",
+        "last_message": "",
+        "phase": "",
+        "start_time": None,
+        "stop_time": None,
+        "params": {},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_skips_cpsim_metadata_lookup_when_not_service_queued(
+    _backend_choices,
+    _state,
+    request_metadata,
+    admin_client,
+):
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    request_metadata.assert_not_called()
+
+
+@pytest.mark.django_db
 @patch(
     "apps.ocpp.views.simulator.get_cpsim_request_metadata",
     return_value={
@@ -110,3 +142,37 @@ def test_cp_simulator_shows_queued_service_warning_and_target_url(
     assert "ws://localhost:8888/CP2" in content
     assert "Start request queued for cpsim-service." in content
     assert "Queue age: 42s" in content
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    side_effect=OSError("read-only"),
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": True,
+        "last_status": "cpsim-service start requested",
+        "last_command": "start",
+        "last_error": "",
+        "last_message": "",
+        "phase": "Service",
+        "start_time": "2026-04-11 09:28:28",
+        "stop_time": None,
+        "params": {"host": "localhost", "ws_port": 8888, "cp_path": "CP2"},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_handles_cpsim_metadata_oserror(
+    _backend_choices,
+    _state,
+    _request_metadata,
+    admin_client,
+):
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -9,10 +9,15 @@ from django.urls import reverse
 @pytest.mark.django_db
 @patch("apps.ocpp.views.simulator._start_simulator")
 @patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={"queued": False, "lock_path": "/tmp/.locks/cpsim-service.lck"},
+)
+@patch(
     "apps.ocpp.views.simulator.get_simulator_backend_choices",
     return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
 )
 def test_cp_simulator_start_posts_selected_backend(
+    _request_metadata,
     _backend_choices,
     start_simulator,
     admin_client,
@@ -46,11 +51,15 @@ def test_cp_simulator_start_posts_selected_backend(
 
 @pytest.mark.django_db
 @patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={"queued": False, "lock_path": "/tmp/.locks/cpsim-service.lck"},
+)
+@patch(
     "apps.ocpp.views.simulator.get_simulator_backend_choices",
     return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
 )
 def test_cp_simulator_backend_selector_has_noscript_apply_fallback(
-    _backend_choices, admin_client
+    _request_metadata, _backend_choices, admin_client
 ):
     response = admin_client.get(reverse("ocpp:cp-simulator"))
 
@@ -59,3 +68,45 @@ def test_cp_simulator_backend_selector_has_noscript_apply_fallback(
     assert 'name="simulator_backend" value="mobilityhouse"' in content
     assert "<noscript>" in content
     assert '<button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>' in content
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={
+        "queued": True,
+        "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
+        "age_seconds": 42,
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": True,
+        "last_status": "cpsim-service start requested",
+        "last_command": "start",
+        "last_error": "",
+        "last_message": "",
+        "phase": "Service",
+        "start_time": "2026-04-11 09:28:28",
+        "stop_time": None,
+        "params": {"host": "localhost", "ws_port": 8888, "cp_path": "CP2"},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_shows_queued_service_warning_and_target_url(
+    _backend_choices,
+    _state,
+    _request_metadata,
+    admin_client,
+):
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "ws://localhost:8888/CP2" in content
+    assert "Start request queued for cpsim-service." in content
+    assert "Queue age: 42s" in content

--- a/apps/ocpp/tests/test_cpsim_service_feature.py
+++ b/apps/ocpp/tests/test_cpsim_service_feature.py
@@ -1,5 +1,7 @@
 """Regression tests for OCPP Simulator suite feature control."""
 
+from datetime import datetime
+
 from django.urls import reverse
 
 import pytest
@@ -74,3 +76,25 @@ def test_get_cpsim_request_metadata_reports_age_for_existing_queue(tmp_path):
 
     assert metadata["queued"] is True
     assert metadata["age_seconds"] >= 0
+    assert isinstance(metadata["queued_at"], datetime)
+
+
+def test_get_cpsim_request_metadata_handles_unreadable_lock_path(monkeypatch):
+    class UnreadablePath:
+        def exists(self):
+            raise PermissionError("read-only")
+
+        def __str__(self):
+            return "/workspace/arthexis/.locks/cpsim-service.lck"
+
+    monkeypatch.setattr(
+        "apps.ocpp.cpsim_service._lock_path",
+        lambda **_kwargs: UnreadablePath(),
+    )
+
+    metadata = get_cpsim_request_metadata()
+
+    assert metadata == {
+        "queued": False,
+        "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
+    }

--- a/apps/ocpp/tests/test_cpsim_service_feature.py
+++ b/apps/ocpp/tests/test_cpsim_service_feature.py
@@ -6,7 +6,12 @@ import pytest
 
 from apps.features.models import Feature
 from apps.nodes.models import Node
-from apps.ocpp.cpsim_service import CPSIM_FEATURE_SLUG, cpsim_service_enabled
+from apps.ocpp.cpsim_service import (
+    CPSIM_FEATURE_SLUG,
+    get_cpsim_request_metadata,
+    queue_cpsim_request,
+    cpsim_service_enabled,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -53,3 +58,19 @@ def test_simulator_admin_toggle_requires_local_node(admin_client, monkeypatch):
     assert response.status_code == 200
     messages = [str(message) for message in response.context["messages"]]
     assert any("No local node is registered" in message for message in messages)
+
+
+def test_get_cpsim_request_metadata_returns_unqueued_when_absent(tmp_path):
+    metadata = get_cpsim_request_metadata(base_dir=tmp_path)
+
+    assert metadata["queued"] is False
+    assert metadata["lock_path"].endswith("cpsim-service.lck")
+
+
+def test_get_cpsim_request_metadata_reports_age_for_existing_queue(tmp_path):
+    queue_cpsim_request(action="start", name="Simulator", base_dir=tmp_path)
+
+    metadata = get_cpsim_request_metadata(base_dir=tmp_path)
+
+    assert metadata["queued"] is True
+    assert metadata["age_seconds"] >= 0

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -403,12 +403,17 @@ def cp_simulator(request):
     target_ws_url = ""
     if target_host and cp_path:
         target_ws_url = f"{ws_scheme}://{target_host}/{cp_path}"
-    cpsim_request = get_cpsim_request_metadata()
     is_service_queued = (
         state.get("running")
         and state.get("phase") == "Service"
         and str(state.get("last_status") or "").startswith("cpsim-service start requested")
     )
+    cpsim_request = {"queued": False}
+    if is_service_queued:
+        try:
+            cpsim_request = get_cpsim_request_metadata()
+        except OSError:
+            cpsim_request = {"queued": False}
     context.update(
         {
             "target_ws_url": target_ws_url,

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -4,6 +4,7 @@ import ipaddress
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from ..cpsim_service import get_cpsim_request_metadata
 from ..utils import resolve_ws_scheme
 from apps.core.notifications import LcdChannel
 from apps.screens.startup_notifications import format_lcd_lines
@@ -394,6 +395,27 @@ def cp_simulator(request):
         "backend_choices": backend_choices,
         "backends_available": backends_available,
     }
+    state_params = state.get("params") or {}
+    cp_path = str(state_params.get("cp_path") or form_params.get("cp_path") or "").strip()
+    host = str(state_params.get("host") or "").strip()
+    ws_port = state_params.get("ws_port")
+    target_host = _format_host_with_port(host, ws_port) if host else ""
+    target_ws_url = ""
+    if target_host and cp_path:
+        target_ws_url = f"{ws_scheme}://{target_host}/{cp_path}"
+    cpsim_request = get_cpsim_request_metadata()
+    is_service_queued = (
+        state.get("running")
+        and state.get("phase") == "Service"
+        and str(state.get("last_status") or "").startswith("cpsim-service start requested")
+    )
+    context.update(
+        {
+            "target_ws_url": target_ws_url,
+            "is_service_queued": is_service_queued,
+            "cpsim_request": cpsim_request,
+        }
+    )
 
     template = "ocpp/includes/cp_simulator_panel.html" if is_htmx else "ocpp/cp_simulator.html"
     return render(request, template, context)


### PR DESCRIPTION
### Motivation
- Operators clicking Start saw `cpsim-service start requested` with no visible websocket attempt and no guidance when the cpsim worker was not processing the queue, making backend switching and troubleshooting confusing.

### Description
- Added `get_cpsim_request_metadata()` to report presence, path, and age of the cpsim lock/queue file in `apps/ocpp/cpsim_service.py` so the UI can detect queued requests.
- Updated the simulator landing view in `apps/ocpp/views/simulator.py` to compute the resolved WebSocket target URL (`ws://`/`wss://<host>:<port>/<cp_path>`) and detect a queued `Service` phase after a `cpsim-service start requested` status, then expose those values to templates.
- Enhanced the simulator panel template `apps/ocpp/templates/ocpp/cp_simulator_block.html` to show a `Target:` field and a warning alert when a start is queued for the cpsim worker, including queue age and lock-file path, along with a short operator guidance message.
- Added a small CSS tweak in `apps/ocpp/static/ocpp/evcs/cp_simulator.css` for lock-path readability.
- Added regression tests for the new metadata helper and the updated simulator UI behavior in `apps/ocpp/tests/test_cpsim_service_feature.py` and `apps/ocpp/tests/test_cp_simulator_view.py`.

### Testing
- Ran environment preparation: `./env-refresh.sh --deps-only` and installed CI deps with `.venv/bin/pip install -r requirements-ci.txt` (both completed successfully).
- Executed the updated tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_cp_simulator_view.py apps/ocpp/tests/test_cpsim_service_feature.py` and all tests passed (`8 passed`).
- Ran the review notifier `./scripts/review-notify.sh --actor Codex` (notification sent via fallback).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da690a664883268ed086f69febfd03)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses a gap in operator visibility when starting an OCPP simulator while the cpsim-service worker is not actively processing the queue. Previously, operators would see a "cpsim-service start requested" status with no indication of a queued request or the WebSocket target, making troubleshooting and backend switching confusing.

## Changes

**Backend (Python)**

- **cpsim_service.py**: Extended `_lock_path()` to support optional directory creation, and added `get_cpsim_request_metadata()` function that inspects the lock file and returns queue status with metadata (queued flag, lock path, queued timestamp, and age in seconds). Gracefully handles file access failures.

- **views/simulator.py**: Enhanced the simulator landing view to compute the resolved WebSocket target URL (ws:// or wss://<host>:<port>/<cp_path>) and detect when the simulator is in a queued Service phase (state running + phase="Service" + last_status begins with "cpsim-service start requested"). These values are added to the template context.

**Frontend (HTML/CSS)**

- **cp_simulator_block.html**: Added display of a "Target" field showing the WebSocket URL, and a conditional warning alert when a cpsim start is queued. The alert includes queue age (in seconds) and the lock file path, with guidance for operators on restarting the worker.

- **cp_simulator.css**: Added styling for inline code elements within the service alert to improve readability of file paths.

**Testing**

- **test_cpsim_service_feature.py**: Added regression tests covering `get_cpsim_request_metadata()` behavior: queued vs. not-queued states, age calculation, and graceful handling of file access errors (e.g., read-only filesystem).

- **test_cp_simulator_view.py**: Extended existing view tests with mocking of `get_cpsim_request_metadata` and added three new test cases: verifying the function is not called when service is not queued, confirming the alert and WebSocket target are displayed when queued, and ensuring the view handles metadata fetch failures without breaking the response.

All changes maintain backward compatibility and focus on exposing queued state information through existing status indicators rather than introducing new APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->