### PR TITLE
scripts: clarify local-only default admin login when showing service URL

### DIFF
--- a/scripts/helpers/ports.sh
+++ b/scripts/helpers/ports.sh
@@ -64,3 +64,10 @@ arthexis_service_url() {
     port="$(arthexis_detect_backend_port "$base_dir" "$fallback_port")"
     printf 'http://%s:%s\n' "$host" "$port"
 }
+
+# arthexis_print_local_admin_login_hint
+#
+# Print the default admin credential hint with localhost-only scope.
+arthexis_print_local_admin_login_hint() {
+    echo "Login hint: use admin/admin from the local machine only."
+}

--- a/scripts/service-start.sh
+++ b/scripts/service-start.sh
@@ -443,6 +443,7 @@ wait_for_suite_startup() {
 
     if arthexis_suite_reachable "$port"; then
       echo "Suite is reachable at http://localhost:$port"
+      arthexis_print_local_admin_login_hint
       return 0
     fi
 

--- a/start.sh
+++ b/start.sh
@@ -145,6 +145,7 @@ wait_for_systemd_service() {
       echo "Service '$service_name' is active."
       if [ "$service_name" = "$SERVICE_NAME" ]; then
         echo "Access the service at $(arthexis_service_url "$BASE_DIR")."
+        arthexis_print_local_admin_login_hint
       fi
       "${SYSTEMCTL_CMD[@]}" status "$service_name" --no-pager --lines 10 || true
       return 0

--- a/status.sh
+++ b/status.sh
@@ -282,6 +282,7 @@ fi
 
 if [ "$SUITE_REACHABLE" = true ]; then
   echo "Application reachable at: http://localhost:$PORT"
+  arthexis_print_local_admin_login_hint
 elif [ "$RUNNING" = true ]; then
   echo "Application process running but port $PORT is not reachable yet"
 else
@@ -313,6 +314,7 @@ if [ "$WAIT_FOR_REACHABLE" = true ] && [ "$SUITE_REACHABLE" = false ]; then
     if arthexis_suite_reachable "$PORT"; then
       SUITE_REACHABLE=true
       echo "Application reachable at: http://localhost:$PORT"
+      arthexis_print_local_admin_login_hint
       break
     fi
     echo "Still waiting for application to become reachable on port $PORT..."


### PR DESCRIPTION
### Motivation
- Make the startup/status messaging explicit that the default `admin/admin` credential is only usable from the local machine when the service URL is printed.

### Description
- Add a shared helper `arthexis_print_local_admin_login_hint()` in `scripts/helpers/ports.sh` and call it where the service URL is printed in `scripts/service-start.sh`, `status.sh`, and `start.sh` so the hint appears consistently with the reachable URL.

### Testing
- Ran shell syntax checks with `bash -n scripts/helpers/ports.sh scripts/service-start.sh status.sh start.sh` which passed.
- Ran `./scripts/review-notify.sh --actor Codex` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac7c4f9cc8326b8372db152162d84)