### PR TITLE
ops: add interactive role and auto-upgrade command builder for operator journey

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -5,47 +5,156 @@
   <div class="module aligned">
     <h1>{{ step.title }}</h1>
     {% if node_role_validation %}
+      <style>
+        .ops-role-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+          gap: 1rem;
+          margin-top: 1rem;
+        }
+        .ops-role-card {
+          border: 1px solid var(--hairline-color);
+          border-radius: 8px;
+          padding: 1rem;
+          background: var(--body-bg, #fff);
+        }
+        .ops-role-card h2 {
+          margin-top: 0;
+        }
+        .ops-role-options {
+          display: grid;
+          gap: 0.5rem;
+          margin-top: 0.75rem;
+        }
+        .ops-role-option {
+          border: 1px solid var(--hairline-color);
+          border-radius: 6px;
+          padding: 0.5rem 0.75rem;
+        }
+        .ops-role-command {
+          margin-top: 0.75rem;
+          padding: 0.75rem;
+          border-radius: 6px;
+          background: var(--darkened-bg, #f6f8fa);
+        }
+        .ops-role-command code {
+          display: block;
+          margin-top: 0.4rem;
+          white-space: pre-wrap;
+        }
+      </style>
       <p>
         {% translate "Confirm the current node setup before proceeding. Node role changes must be applied with install/configure scripts, not by editing Nodes records." %}
       </p>
-      <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-        <thead>
-          <tr>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Check" %}</th>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Current value" %}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Runtime/configured role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.configured_role }}</td>
-          </tr>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Lock file role (.locks/role.lck)" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.lock_role }}</td>
-          </tr>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Registered local node role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
-          </tr>
-        </tbody>
-      </table>
-      {% if node_role_validation.role_mismatch %}
-        <p style="margin-top: 1rem;">
-          <strong>{% translate "Role mismatch detected." %}</strong>
-          {% translate "The local node record does not match the active runtime role. Reconfigure and restart before completing this step." %}
-        </p>
-      {% endif %}
-      <h2 style="margin-top: 1.25rem;">{% translate "If setup is wrong, run these commands" %}</h2>
-      <ol>
-        {% for command in node_role_validation.commands %}
-          <li><code>{{ command }}</code></li>
-        {% endfor %}
-      </ol>
-      <p>
-        {% translate "Decision flow:" %}
-        {% translate "1) Confirm intended role. 2) Run configure with that role. 3) Restart and verify check output, then continue." %}
-      </p>
+      <div class="ops-role-grid">
+        <section class="ops-role-card">
+          <h2>{% translate "Current configuration and command" %}</h2>
+          <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+              <tr>
+                <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Check" %}</th>
+                <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Current value" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Runtime/configured role" %}</td>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.configured_role }}</td>
+              </tr>
+              <tr>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Lock file role (.locks/role.lck)" %}</td>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.lock_role }}</td>
+              </tr>
+              <tr>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Registered local node role" %}</td>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
+              </tr>
+              <tr>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Auto-upgrade status" %}</td>
+                <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">
+                  {% if node_role_validation.interactive.current.auto_upgrade_enabled %}
+                    {% blocktrans with channel=node_role_validation.interactive.current.channel %}Enabled ({{ channel }}){% endblocktrans %}
+                  {% else %}
+                    {% translate "Disabled (manual/fixed)" %}
+                  {% endif %}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          {% if node_role_validation.role_mismatch %}
+            <p style="margin-top: 1rem;">
+              <strong>{% translate "Role mismatch detected." %}</strong>
+              {% translate "The local node record does not match the active runtime role. Reconfigure and restart before completing this step." %}
+            </p>
+          {% endif %}
+          <div class="ops-role-command">
+            <strong>{% translate "Generated command" %}</strong>
+            <code id="ops-generated-command"></code>
+            <button type="button" class="button" id="ops-copy-command" style="margin-top: 0.6rem;">
+              {% translate "Copy command" %}
+            </button>
+          </div>
+        </section>
+
+        <section class="ops-role-card">
+          <h2>{% translate "Role and auto-upgrade options" %}</h2>
+          <p>{% translate "Select a role and upgrade mode to generate the exact configure command." %}</p>
+          <div class="ops-role-options" role="group" aria-label="{% translate 'Role options' %}">
+            {% for role in node_role_validation.interactive.roles %}
+              <label class="ops-role-option">
+                <input
+                  type="radio"
+                  name="ops-role"
+                  value="{{ role.slug }}"
+                  {% if role.slug == node_role_validation.interactive.current.role %}checked{% endif %}
+                />
+                {{ role.label }}
+              </label>
+            {% endfor %}
+          </div>
+          <div class="ops-role-options" role="group" aria-label="{% translate 'Auto-upgrade options' %}">
+            {% for option in node_role_validation.interactive.auto_upgrade_options %}
+              <label class="ops-role-option">
+                <input
+                  type="radio"
+                  name="ops-auto-upgrade"
+                  value="{{ option.slug }}"
+                  {% if option.channel == node_role_validation.interactive.current.channel or option.slug == "fixed" and not node_role_validation.interactive.current.auto_upgrade_enabled %}checked{% endif %}
+                />
+                {{ option.label }}
+              </label>
+            {% endfor %}
+          </div>
+          <p style="margin-top: 0.75rem;">
+            {% translate "Decision flow:" %}
+            {% translate "1) Confirm intended role. 2) Select auto-upgrade mode. 3) Copy and run configure command. 4) Restart and verify check output, then continue." %}
+          </p>
+        </section>
+      </div>
+      <script>
+        (() => {
+          const roleInputs = document.querySelectorAll('input[name="ops-role"]');
+          const upgradeInputs = document.querySelectorAll('input[name="ops-auto-upgrade"]');
+          const output = document.getElementById("ops-generated-command");
+          const copyButton = document.getElementById("ops-copy-command");
+
+          const buildCommand = () => {
+            const role = [...roleInputs].find((input) => input.checked)?.value || "terminal";
+            const upgrade = [...upgradeInputs].find((input) => input.checked)?.value || "fixed";
+            const parts = ["./configure.sh", `--${role}`, `--${upgrade}`];
+            return `${parts.join(" ")}\n./service-start.sh`;
+          };
+
+          const render = () => {
+            output.textContent = buildCommand();
+          };
+
+          roleInputs.forEach((input) => input.addEventListener("change", render));
+          upgradeInputs.forEach((input) => input.addEventListener("change", render));
+          copyButton.addEventListener("click", () => navigator.clipboard?.writeText(buildCommand()));
+          render();
+        })();
+      </script>
     {% else %}
       <p>{{ step.instruction }}</p>
       {% if step.help_text %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1,5 +1,8 @@
 """Regression tests for operator journey progression and admin dashboard surfacing."""
 
+from pathlib import Path
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.template import Context, Template
@@ -9,7 +12,7 @@ from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
 from apps.groups.models import SecurityGroup
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
-from apps.ops.views import _build_node_role_validation_summary
+from apps.ops.views import _build_node_role_validation_summary, _build_role_upgrade_command_builder_context
 
 
 class OperatorJourneyFlowTests(TestCase):
@@ -138,7 +141,9 @@ class OperatorJourneyViewTests(TestCase):
         response = self.client.get(reverse("ops:operator-journey-step", args=[self.step_1.pk]))
 
         self.assertContains(response, "Node role changes must be applied with install/configure scripts")
-        self.assertContains(response, "./configure.sh --check")
+        self.assertContains(response, "Generated command")
+        self.assertContains(response, 'name="ops-role"')
+        self.assertContains(response, 'name="ops-auto-upgrade"')
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)
 
