### PR TITLE
Gate Quick Web Share behind a disabled-by-default suite feature

### DIFF
--- a/apps/features/fixtures/features__quick_web_share.json
+++ b/apps/features/fixtures/features__quick_web_share.json
@@ -7,8 +7,7 @@
       "summary": "Controls public share actions, short-link generation, and share preview embeds in page chrome.",
       "is_enabled": false,
       "main_app": [
-        "links",
-        "sites"
+        "links"
       ],
       "node_feature": null,
       "admin_requirements": "Staff and admin pages should only render the quick-share trigger and modal when this suite feature is enabled.",

--- a/apps/features/fixtures/features__quick_web_share.json
+++ b/apps/features/fixtures/features__quick_web_share.json
@@ -1,0 +1,41 @@
+[
+  {
+    "model": "features.feature",
+    "fields": {
+      "slug": "quick-web-share",
+      "display": "Quick Web Share",
+      "summary": "Controls public share actions, short-link generation, and share preview embeds in page chrome.",
+      "is_enabled": false,
+      "main_app": [
+        "links",
+        "sites"
+      ],
+      "node_feature": null,
+      "admin_requirements": "Staff and admin pages should only render the quick-share trigger and modal when this suite feature is enabled.",
+      "public_requirements": "Public pages should not expose share buttons, short links, QR codes, or preview embeds unless this suite feature is enabled.",
+      "service_requirements": "Requires links short-url storage and share-preview middleware behavior only when enabled.",
+      "admin_views": [
+        "admin:index"
+      ],
+      "public_views": [
+        "pages:index"
+      ],
+      "service_views": [
+        "apps.links.context_processors.share_short_url",
+        "apps.sites.middleware.SharePreviewPublicMiddleware"
+      ],
+      "code_locations": [
+        "apps/features/utils.py",
+        "apps/links/context_processors.py",
+        "apps/sites/middleware.py",
+        "apps/sites/templates/pages/base.html"
+      ],
+      "protocol_coverage": {},
+      "created_at": "2024-02-28T00:00:00Z",
+      "updated_at": "2024-02-28T00:00:00Z",
+      "is_seed_data": true,
+      "is_deleted": false,
+      "source": "mainstream"
+    }
+  }
+]

--- a/apps/features/utils.py
+++ b/apps/features/utils.py
@@ -10,6 +10,7 @@ from .models import Feature
 from .parameters import get_feature_parameter
 
 PAGES_CHAT_FEATURE_SLUG = "pages-chat"
+QUICK_WEB_SHARE_FEATURE_SLUG = "quick-web-share"
 STAFF_CHAT_BRIDGE_FEATURE_SLUG = "staff-chat-bridge"
 
 
@@ -100,13 +101,14 @@ def is_pages_chat_runtime_enabled(*, default: bool = False) -> bool:
         public pages chat to run.
     """
 
-    return bool(getattr(settings, "PAGES_CHAT_ENABLED", False)) and is_pages_chat_enabled(
-        default=default
-    )
+    return bool(
+        getattr(settings, "PAGES_CHAT_ENABLED", False)
+    ) and is_pages_chat_enabled(default=default)
 
 
 __all__ = [
     "PAGES_CHAT_FEATURE_SLUG",
+    "QUICK_WEB_SHARE_FEATURE_SLUG",
     "STAFF_CHAT_BRIDGE_FEATURE_SLUG",
     "get_cached_feature_enabled",
     "get_cached_feature_parameter",

--- a/apps/links/context_processors.py
+++ b/apps/links/context_processors.py
@@ -5,9 +5,10 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import DisallowedHost
 from django.db.utils import DatabaseError
 
+from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG, is_suite_feature_enabled
+
 from .models import get_or_create_short_url
 from .qr_utils import build_qr_png_bytes
-
 
 _FALLBACK_QR_PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB"
@@ -60,7 +61,8 @@ def share_short_url(request):
     Returns
     -------
     dict[str, str]
-        Mapping containing ``share_short_url`` and ``share_short_url_qr``.
+        Mapping containing ``quick_web_share_enabled``, ``share_short_url``, and
+        ``share_short_url_qr``.
 
     Raises
     ------
@@ -68,7 +70,22 @@ def share_short_url(request):
         Exceptions from QR generation are handled and converted to an empty QR value.
     """
     if request is None:
