### PR TITLE
ci: add screenshot artifact verification checklist

### DIFF
--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -350,6 +350,12 @@ jobs:
             artifacts/*.png
             artifacts/README.md
 
+      - name: Verify screenshot artifacts checklist (pull requests)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          source .venv/bin/activate
+          python scripts/verify_screenshot_artifacts.py --artifacts-dir artifacts --report artifacts/screenshot-verification.md
+
       - name: Build PR screenshot comment body
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -386,6 +392,11 @@ jobs:
               ),
               "",
           ]
+
+          verification_report = Path("artifacts/screenshot-verification.md")
+          if verification_report.exists():
+              lines.append(verification_report.read_text(encoding="utf-8").strip())
+              lines.append("")
 
           if not images:
               lines.append("- ⚠️ No screenshots were produced in this run.")
@@ -493,6 +504,12 @@ jobs:
             --ready-selector "body" \
             "${capture_paths[@]}" \
             --output-dir artifacts
+
+      - name: Verify screenshot artifacts checklist (non-pull requests)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          source .venv/bin/activate
+          python scripts/verify_screenshot_artifacts.py --artifacts-dir artifacts --report artifacts/screenshot-verification.md
 
       - name: Upload public screenshot
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -352,12 +352,14 @@ jobs:
 
       - name: Verify screenshot artifacts checklist (pull requests)
         if: ${{ github.event_name == 'pull_request' }}
+        id: verify-pr-screenshot-artifacts
+        continue-on-error: true
         run: |
           source .venv/bin/activate
           python scripts/verify_screenshot_artifacts.py --artifacts-dir artifacts --report artifacts/screenshot-verification.md
 
       - name: Build PR screenshot comment body
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
         run: |
           source .venv/bin/activate
           python <<'PY'
@@ -425,7 +427,7 @@ jobs:
           PY
 
       - name: Upsert pull request screenshot comment
-        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -463,6 +465,10 @@ jobs:
               body,
             });
             core.info('Created screenshot preview comment.');
+
+      - name: Fail pull request build when screenshot verification fails
+        if: ${{ github.event_name == 'pull_request' && steps.verify-pr-screenshot-artifacts.outcome == 'failure' }}
+        run: exit 1
 
       - name: Capture public screenshot
         if: ${{ github.event_name != 'pull_request' }}

--- a/scripts/verify_screenshot_artifacts.py
+++ b/scripts/verify_screenshot_artifacts.py
@@ -32,9 +32,8 @@ def parse_expected_images(readme_path: Path) -> list[str]:
     return expected
 
 
-def detect_visual_blank(image_path: Path, stddev_floor: float) -> bool:
-    with Image.open(image_path) as image:
-        stat = ImageStat.Stat(image.convert("RGB"))
+def detect_visual_blank(image: Image.Image, stddev_floor: float) -> bool:
+    stat = ImageStat.Stat(image.convert("RGB"))
     return max(stat.stddev) < stddev_floor
 
 
@@ -77,22 +76,22 @@ def verify_artifacts(
         with Image.open(image_path) as image:
             width, height = image.size
 
-        if width < min_width or height < min_height:
-            issues.append(
-                VerificationIssue(
-                    image_path.name,
-                    f"Image dimensions are too small ({width}x{height} < {min_width}x{min_height}).",
+            if width < min_width or height < min_height:
+                issues.append(
+                    VerificationIssue(
+                        image_path.name,
+                        f"Image dimensions are too small ({width}x{height} < {min_width}x{min_height}).",
+                    )
                 )
-            )
-            continue
+                continue
 
-        if detect_visual_blank(image_path, stddev_floor):
-            issues.append(
-                VerificationIssue(
-                    image_path.name,
-                    "Image appears visually blank (near-zero color variance).",
+            if detect_visual_blank(image, stddev_floor):
+                issues.append(
+                    VerificationIssue(
+                        image_path.name,
+                        "Image appears visually blank (near-zero color variance).",
+                    )
                 )
-            )
 
     return issues, [path.name for path in images], expected
 
@@ -107,7 +106,7 @@ def write_report(
         "## Screenshot verification checklist",
         "",
         f"- {'✅' if artifact_names else '❌'} PNG artifacts found: `{len(artifact_names)}`",
-        f"- {'✅' if not expected or not any(i.filename in expected for i in issues) else '❌'} README-listed desktop screenshots present",
+        f"- {'✅' if not expected or all(name in artifact_names for name in expected) else '❌'} README-listed desktop screenshots present",
         f"- {'✅' if not any('dimensions' in i.reason for i in issues) else '❌'} Minimum dimensions check",
         f"- {'✅' if not any('too small' in i.reason for i in issues) else '❌'} Minimum file-size check",
         f"- {'✅' if not any('visually blank' in i.reason for i in issues) else '❌'} Non-blank image heuristic",

--- a/scripts/verify_screenshot_artifacts.py
+++ b/scripts/verify_screenshot_artifacts.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import Image, ImageStat
+
+
+@dataclass
+class VerificationIssue:
+    filename: str
+    reason: str
+
+
+def parse_expected_images(readme_path: Path) -> list[str]:
+    if not readme_path.exists():
+        return []
+
+    expected: list[str] = []
+    current_section = False
+    for raw_line in readme_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("## `") and line.endswith("`"):
+            current_section = True
+            continue
+        if not current_section or not line.startswith("- **desktop**: ["):
+            continue
+        link = line.split("[", maxsplit=1)[1].split("]", maxsplit=1)[0].strip()
+        expected.append(Path(link).name)
+    return expected
+
+
+def detect_visual_blank(image_path: Path, stddev_floor: float) -> bool:
+    with Image.open(image_path) as image:
+        stat = ImageStat.Stat(image.convert("RGB"))
+    return max(stat.stddev) < stddev_floor
+
+
+def verify_artifacts(
+    artifacts_dir: Path,
+    min_width: int,
+    min_height: int,
+    min_size_bytes: int,
+    stddev_floor: float,
+) -> tuple[list[VerificationIssue], list[str], list[str]]:
+    images = sorted(artifacts_dir.glob("*.png"))
+    issues: list[VerificationIssue] = []
+
+    if not images:
+        issues.append(VerificationIssue("(all)", "No screenshot PNG artifacts were produced."))
+        return issues, [], []
+
+    expected = parse_expected_images(artifacts_dir / "README.md")
+    if expected:
+        available = {path.name for path in images}
+        missing = sorted(name for name in expected if name not in available)
+        for filename in missing:
+            issues.append(
+                VerificationIssue(
+                    filename,
+                    "Listed in artifacts/README.md but missing from artifacts directory.",
+                )
+            )
+
+    for image_path in images:
+        if image_path.stat().st_size < min_size_bytes:
+            issues.append(
+                VerificationIssue(
+                    image_path.name,
+                    f"File is too small ({image_path.stat().st_size} bytes < {min_size_bytes} bytes).",
+                )
+            )
+            continue
+
+        with Image.open(image_path) as image:
+            width, height = image.size
+
+        if width < min_width or height < min_height:
+            issues.append(
+                VerificationIssue(
+                    image_path.name,
+                    f"Image dimensions are too small ({width}x{height} < {min_width}x{min_height}).",
+                )
+            )
+            continue
+
+        if detect_visual_blank(image_path, stddev_floor):
+            issues.append(
+                VerificationIssue(
+                    image_path.name,
+                    "Image appears visually blank (near-zero color variance).",
+                )
+            )
+
+    return issues, [path.name for path in images], expected
+
+
+def write_report(
+    report_path: Path,
+    artifact_names: list[str],
+    expected: list[str],
+    issues: list[VerificationIssue],
+) -> None:
+    lines = [
+        "## Screenshot verification checklist",
+        "",
+        f"- {'✅' if artifact_names else '❌'} PNG artifacts found: `{len(artifact_names)}`",
+        f"- {'✅' if not expected or not any(i.filename in expected for i in issues) else '❌'} README-listed desktop screenshots present",
+        f"- {'✅' if not any('dimensions' in i.reason for i in issues) else '❌'} Minimum dimensions check",
+        f"- {'✅' if not any('too small' in i.reason for i in issues) else '❌'} Minimum file-size check",
+        f"- {'✅' if not any('visually blank' in i.reason for i in issues) else '❌'} Non-blank image heuristic",
+        "",
+    ]
+
+    if issues:
+        lines.append("### Detected issues")
+        lines.append("")
+        for issue in issues:
+            lines.append(f"- ❌ `{issue.filename}`: {issue.reason}")
+    else:
+        lines.append("All checklist checks passed.")
+
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify generated screenshot artifacts in CI before publishing them to pull requests."
+    )
+    parser.add_argument("--artifacts-dir", default="artifacts")
+    parser.add_argument("--report", default="artifacts/screenshot-verification.md")
+    parser.add_argument("--min-width", type=int, default=320)
+    parser.add_argument("--min-height", type=int, default=240)
+    parser.add_argument("--min-size-bytes", type=int, default=8_000)
+    parser.add_argument("--stddev-floor", type=float, default=2.0)
+    args = parser.parse_args()
+
+    artifacts_dir = Path(args.artifacts_dir)
+    issues, artifact_names, expected = verify_artifacts(
+        artifacts_dir=artifacts_dir,
+        min_width=args.min_width,
+        min_height=args.min_height,
+        min_size_bytes=args.min_size_bytes,
+        stddev_floor=args.stddev_floor,
+    )
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    write_report(report_path, artifact_names, expected, issues)
+
+    print(report_path.read_text(encoding="utf-8"))
+
+    if issues:
+        print("\nScreenshot verification failed.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_screenshot_artifacts.py
+++ b/tests/test_verify_screenshot_artifacts.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from scripts.verify_screenshot_artifacts import verify_artifacts
+
+
+def _write_image(path: Path, *, size=(640, 360), color="white", text: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", size, color=color)
+    if text:
+        draw = ImageDraw.Draw(image)
+        draw.text((10, 10), text, fill="black")
+    image.save(path)
+
+
+def test_verify_artifacts_passes_for_realistic_preview(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    _write_image(artifacts / "admin-desktop.png", text="Admin dashboard")
+
+    (artifacts / "README.md").write_text(
+        "\n".join(
+            [
+                "## `/admin/`",
+                "- **desktop**: [admin-desktop.png](admin-desktop.png)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    issues, artifact_names, expected = verify_artifacts(
+        artifacts,
+        min_width=320,
+        min_height=240,
+        min_size_bytes=500,
+        stddev_floor=1.0,
+    )
+
+    assert issues == []
+    assert artifact_names == ["admin-desktop.png"]
+    assert expected == ["admin-desktop.png"]
+
+
+def test_verify_artifacts_flags_blank_or_tiny_outputs(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    _write_image(artifacts / "blank.png", size=(640, 360), color="white")
+    _write_image(artifacts / "tiny.png", size=(80, 80), color="navy", text="x")
+
+    issues, *_ = verify_artifacts(
+        artifacts,
+        min_width=320,
+        min_height=240,
+        min_size_bytes=1,
+        stddev_floor=2.0,
+    )
+
+    reasons = "\n".join(issue.reason for issue in issues)
+    assert "visually blank" in reasons
+    assert "dimensions are too small" in reasons

--- a/tests/test_verify_screenshot_artifacts.py
+++ b/tests/test_verify_screenshot_artifacts.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from PIL import Image, ImageDraw
 
-from scripts.verify_screenshot_artifacts import verify_artifacts
+from scripts.verify_screenshot_artifacts import VerificationIssue, verify_artifacts, write_report
 
 
 def _write_image(path: Path, *, size=(640, 360), color="white", text: str | None = None) -> None:
@@ -57,3 +57,23 @@ def test_verify_artifacts_flags_blank_or_tiny_outputs(tmp_path):
     reasons = "\n".join(issue.reason for issue in issues)
     assert "visually blank" in reasons
     assert "dimensions are too small" in reasons
+
+
+def test_write_report_marks_readme_presence_from_artifacts_only(tmp_path):
+    report_path = tmp_path / "artifacts" / "screenshot-verification.md"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    write_report(
+        report_path=report_path,
+        artifact_names=["admin-desktop.png"],
+        expected=["admin-desktop.png"],
+        issues=[
+            VerificationIssue(
+                filename="admin-desktop.png",
+                reason="Image appears visually blank (near-zero color variance).",
+            )
+        ],
+    )
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "- ✅ README-listed desktop screenshots present" in report
+    assert "- ❌ Non-blank image heuristic" in report


### PR DESCRIPTION
### Motivation

- Detect early problems in the screenshot CI by validating generated screenshot artifacts before they are uploaded or posted to PRs.
- Provide immediate, human-readable signals in the PR comment so reviewers can spot missing, tiny, or blank previews without digging into workflow artifacts.

### Description

- Add `scripts/verify_screenshot_artifacts.py`, a small verifier that checks PNG artifact presence, README-to-artifact consistency, minimum dimensions, minimum file size, and a non-blank image heuristic (color variance), and emits a markdown report.
- Run the verifier from the screenshot workflow by adding steps in `.github/workflows/dashboard-screenshot.yml` for both pull-request and non-pull-request runs.
- Include the generated `artifacts/screenshot-verification.md` report in the PR screenshot comment so verification status appears inline with the preview table.
- Add unit tests in `tests/test_verify_screenshot_artifacts.py` covering a passing scenario and a failing scenario (blank/tiny outputs).

### Testing

- Ran `python3 -m pytest tests/test_verify_screenshot_artifacts.py` and observed `2 passed` (tests cover realistic and failing artifact scenarios). 
- Executed `python3 scripts/verify_screenshot_artifacts.py --artifacts-dir /tmp/nonexistent --report /tmp/screenshot-verification.md` to validate the verifier returns a non-zero exit and writes the expected report for missing artifacts.
- Ran `./scripts/review-notify.sh --actor Codex` to exercise the repo notifier path used in PR workflows (fallback path exercised successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5ea3f4e483269aa66f8ca7ef03f7)