### PR TITLE
startup: align direct start access notice with install/upgrade

### DIFF
--- a/scripts/helpers/ports.sh
+++ b/scripts/helpers/ports.sh
@@ -75,3 +75,13 @@ arthexis_service_access_message() {
     url="$(arthexis_service_url "$base_dir" "$2" "$3")"
     printf 'Access the service at %s. Local-only default login is admin/admin when unchanged.\n' "$url"
 }
+
+# arthexis_service_access_message_for_port HOST PORT
+#
+# Build a login guidance message for a specific runtime host/port pair.
+arthexis_service_access_message_for_port() {
+    local host="${1:-localhost}"
+    local port="${2:-8888}"
+
+    printf 'Access the service at http://%s:%s. Local-only default login is admin/admin when unchanged.\n' "$host" "$port"
+}

--- a/scripts/service-start.sh
+++ b/scripts/service-start.sh
@@ -442,7 +442,7 @@ wait_for_suite_startup() {
     fi
 
     if arthexis_suite_reachable "$port"; then
-      arthexis_service_access_message "$BASE_DIR" "localhost" "$port"
+      arthexis_service_access_message_for_port "localhost" "$port"
       return 0
     fi
 

--- a/scripts/service-start.sh
+++ b/scripts/service-start.sh
@@ -442,7 +442,7 @@ wait_for_suite_startup() {
     fi
 
     if arthexis_suite_reachable "$port"; then
-      echo "Suite is reachable at http://localhost:$port"
+      arthexis_service_access_message "$BASE_DIR" "localhost" "$port"
       return 0
     fi
 

--- a/start.bat
+++ b/start.bat
@@ -21,7 +21,18 @@ set SHOW_LEVEL=
 :parse
 if "%1"=="" goto run
 if "%1"=="--port" (
-    set PORT=%2
+    if "%~2"=="" (
+        echo Usage: %0 [--port PORT] [--reload] [--debug] [--show LEVEL]
+        set EXIT_CODE=1
+        goto cleanup
+    )
+    echo %~2| findstr /R "^[0-9][0-9]*$" >nul
+    if errorlevel 1 (
+        echo Invalid port: %~2
+        set EXIT_CODE=1
+        goto cleanup
+    )
+    set "PORT=%~2"
     shift
     shift
     goto parse
@@ -120,9 +131,9 @@ if errorlevel 1 (
     set EXIT_CODE=1
     goto cleanup
 )
-call :service_access_message %PORT%
+call :service_access_message "%PORT%"
 set RUNSERVER_SKIP_CHECKS=--skip-checks
-%VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT% %NORELOAD% %RUNSERVER_SKIP_CHECKS%
+%VENV%\Scripts\python.exe manage.py runserver "0.0.0.0:%PORT%" %NORELOAD% %RUNSERVER_SKIP_CHECKS%
 set EXIT_CODE=%ERRORLEVEL%
 goto cleanup
 

--- a/start.bat
+++ b/start.bat
@@ -120,6 +120,7 @@ if errorlevel 1 (
     set EXIT_CODE=1
     goto cleanup
 )
+call :service_access_message %PORT%
 set RUNSERVER_SKIP_CHECKS=--skip-checks
 %VENV%\Scripts\python.exe manage.py runserver 0.0.0.0:%PORT% %NORELOAD% %RUNSERVER_SKIP_CHECKS%
 set EXIT_CODE=%ERRORLEVEL%
@@ -167,6 +168,12 @@ start "" /B powershell -NoProfile -Command ^
  "    }" ^
  "    Write-Host $line" ^
  "  }"
+exit /b 0
+
+:service_access_message
+set "SERVICE_PORT=%~1"
+if "%SERVICE_PORT%"=="" set "SERVICE_PORT=8888"
+echo Access the service at http://localhost:%SERVICE_PORT%. Local-only default login is admin/admin when unchanged.
 exit /b 0
 
 :cleanup


### PR DESCRIPTION
### Motivation

- Make the user-visible access guidance consistent between interactive `start.sh`/`start.bat` runs and the install/upgrade flows so users see the same URL and default `admin/admin` hint when the local server becomes reachable.

### Description

- Replace the ad-hoc `echo "Suite is reachable at ..."` in `scripts/service-start.sh` with a call to the shared helper `arthexis_service_access_message` so the Linux direct-start path prints the standardized access message.
- Add a call to a small helper `:service_access_message` in `start.bat` and implement that helper to print `Access the service at http://localhost:<port>. Local-only default login is admin/admin when unchanged.` before launching `runserver` on Windows.

### Testing

- Ran shell syntax check with `bash -n start.sh scripts/service-start.sh` and it succeeded.
- Verified presence of the new message usage with `rg -n "Access the service at|service_access_message" scripts/service-start.sh start.bat` and confirmed matches.
- Ran `./scripts/review-notify.sh --actor Codex` to emit a review notification and the notifier completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8daec8c48326b460161db7d8e0a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR standardizes the user-visible access guidance message across the Linux and Windows direct-start code paths to match the messaging already used in the install/upgrade flows. Users will now see a consistent URL and default login hint ("admin/admin") regardless of which startup method they use.

## Changes

**scripts/service-start.sh (line 445)**
- Replaced the hardcoded echo statement `"Suite is reachable at http://localhost:$port"` with a call to the shared helper `arthexis_service_access_message "$BASE_DIR" "localhost" "$port"`
- The helper function, defined in `scripts/helpers/ports.sh`, outputs: "Access the service at http://localhost:<port>. Local-only default login is admin/admin when unchanged."
- This aligns the Linux direct-start path with the existing messaging used in install/upgrade flows

**start.bat (lines 123, 173-177)**
- Added a call to `:service_access_message %PORT%` immediately before launching `manage.py runserver`
- Implemented the new `:service_access_message` batch subroutine that:
  - Accepts the service port as a parameter (defaults to `8888` if empty)
  - Outputs: "Access the service at http://localhost:<port>. Local-only default login is admin/admin when unchanged."
  - Returns successfully with `exit /b 0`
- Provides Windows users the same standardized access message as Linux users and install/upgrade flows

## Testing

- Shell syntax validation: `bash -n start.sh scripts/service-start.sh` passed
- Verified message usage with ripgrep confirms proper integration in both files
- Review notification emitted successfully via `scripts/review-notify.sh`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->