### PR TITLE
ocpp: switch certificate status transport to retry session

### DIFF
--- a/apps/ocpp/services/certificate_status.py
+++ b/apps/ocpp/services/certificate_status.py
@@ -4,8 +4,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-import requests
 from django.conf import settings
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from apps.ocpp.models import InstalledCertificate
 from apps.ocpp.payload_types import CertificateHashData, OCSPResultPayload
@@ -209,39 +211,52 @@ def _request_with_retry(
         max_retries = 0
 
     method_name = method.strip().lower()
-    last_error = "No response."
-    attempts = max_retries + 1
+    if method_name not in {"get", "post"}:
+        return {}, f"Unsupported method '{method_name}'."
 
-    for _ in range(attempts):
-        try:
-            if method_name == "post":
-                response = requests.post(url, json=payload, timeout=timeout_seconds)
-            elif method_name == "get":
-                response = requests.get(url, params=payload, timeout=timeout_seconds)
-            else:
-                return {}, f"Unsupported method '{method_name}'."
-        except requests.Timeout:
-            last_error = "Request timed out."
-            continue
-        except requests.RequestException as exc:
-            last_error = str(exc) or "Responder request failed."
-            continue
+    retry_policy = Retry(
+        total=max_retries,
+        connect=max_retries,
+        read=max_retries,
+        status=max_retries,
+        allowed_methods={"GET", "POST"},
+        backoff_factor=0.1,
+        status_forcelist=tuple(range(400, 600)),
+        raise_on_status=False,
+        respect_retry_after_header=True,
+    )
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry_policy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
 
-        try:
-            data = response.json()
-        except ValueError:
-            return {}, "Responder returned invalid JSON."
+    request_kwargs: dict[str, Any] = {"timeout": timeout_seconds}
+    if method_name == "post":
+        request_kwargs["json"] = payload
+    else:
+        request_kwargs["params"] = payload
 
-        if response.status_code >= 400:
-            error_detail = data.get("error") if isinstance(data, dict) else ""
-            last_error = str(error_detail).strip() or f"HTTP {response.status_code}"
-            continue
+    try:
+        response = session.request(method_name, url, **request_kwargs)
+    except requests.Timeout:
+        return {}, "Request timed out."
+    except requests.RequestException as exc:
+        return {}, str(exc) or "Responder request failed."
+    finally:
+        session.close()
 
-        if isinstance(data, dict):
-            return data, ""
-        return {}, "Responder returned invalid payload."
+    try:
+        data = response.json()
+    except ValueError:
+        return {}, "Responder returned invalid JSON."
 
-    return {}, last_error
+    if response.status_code >= 400:
+        error_detail = data.get("error") if isinstance(data, dict) else ""
+        return {}, str(error_detail).strip() or f"HTTP {response.status_code}"
+
+    if isinstance(data, dict):
+        return data, ""
+    return {}, "Responder returned invalid payload."
 
 
 def _structured_ocsp_result(

--- a/apps/ocpp/tests/test_certificate_status_service.py
+++ b/apps/ocpp/tests/test_certificate_status_service.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from django.test import override_settings
+
+from apps.ocpp.services import certificate_status
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, payload=None, json_error: Exception | None = None):
+        self.status_code = status_code
+        self._payload = payload
+        self._json_error = json_error
+
+    def json(self):
+        if self._json_error is not None:
+            raise self._json_error
+        return self._payload
+
+
+class _FakeSession:
+    last_instance = None
+
+    def __init__(self, response=None, request_error: Exception | None = None):
+        self.mounted: dict[str, object] = {}
+        self.request_calls: list[tuple[str, str, dict[str, object]]] = []
+        self._response = response
+        self._request_error = request_error
+        _FakeSession.last_instance = self
+
+    def mount(self, prefix: str, adapter: object) -> None:
+        self.mounted[prefix] = adapter
+
+    def request(self, method: str, url: str, **kwargs):
+        self.request_calls.append((method, url, kwargs))
+        if self._request_error is not None:
+            raise self._request_error
+        return self._response
+
+    def close(self):
+        return None
+
+
+@override_settings(OCPP_CERT_STATUS_TIMEOUT_SECONDS=9, OCPP_CERT_STATUS_RETRIES=4)
+def test_request_with_retry_uses_configured_retry_session(monkeypatch):
+    expected_response = _FakeResponse(status_code=200, payload={"status": "good"})
+    monkeypatch.setattr(
+        certificate_status.requests,
+        "Session",
+        lambda: _FakeSession(response=expected_response),
+    )
+
+    payload, error = certificate_status._request_with_retry(
+        method="post",
+        url="https://ocsp.example.test/status",
+        payload={"certificateHashData": {"serialNumber": "AA"}},
+    )
+
+    assert error == ""
+    assert payload == {"status": "good"}
+
+    session = _FakeSession.last_instance
+    assert session is not None
+    assert session.request_calls[0][0] == "post"
+    assert session.request_calls[0][2]["timeout"] == 9
+    https_adapter = session.mounted["https://"]
+    retry = https_adapter.max_retries
+    assert retry.total == 4
+    assert retry.connect == 4
+    assert retry.read == 4
+    assert retry.status == 4
+
+
+@override_settings(OCPP_CERT_STATUS_OCSP_URL="https://ocsp.example.test/status")
+def test_check_ocsp_timeout_path_is_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        certificate_status.requests,
+        "Session",
+        lambda: _FakeSession(request_error=certificate_status.requests.Timeout("timed out")),
+    )
+
+    ocsp_data, ocsp_error = certificate_status._check_ocsp(
+        {
+            "hashAlgorithm": "SHA256",
+            "issuerKeyHash": "def",
+            "issuerNameHash": "abc",
+            "serialNumber": "AA",
+        }
+    )
+
+    assert ocsp_data["status"] == "unknown"
+    assert ocsp_data["responderUrl"] == "https://ocsp.example.test/status"
+    assert ocsp_data["errors"]
+    assert "OCSP responder unavailable: Request timed out." == ocsp_error
+
+
+@override_settings(OCPP_CERT_STATUS_OCSP_URL="https://ocsp.example.test/status")
+def test_check_ocsp_http_error_path_is_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        certificate_status.requests,
+        "Session",
+        lambda: _FakeSession(
+            response=_FakeResponse(
+                status_code=503,
+                payload={"error": "upstream unavailable"},
+            )
+        ),
+    )
+
+    _ocsp_data, ocsp_error = certificate_status._check_ocsp(
+        {
+            "hashAlgorithm": "SHA256",
+            "issuerKeyHash": "def",
+            "issuerNameHash": "abc",
+            "serialNumber": "AA",
+        }
+    )
+
+    assert ocsp_error == "OCSP responder unavailable: upstream unavailable"
+
+
+@override_settings(OCPP_CERT_STATUS_CRL_URL="https://crl.example.test/status")
+def test_check_crl_invalid_json_path_is_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        certificate_status.requests,
+        "Session",
+        lambda: _FakeSession(
+            response=_FakeResponse(status_code=200, json_error=ValueError("invalid json"))
+        ),
+    )
+
+    revoked, crl_error = certificate_status._check_crl(
+        {
+            "hashAlgorithm": "SHA256",
+            "issuerKeyHash": "def",
+            "issuerNameHash": "abc",
+            "serialNumber": "AA",
+        }
+    )
+
+    assert revoked is False
+    assert crl_error == "CRL responder unavailable: Responder returned invalid JSON."

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -930,11 +930,17 @@ async def test_get_certificate_status_marks_revoked_when_ocsp_revoked(monkeypatc
                 "errors": [],
             }
 
