### PR TITLE
ocpp: add simulator log link in service-phase warning

### DIFF
--- a/apps/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator_block.html
@@ -125,7 +125,14 @@
                 Queue age: {{ cpsim_request.age_seconds|floatformat:0 }}s · Lock file: <code>{{ cpsim_request.lock_path }}</code>
               </div>
               {% endif %}
-              <div class="small mb-0">If this stays in Service phase, start or restart the cpsim worker and check simulator logs.</div>
+              <div class="small mb-0">
+                If this stays in Service phase, start or restart the cpsim worker and
+                {% if simulator_log_url %}
+                <a href="{{ simulator_log_url }}">check simulator logs</a>.
+                {% else %}
+                check simulator logs.
+                {% endif %}
+              </div>
             </div>
             {% endif %}
             {% if cp.last_error %}

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -197,6 +197,101 @@ def test_cp_simulator_service_warning_links_to_simulator_logs(
 @pytest.mark.django_db
 @patch(
     "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={
+        "queued": True,
+        "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
+        "age_seconds": 42,
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": True,
+        "last_status": "cpsim-service start requested",
+        "last_command": "start",
+        "last_error": "",
+        "last_message": "",
+        "phase": "Service",
+        "start_time": "2026-04-11 09:28:28",
+        "stop_time": None,
+        "params": {"host": "localhost", "ws_port": 8888, "cp_path": "CP2"},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_service_warning_links_to_active_simulator_logs(
+    _backend_choices,
+    _state,
+    _request_metadata,
+    admin_client,
+):
+    Simulator.objects.create(
+        name="Default CP",
+        cp_path="CP1",
+        serial_number="CP1",
+        default=True,
+    )
+    simulator = Simulator.objects.create(
+        name="Active CP",
+        cp_path="CP2",
+        serial_number="CP2",
+        default=False,
+    )
+
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert f'href="{reverse("admin:ocpp_simulator_log", args=[simulator.pk])}"' in content
+    assert "check simulator logs" in content
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={
+        "queued": True,
+        "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
+        "age_seconds": 42,
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": True,
+        "last_status": "cpsim-service start requested",
+        "last_command": "start",
+        "last_error": "",
+        "last_message": "",
+        "phase": "Service",
+        "start_time": "2026-04-11 09:28:28",
+        "stop_time": None,
+        "params": {"host": "localhost", "ws_port": 8888, "cp_path": "CP2"},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_service_warning_links_to_log_viewer_when_no_default(
+    _backend_choices,
+    _state,
+    _request_metadata,
+    admin_client,
+):
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert f'href="{reverse("admin:log_viewer")}"' in content
+    assert "check simulator logs" in content
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
     side_effect=OSError("read-only"),
 )
 @patch(

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 
+from apps.ocpp.models import Simulator
+
 
 @pytest.mark.django_db
 @patch("apps.ocpp.views.simulator._start_simulator")
@@ -142,6 +144,54 @@ def test_cp_simulator_shows_queued_service_warning_and_target_url(
     assert "ws://localhost:8888/CP2" in content
     assert "Start request queued for cpsim-service." in content
     assert "Queue age: 42s" in content
+
+
+@pytest.mark.django_db
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={
+        "queued": True,
+        "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
+        "age_seconds": 42,
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_state",
+    return_value={
+        "running": True,
+        "last_status": "cpsim-service start requested",
+        "last_command": "start",
+        "last_error": "",
+        "last_message": "",
+        "phase": "Service",
+        "start_time": "2026-04-11 09:28:28",
+        "stop_time": None,
+        "params": {"host": "localhost", "ws_port": 8888, "cp_path": "CP2"},
+    },
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"),),
+)
+def test_cp_simulator_service_warning_links_to_simulator_logs(
+    _backend_choices,
+    _state,
+    _request_metadata,
+    admin_client,
+):
+    simulator = Simulator.objects.create(
+        name="Local CP",
+        cp_path="CP2",
+        serial_number="CP2",
+        default=True,
+    )
+
+    response = admin_client.get(reverse("ocpp:cp-simulator"))
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert f'href="{reverse("admin:ocpp_simulator_log", args=[simulator.pk])}"' in content
+    assert "check simulator logs" in content
 
 
 @pytest.mark.django_db

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -395,14 +395,28 @@ def cp_simulator(request):
         "backend_choices": backend_choices,
         "backends_available": backends_available,
     }
-    simulator_log_url = None
-    if getattr(user, "is_staff", False):
-        if default_simulator is not None:
-            simulator_log_url = reverse("admin:ocpp_simulator_log", args=[default_simulator.pk])
-        else:
-            simulator_log_url = reverse("admin:log_viewer")
     state_params = state.get("params") or {}
     cp_path = str(state_params.get("cp_path") or form_params.get("cp_path") or "").strip()
+    simulator_log_url = None
+    if getattr(user, "is_staff", False):
+        simulator_for_logs = None
+        if cp_path:
+            simulator_for_logs = (
+                Simulator.objects.filter(cp_path=cp_path, is_deleted=False)
+                .order_by("-default", "pk")
+                .first()
+            )
+        if simulator_for_logs is None:
+            simulator_for_logs = default_simulator
+        try:
+            if simulator_for_logs is not None:
+                simulator_log_url = reverse(
+                    "admin:ocpp_simulator_log", args=[simulator_for_logs.pk]
+                )
+            else:
+                simulator_log_url = reverse("admin:log_viewer")
+        except NoReverseMatch:
+            simulator_log_url = None
     host = str(state_params.get("host") or "").strip()
     ws_port = state_params.get("ws_port")
     target_host = _format_host_with_port(host, ws_port) if host else ""

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -395,6 +395,12 @@ def cp_simulator(request):
         "backend_choices": backend_choices,
         "backends_available": backends_available,
     }
+    simulator_log_url = None
+    if getattr(user, "is_staff", False):
+        if default_simulator is not None:
+            simulator_log_url = reverse("admin:ocpp_simulator_log", args=[default_simulator.pk])
+        else:
+            simulator_log_url = reverse("admin:log_viewer")
     state_params = state.get("params") or {}
     cp_path = str(state_params.get("cp_path") or form_params.get("cp_path") or "").strip()
     host = str(state_params.get("host") or "").strip()
@@ -419,6 +425,7 @@ def cp_simulator(request):
             "target_ws_url": target_ws_url,
             "is_service_queued": is_service_queued,
             "cpsim_request": cpsim_request,
+            "simulator_log_url": simulator_log_url,
         }
     )
 


