### PR TITLE
ops: add superuser provisioning step after role validation

### DIFF
--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -36,7 +36,7 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
     )
     password = forms.CharField(
         required=False,
-        widget=forms.PasswordInput(render_value=True),
+        widget=forms.PasswordInput(),
         help_text="Required only when using a manual password.",
     )
     github_username = forms.CharField(
@@ -46,7 +46,7 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
     )
     github_token = forms.CharField(
         required=False,
-        widget=forms.PasswordInput(render_value=True),
+        widget=forms.PasswordInput(),
         help_text="Optional GitHub token to store for this new user.",
     )
 
@@ -63,8 +63,12 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
     def clean_username(self):
         """Reject usernames that already exist."""
 
-        username = (self.cleaned_data.get("username") or "").strip()
-        if get_user_model().objects.filter(username=username).exists():
+        user_model = get_user_model()
+        username = user_model.normalize_username(
+            (self.cleaned_data.get("username") or "").strip()
+        )
+        user_manager = getattr(user_model, "all_objects", user_model._default_manager)
+        if user_manager.filter(username=username).exists():
             raise forms.ValidationError("A user with this username already exists.")
         return username
 
@@ -72,7 +76,10 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
         """Create the superuser, assign groups, and return the account/password tuple."""
 
         cleaned_data = self.cleaned_data
-        password = cleaned_data.get("password") or self._generate_password()
+        if cleaned_data["password_mode"] == "custom":
+            password = cleaned_data["password"]
+        else:
+            password = self._generate_password()
         username = cleaned_data["username"]
         email = cleaned_data.get("email", "")
 

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -14,8 +14,14 @@ from apps.groups.models import SecurityGroup
 class OperatorJourneyProvisionSuperuserForm(forms.Form):
     """Create a superuser account and optionally attach a GitHub token."""
 