-        return {"share_short_url": "", "share_short_url_qr": ""}
+        return {
+            "quick_web_share_enabled": False,
+            "share_short_url": "",
+            "share_short_url_qr": "",
+        }
+
+    quick_web_share_enabled = is_suite_feature_enabled(
+        QUICK_WEB_SHARE_FEATURE_SLUG,
+        default=False,
+    )
+    if not quick_web_share_enabled:
+        return {
+            "quick_web_share_enabled": False,
+            "share_short_url": "",
+            "share_short_url_qr": "",
+        }
 
     def _build_absolute_with_fallback(path: str) -> str:
         """Build an absolute URI and fall back safely when host validation fails.
@@ -91,7 +108,9 @@ def share_short_url(request):
         try:
             return request.build_absolute_uri(path)
         except DisallowedHost:
-            raw_host = (request.META.get("HTTP_HOST") or request.META.get("SERVER_NAME") or "").strip()
+            raw_host = (
+                request.META.get("HTTP_HOST") or request.META.get("SERVER_NAME") or ""
+            ).strip()
             if not raw_host:
                 return path
 
@@ -110,7 +129,12 @@ def share_short_url(request):
                 return path
 
             try:
-                site_domain = (Site.objects.get_current().domain or "").strip().lower().rstrip(".")
+                site_domain = (
+                    (Site.objects.get_current().domain or "")
+                    .strip()
+                    .lower()
+                    .rstrip(".")
+                )
                 parsed_site = urlsplit(f"//{site_domain}")
                 site_host = (parsed_site.hostname or "").strip().lower().rstrip(".")
                 site_port = parsed_site.port
@@ -148,4 +172,8 @@ def share_short_url(request):
     except Exception:
         qr_data_uri = ""
 
-    return {"share_short_url": share_url, "share_short_url_qr": qr_data_uri}
+    return {
+        "quick_web_share_enabled": True,
+        "share_short_url": share_url,
+        "share_short_url_qr": qr_data_uri,
+    }

--- a/apps/links/context_processors.py
+++ b/apps/links/context_processors.py
@@ -5,7 +5,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import DisallowedHost
 from django.db.utils import DatabaseError
 
-from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG, is_suite_feature_enabled
+from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG, get_cached_feature_enabled
 
 from .models import get_or_create_short_url
 from .qr_utils import build_qr_png_bytes
@@ -14,6 +14,7 @@ _FALLBACK_QR_PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB"
     "/oX6zj4AAAAASUVORK5CYII="
 )
+_QUICK_WEB_SHARE_ENABLED_CACHE_KEY = "features:quick-web-share:enabled"
 
 
 def _encode_share_qr_data_uri(url: str) -> str:
@@ -69,23 +70,21 @@ def share_short_url(request):
     None
         Exceptions from QR generation are handled and converted to an empty QR value.
     """
+    disabled_context = {
+        "quick_web_share_enabled": False,
+        "share_short_url": "",
+        "share_short_url_qr": "",
+    }
     if request is None:
-        return {
-            "quick_web_share_enabled": False,
-            "share_short_url": "",
-            "share_short_url_qr": "",
-        }
+        return disabled_context
 
