### PR TITLE
scripts: resolve instrument-nginx sudo hint path from invocation

### DIFF
--- a/scripts/instrument-nginx.sh
+++ b/scripts/instrument-nginx.sh
@@ -3,8 +3,9 @@
 set -euo pipefail
 
 usage() {
-  cat <<'USAGE'
-Usage: sudo scripts/instrument-nginx.sh [--user <username>]
+  local script_hint="$1"
+  cat <<USAGE
+Usage: sudo ${script_hint} [--user <username>]
 
 Configure nginx permissions and sudoers entries so the Arthexis suite can
 manage nginx configurations without interactive sudo prompts or permission
@@ -15,13 +16,35 @@ Options:
 USAGE
 }
 
+resolve_invocation_path() {
+  local invoked_path="$1"
+
+  if [ -n "$invoked_path" ] && [[ "$invoked_path" = */* ]]; then
+    echo "$(cd -- "$(dirname -- "$invoked_path")" && pwd)/$(basename -- "$invoked_path")"
+    return
+  fi
+
+  local resolved
+  resolved="$(command -v -- "$invoked_path" 2>/dev/null || true)"
+  if [ -n "$resolved" ]; then
+    echo "$resolved"
+    return
+  fi
+
+  local script_dir
+  script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+  echo "${script_dir}/$(basename -- "${BASH_SOURCE[0]}")"
+}
+
+script_hint="$(resolve_invocation_path "${BASH_SOURCE[0]}")"
+
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
-  usage
+  usage "$script_hint"
   exit 0
 fi
 
 if [ "${EUID:-$(id -u)}" -ne 0 ]; then
-  echo "This script must be run as root (use sudo)." >&2
+  echo "Run this script as root, for example: sudo ${script_hint}" >&2
   exit 1
 fi
 

--- a/scripts/instrument-nginx.sh
+++ b/scripts/instrument-nginx.sh
@@ -37,14 +37,15 @@ resolve_invocation_path() {
 }
 
 script_hint="$(resolve_invocation_path "${BASH_SOURCE[0]}")"
+printf -v script_hint_quoted '%q' "$script_hint"
 
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
-  usage "$script_hint"
+  usage "$script_hint_quoted"
   exit 0
 fi
 
 if [ "${EUID:-$(id -u)}" -ne 0 ]; then
-  echo "Run this script as root, for example: sudo ${script_hint}" >&2
+  echo "Run this script as root, for example: sudo ${script_hint_quoted}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation

- Ensure operator guidance and `--help` usage examples reference the actual script path so non-root hints are accurate and actionable.

### Description

- Add `resolve_invocation_path()` to compute an absolute invocation path from the caller, `command -v`, or a `BASH_SOURCE[0]` fallback. 
- Compute `script_hint` early from `BASH_SOURCE[0]` and use it in the help text so the `sudo` example shows the resolved path. 
- Replace the generic non-root message with an explicit runnable command: `Run this script as root, for example: sudo ${script_hint}`.
- Keep existing behavior for determining `service_user` and all subsequent logic unchanged.

### Testing

- Ran `bash -n scripts/instrument-nginx.sh` to validate the script syntax and it passed. 
- Ran `bash scripts/instrument-nginx.sh --help` and verified the usage line shows the resolved absolute path. 
- Ran the script as a non-root user with `su -s /bin/bash nobody -c 'bash /workspace/arthexis/scripts/instrument-nginx.sh'` and verified the non-root hint prints the resolved `sudo` command. 
- Executed `./scripts/review-notify.sh --actor Codex` which completed and reported no reviewable changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafffb8edc8326a75afae2be0c6c21)