-    username = forms.CharField(max_length=150, help_text="Login name for the new superuser.")
-    email = forms.EmailField(required=False, help_text="Optional email address for account recovery.")
+    PASSWORD_ALPHABET = string.ascii_letters + string.digits + "-._~!@#$%^&*"
+
+    username = forms.CharField(
+        max_length=150, help_text="Login name for the new superuser."
+    )
+    email = forms.EmailField(
+        required=False, help_text="Optional email address for account recovery."
+    )
     security_groups = forms.ModelMultipleChoiceField(
         queryset=SecurityGroup.objects.order_by("name"),
         required=True,
@@ -46,9 +52,21 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        if cleaned_data.get("password_mode") == "custom" and not cleaned_data.get("password"):
-            self.add_error("password", "Provide a password or switch to random generation.")
+        if cleaned_data.get("password_mode") == "custom" and not cleaned_data.get(
+            "password"
+        ):
+            self.add_error(
+                "password", "Provide a password or switch to random generation."
+            )
         return cleaned_data
+
+    def clean_username(self):
+        """Reject usernames that already exist."""
+
+        username = (self.cleaned_data.get("username") or "").strip()
+        if get_user_model().objects.filter(username=username).exists():
+            raise forms.ValidationError("A user with this username already exists.")
+        return username
 
     def save(self):
         """Create the superuser, assign groups, and return the account/password tuple."""
@@ -59,12 +77,10 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
         email = cleaned_data.get("email", "")
 
         user_model = get_user_model()
-        user = user_model._default_manager.create_user(
+        user = user_model._default_manager.create_superuser(
             username=username,
             email=email,
             password=password,
-            is_staff=True,
-            is_superuser=True,
         )
         user.groups.set(cleaned_data["security_groups"])
 
@@ -75,12 +91,17 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
 
             GitHubToken.objects.update_or_create(
                 user=user,
-                defaults={"label": github_username or "Ops onboarding token", "token": github_token},
+                defaults={
+                    "label": github_username or "Ops onboarding token",
+                    "token": github_token,
+                },
             )
 
         return user, password
 
     @staticmethod
     def _generate_password(length: int = 24) -> str:
-        alphabet = string.ascii_letters + string.digits + "-._~!@#$%^&*"
-        return "".join(secrets.choice(alphabet) for _ in range(length))
+        return "".join(
+            secrets.choice(OperatorJourneyProvisionSuperuserForm.PASSWORD_ALPHABET)
+            for _ in range(length)
+        )

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -1,0 +1,86 @@
+"""Forms for operator journey guided actions."""
+
+from __future__ import annotations
+
+import secrets
+import string
+
+from django import forms
+from django.contrib.auth import get_user_model
+
+from apps.groups.models import SecurityGroup
+
+
+class OperatorJourneyProvisionSuperuserForm(forms.Form):
+    """Create a superuser account and optionally attach a GitHub token."""
+
+    username = forms.CharField(max_length=150, help_text="Login name for the new superuser.")
+    email = forms.EmailField(required=False, help_text="Optional email address for account recovery.")
+    security_groups = forms.ModelMultipleChoiceField(
+        queryset=SecurityGroup.objects.order_by("name"),
+        required=True,
+        help_text="Pick one or more security groups to assign.",
+    )
+    password_mode = forms.ChoiceField(
+        choices=(
+            ("random", "Generate random password"),
+            ("custom", "Set password manually"),
+        ),
+        initial="random",
+    )
+    password = forms.CharField(
+        required=False,
+        widget=forms.PasswordInput(render_value=True),
+        help_text="Required only when using a manual password.",
+    )
+    github_username = forms.CharField(
+        required=False,
+        max_length=255,
+        help_text="Optional GitHub username for repository, release, and issue operations.",
+    )
+    github_token = forms.CharField(
+        required=False,
+        widget=forms.PasswordInput(render_value=True),
+        help_text="Optional GitHub token to store for this new user.",
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get("password_mode") == "custom" and not cleaned_data.get("password"):
+            self.add_error("password", "Provide a password or switch to random generation.")
+        return cleaned_data
+
+    def save(self):
+        """Create the superuser, assign groups, and return the account/password tuple."""
+
+        cleaned_data = self.cleaned_data
+        password = cleaned_data.get("password") or self._generate_password()
+        username = cleaned_data["username"]
+        email = cleaned_data.get("email", "")
+
+        user_model = get_user_model()
+        user = user_model._default_manager.create_user(
+            username=username,
+            email=email,
+            password=password,
+            is_staff=True,
+            is_superuser=True,
+        )
+        user.groups.set(cleaned_data["security_groups"])
+
+        github_token = (cleaned_data.get("github_token") or "").strip()
+        github_username = (cleaned_data.get("github_username") or "").strip()
+        if github_token:
+            from apps.repos.models import GitHubToken
+
+            GitHubToken.objects.update_or_create(
+                user=user,
+                defaults={"label": github_username or "Ops onboarding token", "token": github_token},
+            )
+
+        return user, password
+
+    @staticmethod
+    def _generate_password(length: int = 24) -> str:
+        alphabet = string.ascii_letters + string.digits + "-._~!@#$%^&*"
+        return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
+++ b/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
@@ -7,14 +7,19 @@ SEEDED_STEP_SLUG = "provision-ops-superuser"
 def seed_operator_journey_superuser_step(apps, schema_editor):
     """Add the post-role-confirmation superuser provisioning step."""
 
+    OperatorJourney = apps.get_model("ops", "OperatorJourney")
     OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+    journey = OperatorJourney.objects.filter(slug=SEEDED_JOURNEY_SLUG).first()
+    if journey is None:
+        return
+
     OperatorJourneyStep.objects.filter(
         journey__slug=SEEDED_JOURNEY_SLUG,
         slug=SEEDED_STEP_SLUG,
         is_seed_data=True,
     ).delete()
     OperatorJourneyStep.objects.create(
-        journey=apps.get_model("ops", "OperatorJourney").objects.get(slug=SEEDED_JOURNEY_SLUG),
+        journey=journey,
         slug=SEEDED_STEP_SLUG,
         title="Create operational superuser and security access",
         instruction=(
@@ -51,5 +56,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(seed_operator_journey_superuser_step, unseed_operator_journey_superuser_step),
+        migrations.RunPython(
+            seed_operator_journey_superuser_step, unseed_operator_journey_superuser_step
+        ),
     ]

--- a/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
+++ b/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
@@ -1,0 +1,55 @@
+from django.db import migrations
+
+SEEDED_JOURNEY_SLUG = "operator-node-readiness"
+SEEDED_STEP_SLUG = "provision-ops-superuser"
+
+
+def seed_operator_journey_superuser_step(apps, schema_editor):
+    """Add the post-role-confirmation superuser provisioning step."""
+
+    OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+    OperatorJourneyStep.objects.filter(
+        journey__slug=SEEDED_JOURNEY_SLUG,
+        slug=SEEDED_STEP_SLUG,
+        is_seed_data=True,
+    ).delete()
+    OperatorJourneyStep.objects.create(
+        journey=apps.get_model("ops", "OperatorJourney").objects.get(slug=SEEDED_JOURNEY_SLUG),
+        slug=SEEDED_STEP_SLUG,
+        title="Create operational superuser and security access",
+        instruction=(
+            "After confirming node role/setup, create a dedicated superuser for operations. "
+            "Assign one or more security groups, choose random/manual password handling, "
+            "and optionally attach GitHub credentials for repository/release/issue management."
+        ),
+        help_text=(
+            "Complete this step by creating the account, recording credentials securely, "
+            "and verifying the account can log in."
+        ),
+        iframe_url="/admin/auth/user/add/",
+        order=2,
+        is_active=True,
+        is_seed_data=True,
+    )
+
+
+def unseed_operator_journey_superuser_step(apps, schema_editor):
+    """Remove only the seeded superuser-provision step."""
+
+    OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+    OperatorJourneyStep.objects.filter(
+        journey__slug=SEEDED_JOURNEY_SLUG,
+        slug=SEEDED_STEP_SLUG,
+        is_seed_data=True,
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ops", "0008_refresh_seeded_validate_role_guidance"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_operator_journey_superuser_step, unseed_operator_journey_superuser_step),
+    ]

--- a/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
+++ b/apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py
@@ -13,29 +13,35 @@ def seed_operator_journey_superuser_step(apps, schema_editor):
     if journey is None:
         return
 
-    OperatorJourneyStep.objects.filter(
-        journey__slug=SEEDED_JOURNEY_SLUG,
-        slug=SEEDED_STEP_SLUG,
-        is_seed_data=True,
-    ).delete()
-    OperatorJourneyStep.objects.create(
-        journey=journey,
-        slug=SEEDED_STEP_SLUG,
-        title="Create operational superuser and security access",
-        instruction=(
-            "After confirming node role/setup, create a dedicated superuser for operations. "
-            "Assign one or more security groups, choose random/manual password handling, "
-            "and optionally attach GitHub credentials for repository/release/issue management."
-        ),
-        help_text=(
-            "Complete this step by creating the account, recording credentials securely, "
-            "and verifying the account can log in."
-        ),
-        iframe_url="/admin/auth/user/add/",
-        order=2,
-        is_active=True,
-        is_seed_data=True,
+    step = OperatorJourneyStep.objects.filter(
+        journey=journey, slug=SEEDED_STEP_SLUG
+    ).first()
+    if step is None:
+        step = OperatorJourneyStep(journey=journey, slug=SEEDED_STEP_SLUG)
+
+    for conflicting_step in (
+        OperatorJourneyStep.objects.filter(journey=journey, order__gte=2)
+        .exclude(pk=step.pk)
+        .order_by("-order", "-id")
+    ):
+        conflicting_step.order += 1
+        conflicting_step.save(update_fields=["order"])
+
+    step.title = "Create operational superuser and security access"
+    step.instruction = (
+        "After confirming node role/setup, create a dedicated superuser for operations. "
+        "Assign one or more security groups, choose random/manual password handling, "
+        "and optionally attach GitHub credentials for repository/release/issue management."
     )
+    step.help_text = (
+        "Complete this step by creating the account, recording credentials securely, "
+        "and verifying the account can log in."
+    )
+    step.iframe_url = "/admin/auth/user/add/"
+    step.order = 2
+    step.is_active = True
+    step.is_seed_data = True
+    step.save()
 
 
 def unseed_operator_journey_superuser_step(apps, schema_editor):

--- a/apps/ops/templates/admin/ops/operator_journey_provision_success.html
+++ b/apps/ops/templates/admin/ops/operator_journey_provision_success.html
@@ -1,0 +1,24 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+  <div class="module aligned">
+    <h1>{% translate "Operational superuser created" %}</h1>
+    <p>
+      {% blocktranslate with username=new_user.get_username %}Created superuser {{ username }}.{% endblocktranslate %}
+    </p>
+    <p>
+      {% translate "Record this password securely now. It will not be shown again." %}
+    </p>
+    <p><code>{{ one_time_password }}</code></p>
+    {% if next_step %}
+      <p>
+        <a class="button default" href="{% url 'ops:operator-journey-step' next_step.pk %}">{% translate "Continue to next step" %}</a>
+      </p>
+    {% else %}
+      <p>
+        <a class="button default" href="{% url 'admin:index' %}">{% translate "Return to admin dashboard" %}</a>
+      </p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -46,6 +46,39 @@
         {% translate "Decision flow:" %}
         {% translate "1) Confirm intended role. 2) Run configure with that role. 3) Restart and verify check output, then continue." %}
       </p>
+    {% elif provision_superuser_form %}
+      <p>
+        {% translate "Create an operational superuser for this node role, assign security groups, and optionally connect GitHub credentials for repository/release/issue workflows." %}
+      </p>
+      {% if last_provisioned_account.username %}
+        <p>
+          <strong>{% translate "Latest created account:" %}</strong>
+          {{ last_provisioned_account.username }}
+          <br>
+          <strong>{% translate "Password:" %}</strong>
+          <code>{{ last_provisioned_account.password }}</code>
+        </p>
+      {% endif %}
+      <p>
+        {% translate "After creation, open a private browser session to verify this account can log in." %}
+      </p>
+      <form method="post" action="{% url 'ops:operator-journey-step-complete' step.pk %}" style="margin-top: 1rem;">
+        {% csrf_token %}
+        {{ provision_superuser_form.non_field_errors }}
+        <fieldset class="module aligned" style="padding: 0.75rem;">
+          {% for field in provision_superuser_form %}
+            <div class="form-row" style="margin-bottom: 0.75rem;">
+              <label for="{{ field.id_for_label }}" style="display: block; font-weight: 600;">{{ field.label }}</label>
+              {{ field }}
+              {% if field.help_text %}
+                <p class="help" style="margin: 0.25rem 0 0;">{{ field.help_text }}</p>
+              {% endif %}
+              {{ field.errors }}
+            </div>
+          {% endfor %}
+        </fieldset>
+        <button type="submit" class="button default">{% translate "Create account and complete step" %}</button>
+      </form>
     {% else %}
       <p>{{ step.instruction }}</p>
       {% if step.help_text %}
@@ -57,9 +90,11 @@
         style="width: 100%; min-height: 60vh; border: 1px solid var(--hairline-color); border-radius: 8px;"
       ></iframe>
     {% endif %}
-    <form method="post" action="{% url 'ops:operator-journey-step-complete' step.pk %}" style="margin-top: 1rem;">
-      {% csrf_token %}
-      <button type="submit" class="button default">{% translate "Mark this step complete" %}</button>
-    </form>
+    {% if not provision_superuser_form %}
+      <form method="post" action="{% url 'ops:operator-journey-step-complete' step.pk %}" style="margin-top: 1rem;">
+        {% csrf_token %}
+        <button type="submit" class="button default">{% translate "Mark this step complete" %}</button>
+      </form>
+    {% endif %}
   </div>
 {% endblock %}

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -50,15 +50,6 @@
       <p>
         {% translate "Create an operational superuser for this node role, assign security groups, and optionally connect GitHub credentials for repository/release/issue workflows." %}
       </p>
-      {% if last_provisioned_account.username %}
-        <p>
-          <strong>{% translate "Latest created account:" %}</strong>
-          {{ last_provisioned_account.username }}
-          <br>
-          <strong>{% translate "Password:" %}</strong>
-          <code>{{ last_provisioned_account.password }}</code>
-        </p>
-      {% endif %}
       <p>
         {% translate "After creation, open a private browser session to verify this account can log in." %}
       </p>

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -270,18 +270,10 @@ class OperatorJourneyViewTests(TestCase):
                 "github_username": "octocat",
                 "github_token": "ghp_example_token",
             },
-            follow=True,
         )
 
-        self.assertContains(response, "Operator journey complete")
-        messages = list(response.context["messages"])
-        self.assertTrue(
-            any(
-                "Record this securely because it will not be shown again."
-                in str(message)
-                for message in messages
-            )
-        )
+        self.assertContains(response, "Operational superuser created")
+        self.assertContains(response, "Record this password securely now")
         created_user = get_user_model().objects.get(username="ops-provisioned")
         self.assertTrue(created_user.is_superuser)
         self.assertTrue(created_user.is_staff)
@@ -291,6 +283,36 @@ class OperatorJourneyViewTests(TestCase):
         )
         token = GitHubToken.objects.get(user=created_user)
         self.assertEqual(token.label, "octocat")
+
+    def test_provision_step_ignores_autofilled_password_when_mode_is_random(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": "ops-random-password",
+                "email": "ops-random-password@example.com",
+                "security_groups": [self.group.pk],
+                "password_mode": "random",
+                "password": "autofilled-password",
+            },
+        )
+
+        created_user = get_user_model().objects.get(username="ops-random-password")
+        self.assertFalse(created_user.check_password("autofilled-password"))
 
     def test_provision_step_rejects_existing_username(self):
         provision_step = OperatorJourneyStep.objects.create(
@@ -353,6 +375,55 @@ class OperatorJourneyViewTests(TestCase):
         )
         self.assertFalse(
             get_user_model().objects.filter(username="ops-not-allowed").exists()
+        )
+
+    def test_non_superuser_staff_cannot_view_or_submit_provision_step(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+
+        staff_user = get_user_model().objects.create_user(
+            username="staff-operator",
+            password="x",
+            is_staff=True,
+            is_superuser=False,
+        )
+        staff_user.groups.add(self.group)
+        self.client.force_login(staff_user)
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+
+        view_response = self.client.get(
+            reverse("ops:operator-journey-step", args=[provision_step.pk])
+        )
+        self.assertEqual(view_response.status_code, 403)
+
+        submit_response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": "ops-should-not-create",
+                "security_groups": [self.group.pk],
+                "password_mode": "random",
+            },
+        )
+        self.assertEqual(submit_response.status_code, 403)
+        self.assertFalse(
+            get_user_model().objects.filter(username="ops-should-not-create").exists()
         )
 
 

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -58,7 +58,10 @@ class OperatorJourneyFlowTests(TestCase):
         status = status_for_user(user=self.user)
         self.assertEqual(status.message, "Step 2")
         self.assertEqual(status.task_title, "Step 2")
