### PR TITLE
sites: remove excess vertical spacing in admin dashboard header

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -22,7 +22,7 @@
         align-items: center;
         align-content: right;
         gap: 0.5rem;
-        padding: 0.35rem 0.65rem;
+        padding: 0 0.65rem;
         border-radius: 6px;
         background: var(--darkened-bg);
         color: var(--body-fg);
@@ -111,6 +111,8 @@
     }
     .admin-home-actions .button {
         white-space: nowrap;
+        padding-top: 0;
+        padding-bottom: 0;
     }
     .admin-home-actions__form {
         margin: 0;

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -7,10 +7,10 @@
     #admin-home-header {
         display: grid;
         grid-template-columns: auto minmax(var(--admin-ui-dashboard-net-message-min-width, 18rem), 30%) minmax(0, 1fr);
-        align-items: center;
+        align-items: start;
         column-gap: 1rem;
-        row-gap: 0.15rem;
-        margin-bottom: 1.25rem;
+        row-gap: 0;
+        margin-bottom: 0;
     }
     #admin-home-header h1 {
         margin: 0;
@@ -99,11 +99,13 @@
     }
     .admin-home-actions {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: flex-end;
         gap: 8px;
         flex-wrap: wrap;
         justify-self: end;
+        align-self: start;
+        margin: 0;
         width: 100%;
         max-width: none;
     }


### PR DESCRIPTION
### Motivation
- Remove unwanted vertical padding above and below the admin dashboard top bar so the net-message and action buttons sit flush with the header. 
- Tighten the top-right action button layout so the buttons no longer float with extra whitespace.

### Description
- Updated `apps/sites/static/sites/css/admin/dashboard.css` to set `#admin-home-header` `align-items` to `start`, clear `row-gap` and remove its bottom margin to collapse the extra vertical space. 
- Adjusted `.admin-home-actions` to `align-items: flex-start`, add `align-self: start` and clear its own margin for a tighter button row.

### Testing
- Ran `./env-refresh.sh --deps-only` which completed successfully. 
- Ran `.venv/bin/python manage.py migrations check` which reported no changes and succeeded. 
- Ran `./scripts/review-notify.sh --actor Codex` which executed and sent a fallback review notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac21effc083268e35d09ea6ef1270)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Modified CSS for the admin dashboard header to remove excess vertical spacing and tighten the action-button layout so net-message and action buttons sit flush with the header.

## Changes

**File: `apps/sites/static/sites/css/admin/dashboard.css`**

- `#admin-home-header`
  - display: grid; grid-template-columns unchanged.
  - align-items: start (was centered).
  - row-gap: 0 (was 0.15rem).
  - margin-bottom: 0 (was 1.25rem).
  - At @media (max-width: 1240px) row-gap is 0.35rem.

- `.admin-home-net-message`
  - padding changed to `0 0.65rem` (vertical padding removed).
  - justify-self: start (ensures message aligns to the left/start).

- `.admin-home-actions`
  - align-items: flex-start (was center).
  - align-self: start added.
  - margin: 0 (cleared).
  - justify-content: flex-end on wide screens (unchanged); changes to flex-start in responsive rules.

- `.admin-home-actions .button`
  - padding-top: 0 and padding-bottom: 0 (removes extra vertical button padding).

- `.admin-home-actions__form .button`
  - margin: 0; line-height: 1.15; min-height: auto; box-sizing: border-box (ensures compact inline form buttons).

These adjustments collapse extra vertical spacing above/below the admin header and produce a tighter, flush layout for the net-message and action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->