-    quick_web_share_enabled = is_suite_feature_enabled(
+    quick_web_share_enabled = get_cached_feature_enabled(
         QUICK_WEB_SHARE_FEATURE_SLUG,
+        cache_key=_QUICK_WEB_SHARE_ENABLED_CACHE_KEY,
         default=False,
     )
     if not quick_web_share_enabled:
-        return {
-            "quick_web_share_enabled": False,
-            "share_short_url": "",
-            "share_short_url_qr": "",
-        }
+        return disabled_context
 
     def _build_absolute_with_fallback(path: str) -> str:
         """Build an absolute URI and fall back safely when host validation fails.

--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -12,13 +12,14 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError
 from django.urls import Resolver404, resolve
 
+from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG, is_suite_feature_enabled
+
 from .models import Landing, LandingLead, ViewHistory
 from .utils import (
     cache_original_referer,
     get_original_referer,
     landing_leads_supported,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -177,9 +178,7 @@ class ViewHistoryMiddleware:
                 .first()
             )
         except Exception:  # pragma: no cover - best effort logging
-            logger.debug(
-                "Failed to resolve Landing for %s", path, exc_info=True
-            )
+            logger.debug("Failed to resolve Landing for %s", path, exc_info=True)
             return None
 
     def _record_landing_lead(self, request, landing):
@@ -267,7 +266,9 @@ class ViewHistoryMiddleware:
 
     def _update_user_last_visit_ip(self, request) -> None:
         user = getattr(request, "user", None)
-        if not getattr(user, "is_authenticated", False) or not getattr(user, "pk", None):
+        if not getattr(user, "is_authenticated", False) or not getattr(
+            user, "pk", None
+        ):
             return
 
         ip_address = self._extract_client_ip(request)
@@ -279,7 +280,8 @@ class ViewHistoryMiddleware:
             user.save(update_fields=["last_visit_ip_address"])
         except Exception:  # pragma: no cover - best effort logging
             logger.debug(
-                "Failed to update last_visit_ip_address for user %s", user.pk,
+                "Failed to update last_visit_ip_address for user %s",
+                user.pk,
                 exc_info=True,
             )
 
@@ -294,7 +296,7 @@ class SharePreviewPublicMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if (
+        if is_suite_feature_enabled(QUICK_WEB_SHARE_FEATURE_SLUG, default=False) and (
             request.GET.get("djdt") == self._PREVIEW_MARKER
             and request.GET.get(self._PUBLIC_FLAG) == "1"
         ):

--- a/apps/sites/middleware.py
+++ b/apps/sites/middleware.py
@@ -12,7 +12,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError
 from django.urls import Resolver404, resolve
 
-from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG, is_suite_feature_enabled
+from apps.features.utils import (
+    QUICK_WEB_SHARE_FEATURE_SLUG,
+    get_cached_feature_enabled,
+)
 
 from .models import Landing, LandingLead, ViewHistory
 from .utils import (
@@ -291,14 +294,20 @@ class SharePreviewPublicMiddleware:
 
     _PREVIEW_MARKER = "share-preview"
     _PUBLIC_FLAG = "share_preview_public"
+    _QUICK_WEB_SHARE_ENABLED_CACHE_KEY = "features:quick-web-share:enabled"
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        if is_suite_feature_enabled(QUICK_WEB_SHARE_FEATURE_SLUG, default=False) and (
+        if (
             request.GET.get("djdt") == self._PREVIEW_MARKER
             and request.GET.get(self._PUBLIC_FLAG) == "1"
+            and get_cached_feature_enabled(
+                QUICK_WEB_SHARE_FEATURE_SLUG,
+                cache_key=self._QUICK_WEB_SHARE_ENABLED_CACHE_KEY,
+                default=False,
+            )
         ):
             request.user = AnonymousUser()
         return self.get_response(request)

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -180,12 +180,14 @@
                 </div>
                 {% endif %}
               </a>
+              {% if quick_web_share_enabled %}
               <button id="share-button" class="btn btn-sm btn-outline-light ms-2" type="button">
                 <svg aria-hidden="true" width="1.5rem" height="1.5rem">
                   <use href="#icon-share"></use>
                 </svg>
                 <span class="visually-hidden">{% trans "Share" %}</span>
               </button>
+              {% endif %}
             </div>
           </div>
         </div>
@@ -204,6 +206,7 @@
     </div>
     {% include "pages/includes/public_chat_widget.html" %}
     {% include "pages/includes/public_feedback_widget.html" %}
+    {% if quick_web_share_enabled %}
     <div class="modal fade" id="shareModal" tabindex="-1" aria-labelledby="shareModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -258,6 +261,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
     {% url 'pages:footer-fragment' as footer_fragment_url %}
     {% if not hide_default_footer and footer_fragment_url %}
       <div

--- a/apps/sites/tests/test_quick_web_share_feature.py
+++ b/apps/sites/tests/test_quick_web_share_feature.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.test import RequestFactory
 from django.urls import reverse
@@ -15,6 +16,14 @@ from apps.links.models import ShortURL
 from apps.sites.middleware import SharePreviewPublicMiddleware
 
 pytestmark = pytest.mark.django_db
+
+
+def _set_quick_web_share_enabled(enabled: bool) -> None:
+    Feature.objects.update_or_create(
+        slug=QUICK_WEB_SHARE_FEATURE_SLUG,
+        defaults={"display": "Quick Web Share", "is_enabled": enabled},
+    )
+    cache.delete("features:quick-web-share:enabled")
 
 
 def test_share_context_returns_empty_values_when_feature_disabled_by_default(
@@ -35,10 +44,7 @@ def test_share_context_returns_empty_values_when_feature_disabled_by_default(
 def test_share_context_builds_short_url_when_feature_enabled(
     rf: RequestFactory,
 ) -> None:
-    Feature.objects.update_or_create(
-        slug=QUICK_WEB_SHARE_FEATURE_SLUG,
-        defaults={"display": "Quick Web Share", "is_enabled": True},
-    )
+    _set_quick_web_share_enabled(True)
     request = rf.get("/public/")
 
     context = share_short_url(request)
@@ -52,6 +58,7 @@ def test_share_context_builds_short_url_when_feature_enabled(
 def test_share_preview_public_middleware_requires_quick_web_share_feature(
     rf: RequestFactory,
 ) -> None:
+    _set_quick_web_share_enabled(False)
     user = get_user_model().objects.create_user(
         username="quick-share-middleware-user",
         email="quick-share-middleware-user@example.com",
@@ -66,10 +73,7 @@ def test_share_preview_public_middleware_requires_quick_web_share_feature(
     disabled_response = middleware(request)
     assert disabled_response.content == b"False"
 
-    Feature.objects.update_or_create(
-        slug=QUICK_WEB_SHARE_FEATURE_SLUG,
-        defaults={"display": "Quick Web Share", "is_enabled": True},
-    )
+    _set_quick_web_share_enabled(True)
     enabled_request = rf.get("/?djdt=share-preview&share_preview_public=1")
     enabled_request.user = user
 
@@ -78,7 +82,7 @@ def test_share_preview_public_middleware_requires_quick_web_share_feature(
 
 
 def test_base_page_hides_share_ui_when_quick_web_share_feature_disabled(client) -> None:
-    Feature.objects.filter(slug=QUICK_WEB_SHARE_FEATURE_SLUG).delete()
+    _set_quick_web_share_enabled(False)
 
     response = client.get(reverse("pages:index"))
 

--- a/apps/sites/tests/test_quick_web_share_feature.py
+++ b/apps/sites/tests/test_quick_web_share_feature.py
@@ -1,0 +1,87 @@
+"""Regression tests for quick web share suite feature gating."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.urls import reverse
+
+from apps.features.models import Feature
+from apps.features.utils import QUICK_WEB_SHARE_FEATURE_SLUG
+from apps.links.context_processors import share_short_url
+from apps.links.models import ShortURL
+from apps.sites.middleware import SharePreviewPublicMiddleware
+
+pytestmark = pytest.mark.django_db
+
+
+def test_share_context_returns_empty_values_when_feature_disabled_by_default(
+    rf: RequestFactory,
+) -> None:
+    request = rf.get("/public/")
+
+    context = share_short_url(request)
+
+    assert context == {
+        "quick_web_share_enabled": False,
+        "share_short_url": "",
+        "share_short_url_qr": "",
+    }
+    assert ShortURL.objects.count() == 0
+
+
+def test_share_context_builds_short_url_when_feature_enabled(
+    rf: RequestFactory,
+) -> None:
+    Feature.objects.update_or_create(
+        slug=QUICK_WEB_SHARE_FEATURE_SLUG,
+        defaults={"display": "Quick Web Share", "is_enabled": True},
+    )
+    request = rf.get("/public/")
+
+    context = share_short_url(request)
+
+    assert context["quick_web_share_enabled"] is True
+    assert "/links/s/" in context["share_short_url"]
+    assert context["share_short_url_qr"].startswith("data:image/png;base64,")
+    assert ShortURL.objects.count() == 1
+
+
+def test_share_preview_public_middleware_requires_quick_web_share_feature(
+    rf: RequestFactory,
+) -> None:
+    user = get_user_model().objects.create_user(
+        username="quick-share-middleware-user",
+        email="quick-share-middleware-user@example.com",
+        password="secret",
+    )
+    request = rf.get("/?djdt=share-preview&share_preview_public=1")
+    request.user = user
+    middleware = SharePreviewPublicMiddleware(
+        lambda req: HttpResponse(str(req.user.is_anonymous))
+    )
+
+    disabled_response = middleware(request)
+    assert disabled_response.content == b"False"
+
+    Feature.objects.update_or_create(
+        slug=QUICK_WEB_SHARE_FEATURE_SLUG,
+        defaults={"display": "Quick Web Share", "is_enabled": True},
+    )
+    enabled_request = rf.get("/?djdt=share-preview&share_preview_public=1")
+    enabled_request.user = user
+
+    enabled_response = middleware(enabled_request)
+    assert enabled_response.content == b"True"
+
+
+def test_base_page_hides_share_ui_when_quick_web_share_feature_disabled(client) -> None:
+    Feature.objects.filter(slug=QUICK_WEB_SHARE_FEATURE_SLUG).delete()
+
+    response = client.get(reverse("pages:index"))
+
+    content = response.content.decode()
+    assert 'id="share-button"' not in content
+    assert 'id="shareModal"' not in content


### PR DESCRIPTION
### Motivation
- Prevent public share affordances (share button, short links, QR, and preview embed) from being exposed unless an operator explicitly enables a suite feature called "Quick Web Share".

### Description
- Add `QUICK_WEB_SHARE_FEATURE_SLUG = "quick-web-share"` and export it for consistent references across the codebase (`apps/features/utils.py`).
- Stop building short links and QR payloads unless the suite feature is enabled by gating `share_short_url` with `is_suite_feature_enabled` and returning `quick_web_share_enabled` in the context (`apps/links/context_processors.py`).
- Hide the navbar share button and the entire share modal/embed area in the base page template when `quick_web_share_enabled` is false (`apps/sites/templates/pages/base.html`).
- Require the feature for share-preview middleware anonymization by gating `SharePreviewPublicMiddleware` so `share_preview_public=1` only takes effect when the feature is enabled (`apps/sites/middleware.py`).
- Add a disabled-by-default fixture `apps/features/fixtures/features__quick_web_share.json` to seed the feature and add regression tests `apps/sites/tests/test_quick_web_share_feature.py` that exercise disabled and enabled behavior.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` (succeeded). 
- Ran the targeted test file with `.venv/bin/python manage.py test run -- apps/sites/tests/test_quick_web_share_feature.py` and all tests passed: `4 passed`.
- Ran the review notifier `./scripts/review-notify.sh --actor Codex` to register the change (fallback notification used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac5c2dbe48326b846fd464d88cb1c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR gates Quick Web Share functionality behind a new disabled-by-default suite feature flag (`QUICK_WEB_SHARE_FEATURE_SLUG = "quick-web-share"`). When disabled, public share affordances (share button, short links, QR codes, and share preview embeds) are not exposed to users.

## Key Changes

**Feature Flag Infrastructure** (`apps/features/utils.py`)
- Added `QUICK_WEB_SHARE_FEATURE_SLUG` constant exported for consistent feature references across the codebase

**Context & Link Generation** (`apps/links/context_processors.py`)
- Short URL and QR code generation is now gated behind the feature flag
- Context processor returns `quick_web_share_enabled` field to indicate feature state
- Returns empty values for `share_short_url` and `share_short_url_qr` when feature is disabled

**Middleware Gating** (`apps/sites/middleware.py`)
- `SharePreviewPublicMiddleware` now checks if the feature is enabled before allowing share preview behavior
- The `share_preview_public=1` query parameter has no effect when the feature is disabled

**Template Updates** (`apps/sites/templates/pages/base.html`)
- Share button in navbar and share modal markup are conditionally rendered based on `quick_web_share_enabled` flag

**Feature Definition & Tests**
- Fixture file defines the suite feature as disabled by default (`is_enabled: false`)
- New test module (`apps/sites/tests/test_quick_web_share_feature.py`) covers:
  - Context processor returning empty values when feature is disabled
  - Short URL generation when feature is enabled
  - Middleware blocking share-preview behavior when disabled
  - Share UI elements hidden in templates when disabled

All tests pass with the feature disabled by default, ensuring backward compatibility and that share functionality is only accessible when explicitly enabled by an operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->