-        self.assertEqual(status.available_since, self.user.operator_journey_step_completions.first().completed_at)
+        self.assertEqual(
+            status.available_since,
+            self.user.operator_journey_step_completions.first().completed_at,
+        )
 
         self.assertTrue(complete_step_for_user(user=self.user, step=self.step_2))
         status = status_for_user(user=self.user)
@@ -87,7 +90,9 @@ class OperatorJourneyViewTests(TestCase):
     """Validate operator journey routes and dashboard link rendering."""
 
     def setUp(self):
-        self.group = SecurityGroup.objects.create(name="Operator Journey Dashboard Group")
+        self.group = SecurityGroup.objects.create(
+            name="Operator Journey Dashboard Group"
+        )
         self.user = get_user_model().objects.create_user(
             username="ops-journey-dashboard",
             password="x",
@@ -131,14 +136,22 @@ class OperatorJourneyViewTests(TestCase):
         )
 
     def test_step_view_redirects_when_opening_future_step(self):
-        response = self.client.get(reverse("ops:operator-journey-step", args=[self.step_2.pk]))
+        response = self.client.get(
+            reverse("ops:operator-journey-step", args=[self.step_2.pk])
+        )
 
-        self.assertRedirects(response, reverse("ops:operator-journey-step", args=[self.step_1.pk]))
+        self.assertRedirects(
+            response, reverse("ops:operator-journey-step", args=[self.step_1.pk])
+        )
 
     def test_validate_role_step_shows_setup_check_instead_of_iframe(self):
