### PR TITLE
Add admin user impersonation support with stop endpoint and tests

### DIFF
--- a/apps/core/admin/users.py
+++ b/apps/core/admin/users.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import NoReverseMatch, path, reverse
 from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from apps.locals.user_data import (
@@ -18,6 +19,10 @@ from apps.locals.user_data import (
     user_allows_user_data,
 )
 from apps.core.admin.mixins import OwnedObjectLinksMixin
+from apps.core.impersonation import (
+    get_impersonator_user_id,
+    store_impersonator_user_id,
+)
 from apps.core.models import get_owned_objects_for_user
 from apps.users import temp_passwords
 from apps.users.models import User
@@ -67,8 +72,12 @@ GUEST_NAME_NOUNS = (
 class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
     form = UserChangeRFIDForm
     add_form = UserCreationWithExpirationForm
-    actions = (DjangoUserAdmin.actions or []) + ["login_as_guest_user"]
+    actions = (DjangoUserAdmin.actions or []) + [
+        "impersonate_selected_user",
+        "login_as_guest_user",
+    ]
     changelist_actions = ["login_as_guest_user"]
+    list_display = (*DjangoUserAdmin.list_display, "impersonate_link")
     fieldsets = _include_site_template(
         _include_temporary_expiration(
             _include_require_2fa(_append_operate_as(DjangoUserAdmin.fieldsets))
@@ -108,6 +117,10 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
         suffix = secrets.token_hex(2)
         return f"{candidate}-{suffix}" if candidate else f"guest-{suffix}"
 
+    def _change_url(self, user_id) -> str:
+        opts = self.model._meta
+        return reverse(f"admin:{opts.app_label}_{opts.model_name}_change", args=[user_id])
+
     def get_urls(self):
         urls = super().get_urls()
         custom = [
@@ -115,7 +128,12 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
                 "login-as-guest/",
                 self.admin_site.admin_view(self.login_as_guest_user),
                 name="core_user_login_as_guest_user",
-            )
+            ),
+            path(
+                "<path:user_id>/impersonate/",
+                self.admin_site.admin_view(self.impersonate_user_view),
+                name="core_user_impersonate",
+            ),
         ]
         custom += [
             path(
@@ -125,6 +143,17 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
             ),
         ]
         return custom + urls
+
+    def _can_impersonate(self, request, target=None) -> bool:
+        if not request.user.is_active or not request.user.is_superuser:
+            return False
+        if target is None:
+            return True
+        if not getattr(target, "is_active", False):
+            return False
+        if target.pk == request.user.pk:
+            return False
+        return True
 
     def get_changelist_actions(self, request):
         parent = getattr(super(), "get_changelist_actions", None)
@@ -136,6 +165,14 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
         if "login_as_guest_user" not in actions:
             actions.append("login_as_guest_user")
         return actions
+
+    def impersonate_link(self, obj):
+        if not getattr(obj, "pk", None):
+            return "—"
+        url = reverse("admin:core_user_impersonate", args=[obj.pk])
+        return format_html('<a class="button" href="{}">{}</a>', url, _("Impersonate"))
+
+    impersonate_link.short_description = _("Impersonate")
 
     @admin.action(description=_("Login as Guest"), permissions=["add"])
     def login_as_guest_user(self, request, queryset=None):
@@ -180,6 +217,63 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
 
     login_as_guest_user.label = _("Login as Guest")
     login_as_guest_user.requires_queryset = False
+
+    @admin.action(
+        description=_("Impersonate selected user"),
+        permissions=["change"],
+    )
+    def impersonate_selected_user(self, request, queryset):
+        if not request.user.is_superuser:
+            raise PermissionDenied
+        selected_ids = list(queryset.values_list("pk", flat=True)[:2])
+        if not selected_ids:
+            self.message_user(
+                request,
+                _("Select one user to impersonate."),
+                level=messages.WARNING,
+            )
+            return None
+        if len(selected_ids) > 1 or queryset.count() > 1:
+            self.message_user(
+                request,
+                _("Please select exactly one user to impersonate."),
+                level=messages.WARNING,
+            )
+            return None
+        return HttpResponseRedirect(
+            reverse("admin:core_user_impersonate", args=[selected_ids[0]])
+        )
+
+    def impersonate_user_view(self, request, user_id):
+        if not request.user.is_superuser:
+            raise PermissionDenied
+        target = self.get_object(request, user_id)
+        if target is None:
+            raise PermissionDenied
+        if not self._can_impersonate(request, target):
+            self.message_user(
+                request,
+                _("You cannot impersonate the selected user."),
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(
+                self._change_url(target.pk)
+            )
+        impersonator_id = get_impersonator_user_id(request.session)
+        if impersonator_id is None:
+            impersonator_id = request.user.pk
+        login(request, target, backend="apps.users.backends.PasswordOrOTPBackend")
+        store_impersonator_user_id(request.session, impersonator_id)
+        self.message_user(
+            request,
+            _("You are now impersonating %(username)s.")
+            % {"username": target.get_username()},
+            level=messages.WARNING,
+        )
+        next_url = request.GET.get("next")
+        if next_url:
+            return HttpResponseRedirect(next_url)
+        return HttpResponseRedirect("/")
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = list(super().get_fieldsets(request, obj))
@@ -259,6 +353,13 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
                 context_data["rfid_write_url"] = reverse(
                     "admin:core_user_write_login_rfid", args=[obj.pk]
                 )
+                if self._can_impersonate(request, obj):
+                    context_data["impersonate_url"] = reverse(
+                        "admin:core_user_impersonate",
+                        args=[obj.pk],
+                    )
+            if get_impersonator_user_id(getattr(request, "session", None)) is not None:
+                context_data["stop_impersonation_url"] = reverse("stop-impersonation")
         return response
 
     def write_login_rfid(self, request, user_id):
@@ -316,10 +417,7 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
                             level=messages.SUCCESS,
                         )
                         return HttpResponseRedirect(
-                            reverse(
-                                "admin:core_user_change",
-                                args=[user.pk],
-                            )
+                            self._change_url(user.pk)
                         )
 
         context = dict(self.admin_site.each_context(request))

--- a/apps/core/admin/users.py
+++ b/apps/core/admin/users.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import NoReverseMatch, path, reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -121,6 +122,16 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
         opts = self.model._meta
         return reverse(f"admin:{opts.app_label}_{opts.model_name}_change", args=[user_id])
 
+    def _safe_next_url(self, request, fallback_url: str = "/") -> str:
+        next_url = request.POST.get("next") or request.GET.get("next")
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return next_url
+        return fallback_url
+
     def get_urls(self):
         urls = super().get_urls()
         custom = [
@@ -162,14 +173,30 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
             parent_actions = parent(request)
             if parent_actions:
                 actions.extend(parent_actions)
+        if not request.user.is_superuser:
+            return [action for action in actions if action != "login_as_guest_user"]
         if "login_as_guest_user" not in actions:
             actions.append("login_as_guest_user")
         return actions
 
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if request.user.is_superuser:
+            return actions
+        actions.pop("impersonate_selected_user", None)
+        actions.pop("login_as_guest_user", None)
+        return actions
+
+    def get_list_display(self, request):
+        list_display = list(super().get_list_display(request))
+        if request.user.is_superuser:
+            return list_display
+        return [item for item in list_display if item != "impersonate_link"]
+
     def impersonate_link(self, obj):
         if not getattr(obj, "pk", None):
             return "—"
-        url = reverse("admin:core_user_impersonate", args=[obj.pk])
+        url = self._change_url(obj.pk)
         return format_html('<a class="button" href="{}">{}</a>', url, _("Impersonate"))
 
     impersonate_link.short_description = _("Impersonate")
@@ -212,7 +239,7 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
             messages.WARNING,
         )
 
-        redirect_url = request.GET.get("next") or reverse("admin:index")
+        redirect_url = self._safe_next_url(request, fallback_url=reverse("admin:index"))
         return HttpResponseRedirect(redirect_url)
 
     login_as_guest_user.label = _("Login as Guest")
@@ -233,18 +260,42 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
                 level=messages.WARNING,
             )
             return None
-        if len(selected_ids) > 1 or queryset.count() > 1:
+        if len(selected_ids) > 1:
             self.message_user(
                 request,
                 _("Please select exactly one user to impersonate."),
                 level=messages.WARNING,
             )
             return None
+        target = queryset.first()
+        if target is None or not self._can_impersonate(request, target):
+            self.message_user(
+                request,
+                _("You cannot impersonate the selected user."),
+                level=messages.ERROR,
+            )
+            return None
+        impersonator_id = get_impersonator_user_id(request.session)
+        if impersonator_id is None:
+            impersonator_id = request.user.pk
+        login(request, target, backend="apps.users.backends.PasswordOrOTPBackend")
+        store_impersonator_user_id(request.session, impersonator_id)
+        self.message_user(
+            request,
+            _("You are now impersonating %(username)s.")
+            % {"username": target.get_username()},
+            level=messages.WARNING,
+        )
         return HttpResponseRedirect(
-            reverse("admin:core_user_impersonate", args=[selected_ids[0]])
+            self._safe_next_url(request, fallback_url=reverse("admin:index"))
         )
 
     def impersonate_user_view(self, request, user_id):
+        if request.method != "POST":
+            target = self.get_object(request, user_id)
+            if target is None:
+                raise PermissionDenied
+            return HttpResponseRedirect(self._change_url(target.pk))
         if not request.user.is_superuser:
             raise PermissionDenied
         target = self.get_object(request, user_id)
@@ -270,10 +321,7 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
             % {"username": target.get_username()},
             level=messages.WARNING,
         )
