### PR TITLE
sites: move ops task status above net message on admin dashboard

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -87,6 +87,7 @@
     }
     .admin-home-operator-journey {
         margin: 0;
+        padding-left: 10px;
         font-size: 0.75rem;
         line-height: 1.05;
     }

--- a/apps/sites/templates/admin/index.html
+++ b/apps/sites/templates/admin/index.html
@@ -16,6 +16,21 @@
 <div id="admin-home-header">
   <h1>Home</h1>
   <div class="admin-home-status">
+    {% operator_journey_status as operator_journey %}
+    {% if operator_journey.has_journey %}
+      <div class="admin-home-operator-journey" role="status" aria-live="polite">
+        {% if operator_journey.url %}
+          <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
+          {% if operator_journey.available_since %}
+            <span class="admin-home-operator-journey__age">
+              {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
+            </span>
+          {% endif %}
+        {% else %}
+          <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
+        {% endif %}
+      </div>
+    {% endif %}
     <div class="admin-home-net-message" role="status" aria-live="polite">
       <a
         class="admin-home-net-message__icon admin-home-net-message__link"
@@ -38,21 +53,6 @@
         <span class="admin-home-net-message__content admin-home-net-message__content--empty" title="{{ no_message_text }}">{{ no_message_text }}</span>
       {% endif %}
     </div>
-    {% operator_journey_status as operator_journey %}
-    {% if operator_journey.has_journey %}
-      <div class="admin-home-operator-journey" role="status" aria-live="polite">
-        {% if operator_journey.url %}
-          <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
-          {% if operator_journey.available_since %}
-            <span class="admin-home-operator-journey__age">
-              {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
-            </span>
-          {% endif %}
-        {% else %}
-          <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
-        {% endif %}
-      </div>
-    {% endif %}
   </div>
   <div class="admin-home-actions-wrap">
     <div class="admin-home-actions">


### PR DESCRIPTION
### Motivation
- Surface the operator journey (ops task) message above the net message on the admin Home header and add left padding to improve alignment per the requested admin UI tweak.

### Description
- Moved the `operator_journey_status` block above the net message in `apps/sites/templates/admin/index.html` and added `padding-left: 10px` to `.admin-home-operator-journey` in `apps/sites/static/sites/css/admin/dashboard.css` to implement the requested layout and spacing change.

### Testing
- Updated environment and dependencies with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt`, then ran the operator-journey dashboard test `OperatorJourneyViewTests.test_dashboard_shows_operator_journey_link` using `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py::OperatorJourneyViewTests::test_dashboard_shows_operator_journey_link`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafa6a58f483268b5f872c00497530)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reorders the admin dashboard layout to surface the operator journey (ops task) status message above the net message and improves its visual alignment.

## Changes

**Template restructuring** (`apps/sites/templates/admin/index.html`):
- Moved the `operator_journey_status` block to appear before the net-message section within the `admin-home-status` container
- The block's conditional rendering logic and template variables remain unchanged

**CSS refinement** (`apps/sites/static/sites/css/admin/dashboard.css`):
- Added `padding-left: 10px` to `.admin-home-operator-journey` for improved left alignment

## Testing

The `OperatorJourneyViewTests.test_dashboard_shows_operator_journey_link` test passes, confirming the operator journey element is correctly rendered on the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->