### PR TITLE
ocpp-simulator: restore Mobility House default backend fallback and add run report

### DIFF
--- a/apps/ocpp/tests/test_simulator_runtime_backend_selection.py
+++ b/apps/ocpp/tests/test_simulator_runtime_backend_selection.py
@@ -132,3 +132,24 @@ def test_backend_selection_flags_backend_available_when_arthexis_enabled(
     assert selection.backend == "legacy"
     assert selection.feature_enabled is True
 
+
+def test_backend_selection_defaults_enable_mobilityhouse_parameter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selection should default Mobility House parameter to enabled when unset."""
+
+    monkeypatch.setattr(
+        simulator_runtime,
+        "get_feature_parameter",
+        _mock_feature_parameters(
+            {
+                simulator_runtime.ARTHEXIS_BACKEND_PARAMETER_KEY: "disabled",
+            }
+        ),
+    )
+    monkeypatch.setattr(simulator_runtime, "find_spec", lambda _: object())
+
+    selection = simulator_runtime.resolve_simulator_backend()
+
+    assert selection.use_mobility_house is True
+    assert selection.backend == "mobility_house"

--- a/apps/simulators/simulator_runtime.py
+++ b/apps/simulators/simulator_runtime.py
@@ -255,7 +255,7 @@ def get_simulator_backend_choices() -> tuple[tuple[str, str], ...]:
         choices.append((ARTHEXIS_BACKEND, ARTHEXIS_BACKEND))
     if _is_simulator_backend_parameter_enabled(
         MOBILITY_HOUSE_BACKEND_PARAMETER_KEY,
-        default=False,
+        default=True,
     ):
         choices.append((MOBILITY_HOUSE_BACKEND, MOBILITY_HOUSE_BACKEND))
     return tuple(choices)
@@ -272,7 +272,7 @@ def resolve_simulator_backend(
     )
     mobility_house_enabled = _is_simulator_backend_parameter_enabled(
         MOBILITY_HOUSE_BACKEND_PARAMETER_KEY,
-        default=False,
+        default=True,
     )
     dependency_available = find_spec("ocpp") is not None
     backend_available = arthexis_enabled or (

--- a/docs/operations/mobilityhouse-simulator-run-report-2026-04-13.md
+++ b/docs/operations/mobilityhouse-simulator-run-report-2026-04-13.md
@@ -1,0 +1,70 @@
+# Mobility House simulator run report (2026-04-13)
+
+## Scope
+
+Run the Mobility House simulator against the Arthexis charge point WebSocket endpoint, fix issues encountered during execution, and capture the reproducible process/results.
+
+## Environment
+
+- Repo: `arthexis`
+- Date: 2026-04-13 (UTC)
+- Python env: `.venv`
+- Web server target: `ws://127.0.0.1:8000/ocpp/c/CP2`
+- Simulator slot: `1`
+- Backend: `mobilityhouse`
+
+## Process
+
+1. Refreshed dependencies with `./env-refresh.sh --deps-only`.
+2. Attempted to run simulator command with Mobility House backend.
+3. Hit backend selection failure:
+   - `CommandError: Unsupported backend 'mobilityhouse'. Enabled backends: arthexis`
+4. Investigated simulator backend selection and found Mobility House fallback defaulted to disabled in runtime selection logic when feature metadata is unset.
+5. Fixed runtime defaults so Mobility House matches feature parameter defaults (`enabled`) when explicit metadata is absent.
+6. Added regression coverage to protect the default behavior.
+7. Installed optional `ocpp` dependency required by Mobility House runtime: `.venv/bin/pip install ocpp==0.26.0`.
+8. Ran DB migrations (`.venv/bin/python manage.py migrate`) so suite feature/runtime tables exist.
+9. Started Django ASGI dev server and ran simulator against charge point socket target.
+10. Captured simulator status/log evidence.
+
+## Code changes made
+
+- `apps/simulators/simulator_runtime.py`
+  - Changed `mobilityhouse_backend` fallback default from disabled to enabled in:
+    - `get_simulator_backend_choices`
+    - `resolve_simulator_backend`
+- `apps/ocpp/tests/test_simulator_runtime_backend_selection.py`
+  - Added `test_backend_selection_defaults_enable_mobilityhouse_parameter`.
+
+## Commands used
+
+```bash
+./env-refresh.sh --deps-only
+.venv/bin/pip install ocpp==0.26.0
+.venv/bin/python manage.py migrate
+.venv/bin/python manage.py runserver 127.0.0.1:8000
+.venv/bin/python manage.py feature ocpp-simulator --disabled
+.venv/bin/python manage.py simulator stop --slot 1
+.venv/bin/python manage.py simulator start --slot 1 --host 127.0.0.1 --ws-port 8000 --cp-path ocpp/c/CP2 --serial-number CP2 --backend mobilityhouse --duration 15 --interval 2 --meter-interval 2 --allow-private-network
+.venv/bin/python manage.py simulator status --slot 1
+```
+
+## Result
+
+- Simulator startup command succeeded with `Connection accepted`.
+- Status confirms running simulator with backend `mobilityhouse` and WebSocket target settings.
+- Log file written at `logs/simulator.ocpp_c_CP2.log` with successful connection and BootNotification transmission.
+
+Example observed log lines:
+
+- `Connected (subprotocol=ocpp1.6j)`
+- `> [2, "boot-1", "BootNotification", ...]`
+
+## Notes
+
+- When the suite feature `ocpp-simulator` is enabled, starts are queued to `cpsim-service` rather than run inline. For direct CLI runtime in this environment, disabling that feature was used during verification.
+- After verification, re-enable service mode if desired:
+
+```bash
+.venv/bin/python manage.py feature ocpp-simulator --enabled
+```


### PR DESCRIPTION
### Motivation
- Running the Mobility House EVCS simulator with `--backend mobilityhouse` failed because runtime backend selection treated the Mobility House parameter as disabled when feature metadata was unset, contradicting feature parameter definitions.
- The change aligns runtime defaults with the suite feature parameter defaults so the Mobility House backend is selectable and behaves predictably when parameters are absent.

### Description
- In `apps/simulators/simulator_runtime.py` changed the `mobilityhouse_backend` fallback default from `False` to `True` in `get_simulator_backend_choices` and `resolve_simulator_backend` so Mobility House is enabled by default when metadata is unset.
- Added a regression test `test_backend_selection_defaults_enable_mobilityhouse_parameter` to `apps/ocpp/tests/test_simulator_runtime_backend_selection.py` to lock in the expected default behavior.
- Added an operations run report `docs/operations/mobilityhouse-simulator-run-report-2026-04-13.md` documenting the reproducible run, issue, fix, and observed simulator logs.

### Testing
- Ran the backend-selection and simulator command tests via `manage.py test run -- apps/ocpp/tests/test_simulator_runtime_backend_selection.py apps/ocpp/tests/test_simulator_command.py` and all tests passed (`11 passed`).
- The Mobility House simulator was executed end-to-end against the local charge-point WebSocket and produced `Connection accepted`, with simulator logs showing `Connected (subprotocol=ocpp1.6j)` and the `BootNotification` frame, validating the runtime fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf4353928832692468cb9a29ee386)