### PR TITLE
sites: add small bottom spacing under dashboard net message

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -23,6 +23,7 @@
         align-content: right;
         gap: 0.5rem;
         padding: 0 0.65rem;
+        margin-bottom: 0.2rem;
         border-radius: 6px;
         background: var(--darkened-bg);
         color: var(--body-fg);


### PR DESCRIPTION
### Motivation
- Prevent the admin dashboard net message box from visually touching the model/app list header below by adding a tiny vertical gap.

### Description
- Add `margin-bottom: 0.2rem` to `.admin-home-net-message` in `apps/sites/static/sites/css/admin/dashboard.css` to provide a small space under the net message container.

### Testing
- Ran `git diff --check` with no issues and executed `./scripts/review-notify.sh --actor Codex`, which reported a skipped review notification due to branch state (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db07791b2483268b9564021dd4f7fb)