### PR TITLE
widgets: add sidebar visibility reason to widget admin changelist

### DIFF
--- a/apps/widgets/admin.py
+++ b/apps/widgets/admin.py
@@ -1,8 +1,13 @@
+from contextvars import ContextVar
+
 from django.contrib import admin
 
 from apps.locals.user_data import EntityModelAdmin
+from apps.widgets.services import evaluate_widget_visibility
 
 from .models import Widget, WidgetProfile, WidgetZone
+
+_changelist_request: ContextVar = ContextVar("widgets_changelist_request", default=None)
 
 
 @admin.register(WidgetZone)
@@ -13,10 +18,45 @@ class WidgetZoneAdmin(EntityModelAdmin):
 
 @admin.register(Widget)
 class WidgetAdmin(EntityModelAdmin):
-    list_display = ("name", "slug", "zone", "required_feature", "is_enabled", "priority")
+    list_display = (
+        "name",
+        "slug",
+        "zone",
+        "required_feature",
+        "is_enabled",
+        "visibility_for_current_user",
+        "priority",
+    )
     list_filter = ("zone", "required_feature", "is_enabled")
     search_fields = ("name", "slug", "renderer_path")
     ordering = ("priority", "name")
+
+    @admin.display(description="Sidebar visibility")
+    def visibility_for_current_user(self, obj: Widget) -> str:
+        if obj.zone.slug != WidgetZone.ZONE_SIDEBAR:
+            return "N/A (non-sidebar zone)"
+        if not obj.is_enabled:
+            return "Hidden: widget disabled"
+        request = _changelist_request.get()
+        if request is None:
+            return "Unknown"
+        _, blocker = evaluate_widget_visibility(widget=obj, request=request)
+        if blocker == "missing_permission":
+            return "Hidden: missing permission"
+        if blocker == "missing_required_feature":
+            return "Hidden: missing required feature"
+        if blocker == "profile_restriction":
+            return "Hidden: profile restriction"
+        if blocker == "missing_registration":
+            return "Hidden: widget not registered"
+        return "Visible"
+
+    def changelist_view(self, request, extra_context=None):
+        token = _changelist_request.set(request)
+        try:
+            return super().changelist_view(request, extra_context=extra_context)
+        finally:
+            _changelist_request.reset(token)
 
 
 @admin.register(WidgetProfile)