-        response = self.client.get(reverse("ops:operator-journey-step", args=[self.step_1.pk]))
+        response = self.client.get(
+            reverse("ops:operator-journey-step", args=[self.step_1.pk])
+        )
 
-        self.assertContains(response, "Node role changes must be applied with install/configure scripts")
+        self.assertContains(
+            response, "Node role changes must be applied with install/configure scripts"
+        )
         self.assertContains(response, "./configure.sh --check")
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)
@@ -149,10 +162,15 @@ class OperatorJourneyViewTests(TestCase):
 
         self.assertEqual(summary["configured_role"], "Watchtower")
         self.assertIn("./configure.sh --watchtower", summary["commands"])
-        self.assertNotIn("./configure.sh --terminal|--satellite|--control|--watchtower", summary["commands"])
+        self.assertNotIn(
+            "./configure.sh --terminal|--satellite|--control|--watchtower",
+            summary["commands"],
+        )
 
     def test_completing_all_steps_shows_completion_message_on_dashboard(self):
-        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
         complete_response = self.client.post(
             reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
         )
@@ -165,8 +183,12 @@ class OperatorJourneyViewTests(TestCase):
             "All Operator tasks completed to date. Keep coming back for more.",
         )
 
-    def test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment(self):
-        site_operator_group = SecurityGroup.objects.create(name=SITE_OPERATOR_GROUP_NAME)
+    def test_dashboard_shows_operator_journey_for_admin_user_without_group_assignment(
+        self,
+    ):
+        site_operator_group = SecurityGroup.objects.create(
+            name=SITE_OPERATOR_GROUP_NAME
+        )
         admin_user = get_user_model().objects.create_user(
             username="admin",
             password="x",
@@ -194,7 +216,9 @@ class OperatorJourneyViewTests(TestCase):
         response = self.client.get(reverse("admin:index"))
 
         self.assertContains(response, "Run admin setup")
-        self.assertTrue(admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists())
+        self.assertTrue(
+            admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists()
+        )
 
     def test_provision_step_renders_account_form(self):
         provision_step = OperatorJourneyStep.objects.create(
@@ -205,10 +229,16 @@ class OperatorJourneyViewTests(TestCase):
             iframe_url="/admin/",
             order=3,
         )
-        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))
-        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_2.pk]))
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
 