-        next_url = request.GET.get("next")
-        if next_url:
-            return HttpResponseRedirect(next_url)
-        return HttpResponseRedirect("/")
+        return HttpResponseRedirect(self._safe_next_url(request))
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = list(super().get_fieldsets(request, obj))

--- a/apps/core/impersonation.py
+++ b/apps/core/impersonation.py
@@ -1,0 +1,40 @@
+"""Utilities for admin-driven user impersonation sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+IMPERSONATOR_SESSION_KEY = "core_admin_impersonator_user_id"
+
+
+def get_impersonator_user_id(session: Mapping[str, object] | None) -> int | None:
+    """Return the stored impersonator user id from a session mapping."""
+
+    if session is None:
+        return None
+    raw = session.get(IMPERSONATOR_SESSION_KEY)
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_impersonating(session: Mapping[str, object] | None) -> bool:
+    """Return whether the current session has an active impersonator id."""
+
+    return get_impersonator_user_id(session) is not None
+
+
+def store_impersonator_user_id(session, user_id: int) -> None:
+    """Persist the original admin user id before impersonation starts."""
+
+    session[IMPERSONATOR_SESSION_KEY] = int(user_id)
+
+
+def clear_impersonator_user_id(session) -> None:
+    """Remove impersonation tracking data from the active session."""
+
+    session.pop(IMPERSONATOR_SESSION_KEY, None)
+

--- a/apps/core/routes.py
+++ b/apps/core/routes.py
@@ -48,6 +48,7 @@ ROOT_URLPATTERNS = [
         RedirectView.as_view(pattern_name="django-admindocs-docroot"),
     ),
     path("version/", core_views.version_info, name="version-info"),
+    path("core/impersonation/stop/", core_views.stop_impersonation, name="stop-impersonation"),
     path(
         admin_route("core/releases/<int:pk>/<str:action>/"),
         core_views.release_progress,

--- a/apps/core/templates/admin/user_profile_change_form.html
+++ b/apps/core/templates/admin/user_profile_change_form.html
@@ -54,6 +54,16 @@
       <a href="{{ rfid_write_url }}" class="historylink">{% trans "Write RFID login data" %}</a>
     </li>
   {% endif %}
+  {% if impersonate_url %}
+    <li>
+      <a href="{{ impersonate_url }}" class="historylink">{% trans "Impersonate user" %}</a>
+    </li>
+  {% endif %}
+  {% if stop_impersonation_url %}
+    <li>
+      <a href="{{ stop_impersonation_url }}" class="historylink">{% trans "Stop impersonation" %}</a>
+    </li>
+  {% endif %}
 {% endblock %}
 
 {% block extrajs %}

--- a/apps/core/templates/admin/user_profile_change_form.html
+++ b/apps/core/templates/admin/user_profile_change_form.html
@@ -56,12 +56,20 @@
   {% endif %}
   {% if impersonate_url %}
     <li>
-      <a href="{{ impersonate_url }}" class="historylink">{% trans "Impersonate user" %}</a>
+      <form action="{{ impersonate_url }}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit" class="historylink">{% trans "Impersonate user" %}</button>
+      </form>
     </li>
   {% endif %}
   {% if stop_impersonation_url %}
     <li>
-      <a href="{{ stop_impersonation_url }}" class="historylink">{% trans "Stop impersonation" %}</a>
+      <form action="{{ stop_impersonation_url }}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit" class="historylink">{% trans "Stop impersonation" %}</button>
+      </form>
     </li>
   {% endif %}
 {% endblock %}

--- a/apps/core/tests/test_user_impersonation_admin.py
+++ b/apps/core/tests/test_user_impersonation_admin.py
@@ -33,21 +33,23 @@ class UserImpersonationAdminTests(TestCase):
     def test_superuser_can_impersonate_user_from_admin_url(self):
         self.client.force_login(self.superuser)
 
-        response = self.client.get(
-            reverse("admin:core_user_impersonate", args=[self.target_user.pk])
+        url = reverse("admin:core_user_impersonate", args=[self.target_user.pk])
+        response = self.client.post(
+            url,
+            data={"next": reverse("admin:index")},
         )
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/")
+        self.assertEqual(response.url, reverse("admin:index"))
         session = self.client.session
         self.assertEqual(session.get(IMPERSONATOR_SESSION_KEY), self.superuser.pk)
         self.assertEqual(int(session.get("_auth_user_id")), self.target_user.pk)
 
     def test_stop_impersonation_restores_original_superuser(self):
         self.client.force_login(self.superuser)
-        self.client.get(reverse("admin:core_user_impersonate", args=[self.target_user.pk]))
+        self.client.post(reverse("admin:core_user_impersonate", args=[self.target_user.pk]))
 
-        response = self.client.get(reverse("stop-impersonation"))
+        response = self.client.post(reverse("stop-impersonation"))
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("admin:index"))
@@ -55,10 +57,23 @@ class UserImpersonationAdminTests(TestCase):
         self.assertNotIn(IMPERSONATOR_SESSION_KEY, session)
         self.assertEqual(int(session.get("_auth_user_id")), self.superuser.pk)
 
+    def test_stop_impersonation_logs_out_when_impersonator_missing(self):
+        self.client.force_login(self.superuser)
+        self.client.post(reverse("admin:core_user_impersonate", args=[self.target_user.pk]))
+        self.superuser.delete()
+
+        response = self.client.post(reverse("stop-impersonation"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:index"))
+        session = self.client.session
+        self.assertNotIn(IMPERSONATOR_SESSION_KEY, session)
+        self.assertNotIn("_auth_user_id", session)
+
     def test_staff_without_superuser_access_cannot_impersonate(self):
         self.client.force_login(self.staff_user)
 
-        response = self.client.get(
+        response = self.client.post(
             reverse("admin:core_user_impersonate", args=[self.target_user.pk])
         )
 
@@ -76,3 +91,42 @@ class UserImpersonationAdminTests(TestCase):
             response,
             reverse("admin:core_user_impersonate", args=[self.target_user.pk]),
         )
+
+    def test_impersonate_view_get_does_not_switch_session(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(
+            reverse("admin:core_user_impersonate", args=[self.target_user.pk])
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("admin:users_user_change", args=[self.target_user.pk]),
+        )
+        session = self.client.session
+        self.assertNotIn(IMPERSONATOR_SESSION_KEY, session)
+        self.assertEqual(int(session.get("_auth_user_id")), self.superuser.pk)
+
+    def test_impersonation_next_url_rejects_external_target(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.post(
+            reverse("admin:core_user_impersonate", args=[self.target_user.pk]),
+            data={"next": "https://evil.example/phish"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
+
+    def test_stop_impersonation_next_url_rejects_external_target(self):
+        self.client.force_login(self.superuser)
+        self.client.post(reverse("admin:core_user_impersonate", args=[self.target_user.pk]))
+
+        response = self.client.post(
+            reverse("stop-impersonation"),
+            data={"next": "https://evil.example/phish"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:index"))

--- a/apps/core/tests/test_user_impersonation_admin.py
+++ b/apps/core/tests/test_user_impersonation_admin.py
@@ -1,0 +1,78 @@
+"""Regression coverage for admin user impersonation tools."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.core.impersonation import IMPERSONATOR_SESSION_KEY
+
+
+class UserImpersonationAdminTests(TestCase):
+    """Validate superuser impersonation flows from the users admin."""
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.superuser = user_model.objects.create_superuser(
+            username="root-admin",
+            email="root-admin@example.com",
+            password="Password123",
+        )
+        self.staff_user = user_model.objects.create_user(
+            username="staff-user",
+            email="staff-user@example.com",
+            password="Password123",
+            is_staff=True,
+        )
+        self.target_user = user_model.objects.create_user(
+            username="target-user",
+            email="target-user@example.com",
+            password="Password123",
+            is_staff=False,
+        )
+
+    def test_superuser_can_impersonate_user_from_admin_url(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(
+            reverse("admin:core_user_impersonate", args=[self.target_user.pk])
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
+        session = self.client.session
+        self.assertEqual(session.get(IMPERSONATOR_SESSION_KEY), self.superuser.pk)
+        self.assertEqual(int(session.get("_auth_user_id")), self.target_user.pk)
+
+    def test_stop_impersonation_restores_original_superuser(self):
+        self.client.force_login(self.superuser)
+        self.client.get(reverse("admin:core_user_impersonate", args=[self.target_user.pk]))
+
+        response = self.client.get(reverse("stop-impersonation"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:index"))
+        session = self.client.session
+        self.assertNotIn(IMPERSONATOR_SESSION_KEY, session)
+        self.assertEqual(int(session.get("_auth_user_id")), self.superuser.pk)
+
+    def test_staff_without_superuser_access_cannot_impersonate(self):
+        self.client.force_login(self.staff_user)
+
+        response = self.client.get(
+            reverse("admin:core_user_impersonate", args=[self.target_user.pk])
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_change_form_exposes_impersonate_button_for_superuser(self):
+        self.client.force_login(self.superuser)
+
+        response = self.client.get(
+            reverse("admin:users_user_change", args=[self.target_user.pk])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("admin:core_user_impersonate", args=[self.target_user.pk]),
+        )

--- a/apps/core/views/__init__.py
+++ b/apps/core/views/__init__.py
@@ -35,9 +35,9 @@ __all__ = [
     "product_list",
     "release_progress",
     "request_temp_password",
-    "stop_impersonation",
     "rfid_batch",
     "rfid_login",
+    "stop_impersonation",
     "usage_analytics_summary",
     "version_info",
 ]

--- a/apps/core/views/__init__.py
+++ b/apps/core/views/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .admin_tools import request_temp_password, version_info
+from .admin_tools import request_temp_password, stop_impersonation, version_info
 from .auth import rfid_login
 from .odoo import (
     add_live_subscription,
@@ -35,6 +35,7 @@ __all__ = [
     "product_list",
     "release_progress",
     "request_temp_password",
+    "stop_impersonation",
     "rfid_batch",
     "rfid_login",
     "usage_analytics_summary",

--- a/apps/core/views/admin_tools.py
+++ b/apps/core/views/admin_tools.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from django.contrib.admin.sites import site as admin_site
 from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth import login, logout
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils import timezone
 from django.utils.translation import gettext as _
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_POST
 
 from apps.core.impersonation import clear_impersonator_user_id, get_impersonator_user_id
 from apps.users import temp_passwords
@@ -59,20 +61,32 @@ def version_info(request):
     )
 
 
-@require_GET
+def _safe_next_url(request, *, fallback_url: str) -> str:
+    next_url = request.POST.get("next") or request.GET.get("next")
+    if next_url and url_has_allowed_host_and_scheme(
+        next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return next_url
+    return fallback_url
+
+
+@require_POST
 def stop_impersonation(request):
     """Restore the original admin account when the session is impersonating."""
 
+    redirect_url = _safe_next_url(request, fallback_url=reverse("admin:index"))
     impersonator_id = get_impersonator_user_id(getattr(request, "session", None))
     if impersonator_id is None:
-        return redirect(request.GET.get("next") or reverse("admin:index"))
+        return redirect(redirect_url)
 
     impersonator = User.all_objects.filter(pk=impersonator_id, is_active=True).first()
     clear_impersonator_user_id(request.session)
 
     if impersonator is not None:
-        from django.contrib.auth import login
-
         login(request, impersonator, backend="apps.users.backends.PasswordOrOTPBackend")
+    else:
+        logout(request)
 
-    return redirect(request.GET.get("next") or reverse("admin:index"))
+    return redirect(redirect_url)

--- a/apps/core/views/admin_tools.py
+++ b/apps/core/views/admin_tools.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from django.contrib.admin.sites import site as admin_site
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import JsonResponse
+from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET
 
+from apps.core.impersonation import clear_impersonator_user_id, get_impersonator_user_id
 from apps.users import temp_passwords
+from apps.users.models import User
 from utils import revision
 from utils.version import get_version
 
@@ -54,3 +57,22 @@ def version_info(request):
             "revision": revision.get_revision(),
         }
     )
+
+
+@require_GET
+def stop_impersonation(request):
+    """Restore the original admin account when the session is impersonating."""
+
+    impersonator_id = get_impersonator_user_id(getattr(request, "session", None))
+    if impersonator_id is None:
+        return redirect(request.GET.get("next") or reverse("admin:index"))
+
+    impersonator = User.all_objects.filter(pk=impersonator_id, is_active=True).first()
+    clear_impersonator_user_id(request.session)
+
+    if impersonator is not None:
+        from django.contrib.auth import login
+
+        login(request, impersonator, backend="apps.users.backends.PasswordOrOTPBackend")
+
+    return redirect(request.GET.get("next") or reverse("admin:index"))

--- a/apps/sites/templates/admin/users/user/change_list.html
+++ b/apps/sites/templates/admin/users/user/change_list.html
@@ -11,9 +11,11 @@
   {% endif %}
   {% if request.session.core_admin_impersonator_user_id %}
     <li>
-      <a href="{% url 'stop-impersonation' %}?next={{ request.get_full_path|urlencode }}">
-        {% translate "Stop impersonation" %}
-      </a>
+      <form action="{% url 'stop-impersonation' %}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit">{% translate "Stop impersonation" %}</button>
+      </form>
     </li>
   {% endif %}
   {{ block.super }}

--- a/apps/sites/templates/admin/users/user/change_list.html
+++ b/apps/sites/templates/admin/users/user/change_list.html
@@ -9,5 +9,12 @@
       </a>
     </li>
   {% endif %}
+  {% if request.session.core_admin_impersonator_user_id %}
+    <li>
+      <a href="{% url 'stop-impersonation' %}?next={{ request.get_full_path|urlencode }}">
+        {% translate "Stop impersonation" %}
+      </a>
+    </li>
+  {% endif %}
   {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
### Motivation

- Provide a way for superusers to impersonate other users from the admin UI for troubleshooting and support.
- Track the original admin in session so impersonation can be stopped and the original account restored.

### Description

- Add `apps/core/impersonation.py` with utilities `get_impersonator_user_id`, `store_impersonator_user_id`, `clear_impersonator_user_id`, and `is_impersonating` to manage impersonation state in the session.
- Extend the `UserAdmin` in `apps/core/admin/users.py` with an `impersonate_selected_user` action, an `impersonate_user_view` handler, an `impersonate_link` list column, URL registration, permission checks, and helper `_change_url` and `_can_impersonate` methods; store the original admin id in session when impersonation begins.
- Add a stop-impersonation endpoint at `core/impersonation/stop/` and implement `stop_impersonation` in `apps/core/views/admin_tools.py` to restore the original admin via session lookup and `login` and to clear the impersonation marker.
- Wire templates and routes: update the user change form and change list templates to show `Impersonate user` and `Stop impersonation` links when appropriate, register the `stop-impersonation` route in `apps/core/routes.py`, and export the new view in `apps/core/views/__init__.py`.

### Testing

- Added `apps/core/tests/test_user_impersonation_admin.py` which exercises impersonation flows including `test_superuser_can_impersonate_user_from_admin_url`, `test_stop_impersonation_restores_original_superuser`, `test_staff_without_superuser_access_cannot_impersonate`, and `test_change_form_exposes_impersonate_button_for_superuser`.
- Ran the new test module (`apps/core/tests/test_user_impersonation_admin.py`) as part of the test suite and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9e3aa5708326894bc213a96ec177)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds admin user impersonation functionality, enabling superusers to log in as other users from the Django admin interface for troubleshooting and support purposes. The original admin account is tracked in the session, allowing restoration via a dedicated stop-impersonation endpoint.

## Key Changes

### Core Impersonation Tracking
- New module `apps/core/impersonation.py` provides session-based tracking:
  - `IMPERSONATOR_SESSION_KEY` constant for session storage
  - `get_impersonator_user_id()` / `store_impersonator_user_id()` / `clear_impersonator_user_id()` for managing original admin ID
  - `is_impersonating()` to check active impersonation state
  - Defensive handling for `None`, empty strings, and invalid values

### Admin Interface Extensions
- `apps/core/admin/users.py` extended with:
  - `impersonate_user_view()` handler that validates superuser status, stores original admin ID in session, logs in as target user, displays warning message, and redirects
  - `impersonate_selected_user` admin action for bulk operations
  - `impersonate_link` list display column showing per-user impersonate button
  - `_can_impersonate()` permission gate (requires active superuser; blocks inactive targets and self-impersonation)
  - `_change_url()` helper for admin redirect URLs
  - URL route registration at `<user_id>/impersonate/`
  - Updated `actions` and `list_display` to include new functionality

### Stop-Impersonation Endpoint
- `apps/core/views/admin_tools.py` implements `stop_impersonation` view:
  - GET-only endpoint retrieving original admin from session
  - Clears impersonation marker and re-authenticates original admin using `PasswordOrOTPBackend`
  - Redirects to `next` query parameter or admin index
- Route registered at `core/impersonation/stop/` in `apps/core/routes.py`
- Exported via `apps/core/views/__init__.py`

### UI/Templates
- `apps/core/templates/admin/user_profile_change_form.html`: Conditionally displays "Impersonate user" and "Stop impersonation" links in object tools
- `apps/sites/templates/admin/users/user/change_list.html`: Adds "Stop impersonation" link to change-list tools with `next` parameter to maintain page context

## Testing
New test module `apps/core/tests/test_user_impersonation_admin.py` covers:
- Superuser can initiate impersonation via admin URL and verify session state changes
- Stop-impersonation endpoint restores original superuser and clears session marker
- Staff users without superuser access receive 403 when attempting impersonation
- User change form renders impersonate button for superuser

## Implementation Details
- Impersonation uses existing `apps.users.backends.PasswordOrOTPBackend` for authentication
- Session-based tracking prevents storage bloat and automatically clears on logout
- Impersonation state is checked and displayed contextually in templates based on session key presence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->