--- a/apps/widgets/services.py
+++ b/apps/widgets/services.py
@@ -203,15 +203,12 @@ def render_zone_widgets(
 
     rendered: list[RenderedWidget] = []
     for widget in widgets:
-        definition = get_registered_widget(widget.slug)
-        if definition is None:
-            logger.debug("No registered widget definition for %s", widget.slug)
-            continue
-        if definition.permission and not definition.permission(request=request, widget=widget, **extra_context):
-            continue
-        if not _has_required_feature(widget, request):
-            continue
-        if not _visible(widget, getattr(request, "user", None)):
+        definition, blocker = evaluate_widget_visibility(
+            widget=widget,
+            request=request,
+            extra_context=extra_context,
+        )
+        if blocker:
             continue
 
         context = _build_context(definition, widget, request=request, **extra_context)
@@ -283,8 +280,35 @@ def invalidate_zone_cache(zone_slug: str) -> None:
     logger.debug("Invalidated widget cache for zone %s", zone_slug)
 
 
+def evaluate_widget_visibility(
+    *,
+    widget: Widget,
+    request,
+    extra_context: dict[str, Any] | None = None,
+) -> tuple[WidgetDefinition | None, str | None]:
+    """Return a widget definition and first visibility blocker for a request."""
+
+    extra_context = extra_context or {}
+    definition = get_registered_widget(widget.slug)
+    if definition is None:
+        logger.debug("No registered widget definition for %s", widget.slug)
+        return None, "missing_registration"
+    if definition.permission and not definition.permission(
+        request=request,
+        widget=widget,
+        **extra_context,
+    ):
+        return definition, "missing_permission"
+    if not _has_required_feature(widget, request):
+        return definition, "missing_required_feature"
+    if not _visible(widget, getattr(request, "user", None)):
+        return definition, "profile_restriction"
+    return definition, None
+
+
 __all__ = [
     "RenderedWidget",
+    "evaluate_widget_visibility",
     "invalidate_zone_cache",
     "render_zone_html",
     "render_zone_widgets",

--- a/apps/widgets/tests/test_services.py
+++ b/apps/widgets/tests/test_services.py
@@ -5,12 +5,13 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import RequestFactory
 
+from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
 from apps.widgets import register_widget
 from apps.widgets.models import Widget, WidgetProfile, WidgetZone
-from apps.widgets.services import render_zone_widgets, sync_registered_widgets
-from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
+from apps.widgets.services import evaluate_widget_visibility, render_zone_widgets, sync_registered_widgets
 
 pytestmark = pytest.mark.django_db
+
 
 @pytest.fixture(autouse=True)
 def clear_registry(monkeypatch):
@@ -20,6 +21,7 @@ def clear_registry(monkeypatch):
     monkeypatch.setattr(registry, "_WIDGET_REGISTRY", {})
     monkeypatch.setattr(widgets_module, "register_widget", registry.register_widget)
     yield
+
 
 def test_render_zone_widgets_respects_profiles():
     User = get_user_model()
@@ -149,3 +151,40 @@ def test_render_zone_widgets_syncs_when_zone_is_missing_new_registered_widget():
 
     assert Widget.objects.filter(slug="new-widget").exists()
     assert {item.widget.slug for item in rendered} >= {"existing-widget", "new-widget"}
+
+
+def test_evaluate_widget_visibility_returns_permission_and_profile_blockers():
+    User = get_user_model()
+    user = User.objects.create_user(username="visibility-user")
+    request = RequestFactory().get("/")
+    request.user = user
+
+    @register_widget(
+        slug="blocked-by-permission",
+        name="Blocked by Permission",
+        zone=WidgetZone.ZONE_SIDEBAR,
+        template_name="widgets/tests/sample.html",
+        permission=lambda **_kwargs: False,
+    )
+    def _render_blocked_permission(**_kwargs):
+        return {"message": "nope"}
+
+    @register_widget(
+        slug="blocked-by-profile",
+        name="Blocked by Profile",
+        zone=WidgetZone.ZONE_SIDEBAR,
+        template_name="widgets/tests/sample.html",
+    )
+    def _render_blocked_profile(**_kwargs):
+        return {"message": "nope"}
+
+    sync_registered_widgets()
+    permission_widget = Widget.objects.get(slug="blocked-by-permission")
+    profile_widget = Widget.objects.get(slug="blocked-by-profile")
+
+    _, permission_blocker = evaluate_widget_visibility(widget=permission_widget, request=request)
+    assert permission_blocker == "missing_permission"
+
+    WidgetProfile.objects.create(widget=profile_widget, user=user, is_enabled=False)
+    _, profile_blocker = evaluate_widget_visibility(widget=profile_widget, request=request)
+    assert profile_blocker == "profile_restriction"


### PR DESCRIPTION
### Motivation
- Operators reported widgets marked `is_enabled` but missing from the admin sidebar, causing confusion about whether a permission/feature/profile issue or a runtime error is responsible.
- The admin changelist lacked per-request diagnostics to explain why a sidebar widget would be hidden for the current user.

### Description
- Add a new `Sidebar visibility` column to the `Widget` admin changelist via `WidgetAdmin.visibility_for_current_user` to explain visibility state for the current request/user. (`apps/widgets/admin.py`)
- Centralize the gating logic in a reusable helper `evaluate_widget_visibility(...)` which returns the registered definition and the first blocker reason (for example `missing_permission`, `missing_required_feature`, `profile_restriction`, `missing_registration`). (`apps/widgets/services.py`)
- Make runtime sidebar rendering reuse the same helper by updating `render_zone_widgets` to call `evaluate_widget_visibility(...)`, keeping admin diagnostics and runtime behavior consistent. (`apps/widgets/services.py`)
- Add tests asserting visibility blocker reasons for permission-gated and profile-restricted widgets. (`apps/widgets/tests/test_services.py`)

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` after an initial test run failed because `pytest` was not present. The missing-deps issue was resolved by installing `requirements-ci.txt`.
- Ran the widget service tests with `.venv/bin/python manage.py test run -- apps/widgets/tests/test_services.py`, and all tests passed: `5 passed`.
- Sent review notification via `./scripts/review-notify.sh --actor Codex` after changes were staged and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafad05d448326bd31a3de9bd90d3d)