### PR TITLE
Require login for Docs library routes and hide Docs module pill for anonymous users

### DIFF
--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -42,7 +42,7 @@ FULL_CONTENT_DEFAULT_DOCUMENTS = {
 
 def _show_docs_navigation_link(*, request, landing) -> bool:
     del landing
-    return bool(getattr(request.user, "is_authenticated", False))
+    return bool(getattr(request, "user", None) and request.user.is_authenticated)
 
 
 def _is_allowed_doc_path(path: Path) -> bool:

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from urllib.parse import urlencode, urlunsplit
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.http import FileResponse, Http404, HttpResponse
@@ -15,6 +16,7 @@ from django.views.decorators.cache import never_cache
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
 from apps.modules.models import Module
+from apps.sites.utils import module_pill_link_validation
 
 from . import assets, rendering
 
@@ -36,6 +38,11 @@ DOCS_CANONICAL_HOST_OVERRIDES = {
 FULL_CONTENT_DEFAULT_DOCUMENTS = {
     "docs/development/install-lifecycle-scripts-manual.md",
 }
+
+
+def _show_docs_navigation_link(*, request, landing) -> bool:
+    del landing
+    return bool(getattr(request.user, "is_authenticated", False))
 
 
 def _is_allowed_doc_path(path: Path) -> bool:
@@ -567,6 +574,8 @@ def render_readme_page(
     return response
 
 
+@module_pill_link_validation(_show_docs_navigation_link)
+@login_required(login_url="pages:login")
 def document_library(request):
     """Render the developer documentation library index."""
 
@@ -580,7 +589,9 @@ def _render_missing_document(request, *, doc: str | None, prepend_docs: bool) ->
     return _render_document_library(request, status=404, missing_document=missing_path)
 
 
+@module_pill_link_validation(_show_docs_navigation_link)
 @never_cache
+@login_required(login_url="pages:login")
 def readme(request, doc=None, prepend_docs: bool = False):
     try:
         return render_readme_page(request, doc=doc, prepend_docs=prepend_docs)
@@ -591,6 +602,7 @@ def readme(request, doc=None, prepend_docs: bool = False):
         raise
 
 
+@login_required(login_url="pages:login")
 def readme_asset(request, source: str, asset: str):
     source_normalized = (source or "").lower()
     if source_normalized == "static":

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -239,3 +239,37 @@ def test_charge_points_module_hides_operator_only_map_link_from_anonymous_users(
     )
 
     assert charge_point_module is None
+
+
+def test_docs_library_and_documents_require_login(client):
+    library_url = reverse("docs:docs-library")
+    document_url = reverse("docs:docs-document", args=["index.md"])
+    apps_document_url = reverse("docs:apps-docs-document", args=["README.md"])
+
+    library_response = client.get(library_url)
+    document_response = client.get(document_url)
+    apps_document_response = client.get(apps_document_url)
+
+    expected_prefix = f"{reverse('pages:login')}?next="
+    assert library_response.status_code == 302
+    assert library_response.url.startswith(expected_prefix)
+    assert document_response.status_code == 302
+    assert document_response.url.startswith(expected_prefix)
+    assert apps_document_response.status_code == 302
+    assert apps_document_response.url.startswith(expected_prefix)
+
+
+def test_docs_module_pill_hidden_from_anonymous_users_when_landing_is_docs_library():
+    module = Module.objects.create(path="/docs/", menu="Docs")
+    Landing.objects.create(
+        module=module,
+        path=reverse("docs:docs-library"),
+        label="Developer Documents",
+    )
+    request = RequestFactory().get("/")
+    request.user = AnonymousUser()
+
+    nav_context = context_processors.nav_links(request)
+    nav_modules = nav_context["nav_modules"]
+
+    assert not any(candidate.path == "/docs/" for candidate in nav_modules)


### PR DESCRIPTION
### Motivation

- Limit access to the in-repo Docs surfaces so only authenticated users can view the docs library and individual docs pages at `/docs/library/` and under `/docs/`.
- Prevent the Docs navigation pill from appearing to anonymous visitors when the module's landing is the docs library so public nav does not expose protected content.
- Add regression coverage to ensure the docs routes remain protected and the nav behavior does not regress.

### Description

- Add a visibility validator `_show_docs_navigation_link` and attach it via `module_pill_link_validation` in `apps/docs/views.py` to make the Docs module pill visible only to authenticated users.
- Protect the docs endpoints by adding `@login_required(login_url="pages:login")` to `document_library`, `readme` and `readme_asset` in `apps/docs/views.py` so unauthenticated requests are redirected to the login page.
- Add tests in `apps/sites/tests/test_public_routes.py` that assert unauthenticated access to `docs:docs-library`, `docs:docs-document`, and `docs:apps-docs-document` results in login redirects, and that the `/docs/` module pill is not included in `nav_modules` for anonymous users.

### Testing

- Prepared the environment with `./env-refresh.sh --deps-only` and installed test deps via `.venv/bin/pip install -r requirements-ci.txt` to ensure pytest and related test packages were available.
- Ran the focused test selection with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py -k "docs_library_and_documents_require_login or docs_module_pill_hidden_from_anonymous_users_when_landing_is_docs_library"` and the selected tests passed (`2 passed`).
- The new tests exercise the route redirect behavior and navigation context behavior and passed, confirming the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8ff30ffc8326bbce92adef80e33c)