### PR TITLE
links: unify legacy reference reads/writes via attachment helpers

### DIFF
--- a/apps/cards/models/rfid.py
+++ b/apps/cards/models/rfid.py
@@ -196,6 +196,7 @@ class RFID(Entity):
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get("update_fields")
+        update_fields_set = set(update_fields) if update_fields is not None else None
         if not self.origin_node_id:
             try:
                 from apps.nodes.models import (
@@ -239,7 +240,10 @@ class RFID(Entity):
         if self.endianness:
             self.endianness = self.normalize_endianness(self.endianness)
         super().save(*args, **kwargs)
-        mirror_legacy_reference_attachment(self)
+        mirror_legacy_reference_attachment(
+            self,
+            update_fields=update_fields_set,
+        )
         if not self.allowed:
             self.energy_accounts.clear()
 

--- a/apps/cards/models/rfid.py
+++ b/apps/cards/models/rfid.py
@@ -4,8 +4,6 @@ import base64
 from io import BytesIO
 from typing import Any
 
-from apps.cards.actions import get_rfid_action_choices
-
 from django.apps import apps
 from django.core.management.color import no_style
 from django.core.validators import RegexValidator
@@ -16,6 +14,8 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from apps.base.models import Entity
+from apps.cards.actions import get_rfid_action_choices
+from apps.links.reference_utils import mirror_legacy_reference_attachment
 
 __all__ = ["RFID"]
 
@@ -239,6 +239,7 @@ class RFID(Entity):
         if self.endianness:
             self.endianness = self.normalize_endianness(self.endianness)
         super().save(*args, **kwargs)
+        mirror_legacy_reference_attachment(self)
         if not self.allowed:
             self.energy_accounts.clear()
 

--- a/apps/links/reference_utils.py
+++ b/apps/links/reference_utils.py
@@ -40,21 +40,31 @@ def mirror_legacy_reference_attachment(
     *,
     legacy_field: str = "reference",
     slot: str | None = None,
+    update_fields: set[str] | None = None,
 ) -> "ReferenceAttachment | None":
     """Mirror ``instance.<legacy_field>`` into ``ReferenceAttachment``."""
 
     if not getattr(instance, "pk", None):
         return None
-    reference = getattr(instance, legacy_field, None)
-    if reference is None:
+    if update_fields is not None and legacy_field not in update_fields:
         return None
 
     from .models import ReferenceAttachment
 
     attachment_slot = slot or default_reference_slot(instance)
     content_type = ContentType.objects.get_for_model(
-        instance, for_concrete_model=False
+        instance, for_concrete_model=True
     )
+    reference = getattr(instance, legacy_field, None)
+    if reference is None:
+        ReferenceAttachment.objects.filter(
+            content_type=content_type,
+            object_id=str(instance.pk),
+            slot=attachment_slot,
+            is_primary=True,
+        ).delete()
+        return None
+
     attachment, _ = ReferenceAttachment.objects.update_or_create(
         content_type=content_type,
         object_id=str(instance.pk),
@@ -79,7 +89,7 @@ def get_attached_references(
     from .models import ReferenceAttachment
 
     content_type = ContentType.objects.get_for_model(
-        instance, for_concrete_model=False
+        instance, for_concrete_model=True
     )
     queryset = ReferenceAttachment.objects.filter(
         content_type=content_type,
@@ -105,14 +115,28 @@ def get_primary_reference(
 ) -> "Reference | None":
     """Return one reference for integrations/UI using staged fallback logic."""
 
-    references = get_attached_references(
-        instance,
-        slot=slot,
-        legacy_field=legacy_field,
-    )
-    if not references:
+    if not getattr(instance, "pk", None):
         return None
-    return references[0]
+
+    from .models import ReferenceAttachment
+
+    content_type = ContentType.objects.get_for_model(
+        instance, for_concrete_model=True
+    )
+    queryset = ReferenceAttachment.objects.filter(
+        content_type=content_type,
+        object_id=str(instance.pk),
+        is_primary=True,
+    ).select_related("reference")
+    if slot is not None:
+        queryset = queryset.filter(slot=slot)
+
+    attachment = queryset.order_by("sort_order", "id").first()
+    if attachment is not None:
+        return attachment.reference
+
+    legacy_reference = getattr(instance, legacy_field, None)
+    return legacy_reference
 
 
 def _normalize_host(host: str | None) -> str:

--- a/apps/links/reference_utils.py
+++ b/apps/links/reference_utils.py
@@ -1,17 +1,118 @@
-"""Utility helpers for working with :class:`apps.links.models.Reference`."""
+"""Utility helpers for link references and reference attachments."""
 
 from __future__ import annotations
 
 import ipaddress
-from typing import Iterable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 from urllib.parse import urlparse
 
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from django.db import models
     from django.http import HttpRequest
+
     from apps.nodes.models import Node
-    from .models import Reference
+
+    from .models import Reference, ReferenceAttachment
+
+
+DEFAULT_REFERENCE_SLOT = "default"
+REFERENCE_SLOT_BY_MODEL_LABEL = {
+    "cards.rfid": "rfid",
+    "ocpp.charger": "charger",
+    "terms.term": "term",
+}
+
+
+def default_reference_slot(
+    instance: "models.Model", *, fallback: str = DEFAULT_REFERENCE_SLOT
+) -> str:
+    """Return the default attachment slot name for ``instance``."""
+
+    model_label = instance._meta.label_lower
+    return REFERENCE_SLOT_BY_MODEL_LABEL.get(model_label, fallback)
+
+
+def mirror_legacy_reference_attachment(
+    instance: "models.Model",
+    *,
+    legacy_field: str = "reference",
+    slot: str | None = None,
+) -> "ReferenceAttachment | None":
+    """Mirror ``instance.<legacy_field>`` into ``ReferenceAttachment``."""
+
+    if not getattr(instance, "pk", None):
+        return None
+    reference = getattr(instance, legacy_field, None)
+    if reference is None:
+        return None
+
+    from .models import ReferenceAttachment
+
+    attachment_slot = slot or default_reference_slot(instance)
+    content_type = ContentType.objects.get_for_model(
+        instance, for_concrete_model=False
+    )
+    attachment, _ = ReferenceAttachment.objects.update_or_create(
+        content_type=content_type,
+        object_id=str(instance.pk),
+        slot=attachment_slot,
+        is_primary=True,
+        defaults={"reference": reference},
+    )
+    return attachment
+
+
+def get_attached_references(
+    instance: "models.Model",
+    *,
+    slot: str | None = None,
+    legacy_field: str = "reference",
+) -> list["Reference"]:
+    """Return references for ``instance``, preferring attachments first."""
+
+    if not getattr(instance, "pk", None):
+        return []
+
+    from .models import ReferenceAttachment
+
+    content_type = ContentType.objects.get_for_model(
+        instance, for_concrete_model=False
+    )
+    queryset = ReferenceAttachment.objects.filter(
+        content_type=content_type,
+        object_id=str(instance.pk),
+    ).select_related("reference")
+    if slot is not None:
+        queryset = queryset.filter(slot=slot)
+    references = [attachment.reference for attachment in queryset]
+    if references:
+        return references
+
+    legacy_reference = getattr(instance, legacy_field, None)
+    if legacy_reference is None:
+        return []
+    return [legacy_reference]
+
+
+def get_primary_reference(
+    instance: "models.Model",
+    *,
+    slot: str | None = None,
+    legacy_field: str = "reference",
+) -> "Reference | None":
+    """Return one reference for integrations/UI using staged fallback logic."""
+
+    references = get_attached_references(
+        instance,
+        slot=slot,
+        legacy_field=legacy_field,
+    )
+    if not references:
+        return None
+    return references[0]
 
 
 def _normalize_host(host: str | None) -> str:
@@ -68,7 +169,9 @@ def filter_visible_references(
 
     if node is None:
         try:
-            from apps.nodes.models import Node  # imported lazily to avoid circular import
+            from apps.nodes.models import (
+                Node,  # imported lazily to avoid circular import
+            )
 
             node = Node.get_local()
         except Exception:
@@ -142,7 +245,12 @@ def filter_visible_references(
 
 
 __all__ = [
+    "DEFAULT_REFERENCE_SLOT",
+    "default_reference_slot",
     "filter_visible_references",
+    "get_attached_references",
+    "get_primary_reference",
     "host_is_local_loopback",
+    "mirror_legacy_reference_attachment",
     "url_targets_local_loopback",
 ]

--- a/apps/links/tests/test_reference_utils_attachments.py
+++ b/apps/links/tests/test_reference_utils_attachments.py
@@ -90,3 +90,59 @@ def test_mirror_legacy_reference_attachment_updates_existing_slot() -> None:
         is_primary=True,
     )
     assert attachment.reference_id == second_reference.pk
+
+
+def test_mirror_legacy_reference_attachment_deletes_primary_on_clear() -> None:
+    reference = Reference.objects.create(
+        alt_text="Present",
+        value="https://example.com/present",
+    )
+    term = Term.objects.create(
+        title="Clearable",
+        slug="clearable",
+        reference=reference,
+    )
+    assert ReferenceAttachment.objects.filter(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    ).exists()
+
+    term.reference = None
+    mirror_legacy_reference_attachment(term)
+
+    assert not ReferenceAttachment.objects.filter(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    ).exists()
+    assert get_primary_reference(term) is None
+
+
+def test_mirror_legacy_reference_attachment_skips_when_field_not_updated() -> None:
+    first_reference = Reference.objects.create(
+        alt_text="First",
+        value="https://example.com/first-ref",
+    )
+    second_reference = Reference.objects.create(
+        alt_text="Second",
+        value="https://example.com/second-ref",
+    )
+    term = Term.objects.create(
+        title="Skip updates",
+        slug="skip-updates",
+        reference=first_reference,
+    )
+
+    term.reference = second_reference
+    mirror_legacy_reference_attachment(
+        term,
+        update_fields={"title"},
+    )
+
+    attachment = ReferenceAttachment.objects.get(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    )
+    assert attachment.reference_id == first_reference.pk

--- a/apps/links/tests/test_reference_utils_attachments.py
+++ b/apps/links/tests/test_reference_utils_attachments.py
@@ -1,0 +1,92 @@
+"""Tests for staged reference attachment helper APIs."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.links.models import Reference, ReferenceAttachment
+from apps.links.reference_utils import (
+    get_attached_references,
+    get_primary_reference,
+    mirror_legacy_reference_attachment,
+)
+from apps.terms.models import Term
+
+pytestmark = pytest.mark.django_db
+
+
+def test_term_save_mirrors_legacy_reference_to_attachment_slot() -> None:
+    reference = Reference.objects.create(
+        alt_text="Term reference",
+        value="https://example.com/term",
+    )
+    term = Term.objects.create(
+        title="Terms",
+        slug="terms",
+        reference=reference,
+    )
+
+    attachment = ReferenceAttachment.objects.get(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    )
+
+    assert attachment.reference_id == reference.pk
+
+
+def test_get_primary_reference_prefers_attachment_and_falls_back_to_legacy() -> None:
+    legacy_reference = Reference.objects.create(
+        alt_text="Legacy",
+        value="https://example.com/legacy",
+    )
+    attachment_reference = Reference.objects.create(
+        alt_text="Attachment",
+        value="https://example.com/attachment",
+    )
+    term = Term.objects.create(
+        title="Reference order",
+        slug="reference-order",
+        reference=legacy_reference,
+    )
+
+    attachment = ReferenceAttachment.objects.get(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    )
+    attachment.reference = attachment_reference
+    attachment.save(update_fields=["reference"])
+
+    assert get_primary_reference(term) == attachment_reference
+
+    ReferenceAttachment.objects.filter(pk=attachment.pk).delete()
+
+    assert get_primary_reference(term) == legacy_reference
+    assert get_attached_references(term) == [legacy_reference]
+
+
+def test_mirror_legacy_reference_attachment_updates_existing_slot() -> None:
+    first_reference = Reference.objects.create(
+        alt_text="First",
+        value="https://example.com/first",
+    )
+    second_reference = Reference.objects.create(
+        alt_text="Second",
+        value="https://example.com/second",
+    )
+    term = Term.objects.create(
+        title="Mirror",
+        slug="mirror",
+        reference=first_reference,
+    )
+
+    term.reference = second_reference
+    mirror_legacy_reference_attachment(term)
+
+    attachment = ReferenceAttachment.objects.get(
+        object_id=str(term.pk),
+        slot="term",
+        is_primary=True,
+    )
+    assert attachment.reference_id == second_reference.pk

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -938,12 +938,13 @@ class Charger(Ownable):
             )
 
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        update_fields_set = set(update_fields) if update_fields is not None else None
         self.clean()
         if self.node_origin_id is None:
             local = Node.get_local()
             if local:
                 self.node_origin = local
-        update_fields = kwargs.get("update_fields")
         update_list = list(update_fields) if update_fields is not None else None
         if not self.manager_node_id:
             local_node = Node.get_local()
@@ -988,7 +989,10 @@ class Charger(Ownable):
             )
             self.reference.value = ref_value
             self.reference.alt_text = self.charger_id
-        mirror_legacy_reference_attachment(self)
+        mirror_legacy_reference_attachment(
+            self,
+            update_fields=update_fields_set,
+        )
 
     def refresh_manager_node(self, node: Node | None = None) -> Node | None:
         """Ensure ``manager_node`` matches the provided or local node."""

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from django.conf import settings
 from django.urls import NoReverseMatch
 
+from apps.links.reference_utils import mirror_legacy_reference_attachment
 from apps.locale.models import Language
-from apps.sites.utils import SITE_OPERATOR_GROUP_NAME, user_in_charge_station_manager_group
+from apps.sites.utils import (
+    SITE_OPERATOR_GROUP_NAME,
+    user_in_charge_station_manager_group,
+)
 
 from .. import store
 from .base import *
 from .transaction import annotate_transaction_energy_bounds
+
 
 class Charger(Ownable):
     """Known charge point."""
@@ -983,6 +988,7 @@ class Charger(Ownable):
             )
             self.reference.value = ref_value
             self.reference.alt_text = self.charger_id
+        mirror_legacy_reference_attachment(self)
 
     def refresh_manager_node(self, node: Node | None = None) -> Node | None:
         """Ensure ``manager_node`` matches the provided or local node."""

--- a/apps/terms/models.py
+++ b/apps/terms/models.py
@@ -122,6 +122,8 @@ class Term(models.Model):
         return self.title
 
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        update_fields_set = set(update_fields) if update_fields is not None else None
         is_new = self.pk is None
         super().save(*args, **kwargs)
         if is_new and not self.reference_id and self.slug:
@@ -134,7 +136,10 @@ class Term(models.Model):
             desired_value = self.get_absolute_url()
             if self.reference.value != desired_value:
                 Reference.objects.filter(pk=self.reference_id).update(value=desired_value)
-        mirror_legacy_reference_attachment(self)
+        mirror_legacy_reference_attachment(
+            self,
+            update_fields=update_fields_set,
+        )
 
     def clean(self):
         super().clean()

--- a/apps/terms/models.py
+++ b/apps/terms/models.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from apps.links.models import Reference
+from apps.links.reference_utils import mirror_legacy_reference_attachment
 from apps.media.models import MediaFile
 from apps.media.utils import ensure_media_bucket
 
@@ -133,6 +134,7 @@ class Term(models.Model):
             desired_value = self.get_absolute_url()
             if self.reference.value != desired_value:
                 Reference.objects.filter(pk=self.reference_id).update(value=desired_value)
+        mirror_legacy_reference_attachment(self)
 
     def clean(self):
         super().clean()

--- a/docs/development/reference-attachment-migration.md
+++ b/docs/development/reference-attachment-migration.md
@@ -1,0 +1,41 @@
+# Reference attachment staged migration
+
+Arthexis is moving from direct model-level `reference` fields to the generic
+`links.ReferenceAttachment` model so references can be attached in a unified
+way across apps.
+
+To avoid breaking existing admin forms, integrations, and templates, use this
+staged path.
+
+## Stage 1: mirror writes, keep legacy fields
+
+- Keep legacy `reference` fields on models.
+- Call `mirror_legacy_reference_attachment(instance)` after save when the
+  model exposes a legacy `reference` field.
+- Mirror the legacy value into a primary slot on `ReferenceAttachment` using a
+  stable slot name (`term`, `rfid`, `charger`, or `default`).
+
+This stage is now wired for:
+
+- `terms.Term`
+- `cards.RFID`
+- `ocpp.Charger`
+
+## Stage 2: read through unified helpers
+
+For UI and integration reads, switch to helpers in
+`apps.links.reference_utils`:
+
+- `get_attached_references(instance)`
+- `get_primary_reference(instance)`
+
+These functions prefer attachment-backed reads and gracefully fall back to the
+legacy `reference` field when no attachment is present.
+
+## Stage 3: remove legacy fields
+
+After all read/write paths have been migrated and data backfills are complete,
+legacy `reference` fields can be removed in follow-up schema migrations.
+
+Until then, keep both paths in place to preserve admin and template
+compatibility.


### PR DESCRIPTION
### Motivation

- Provide a staged migration path from model-level `reference` fields to the generic `links.ReferenceAttachment` so references can be attached uniformly across apps.
- Preserve existing admin, template and integration behavior during migration by mirroring legacy writes and providing attachment-first read helpers.
- Avoid breaking templates and admin UIs while allowing read/write migration to proceed incrementally.

### Description

- Added helper APIs in `apps/links/reference_utils.py`: `default_reference_slot`, `mirror_legacy_reference_attachment`, `get_attached_references`, and `get_primary_reference` which prefer attachment-backed reads and fall back to legacy `reference` fields.
- Implemented model-specific default slots and mapping for known models and a `DEFAULT_REFERENCE_SLOT` fallback.
- Wired legacy-write mirroring by calling `mirror_legacy_reference_attachment(instance)` from `Term.save()`, `RFID.save()`, and `Charger.save()` so legacy `reference` writes are mirrored into a `ReferenceAttachment` primary slot.
- Added tests `apps/links/tests/test_reference_utils_attachments.py` validating slot mirroring, attachment-first reads, legacy fallback, and update behavior, and documented the staged migration in `docs/development/reference-attachment-migration.md`.

### Testing

- Ran `./env-refresh.sh --deps-only` and then executed the test suite for the changes with `./.venv/bin/python manage.py test run -- apps/links/tests/test_reference_utils_attachments.py apps/links/tests/test_reference_attachment_model.py` and all tests passed.
- Test results: the two focused test files ran and completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc10fd42ec83268a56a56d8e206b5a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds unified attachment helpers and a staged migration path from model-level `reference` fields to the generic `links.ReferenceAttachment` model. It preserves existing admin, template, and integration behavior by mirroring legacy writes into attachment-backed primary slots and providing attachment-first read helpers with legacy fallbacks, allowing incremental migration without breaking UIs.

## Key Changes

### New Helper APIs (apps/links/reference_utils.py)
- DEFAULT_REFERENCE_SLOT: fallback slot name ("default").
- REFERENCE_SLOT_BY_MODEL_LABEL: mapping of model labels to stable slot names (e.g. "term", "rfid", "charger").
- default_reference_slot(instance, fallback=...): resolve a slot name for an instance with fallback.
- mirror_legacy_reference_attachment(instance, *, legacy_field="reference", slot=None, update_fields=None): after save, create/update/delete a primary ReferenceAttachment for the instance based on the legacy `reference` value. No-op when instance.pk is missing or when an update_fields set is provided that excludes the legacy field. Clears mirrored primary attachment when the legacy reference is set to None.
- get_attached_references(instance, *, slot=None, legacy_field="reference"): return attached ReferenceAttachment.reference values (optionally filtered by slot), falling back to [instance.<legacy_field>] only when no attachments exist and legacy value is not None.
- get_primary_reference(instance, *, slot=None, legacy_field="reference"): return the first is_primary attachment (ordered by sort_order then id), falling back to instance.<legacy_field> when no primary attachment exists.

### Integration with Model save() Methods
- apps/terms/models.py: calls mirror_legacy_reference_attachment(self, update_fields=...) at the end of Term.save() (respects update_fields behavior).
- apps/cards/models/rfid.py: calls mirror_legacy_reference_attachment(self, update_fields=...) at the end of RFID.save().
- apps/ocpp/models/charger.py: calls mirror_legacy_reference_attachment(self, update_fields=...) at the end of Charger.save().

These hooks mirror legacy `reference` writes into a primary attachment slot (model-specific slot names), honor save(update_fields=...) semantics, and clear mirrored attachments when the legacy field is cleared.

### Tests (apps/links/tests/test_reference_utils_attachments.py)
Database tests validate:
- Mirroring on save: creating a Term with a legacy reference creates a primary ReferenceAttachment with correct content_type, object_id, slot, and is_primary=True.
- Attachment-first reads and fallback: get_primary_reference() and get_attached_references() prefer attachment-backed data and fall back to the legacy `reference` when attachments are removed.
- Update propagation: mirror_legacy_reference_attachment() updates an existing primary attachment when the legacy reference changes.
- Clearing behavior: clearing the legacy reference causes mirror_legacy_reference_attachment() to delete the primary attachment and make get_primary_reference() return None.
- update_fields respect: mirror_legacy_reference_attachment(..., update_fields={...}) is a no-op when the legacy field is not included in update_fields, preserving existing attachments.

Test run: dependency refresh and focused tests completed; the two targeted test files completed with 5 passed.

### Documentation
- docs/development/reference-attachment-migration.md: documents the staged migration (1. mirror writes — current; 2. update reads to attachments-first; 3. remove legacy fields after backfill), and lists the stable slot wiring for Term, RFID, and Charger.

## Notes for Reviewers
- The mirroring implementation intentionally preserves existing save-side behavior and respects update_fields to avoid surprising side effects during partial updates.
- The helpers provide a safe, incremental migration path: mirror writes first, switch reads to attachment-first using the new helpers, then remove legacy fields after backfills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->