### PR TITLE
Add ReferenceAttachment inline and admin mixin; enable on Charger, RFID, and Term admins

### DIFF
--- a/apps/core/admin/rfid.py
+++ b/apps/core/admin/rfid.py
@@ -39,6 +39,7 @@ from apps.cards.rfid_import_export import (
 )
 from apps.cards.utils import build_mode_toggle
 from apps.energy.models import ClientReport, CustomerAccount
+from apps.links.admin import ReferenceAttachmentAdminMixin
 from apps.links.models.reference import ExperienceReference, Reference
 from apps.locals.user_data import EntityModelAdmin
 from apps.nodes.utils import ensure_feature_enabled
@@ -209,7 +210,9 @@ class CopyRFIDForm(forms.Form):
         return normalized
 
 
-class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
+class RFIDAdmin(
+    ReferenceAttachmentAdminMixin, EntityModelAdmin, ImportExportModelAdmin
+):
     change_list_template = "admin/cards/rfid/change_list.html"
     import_export_change_list_template = None
     resource_class = RFIDResource

--- a/apps/links/admin.py
+++ b/apps/links/admin.py
@@ -29,7 +29,7 @@ from .models import (
 
 class ReferenceAttachmentInline(GenericTabularInline):
     model = ReferenceAttachment
-    autocomplete_fields = ("reference",)
+    raw_id_fields = ("reference",)
     extra = 0
     fields = ("reference", "slot", "is_primary", "sort_order")
 

--- a/apps/links/admin.py
+++ b/apps/links/admin.py
@@ -3,8 +3,9 @@ import uuid
 
 from django import forms
 from django.contrib import admin
-from django.http import JsonResponse
+from django.contrib.contenttypes.admin import GenericTabularInline
 from django.http import Http404
+from django.http import JsonResponse
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -19,10 +20,30 @@ from .models import (
     QRRedirect,
     QRRedirectLead,
     Reference,
+    ReferenceAttachment,
     ShortURL,
     get_reference_file_bucket,
     get_reference_qr_bucket,
 )
+
+
+class ReferenceAttachmentInline(GenericTabularInline):
+    model = ReferenceAttachment
+    autocomplete_fields = ("reference",)
+    extra = 0
+    fields = ("reference", "slot", "is_primary", "sort_order")
+
+
+class ReferenceAttachmentAdminMixin:
+    """Add generic reference attachments to model admin change forms."""
+
+    reference_attachment_inline = ReferenceAttachmentInline
+
+    def get_inlines(self, request, obj):
+        inlines = list(super().get_inlines(request, obj))
+        if self.reference_attachment_inline not in inlines:
+            inlines.append(self.reference_attachment_inline)
+        return inlines
 
 
 class ReferenceAdminForm(forms.ModelForm):

--- a/apps/links/tests/test_reference_attachment_admin_mixin.py
+++ b/apps/links/tests/test_reference_attachment_admin_mixin.py
@@ -1,0 +1,41 @@
+"""Tests for generic reference attachment admin integration."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from apps.cards.models import RFID
+from apps.core.admin.rfid import RFIDAdmin
+from apps.links.admin import ReferenceAdmin, ReferenceAttachmentInline
+from apps.links.models import ExperienceReference
+from apps.ocpp.admin.charge_point.admin import ChargerAdmin
+from apps.ocpp.models import Charger
+from apps.terms.admin import TermAdmin
+from apps.terms.models import Term
+
+
+@pytest.mark.parametrize(
+    ("admin_class", "model"),
+    (
+        (ChargerAdmin, Charger),
+        (RFIDAdmin, RFID),
+        (TermAdmin, Term),
+    ),
+)
+def test_reference_attachment_inline_is_enabled_for_reference_models(
+    admin_class,
+    model,
+) -> None:
+    admin_instance = admin_class(model, AdminSite())
+    request = RequestFactory().get("/admin/")
+
+    assert ReferenceAttachmentInline in admin_instance.get_inlines(request, None)
+
+
+def test_reference_admin_keeps_attachment_context_out_of_reference_form() -> None:
+    admin_instance = ReferenceAdmin(ExperienceReference, AdminSite())
+    request = RequestFactory().get("/admin/")
+
+    assert ReferenceAttachmentInline not in admin_instance.get_inlines(request, None)

--- a/apps/links/tests/test_reference_attachment_admin_mixin.py
+++ b/apps/links/tests/test_reference_attachment_admin_mixin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory
 
@@ -39,3 +40,20 @@ def test_reference_admin_keeps_attachment_context_out_of_reference_form() -> Non
     request = RequestFactory().get("/admin/")
 
     assert ReferenceAttachmentInline not in admin_instance.get_inlines(request, None)
+
+
+class ExistingInline(admin.TabularInline):
+    model = ExperienceReference
+
+
+class AdminWithExistingInline(RFIDAdmin):
+    inlines = (ExistingInline,)
+
+
+def test_reference_attachment_inline_is_appended_to_existing_inlines() -> None:
+    admin_instance = AdminWithExistingInline(RFID, AdminSite())
+    request = RequestFactory().get("/admin/")
+
+    inlines = admin_instance.get_inlines(request, None)
+    assert inlines[0] is ExistingInline
+    assert ReferenceAttachmentInline in inlines

--- a/apps/ocpp/admin/charge_point/admin.py
+++ b/apps/ocpp/admin/charge_point/admin.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _, ngettext
 
 from apps.core.admin import OwnableAdminMixin
 from apps.energy.models import EnergyTariff
+from apps.links.admin import ReferenceAttachmentAdminMixin
 from apps.locals.user_data import EntityModelAdmin
 
 from ... import store
@@ -31,6 +32,7 @@ class ChargerAdmin(
     ChargerAdminViewsMixin,
     LogViewAdminMixin,
     OwnableAdminMixin,
+    ReferenceAttachmentAdminMixin,
     EntityModelAdmin,
 ):
     change_form_template = "admin/ocpp/charger/change_form.html"

--- a/apps/terms/admin.py
+++ b/apps/terms/admin.py
@@ -4,6 +4,7 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from apps.core.admin.mixins import PublicViewLinksAdminMixin
+from apps.links.admin import ReferenceAttachmentAdminMixin
 from apps.media.models import MediaFile
 
 from .models import (
@@ -15,7 +16,9 @@ from .models import (
 
 
 @admin.register(Term)
-class TermAdmin(PublicViewLinksAdminMixin, admin.ModelAdmin):
+class TermAdmin(
+    PublicViewLinksAdminMixin, ReferenceAttachmentAdminMixin, admin.ModelAdmin
+):
     list_display = (
         "title",
         "slug",


### PR DESCRIPTION
### Motivation
- Keep `Reference` editing focused on reference content while managing per-object attachment context (slot, primary, order) on related models.
- Provide a reusable admin component so any `ModelAdmin` can opt-in to manage `ReferenceAttachment` without overwriting existing inline configuration.
- Enable operators to add multiple contextual references immediately on models that already have a `reference` field.

### Description
- Add `ReferenceAttachmentInline` (a `GenericTabularInline`) and `ReferenceAttachmentAdminMixin` to `apps/links/admin.py`, where the mixin appends the inline via `get_inlines()` to avoid clobbering existing inline lists.
- Import and apply `ReferenceAttachmentAdminMixin` to `ChargerAdmin`, `RFIDAdmin`, and `TermAdmin` so those change forms include the `ReferenceAttachment` inline for per-object context management.
- Keep `ReferenceAdmin` unchanged so reference content editing remains separate from per-object attachment configuration.
- Add `apps/links/tests/test_reference_attachment_admin_mixin.py` to verify the inline is present for the three updated admins and absent for the `ReferenceAdmin` form.

### Testing
- Installed test dependencies and ran `./env-refresh.sh --deps-only` followed by ` .venv/bin/python manage.py test run -- apps/links/tests/test_reference_attachment_model.py apps/links/tests/test_reference_attachment_admin_mixin.py`, and all tests passed.
- Ran ` .venv/bin/python manage.py test run -- apps/links/tests/test_reference_attachment_admin_mixin.py` to re-check the admin integration and it passed (tests: 4 passed).
- Sent review notification via `./scripts/review-notify.sh --actor Codex` (ran successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc110344608326b93fe8da89261c21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR successfully implements reusable admin infrastructure for managing `ReferenceAttachment` objects within the context of specific models (Charger, RFID, Term), keeping reference content editing separate.

### Implementation

**apps/links/admin.py:**
- `ReferenceAttachmentInline`: A `GenericTabularInline` configured with `autocomplete_fields` on the reference field, `extra=0`, and fields for `reference`, `slot`, `is_primary`, and `sort_order`.
- `ReferenceAttachmentAdminMixin`: Provides a `get_inlines()` method that appends `ReferenceAttachmentInline` to the admin inlines list, checking for duplicates to prevent redundant additions.

**Applied to admins with proper imports:**
- `ChargerAdmin` (apps/ocpp/admin/charge_point/admin.py): Mixin imported and added to inheritance chain with other mixins.
- `RFIDAdmin` (apps/core/admin/rfid.py): Mixin imported and added as first base class.
- `TermAdmin` (apps/terms/admin.py): Mixin imported and added between `PublicViewLinksAdminMixin` and `admin.ModelAdmin`.

**ReferenceAdmin remains unchanged:** No inline is added, preserving the existing reference content editing workflow separate from per-object attachment management.

### Testing

Two focused tests validate the design:
1. Parametrized test confirms `ReferenceAttachmentInline` is present in `get_inlines()` for Charger, RFID, and Term admins.
2. Direct test confirms `ReferenceAttachmentInline` is absent from ReferenceAdmin's `get_inlines()`.

The tests are minimal and specific, avoiding unnecessary coverage and confirming the core requirement: reference attachments can be managed per-object context without modifying reference editing itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->