### PR TITLE
Normalize pyproject dependency ordering to fix install health check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,9 @@ dependencies = [
   "txaio==25.9.2",
   "typing_extensions==4.15.0",
   "urllib3~=2.6.3",
+  "weasyprint==66.0",
   "webauthn==2.7.1",
   "websocket-client==1.8.0",
-  "weasyprint==66.0",
   "websockets>=15,<17",
   "whitenoise==6.12.0",
 ]


### PR DESCRIPTION
### Motivation
- The hourly Install Health Check was failing in the CI step `Validate pyproject dependency ordering`, causing deterministic failures across roles; normalizing the dependency list resolves that gate failure.

### Description
- Reordered the `dependencies` array in `pyproject.toml` to the normalized ordering expected by `scripts/sort_pyproject_deps.py`, with no package or version changes.

### Testing
- Ran `python scripts/sort_pyproject_deps.py --check` and `python scripts/generate_requirements.py --check`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9ae7d6648326a143e1b6b9c221dc)