### PR TITLE
Add environment-switched JSON logging formatter with request correlation

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -13,7 +13,7 @@ from apps.nodes.models import Node
 from utils.sites import get_site
 
 from .active_app import active_app
-from .request_utils import is_https_request
+from .request_utils import is_https_request, reset_request_log_context, set_request_log_context
 
 _is_https_request = is_https_request
 
@@ -30,10 +30,15 @@ class ActiveAppMiddleware:
         role_name = node.role.name if node and node.role else "Terminal"
         site_name = site.name if site else ""
         active = site_name or role_name
+        node_id = str(getattr(node, "pk", "") or "")
+        request_log_token = set_request_log_context(request, node_id=node_id)
         with active_app(active):
             request.site = site
             request.active_app = active
-            response = self.get_response(request)
+            try:
+                response = self.get_response(request)
+            finally:
+                reset_request_log_context(request_log_token)
         return response
 
 

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -31,6 +31,11 @@ class ActiveAppMiddleware:
         site_name = site.name if site else ""
         active = site_name or role_name
         node_id = str(getattr(node, "pk", "") or "")
+        if getattr(request, "resolver_match", None) is None:
+            try:
+                request.resolver_match = resolve(request.path_info)
+            except Resolver404:
+                request.resolver_match = None
         request_log_token = set_request_log_context(request, node_id=node_id)
         with active_app(active):
             request.site = site

--- a/config/request_utils.py
+++ b/config/request_utils.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from contextvars import ContextVar, Token
 import logging
 import os
