### PR TITLE
sites: add autocomplete for feedback dialog comment textareas

### DIFF
--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -133,6 +133,7 @@
             name="comments"
             rows="4"
             placeholder="{% trans 'Share details about your experience' %}"
+            autocomplete="on"
             required
           ></textarea>
         </div>

--- a/apps/sites/templates/pages/includes/public_feedback_widget.html
+++ b/apps/sites/templates/pages/includes/public_feedback_widget.html
@@ -133,6 +133,7 @@
             name="comments"
             rows="4"
             placeholder="{% trans 'Share details about your experience' %}"
+            autocomplete="on"
             required
           ></textarea>
         </div>

--- a/apps/sites/tests/test_user_story_feedback_form.py
+++ b/apps/sites/tests/test_user_story_feedback_form.py
@@ -55,3 +55,33 @@ def test_user_story_feedback_template_omits_security_groups_for_non_staff_users(
     html = render_to_string("admin/includes/user_story_feedback.html", request=request)
 
     assert 'data-security-groups=""' in html
+
+
+def test_user_story_feedback_template_enables_comments_autocomplete():
+    user = get_user_model().objects.create_user(
+        username="staff-user",
+        password="x",
+        email="staff-user@example.com",
+        is_staff=True,
+    )
+    request = RequestFactory().get("/admin/")
+    request.user = user
+
+    html = render_to_string("admin/includes/user_story_feedback.html", request=request)
+
+    assert 'name="comments"' in html
+    assert 'autocomplete="on"' in html
+
+
+def test_public_feedback_template_enables_comments_autocomplete():
+    request = RequestFactory().get("/")
+    request.user = get_user_model()()
+
+    html = render_to_string(
+        "pages/includes/public_feedback_widget.html",
+        {"feedback_ingestion_enabled": True},
+        request=request,
+    )
+
+    assert 'name="comments"' in html
+    assert 'autocomplete="on"' in html

--- a/apps/sites/tests/test_user_story_feedback_form.py
+++ b/apps/sites/tests/test_user_story_feedback_form.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 
@@ -58,11 +61,11 @@ def test_user_story_feedback_template_omits_security_groups_for_non_staff_users(
 
 
 def test_user_story_feedback_template_enables_comments_autocomplete():
-    user = get_user_model().objects.create_user(
+    user = SimpleNamespace(
         username="staff-user",
-        password="x",
-        email="staff-user@example.com",
+        is_authenticated=True,
         is_staff=True,
+        groups=SimpleNamespace(all=lambda: []),
     )
     request = RequestFactory().get("/admin/")
     request.user = user
@@ -75,7 +78,7 @@ def test_user_story_feedback_template_enables_comments_autocomplete():
 
 def test_public_feedback_template_enables_comments_autocomplete():
     request = RequestFactory().get("/")
-    request.user = get_user_model()()
+    request.user = AnonymousUser()
 
     html = render_to_string(
         "pages/includes/public_feedback_widget.html",


### PR DESCRIPTION
### Motivation
- Improve usability by enabling browser autocomplete on the feedback comment field in both admin and public feedback dialogs.

### Description
- Add `autocomplete="on"` to the comments textarea in `apps/sites/templates/admin/includes/user_story_feedback.html`.
- Add `autocomplete="on"` to the comments textarea in `apps/sites/templates/pages/includes/public_feedback_widget.html`.
- Add template tests in `apps/sites/tests/test_user_story_feedback_form.py` asserting the comments field includes `autocomplete="on"` for both admin and public variants.

### Testing
- Prepared the environment with `./env-refresh.sh --deps-only` and installed CI test deps; environment setup completed successfully.
- Ran `.venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py`, and the test run passed (5 passed).
- Sent the review notification using `./scripts/review-notify.sh --actor Codex`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db25207b708326957d04249245d63d)