@@ -149,6 +154,19 @@ class OperatorJourneyViewTests(TestCase):
         self.assertEqual(summary["configured_role"], "Watchtower")
         self.assertIn("./configure.sh --watchtower", summary["commands"])
         self.assertNotIn("./configure.sh --terminal|--satellite|--control|--watchtower", summary["commands"])
+        self.assertEqual(summary["interactive"]["current"]["role"], "watchtower")
+
+    def test_role_upgrade_command_builder_defaults_to_manual_for_unknown_mode(self):
+        context = _build_role_upgrade_command_builder_context(
+            default_role="Unknown",
+            base_dir=Path(settings.BASE_DIR),
+        )
+
+        self.assertEqual(context["current"]["role"], "terminal")
+        self.assertIn(
+            {"slug": "fixed", "label": "Manual (fixed)", "enabled": False, "channel": "manual"},
+            context["auto_upgrade_options"],
+        )
 
     def test_completing_all_steps_shows_completion_message_on_dashboard(self):
         self.client.post(reverse("ops:operator-journey-step-complete", args=[self.step_1.pk]))

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -10,6 +10,8 @@ from django.http import Http404, HttpRequest, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
+from apps.core.system.upgrade import _read_auto_upgrade_mode
+
 OPERATOR_JOURNEY_STEP_URL_NAME = "ops:operator-journey-step"
 
 from .models import OperatorJourneyStep
