### PR TITLE
docs: move energy transactions ledger into non-canonical archive

### DIFF
--- a/docs/non-canonical/archive/development/energy-transactions-ledger.md
+++ b/docs/non-canonical/archive/development/energy-transactions-ledger.md
@@ -1,3 +1,5 @@
+> **Historical-only note:** This document is retained for historical context only and is **not** a release plan.
+
 # Proposal: use Energy Transactions as the unified energy ledger
 
 ## Context


### PR DESCRIPTION
### Motivation
- Remove `docs/energy-transactions-ledger.md` from the canonical docs set while preserving its historical context in the repository.

### Description
- Moved `docs/energy-transactions-ledger.md` to `docs/non-canonical/archive/development/energy-transactions-ledger.md` and prepended a `> **Historical-only note:**` banner to mark it as historical-only, then committed the change.

### Testing
- Verified there are no inbound references by running `rg -n "energy-transactions-ledger\.md|energy-transactions-ledger" docs/index.md docs --glob '**/*.md' apps/docs` and ran `./scripts/review-notify.sh --actor Codex`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae44f09b483269edb64aeb6532cb5)