### PR TITLE
ops: split GitHub onboarding into Product Developer journey step

### DIFF
--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -12,7 +12,7 @@ from apps.groups.models import SecurityGroup
 
 
 class OperatorJourneyProvisionSuperuserForm(forms.Form):
-    """Create a superuser account and optionally attach a GitHub token."""
+    """Create a superuser account for operations onboarding."""
 
     PASSWORD_ALPHABET = string.ascii_letters + string.digits + "-._~!@#$%^&*"
 
@@ -38,16 +38,6 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
         required=False,
         widget=forms.PasswordInput(),
         help_text="Required only when using a manual password.",
-    )
-    github_username = forms.CharField(
-        required=False,
-        max_length=255,
-        help_text="Optional GitHub username for repository, release, and issue operations.",
-    )
-    github_token = forms.CharField(
-        required=False,
-        widget=forms.PasswordInput(),
-        help_text="Optional GitHub token to store for this new user.",
     )
 
     def clean(self):
@@ -90,19 +80,6 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
             password=password,
         )
         user.groups.set(cleaned_data["security_groups"])
-
-        github_token = (cleaned_data.get("github_token") or "").strip()
-        github_username = (cleaned_data.get("github_username") or "").strip()
-        if github_token:
-            from apps.repos.models import GitHubToken
-
-            GitHubToken.objects.update_or_create(
-                user=user,
-                defaults={
-                    "label": github_username or "Ops onboarding token",
-                    "token": github_token,
-                },
-            )
 
         return user, password
 

--- a/apps/ops/migrations/0010_split_github_setup_into_product_developer_journey.py
+++ b/apps/ops/migrations/0010_split_github_setup_into_product_developer_journey.py
@@ -45,40 +45,48 @@ def split_github_setup_into_product_developer_journey(apps, schema_editor):
         },
     )
 
-    update_fields = []
-    if journey.security_group_id != product_developer_group.id:
-        journey.security_group = product_developer_group
-        update_fields.append("security_group")
-    if created:
-        update_fields.append("is_seed_data")
-    elif not journey.is_seed_data:
-        journey.is_seed_data = True
-        update_fields.append("is_seed_data")
-    if update_fields:
-        journey.save(update_fields=update_fields)
+    if not created:
+        update_fields = []
+        if journey.security_group_id != product_developer_group.id:
+            journey.security_group = product_developer_group
+            update_fields.append("security_group")
+        if not journey.is_seed_data:
+            journey.is_seed_data = True
+            update_fields.append("is_seed_data")
+        if update_fields:
+            journey.save(update_fields=update_fields)
 