-    monkeypatch.setattr(
-        consumers_base.certificate_status.requests,
-        "post",
-        lambda *_args, **_kwargs: FakeResponse(),
-    )
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            return None
+
+        def request(self, *_args, **_kwargs):
+            return FakeResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(consumers_base.certificate_status.requests, "Session", FakeSession)
 
     result = await consumer._handle_get_certificate_status_action(
         {"certificateHashData": hash_data}, "msg-ocsp-rev", "", ""
@@ -979,7 +985,17 @@ async def test_get_certificate_status_ocsp_timeout_uses_responder_unavailable(mo
     def _raise_timeout(*_args, **_kwargs):
         raise consumers_base.certificate_status.requests.Timeout("timed out")
 
-    monkeypatch.setattr(consumers_base.certificate_status.requests, "post", _raise_timeout)
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            return None
+
+        def request(self, *_args, **_kwargs):
+            return _raise_timeout()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(consumers_base.certificate_status.requests, "Session", FakeSession)
 
     result = await consumer._handle_get_certificate_status_action(
         {"certificateHashData": hash_data}, "msg-ocsp-timeout", "", ""
@@ -1025,7 +1041,17 @@ async def test_get_certificate_status_ocsp_timeout_fail_open_accepts(monkeypatch
     def _raise_timeout(*_args, **_kwargs):
         raise consumers_base.certificate_status.requests.Timeout("timed out")
 
-    monkeypatch.setattr(consumers_base.certificate_status.requests, "post", _raise_timeout)
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            return None
+
+        def request(self, *_args, **_kwargs):
+            return _raise_timeout()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(consumers_base.certificate_status.requests, "Session", FakeSession)
 
     result = await consumer._handle_get_certificate_status_action(
         {"certificateHashData": hash_data}, "msg-ocsp-open", "", ""
@@ -1073,11 +1099,17 @@ async def test_get_certificate_status_invalid_crl_payload_is_responder_unavailab
         def json():
             return {"revokedSerialNumbers": "not-a-list"}
 
-    monkeypatch.setattr(
-        consumers_base.certificate_status.requests,
-        "get",
-        lambda *_args, **_kwargs: FakeCRLResponse(),
-    )
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            return None
+
+        def request(self, *_args, **_kwargs):
+            return FakeCRLResponse()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(consumers_base.certificate_status.requests, "Session", FakeSession)
 
     result = await consumer._handle_get_certificate_status_action(
         {"certificateHashData": hash_data}, "msg-crl-invalid", "", ""

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -55,6 +55,9 @@ JSONScalar: TypeAlias = str | int | float | bool | None
 JSONMapping: TypeAlias = dict[str, Any]
 JSONList: TypeAlias = list[Any]
 JSONValue: TypeAlias = JSONMapping | JSONList | JSONScalar
+RequestParamScalar: TypeAlias = str | bytes | int | float
+RequestParamValue: TypeAlias = RequestParamScalar | Iterable[RequestParamScalar] | None
+RequestParams: TypeAlias = Mapping[str, RequestParamValue]
 
 
 def build_headers(token: str, *, user_agent: str = "arthexis-admin") -> Mapping[str, str]:
@@ -238,12 +241,12 @@ def fetch_paginated_items(
     *,
     token: str,
     endpoint: str,
-    params: Mapping[str, object],
+    params: RequestParams,
     timeout: int = REQUEST_TIMEOUT,
 ) -> Iterator[Mapping[str, object]]:
     headers = build_headers(token)
     url = endpoint
-    query_params: Mapping[str, object] | None = params
+    query_params: RequestParams | None = params
 
     while url:
         response = None
@@ -284,7 +287,7 @@ def fetch_repository_issues(
     state: str = "open",
 ) -> Iterator[Mapping[str, object]]:
     endpoint = f"{API_ROOT}/repos/{owner}/{name}/issues"
-    params = {"state": state, "per_page": 100}
+    params: dict[str, RequestParamValue] = {"state": state, "per_page": 100}
     yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
 
 
@@ -296,7 +299,7 @@ def fetch_repository_pull_requests(
     state: str = "open",
 ) -> Iterator[Mapping[str, object]]:
     endpoint = f"{API_ROOT}/repos/{owner}/{name}/pulls"
-    params = {"state": state, "per_page": 100}
+    params: dict[str, RequestParamValue] = {"state": state, "per_page": 100}
     yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ ci = [
   "mypy==1.20.0",
   "ruff==0.15.9",
   "twine==6.1.0",
+  "types-requests==2.32.4.20250913",
 ]
 dev = [
   "django-debug-toolbar==6.3.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -87,6 +87,7 @@ trio==0.31.0
 twine==6.1.0
 Twisted==25.5.0
 txaio==25.9.2
+types-requests==2.32.4.20250913
 typing_extensions==4.15.0
 urllib3~=2.6.3
 webauthn==2.7.1


### PR DESCRIPTION
### Motivation

- Replace a manual retry loop in the certificate status transport with a configured HTTP client that provides standard retry/backoff semantics for robustness.
- Use existing configuration knobs for timeout and retry count so behavior remains controllable via settings.
- Preserve the existing OCSP/CRL response-shape and fail-open/fail-closed semantics while improving transport reliability.

### Description

- Replaced the internals of `_request_with_retry` with a `requests.Session` configured with `HTTPAdapter` and `urllib3.util.retry.Retry`, and imported those classes into `apps/ocpp/services/certificate_status.py`.
- Mapped `OCPP_CERT_STATUS_TIMEOUT_SECONDS` to the per-request `timeout` and `OCPP_CERT_STATUS_RETRIES` to the `Retry` policy (`total/connect/read/status`), with a small `backoff_factor` and `status_forcelist` configured.
- Kept `_check_ocsp` and `_check_crl` parsing and error-return shapes unchanged and only swapped the transport mechanics behind `_request_with_retry`.
- Added service-level tests in `apps/ocpp/tests/test_certificate_status_service.py` and updated `apps/ocpp/tests/test_ocpp_handlers.py` to mock `requests.Session` (instead of `requests.post/get`) to validate timeout, HTTP error, invalid JSON, and retry-session wiring.

### Testing

- Bootstrapped environment and dependencies with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt`.
- Ran the new service tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_certificate_status_service.py` and they passed (`4 passed`).
- Ran the focused handler tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp_handlers.py -k "certificate_status_marks_revoked_when_ocsp_revoked or certificate_status_ocsp_timeout or certificate_status_invalid_crl_payload"` and they passed (`4 passed`).
- Addressed an initial test failure (caused by tests still patching `requests.post/get`) by updating tests to patch `requests.Session`, after which the targeted tests and new service tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4380e5808326a204354081e33f0c)