### PR TITLE
docs: align node feature documentation with current behavior

### DIFF
--- a/apps/docs/cookbooks/node-features.md
+++ b/apps/docs/cookbooks/node-features.md
@@ -7,6 +7,8 @@ Coordinate capabilities across nodes by managing `nodes.NodeFeature` records in 
 - [Current feature catalog](#current-feature-catalog)
 - [Assigning features to roles and nodes](#assigning-features-to-roles-and-nodes)
 - [Running eligibility checks](#running-eligibility-checks)
+- [Playwright global vs engine-level controls](#playwright-global-vs-engine-level-controls)
+- [Declaring feature setup hooks](#declaring-feature-setup-hooks)
 - [Enabling features manually](#enabling-features-manually)
 - [Troubleshooting](#troubleshooting)
 
@@ -14,7 +16,7 @@ Coordinate capabilities across nodes by managing `nodes.NodeFeature` records in 
 
 1. Open the Django admin and locate the **Nodes** application.
 2. Click **Node features** (model `nodes.NodeFeature`) to open the changelist (`admin:nodes_nodefeature_changelist`).
-3. The changelist is registered in [`apps/nodes/admin/node_feature_admin.py`](../../nodes/admin/node_feature_admin.py) and displays columns for the display name, slug, default roles, enablement status, and available actions.
+3. The changelist is registered in [`apps/nodes/admin/node_feature_admin.py`](../../nodes/admin/node_feature_admin.py) and displays columns for the display name, slug, default roles, control mode, enablement status, and available actions.
 
 ## Reviewing feature metadata
 
@@ -22,61 +24,59 @@ Each feature encapsulates a capability that nodes can expose. The admin form pro
 
 - **Slug** – A unique identifier that code paths reference. Ensure slugs remain stable across releases.
 - **Display** – A human-friendly label surfaced in the UI.
-- **Description** – Operational context for administrators.
-- **Roles** – Default node roles that should receive the feature (`filter_horizontal = ("roles",)` in `NodeFeatureAdmin`).
+- **Roles** – Default node roles that should receive the feature (`filter_horizontal = ("roles",)` in `NodeFeatureAdminForm`).
+- **Control mode** – Manual (`Node.MANUAL_FEATURE_SLUGS`) or automatic (`Node.AUTO_MANAGED_FEATURES`).
 - **Default actions** – Optional links that appear in the `Actions` column when a feature is enabled (`NodeFeature.get_default_actions`).
 
-Use the search field to find features by slug or display string. The queryset prefetches role relations, keeping list navigation fast even with many records.
+Use the search field to find features by slug or display string. The queryset prefetches role relations and linked suite features, keeping list navigation fast even with many records.
 
 ## Current feature catalog
+
+The current seed catalog in `apps/nodes/fixtures/node_features__nodefeature_*.json` is:
 
 | Feature | Slug | Default roles | Key actions / notes |
 | --- | --- | --- | --- |
 | Celery Queue | `celery-queue` | Satellite, Control, Watchtower | Auto-managed feature with a **Celery Report** admin action. |
-| GUI Toast | `gui-toast` | Terminal, Control | Auto-managed feature that surfaces GUI toast notifications when supported. |
+| Charge Points | `charge-points` | Satellite | Role-assignment feature with no built-in default action link. |
+| Chat Bridge | `chat-bridge` | Control, Terminal, Watchtower | Role-assignment feature with no built-in default action link. |
+| GPIO RTC | `gpio-rtc` | Control | Auto-managed feature with a **Find Clock Devices** admin action. |
+| GUI Toast | `gui-toast` | Terminal, Control | Auto-managed feature for GUI toast notifications when supported. |
 | LCD Screen | `lcd-screen` | Control | Auto-managed flag for nodes driving an attached LCD panel. |
+| LLM Summary | `llm-summary` | Control | Auto-managed feature with a **Configure** admin action. |
 | NGINX Server | `nginx-server` | Satellite, Control, Watchtower | Auto-managed flag for nodes running the bundled NGINX front end. |
-| RFID Scanner | `rfid-scanner` | Control, Satellite | Auto-managed feature with a **Scanner** admin action. |
+| RFID Scanner | `rfid-scanner` | Control, Satellite | Auto-managed feature with scanner-related default actions. |
 | Playwright Automation | `playwright-automation` | (auto-detected) | Wrapper node capability that must be active before any Playwright browser engine feature can run. |
 | Playwright Chromium | `playwright-browser-chromium` | (auto-detected) | Engine-specific Playwright node capability. |
 | Playwright Firefox | `playwright-browser-firefox` | (auto-detected) | Engine-specific Playwright node capability. |
 | Playwright WebKit | `playwright-browser-webkit` | (auto-detected) | Engine-specific Playwright node capability. |
-| Video Camera | `video-cam` | (manual enablement) | Auto-managed feature with built-in eligibility checks, **Take a Snapshot**/**View stream** default actions, and RFID/QR snapshot and scan integrations. |
+| Video Camera | `video-cam` | (manual enablement) | Auto-managed feature with **Discover** and **Take Snapshot** default actions. |
 | Screenshot Poll | `screenshot-poll` | (manual enablement) | Manual feature providing a **Take Screenshot** admin action. |
 
-Features without default roles still appear in the changelist and can be enabled through admin actions once local hardware or environment checks pass.
+Features without default roles still appear in the changelist and can be enabled when local hardware or environment checks pass.
 
 ## Assigning features to roles and nodes
 
 Node roles and individual nodes both control feature availability:
 
-- **Default roles** – Selecting roles on the feature form ensures new nodes that join the role automatically inherit the feature. The admin prepopulates `NodeFeature.roles` through the horizontal selector.
+- **Default roles** – Selecting roles on the feature form ensures new nodes that join the role automatically inherit the feature.
 - **Node-specific assignments** – Open a node change form (`admin:nodes_node_change`) to adjust the inline **Node feature assignments** table. The inline is provided by `NodeFeatureAssignmentInline` (`apps/nodes/admin/inlines.py`) and writes to the `NodeFeatureAssignment` through model.
 
 Changes to assignments are applied immediately after saving the node or feature form. Use Django’s history view to audit adjustments.
 
 ## Running eligibility checks
 
-Select one or more features on the changelist and choose **Check features for eligibility**. The admin action (`NodeFeatureAdmin.check_features_for_eligibility`) calls the registry in [`nodes/feature_checks.py`](../../nodes/feature_checks.py) to evaluate whether the local node satisfies hardware or software requirements. Results appear as Django messages (success, warning, or error).
+Select one or more features on the changelist and choose **Check features for eligibility**. The admin action (`NodeFeatureAdmin.check_features_for_eligibility`) calls the registry in [`apps/nodes/feature_checks.py`](../../nodes/feature_checks.py) to evaluate whether the local node satisfies hardware or software requirements. Results appear as Django messages (success, warning, or error).
 
 Eligibility runs also report whether a feature can be enabled manually. The helper `_manual_enablement_data` in `NodeFeatureAdmin` communicates whether the feature belongs to `Node.MANUAL_FEATURE_SLUGS` or requires automation.
 
 ## Playwright global vs engine-level controls
 
-Playwright execution now uses **two gates**:
+Playwright execution uses two gates:
 
 1. **Suite feature gate**: `playwright-automation` (global toggle in Suite Features).
 2. **Node feature gate**: engine-specific node feature (`playwright-browser-chromium`, `playwright-browser-firefox`, `playwright-browser-webkit`).
 
-An engine can run only when both gates are open. Practical effects:
-
-- If `playwright-automation` is disabled, browser launch checks and admin browser-test actions short-circuit globally.
-- If `playwright-automation` is enabled but a specific `playwright-browser-*` node feature is disabled, that engine is rejected on the local node.
-
-Use this pattern to separate policy from capability:
-
-- **Policy** (all Playwright runtime execution): Suite Feature.
-- **Capability** (which browser engine can run on a node): Node Features.
+An engine can run only when both gates are open.
 
 ## Declaring feature setup hooks
 
@@ -84,19 +84,19 @@ Auto-managed features discover their enablement and lifecycle through app-level 
 
 - Add a `node_features.py` module to an app.
 - Export `check_node_feature(slug, *, node, base_dir=None, base_path=None)` to return `True` when a feature could be meaningfully enabled on the provided node. Return `None` when the slug is unknown to the module.
-- Export `setup_node_feature(slug, *, node, base_dir=None, base_path=None)` for any setup or side-effects the feature needs during auto-detection (returning `True`/`False` mirrors `check_node_feature`).
+- Export `setup_node_feature(slug, *, node, base_dir=None, base_path=None)` for setup side-effects needed during auto-detection (returning `True`/`False` mirrors `check_node_feature`).
 - Export `register_node_feature_detection(registry)` and register one detector per feature slug using `registry.register(slug, check=..., setup=...)`.
 
-The nodes app discovers and orchestrates these detectors from every installed app so each feature can own its own auto-detection lifecycle.
+The nodes app discovers and orchestrates these detectors from approved registrars in `apps/nodes/feature_registry.py`.
 
 ## Enabling features manually
 
-To toggle features outside of automatic provisioning, select them in the changelist and execute **Enable selected features**. When a local node is registered, the action creates `NodeFeatureAssignment` rows for that node (see `NodeFeatureAssignment.objects.update_or_create` calls in [`apps/nodes/models/features.py`](../../nodes/models/features.py)).
+To toggle features outside automatic provisioning, select them in the changelist and execute **Enable selected features**. When a local node is registered, the action creates `NodeFeatureAssignment` rows for that node.
 
 If no local node exists, the admin posts an informational message. Register a node first via the Nodes interface, then re-run the enable action.
 
 ## Troubleshooting
 
 - **Actions menu shows em dash (—)** – The feature is not currently enabled, or no default actions exist. Enable the feature or configure `DEFAULT_ACTIONS` in [`apps/nodes/models/features.py`](../../nodes/models/features.py).
-- **Eligibility checks always warn about missing checks** – Add an implementation to the `feature_checks` registry in [`nodes/feature_checks.py`](../../nodes/feature_checks.py) to cover the slug in question.
-- **Assignments disappear after deployments** – Verify that fixtures in `nodes/fixtures/` or migrations are not removing the feature (`nodes/migrations/0018`, `0027`, etc.). Reapply role assignments if a migration intentionally deprecates the feature.
+- **Eligibility checks always warn about missing checks** – Add an implementation to the `feature_checks` registry in [`apps/nodes/feature_checks.py`](../../nodes/feature_checks.py) to cover the slug in question.
+- **Assignments disappear after deployments** – Verify that fixtures in `apps/nodes/fixtures/` or migrations are not removing the feature. Reapply role assignments if a migration intentionally deprecates a feature.

--- a/docs/services/celery-beat.md
+++ b/docs/services/celery-beat.md
@@ -28,4 +28,3 @@ Celery beat is the scheduler service that triggers periodic background tasks for
 
 ## Notes
 - Celery beat is typically paired with the Celery worker; disabling the lock disables both.
-- Optional feature reference: [LLM LCD log summary](../feature/llm-summary.md).

--- a/docs/services/celery-worker.md
+++ b/docs/services/celery-worker.md
@@ -34,4 +34,3 @@ The Celery worker is the background job processor for Arthexis. It executes asyn
 
 - The worker starts with a unique worker node name (`-n worker.<service>@%h`) to avoid `DuplicateNodenameWarning` when multiple nodes share the same host.
 - In embedded mode without a configured service lock, the worker falls back to `worker.embedded-<pid>@%h` so concurrently started terminal instances still get unique nodenames.
-- Optional feature reference: [LLM LCD log summary](../feature/llm-summary.md).

--- a/docs/services/lcd-screen.md
+++ b/docs/services/lcd-screen.md
@@ -31,4 +31,3 @@ The LCD screen service drives a 16x2 I²C display on Control nodes, showing upti
 ## Notes
 - Control presets enable the LCD lock automatically.
 - The Suite Services Report lists the LCD row even when the lock is missing so operators can enable it later.
-- Optional feature reference: [LLM LCD log summary](../feature/llm-summary.md).

--- a/docs/suite-services-report.md
+++ b/docs/suite-services-report.md
@@ -23,4 +23,3 @@ The Suite Services Report (Admin → System → Suite Services Report) summarize
 - [Install & Lifecycle Scripts Manual](development/install-lifecycle-scripts-manual.md)
 - [LCD Screen Hardware](lcd-screen-hardware.md)
 - [Auto-Upgrade Flow](auto-upgrade.md)
-- [LLM LCD log summary (optional feature)](feature/llm-summary.md)


### PR DESCRIPTION
### Motivation
- Ensure feature documentation only describes behavior and features that actually exist today and avoid dangling references to non-existent docs.
- Centralize feature guidance in the Node Features cookbook and remove scattered/obsolete links that pointed to a removed `feature/llm-summary` page.
- Keep admin-facing guidance accurate to help operators use the Nodes admin UI without following stale instructions.

### Description
- Updated `apps/docs/cookbooks/node-features.md` to reflect the current seeded node feature catalog, current admin columns (`control mode`), and eligibility/setup hook behavior. 
- Removed stale references to a non-existent `docs/feature/llm-summary.md` from `docs/services/lcd-screen.md`, `docs/services/celery-worker.md`, `docs/services/celery-beat.md`, and `docs/suite-services-report.md`.
- Cleaned wording to reference the actual fixtures and code locations (e.g. `apps/nodes/fixtures/*` and `apps/nodes/feature_checks.py`).
- Files changed: `apps/docs/cookbooks/node-features.md`, `docs/services/lcd-screen.md`, `docs/services/celery-worker.md`, `docs/services/celery-beat.md`, and `docs/suite-services-report.md`.

### Testing
- Ran `rg -n "feature/llm-summary|/feature/|Optional feature reference" docs apps/docs -g '*.md'` and confirmed there are no remaining stale references (command succeeded with no matches).
- Verified the current seeded node feature fixtures count with `find apps/nodes/fixtures -maxdepth 1 -type f -name 'node_features__nodefeature_*.json' | wc -l` which returned the existing fixtures (15) and matched the cookbook catalog.
- Executed `./scripts/review-notify.sh --actor Codex` which completed via the fallback notifier, and verified the workspace is clean with `git status --short` (no unstaged changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db20164868832680a58badcda95705)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates documentation to align with current Node Features behavior and removes references to an obsolete documentation page. The changes centralize feature guidance in the Node Features cookbook while removing stale links scattered across service documentation.

## Key Changes

### apps/docs/cookbooks/node-features.md
Updated the Node Features cookbook to reflect current admin UI and implementation:
- Added **control mode** (manual vs auto-managed) as a documented column in the admin UI, replacing references to **default roles**
- Updated feature metadata section to reference `NodeFeatureAdminForm` instead of `NodeFeatureAdmin`
- Updated "Current feature catalog" section to reference seed fixtures at `apps/nodes/fixtures/node_features__nodefeature_*.json`
- Revised catalog entries with accurate default actions and role assignments (e.g., RFID Scanner action details, Video Camera actions changed to "Discover"/"Take Snapshot", new entries for charge-points, chat-bridge, gpio-rtc, llm-summary)
- Simplified Playwright documentation by removing explicit "practical effects" bullets while retaining the two-gate model
- Updated "Declaring feature setup hooks" section to reference `apps/nodes/feature_registry.py` for discoverable registrars
- Clarified eligibility-driven enablement guidance and adjusted fixture path references

### Removed Stale References
Deleted outdated cross-references to `../feature/llm-summary.md` (a non-existent documentation page) from:
- docs/services/lcd-screen.md
- docs/services/celery-worker.md
- docs/services/celery-beat.md
- docs/suite-services-report.md

## Testing
- Verified no remaining stale references to the removed docs page using rg
- Confirmed seeded node feature fixtures count (15) matches the cookbook catalog
- Validated clean workspace via git status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->