### PR TITLE
ops: add interactive role and auto-upgrade command builder in operator journey step

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -5,47 +5,162 @@
   <div class="module aligned">
     <h1>{{ step.title }}</h1>
     {% if node_role_validation %}
+      <style>
+        .operator-journey-grid {
+          display: grid;
+          gap: 1rem;
+          grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+          margin-top: 1rem;
+        }
+        .operator-journey-card {
+          border: 1px solid var(--hairline-color);
+          border-radius: 8px;
+          padding: 1rem;
+        }
+        .operator-journey-card h2 {
+          margin-top: 0;
+        }
+        .operator-journey-config-table {
+          border-collapse: collapse;
+          width: 100%;
+        }
+        .operator-journey-config-table th,
+        .operator-journey-config-table td {
+          border-bottom: 1px solid var(--hairline-color);
+          padding: 0.5rem;
+          text-align: left;
+          vertical-align: top;
+        }
+        .operator-journey-option-list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+        }
+        .operator-journey-option-list li + li {
+          margin-top: 0.5rem;
+        }
+        .operator-journey-command-preview {
+          background: var(--darkened-bg, #f4f6f8);
+          border-radius: 6px;
+          display: block;
+          margin-top: 0.75rem;
+          padding: 0.75rem;
+          white-space: pre-wrap;
+        }
+      </style>
       <p>
         {% translate "Confirm the current node setup before proceeding. Node role changes must be applied with install/configure scripts, not by editing Nodes records." %}
       </p>
-      <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-        <thead>
-          <tr>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Check" %}</th>
-            <th style="text-align: left; padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Current value" %}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Runtime/configured role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.configured_role }}</td>
-          </tr>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Lock file role (.locks/role.lck)" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.lock_role }}</td>
-          </tr>
-          <tr>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{% translate "Registered local node role" %}</td>
-            <td style="padding: 0.5rem; border-bottom: 1px solid var(--hairline-color);">{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
-          </tr>
-        </tbody>
-      </table>
-      {% if node_role_validation.role_mismatch %}
-        <p style="margin-top: 1rem;">
-          <strong>{% translate "Role mismatch detected." %}</strong>
-          {% translate "The local node record does not match the active runtime role. Reconfigure and restart before completing this step." %}
-        </p>
-      {% endif %}
-      <h2 style="margin-top: 1.25rem;">{% translate "If setup is wrong, run these commands" %}</h2>
-      <ol>
-        {% for command in node_role_validation.commands %}
-          <li><code>{{ command }}</code></li>
-        {% endfor %}
-      </ol>
-      <p>
+      <div class="operator-journey-grid">
+        <section class="operator-journey-card" aria-labelledby="current-config-title">
+          <h2 id="current-config-title">{% translate "Current config and completion command" %}</h2>
+          <table class="operator-journey-config-table">
+            <thead>
+              <tr>
+                <th>{% translate "Check" %}</th>
+                <th>{% translate "Current value" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{% translate "Runtime/configured role" %}</td>
+                <td>{{ node_role_validation.configured_role }}</td>
+              </tr>
+              <tr>
+                <td>{% translate "Lock file role (.locks/role.lck)" %}</td>
+                <td>{{ node_role_validation.lock_role }}</td>
+              </tr>
+              <tr>
+                <td>{% translate "Registered local node role" %}</td>
+                <td>{{ node_role_validation.local_node_role }} ({{ node_role_validation.local_node_label }})</td>
+              </tr>
+            </tbody>
+          </table>
+          {% if node_role_validation.role_mismatch %}
+            <p style="margin-top: 1rem;">
+              <strong>{% translate "Role mismatch detected." %}</strong>
+              {% translate "The local node record does not match the active runtime role. Reconfigure and restart before completing this step." %}
+            </p>
+          {% endif %}
+          <p style="margin-top: 1rem;"><strong>{% translate "Role command preview" %}</strong></p>
+          <code id="operator-role-command" class="operator-journey-command-preview">{{ node_role_validation.commands.1 }}</code>
+          <p style="margin-top: 1rem;"><strong>{% translate "Upgrade command preview" %}</strong></p>
+          <code id="operator-upgrade-command" class="operator-journey-command-preview">{{ node_role_validation.default_upgrade_command }}</code>
+          <ol style="margin-top: 0.75rem;">
+            {% for command in node_role_validation.commands %}
+              <li><code>{{ command }}</code></li>
+            {% endfor %}
+          </ol>
+        </section>
+        <section class="operator-journey-card" aria-labelledby="command-builder-title">
+          <h2 id="command-builder-title">{% translate "Roles and auto-upgrade options" %}</h2>
+          <p>{% translate "Select a role and toggle options to generate copy/paste-ready commands." %}</p>
+          <p><strong>{% translate "Role" %}</strong></p>
+          <ul class="operator-journey-option-list">
+            {% for role in node_role_validation.available_roles %}
+              <li>
+                <label>
+                  <input
+                    type="radio"
+                    name="node-role-choice"
+                    value="{{ role|lower }}"
+                    {% if role == node_role_validation.configured_role or role == node_role_validation.local_node_role %}checked{% endif %}
+                  >
+                  {{ role }}
+                </label>
+              </li>
+            {% endfor %}
+          </ul>
+          <p style="margin-top: 1rem;"><strong>{% translate "Upgrade toggles" %}</strong></p>
+          <ul class="operator-journey-option-list">
+            {% for option in node_role_validation.upgrade_policy_options %}
+              <li>
+                <label>
+                  <input type="checkbox" name="upgrade-flag" value="{{ option.flags|join:' ' }}" {% if forloop.first %}checked{% endif %}>
+                  {{ option.label }}
+                </label>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      </div>
+      <p style="margin-top: 1rem;">
         {% translate "Decision flow:" %}
-        {% translate "1) Confirm intended role. 2) Run configure with that role. 3) Restart and verify check output, then continue." %}
+        {% translate "1) Confirm intended role. 2) Toggle options until the command preview matches your plan. 3) Run configure/upgrade, restart, verify, then continue." %}
       </p>
+      <script>
+        (() => {
+          const roleInputs = document.querySelectorAll('input[name="node-role-choice"]');
+          const flagInputs = document.querySelectorAll('input[name="upgrade-flag"]');
+          const rolePreview = document.getElementById("operator-role-command");
+          const upgradePreview = document.getElementById("operator-upgrade-command");
+
+          const currentRole = () => {
+            const selected = Array.from(roleInputs).find((input) => input.checked);
+            return selected ? selected.value : "";
+          };
+
+          const currentFlags = () => Array.from(flagInputs)
+            .filter((input) => input.checked)
+            .flatMap((input) => input.value.split(" "))
+            .filter(Boolean);
+
+          const updatePreview = () => {
+            const role = currentRole();
+            if (rolePreview) {
+              rolePreview.textContent = role ? `./configure.sh --${role}` : "./configure.sh --check";
+            }
+            if (upgradePreview) {
+              const flags = currentFlags();
+              upgradePreview.textContent = ["./upgrade.sh", ...flags].join(" ").trim();
+            }
+          };
+
+          roleInputs.forEach((input) => input.addEventListener("change", updatePreview));
+          flagInputs.forEach((input) => input.addEventListener("change", updatePreview));
+          updatePreview();
+        })();
+      </script>
     {% elif provision_superuser_form %}
       <p>
         {% translate "Create an operational superuser for this node role, assign security groups, and optionally connect GitHub credentials for repository/release/issue workflows." %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -152,6 +152,9 @@ class OperatorJourneyViewTests(TestCase):
         self.assertContains(
             response, "Node role changes must be applied with install/configure scripts"
         )
+        self.assertContains(response, "Current config and completion command")
+        self.assertContains(response, "Roles and auto-upgrade options")
+        self.assertContains(response, 'id="operator-upgrade-command"', html=False)
         self.assertContains(response, "./configure.sh --check")
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
 from apps.groups.models import SecurityGroup
+from apps.nodes.models import NodeRole
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
 from apps.ops.views import _build_node_role_validation_summary
@@ -154,10 +155,21 @@ class OperatorJourneyViewTests(TestCase):
         )
         self.assertContains(response, "Current config and completion command")
         self.assertContains(response, "Roles and auto-upgrade options")
+        self.assertContains(response, 'name="node-role-choice"', html=False)
         self.assertContains(response, 'id="operator-upgrade-command"', html=False)
         self.assertContains(response, "./configure.sh --check")
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)
+
+    def test_validate_role_step_limits_role_choices_to_basic_configure_roles(self):
+        NodeRole.objects.create(name="Gateway")
+        response = self.client.get(
+            reverse("ops:operator-journey-step", args=[self.step_1.pk])
+        )
+
+        self.assertNotContains(response, 'value="gateway"', html=False)
+        for role in ("terminal", "satellite", "control", "watchtower"):
+            self.assertContains(response, f'value="{role}"', html=False)
 
     @override_settings(NODE_ROLE="Constellation")
     def test_role_validation_normalizes_constellation_alias_for_commands(self):

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -70,17 +70,59 @@ def _build_node_role_validation_summary() -> dict[str, object]:
 
     suggested_role = current_role or local_node_role
     normalized_slug = str(suggested_role or "").strip().lower()
+    available_roles = list(KNOWN_NODE_ROLES)
+    try:
+        from apps.nodes.models import NodeRole, UpgradePolicy
+    except (ImportError, LookupError):
+        upgrade_policy_options = [
+            {"label": "Stable", "flags": ["--stable"]},
+            {"label": "Unstable", "flags": ["--latest"]},
+            {"label": "Force refresh", "flags": ["--force-refresh"]},
+            {"label": "Pre-check", "flags": ["--pre-check"]},
+            {"label": "No restart", "flags": ["--no-restart"]},
+        ]
+    else:
+        role_names = list(
+            NodeRole.objects.order_by("name").values_list("name", flat=True)
+        )
+        if role_names:
+            available_roles = role_names
+        upgrade_policy_options = []
+        for policy in UpgradePolicy.objects.order_by("name"):
+            channel_flag = (
+                "--latest" if policy.channel == UpgradePolicy.Channel.UNSTABLE else "--stable"
+            )
+            option_label = f"Policy: {policy.name}"
+            if not policy.is_active:
+                option_label = f"{option_label} (inactive)"
+            option_flags = [channel_flag]
+            if policy.requires_pypi_packages:
+                option_flags.append("--force-refresh")
+            upgrade_policy_options.append(
+                {"label": option_label, "flags": option_flags}
+            )
+        if not upgrade_policy_options:
+            upgrade_policy_options = [
+                {"label": "Stable", "flags": ["--stable"]},
+                {"label": "Unstable", "flags": ["--latest"]},
+                {"label": "Force refresh", "flags": ["--force-refresh"]},
+                {"label": "Pre-check", "flags": ["--pre-check"]},
+                {"label": "No restart", "flags": ["--no-restart"]},
+            ]
+
     commands: list[str] = ["./configure.sh --check"]
-    if normalized_slug in {role.lower() for role in KNOWN_NODE_ROLES}:
+    valid_roles = {_normalize_role_name(role).lower() for role in available_roles}
+    if normalized_slug in valid_roles:
         commands.extend([f"./configure.sh --{normalized_slug}", "./service-start.sh"])
     else:
-        commands.extend(
-            [f"./configure.sh --{role.lower()}" for role in KNOWN_NODE_ROLES]
-        )
+        commands.extend([f"./configure.sh --{role.lower()}" for role in available_roles])
         commands.append("./service-start.sh")
 
     return {
+        "available_roles": available_roles,
         "configured_role": configured_role or "Unknown",
+        "default_upgrade_command": "./upgrade.sh --stable --pre-check",
+        "upgrade_policy_options": upgrade_policy_options,
         "lock_role": lock_role or "Unknown",
         "local_node_role": local_node_role or "Unknown",
         "local_node_label": local_node_label,

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -72,7 +72,7 @@ def _build_node_role_validation_summary() -> dict[str, object]:
     normalized_slug = str(suggested_role or "").strip().lower()
     available_roles = list(KNOWN_NODE_ROLES)
     try:
-        from apps.nodes.models import NodeRole, UpgradePolicy
+        from apps.nodes.models import UpgradePolicy
     except (ImportError, LookupError):
         upgrade_policy_options = [
             {"label": "Stable", "flags": ["--stable"]},
@@ -82,11 +82,6 @@ def _build_node_role_validation_summary() -> dict[str, object]:
             {"label": "No restart", "flags": ["--no-restart"]},
         ]
     else:
-        role_names = list(
-            NodeRole.objects.order_by("name").values_list("name", flat=True)
-        )
-        if role_names:
-            available_roles = role_names
         upgrade_policy_options = []
         for policy in UpgradePolicy.objects.order_by("name"):
             channel_flag = (


### PR DESCRIPTION
### Motivation
- Improve the `validate-local-node-role` operator step so admins can see the current runtime/configuration and build exact `./configure.sh`/`./upgrade.sh` commands interactively rather than copying generic instructions.
- Surface available node roles and upgrade-policy options so operators can toggle options (channel, force-refresh, pre-check, no-restart) and get a copy/paste-ready command matching their choices.
- Keep the improvement lightweight and integrated with the existing operator journey flow and role/upgrade models.

### Description
- Enriched `_build_node_role_validation_summary()` in `apps/ops/views.py` to expose `available_roles`, `upgrade_policy_options` (derived from `UpgradePolicy` when present, with sensible fallbacks), and `default_upgrade_command` for the UI, while preserving existing role-mismatch and command guidance logic.
- Reworked `apps/ops/templates/admin/ops/operator_journey_step.html` to a two-panel layout showing current config and command previews on the left and selectable roles + upgrade toggles on the right, plus a small inline script that updates the `./configure.sh` and `./upgrade.sh` preview live as options change.
- Updated `apps/ops/tests/test_operator_journey.py` to assert new interactive elements render (checks for the new headings and `id="operator-upgrade-command"`) so the feature is covered by regression tests.

### Testing
- Ran the operator-journey unit tests with `./env-refresh.sh --deps-only` + test dependencies installed and executed `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py`, which collected 15 items and completed successfully (`15 passed`).
- The modified tests in `apps/ops/tests/test_operator_journey.py` passed as part of that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dadca7dde88326b4358db879b06631)