### PR TITLE
ops/sites: simplify operator task header and include security groups in feedback context

### DIFF
--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -105,6 +105,7 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
 
 
 def _first_available_at(*, user: AbstractBaseUser, next_step: OperatorJourneyStep) -> datetime:
+    fallback_available_at = getattr(user, "date_joined", timezone.localtime())
     previous_step = (
         OperatorJourneyStep.objects.filter(journey=next_step.journey, is_active=True)
         .exclude(pk=next_step.pk)
@@ -114,15 +115,11 @@ def _first_available_at(*, user: AbstractBaseUser, next_step: OperatorJourneySte
     )
 
     if previous_step is None:
-        return user.date_joined
+        return fallback_available_at
 
-    completion = (
-        OperatorJourneyStepCompletion.objects.filter(user=user, step=previous_step)
-        .order_by("completed_at")
-        .first()
-    )
+    completion = OperatorJourneyStepCompletion.objects.filter(user=user, step=previous_step).first()
     if completion is None:
-        return timezone.now()
+        return fallback_available_at
     return completion.completed_at
 
 

--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from django.contrib.auth.models import AbstractBaseUser
+from django.db.models import Q
 from django.urls import reverse
+from django.utils import timezone
 
 from apps.groups.security import ensure_default_staff_groups
 
@@ -19,7 +22,9 @@ class OperatorJourneyStatus:
     has_journey: bool
     is_complete: bool
     message: str
+    task_title: str
     url: str
+    available_since: datetime | None = None
 
 
 def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
@@ -56,7 +61,13 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
     """Build dashboard status text and URL for the signed-in user."""
 
     if not user.is_authenticated:
-        return OperatorJourneyStatus(has_journey=False, is_complete=True, message="", url="")
+        return OperatorJourneyStatus(
+            has_journey=False,
+            is_complete=True,
+            message="",
+            task_title="",
+            url="",
+        )
 
     has_journey_steps = OperatorJourneyStep.objects.filter(
         is_active=True,
@@ -65,7 +76,13 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
     )
 
     if not has_journey_steps.exists():
-        return OperatorJourneyStatus(has_journey=False, is_complete=True, message="", url="")
+        return OperatorJourneyStatus(
+            has_journey=False,
+            is_complete=True,
+            message="",
+            task_title="",
+            url="",
+        )
 
     next_step = next_step_for_user(user=user)
     if next_step is None:
@@ -73,15 +90,40 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
             has_journey=True,
             is_complete=True,
             message="All Operator tasks completed to date. Keep coming back for more.",
+            task_title="",
             url="",
         )
 
     return OperatorJourneyStatus(
         has_journey=True,
         is_complete=False,
-        message=f"Next Operator task: {next_step.title}",
+        message=next_step.title,
+        task_title=next_step.title,
         url=reverse("ops:operator-journey-step", args=[next_step.pk]),
+        available_since=_first_available_at(user=user, next_step=next_step),
     )
+
+
+def _first_available_at(*, user: AbstractBaseUser, next_step: OperatorJourneyStep) -> datetime:
+    previous_step = (
+        OperatorJourneyStep.objects.filter(journey=next_step.journey, is_active=True)
+        .exclude(pk=next_step.pk)
+        .filter(Q(order__lt=next_step.order) | Q(order=next_step.order, id__lt=next_step.id))
+        .order_by("-order", "-id")
+        .first()
+    )
+
+    if previous_step is None:
+        return user.date_joined
+
+    completion = (
+        OperatorJourneyStepCompletion.objects.filter(user=user, step=previous_step)
+        .order_by("completed_at")
+        .first()
+    )
+    if completion is None:
+        return timezone.now()
+    return completion.completed_at
 
 
 def _active_security_groups_for_user(user: AbstractBaseUser):

--- a/apps/ops/templatetags/operator_journey.py
+++ b/apps/ops/templatetags/operator_journey.py
@@ -17,6 +17,7 @@ def operator_journey_status(context):
             has_journey=False,
             is_complete=True,
             message="",
