### PR TITLE
docs/integrations: reframe documentation checklist as freeze-safe current-state audit

### DIFF
--- a/docs/integrations/documentation-completeness-checklist.md
+++ b/docs/integrations/documentation-completeness-checklist.md
@@ -1,55 +1,57 @@
 # Documentation Completeness Checklist (HTTP + WebSocket Endpoints)
 
-Use this page to track endpoint-documentation status across the Arthexis suite.
+Operational audit artifact for endpoint-documentation status across the Arthexis suite.
 
-## Status rubric
-- **Complete**: purpose, caller, request/response (including errors), auth/authorization, idempotency/retry, model/migration links documented.
-- **In progress**: partial documentation exists but at least one of the required fields is missing.
-- **Missing**: endpoint exists but no usable contract documentation yet.
+## Current-state coverage matrix
 
-## Charging and external integrations (prioritized)
+### Status rubric
+- **Documented (current state)**: purpose, caller, request/response (including errors), auth/authorization, idempotency/retry, and model/migration links are documented.
+- **Partially documented (current state)**: some contract documentation exists, but at least one required field is missing.
+- **Not yet documented (current state)**: endpoint exists but no usable contract documentation is available.
+
+### Charging and external integrations
 
 | App | Endpoint group | Status | Notes |
 |---|---|---|---|
-| `apps.ocpp` | `/ocpp/chargers/`, `/ocpp/chargers/<cid>/`, `/ocpp/chargers/<cid>/action/` (plus connector-scoped action endpoint variant, e.g. `/ocpp/chargers/<cid>/connector/<connector>/action/`) | Complete | Primary charging control and state APIs documented in inventory page. |
-| `apps.ocpp` | OCPP CSMS WebSocket catch-all (`/<...>/<cid>/`) | Complete | Auth + retry/idempotency behavior documented. |
-| `apps.ocpp` | Firmware download + public status/log/chart/session pages | In progress | Needs per-endpoint error payload and auth matrix expansion. |
-| `apps.nodes` | `/nodes/info/`, `/nodes/register/`, `/nodes/register/enrollment-public-key/` | Complete | Enrollment and registration contracts documented. |
-| `apps.nodes` | `/nodes/network/chargers/`, `/nodes/network/chargers/forward/`, `/nodes/network/chargers/action/` | Complete | Signed peer sync and delegated charger control documented. |
-| `apps.nodes` | `/nodes/net-message/`, `/nodes/net-message/pull/`, `/nodes/register/proxy/`, `/nodes/register/telemetry/` | In progress | Basic contract covered; add fuller error matrices and replay policies. |
-| `apps.actions.api` | `/actions/api/v1/security-groups/` | Complete | Caller/auth and payload contract documented. |
-| `apps.sites` | `/webhooks/whatsapp/` | Complete | Webhook request/response + feature gating documented. |
-| `apps.sites` | `/login/passkey/options/`, `/login/passkey/verify/`, `/ws/pages/chat/` | In progress | Needs fuller role/scope/session-expiry detail and socket event schema. |
-| `apps.cards` | RFID scan/import/export endpoints | In progress | Needs complete request/response examples for all variants. |
-| `apps.video` | `/ws/video/...` sockets | In progress | Needs complete signaling/frame/error schema docs. |
-| `apps.odoo` | `/odoo/query/<slug>/` | In progress | Needs explicit auth and parameter validation examples. |
-| `apps.evergo` | dashboard/tracking/customer/artifact endpoints | In progress | Needs complete auth and retry semantics, especially tokenized pages. |
+| `apps.ocpp` | `/ocpp/chargers/`, `/ocpp/chargers/<cid>/`, `/ocpp/chargers/<cid>/action/` (plus connector-scoped action endpoint variant, e.g. `/ocpp/chargers/<cid>/connector/<connector>/action/`) | Documented (current state) | Primary charging control and state APIs are documented in the inventory page. |
+| `apps.ocpp` | OCPP CSMS WebSocket catch-all (`/<...>/<cid>/`) | Documented (current state) | Auth plus retry/idempotency behavior is documented. |
+| `apps.ocpp` | Firmware download + public status/log/chart/session pages | Partially documented (current state) | Per-endpoint error payload and auth matrix details are incomplete. |
+| `apps.nodes` | `/nodes/info/`, `/nodes/register/`, `/nodes/register/enrollment-public-key/` | Documented (current state) | Enrollment and registration contracts are documented. |
+| `apps.nodes` | `/nodes/network/chargers/`, `/nodes/network/chargers/forward/`, `/nodes/network/chargers/action/` | Documented (current state) | Signed peer sync and delegated charger control are documented. |
+| `apps.nodes` | `/nodes/net-message/`, `/nodes/net-message/pull/`, `/nodes/register/proxy/`, `/nodes/register/telemetry/` | Partially documented (current state) | Error matrices and replay-policy details are incomplete. |
+| `apps.actions.api` | `/actions/api/v1/security-groups/` | Documented (current state) | Caller/auth and payload contract are documented. |
+| `apps.sites` | `/webhooks/whatsapp/` | Documented (current state) | Webhook request/response and feature gating are documented. |
+| `apps.sites` | `/login/passkey/options/`, `/login/passkey/verify/`, `/ws/pages/chat/` | Partially documented (current state) | Role/scope/session-expiry detail and socket event schema are incomplete. |
+| `apps.cards` | RFID scan/import/export endpoints | Partially documented (current state) | Request/response examples for endpoint variants are incomplete. |
+| `apps.video` | `/ws/video/...` sockets | Partially documented (current state) | Signaling/frame/error schema documentation is incomplete. |
+| `apps.odoo` | `/odoo/query/<slug>/` | Partially documented (current state) | Auth and parameter-validation examples are incomplete. |
+| `apps.evergo` | dashboard/tracking/customer/artifact endpoints | Partially documented (current state) | Auth and retry semantics are incomplete, including tokenized pages. |
 
