### PR TITLE
ops: prioritize Security Alerts widget and add empty-state rules link

### DIFF
--- a/apps/ops/templates/widgets/security_alerts.html
+++ b/apps/ops/templates/widgets/security_alerts.html
@@ -19,7 +19,10 @@
       {% endfor %}
     </ul>
   {% else %}
-    <p class="help">{% trans "No active security alerts." %}</p>
+    <p class="help">
+      {% trans "No active security alerts." %}
+      <a href="{{ dashboard_rules_report_url }}">{% trans "View passed and unmet rules" %}</a>
+    </p>
   {% endif %}
 </div>
 <style>

--- a/apps/ops/tests/test_security_alerts.py
+++ b/apps/ops/tests/test_security_alerts.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 from django.utils import timezone
@@ -56,6 +55,7 @@ def test_build_security_alerts_isolates_collector_failures(monkeypatch) -> None:
     assert alerts == []
     persisted_event = SecurityAlertEvent.objects.get(key="security-alert-source-error-events")
     assert persisted_event.occurrence_count == 1
+
 
 def test_record_occurrence_keeps_last_occurred_at_monotonic() -> None:
     """Older occurrences should not move last_occurred_at backwards."""
@@ -125,6 +125,7 @@ def test_build_security_alerts_clears_collector_failure_on_success(monkeypatch) 
     persisted_event = SecurityAlertEvent.objects.get(key="security-alert-source-error-events")
     assert persisted_event.is_active is False
 
+
 def test_error_event_security_alerts_surface_last_seen_and_count() -> None:
     """Recorded event alerts should expose summary with timestamp and occurrence count."""
 
@@ -149,3 +150,34 @@ def test_error_event_security_alerts_surface_last_seen_and_count() -> None:
     assert len(alerts) == 1
     assert alerts[0].message == "Email worker failed."
     assert "Count: 2" in alerts[0].summary
+
+
+def test_security_alerts_widget_exposes_dashboard_rules_report_url() -> None:
+    widget_context = ops_widgets.security_alerts_widget()
+
+    assert widget_context["dashboard_rules_report_url"] == "/admin/system/dashboard-rules-report/"
+
+
+def test_security_alerts_empty_state_links_to_dashboard_rules_report() -> None:
+    html = render_to_string(
+        "widgets/security_alerts.html",
+        {"alerts": [], "dashboard_rules_report_url": "/admin/system/dashboard-rules-report/"},
+    )
+
+    assert "No active security alerts." in html
+    assert 'href="/admin/system/dashboard-rules-report/"' in html
+    assert "View passed and unmet rules" in html
+
+
+def test_security_alerts_widget_priority_is_topmost() -> None:
+    sync_registered_widgets()
+    request = RequestFactory().get("/admin/")
+    request.user = get_user_model().objects.create_user(
+        username="widget-priority-admin",
+        password="password",
+        is_staff=True,
+    )
+
+    rendered_widgets = render_zone_widgets(request=request, zone_slug=WidgetZone.ZONE_SIDEBAR)
+
+    assert rendered_widgets[0].widget.slug == "security-alerts"

--- a/apps/ops/widgets.py
+++ b/apps/ops/widgets.py
@@ -1,11 +1,19 @@
 """Widgets exposed by the operations app."""
 
+from django.urls import NoReverseMatch, reverse
 from django.utils.translation import gettext_lazy as _
 
 from apps.widgets import register_widget
 from apps.widgets.models import WidgetZone
 
 from .security_alerts import build_security_alerts
+
+
+def _dashboard_rules_report_url() -> str:
+    try:
+        return reverse("admin:system-dashboard-rules-report")
+    except NoReverseMatch:
+        return "/admin/system/dashboard-rules-report/"
 
 
 def _is_authenticated_staff(*, request, **_kwargs) -> bool:
@@ -19,10 +27,13 @@ def _is_authenticated_staff(*, request, **_kwargs) -> bool:
     zone=WidgetZone.ZONE_SIDEBAR,
     template_name="widgets/security_alerts.html",
     description=_("Critical operational and security readiness alerts."),
-    order=5,
+    order=-100,
     permission=_is_authenticated_staff,
 )
 def security_alerts_widget(**_kwargs):
     """Render normalized security alerts for the sidebar."""
 
-    return {"alerts": build_security_alerts()}
+    return {
+        "alerts": build_security_alerts(),
+        "dashboard_rules_report_url": _dashboard_rules_report_url(),
+    }


### PR DESCRIPTION
### Motivation
- Surface critical security alerts more prominently by placing the Security Alerts widget at the top of the admin sidebar. 
- Provide a helpful remediation path when there are no active alerts by linking to the dashboard rules report (passed/unmet rules). 

### Description
- Move the Security Alerts widget to the top of the sidebar by setting `order=-100` in `apps/ops/widgets.py`. 
- Add a resilient admin URL resolver that returns `reverse("admin:system-dashboard-rules-report")` with a fallback to `"/admin/system/dashboard-rules-report/"` and expose it as `dashboard_rules_report_url` in the widget context. 
- Update `apps/ops/templates/widgets/security_alerts.html` to render a “View passed and unmet rules” link in the empty state using `dashboard_rules_report_url`. 
- Add tests in `apps/ops/tests/test_security_alerts.py` that assert the widget exposes the rules URL, the empty-state template includes the link and label, and the widget is rendered topmost in the sidebar ordering. 

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` successfully. 
- Executed the ops security alert tests with `.venv/bin/python manage.py test run -- apps/ops/tests/test_security_alerts.py` and all tests passed (`10 passed`). 
- Sent review notification via `./scripts/review-notify.sh --actor Codex` as part of validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db08ed01b08326b512d5931278c731)