### PR TITLE
features/ocpp/deploy: shorten suite feature names and slugs

### DIFF
--- a/apps/deploy/management/commands/lightsail.py
+++ b/apps/deploy/management/commands/lightsail.py
@@ -30,7 +30,7 @@ from apps.features.utils import is_suite_feature_enabled
 from apps.nodes.models import Node
 
 
-LIGHTSAIL_CLI_AUTH_BOOTSTRAP_FEATURE_SLUG = "deploy-lightsail-cli-auth-bootstrap"
+LIGHTSAIL_CLI_AUTH_BOOTSTRAP_FEATURE_SLUG = "lightsail-deployer"
 
 
 class Command(BaseCommand):

--- a/apps/features/fixtures/features__deploy_lightsail_cli_auth_bootstrap.json
+++ b/apps/features/fixtures/features__deploy_lightsail_cli_auth_bootstrap.json
@@ -11,7 +11,7 @@
         "apps/aws/services.py"
       ],
       "created_at": "2026-03-29T00:00:00Z",
-      "display": "Deploy Lightsail CLI Auth Bootstrap",
+      "display": "Lightsail Deployer",
       "is_deleted": false,
       "is_enabled": true,
       "is_seed_data": true,
@@ -28,7 +28,7 @@
         "apps.deploy.management.commands.lightsail.Command._resolve_credentials",
         "apps.deploy.management.commands.lightsail.Command._resolve_aws_auth_kwargs"
       ],
-      "slug": "deploy-lightsail-cli-auth-bootstrap",
+      "slug": "lightsail-deployer",
       "source": "mainstream",
       "summary": "Controls interactive credential and MFA auth bootstrap in deploy lightsail CLI flows.",
       "updated_at": "2026-03-29T00:00:00Z"

--- a/apps/features/fixtures/features__standard_charge_point.json
+++ b/apps/features/fixtures/features__standard_charge_point.json
@@ -10,7 +10,7 @@
         "apps/ocpp/consumers/base/connection_flow.py"
       ],
       "created_at": "2024-03-01T00:00:00Z",
-      "display": "Standard Charge Point Creation",
+      "display": "CP Auto-enrollment",
       "is_deleted": false,
       "is_enabled": true,
       "is_seed_data": true,
@@ -26,7 +26,7 @@
       "service_views": [
         "apps.ocpp.consumers.base.connection_flow.CSMSConnectionFlow._is_creation_allowed"
       ],
-      "slug": "standard-charge-point",
+      "slug": "cp-auto-enrollment",
       "source": "mainstream",
       "summary": "Controls baseline charge-point creation admission for websocket connections.",
       "updated_at": "2024-03-01T00:00:00Z"

--- a/apps/features/migrations/0007_shorten_feature_slugs.py
+++ b/apps/features/migrations/0007_shorten_feature_slugs.py
@@ -1,0 +1,72 @@
+from django.db import migrations
+
+
+def shorten_suite_feature_names(apps, schema_editor):
+    Feature = apps.get_model("features", "Feature")
+
+    updates = (
+        (
+            "deploy-lightsail-cli-auth-bootstrap",
+            "lightsail-deployer",
+            "Lightsail Deployer",
+        ),
+        (
+            "standard-charge-point",
+            "cp-auto-enrollment",
+            "CP Auto-enrollment",
+        ),
+    )
+
+    for old_slug, new_slug, new_display in updates:
+        legacy = Feature.objects.filter(slug=old_slug).order_by("pk").first()
+        if legacy is None:
+            existing = Feature.objects.filter(slug=new_slug).order_by("pk").first()
+            if existing is not None:
+                existing.display = new_display
+                existing.save(update_fields=["display", "updated_at"])
+            continue
+
+        duplicate = Feature.objects.filter(slug=new_slug).exclude(pk=legacy.pk).order_by("pk").first()
+        if duplicate is not None:
+            duplicate.delete()
+
+        legacy.slug = new_slug
+        legacy.display = new_display
+        legacy.save(update_fields=["slug", "display", "updated_at"])
+
+
+def restore_suite_feature_names(apps, schema_editor):
+    Feature = apps.get_model("features", "Feature")
+
+    updates = (
+        ("lightsail-deployer", "deploy-lightsail-cli-auth-bootstrap", "Deploy Lightsail CLI Auth Bootstrap"),
+        ("cp-auto-enrollment", "standard-charge-point", "Standard Charge Point Creation"),
+    )
+
+    for old_slug, new_slug, new_display in updates:
+        current = Feature.objects.filter(slug=old_slug).order_by("pk").first()
+        if current is None:
+            existing = Feature.objects.filter(slug=new_slug).order_by("pk").first()
+            if existing is not None:
+                existing.display = new_display
+                existing.save(update_fields=["display", "updated_at"])
+            continue
+
+        duplicate = Feature.objects.filter(slug=new_slug).exclude(pk=current.pk).order_by("pk").first()
+        if duplicate is not None:
+            duplicate.delete()
+
+        current.slug = new_slug
+        current.display = new_display
+        current.save(update_fields=["slug", "display", "updated_at"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("features", "0006_feature_baseline_version"),
+    ]
+
+    operations = [
+        migrations.RunPython(shorten_suite_feature_names, restore_suite_feature_names),
+    ]

--- a/apps/ocpp/consumers/base/connection_flow.py
+++ b/apps/ocpp/consumers/base/connection_flow.py
@@ -20,7 +20,7 @@ from config.offline import requires_network
 
 logger = logging.getLogger(__name__)
 
-CHARGER_CREATION_FEATURE_SLUG = "standard-charge-point"
+CHARGER_CREATION_FEATURE_SLUG = "cp-auto-enrollment"
 OCPP_VERSION_FEATURE_SLUGS = {
     "ocpp1.6": "ocpp-16-charge-point",
     "ocpp2.0.1": "ocpp-201-charge-point",


### PR DESCRIPTION
### Motivation
- Shorten two Suite Feature names and slugs for clearer admin display and to match operator feedback: Lightsail CLI auth bootstrap and standard charge-point creation needed more concise identifiers.
- Ensure runtime code and seed data remain consistent so feature checks continue to work after the rename.

### Description
- Updated seed fixtures to rename the Lightsail feature to `Lightsail Deployer` with slug `lightsail-deployer` in `apps/features/fixtures/features__deploy_lightsail_cli_auth_bootstrap.json`.
- Updated seed fixtures to rename the charge-point creation feature to `CP Auto-enrollment` with slug `cp-auto-enrollment` in `apps/features/fixtures/features__standard_charge_point.json`.
- Replaced runtime constants to reference the new slugs in `apps/deploy/management/commands/lightsail.py` (`LIGHTSAIL_CLI_AUTH_BOOTSTRAP_FEATURE_SLUG`) and `apps/ocpp/consumers/base/connection_flow.py` (`CHARGER_CREATION_FEATURE_SLUG`).
- Added a reversible data migration `apps/features/migrations/0007_shorten_feature_slugs.py` that renames existing `Feature` rows in-place, updates displays, and safely removes duplicate-slug collisions during the migration and its reverse.

### Testing
- Ran `./env-refresh.sh --deps-only` successfully to refresh the environment.
- Ran `.venv/bin/python manage.py migrations check` which reported no unapplied changes.
- Installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` and then ran `.venv/bin/python manage.py test run -- apps/deploy/tests/test_deploy_command.py apps/ocpp/tests/test_websocket_creation.py`, which completed with `51 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae06e8a4083269b73374dc2063c11)