### PR TITLE
Tighten operator-journey spacing on admin dashboard

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -8,7 +8,8 @@
         display: grid;
         grid-template-columns: auto minmax(var(--admin-ui-dashboard-net-message-min-width, 18rem), 30%) minmax(0, 1fr);
         align-items: center;
-        gap: 1rem;
+        column-gap: 1rem;
+        row-gap: 0.15rem;
         margin-bottom: 1.25rem;
     }
     #admin-home-header h1 {
@@ -81,9 +82,10 @@
     }
     .admin-home-operator-journey {
         grid-column: 2;
-        margin-top: 0;
+        margin: 0;
         font-size: 0.75rem;
-        line-height: 1.2;
+        line-height: 1.05;
+        align-self: start;
     }
     .admin-home-operator-journey__link {
         font-weight: 400;
@@ -150,7 +152,7 @@
     @media (max-width: 1240px) {
         #admin-home-header {
             grid-template-columns: auto minmax(18rem, 1fr);
-            row-gap: 0.75rem;
+            row-gap: 0.35rem;
         }
         .admin-home-actions {
             grid-column: 2;


### PR DESCRIPTION
### Motivation
- The operator-journey / ops-task message on the admin dashboard had excessive vertical spacing above and below it, so reduce that spacing to a compact minimum while preserving responsive layout behavior.

### Description
- Replace the single `gap` usage on `#admin-home-header` with explicit `column-gap` and a much smaller `row-gap` to tighten header rows in `apps/sites/static/sites/css/admin/dashboard.css`.
- Remove the extra top margin and reduce `line-height` for `.admin-home-operator-journey`, and align it to the start of the grid cell for a compact presentation.
- Reduce the header `row-gap` at the `@media (max-width: 1240px)` breakpoint so the compact spacing remains on tablet widths.

### Testing
- Ran `./env-refresh.sh --deps-only` to refresh the environment and dependencies, which completed successfully.
- Ran `.venv/bin/python manage.py check`, which reported no issues.
- Ran `./scripts/review-notify.sh --actor Codex` to publish review notification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab63147f8832689dfd84921f1aa7f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR tightens the vertical spacing for the operator-journey component on the admin dashboard while preserving responsive behavior across different viewport sizes.

## Changes

**File Modified:** `apps/sites/static/sites/css/admin/dashboard.css`

- **Header Grid Spacing:** Replaced unified `gap: 1rem` with explicit `column-gap: 1rem` and reduced `row-gap: 0.15rem` on `#admin-home-header` to eliminate excessive vertical spacing between header rows.

- **Operator Journey Typography:** Updated `.admin-home-operator-journey` styling:
  - Removed extra top margin (`margin: 0`)
  - Reduced `line-height` from `1.2` to `1.05` for tighter text rendering
  - Added `align-self: start` to align content to the top of its grid cell

- **Responsive Adjustment:** Updated the `@media (max-width: 1240px)` breakpoint to apply tighter vertical spacing on tablet widths by reducing `#admin-home-header` `row-gap` from `0.75rem` to `0.35rem`.

## Testing

- `./env-refresh.sh --deps-only` executed successfully
- `./venv/bin/python manage.py check` passed with no issues
- `./scripts/review-notify.sh --actor Codex` successfully published review notification

**Lines Changed:** +6 / -4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->