+            task_title="",
             url="",
         )
     return status_for_user(user=request.user)

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -47,11 +47,15 @@ class OperatorJourneyFlowTests(TestCase):
 
     def test_status_tracks_progress_and_catches_up_on_new_steps(self):
         status = status_for_user(user=self.user)
-        self.assertEqual(status.message, "Next Operator task: Step 1")
+        self.assertEqual(status.message, "Step 1")
+        self.assertEqual(status.task_title, "Step 1")
+        self.assertEqual(status.available_since, self.user.date_joined)
 
         self.assertTrue(complete_step_for_user(user=self.user, step=self.step_1))
         status = status_for_user(user=self.user)
-        self.assertEqual(status.message, "Next Operator task: Step 2")
+        self.assertEqual(status.message, "Step 2")
+        self.assertEqual(status.task_title, "Step 2")
+        self.assertEqual(status.available_since, self.user.operator_journey_step_completions.first().completed_at)
 
         self.assertTrue(complete_step_for_user(user=self.user, step=self.step_2))
         status = status_for_user(user=self.user)
@@ -66,7 +70,8 @@ class OperatorJourneyFlowTests(TestCase):
             order=3,
         )
         status = status_for_user(user=self.user)
-        self.assertEqual(status.message, "Next Operator task: Step 3")
+        self.assertEqual(status.message, "Step 3")
+        self.assertEqual(status.task_title, "Step 3")
         self.assertIn(str(step_3.pk), status.url)
 
     def test_cannot_complete_out_of_order_step(self):
@@ -116,7 +121,7 @@ class OperatorJourneyViewTests(TestCase):
     def test_dashboard_shows_operator_journey_link(self):
         response = self.client.get(reverse("admin:index"))
 
-        self.assertContains(response, "Next Operator task: Validate role")
+        self.assertContains(response, "Validate role")
         self.assertContains(
             response,
             reverse("ops:operator-journey-step", args=[self.step_1.pk]),
@@ -169,5 +174,5 @@ class OperatorJourneyViewTests(TestCase):
         self.client.force_login(admin_user)
         response = self.client.get(reverse("admin:index"))
 
-        self.assertContains(response, "Next Operator task: Run admin setup")
+        self.assertContains(response, "Run admin setup")
         self.assertTrue(admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists())

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1,6 +1,7 @@
 """Regression tests for operator journey progression and admin dashboard surfacing."""
 
 from django.contrib.auth import get_user_model
+from django.template import Context, Template
 from django.test import TestCase
 from django.urls import reverse
 
@@ -176,3 +177,16 @@ class OperatorJourneyViewTests(TestCase):
 
         self.assertContains(response, "Run admin setup")
         self.assertTrue(admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists())
+
+
+class OperatorJourneyTemplateTagTests(TestCase):
+    """Validate operator journey template tag fallback contexts."""
+
+    def test_tag_returns_empty_status_without_request_context(self):
+        rendered = Template(
+            "{% load operator_journey %}"
+            "{% operator_journey_status as operator_journey %}"
+            "{{ operator_journey.task_title|default:'__empty__' }}"
+        ).render(Context({}))
+
+        self.assertEqual(rendered, "__empty__")

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -27,6 +27,7 @@
   const copyErrorMessage = form.dataset.copyError;
   const copyAriaLabel = form.dataset.copyAriaLabel;
   const canCopyStaffDetails = form.dataset.copyStaffDetails === '1';
+  const securityGroups = (form.dataset.securityGroups || '').trim();
   const messageField = form.querySelector('input[name="messages"]');
   let previousFocus = null;
   let copyFeedbackTimeout = null;
@@ -325,6 +326,9 @@
       return baseValue;
     }
     const details = getFormDetails();
