### PR TITLE
docs: neutralize freeze-era language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Arthexis Constellation is a Django-based software suite that centralizes tools for managing electric vehicle charging infrastructure and orchestrating energy-related products and services.
 
-Visit our [Changelog Report](https://arthexis.com/changelog/) to browse shipped changes, release notes, and operational updates.
+Visit our [Changelog Report](https://arthexis.com/changelog/) to browse release history and operational updates.
 
 For release confidence and version lifecycle expectations, see the [Versioning and Maturity Policy](docs/development/versioning-maturity-policy.md).
 
@@ -129,7 +129,7 @@ Detailed install flags, service-management choices, and upgrade-channel behavior
 - Reference the [Sigils Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/sigils.md) when configuring tokenized settings across environments.
 - Understand seed fixtures and per-user files with [Managing Local Node Data](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/managing-local-node-data.md).
 - Manage exports, imports, and audit trails with the [User Data Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/user-data.md).
-- Plan node capability adoption and configuration using the [Node Features Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/node-features.md).
+- Plan node capability adoption and configuration using the [Node Features Cookbook](apps/docs/cookbooks/node-features.md).
 - Curate shortcuts for power users through the [Favorites Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/favorites.md).
 - Connect Slack workspaces through the [Slack Bot Onboarding Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/slack-bot-onboarding.md).
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 Arthexis Constellation is a Django-based software suite that centralizes tools for managing electric vehicle charging infrastructure and orchestrating energy-related products and services.
 
-Visit our [Changelog Report](https://arthexis.com/changelog/) to browse past and future features and other updates.
+Visit our [Changelog Report](https://arthexis.com/changelog/) to browse shipped changes, release notes, and operational updates.
 
-For release confidence and roadmap transparency, see the [Versioning and Maturity Policy](docs/development/versioning-maturity-policy.md).
+For release confidence and version lifecycle expectations, see the [Versioning and Maturity Policy](docs/development/versioning-maturity-policy.md).
 
 ## Suite Features
 
@@ -129,7 +129,7 @@ Detailed install flags, service-management choices, and upgrade-channel behavior
 - Reference the [Sigils Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/sigils.md) when configuring tokenized settings across environments.
 - Understand seed fixtures and per-user files with [Managing Local Node Data](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/managing-local-node-data.md).
 - Manage exports, imports, and audit trails with the [User Data Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/user-data.md).
-- Plan feature rollout strategies using the [Node Features Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/node-features.md).
+- Plan node capability adoption and configuration using the [Node Features Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/node-features.md).
 - Curate shortcuts for power users through the [Favorites Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/favorites.md).
 - Connect Slack workspaces through the [Slack Bot Onboarding Cookbook](https://github.com/arthexis/arthexis/blob/main/apps/docs/cookbooks/slack-bot-onboarding.md).
 
@@ -142,7 +142,7 @@ Detailed install flags, service-management choices, and upgrade-channel behavior
 
 ## Support
 
-Arthexis Constellation is still under very active development and new features are added every day.
+Arthexis Constellation is actively maintained with documented release notes and operational guidance.
 
 If you decide to use our suite for your energy projects, you may contact us at [tecnologia@gelectriic.com](mailto:tecnologia@gelectriic.com) or visit our [web page](https://www.gelectriic.com/) for professional services and commercial support.
 


### PR DESCRIPTION
### Motivation
- Remove phrasing that suggests an active future-feature pipeline and replace it with neutral release-history and lifecycle wording to avoid implying commitments during freeze.

### Description
- Reworded the Changelog line to reference “shipped changes, release notes, and operational updates.”
- Updated the Versioning and Maturity Policy reference to use lifecycle-oriented wording (`version lifecycle expectations`).
- Rephrased the Node Features cookbook entry to “Plan node capability adoption and configuration.”
- Replaced the Support line with a neutral statement that the project is “actively maintained with documented release notes and operational guidance.”

### Testing
- Ran `rg -n "future features|roadmap transparency|new features are added every day|past and future" README.md` and verified the updated phrases appear as intended.
- Ran `./scripts/review-notify.sh --actor Codex` and observed a successful fallback review notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae46200f8832692199690d1894bbe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Updated README.md documentation to adopt neutral, release-focused language that removes freeze-era phrasing implying future commitments:

**Changelog & Versioning references:**
- Changed Changelog description to "release history and operational updates"
- Reworded Versioning and Maturity Policy reference to "version lifecycle expectations"

**Administration checklist:**
- Rephrased Node Features Cookbook entry to "plan node capability adoption and configuration"
- Updated link path from fully qualified GitHub URL to relative path: `apps/docs/cookbooks/node-features.md`

**Support statement:**
- Updated project status description to "actively maintained with documented release notes and operational guidance"

The changes establish neutral terminology appropriate for a stable release cycle while maintaining existing functionality and documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->