+from typing import Any
+from uuid import uuid4
 
 _LOG_X_FORWARDED_PROTO = os.getenv("LOG_X_FORWARDED_PROTO", "").lower() in {
     "1",
@@ -15,6 +18,75 @@ _PROXY_HEADERS = (
     "HTTP_FORWARDED",
 )
 _logger = logging.getLogger("proxy_headers")
+_REQUEST_LOG_CONTEXT: ContextVar[dict[str, str]] = ContextVar(
+    "request_log_context",
+    default={},
+)
+_CHARGER_KEYS = ("charger", "charger_id", "charge_box_id", "chargeBoxId", "chargerId")
+_SESSION_KEYS = ("session", "session_id", "transaction_id", "transactionId")
+_REQUEST_ID_HEADERS = (
+    "HTTP_X_REQUEST_ID",
+    "HTTP_X_CORRELATION_ID",
+    "HTTP_X_AMZN_TRACE_ID",
+)
+
+
+def get_request_log_context() -> dict[str, str]:
+    """Return the active request log context for the current execution context."""
+
+    return _REQUEST_LOG_CONTEXT.get()
+
+
+def set_request_log_context(request: Any, *, node_id: str = "") -> Token[dict[str, str]]:
+    """Bind request identifiers into contextvars so logging filters can enrich records."""
+
+    context = {
+        "request_id": _extract_request_id(request),
+        "node_id": str(node_id or ""),
+        "charger_id": _extract_identifier(request, _CHARGER_KEYS),
+        "session_id": _extract_identifier(request, _SESSION_KEYS),
+    }
+    return _REQUEST_LOG_CONTEXT.set(context)
+
+
+def reset_request_log_context(token: Token[dict[str, str]]) -> None:
+    """Restore request log context using a token returned by ``set_request_log_context``."""
+
+    _REQUEST_LOG_CONTEXT.reset(token)
+
+
+def _extract_identifier(request: Any, keys: tuple[str, ...]) -> str:
+    resolver_match = getattr(request, "resolver_match", None)
+    kwargs = getattr(resolver_match, "kwargs", {}) if resolver_match else {}
+    for key in keys:
+        value = kwargs.get(key)
+        if value not in (None, ""):
+            return str(value)
+
+    for key in keys:
+        value = request.GET.get(key)
+        if value:
+            return str(value)
+
+    for key in keys:
+        value = request.POST.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _extract_request_id(request: Any) -> str:
+    for header in _REQUEST_ID_HEADERS:
+        value = request.META.get(header, "")
+        if value:
+            return str(value)
+
+    for attr_name in ("request_id", "id"):
+        value = getattr(request, attr_name, "")
+        if value:
+            return str(value)
+
+    return str(uuid4())
 
 
 def _has_proxy_headers(request) -> bool:

--- a/config/request_utils.py
+++ b/config/request_utils.py
@@ -67,11 +67,6 @@ def _extract_identifier(request: Any, keys: tuple[str, ...]) -> str:
         value = request.GET.get(key)
         if value:
             return str(value)
-
-    for key in keys:
-        value = request.POST.get(key)
-        if value:
-            return str(value)
     return ""
 
 

--- a/docs/logging-domain.md
+++ b/docs/logging-domain.md
@@ -2,6 +2,13 @@
 
 This domain centralizes how Arthexis selects log destinations and routes output from Django, Celery, and supporting scripts.
 
+## Formatter mode selection
+* `ARTHEXIS_LOG_FORMAT` controls the formatter at runtime.
+  * `text` (default): keeps the existing line format (`%(asctime)s [%(levelname)s] %(name)s: %(message)s`) for backward compatibility.
+  * `json`: emits stable JSON keys for Loki/LogQL pipelines.
+* JSON records include core keys (`timestamp`, `level`, `logger`, `message`, `app`, `hostname`, `process`, `thread`) and correlation keys (`request_id`, `node_id`, `charger_id`, `session_id`).
+* Correlation keys are injected using request context hooks in `config.middleware.ActiveAppMiddleware` and `config.request_utils`, so HTTP request-scoped IDs appear automatically when available.
+
 ## Log directory selection
 * `select_log_dir` chooses the first writable candidate from `ARTHEXIS_LOG_DIR`, the repository `logs/` folder, user state directories, or system fallbacks (including `/var/log/arthexis` when running as root). It also exports `ARTHEXIS_LOG_DIR` for child processes so Python and shell tooling share the same location.
 * Django loads `LOG_DIR` via `build_logging_settings`, which calls `select_log_dir` and exposes the resolved path alongside the full `LOGGING` dict used by the app and Celery workers.
@@ -12,11 +19,17 @@ This domain centralizes how Arthexis selects log destinations and routes output 
 * **Celery log**: `celery.log` (or `tests-celery.log`) receives Celery and worker trace output via `CeleryFileHandler`, keeping worker chatter separate from the shared error log. Celery-specific loggers are wired to this handler and the error handler without propagation to other handlers.
 
 ## Dependent systems and auxiliary outputs
-* **Celery runtime**: Celery workers reuse the `standard` formatter from the logging config so worker log lines match Django output while respecting the `celery.log` routing described above.
+* **Celery runtime**: Celery workers reuse the selected formatter mode from the logging config so worker output stays aligned with Django while respecting the `celery.log` routing described above.
 * **OCPP session logging**: The OCPP store selects the same `LOG_DIR`, then writes per-charger and simulator files (e.g., `charger.<id>.log`) and session captures under `logs/sessions/` using that shared path.
 * **Release publishing**: Headless release workflows and the `release clean-logs` management subcommand rely on `settings.LOG_DIR` for publish logs named `pr.<package>.v<version>.log`, and they fall back to `select_log_dir` when the preferred path is not writable.
 * **Node utilities**: Screenshot and audio captures land in `logs/screenshots/` and `logs/audio/`, and node registration helpers create dedicated `register_visitor_node.log` and `register_local_node.log` files alongside the main logs.
 * **Shell automation**: Startup, upgrade, and service scripts source `scripts/helpers/logging.sh` to mirror `select_log_dir`'s candidate search (including honoring `ARTHEXIS_LOG_DIR`) so their `.log` outputs live beside the Django logs.
+
+## LogQL-friendly field conventions
+* Recommended Loki labels: keep low-cardinality labels such as `level`, `logger`, `app`, and `hostname`.
+* Keep higher-cardinality correlation keys (`request_id`, `node_id`, `charger_id`, `session_id`) as JSON fields and query them with `| json` expressions.
+* Example query pattern:
+  * `{logger="apps.forwarder.ocpp"} | json | request_id!="" | line_format "{{.timestamp}} {{.level}} {{.charger_id}} {{.message}}"`
 
 ## Retention policy and unattended disk safety
 * **Lower transactional retention stays in force**: Django/Celery transactional handlers keep using daily rotation with their existing short retention windows (for example `TRANSACTIONAL_LOG_RETENTION_DAYS`).

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,7 +4,8 @@ import json
 import logging
 from types import SimpleNamespace
 
-from config.request_utils import reset_request_log_context, set_request_log_context
+from config.middleware import ActiveAppMiddleware
+from config.request_utils import get_request_log_context, reset_request_log_context, set_request_log_context
 from utils.loggers.config import resolve_log_formatter
 from utils.loggers.filters import RequestContextFilter
 from utils.loggers.json_formatter import JSONFormatter
@@ -56,6 +57,54 @@ def test_request_context_filter_applies_request_identifiers():
     assert record.node_id == "42"
     assert record.charger_id == "CP-1"
     assert record.session_id == "S-9"
+
+
+def test_set_request_log_context_does_not_touch_post_body():
+    class _RaisingPOST:
+        def get(self, _key):
+            raise AssertionError("POST should not be accessed while binding log context")
+
+    request = _build_request(
+        META={"HTTP_X_REQUEST_ID": "req-123"},
+        resolver_match=SimpleNamespace(kwargs={"charger_id": "CP-1"}),
+        POST=_RaisingPOST(),
+    )
+
+    token = set_request_log_context(request, node_id="42")
+    try:
+        context = get_request_log_context()
+    finally:
+        reset_request_log_context(token)
+
+    assert context["charger_id"] == "CP-1"
+    assert context["session_id"] == ""
+
+
+def test_active_app_middleware_binds_context_after_resolving_route(monkeypatch):
+    middleware = ActiveAppMiddleware(
+        lambda request: SimpleNamespace(
+            status_code=200,
+            context_snapshot=get_request_log_context().copy(),
+            active_app=request.active_app,
+        )
+    )
+
+    monkeypatch.setattr(
+        "config.middleware.resolve",
+        lambda _path: SimpleNamespace(kwargs={"charger_id": "CP-2", "session_id": "S-2"}),
+    )
+    monkeypatch.setattr("config.middleware.get_site", lambda _request: None)
+    monkeypatch.setattr(
+        "config.middleware.Node.get_local",
+        lambda: SimpleNamespace(pk=5, role=SimpleNamespace(name="Terminal")),
+    )
+    request = _build_request(path_info="/ocpp/c/CP-2/", resolver_match=None)
+
+    response = middleware(request)
+
+    assert response.context_snapshot["node_id"] == "5"
+    assert response.context_snapshot["charger_id"] == "CP-2"
+    assert response.context_snapshot["session_id"] == "S-2"
 
 
 def test_json_formatter_outputs_stable_fields():

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+from config.request_utils import reset_request_log_context, set_request_log_context
+from utils.loggers.config import resolve_log_formatter
+from utils.loggers.filters import RequestContextFilter
+from utils.loggers.json_formatter import JSONFormatter
+
+
+def _build_request(**kwargs):
+    resolver_match = kwargs.pop("resolver_match", None)
+    return SimpleNamespace(
+        META=kwargs.pop("META", {}),
+        GET=kwargs.pop("GET", {}),
+        POST=kwargs.pop("POST", {}),
+        resolver_match=resolver_match,
+        **kwargs,
+    )
+
+
+def test_resolve_log_formatter_defaults_to_text(monkeypatch):
+    monkeypatch.delenv("ARTHEXIS_LOG_FORMAT", raising=False)
+    assert resolve_log_formatter() == "standard"
+
+
+def test_resolve_log_formatter_json_mode(monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_LOG_FORMAT", "json")
+    assert resolve_log_formatter() == "json"
+
+
+def test_request_context_filter_applies_request_identifiers():
+    request = _build_request(
+        META={"HTTP_X_REQUEST_ID": "req-123"},
+        resolver_match=SimpleNamespace(kwargs={"charger_id": "CP-1", "session_id": "S-9"}),
+    )
+    token = set_request_log_context(request, node_id="42")
+    record = logging.LogRecord(
+        name="apps.forwarder.ocpp",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    try:
+        accepted = RequestContextFilter().filter(record)
+    finally:
+        reset_request_log_context(token)
+
+    assert accepted is True
+    assert record.request_id == "req-123"
+    assert record.node_id == "42"
+    assert record.charger_id == "CP-1"
+    assert record.session_id == "S-9"
+
+
+def test_json_formatter_outputs_stable_fields():
+    record = logging.LogRecord(
+        name="apps.forwarder.ocpp",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="connected",
+        args=(),
+        exc_info=None,
+    )
+    record.app = "Terminal"
+    record.hostname = "host-a"
+    record.request_id = "req-1"
+    record.node_id = "node-1"
+    record.charger_id = "CP-10"
+    record.session_id = "sess-10"
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert sorted(payload.keys()) == [
+        "app",
+        "charger_id",
+        "hostname",
+        "level",
+        "logger",
+        "message",
+        "node_id",
+        "process",
+        "request_id",
+        "session_id",
+        "thread",
+        "timestamp",
+    ]
+    assert payload["logger"] == "apps.forwarder.ocpp"
+    assert payload["message"] == "connected"

--- a/utils/loggers/config.py
+++ b/utils/loggers/config.py
@@ -15,6 +15,14 @@ from .rotation import TRANSACTIONAL_LOG_RETENTION_DAYS
 
 FILTERS_MODULE = "utils.loggers.filters"
 HANDLERS_MODULE = "utils.loggers.handlers"
+FORMATTERS_MODULE = "utils.loggers.json_formatter"
+
+
+def resolve_log_formatter() -> str:
+    """Resolve the configured formatter mode from ``ARTHEXIS_LOG_FORMAT``."""
+
+    selected = os.environ.get("ARTHEXIS_LOG_FORMAT", "text").strip().lower()
+    return "json" if selected == "json" else "standard"
 
 
 def configure_library_loggers(
@@ -51,6 +59,7 @@ def build_logging_settings(
     )
 
     debug_control = parse_debug_logging(os.environ.get("DEBUG"), debug_enabled)
+    selected_formatter = resolve_log_formatter()
 
     logging_config: dict[str, Any] = {
         "version": 1,
@@ -58,7 +67,8 @@ def build_logging_settings(
         "formatters": {
             "standard": {
                 "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            }
+            },
+            "json": {"()": f"{FORMATTERS_MODULE}.JSONFormatter"},
         },
         "filters": {
             "debug_app_filter": {
@@ -69,6 +79,9 @@ def build_logging_settings(
             "ignore_static_asset_requests": {
                 "()": f"{FILTERS_MODULE}.IgnoreStaticAssetRequestsFilter",
             },
+            "request_context": {
+                "()": f"{FILTERS_MODULE}.RequestContextFilter",
+            },
         },
         "handlers": {
             "file": {
@@ -77,8 +90,8 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
-                "filters": ["debug_app_filter"],
+                "formatter": selected_formatter,
+                "filters": ["debug_app_filter", "request_context"],
             },
             "cp_forwarder_file": {
                 "class": f"{HANDLERS_MODULE}.CPForwarderFileHandler",
@@ -86,8 +99,9 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
+                "formatter": selected_formatter,
                 "level": "INFO",
+                "filters": ["request_context"],
             },
             "rfid_file": {
                 "class": f"{HANDLERS_MODULE}.RFIDFileHandler",
@@ -95,8 +109,9 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
+                "formatter": selected_formatter,
                 "level": "INFO",
+                "filters": ["request_context"],
             },
             "error_file": {
                 "class": f"{HANDLERS_MODULE}.ErrorFileHandler",
@@ -104,8 +119,9 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
+                "formatter": selected_formatter,
                 "level": "WARNING",
+                "filters": ["request_context"],
             },
             "celery_file": {
                 "class": f"{HANDLERS_MODULE}.CeleryFileHandler",
@@ -113,8 +129,9 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
+                "formatter": selected_formatter,
                 "level": "INFO",
+                "filters": ["request_context"],
             },
             "page_misses_file": {
                 "class": f"{HANDLERS_MODULE}.PageMissesFileHandler",
@@ -122,13 +139,15 @@ def build_logging_settings(
                 "when": "midnight",
                 "backupCount": TRANSACTIONAL_LOG_RETENTION_DAYS,
                 "encoding": "utf-8",
-                "formatter": "standard",
+                "formatter": selected_formatter,
                 "level": "INFO",
+                "filters": ["request_context"],
             },
             "console": {
                 "class": "logging.StreamHandler",
                 "level": "ERROR",
-                "formatter": "standard",
+                "formatter": selected_formatter,
+                "filters": ["request_context"],
             },
         },
         "root": {

--- a/utils/loggers/filters.py
+++ b/utils/loggers/filters.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import socket
 
 from config.active_app import get_active_app
+from config.request_utils import get_request_log_context
 
 from .debug import parse_debug_logging
 
@@ -42,3 +44,19 @@ class IgnoreStaticAssetRequestsFilter(logging.Filter):
         except IndexError:
             # Not in the expected format of an access log, so don't filter.
             return True
+
+
+class RequestContextFilter(logging.Filter):
+    """Attach request correlation metadata to each log record."""
+
+    _hostname = socket.gethostname()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        context = get_request_log_context()
+        record.app = getattr(record, "app", get_active_app())
+        record.hostname = getattr(record, "hostname", self._hostname)
+        record.request_id = getattr(record, "request_id", context.get("request_id", ""))
+        record.node_id = getattr(record, "node_id", context.get("node_id", ""))
+        record.charger_id = getattr(record, "charger_id", context.get("charger_id", ""))
+        record.session_id = getattr(record, "session_id", context.get("session_id", ""))
+        return True

--- a/utils/loggers/json_formatter.py
+++ b/utils/loggers/json_formatter.py
@@ -1,0 +1,36 @@
+"""JSON log formatter for LogQL/Loki-friendly structured log output."""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from datetime import UTC, datetime
+
+
+class JSONFormatter(logging.Formatter):
+    """Serialize log records as stable JSON objects."""
+
+    _hostname = socket.gethostname()
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "app": getattr(record, "app", ""),
+            "hostname": getattr(record, "hostname", self._hostname),
+            "process": record.process,
+            "thread": record.thread,
+            "request_id": getattr(record, "request_id", ""),
+            "node_id": getattr(record, "node_id", ""),
+            "charger_id": getattr(record, "charger_id", ""),
+            "session_id": getattr(record, "session_id", ""),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)


### PR DESCRIPTION
### Motivation
- Provide an optional JSON log mode for Loki/LogQL-friendly ingestion while keeping the existing text formatter as the default for backward compatibility.
- Ensure request-scoped correlation identifiers (request ID, node ID, charger/session IDs) can be injected into log records so traces can be correlated across systems.
- Preserve existing logger names and routing (for example `apps.forwarder.ocpp` and Celery loggers) so current handlers and label strategies remain stable.

### Description
- Add runtime formatter selection via `ARTHEXIS_LOG_FORMAT` and helper `resolve_log_formatter()` in `utils/loggers/config.py`, and wire the resolved formatter into core handlers without changing logger names or routing.
- Introduce `utils/loggers/json_formatter.py` containing `JSONFormatter` that emits stable JSON keys: `timestamp`, `level`, `logger`, `message`, `app`, `hostname`, `process`, `thread` plus correlation keys `request_id`, `node_id`, `charger_id`, and `session_id`.
- Add request correlation context support in `config/request_utils.py` using `contextvars` with `set_request_log_context()`, `get_request_log_context()`, and `reset_request_log_context()` to extract request headers/route params and provide values to logging filters.
- Bind and reset request context in `ActiveAppMiddleware` (`config/middleware.py`) for each incoming HTTP request so correlation fields are available during request handling.
- Add `RequestContextFilter` to `utils/loggers/filters.py` to enrich `LogRecord` objects with `app`, `hostname`, `request_id`, `node_id`, `charger_id`, and `session_id`.
- Update `docs/logging-domain.md` to document `ARTHEXIS_LOG_FORMAT` and recommended LogQL/Loki conventions, and add focused tests in `tests/test_logging_config.py` covering formatter resolution, filter enrichment, and JSON payload stability.

### Testing
- Ran environment prep: `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` to ensure test runner availability.
- Executed `./.venv/bin/python manage.py test run -- tests/test_logging_config.py` which ran the new test module and reported `4 passed`.
- The added tests assert `resolve_log_formatter()` behavior, that `RequestContextFilter` injects identifiers into `LogRecord`, and that `JSONFormatter` outputs the expected stable JSON keys.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db010de5a88326b7ff392810adfc82)