### PR TITLE
Link LLM Summary suite feature to LCD Screen node feature

### DIFF
--- a/apps/features/fixtures/features__llm_summary_suite.json
+++ b/apps/features/fixtures/features__llm_summary_suite.json
@@ -21,7 +21,9 @@
         "summary"
       ],
       "metadata": {},
-      "node_feature": null,
+      "node_feature": [
+        "lcd-screen"
+      ],
       "protocol_coverage": {},
       "public_requirements": "No direct public interface; summarization updates internal displays.",
       "public_views": [],

--- a/apps/summary/admin.py
+++ b/apps/summary/admin.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 
 from apps.features.models import Feature
 from apps.features.parameters import set_feature_parameter_values
+from apps.nodes.models import NodeFeature
 
 from .constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
 from .models import LLMSummaryConfig
@@ -84,6 +85,35 @@ class LLMSummaryConfigAdmin(admin.ModelAdmin):
     )
     change_list_template = "admin/summary/llmsummaryconfig/change_list.html"
 
+    def _sync_summary_suite_feature(self, config: LLMSummaryConfig) -> Feature:
+        """Persist suite feature parameters and ensure node-feature linkage is present."""
+
+        lcd_node_feature = NodeFeature.objects.filter(slug="lcd-screen").first()
+        suite_feature, _created = Feature.objects.get_or_create(
+            slug=LLM_SUMMARY_SUITE_FEATURE_SLUG,
+            defaults={
+                "display": "LLM Summary Suite",
+                "source": Feature.Source.CUSTOM,
+                "is_enabled": True,
+                "node_feature": lcd_node_feature,
+            },
+        )
+        updated_fields: set[str] = set()
+        if suite_feature.node_feature_id != (lcd_node_feature.pk if lcd_node_feature else None):
+            suite_feature.node_feature = lcd_node_feature
+            updated_fields.add("node_feature")
+
+        set_feature_parameter_values(
+            suite_feature,
+            {
+                "backend": config.backend,
+                "model_path": config.model_path,
+            },
+        )
+        updated_fields.update({"metadata", "updated_at"})
+        suite_feature.save(update_fields=sorted(updated_fields))
+        return suite_feature
+
     def get_urls(self):
         """Add the summary configuration wizard endpoint."""
 
@@ -152,23 +182,7 @@ class LLMSummaryConfigAdmin(admin.ModelAdmin):
                 ]
             )
 
-            suite_feature, _created = Feature.objects.get_or_create(
-                slug=LLM_SUMMARY_SUITE_FEATURE_SLUG,
-                defaults={
-                    "display": "LLM Summary Suite",
-                    "source": Feature.Source.CUSTOM,
-                    "is_enabled": True,
-                    "node_feature": None,
-                },
-            )
-            set_feature_parameter_values(
-                suite_feature,
-                {
-                    "backend": config.backend,
-                    "model_path": config.model_path,
-                },
-            )
-            suite_feature.save(update_fields=["metadata", "updated_at"])
+            self._sync_summary_suite_feature(config)
             messages.success(request, _("LLM summary settings updated."))
             return redirect(
                 reverse("admin:summary_llmsummaryconfig_change", args=[config.pk])

--- a/apps/summary/tests/test_admin.py
+++ b/apps/summary/tests/test_admin.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib import admin
+
+from apps.features.models import Feature
+from apps.nodes.models import NodeFeature
+from apps.summary.admin import LLMSummaryConfigAdmin
+from apps.summary.constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from apps.summary.models import LLMSummaryConfig
+
+
+@pytest.mark.django_db
+def test_sync_summary_suite_feature_links_lcd_node_feature() -> None:
+    """LLM Summary suite feature should stay linked to the lcd-screen node feature."""
+
+    lcd_feature = NodeFeature.objects.create(slug="lcd-screen", display="LCD Screen")
+    config = LLMSummaryConfig.objects.create(
+        backend=LLMSummaryConfig.Backend.DETERMINISTIC,
+        model_path="/tmp/llm",
+    )
+    suite_feature = Feature.objects.create(
+        slug=LLM_SUMMARY_SUITE_FEATURE_SLUG,
+        display="LLM Summary Suite",
+        is_enabled=True,
+        node_feature=None,
+    )
+
+    model_admin = LLMSummaryConfigAdmin(LLMSummaryConfig, admin.site)
+    model_admin._sync_summary_suite_feature(config)
+
+    suite_feature.refresh_from_db()
+    assert suite_feature.node_feature == lcd_feature


### PR DESCRIPTION
### Motivation
- Ensure the LLM summary Suite Feature is represented in admin as tied to the LCD Screen runtime dependency so suite-level toggles reflect node-level requirements (similar to Celery and RFID features).
- Keep suite feature metadata (backend and model path) and the node-feature linkage in sync when operators save summary wizard settings.

### Description
- Added `_sync_summary_suite_feature` to `LLMSummaryConfigAdmin` to persist suite feature parameters and attach the `lcd-screen` `NodeFeature` to the `llm-summary-suite` `Feature` when saving the wizard.
- Updated the summary wizard save flow to call `self._sync_summary_suite_feature(config)` instead of duplicating `Feature.objects.get_or_create` logic inline.
- Updated the seeded fixture `apps/features/fixtures/features__llm_summary_suite.json` to reference the `lcd-screen` node feature.
- Added regression test `apps/summary/tests/test_admin.py::test_sync_summary_suite_feature_links_lcd_node_feature` to assert the suite feature is linked to the `lcd-screen` node feature after sync.

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt`, both completed successfully.
- Ran unit tests with `.venv/bin/python manage.py test run -- apps/summary/tests/test_admin.py apps/features/tests/test_models.py` and all tests passed (`14 passed`).
- Verified migrations with `.venv/bin/python manage.py migrations check` which reported no changes detected.
- Triggered review notification with `./scripts/review-notify.sh --actor Codex` which ran (fallback notification used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae0d0d8f88326a45481c111b6d4e1)