-## Other suite endpoints (coverage backlog)
+### Other suite endpoint surfaces
 
 | App | Endpoint surface | Status |
 |---|---|---|
-| `apps.core` | `core/urls.py` mounted routes | Missing |
-| `apps.links` | public redirects/reference routes | Missing |
-| `apps.docs` | docs reader/library routes | Missing |
-| `apps.features` | feature routes | Missing |
-| `apps.embeds` | embed routes | Missing |
-| `apps.teams` | team routes | Missing |
-| `apps.awg` | awg routes | Missing |
-| `apps.shortcuts` | shortcut routes | Missing |
-| `apps.widgets` | widget routes | Missing |
-| `apps.certs` | certificate routes | Missing |
-| `apps.ops` | ops routes | Missing |
-| `apps.repos` | repo routes | Missing |
-| `apps.terms` | terms routes | Missing |
-| `apps.tasks` | task routes | Missing |
-| `apps.logbook` | logbook routes | Missing |
-| `apps.clocks` | clock routes | Missing |
-| `apps.meta` | meta routes | Missing |
-| `apps.shop` | shop routes | Missing |
-| `apps.sites` | non-webhook page/auth routes not listed above | In progress |
+| `apps.core` | `core/urls.py` mounted routes | Not yet documented (current state) |
+| `apps.links` | public redirects/reference routes | Not yet documented (current state) |
+| `apps.docs` | docs reader/library routes | Not yet documented (current state) |
+| `apps.features` | feature routes | Not yet documented (current state) |
+| `apps.embeds` | embed routes | Not yet documented (current state) |
+| `apps.teams` | team routes | Not yet documented (current state) |
+| `apps.awg` | awg routes | Not yet documented (current state) |
+| `apps.shortcuts` | shortcut routes | Not yet documented (current state) |
+| `apps.widgets` | widget routes | Not yet documented (current state) |
+| `apps.certs` | certificate routes | Not yet documented (current state) |
+| `apps.ops` | ops routes | Not yet documented (current state) |
+| `apps.repos` | repo routes | Not yet documented (current state) |
+| `apps.terms` | terms routes | Not yet documented (current state) |
+| `apps.tasks` | task routes | Not yet documented (current state) |
+| `apps.logbook` | logbook routes | Not yet documented (current state) |
+| `apps.clocks` | clock routes | Not yet documented (current state) |
+| `apps.meta` | meta routes | Not yet documented (current state) |
+| `apps.shop` | shop routes | Not yet documented (current state) |
+| `apps.sites` | non-webhook page/auth routes not listed above | Partially documented (current state) |
 
-## Next pass recommendation
-1. Finish `In progress` entries in charging- and integration-adjacent apps first (`ocpp`, `nodes`, `cards`, `sites`, `video`).
-2. Move to remaining app URL surfaces by descending operational criticality.
-3. Keep this checklist updated as part of each endpoint-related PR.
+## Immediate maintenance actions
+1. Update this matrix in every endpoint-related PR whenever endpoint contracts or auth behavior change.
+2. Convert any "Partially documented (current state)" entry to "Documented (current state)" as soon as missing contract fields are added.
+3. Convert any "Not yet documented (current state)" entry to "Partially documented (current state)" or "Documented (current state)" as soon as first-pass contract details are added.


### PR DESCRIPTION
### Motivation
- Remove planning and roadmap language so the checklist serves as an operational audit artifact suitable for freeze periods.
- Make gap tracking explicit and present-tense to avoid future-pass or roadmap framing.

### Description
- Replace the old rubric and backlog wording with a `Current-state coverage matrix` and present-tense status categories (`Documented (current state)`, `Partially documented (current state)`, `Not yet documented (current state)`).
- Update the charging/integrations and suite-surface tables to use the new status language and adjust notes to current-state phrasing.
- Replace the roadmap-style `Next pass recommendation` with `Immediate maintenance actions` focused on near-term checklist upkeep.
- Sent a review notification as part of the update workflow.

### Testing
- Ran `./scripts/review-notify.sh --actor Codex` which completed and sent a fallback review notification (LCD unavailable).
- Verified changes with `git status --short` and recorded the update via `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae45c652c8326b752b6a97f97f327)