### PR TITLE
ops: show node setup validation and script-first guidance for role step

### DIFF
--- a/apps/ops/migrations/0008_refresh_seeded_validate_role_guidance.py
+++ b/apps/ops/migrations/0008_refresh_seeded_validate_role_guidance.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+SEEDED_JOURNEY_SLUG = "operator-node-readiness"
+SEEDED_STEP_SLUG = "validate-local-node-role"
+
+
+def refresh_seeded_validate_role_guidance(apps, schema_editor):
+    """Refresh seeded role-validation guidance with script-first instructions."""
+
+    OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+    OperatorJourneyStep.objects.filter(
+        journey__slug=SEEDED_JOURNEY_SLUG,
+        slug=SEEDED_STEP_SLUG,
+        is_seed_data=True,
+    ).update(
+        title="Validate local node setup and role before continuing",
+        instruction=(
+            "Confirm this node runtime setup is correct before proceeding. "
+            "If role or setup is wrong, apply changes with configure/install scripts and restart."
+        ),
+        help_text=(
+            "Use the setup summary shown in this step. "
+            "Do not use Nodes records to change active runtime role."
+        ),
+    )
+
+
+def noop_reverse(apps, schema_editor):
+    """Do not rewrite user-edited journey step content on migration reverse."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ops", "0007_retarget_seeded_operator_journey_to_site_operator"),
+    ]
+
+    operations = [
+        migrations.RunPython(refresh_seeded_validate_role_guidance, noop_reverse),
+    ]

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -4,15 +4,59 @@
 {% block content %}
   <div class="module aligned">
     <h1>{{ step.title }}</h1>
-    <p>{{ step.instruction }}</p>
-    {% if step.help_text %}
-      <p><strong>{% translate "Manual help:" %}</strong> {{ step.help_text }}</p>
+    {% if node_role_validation %}
+      <p>
+        {% translate "Confirm the current node setup before proceeding. Node role changes must be applied with install/configure scripts, not by editing Nodes records." %}
+      </p>
+      <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid #444;">{% translate "Check" %}</th>
+            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid #444;">{% translate "Current value" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Runtime/configured role" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.configured_role }}</td>
+          </tr>
+          <tr>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Lock file role (.locks/role.lck)" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.lock_role }}</td>
+          </tr>
+          <tr>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Registered local node role" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
+          </tr>
+        </tbody>
+      </table>
+      {% if node_role_validation.role_mismatch %}
+        <p style="margin-top: 1rem;">
+          <strong>{% translate "Role mismatch detected." %}</strong>
+          {% translate "The local node record does not match the active runtime role. Reconfigure and restart before completing this step." %}
+        </p>
+      {% endif %}
+      <h2 style="margin-top: 1.25rem;">{% translate "If setup is wrong, run these commands" %}</h2>
+      <ol>
+        {% for command in node_role_validation.commands %}
+          <li><code>{{ command }}</code></li>
+        {% endfor %}
+      </ol>
+      <p>
+        {% translate "Decision flow:" %}
+        {% translate "1) Confirm intended role. 2) Run configure with that role. 3) Restart and verify check output, then continue." %}
+      </p>
+    {% else %}
+      <p>{{ step.instruction }}</p>
+      {% if step.help_text %}
+        <p><strong>{% translate "Manual help:" %}</strong> {{ step.help_text }}</p>
+      {% endif %}
+      <iframe
+        src="{{ step.iframe_url }}"
+        title="{{ step.title }}"
+        style="width: 100%; min-height: 60vh; border: 1px solid #d5d5d5; border-radius: 8px;"
+      ></iframe>
     {% endif %}
-    <iframe
-      src="{{ step.iframe_url }}"
-      title="{{ step.title }}"
-      style="width: 100%; min-height: 60vh; border: 1px solid #d5d5d5; border-radius: 8px;"
-    ></iframe>
     <form method="post" action="{% url 'ops:operator-journey-step-complete' step.pk %}" style="margin-top: 1rem;">
       {% csrf_token %}
       <button type="submit" class="button default">{% translate "Mark this step complete" %}</button>

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -11,22 +11,22 @@
       <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
         <thead>
           <tr>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid #444;">{% translate "Check" %}</th>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid #444;">{% translate "Current value" %}</th>
+            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Check" %}</th>
+            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Current value" %}</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Runtime/configured role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.configured_role }}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Runtime/configured role" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.configured_role }}</td>
           </tr>
           <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Lock file role (.locks/role.lck)" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.lock_role }}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Lock file role (.locks/role.lck)" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.lock_role }}</td>
           </tr>
           <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{% translate "Registered local node role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid #333;">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Registered local node role" %}</td>
+            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
           </tr>
         </tbody>
       </table>
@@ -54,7 +54,7 @@
       <iframe
         src="{{ step.iframe_url }}"
         title="{{ step.title }}"
-        style="width: 100%; min-height: 60vh; border: 1px solid #d5d5d5; border-radius: 8px;"
+        style="width: 100%; min-height: 60vh; border: 1px solid var(--hairline-color); border-radius: 8px;"
       ></iframe>
     {% endif %}
     <form method="post" action="{% url 'ops:operator-journey-step-complete' step.pk %}" style="margin-top: 1rem;">

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1,13 +1,14 @@
 """Regression tests for operator journey progression and admin dashboard surfacing."""
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
 from apps.groups.models import SecurityGroup
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
+from apps.ops.views import _build_node_role_validation_summary
 
 
 class OperatorJourneyFlowTests(TestCase):
@@ -134,6 +135,14 @@ class OperatorJourneyViewTests(TestCase):
         self.assertContains(response, "./configure.sh --check")
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)
+
+    @override_settings(NODE_ROLE="Constellation")
+    def test_role_validation_normalizes_constellation_alias_for_commands(self):
+        summary = _build_node_role_validation_summary()
+
+        self.assertEqual(summary["configured_role"], "Watchtower")
+        self.assertIn("./configure.sh --watchtower", summary["commands"])
+        self.assertNotIn("./configure.sh --terminal|--satellite|--control|--watchtower", summary["commands"])
 
     def test_completing_all_steps_shows_completion_message_on_dashboard(self):
         self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -98,7 +98,7 @@ class OperatorJourneyViewTests(TestCase):
         self.step_1 = OperatorJourneyStep.objects.create(
             journey=self.journey,
             title="Validate role",
-            slug="validate-role",
+            slug="validate-local-node-role",
             instruction="Validate the role.",
             help_text="Switch role and restart if required.",
             iframe_url="/admin/nodes/node/",
@@ -126,6 +126,14 @@ class OperatorJourneyViewTests(TestCase):
         response = self.client.get(reverse("ops:operator-journey-step", args=[self.step_2.pk]))
 
         self.assertRedirects(response, reverse("ops:operator-journey-step", args=[self.step_1.pk]))
+
+    def test_validate_role_step_shows_setup_check_instead_of_iframe(self):
+        response = self.client.get(reverse("ops:operator-journey-step", args=[self.step_1.pk]))
+
+        self.assertContains(response, "Node role changes must be applied with install/configure scripts")
+        self.assertContains(response, "./configure.sh --check")
+        self.assertContains(response, "Decision flow:")
+        self.assertNotContains(response, "<iframe", html=False)
 
     def test_completing_all_steps_shows_completion_message_on_dashboard(self):
         self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -19,6 +19,7 @@ from .status_surface import build_status_surface, scoped_log_excerpts
 
 ROLE_VALIDATION_STEP_SLUG = "validate-local-node-role"
 KNOWN_NODE_ROLES = ("Terminal", "Satellite", "Control", "Watchtower")
+ROLE_ALIASES = {"constellation": "Watchtower"}
 
 
 def _normalize_role_name(value: str) -> str:
@@ -28,6 +29,7 @@ def _normalize_role_name(value: str) -> str:
     if not cleaned:
         return ""
     role_lookup = {role.lower(): role for role in KNOWN_NODE_ROLES}
+    role_lookup.update(ROLE_ALIASES)
     return role_lookup.get(cleaned.lower(), cleaned)
 
 
@@ -48,7 +50,7 @@ def _build_node_role_validation_summary() -> dict[str, object]:
     local_node_label = "Not registered"
     try:
         from apps.nodes.models import Node
-    except Exception:
+    except (ImportError, LookupError):
         local_node = None
     else:
         local_node = Node.get_local()
@@ -66,12 +68,8 @@ def _build_node_role_validation_summary() -> dict[str, object]:
     if normalized_slug in {role.lower() for role in KNOWN_NODE_ROLES}:
         commands.extend([f"./configure.sh --{normalized_slug}", "./service-start.sh"])
     else:
-        commands.extend(
-            [
-                "./configure.sh --terminal|--satellite|--control|--watchtower",
-                "./service-start.sh",
-            ]
-        )
+        commands.extend([f"./configure.sh --{role.lower()}" for role in KNOWN_NODE_ROLES])
+        commands.append("./service-start.sh")
 
     return {
         "configured_role": configured_role or "Unknown",

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -1,5 +1,8 @@
 """Views supporting in-progress operation banners."""
 
+from pathlib import Path
+
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
@@ -13,6 +16,71 @@ from .models import OperatorJourneyStep
 from .operator_journey import complete_step_for_user, next_step_for_user
 from .redirects import safe_host_redirect
 from .status_surface import build_status_surface, scoped_log_excerpts
+
+ROLE_VALIDATION_STEP_SLUG = "validate-local-node-role"
+KNOWN_NODE_ROLES = ("Terminal", "Satellite", "Control", "Watchtower")
+
+
+def _normalize_role_name(value: str) -> str:
+    """Return the canonical role name when known, else the input as-is."""
+
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        return ""
+    role_lookup = {role.lower(): role for role in KNOWN_NODE_ROLES}
+    return role_lookup.get(cleaned.lower(), cleaned)
+
+
+def _build_node_role_validation_summary() -> dict[str, object]:
+    """Build operator-facing local role checks and command guidance."""
+
+    lock_role = ""
+    lock_path = Path(settings.BASE_DIR) / ".locks" / "role.lck"
+    if lock_path.exists():
+        try:
+            lock_role = _normalize_role_name(lock_path.read_text().strip())
+        except OSError:
+            lock_role = ""
+
+    configured_role = _normalize_role_name(getattr(settings, "NODE_ROLE", ""))
+
+    local_node_role = ""
+    local_node_label = "Not registered"
+    try:
+        from apps.nodes.models import Node
+    except Exception:
+        local_node = None
+    else:
+        local_node = Node.get_local()
+    if local_node:
+        local_node_label = str(local_node)
+        role_name = getattr(getattr(local_node, "role", None), "name", "")
+        local_node_role = _normalize_role_name(role_name)
+
+    current_role = configured_role or lock_role or local_node_role
+    role_mismatch = bool(local_node_role and current_role and local_node_role != current_role)
+
+    suggested_role = current_role or local_node_role
+    normalized_slug = str(suggested_role or "").strip().lower()
+    commands: list[str] = ["./configure.sh --check"]
+    if normalized_slug in {role.lower() for role in KNOWN_NODE_ROLES}:
+        commands.extend([f"./configure.sh --{normalized_slug}", "./service-start.sh"])
+    else:
+        commands.extend(
+            [
+                "./configure.sh --terminal|--satellite|--control|--watchtower",
+                "./service-start.sh",
+            ]
+        )
+
+    return {
+        "configured_role": configured_role or "Unknown",
+        "lock_role": lock_role or "Unknown",
+        "local_node_role": local_node_role or "Unknown",
+        "local_node_label": local_node_label,
+        "role_mismatch": role_mismatch,
+        "commands": commands,
+    }
 
 
 @staff_member_required
@@ -60,7 +128,11 @@ def operator_journey_step(request: HttpRequest, step_id: int):
         )
         return redirect(reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[next_step.pk]))
 
-    return render(request, "admin/ops/operator_journey_step.html", {"step": step})
+    context = {"step": step}
+    if step.slug == ROLE_VALIDATION_STEP_SLUG:
+        context["node_role_validation"] = _build_node_role_validation_summary()
+
+    return render(request, "admin/ops/operator_journey_step.html", context)
 
 
 @staff_member_required


### PR DESCRIPTION
### Motivation

- The operator journey step for validating node role previously embedded the Nodes admin iframe, which suggested changing runtime role via the UI but in reality the role must be set via install/configure scripts; the change aligns the guided experience with actual operator workflow.

### Description

- Replace the iframe rendering for the seeded role-validation step (`validate-local-node-role`) with a setup summary that shows runtime/configured role, lock-file role (`.locks/role.lck`), and the registered local node role. (`apps/ops/views.py`, `apps/ops/templates/admin/ops/operator_journey_step.html`).
- Add logic to build an operator-facing validation summary (`_build_node_role_validation_summary`) that normalizes known roles and suggests remediation commands such as `./configure.sh --check`, role-specific `./configure.sh --<role>`, and `./service-start.sh` when applicable. (`apps/ops/views.py`).
- Update the seeded step wording via a data migration so existing seeded deployments receive script-first guidance (`apps/ops/migrations/0008_refresh_seeded_validate_role_guidance.py`).
- Add regression coverage ensuring the role-validation step renders the setup-check UX (no iframe) and displays the command-first guidance (`apps/ops/tests/test_operator_journey.py`).

### Testing

- Ran environment preparation: `./env-refresh.sh --deps-only` and installed CI deps with `.venv/bin/pip install -r requirements-ci.txt`, both completed successfully. 
- Executed the updated unit tests with `.venv/bin/python manage.py test run -- apps.ops.tests.test_operator_journey.py`, which passed (`7 passed`).
- Verified migrations with `.venv/bin/python manage.py migrations check`, which reported no unexpected changes.
- Triggered the repository review notifier script `./scripts/review-notify.sh --actor Codex` as part of the review workflow (notification sent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9c3a45088326b5f90390f247f53a)