-        response = self.client.get(reverse("ops:operator-journey-step", args=[provision_step.pk]))
+        response = self.client.get(
+            reverse("ops:operator-journey-step", args=[provision_step.pk])
+        )
 
         self.assertContains(response, "Create account and complete step")
         self.assertNotContains(response, "<iframe", html=False)
@@ -222,8 +252,12 @@ class OperatorJourneyViewTests(TestCase):
             iframe_url="/admin/",
             order=3,
         )
-        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))
-        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_2.pk]))
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
         extra_group = SecurityGroup.objects.create(name="Provisioned Ops Group")
 
         response = self.client.post(
@@ -240,6 +274,14 @@ class OperatorJourneyViewTests(TestCase):
         )
 
         self.assertContains(response, "Operator journey complete")
+        messages = list(response.context["messages"])
+        self.assertTrue(
+            any(
+                "Record this securely because it will not be shown again."
+                in str(message)
+                for message in messages
+            )
+        )
         created_user = get_user_model().objects.get(username="ops-provisioned")
         self.assertTrue(created_user.is_superuser)
         self.assertTrue(created_user.is_staff)
@@ -249,6 +291,69 @@ class OperatorJourneyViewTests(TestCase):
         )
         token = GitHubToken.objects.get(user=created_user)
         self.assertEqual(token.label, "octocat")
+
+    def test_provision_step_rejects_existing_username(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+        get_user_model().objects.create_user(
+            username="existing-ops-user",
+            password="x",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": "existing-ops-user",
+                "email": "ops-provisioned@example.com",
+                "security_groups": [self.group.pk],
+                "password_mode": "random",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "A user with this username already exists.")
+
+    def test_provision_step_post_rejects_when_not_current_required_step(self):
+        blocked_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+
+        response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[blocked_step.pk]),
+            {
+                "username": "ops-not-allowed",
+                "email": "ops-provisioned@example.com",
+                "security_groups": [self.group.pk],
+                "password_mode": "random",
+            },
+            follow=True,
+        )
+
+        self.assertRedirects(
+            response, reverse("ops:operator-journey-step", args=[self.step_1.pk])
+        )
+        self.assertFalse(
+            get_user_model().objects.filter(username="ops-not-allowed").exists()
+        )
 
 
 class OperatorJourneyTemplateTagTests(TestCase):

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -10,6 +10,7 @@ from apps.groups.models import SecurityGroup
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
 from apps.ops.views import _build_node_role_validation_summary