+    if (securityGroups) {
+      details.push(`Security groups: ${securityGroups}`);
+    }
     const messages = getPageMessages();
     syncMessageField(messages);
     if (!details.length && !messages.length) {

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -81,12 +81,16 @@
     }
     .admin-home-operator-journey {
         grid-column: 2;
-        margin-top: -0.35rem;
-        font-size: 0.9rem;
+        margin-top: 0;
+        font-size: 0.75rem;
+        line-height: 1.2;
     }
     .admin-home-operator-journey__link {
-        font-weight: 600;
+        font-weight: 400;
         text-decoration: underline;
+    }
+    .admin-home-operator-journey__age {
+        color: var(--body-quiet-color);
     }
     .admin-home-operator-journey__text {
         color: var(--body-quiet-color);

--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -46,7 +46,7 @@
         data-copy-error="{% trans 'Copy failed. Please try again.' %}"
         data-copy-aria-label="{% trans 'Copy feedback details to clipboard' %}"
         data-copy-staff-details="{% if request.user.is_staff %}1{% else %}0{% endif %}"
-        data-security-groups="{% if request.user.is_authenticated %}{% for group in request.user.groups.all %}{% if not forloop.first %}, {% endif %}{{ group.name }}{% endfor %}{% endif %}"
+        data-security-groups="{% if request.user.is_authenticated and request.user.is_staff %}{% for group in request.user.groups.all %}{% if not forloop.first %}, {% endif %}{{ group.name }}{% endfor %}{% endif %}"
       >
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">

--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -46,6 +46,7 @@
         data-copy-error="{% trans 'Copy failed. Please try again.' %}"
         data-copy-aria-label="{% trans 'Copy feedback details to clipboard' %}"
         data-copy-staff-details="{% if request.user.is_staff %}1{% else %}0{% endif %}"
+        data-security-groups="{% if request.user.is_authenticated %}{% for group in request.user.groups.all %}{% if not forloop.first %}, {% endif %}{{ group.name }}{% endfor %}{% endif %}"
       >
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">

--- a/apps/sites/templates/admin/index.html
+++ b/apps/sites/templates/admin/index.html
@@ -41,7 +41,10 @@
   {% if operator_journey.has_journey %}
     <div class="admin-home-operator-journey" role="status" aria-live="polite">
       {% if operator_journey.url %}
-        <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.message }}</a>
+        <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
+        {% if operator_journey.available_since %}
+          <span class="admin-home-operator-journey__age"> · {{ operator_journey.available_since|timesince }} ago</span>
+        {% endif %}
       {% else %}
         <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
       {% endif %}

--- a/apps/sites/templates/admin/index.html
+++ b/apps/sites/templates/admin/index.html
@@ -43,7 +43,9 @@
       {% if operator_journey.url %}
         <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
         {% if operator_journey.available_since %}
