### PR TITLE
widgets: remove "By Required Feature" admin filter from Widget selector

### DIFF
--- a/apps/widgets/admin.py
+++ b/apps/widgets/admin.py
@@ -14,7 +14,7 @@ class WidgetZoneAdmin(EntityModelAdmin):
 @admin.register(Widget)
 class WidgetAdmin(EntityModelAdmin):
     list_display = ("name", "slug", "zone", "required_feature", "is_enabled", "priority")
-    list_filter = ("zone", "required_feature", "is_enabled")
+    list_filter = ("zone", "is_enabled")
     search_fields = ("name", "slug", "renderer_path")
     ordering = ("priority", "name")
 

--- a/apps/widgets/tests/test_admin.py
+++ b/apps/widgets/tests/test_admin.py
@@ -1,0 +1,5 @@
+from apps.widgets.admin import WidgetAdmin
+
+
+def test_widget_admin_list_filters_excludes_required_feature():
+    assert WidgetAdmin.list_filter == ("zone", "is_enabled")


### PR DESCRIPTION
### Motivation
- Remove the "By Required Feature" filter from the widget chooser in the admin selector flow so the Select Widget UI no longer shows that filter (user feedback from the Constellation selector).

### Description
- Remove `required_feature` from `WidgetAdmin.list_filter` in `apps/widgets/admin.py` and add a small regression test `apps/widgets/tests/test_admin.py` asserting `WidgetAdmin.list_filter == ("zone", "is_enabled")`.

### Testing
- Bootstrapped the environment and installed CI deps, then ran `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt`, and executed ` .venv/bin/python manage.py test run -- apps/widgets/tests/test_admin.py apps/widgets/tests/test_services.py`, with all tests passing (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafafd00788326aadd4e706da9b561)