-    step, _ = OperatorJourneyStep.objects.get_or_create(
-        journey=journey,
-        slug=PRODUCT_DEVELOPER_GITHUB_STEP_SLUG,
-        defaults={
-            "title": "Connect your GitHub access",
-            "instruction": (
-                "Use the GitHub token setup wizard to connect your product developer account "
-                "for repository, release, and issue workflows."
-            ),
-            "help_text": (
-                "This step is for Product Developer members only. "
-                "The wizard opens your token record and keeps setup in one place."
-            ),
-            "iframe_url": "/admin/repos/githubrepository/setup-token/",
-            "order": 1,
-            "is_active": True,
-            "is_seed_data": True,
-        },
+    step = OperatorJourneyStep.objects.filter(
+        journey=journey, slug=PRODUCT_DEVELOPER_GITHUB_STEP_SLUG
+    ).first()
+    if step is None:
+        step = OperatorJourneyStep(
+            journey=journey,
+            slug=PRODUCT_DEVELOPER_GITHUB_STEP_SLUG,
+        )
+
+    for conflicting_step in (
+        OperatorJourneyStep.objects.filter(journey=journey, order__gte=1)
+        .exclude(pk=step.pk)
+        .order_by("-order", "-id")
+    ):
+        conflicting_step.order += 1
+        conflicting_step.save(update_fields=["order"])
+
+    step.title = "Connect your GitHub access"
+    step.instruction = (
+        "Use the GitHub token setup wizard to connect your product developer account "
+        "for repository, release, and issue workflows."
     )
-    if not step.is_seed_data:
-        step.is_seed_data = True
-        step.save(update_fields=["is_seed_data"])
+    step.help_text = (
+        "This step is for Product Developer members only. "
+        "The wizard opens your token record and keeps setup in one place."
+    )
+    step.iframe_url = "/admin/repos/githubrepository/setup-token/"
+    step.order = 1
+    step.is_active = True
+    step.is_seed_data = True
+    step.save()
 
 
 def noop_reverse(apps, schema_editor):

--- a/apps/ops/migrations/0010_split_github_setup_into_product_developer_journey.py
+++ b/apps/ops/migrations/0010_split_github_setup_into_product_developer_journey.py
@@ -1,0 +1,99 @@
+from django.db import migrations
+
+OPERATOR_JOURNEY_SLUG = "operator-node-readiness"
+PROVISION_STEP_SLUG = "provision-ops-superuser"
+PRODUCT_DEVELOPER_GROUP_NAME = "Product Developer"
+PRODUCT_DEVELOPER_JOURNEY_SLUG = "product-developer-github-access"
+PRODUCT_DEVELOPER_GITHUB_STEP_SLUG = "setup-github-token"
+
+
+def split_github_setup_into_product_developer_journey(apps, schema_editor):
+    """Keep ops provisioning focused and move GitHub setup to product developers."""
+
+    OperatorJourney = apps.get_model("ops", "OperatorJourney")
+    OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+    SecurityGroup = apps.get_model("groups", "SecurityGroup")
+
+    OperatorJourneyStep.objects.filter(
+        journey__slug=OPERATOR_JOURNEY_SLUG,
+        slug=PROVISION_STEP_SLUG,
+        is_seed_data=True,
+    ).update(
+        title="Create operational superuser and security access",
+        instruction=(
+            "After confirming node role/setup, create a dedicated superuser for operations. "
+            "Assign one or more security groups and choose random/manual password handling."
+        ),
+        help_text=(
+            "Complete this step by creating the account, recording credentials securely, "
+            "and verifying the account can log in."
+        ),
+    )
+
+    product_developer_group, _ = SecurityGroup.objects.get_or_create(
+        name=PRODUCT_DEVELOPER_GROUP_NAME
+    )
+    journey, created = OperatorJourney.objects.get_or_create(
+        slug=PRODUCT_DEVELOPER_JOURNEY_SLUG,
+        defaults={
+            "name": "Product Developer GitHub Access",
+            "description": "Guided GitHub token setup for product developers.",
+            "security_group": product_developer_group,
+            "priority": 20,
+            "is_active": True,
+            "is_seed_data": True,
+        },
+    )
+
+    update_fields = []
+    if journey.security_group_id != product_developer_group.id:
+        journey.security_group = product_developer_group
+        update_fields.append("security_group")
+    if created:
+        update_fields.append("is_seed_data")
+    elif not journey.is_seed_data:
+        journey.is_seed_data = True
+        update_fields.append("is_seed_data")
+    if update_fields:
+        journey.save(update_fields=update_fields)
+
+    step, _ = OperatorJourneyStep.objects.get_or_create(
+        journey=journey,
+        slug=PRODUCT_DEVELOPER_GITHUB_STEP_SLUG,
+        defaults={
+            "title": "Connect your GitHub access",
+            "instruction": (
+                "Use the GitHub token setup wizard to connect your product developer account "
+                "for repository, release, and issue workflows."
+            ),
+            "help_text": (
+                "This step is for Product Developer members only. "
+                "The wizard opens your token record and keeps setup in one place."
+            ),
+            "iframe_url": "/admin/repos/githubrepository/setup-token/",
+            "order": 1,
+            "is_active": True,
+            "is_seed_data": True,
+        },
+    )
+    if not step.is_seed_data:
+        step.is_seed_data = True
+        step.save(update_fields=["is_seed_data"])
+
+
+def noop_reverse(apps, schema_editor):
+    """Keep user-updated journey configuration intact on reverse."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ops", "0009_seed_operator_journey_superuser_provision_step"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            split_github_setup_into_product_developer_journey,
+            noop_reverse,
+        ),
+    ]

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -163,7 +163,7 @@
       </script>
     {% elif provision_superuser_form %}
       <p>
-        {% translate "Create an operational superuser for this node role, assign security groups, and optionally connect GitHub credentials for repository/release/issue workflows." %}
+        {% translate "Create an operational superuser for this node role and assign the required security groups." %}
       </p>
       <p>
         {% translate "After creation, open a private browser session to verify this account can log in." %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -11,7 +11,6 @@ from apps.nodes.models import NodeRole
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import complete_step_for_user, status_for_user
 from apps.ops.views import _build_node_role_validation_summary
-from apps.repos.models import GitHubToken
 
 
 class OperatorJourneyFlowTests(TestCase):
@@ -258,7 +257,7 @@ class OperatorJourneyViewTests(TestCase):
         self.assertContains(response, "Create account and complete step")
         self.assertNotContains(response, "<iframe", html=False)
 
-    def test_provision_step_creates_superuser_groups_and_github_token(self):
+    def test_provision_step_creates_superuser_with_assigned_groups(self):
         provision_step = OperatorJourneyStep.objects.create(
             journey=self.journey,
             title="Create ops superuser",
@@ -282,8 +281,6 @@ class OperatorJourneyViewTests(TestCase):
                 "email": "ops-provisioned@example.com",
                 "security_groups": [self.group.pk, extra_group.pk],
                 "password_mode": "random",
-                "github_username": "octocat",
-                "github_token": "ghp_example_token",
             },
         )
 
@@ -296,8 +293,6 @@ class OperatorJourneyViewTests(TestCase):
             set(created_user.groups.values_list("name", flat=True)),
             {self.group.name, extra_group.name},
         )
-        token = GitHubToken.objects.get(user=created_user)
-        self.assertEqual(token.label, "octocat")
 
     def test_provision_step_ignores_autofilled_password_when_mode_is_random(self):
         provision_step = OperatorJourneyStep.objects.create(

--- a/apps/ops/tests/test_seeded_product_developer_journey.py
+++ b/apps/ops/tests/test_seeded_product_developer_journey.py
@@ -1,0 +1,60 @@
+"""Regression tests for seeded product developer GitHub journey defaults."""
+
+from importlib import import_module
+
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+from apps.groups.models import SecurityGroup
+from apps.ops.models import OperatorJourney, OperatorJourneyStep
+
+migration_module = import_module(
+    "apps.ops.migrations.0010_split_github_setup_into_product_developer_journey"
+)
+
+
+class SeededProductDeveloperJourneyTests(TestCase):
+    """Ensure GitHub setup guidance is split from the Site Operator superuser step."""
+
+    def test_split_github_setup_into_product_developer_journey(self):
+        site_operator = SecurityGroup.objects.create(name="Site Operator")
+        operator_journey = OperatorJourney.objects.create(
+            name="Operator Node Readiness",
+            slug="operator-node-readiness",
+            security_group=site_operator,
+            is_active=True,
+            is_seed_data=True,
+        )
+        OperatorJourneyStep.objects.create(
+            journey=operator_journey,
+            title="Create operational superuser and security access",
+            slug="provision-ops-superuser",
+            instruction="Old instruction with GitHub guidance.",
+            help_text="Old help text with GitHub guidance.",
+            iframe_url="/admin/auth/user/add/",
+            order=2,
+            is_active=True,
+            is_seed_data=True,
+        )
+
+        migration_module.split_github_setup_into_product_developer_journey(
+            django_apps, None
+        )
+
+        refreshed_step = OperatorJourneyStep.objects.get(
+            journey=operator_journey,
+            slug="provision-ops-superuser",
+        )
+        self.assertNotIn("GitHub", refreshed_step.instruction)
+
+        developer_journey = OperatorJourney.objects.get(
+            slug="product-developer-github-access"
+        )
+        self.assertEqual(developer_journey.security_group.name, "Product Developer")
+
+        github_step = OperatorJourneyStep.objects.get(
+            journey=developer_journey,
+            slug="setup-github-token",
+        )
+        self.assertEqual(github_step.iframe_url, "/admin/repos/githubrepository/setup-token/")
+        self.assertIn("GitHub token setup wizard", github_step.instruction)


### PR DESCRIPTION
### Motivation
- Keep the Site Operator superuser provisioning step focused on account creation and security group assignment and avoid prompting site operators for product-developer responsibilities. 
- Surface GitHub token setup only to product developers so repository/release/issue operations are set up via a dedicated guidance flow.

### Description
- Removed `github_username` and `github_token` fields and the logic that stored them from `OperatorJourneyProvisionSuperuserForm` so the Site Operator provisioning form only creates the account, assigns security groups, and handles password mode (`apps/ops/forms.py`).
- Updated the operator journey step copy to remove GitHub setup language and reflect the narrowed scope of the superuser provisioning step (`apps/ops/templates/admin/ops/operator_journey_step.html`).
- Added a data migration `apps/ops/migrations/0010_split_github_setup_into_product_developer_journey.py` which refreshes the seeded Site Operator provisioning step text and seeds a new Product Developer journey (`product-developer-github-access`) with a GitHub setup step that opens the token wizard at `/admin/repos/githubrepository/setup-token/`.
- Updated existing tests and added a new regression test to validate the revised provisioning behavior and the seeded Product Developer journey (`apps/ops/tests/test_operator_journey.py`, `apps/ops/tests/test_seeded_product_developer_journey.py`).

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` (succeeded). 
- Ran the operator-journey test suite with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py apps/ops/tests/test_seeded_product_developer_journey.py apps/ops/tests/test_seeded_operator_journey.py`, and all tests passed (`18 passed`).
- Verified migrations with `.venv/bin/python manage.py migrations check` which reported no changes detected (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db23e0663c8326bd5ba613446f4c88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR reorganizes GitHub token onboarding to follow a different user journey pattern, removing it from the Site Operator superuser provisioning flow and placing it into a dedicated Product Developer journey. This keeps the Site Operator flow focused on core account creation, security group assignment, and password configuration.

## Changes

### Form Updates
Removed `github_username` and `github_token` fields and associated persistence logic from `OperatorJourneyProvisionSuperuserForm` in `apps/ops/forms.py`. The form now exclusively handles superuser account creation, group assignment, and password mode configuration, with no GitHub-specific functionality.

### Data Migration
Added migration `0010_split_github_setup_into_product_developer_journey.py` that:
- Updates the existing "operator-node-readiness" journey's "provision-ops-superuser" step to remove GitHub setup guidance from the instruction text
- Creates a new "product-developer-github-access" journey assigned to the Product Developer security group
- Seeds a "setup-github-token" step within the new journey that directs users to the token wizard at `/admin/repos/githubrepository/setup-token/`

### Template and Test Updates
- Updated operator journey step template to remove GitHub credential setup language
- Modified existing provisioning test to remove GitHub token field submissions and assertions
- Added regression test `test_seeded_product_developer_journey.py` validating that the split correctly removes GitHub references from the original step while properly seeding the new Product Developer journey and its GitHub setup step

## Testing
- Existing provisioning tests updated to reflect the removal of GitHub fields
- New regression test validates the migration behavior and the seeded Product Developer journey structure
- All relevant tests pass (18 passed)
- Migration verification shows no schema changes required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->