### PR TITLE
reports: adopt HTML-to-PDF rendering with graceful fallback

### DIFF
--- a/apps/reports/services.py
+++ b/apps/reports/services.py
@@ -5,16 +5,18 @@ from dataclasses import dataclass
 from datetime import timedelta
 from time import perf_counter
 from typing import Any
+from urllib.parse import urlparse
 
-from django.core.exceptions import ValidationError
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.utils import timezone
 
 try:  # pragma: no cover - exercised through fallback behavior tests
-    from weasyprint import HTML
+    from weasyprint import HTML, default_url_fetcher
 except ImportError:  # pragma: no cover - optional dependency
     HTML = None
+    default_url_fetcher = None
 
 from .models import SQLReport, SQLReportProduct
 from .report_definitions import get_report_definition, report_catalog
@@ -217,7 +219,7 @@ def _render_pdf_bytes(rendered_html: str) -> bytes:
     """
 
     if not getattr(settings, "REPORTS_HTML_TO_PDF_ENABLED", True):
-        logger.info("Report PDF rendering disabled by REPORTS_HTML_TO_PDF_ENABLED")
+        logger.debug("Report PDF rendering disabled by REPORTS_HTML_TO_PDF_ENABLED")
         return b""
 
     if HTML is None:
@@ -225,7 +227,16 @@ def _render_pdf_bytes(rendered_html: str) -> bytes:
         return b""
 
     try:
-        return HTML(string=rendered_html).write_pdf()
+        return HTML(string=rendered_html, url_fetcher=_safe_report_url_fetcher).write_pdf()
     except (OSError, RuntimeError, ValueError) as exc:
         logger.warning("Report PDF rendering failed; returning empty PDF payload", exc_info=exc)
         return b""
+
+
+def _safe_report_url_fetcher(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Restrict WeasyPrint URL fetching to data URIs only."""
+
+    parsed = urlparse(url)
+    if parsed.scheme == "data" and default_url_fetcher is not None:
+        return default_url_fetcher(url, *args, **kwargs)
+    raise ValueError("External resource loading is disabled for report PDF rendering")

--- a/apps/reports/services.py
+++ b/apps/reports/services.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import timedelta
-from io import BytesIO
 from time import perf_counter
 from typing import Any
 
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.html import strip_tags
 
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
+try:  # pragma: no cover - exercised through fallback behavior tests
+    from weasyprint import HTML
+except ImportError:  # pragma: no cover - optional dependency
+    HTML = None
 
 from .models import SQLReport, SQLReportProduct
 from .report_definitions import get_report_definition, report_catalog
@@ -206,7 +207,7 @@ def run_due_scheduled_reports(now: timezone.datetime | None = None) -> int:
 
 
 def _render_pdf_bytes(rendered_html: str) -> bytes:
-    """Create a basic PDF document from rendered template text content.
+    """Render report HTML into PDF bytes using the configured HTML renderer.
 
     Parameters:
         rendered_html: Rendered HTML payload.