### PR DESCRIPTION
### Motivation

- Provide a convenient staff-facing link from the OCPP Simulator UI when a simulator enters the Service phase so administrators can quickly open the relevant logs instead of being told to "check the logs".

### Description

- Add `simulator_log_url` to the simulator view context for staff users, preferring the default simulator's admin log page and falling back to the general admin log viewer when no default exists.
- Update the Service-phase warning in `ocpp/cp_simulator_block.html` to render a direct `check simulator logs` hyperlink when `simulator_log_url` is available.
- Add a regression test `test_cp_simulator_service_warning_links_to_simulator_logs` to confirm the queued Service warning includes the simulator log link for default simulators.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`, both completed successfully.
- Ran the targeted test suite with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_cp_simulator_view.py` and all tests passed (`6 passed`).
- Sent review notification with `./scripts/review-notify.sh --actor Codex` which completed via fallback notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da99216ef08326a1016d8a38dd8a28)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a staff-facing simulator log link in the OCPP Simulator UI, enabling administrators to quickly access relevant logs when a simulator enters the Service phase.

## Changes

**apps/ocpp/views/simulator.py** (+7 lines)
- Computes `simulator_log_url` for staff users, generating a direct link to the default simulator's admin log page via `admin:ocpp_simulator_log` with the simulator's primary key
- Falls back to the generic admin log viewer (`admin:log_viewer`) when no default simulator exists
- Non-staff users receive `None` for this context variable
- Adds `simulator_log_url` to the template context

**apps/ocpp/templates/ocpp/cp_simulator_block.html** (+8/-1 lines)
- Updates the Service-phase queued-state warning to conditionally render a hyperlink
- When `simulator_log_url` is available, wraps "check simulator logs" in an anchor element; otherwise renders as plain text
- Maintains all existing alert structure and queued/age/lock-file display

**apps/ocpp/tests/test_cp_simulator_view.py** (+50 lines)
- Adds `Simulator` model import
- Introduces `test_cp_simulator_service_warning_links_to_simulator_logs` test that creates a default simulator and verifies the rendered page includes an `href` link to the simulator's log page and the "check simulator logs" text when the Service phase condition is triggered
- Patches simulator state helpers to simulate the queued Service state

## Testing

- Bootstrapped dependencies and ran targeted test suite: `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_cp_simulator_view.py` — all 6 tests passed
- Executed review notification script via `./scripts/review-notify.sh --actor Codex`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->