### PR TITLE
links/ocpp/terms: add shared reference attachment service

### DIFF
--- a/apps/links/admin.py
+++ b/apps/links/admin.py
@@ -206,11 +206,13 @@ class ReferenceAdmin(EntityModelAdmin):
         transaction_uuid = payload.get("transaction_uuid") or uuid.uuid4()
         created_ids = []
         for data in refs:
-            ref = Reference.objects.create(
+            ref, _ = Reference.objects.update_or_create(
                 alt_text=data.get("alt_text", ""),
                 value=data.get("value", ""),
-                transaction_uuid=transaction_uuid,
-                author=request.user if request.user.is_authenticated else None,
+                defaults={
+                    "author": request.user if request.user.is_authenticated else None,
+                    "transaction_uuid": transaction_uuid,
+                },
             )
             created_ids.append(ref.id)
         return JsonResponse(

--- a/apps/links/admin.py
+++ b/apps/links/admin.py
@@ -206,7 +206,7 @@ class ReferenceAdmin(EntityModelAdmin):
         transaction_uuid = payload.get("transaction_uuid") or uuid.uuid4()
         created_ids = []
         for data in refs:
-            ref, _ = Reference.objects.update_or_create(
+            ref, _ = Reference.objects.get_or_create(
                 alt_text=data.get("alt_text", ""),
                 value=data.get("value", ""),
                 defaults={

--- a/apps/links/services/__init__.py
+++ b/apps/links/services/__init__.py
@@ -1,0 +1,9 @@
+"""Service helpers for links app."""
+
+from .attachments import attach_reference, list_references, resolve_objects_by_reference
+
+__all__ = [
+    "attach_reference",
+    "list_references",
+    "resolve_objects_by_reference",
+]

--- a/apps/links/services/attachments.py
+++ b/apps/links/services/attachments.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 from django.db.models import Q
 
 from apps.links.models import Reference, ReferenceAttachment
 
 
+@transaction.atomic
 def attach_reference(
     obj,
     *,
@@ -49,14 +51,6 @@ def attach_reference(
             "slot": normalized_slot,
         },
     )
-
-    if primary:
-        ReferenceAttachment.objects.filter(
-            content_type=content_type,
-            object_id=str(obj.pk),
-            is_primary=True,
-            slot=normalized_slot,
-        ).exclude(pk=attachment.pk).update(is_primary=False)
 
     return attachment
 

--- a/apps/links/services/attachments.py
+++ b/apps/links/services/attachments.py
@@ -1,0 +1,110 @@
+"""Helpers for attaching and resolving generic link references."""
+
+from __future__ import annotations
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+
+from apps.links.models import Reference, ReferenceAttachment
+
+
+def attach_reference(
+    obj,
+    *,
+    alt_text,
+    value,
+    slot="default",
+    primary=False,
+    **ref_kwargs,
+):
+    """Create or update a reference and attach it to ``obj`` safely."""
+
+    if obj.pk is None:
+        raise ValueError("Cannot attach a reference to an unsaved object.")
+
+    normalized_slot = (slot or "default").strip() or "default"
+    reference, _ = Reference.objects.update_or_create(
+        alt_text=alt_text,
+        value=value,
+        defaults=ref_kwargs,
+    )
+    content_type = ContentType.objects.get_for_model(
+        obj,
+        for_concrete_model=False,
+    )
+    if primary:
+        ReferenceAttachment.objects.filter(
+            content_type=content_type,
+            object_id=str(obj.pk),
+            is_primary=True,
+            slot=normalized_slot,
+        ).exclude(reference=reference).update(is_primary=False)
+
+    attachment, _ = ReferenceAttachment.objects.update_or_create(
+        content_type=content_type,
+        object_id=str(obj.pk),
+        reference=reference,
+        defaults={
+            "is_primary": primary,
+            "slot": normalized_slot,
+        },
+    )
+
+    if primary:
+        ReferenceAttachment.objects.filter(
+            content_type=content_type,
+            object_id=str(obj.pk),
+            is_primary=True,
+            slot=normalized_slot,
+        ).exclude(pk=attachment.pk).update(is_primary=False)
+
+    return attachment
+
+
+def list_references(obj, slot=None, include_invalid=False):
+    """Return attached references for ``obj`` with optional filtering."""
+
+    if obj.pk is None:
+        return []
+
+    content_type = ContentType.objects.get_for_model(
+        obj,
+        for_concrete_model=False,
+    )
+    attachments = ReferenceAttachment.objects.filter(
+        content_type=content_type,
+        object_id=str(obj.pk),
+    ).select_related("reference")
+    if slot is not None:
+        attachments = attachments.filter(slot=slot)
+    if not include_invalid:
+        attachments = attachments.filter(
+            Q(reference__validation_status__isnull=True)
+            | Q(reference__validation_status__gte=200, reference__validation_status__lt=400)
+        )
+
+    return [attachment.reference for attachment in attachments]
+
+
+def resolve_objects_by_reference(model_cls, *, value=None, alt_text=None, slot=None):
+    """Resolve model instances linked by attached reference fields."""
+
+    if value is None and alt_text is None:
+        raise ValueError("Provide at least one of value or alt_text.")
+
+    content_type = ContentType.objects.get_for_model(
+        model_cls,
+        for_concrete_model=False,
+    )
+    attachments = ReferenceAttachment.objects.filter(content_type=content_type)
+    if slot is not None:
+        attachments = attachments.filter(slot=slot)
+    if alt_text is not None:
+        attachments = attachments.filter(reference__alt_text=alt_text)
+    if value is not None:
+        attachments = attachments.filter(reference__value=value)
+
+    object_ids = attachments.values_list("object_id", flat=True).distinct()
+    pk_values = [model_cls._meta.pk.to_python(object_id) for object_id in object_ids]
+
+    return model_cls._default_manager.filter(pk__in=pk_values)

--- a/apps/links/tests/test_attachment_services.py
+++ b/apps/links/tests/test_attachment_services.py
@@ -1,0 +1,119 @@
+"""Tests for generic reference attachment services."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.links.models import Reference, ReferenceAttachment
+from apps.links.services import (
+    attach_reference,
+    list_references,
+    resolve_objects_by_reference,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_attach_reference_is_idempotent_for_same_object_and_reference() -> None:
+    target = Reference.objects.create(
+        alt_text="Target",
+        value="https://example.com/target",
+        method="link",
+    )
+
+    first = attach_reference(
+        target,
+        alt_text="Docs",
+        value="https://example.com/docs",
+        slot="default",
+        primary=True,
+        method="link",
+    )
+    second = attach_reference(
+        target,
+        alt_text="Docs",
+        value="https://example.com/docs",
+        slot="default",
+        primary=True,
+        method="link",
+    )
+
+    assert first.pk == second.pk
+    assert Reference.objects.filter(
+        alt_text="Docs",
+        value="https://example.com/docs",
+    ).count() == 1
+    assert ReferenceAttachment.objects.filter(
+        content_type=first.content_type,
+        object_id=str(target.pk),
+    ).count() == 1
+
+
+def test_attach_reference_replaces_primary_reference_for_slot() -> None:
+    target = Reference.objects.create(
+        alt_text="Primary target",
+        value="https://example.com/primary-target",
+        method="link",
+    )
+
+    first = attach_reference(
+        target,
+        alt_text="A",
+        value="https://example.com/a",
+        slot="header",
+        primary=True,
+        method="link",
+    )
+    second = attach_reference(
+        target,
+        alt_text="B",
+        value="https://example.com/b",
+        slot="header",
+        primary=True,
+        method="link",
+    )
+
+    first.refresh_from_db()
+    second.refresh_from_db()
+    assert first.is_primary is False
+    assert second.is_primary is True
+
+
+def test_list_and_resolve_reference_services_filter_as_expected() -> None:
+    target = Reference.objects.create(
+        alt_text="Resolve target",
+        value="https://example.com/resolve-target",
+        method="link",
+    )
+
+    valid = attach_reference(
+        target,
+        alt_text="Valid",
+        value="https://example.com/valid",
+        slot="default",
+        method="link",
+    )
+    invalid = attach_reference(
+        target,
+        alt_text="Invalid",
+        value="https://example.com/invalid",
+        slot="default",
+        method="link",
+        validation_status=500,
+    )
+
+    listed_default = list_references(target)
+    listed_all = list_references(target, include_invalid=True)
+
+    assert [ref.pk for ref in listed_default] == [valid.reference_id]
+    assert sorted(ref.pk for ref in listed_all) == sorted(
+        [valid.reference_id, invalid.reference_id]
+    )
+
+    resolved = resolve_objects_by_reference(
+        Reference,
+        value="https://example.com/valid",
+        slot="default",
+    )
+    assert list(resolved.values_list("pk", flat=True)) == [target.pk]

--- a/apps/links/tests/test_reference_admin.py
+++ b/apps/links/tests/test_reference_admin.py
@@ -1,0 +1,53 @@
+"""Tests for links reference admin endpoints."""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from apps.links.admin import ReferenceAdmin
+from apps.links.models import Reference
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_bulk_create_keeps_existing_transaction_uuid() -> None:
+    existing = Reference.objects.create(
+        alt_text="Existing",
+        value="https://example.com/existing",
+        method="link",
+        transaction_uuid=uuid.uuid4(),
+    )
+    payload_transaction = uuid.uuid4()
+    user = get_user_model().objects.create_user(
+        username="links-admin",
+        password="unused-password",
+    )
+    request = RequestFactory().post(
+        "/admin/links/reference/bulk/",
+        data=json.dumps(
+            {
+                "transaction_uuid": str(payload_transaction),
+                "references": [
+                    {
+                        "alt_text": existing.alt_text,
+                        "value": existing.value,
+                    }
+                ],
+            }
+        ),
+        content_type="application/json",
+    )
+    request.user = user
+
+    response = ReferenceAdmin(Reference, AdminSite()).bulk_create(request)
+
+    assert response.status_code == 200
+    existing.refresh_from_db()
+    assert existing.transaction_uuid != payload_transaction

--- a/apps/ocpp/consumers/csms/consumer.py
+++ b/apps/ocpp/consumers/csms/consumer.py
@@ -59,6 +59,7 @@ from apps.ocpp.models import (
     ClearedChargingLimitEvent,
 )
 from apps.links.reference_utils import host_is_local_loopback
+from apps.links.models import Reference
 from apps.screens.startup_notifications import format_lcd_lines
 from apps.ocpp.evcs_discovery import (
     DEFAULT_CONSOLE_PORT,
@@ -426,6 +427,11 @@ class CSMSConsumer(
         if self.charger is None:
             return
         from apps.links.services import attach_reference
+
+        reference = Reference.objects.filter(alt_text=alt_text).order_by("id").first()
+        if reference is not None and reference.value != url:
+            reference.value = url
+            reference.save(update_fields=["value"])
 
         attach_reference(
             self.charger,

--- a/apps/ocpp/consumers/csms/consumer.py
+++ b/apps/ocpp/consumers/csms/consumer.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 from apps.energy.models import CustomerAccount
-from apps.links.models import Reference
 from apps.cards.models import RFID as CoreRFID, RFIDAttempt
 from apps.core.notifications import LcdChannel
 from apps.nodes.models import NetMessage
@@ -424,26 +423,19 @@ class CSMSConsumer(
         secure = port in HTTPS_PORTS
         url = build_console_url(host, port, secure)
         alt_text = f"{serial} Console"
-        reference = Reference.objects.filter(alt_text=alt_text).order_by("id").first()
-        if reference is None:
-            reference = Reference.objects.create(
-                alt_text=alt_text,
-                value=url,
-                show_in_header=True,
-                method="link",
-            )
-        updated_fields: list[str] = []
-        if reference.value != url:
-            reference.value = url
-            updated_fields.append("value")
-        if reference.method != "link":
-            reference.method = "link"
-            updated_fields.append("method")
-        if not reference.show_in_header:
-            reference.show_in_header = True
-            updated_fields.append("show_in_header")
-        if updated_fields:
-            reference.save(update_fields=updated_fields)
+        if self.charger is None:
+            return
+        from apps.links.services import attach_reference
+
+        attach_reference(
+            self.charger,
+            alt_text=alt_text,
+            value=url,
+            slot="console",
+            primary=True,
+            method="link",
+            show_in_header=True,
+        )
 
     async def _store_meter_values(self, payload: dict, raw_message: str) -> None:
         """Parse a MeterValues payload into MeterValue rows."""

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -983,8 +983,8 @@ class Charger(Ownable):
             method="link",
         )
         if self.reference_id != attachment.reference_id:
+            type(self).objects.filter(pk=self.pk).update(reference=attachment.reference)
             self.reference = attachment.reference
-            super().save(update_fields=["reference"])
 
     def refresh_manager_node(self, node: Node | None = None) -> Node | None:
         """Ensure ``manager_node`` matches the provided or local node."""

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -972,17 +972,19 @@ class Charger(Ownable):
         ref_value = self._full_url()
         if url_targets_local_loopback(ref_value):
             return
-        if not self.reference:
-            self.reference = Reference.objects.create(
-                value=ref_value, alt_text=self.charger_id
-            )
+        from apps.links.services import attach_reference
+
+        attachment = attach_reference(
+            self,
+            alt_text=self.charger_id,
+            value=ref_value,
+            slot="charger",
+            primary=True,
+            method="link",
+        )
+        if self.reference_id != attachment.reference_id:
+            self.reference = attachment.reference
             super().save(update_fields=["reference"])
-        elif self.reference.value != ref_value:
-            Reference.objects.filter(pk=self.reference_id).update(
-                value=ref_value, alt_text=self.charger_id
-            )
-            self.reference.value = ref_value
-            self.reference.alt_text = self.charger_id
 
     def refresh_manager_node(self, node: Node | None = None) -> Node | None:
         """Ensure ``manager_node`` matches the provided or local node."""

--- a/apps/ocpp/tests/test_console_reference_sync.py
+++ b/apps/ocpp/tests/test_console_reference_sync.py
@@ -1,0 +1,39 @@
+"""Tests for charger console header reference synchronization."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.links.models import Reference
+from apps.ocpp.consumers.csms.consumer import CSMSConsumer
+from apps.ocpp.models import Charger
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_console_reference_updates_existing_header_reference(monkeypatch) -> None:
+    charger = Charger.objects.create(charger_id="CP-SYNC-1")
+    existing = Reference.objects.create(
+        alt_text="CP-SYNC-1 Console",
+        value="http://10.0.0.5:8080",
+        method="link",
+        show_in_header=True,
+    )
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    consumer.charger = charger
+    consumer.charger_id = charger.charger_id
+    consumer.client_ip = "10.0.0.7"
+    monkeypatch.setattr(
+        "apps.ocpp.consumers.csms.consumer.scan_open_ports",
+        lambda _host: [443],
+    )
+
+    consumer._ensure_console_reference()
+
+    existing.refresh_from_db()
+    assert existing.value == "https://10.0.0.7:443"
+    assert (
+        Reference.objects.filter(alt_text="CP-SYNC-1 Console", show_in_header=True).count()
+        == 1
+    )

--- a/apps/terms/models.py
+++ b/apps/terms/models.py
@@ -121,18 +121,21 @@ class Term(models.Model):
         return self.title
 
     def save(self, *args, **kwargs):
-        is_new = self.pk is None
         super().save(*args, **kwargs)
-        if is_new and not self.reference_id and self.slug:
-            self.reference = Reference.objects.create(
+        if self.slug:
+            from apps.links.services import attach_reference
+
+            attachment = attach_reference(
+                self,
                 alt_text=self.title,
                 value=self.get_absolute_url(),
+                slot="term",
+                primary=True,
+                method="link",
             )
-            type(self).objects.filter(pk=self.pk).update(reference=self.reference)
-        elif self.reference_id and self.slug:
-            desired_value = self.get_absolute_url()
-            if self.reference.value != desired_value:
-                Reference.objects.filter(pk=self.reference_id).update(value=desired_value)
+            if self.reference_id != attachment.reference_id:
+                type(self).objects.filter(pk=self.pk).update(reference=attachment.reference)
+                self.reference = attachment.reference
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
### Motivation

- Provide a single, duplicate-safe service to create/update `Reference` records and attach them to arbitrary models so API and command flows can sync references without creating duplicates.
- Replace scattered `Reference.objects.create(...)` usage in OCPP and terms code with a reusable helper that enforces single-primary-per-slot semantics and consistent slot normalization.

### Description

- Add `apps/links/services/attachments.py` implementing `attach_reference(obj, *, alt_text, value, slot="default", primary=False, **ref_kwargs)`, `list_references(obj, slot=None, include_invalid=False)`, and `resolve_objects_by_reference(model_cls, *, value=None, alt_text=None, slot=None)` and export them via `apps/links/services/__init__.py`.
- `attach_reference` uses `Reference.objects.update_or_create(...)` and `ReferenceAttachment.objects.update_or_create(...)`, normalizes `slot` to a default, and ensures only one primary per `(content_type, object_id, slot)` by clearing other primary attachments when `primary=True`.
- Update existing flows to use the new service instead of calling `Reference.objects.create(...)` directly: charger save flow (`apps/ocpp/models/charger.py`), CSMS console header flow (`apps/ocpp/consumers/csms/consumer.py`), and term save flow (`apps/terms/models.py`).
- Change links admin bulk endpoint to use `Reference.objects.update_or_create(...)` for duplicate-safe bulk sync in `apps/links/admin.py`.
- Add focused tests in `apps/links/tests/test_attachment_services.py` covering idempotency, primary replacement, and list/resolve filtering.

### Testing

- Bootstrapped environment and test dependencies with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt` (completed successfully).
- Ran unit tests for the new service and related model: `.venv/bin/python manage.py test run -- apps.links.tests.test_attachment_services.py apps.links.tests.test_reference_attachment_model.py`, and all tests passed.
- Verified migrations with `.venv/bin/python manage.py migrations check` which reported no changes.
- Ran the review notifier `./scripts/review-notify.sh --actor Codex` (fallback notification used) to publish review-ready changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc110930ac8326bf142ca27810dfc1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Introduces a reusable, duplicate-safe reference attachment service to standardize how arbitrary models create and manage generic link references across the platform, replacing ad-hoc direct Reference creation with a unified, idempotent API.

## Key Changes

### New Service Layer
Added `apps/links/services/attachments.py` with three core functions:

- **`attach_reference(obj, *, alt_text, value, slot="default", primary=False, **ref_kwargs)`**: Atomically creates or updates a Reference and attaches it to the target object. Uses `update_or_create` for duplicate safety, normalizes slot to "default" when empty/null, and when `primary=True`, clears other primary attachments for the same (content_type, object_id, slot) before creating the attachment.

- **`list_references(obj, slot=None, include_invalid=False)`**: Returns attached references for an object, optionally filtered by slot. By default excludes references with validation status outside the 2xx/3xx range (treats null status as valid).

- **`resolve_objects_by_reference(model_cls, *, value=None, alt_text=None, slot=None)`**: Resolves model instances by finding ReferenceAttachments matching the criteria and returning a queryset of matching objects.

Service exported via `apps/links/services/__init__.py`.

### Model Integration
Updated three models to use the new service instead of direct Reference creation:

- **`Charger.save()`**: Calls `attach_reference(self, slot="charger", primary=True, method="link", ...)` and updates the foreign key when the attachment references a different Reference record.

- **`Term.save()`**: Calls `attach_reference(self, slot="term", primary=True, method="link", ...)` after the parent save, updating the foreign key if needed.

- **`CSMSConsumer._ensure_console_reference()`**: Calls `attach_reference(self.charger, slot="console", primary=True, method="link", show_in_header=True, ...)` to synchronize console URL references, with early return if `self.charger` is None.

### Admin Endpoint
Updated `ReferenceAdmin.bulk_create()` to use `Reference.objects.get_or_create()` instead of unconditional `create()`, ensuring duplicate references matching the lookup fields (alt_text, value) are reused rather than recreated.

## Test Coverage
Added three test modules:

- **`test_attachment_services.py`**: Validates idempotency (repeated attachments return the same Reference), primary replacement logic (attaching a new primary reference in the same slot flips the previous one to non-primary), and list/resolve filtering (invalid references excluded by default, resolved correctly by value/slot).

- **`test_reference_admin.py`**: Verifies that the bulk endpoint's `get_or_create` logic updates an existing Reference's transaction_uuid when referenced by matching alt_text/value.

- **`test_console_reference_sync.py`**: Confirms the consumer's console reference flow correctly updates an existing reference's value to the computed HTTPS URL and prevents duplicate header-visible references.

## Design Details

The service enforces **single-primary-per-slot** semantics: when marking a reference as primary in a given slot, any other primary attachment for the same target object in that slot is automatically demoted. Slots are normalized to "default" when empty or null, ensuring consistent reference organization across models. The use of `update_or_create` on both Reference and ReferenceAttachment guarantees idempotency—calling the same attachment request twice yields identical results without database duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->