### PR TITLE
ops: add breadcrumb trail to operator journey step pages

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -1,6 +1,16 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate "Home" %}</a>
+    &rsaquo;
+    <span>{% translate "Operator journey" %}</span>
+    &rsaquo;
+    <span>{{ step.title }}</span>
+  </div>
+{% endblock %}
+
 {% block content %}
   <div class="module aligned">
     <h1>{{ step.title }}</h1>

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -161,6 +161,15 @@ class OperatorJourneyViewTests(TestCase):
         self.assertContains(response, "Decision flow:")
         self.assertNotContains(response, "<iframe", html=False)
 
+    def test_step_view_renders_breadcrumb_with_step_title(self):
+        response = self.client.get(
+            reverse("ops:operator-journey-step", args=[self.step_1.pk])
+        )
+
+        self.assertContains(response, '<div class="breadcrumbs">', html=False)
+        self.assertContains(response, "Operator journey")
+        self.assertContains(response, self.step_1.title)
+
     def test_validate_role_step_limits_role_choices_to_basic_configure_roles(self):
         NodeRole.objects.create(name="Gateway")
         response = self.client.get(


### PR DESCRIPTION
### Motivation
- Provide clear contextual navigation on operator journey admin pages by showing a breadcrumb that includes the current step name so users can see which step they are viewing and navigate back to the admin home.

### Description
- Add a `breadcrumbs` block to `apps/ops/templates/admin/ops/operator_journey_step.html` that renders `Home › Operator journey › <step title>` and add a regression test `test_step_view_renders_breadcrumb_with_step_title` to `apps/ops/tests/test_operator_journey.py` to assert the breadcrumb and step title are present.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI deps with `pip install -r requirements-ci.txt`, then ran `./.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py::OperatorJourneyViewTests`, which passed (14 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db22f303548326910cf6bcbd96705c)