+from apps.repos.models import GitHubToken
 
 
 class OperatorJourneyFlowTests(TestCase):
@@ -194,6 +195,60 @@ class OperatorJourneyViewTests(TestCase):
 
         self.assertContains(response, "Run admin setup")
         self.assertTrue(admin_user.groups.filter(name=SITE_OPERATOR_GROUP_NAME).exists())
+
+    def test_provision_step_renders_account_form(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))
+        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_2.pk]))
+
+        response = self.client.get(reverse("ops:operator-journey-step", args=[provision_step.pk]))
+
+        self.assertContains(response, "Create account and complete step")
+        self.assertNotContains(response, "<iframe", html=False)
+
+    def test_provision_step_creates_superuser_groups_and_github_token(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))
+        self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_2.pk]))
+        extra_group = SecurityGroup.objects.create(name="Provisioned Ops Group")
+
+        response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": "ops-provisioned",
+                "email": "ops-provisioned@example.com",
+                "security_groups": [self.group.pk, extra_group.pk],
+                "password_mode": "random",
+                "github_username": "octocat",
+                "github_token": "ghp_example_token",
+            },
+            follow=True,
+        )
+
+        self.assertContains(response, "Operator journey complete")
+        created_user = get_user_model().objects.get(username="ops-provisioned")
+        self.assertTrue(created_user.is_superuser)
+        self.assertTrue(created_user.is_staff)
+        self.assertSetEqual(
+            set(created_user.groups.values_list("name", flat=True)),
+            {self.group.name, extra_group.name},
+        )
+        token = GitHubToken.objects.get(user=created_user)
+        self.assertEqual(token.label, "octocat")
 
 
 class OperatorJourneyTemplateTagTests(TestCase):

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import Http404, HttpRequest, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -138,6 +140,8 @@ def operator_journey_step(request: HttpRequest, step_id: int):
     if step.slug == ROLE_VALIDATION_STEP_SLUG:
         context["node_role_validation"] = _build_node_role_validation_summary()
     if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
+        if not request.user.is_superuser:
+            raise PermissionDenied
         context["provision_superuser_form"] = OperatorJourneyProvisionSuperuserForm()
 
     return render(request, "admin/ops/operator_journey_step.html", context)
@@ -171,6 +175,8 @@ def complete_operator_journey_step(request: HttpRequest, step_id: int):
         return redirect(reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[current_step.pk]))
 
     if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
+        if not request.user.is_superuser:
+            raise PermissionDenied
         provision_form = OperatorJourneyProvisionSuperuserForm(request.POST)
         if not provision_form.is_valid():
             return render(
@@ -178,13 +184,39 @@ def complete_operator_journey_step(request: HttpRequest, step_id: int):
                 "admin/ops/operator_journey_step.html",
                 {"step": step, "provision_superuser_form": provision_form},
             )
-        new_user, password = provision_form.save()
-        messages.success(
+        with transaction.atomic():
+            request.user.__class__._default_manager.select_for_update().get(
+                pk=request.user.pk
+            )
+            locked_step = next_step_for_user(user=request.user)
+            if locked_step is None:
+                return redirect(reverse("admin:index"))
+            if locked_step.pk != step.pk:
+                messages.warning(
+                    request,
+                    "That step is not available yet. Finish the current required operator step first.",
+                )
+                return redirect(
+                    reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[locked_step.pk])
+                )
+            if not complete_step_for_user(user=request.user, step=step):
+                messages.warning(
+                    request,
+                    "That step is not available yet. Finish the current required operator step first.",
+                )
+                return redirect(
+                    reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[locked_step.pk])
+                )
+            new_user, password = provision_form.save()
+        next_step = next_step_for_user(user=request.user)
+        return render(
             request,
-            (
-                f"Created superuser {new_user.get_username()} with password: {password}. "
-                "Record this securely because it will not be shown again."
-            ),
+            "admin/ops/operator_journey_provision_success.html",
+            {
+                "new_user": new_user,
+                "one_time_password": password,
+                "next_step": next_step,
+            },
         )
 
     if not complete_step_for_user(user=request.user, step=step):

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -62,7 +62,9 @@ def _build_node_role_validation_summary() -> dict[str, object]:
         local_node_role = _normalize_role_name(role_name)
 
     current_role = configured_role or lock_role or local_node_role
-    role_mismatch = bool(local_node_role and current_role and local_node_role != current_role)
+    role_mismatch = bool(
+        local_node_role and current_role and local_node_role != current_role
+    )
 
     suggested_role = current_role or local_node_role
     normalized_slug = str(suggested_role or "").strip().lower()
@@ -70,7 +72,9 @@ def _build_node_role_validation_summary() -> dict[str, object]:
     if normalized_slug in {role.lower() for role in KNOWN_NODE_ROLES}:
         commands.extend([f"./configure.sh --{normalized_slug}", "./service-start.sh"])
     else:
-        commands.extend([f"./configure.sh --{role.lower()}" for role in KNOWN_NODE_ROLES])
+        commands.extend(
+            [f"./configure.sh --{role.lower()}" for role in KNOWN_NODE_ROLES]
+        )
         commands.append("./service-start.sh")
 
     return {
@@ -111,7 +115,9 @@ def operator_journey_step(request: HttpRequest, step_id: int):
     """Render the next required journey step with embedded action frame."""
 
     step = (
-        OperatorJourneyStep.objects.filter(pk=step_id, is_active=True, journey__is_active=True)
+        OperatorJourneyStep.objects.filter(
+            pk=step_id, is_active=True, journey__is_active=True
+        )
         .select_related("journey")
         .first()
     )
@@ -133,10 +139,6 @@ def operator_journey_step(request: HttpRequest, step_id: int):
         context["node_role_validation"] = _build_node_role_validation_summary()
     if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
         context["provision_superuser_form"] = OperatorJourneyProvisionSuperuserForm()
-        context["last_provisioned_account"] = request.session.get(
-            "operator_journey_last_provisioned_account",
-            {},
-        )
 
     return render(request, "admin/ops/operator_journey_step.html", context)
 
@@ -149,12 +151,24 @@ def complete_operator_journey_step(request: HttpRequest, step_id: int):
         return redirect(reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[step_id]))
 
     step = (
-        OperatorJourneyStep.objects.filter(pk=step_id, is_active=True, journey__is_active=True)
+        OperatorJourneyStep.objects.filter(
+            pk=step_id, is_active=True, journey__is_active=True
+        )
         .select_related("journey")
         .first()
     )
     if step is None:
         raise Http404("Journey step not found")
+
+    current_step = next_step_for_user(user=request.user)
+    if current_step is None:
+        return redirect(reverse("admin:index"))
+    if current_step.pk != step.pk:
+        messages.warning(
+            request,
+            "That step is not available yet. Finish the current required operator step first.",
+        )
+        return redirect(reverse(OPERATOR_JOURNEY_STEP_URL_NAME, args=[current_step.pk]))
 
     if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
         provision_form = OperatorJourneyProvisionSuperuserForm(request.POST)
@@ -165,13 +179,12 @@ def complete_operator_journey_step(request: HttpRequest, step_id: int):
                 {"step": step, "provision_superuser_form": provision_form},
             )
         new_user, password = provision_form.save()
-        request.session["operator_journey_last_provisioned_account"] = {
-            "username": new_user.get_username(),
-            "password": password,
-        }
         messages.success(
             request,
-            f"Created superuser {new_user.get_username()}. Log in with that account when needed.",
+            (
+                f"Created superuser {new_user.get_username()} with password: {password}. "
+                "Record this securely because it will not be shown again."
+            ),
         )
 
     if not complete_step_for_user(user=request.user, step=step):

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -12,12 +12,14 @@ from django.urls import reverse
 
 OPERATOR_JOURNEY_STEP_URL_NAME = "ops:operator-journey-step"
 
+from .forms import OperatorJourneyProvisionSuperuserForm
 from .models import OperatorJourneyStep
 from .operator_journey import complete_step_for_user, next_step_for_user
 from .redirects import safe_host_redirect
 from .status_surface import build_status_surface, scoped_log_excerpts
 
 ROLE_VALIDATION_STEP_SLUG = "validate-local-node-role"
+PROVISION_SUPERUSER_STEP_SLUG = "provision-ops-superuser"
 KNOWN_NODE_ROLES = ("Terminal", "Satellite", "Control", "Watchtower")
 ROLE_ALIASES = {"constellation": "Watchtower"}
 
@@ -129,6 +131,12 @@ def operator_journey_step(request: HttpRequest, step_id: int):
     context = {"step": step}
     if step.slug == ROLE_VALIDATION_STEP_SLUG:
         context["node_role_validation"] = _build_node_role_validation_summary()
+    if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
+        context["provision_superuser_form"] = OperatorJourneyProvisionSuperuserForm()
+        context["last_provisioned_account"] = request.session.get(
+            "operator_journey_last_provisioned_account",
+            {},
+        )
 
     return render(request, "admin/ops/operator_journey_step.html", context)
 
@@ -147,6 +155,24 @@ def complete_operator_journey_step(request: HttpRequest, step_id: int):
     )
     if step is None:
         raise Http404("Journey step not found")
+
+    if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
+        provision_form = OperatorJourneyProvisionSuperuserForm(request.POST)
+        if not provision_form.is_valid():
+            return render(
+                request,
+                "admin/ops/operator_journey_step.html",
+                {"step": step, "provision_superuser_form": provision_form},
+            )
+        new_user, password = provision_form.save()
+        request.session["operator_journey_last_provisioned_account"] = {
+            "username": new_user.get_username(),
+            "password": password,
+        }
+        messages.success(
+            request,
+            f"Created superuser {new_user.get_username()}. Log in with that account when needed.",
+        )
 
     if not complete_step_for_user(user=request.user, step=step):
         next_step = next_step_for_user(user=request.user)


### PR DESCRIPTION
### Motivation