-          <span class="admin-home-operator-journey__age"> · {{ operator_journey.available_since|timesince }} ago</span>
+          <span class="admin-home-operator-journey__age">
+            {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
+          </span>
         {% endif %}
       {% else %}
         <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>

--- a/apps/sites/tests/test_user_story_feedback_form.py
+++ b/apps/sites/tests/test_user_story_feedback_form.py
@@ -1,4 +1,7 @@
 import pytest
+from django.contrib.auth import get_user_model
+from django.template.loader import render_to_string
+from django.test import RequestFactory
 
 from apps.sites.forms import UserStoryForm
 from apps.sites.models import UserStory
@@ -38,3 +41,17 @@ def test_user_story_issue_body_omits_javascript_enabled_line():
 
     assert "**Contact via chat:** Yes" in issue_body
     assert "JavaScript enabled" not in issue_body
+
+
+def test_user_story_feedback_template_omits_security_groups_for_non_staff_users():
+    user = get_user_model().objects.create_user(
+        username="regular-user",
+        password="x",
+        email="regular-user@example.com",
+    )
+    request = RequestFactory().get("/admin/")
+    request.user = user
+
+    html = render_to_string("admin/includes/user_story_feedback.html", request=request)
+
+    assert 'data-security-groups=""' in html


### PR DESCRIPTION
### Motivation

- Surface operator tasks more directly by removing the verbose "Next Operator task:" prelude and showing the actionable task title in the admin header. 
- Make the operator task callout visually compact (smaller font, no bold, no extra vertical offset) to better match admin UI space constraints. 
- Help reviewers reproduce and triage operator feedback by including the signed-in user’s security groups in copied feedback details. 
- Provide an indication of how long the current step has been actionable so operators can prioritise older tasks.

### Description

- Added `task_title` and `available_since` to `OperatorJourneyStatus` and compute availability with a new helper `_first_available_at` which falls back to `user.date_joined` for first steps or the previous step’s `completed_at` otherwise in `apps/ops/operator_journey.py`. 
- Return the raw step title as the status `message` (instead of the "Next Operator task:" prelude) and populate `available_since` for template rendering. 
- Updated admin dashboard template `apps/sites/templates/admin/index.html` to render the task title link (using `task_title|default:message`) and show a humanized age via `|timesince` when `available_since` is present. 
- Adjusted dashboard stylesheet `apps/sites/static/sites/css/admin/dashboard.css` to use a smaller, non-bold, non-offset style for the operator task callout and added a muted style for the age text. 
- Added a `data-security-groups` attribute to the feedback form in `apps/sites/templates/admin/includes/user_story_feedback.html` and included that list in the copied feedback payload in `apps/sites/static/pages/js/user_story_feedback.js`. 
- Updated operator journey tests in `apps/ops/tests/test_operator_journey.py` to assert the new `message`/`task_title` semantics and `available_since` behaviour, and adjusted admin-dashboard assertions that previously expected the old prelude.

### Testing

- Bootstrapped the environment and dependencies with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` as part of the test run preparation. 
- Ran ` .venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` and observed `6 passed` (all operator-journey regression tests passed). 
- Ran ` .venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py` and observed `2 passed` (feedback form tests passed). 
- Executed the review notification script `./scripts/review-notify.sh --actor Codex` which completed successfully to record the change for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9a434ffc8326942a355139408676)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary

This PR simplifies the operator task header display and extends feedback context with security group information.

## Changes

### Core Logic (`apps/ops/operator_journey.py`)
- Extended `OperatorJourneyStatus` dataclass with:
  - `task_title: str` — the clean task title for admin header display
  - `available_since: datetime | None` — timestamp when the current step became actionable
- Modified `status_for_user()` to:
  - Return the raw step title as `message` (removing the "Next Operator task:" prefix)
  - Populate `task_title` with the same value for explicit access
  - Calculate `available_since` using new `_first_available_at()` helper, which determines when a task became actionable by:
    - Returning `user.date_joined` for first steps or when no previous step exists
    - Returning the previous step's `completed_at` for subsequent steps

### Template & Style Updates
- **Dashboard template** (`apps/sites/templates/admin/index.html`):
  - Uses `task_title` (falling back to `message`) for the operator task link text
  - Displays humanized age via `available_since|timesince` when the timestamp is available
- **Dashboard stylesheet** (`apps/sites/static/sites/css/admin/dashboard.css`):
  - Reduced operator task callout font size from `0.9rem` to `0.75rem` with tighter line height
  - Changed link font weight from `600` to `400` for less visual prominence
  - Added `.admin-home-operator-journey__age` class for muted age text styling

### Feedback Form Enhancement
- **User feedback form** (`apps/sites/templates/admin/includes/user_story_feedback.html`):
  - Added `data-security-groups` attribute containing comma-separated authenticated user group names
- **Feedback JavaScript** (`apps/sites/static/pages/js/user_story_feedback.js`):
  - Reads security groups from form dataset and conditionally appends them to copied feedback payload when staff-detail copying is enabled

### Tests
- Updated `apps/ops/tests/test_operator_journey.py` to validate:
  - `task_title` matches expected step names
  - `available_since` is correctly set to `user.date_joined` initially and step completion times thereafter
  - Dashboard rendering no longer expects the "Next Operator task:" prefix

## Testing
- Operator journey tests: 6 passed
- Feedback form tests: 2 passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->