### PR TITLE
Show service access URL after service becomes active

### DIFF
--- a/scripts/helpers/ports.sh
+++ b/scripts/helpers/ports.sh
@@ -51,3 +51,16 @@ arthexis_detect_backend_port() {
 
     printf '%s\n' "$fallback"
 }
+
+# arthexis_service_url BASE_DIR [HOST] [FALLBACK_PORT]
+#
+# Build the suite URL using the configured backend port.
+arthexis_service_url() {
+    local base_dir="$1"
+    local host="${2:-localhost}"
+    local fallback_port="${3:-8888}"
+    local port
+
+    port="$(arthexis_detect_backend_port "$base_dir" "$fallback_port")"
+    printf 'http://%s:%s\n' "$host" "$port"
+}

--- a/start.sh
+++ b/start.sh
@@ -143,7 +143,9 @@ wait_for_systemd_service() {
 
     if [ "$active_state" = "active" ]; then
       echo "Service '$service_name' is active."
-      echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+      if [ "$service_name" = "$SERVICE_NAME" ]; then
+        echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+      fi
       "${SYSTEMCTL_CMD[@]}" status "$service_name" --no-pager --lines 10 || true
       return 0
     fi

--- a/start.sh
+++ b/start.sh
@@ -13,6 +13,8 @@ mkdir -p "$LOCK_DIR"
 . "$BASE_DIR/scripts/helpers/service_manager.sh"
 # shellcheck source=scripts/helpers/suite-uptime-lock.sh
 . "$BASE_DIR/scripts/helpers/suite-uptime-lock.sh"
+# shellcheck source=scripts/helpers/ports.sh
+. "$BASE_DIR/scripts/helpers/ports.sh"
 arthexis_load_env_file "$BASE_DIR"
 STARTUP_SCRIPT_NAME="$(basename "$0")"
 arthexis_log_startup_event "$BASE_DIR" "$STARTUP_SCRIPT_NAME" "start" "invoked"
@@ -141,6 +143,7 @@ wait_for_systemd_service() {
 
     if [ "$active_state" = "active" ]; then
       echo "Service '$service_name' is active."
+      echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
       "${SYSTEMCTL_CMD[@]}" status "$service_name" --no-pager --lines 10 || true
       return 0
     fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1270,7 +1270,9 @@ wait_for_service_active() {
     case "$status" in
       active)
         echo "Service $service is active."
-        echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+        if [ "$service" = "$SERVICE_NAME" ]; then
+          echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+        fi
         return 0
         ;;
       failed)

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1270,6 +1270,7 @@ wait_for_service_active() {
     case "$status" in
       active)
         echo "Service $service is active."
+        echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
         return 0
         ;;
       failed)


### PR DESCRIPTION
### Motivation
- Make lifecycle output actionable by printing a direct URL to open once the suite/service reports active after `start.sh` or `upgrade.sh` run.
- Reuse existing port detection logic so the URL reflects the configured backend port stored in locks rather than duplicating logic.

### Description
- Add `arthexis_service_url` helper to `scripts/helpers/ports.sh` to build `http://<host>:<port>` using the configured backend port (reads `.locks/backend_port.lck` with fallback `8888`).
- Update `upgrade.sh` to echo `Access the service at $(arthexis_service_url "$BASE_DIR").` immediately after printing `Service <name> is active.` in `wait_for_service_active`.
- Update `start.sh` to source `scripts/helpers/ports.sh` and print the same `Access the service at ...` line when a systemd-managed service reaches `active` state.

### Testing
- Ran `bash -n upgrade.sh start.sh scripts/helpers/ports.sh` to validate shell syntax; the check succeeded.
- Ran `./scripts/review-notify.sh --actor Codex` to produce a review notification; the script executed and sent the fallback notification successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab722c8b083269af4a101c14d519d)