### PR TITLE
ci: add curated critical smoke step to install-hourly workflow

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -144,6 +144,18 @@ jobs:
           source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 --junitxml=pytest-junit.xml -m "not critical and not slow and not integration" | tee pytest.log
+      - name: Run install critical smoke tests
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          source .venv/bin/activate
+          critical_smoke_tests=(
+            "apps/netmesh/tests/test_api.py::test_netmesh_token_lifecycle_errors_are_stable"
+            "apps/ocpp/tests/test_charger_status_polling.py::test_dedupe_event_rows_keeps_newest_status_for_out_of_order_retry_collisions"
+            "apps/meta/tests/test_webhooks.py::test_whatsapp_webhook_rejects_invalid_signature"
+            "tests/test_nodes_registration.py::test_register_visitor_proxy_reports_partial_failure_on_visitor_confirmation"
+          )
+          pytest --maxfail=1 --disable-warnings -q --timeout=120 --junitxml=pytest-critical-junit.xml "${critical_smoke_tests[@]}" | tee pytest-critical.log
       - name: Upload pytest log
         if: always()
         uses: actions/upload-artifact@v7
@@ -152,6 +164,15 @@ jobs:
           path: |
             pytest.log
             pytest-junit.xml
+          if-no-files-found: warn
+      - name: Upload critical pytest log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: install-hourly-critical-smoke-${{ matrix.role }}
+          path: |
+            pytest-critical.log
+            pytest-critical-junit.xml
           if-no-files-found: warn
 
   notify_failure:


### PR DESCRIPTION
### Motivation

- Surface regressions quickly in historically fragile end-to-end areas (auth token lifecycle, OCPP retry collisions, webhook signatures, and visitor partial-failure handling) without increasing overall install-hourly runtime. 
- Keep the primary non-critical smoke run unchanged while providing a separate strict gate for a tiny high-value set of tests so triage is easier. 
- Use the existing guidance and seed lists from `tests/critical_path_test_matrix.md` and `docs/non-canonical/archive/testing/critical-promotions-2026-04-04.md` to pick the curated subset.

### Description

- Added a second pytest step `Run install critical smoke tests` immediately after the existing non-critical smoke run in `.github/workflows/install-hourly.yml` that executes a curated list of four historically fragile tests. 
- The curated tests invoked are: `apps/netmesh/tests/test_api.py::test_netmesh_token_lifecycle_errors_are_stable`, `apps/ocpp/tests/test_charger_status_polling.py::test_dedupe_event_rows_keeps_newest_status_for_out_of_order_retry_collisions`, `apps/meta/tests/test_webhooks.py::test_whatsapp_webhook_rejects_invalid_signature`, and `tests/test_nodes_registration.py::test_register_visitor_proxy_reports_partial_failure_on_visitor_confirmation`. 
- The critical step runs with stricter bounds using `--maxfail=1` and `--timeout=120` and emits `pytest-critical-junit.xml` and `pytest-critical.log`. 
- Added a separate artifact upload `install-hourly-critical-smoke-${{ matrix.role }}` that publishes `pytest-critical.log` and `pytest-critical-junit.xml` to keep critical logs separate from the existing `install-hourly-pytest-results` artifact.

### Testing

- Verified the workflow YAML parses successfully with `python` and `yaml.safe_load`, which completed without error. 
- Ran the repository review notifier `./scripts/review-notify.sh --actor Codex`, which executed and returned a successful fallback notification. 
- The workflow file was lint-checked by loading it as valid YAML and committed; no automated pytest runs were executed locally as part of this change beyond the validation steps above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae376a3d88326b1be20bdb89c0a91)