- Provide an ops workflow step that runs after node role confirmation to onboard an operational superuser with appropriate security groups, a convenient password flow (random/manual), and optional GitHub credentials for repo/release/issue management.

### Description

- Added `OperatorJourneyProvisionSuperuserForm` to `apps/ops/forms.py` to collect username, email, security groups, password mode (random/manual), and optional GitHub username/token and to create the superuser and (optionally) persist a `GitHubToken` for that user.
- Updated `apps/ops/views.py` to render the provisioning form for a new `provision-ops-superuser` step, validate and create the account on POST, store last-created credentials in session for handoff, and emit a success message.
- Modified `apps/ops/templates/admin/ops/operator_journey_step.html` to render a guided provisioning UI (showing last-created credentials when present) instead of the iframe when the new step is active, and to change the step completion UX accordingly.
- Added migration `apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py` to seed a new `provision-ops-superuser` step (order=2) in the default `operator-node-readiness` journey.
- Extended `apps/ops/tests/test_operator_journey.py` with regression tests that verify the provisioning step renders and that posting the form creates a superuser, assigns the requested security groups, and persists the GitHub token.

### Testing

- Ran environment preparation: `./env-refresh.sh --deps-only` (completed).
- Installed CI test deps: `.venv/bin/pip install -r requirements-ci.txt` (completed).
- Executed targeted test suite: `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` which collected and ran the updated tests and reported `11 passed`.
- Verified migrations: `.venv/bin/python manage.py migrations check` reported no outstanding issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac66837c0832697c6a82cf10e4f44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a guided operational superuser provisioning step to the operator journey workflow that runs after node role confirmation. It enables administrators (superusers) to create an operational superuser account, assign security groups, choose random or manual password handling, and optionally persist GitHub credentials — all inside the operator-journey UI with server-side validation and a one-time password handoff.

## Changes

Forms (apps/ops/forms.py)
- Added OperatorJourneyProvisionSuperuserForm:
  - Fields: username, email, security_groups (ModelMultipleChoice), password_mode (random/custom), password (conditional), github_username, github_token.
  - Validation: rejects existing usernames via normalized lookup; requires password when password_mode == "custom".
  - save(): creates the superuser via user_model._default_manager.create_superuser(...), assigns selected SecurityGroup(s), and update_or_create()s a GitHubToken when a token is provided. Returns (user, password).
  - Static helper _generate_password() uses secrets.choice() over a curated PASSWORD_ALPHABET for secure random password generation.

Views (apps/ops/views.py)
- Added PROVISION_SUPERUSER_STEP_SLUG = "provision-ops-superuser".
- operator_journey_step(): when the current step matches the provision slug, enforces that only superusers may view it and injects an unbound OperatorJourneyProvisionSuperuserForm into template context.
- complete_operator_journey_step(): handles POST for the provision step:
  - Re-validates the step is the current required step; enforces superuser-only access.
  - On invalid form: re-renders the step with bound form errors.
  - On valid form: wraps provisioning in transaction.atomic(), locks the requester’s user row via select_for_update(), re-checks the current step to avoid TOCTOU, calls provision_form.save() to create the new user and one-time password, and proceeds to render a provision success template with new_user, one_time_password, and next_step.
- Preserves existing journey completion logic and user-facing warnings for out-of-order step attempts.

Templates
- apps/ops/templates/admin/ops/operator_journey_step.html:
  - Conditionals added to render the provision_superuser_form UI (fields, per-field help, errors) and change the submit button to "Create account and complete step" when the provision form is present.
  - Suppresses the generic "Mark this step complete" form while the provision UI is active; preserves the iframe-based UI and generic completion form for other steps.
- apps/ops/templates/admin/ops/operator_journey_provision_success.html:
  - New success screen that shows created username, a one-time password (emphasized for secure recording), and a primary action linking to the next step or admin dashboard.

Migration (apps/ops/migrations/0009_seed_operator_journey_superuser_provision_step.py)
- Adds reversible data migration to seed a provision-ops-superuser step (order=2) into the operator-node-readiness journey:
  - Inserts the step (or updates existing), shifts existing steps with order >= 2 to make room, marks the seeded step with is_seed_data=True.
  - Reverse migration deletes only seed-marked matching entries.

Tests (apps/ops/tests/test_operator_journey.py)
- Extended regression coverage to include the provision step behavior:
  - Asserts the provision step renders an account-creation UI (replacing the iframe) when active.
  - Tests that posting a valid provision form creates a superuser with requested security groups and persists a GitHubToken (label set from submitted github_username), and that a one-time password is returned for handoff.
  - Tests that random password mode ignores any submitted password and that manual-password mode requires the password.
  - Tests that duplicate username submission is rejected and does not create a user.
  - Tests enforcement that the step must be the current required step (out-of-order POSTs redirect and do not create accounts).
  - Tests that non-superuser staff cannot view or submit the provision step (PermissionDenied / 403 expected).
- Includes GitHubToken import and assertions on token persistence.

## Testing

- Author ran targeted tests in apps/ops/tests/test_operator_journey.py (reported 11 passed) and verified migrations had no outstanding issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->