### PR TITLE
Clarify local-only admin credentials in install/upgrade URL output

### DIFF
--- a/scripts/helpers/ports.sh
+++ b/scripts/helpers/ports.sh
@@ -64,3 +64,16 @@ arthexis_service_url() {
     port="$(arthexis_detect_backend_port "$base_dir" "$fallback_port")"
     printf 'http://%s:%s\n' "$host" "$port"
 }
+
+# arthexis_service_access_message BASE_DIR [HOST] [FALLBACK_PORT]
+#
+# Build a login guidance message for the suite URL shown by install/upgrade flows.
+arthexis_service_access_message() {
+    local base_dir="$1"
+    local host="${2:-localhost}"
+    local fallback_port="${3:-8888}"
+    local url
+
+    url="$(arthexis_service_url "$base_dir" "$host" "$fallback_port")"
+    printf 'Access the service at %s. Login with admin/admin (local machine only).\n' "$url"
+}

--- a/scripts/helpers/ports.sh
+++ b/scripts/helpers/ports.sh
@@ -70,10 +70,8 @@ arthexis_service_url() {
 # Build a login guidance message for the suite URL shown by install/upgrade flows.
 arthexis_service_access_message() {
     local base_dir="$1"
-    local host="${2:-localhost}"
-    local fallback_port="${3:-8888}"
     local url
 
-    url="$(arthexis_service_url "$base_dir" "$host" "$fallback_port")"
-    printf 'Access the service at %s. Login with admin/admin (local machine only).\n' "$url"
+    url="$(arthexis_service_url "$base_dir" "$2" "$3")"
+    printf 'Access the service at %s. Local-only default login is admin/admin when unchanged.\n' "$url"
 }

--- a/start.sh
+++ b/start.sh
@@ -144,7 +144,7 @@ wait_for_systemd_service() {
     if [ "$active_state" = "active" ]; then
       echo "Service '$service_name' is active."
       if [ "$service_name" = "$SERVICE_NAME" ]; then
-        echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+        arthexis_service_access_message "$BASE_DIR"
       fi
       "${SYSTEMCTL_CMD[@]}" status "$service_name" --no-pager --lines 10 || true
       return 0

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1271,7 +1271,7 @@ wait_for_service_active() {
       active)
         echo "Service $service is active."
         if [ "$service" = "$SERVICE_NAME" ]; then
-          echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+          arthexis_service_access_message "$BASE_DIR"
         fi
         return 0
         ;;


### PR DESCRIPTION
### Motivation
- Make the service URL shown after install/upgrade/start clearer by explicitly stating the default admin credentials and that they are only valid from the local machine.
- Provide a single helper for constructing the access line so messaging is consistent across startup and upgrade flows.

### Description
- Added `arthexis_service_access_message` to `scripts/helpers/ports.sh` which prints the service URL and the note: "Login with admin/admin (local machine only)."
- Replaced inline `echo "Access the service at ..."` calls in `start.sh` with `arthexis_service_access_message` to standardize output.
- Replaced the corresponding inline message in `upgrade.sh` with the same helper so upgrade flows also show the local-login guidance.

### Testing
- Ran syntax checks with `bash -n scripts/helpers/ports.sh start.sh upgrade.sh`, which completed successfully.
- Executed the review notifier with `./scripts/review-notify.sh --actor Codex`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac7c4f9cc8326b8372db152162d84)