### PR TITLE
sites: align admin dashboard status and action rows

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -80,12 +80,15 @@
     .admin-home-net-message {
         justify-self: start;
     }
+    .admin-home-status {
+        display: grid;
+        row-gap: 0.25rem;
+        align-content: start;
+    }
     .admin-home-operator-journey {
-        grid-column: 2;
         margin: 0;
         font-size: 0.75rem;
         line-height: 1.05;
-        align-self: start;
     }
     .admin-home-operator-journey__link {
         font-weight: 400;
@@ -97,14 +100,17 @@
     .admin-home-operator-journey__text {
         color: var(--body-quiet-color);
     }
+    .admin-home-actions-wrap {
+        align-self: start;
+        justify-self: end;
+        width: 100%;
+    }
     .admin-home-actions {
         display: flex;
         align-items: flex-start;
         justify-content: flex-end;
         gap: 8px;
         flex-wrap: wrap;
-        justify-self: end;
-        align-self: start;
         margin: 0;
         width: 100%;
         max-width: none;
@@ -113,6 +119,7 @@
         white-space: nowrap;
         padding-top: 0;
         padding-bottom: 0;
+        margin-top: 0;
     }
     .admin-home-actions__form {
         margin: 0;
@@ -159,13 +166,12 @@
             row-gap: 0.35rem;
         }
         .admin-home-actions {
-            grid-column: 2;
             justify-content: flex-start;
             max-width: none;
         }
-        .admin-home-operator-journey {
+        .admin-home-actions-wrap {
             grid-column: 2;
-            margin-top: 0;
+            justify-self: start;
         }
     }
     @media (max-width: 992px) {
@@ -174,15 +180,15 @@
             gap: 0.75rem;
         }
         .admin-home-actions {
-            grid-column: auto;
             justify-content: flex-start;
+        }
+        .admin-home-actions-wrap {
+            grid-column: auto;
+            justify-self: start;
         }
         .admin-home-net-message {
             width: 100%;
             min-width: 0;
-        }
-        .admin-home-operator-journey {
-            grid-column: auto;
         }
     }
     .dashboard-main {

--- a/apps/sites/templates/admin/index.html
+++ b/apps/sites/templates/admin/index.html
@@ -15,58 +15,62 @@
 {% last_net_message as admin_last_net_message %}
 <div id="admin-home-header">
   <h1>Home</h1>
-  <div class="admin-home-net-message" role="status" aria-live="polite">
-    <a
-      class="admin-home-net-message__icon admin-home-net-message__link"
-      href="{% url 'admin:nodes_netmessage_changelist' %}"
-      aria-label="{% translate 'Net messages' %}"
-      title="{% translate 'Net messages' %}"
-    >
-      <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-        <path fill="currentColor" d="M3 6.75A1.75 1.75 0 0 1 4.75 5h14.5A1.75 1.75 0 0 1 21 6.75v10.5A1.75 1.75 0 0 1 19.25 19H4.75A1.75 1.75 0 0 1 3 17.25V6.75zm2.16-.25L12 11.18l6.84-4.68H5.16zM19.5 8.2l-6.93 4.74a1 1 0 0 1-1.14 0L4.5 8.2v9.05c0 .14.11.25.25.25h14.5c.14 0 .25-.11.25-.25V8.2z"/>
-      </svg>
-    </a>
-    {% if admin_last_net_message.has_content %}
-      {% if admin_last_net_message.url %}
-        <a class="admin-home-net-message__content admin-home-net-message__link" href="{{ admin_last_net_message.url }}" title="{{ admin_last_net_message.text }}">{{ admin_last_net_message.text }}</a>
-      {% else %}
-        <span class="admin-home-net-message__content" title="{{ admin_last_net_message.text }}">{{ admin_last_net_message.text }}</span>
-      {% endif %}
-    {% else %}
-      {% translate 'No net messages available' as no_message_text %}
-      <span class="admin-home-net-message__content admin-home-net-message__content--empty" title="{{ no_message_text }}">{{ no_message_text }}</span>
-    {% endif %}
-  </div>
-  {% operator_journey_status as operator_journey %}
-  {% if operator_journey.has_journey %}
-    <div class="admin-home-operator-journey" role="status" aria-live="polite">
-      {% if operator_journey.url %}
-        <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
-        {% if operator_journey.available_since %}
-          <span class="admin-home-operator-journey__age">
-            {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
-          </span>
+  <div class="admin-home-status">
+    <div class="admin-home-net-message" role="status" aria-live="polite">
+      <a
+        class="admin-home-net-message__icon admin-home-net-message__link"
+        href="{% url 'admin:nodes_netmessage_changelist' %}"
+        aria-label="{% translate 'Net messages' %}"
+        title="{% translate 'Net messages' %}"
+      >
+        <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <path fill="currentColor" d="M3 6.75A1.75 1.75 0 0 1 4.75 5h14.5A1.75 1.75 0 0 1 21 6.75v10.5A1.75 1.75 0 0 1 19.25 19H4.75A1.75 1.75 0 0 1 3 17.25V6.75zm2.16-.25L12 11.18l6.84-4.68H5.16zM19.5 8.2l-6.93 4.74a1 1 0 0 1-1.14 0L4.5 8.2v9.05c0 .14.11.25.25.25h14.5c.14 0 .25-.11.25-.25V8.2z"/>
+        </svg>
+      </a>
+      {% if admin_last_net_message.has_content %}
+        {% if admin_last_net_message.url %}
+          <a class="admin-home-net-message__content admin-home-net-message__link" href="{{ admin_last_net_message.url }}" title="{{ admin_last_net_message.text }}">{{ admin_last_net_message.text }}</a>
+        {% else %}
+          <span class="admin-home-net-message__content" title="{{ admin_last_net_message.text }}">{{ admin_last_net_message.text }}</span>
         {% endif %}
       {% else %}
-        <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
+        {% translate 'No net messages available' as no_message_text %}
+        <span class="admin-home-net-message__content admin-home-net-message__content--empty" title="{{ no_message_text }}">{{ no_message_text }}</span>
       {% endif %}
     </div>
-  {% endif %}
-  <div class="admin-home-actions">
-    {% if perms.features.view_feature %}
-      <a class="button" href="{% url 'admin:features_feature_changelist' %}">
-        {% translate "Features" %}
-      </a>
+    {% operator_journey_status as operator_journey %}
+    {% if operator_journey.has_journey %}
+      <div class="admin-home-operator-journey" role="status" aria-live="polite">
+        {% if operator_journey.url %}
+          <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
+          {% if operator_journey.available_since %}
+            <span class="admin-home-operator-journey__age">
+              {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
+            </span>
+          {% endif %}
+        {% else %}
+          <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
+        {% endif %}
+      </div>
     {% endif %}
-    {% if perms.ocpp.view_charger %}
-      <a class="button" href="{% url 'admin:chargers-shortcut' %}">
-        {% translate "Chargers" %}
-      </a>
-    {% endif %}
-    {% admin_staff_tasks as staff_tasks %}
-    {% for task in staff_tasks %}
-      <a class="button" href="{{ task.url }}">{{ task.label }}</a>
-    {% endfor %}
+  </div>
+  <div class="admin-home-actions-wrap">
+    <div class="admin-home-actions">
+      {% if perms.features.view_feature %}
+        <a class="button" href="{% url 'admin:features_feature_changelist' %}">
+          {% translate "Features" %}
+        </a>
+      {% endif %}
+      {% if perms.ocpp.view_charger %}
+        <a class="button" href="{% url 'admin:chargers-shortcut' %}">
+          {% translate "Chargers" %}
+        </a>
+      {% endif %}
+      {% admin_staff_tasks as staff_tasks %}
+      {% for task in staff_tasks %}
+        <a class="button" href="{{ task.url }}">{{ task.label }}</a>
+      {% endfor %}
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation

- Reduce the large vertical gap above the dashboard action buttons by decoupling the status stack (net message + operator journey) from the action button row so each side can align independently.

### Description

- Restructured the admin header markup to introduce a status column and an actions column by adding `admin-home-status` and `admin-home-actions-wrap` around the existing elements in `apps/sites/templates/admin/index.html`.
- Grouped the net message and operator-journey output into the new `admin-home-status` container so the two stacks share a top alignment independent of the actions column.
- Updated `apps/sites/static/sites/css/admin/dashboard.css` to add styles for `.admin-home-status` and `.admin-home-actions-wrap`, removed the extra top offset on buttons (`margin-top: 0`), and adjusted responsive rules so the two-side layout stays aligned across breakpoints.

### Testing

- Ran environment bootstrap with `./env-refresh.sh --deps-only` which completed successfully.
- Resolved test-dependency issue by installing CI test deps via `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed the targeted dashboard tests with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py -k dashboard` and the selection passed (`3 passed, 6 deselected`).
- Sent review notification via `./scripts/review-notify.sh --actor Codex` (fallback notification used when LCD was unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac88abb188326ada354ecc9dc84ea)