@@ -215,23 +216,16 @@ def _render_pdf_bytes(rendered_html: str) -> bytes:
         PDF bytes.
     """
 
-    stream = BytesIO()
-    pdf = canvas.Canvas(stream, pagesize=letter)
-    y = 760
+    if not getattr(settings, "REPORTS_HTML_TO_PDF_ENABLED", True):
+        logger.info("Report PDF rendering disabled by REPORTS_HTML_TO_PDF_ENABLED")
+        return b""
 
-    text_content = strip_tags(rendered_html)
+    if HTML is None:
+        logger.warning("Report PDF rendering unavailable: missing WeasyPrint dependency")
+        return b""
 
-    for line in text_content.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-
-        if y <= 60:
-            pdf.showPage()
-            y = 760
-
-        pdf.drawString(40, y, stripped[:140])
-        y -= 14
-
-    pdf.save()
-    return stream.getvalue()
+    try:
+        return HTML(string=rendered_html).write_pdf()
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("Report PDF rendering failed; returning empty PDF payload", exc_info=exc)
+        return b""

--- a/apps/reports/tests/test_services.py
+++ b/apps/reports/tests/test_services.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from apps.reports.models import SQLReport, SQLReportProduct
 from apps.reports.report_definitions import report_catalog
-from apps.reports.services import run_due_scheduled_reports, run_sql_report
+from apps.reports.services import _render_pdf_bytes, run_due_scheduled_reports, run_sql_report
 from apps.sigils.models import SigilRoot
 
 @pytest.mark.django_db
@@ -27,7 +27,7 @@ def test_run_named_report_generates_html_and_pdf_products():
     assert product is not None
     assert SQLReportProduct.objects.filter(report=report).count() == 1
     assert "Sigil catalog" in product.html_content
-    assert product.pdf_content
+    assert product.pdf_content is not None
     assert product.renderer_template_name == "reports/sql/sigil_roots.html"
 
     report.refresh_from_db()
@@ -132,3 +132,108 @@ def test_sigil_root_report_uses_orm_backed_results():
     assert product is not None
     assert result.row_count >= 1
     assert any(row[0] == "REPORT_NODE_TEST" for row in result.rows)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("report_type", "parameters"),
+    [
+        (
+            SQLReport.ReportType.REPORT_PRODUCT_ACTIVITY,
+            {"report_name_contains": "", "created_since": "", "limit": 10},
+        ),
+        (
+            SQLReport.ReportType.SCHEDULED_REPORTS,
+            {"schedule_state": "all", "name_contains": ""},
+        ),
+        (
+            SQLReport.ReportType.SIGIL_ROOTS,
+            {"context_type": "all"},
+        ),
+    ],
+)
+def test_catalog_templates_render_with_html_pdf_engine(monkeypatch, report_type, parameters):
+    """Catalog report templates should render as HTML tables before PDF conversion."""
+
+    captured_html: list[str] = []
+
+    class FakeHTML:
+        def __init__(self, string: str):
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"%PDF-fake"
+
+    monkeypatch.setattr("apps.reports.services.HTML", FakeHTML)
+
+    report = SQLReport.objects.create(
+        name=f"{report_type} report",
+        report_type=report_type,
+        parameters=parameters,
+    )
+
+    result, product = run_sql_report(report)
+
+    assert result.error is None
+    assert product is not None
+    assert product.pdf_content == b"%PDF-fake"
+    assert captured_html
+    assert "<table>" in captured_html[0]
+    assert "<th>" in captured_html[0]
+
+
+@pytest.mark.django_db
+def test_report_pdf_rendering_gracefully_degrades_when_engine_missing(monkeypatch):
+    """Missing HTML-to-PDF dependency should not fail report product generation."""
+
+    monkeypatch.setattr("apps.reports.services.HTML", None)
+    report = SQLReport.objects.create(
+        name="No engine",
+        report_type=SQLReport.ReportType.SIGIL_ROOTS,
+        parameters={"context_type": "all"},
+    )
+
+    result, product = run_sql_report(report)
+
+    assert result.error is None
+    assert product is not None
+    assert product.pdf_content == b""
+
+
+@pytest.mark.django_db
+def test_report_pdf_rendering_can_be_feature_flag_disabled(settings, monkeypatch):
+    """Feature flag should allow runtime opt-out of PDF rendering dependencies."""
+
+    class RaisingHTML:
+        def __init__(self, string: str):
+            raise AssertionError("HTML renderer should not be instantiated when disabled")
+
+    settings.REPORTS_HTML_TO_PDF_ENABLED = False
+    monkeypatch.setattr("apps.reports.services.HTML", RaisingHTML)
+
+    report = SQLReport.objects.create(
+        name="Disabled engine",
+        report_type=SQLReport.ReportType.SIGIL_ROOTS,
+        parameters={"context_type": "all"},
+    )
+
+    result, product = run_sql_report(report)
+
+    assert result.error is None
+    assert product is not None
+    assert product.pdf_content == b""
+
+
+def test_render_pdf_bytes_returns_empty_when_renderer_errors(monkeypatch):
+    """Renderer errors should degrade to empty PDF bytes instead of bubbling up."""
+
+    class FailingHTML:
+        def __init__(self, string: str):
+            pass
+
+        def write_pdf(self) -> bytes:
+            raise OSError("missing cairo libs")
+
+    monkeypatch.setattr("apps.reports.services.HTML", FailingHTML)
+
+    assert _render_pdf_bytes("<table><tr><td>x</td></tr></table>") == b""

--- a/apps/reports/tests/test_services.py
+++ b/apps/reports/tests/test_services.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
-
 import importlib
+from datetime import timedelta
 
 import pytest
 from django.apps import apps as django_apps
@@ -8,8 +7,13 @@ from django.utils import timezone
 
 from apps.reports.models import SQLReport, SQLReportProduct
 from apps.reports.report_definitions import report_catalog
-from apps.reports.services import _render_pdf_bytes, run_due_scheduled_reports, run_sql_report
+from apps.reports.services import (
+    _render_pdf_bytes,
+    run_due_scheduled_reports,
+    run_sql_report,
+)
 from apps.sigils.models import SigilRoot
+
 
 @pytest.mark.django_db
 def test_run_named_report_generates_html_and_pdf_products():
@@ -27,7 +31,7 @@ def test_run_named_report_generates_html_and_pdf_products():
     assert product is not None
     assert SQLReportProduct.objects.filter(report=report).count() == 1
     assert "Sigil catalog" in product.html_content
-    assert product.pdf_content is not None
+    assert product.pdf_content
     assert product.renderer_template_name == "reports/sql/sigil_roots.html"
 
     report.refresh_from_db()
@@ -158,8 +162,10 @@ def test_catalog_templates_render_with_html_pdf_engine(monkeypatch, report_type,
     captured_html: list[str] = []
 
     class FakeHTML:
-        def __init__(self, string: str):
+        def __init__(self, string: str, url_fetcher):
             captured_html.append(string)
+            with pytest.raises(ValueError, match="External resource loading is disabled"):
+                url_fetcher("https://example.com/image.png")
 
         def write_pdf(self) -> bytes:
             return b"%PDF-fake"
@@ -228,7 +234,7 @@ def test_render_pdf_bytes_returns_empty_when_renderer_errors(monkeypatch):
     """Renderer errors should degrade to empty PDF bytes instead of bubbling up."""
 
     class FailingHTML:
-        def __init__(self, string: str):
+        def __init__(self, string: str, url_fetcher):
             pass
 
         def write_pdf(self) -> bytes:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -61,6 +61,7 @@ HAS_DEBUG_TOOLBAR = DEBUG and importlib.util.find_spec("debug_toolbar") is not N
 NET_MESSAGE_DISABLE_PROPAGATION = env_bool("NET_MESSAGE_DISABLE_PROPAGATION", False)
 NODES_ENABLE_SIBLING_IPC = env_bool("NODES_ENABLE_SIBLING_IPC", False)
 ENABLE_USAGE_ANALYTICS = env_bool("ENABLE_USAGE_ANALYTICS", False)
+REPORTS_HTML_TO_PDF_ENABLED = env_bool("REPORTS_HTML_TO_PDF_ENABLED", True)
 ROUTE_PROVIDERS = [
     "apps.actions.routes",
     "apps.awg.routes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
   "urllib3~=2.6.3",
   "webauthn==2.7.1",
   "websocket-client==1.8.0",
+  "weasyprint==66.0",
   "websockets>=15,<17",
   "whitenoise==6.12.0",
 ]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -89,6 +89,7 @@ Twisted==25.5.0
 txaio==25.9.2
 typing_extensions==4.15.0
 urllib3~=2.6.3
+weasyprint==66.0
 webauthn==2.7.1
 websocket-client==1.8.0
 websockets>=15,<17

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ Twisted==25.5.0
 txaio==25.9.2
 typing_extensions==4.15.0
 urllib3~=2.6.3
+weasyprint==66.0
 webauthn==2.7.1
 websocket-client==1.8.0
 websockets>=15,<17


### PR DESCRIPTION
### Motivation
- Replace fragile text-stripping/ReportLab PDF generation with an HTML→PDF renderer so table-heavy report templates render faithfully.
- Preserve the existing `SQLReportProduct.pdf_content` storage contract while allowing environments without system PDF deps to degrade safely.
- Provide an operator/CI toggle so PDF rendering can be disabled in environments where the HTML-to-PDF engine or system libraries are unavailable.

### Description
- Replaced `_render_pdf_bytes` in `apps/reports/services.py` to use an HTML-to-PDF path backed by `weasyprint.HTML(string=...).write_pdf()` when available and enabled, and removed the `strip_tags`/manual pagination ReportLab implementation.
- Added an import fallback so missing `weasyprint` sets `HTML = None` and the service returns an empty PDF payload instead of raising, and added runtime feature flag `REPORTS_HTML_TO_PDF_ENABLED` to `config/settings/base.py` (default `True`).
- Kept the `render_report_product` output contract unchanged so `SQLReportProduct.pdf_content` is still written (now `b""` when rendering is disabled/missing/fails).
- Extended `apps/reports/tests/test_services.py` with tests that validate catalog templates render HTML tables via the HTML renderer path and that cover missing-dependency, feature-flag-disabled, and renderer-error fallbacks.

### Testing
- Bootstrapped deps with `./env-refresh.sh --deps-only` and installed CI extras with `.venv/bin/pip install -r requirements-ci.txt`.
- Ran the report service unit tests with `.venv/bin/python manage.py test run -- apps/reports/tests/test_services.py` and all tests passed (`12 passed`).
- Verified migrations with `.venv/bin/python manage.py migrations check` which reported no changes.
- Sent review notification via `./scripts/review-notify.sh --actor Codex` after making the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd44b6c5448326ae660768e54d79c0)