@@ -78,6 +80,43 @@ def _build_node_role_validation_summary() -> dict[str, object]:
         "local_node_label": local_node_label,
         "role_mismatch": role_mismatch,
         "commands": commands,
+        "interactive": _build_role_upgrade_command_builder_context(
+            default_role=suggested_role,
+            base_dir=Path(settings.BASE_DIR),
+        ),
+    }
+
+
+def _build_role_upgrade_command_builder_context(*, default_role: str, base_dir: Path) -> dict[str, object]:
+    """Return current and selectable configure options for role/upgrade command building."""
+
+    upgrade_mode = _read_auto_upgrade_mode(base_dir=base_dir)
+    current_channel = str(upgrade_mode.get("mode") or "manual").strip().lower()
+    if current_channel not in {"manual", "stable", "regular", "latest", "mixed"}:
+        current_channel = "manual"
+    auto_upgrade_enabled = bool(upgrade_mode.get("enabled", False))
+
+    valid_roles = {role.lower() for role in KNOWN_NODE_ROLES}
+    normalized_default_role = str(default_role or "").strip().lower()
+    if normalized_default_role not in valid_roles:
+        normalized_default_role = "terminal"
+
+    return {
+        "current": {
+            "role": normalized_default_role,
+            "auto_upgrade_enabled": auto_upgrade_enabled,
+            "channel": current_channel,
+        },
+        "roles": [
+            {"slug": role.lower(), "label": role}
+            for role in KNOWN_NODE_ROLES
+        ],
+        "auto_upgrade_options": [
+            {"slug": "fixed", "label": "Manual (fixed)", "enabled": False, "channel": "manual"},
+            {"slug": "stable", "label": "Auto-upgrade stable", "enabled": True, "channel": "stable"},
+            {"slug": "regular", "label": "Auto-upgrade regular", "enabled": True, "channel": "regular"},
+            {"slug": "latest", "label": "Auto-upgrade latest", "enabled": True, "channel": "latest"},
+        ],
     }
 
 


### PR DESCRIPTION
### Motivation

- Improve the operator journey role-validation step so operators can see the current node role/auto-upgrade state and generate the exact `./configure.sh` command interactively without guessing or editing admin records.
- Preserve the existing script-first guidance and safety model by surfacing configure/script commands rather than enabling direct admin edits.

### Description

- Add interactive command-builder context to the role-validation step by calling `_read_auto_upgrade_mode` and returning a new `_build_role_upgrade_command_builder_context` payload in `apps/ops/views.py` so templates can render current mode, selectable roles, and upgrade options.
- Replace the single-table role summary with a two-panel layout in `apps/ops/templates/admin/ops/operator_journey_step.html` that shows current config and a generated, copyable command on the left and selectable role / auto-upgrade options on the right, plus small JS that updates the command live.
- Update `apps/ops/tests/test_operator_journey.py` to assert the presence of the new interactive elements and to test the command-builder defaults.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` (automated environment setup used by CI).
- Ran template/backend sanity compile with `python -m py_compile apps/ops/views.py` which completed successfully.
- Executed the updated test suite with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` and observed `10 passed` for that test module.
- Ran the project review notifier script `./scripts/review-notify.sh --actor Codex` (notification run completed via fallback).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad88546248326a8a65142fa743528)