### PR TITLE
sensors/screens: support i2c-first temperature reads for LCD temperature flow

### DIFF
--- a/apps/screens/lcd_screen/rendering.py
+++ b/apps/screens/lcd_screen/rendering.py
@@ -8,21 +8,23 @@ import os
 import random
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone as datetime_timezone
+from datetime import datetime
+from datetime import timezone as datetime_timezone
 from decimal import Decimal, InvalidOperation
 from glob import glob
 from itertools import cycle, islice
 from pathlib import Path
-from typing import Callable, NamedTuple
+from typing import NamedTuple
 
 import psutil
 
-from apps.screens.animations import AnimationLoadError, default_tree_frames
 from apps.core import uptime_utils
+from apps.screens.animations import AnimationLoadError, default_tree_frames
 
 from . import locks
-from .hardware import LCDFrameWriter, LCD_COLUMNS, LCD_ROWS
+from .hardware import LCD_COLUMNS, LCD_ROWS, LCDFrameWriter
 from .logging import BASE_DIR
 
 logger = logging.getLogger(__name__)
@@ -431,18 +433,27 @@ def _refresh_uptime_payload(
 
 
 def _lcd_temperature_label_from_sensors() -> str | None:
-    return None
+    from apps.sensors.models import Thermometer
+
+    thermometer = (
+        Thermometer.objects.filter(is_active=True, last_reading__isnull=False)
+        .order_by("-last_read_at", "name")
+        .first()
+    )
+    if not thermometer:
+        return None
+    return thermometer.format_lcd_reading() or None
 
 
 def _lcd_temperature_label_from_sysfs() -> str | None:
     try:
-        from apps.sensors.thermometers import format_w1_temperature
+        from apps.sensors.thermometers import format_temperature
     except Exception:
-        format_w1_temperature = None
+        format_temperature = None
 
-    if format_w1_temperature:
+    if format_temperature:
         try:
-            label = format_w1_temperature()
+            label = format_temperature()
         except Exception:
             logger.debug("Unable to load sysfs thermometer reading", exc_info=True)
         else:

--- a/apps/screens/tests/test_lcd_rendering_temperature.py
+++ b/apps/screens/tests/test_lcd_rendering_temperature.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from apps.screens.lcd_screen import rendering
+from apps.sensors.models import Thermometer
+
+pytestmark = pytest.mark.django_db
+
+
+def test_lcd_temperature_label_from_sensors_uses_latest_active_reading() -> None:
+    first = Thermometer.objects.create(
+        name="First",
+        slug="first",
+        unit="C",
+        is_active=True,
+    )
+    latest = Thermometer.objects.create(
+        name="Second",
+        slug="second",
+        unit="C",
+        is_active=True,
+    )
+    first.record_reading(
+        Decimal("20.1"),
+        read_at=timezone.now() - timedelta(minutes=5),
+    )
+    latest.record_reading(Decimal("21.6"), read_at=timezone.now())
+
+    label = rendering._lcd_temperature_label_from_sensors()
+
+    assert label == latest.format_lcd_reading()
+
+
+def test_lcd_temperature_label_from_sensors_ignores_inactive_and_empty() -> None:
+    Thermometer.objects.create(
+        name="Inactive",
+        slug="inactive",
+        unit="C",
+        last_reading=Decimal("19.5"),
+        is_active=False,
+    )
+    Thermometer.objects.create(
+        name="Empty",
+        slug="empty",
+        unit="C",
+        last_reading=None,
+        is_active=True,
+    )
+
+    assert rendering._lcd_temperature_label_from_sensors() is None

--- a/apps/sensors/admin.py
+++ b/apps/sensors/admin.py
@@ -40,11 +40,16 @@ class ThermometerAdmin(admin.ModelAdmin):
         updated_count = 0
         failed_names = []
         source = str(getattr(settings, "THERMOMETER_SOURCE", "auto")).strip().lower()
+        w1_path_template = getattr(
+            settings,
+            "THERMOMETER_PATH_TEMPLATE",
+            "/sys/bus/w1/devices/{slug}/temperature",
+        )
         i2c_path_template = str(
             getattr(settings, "THERMOMETER_I2C_PATH_TEMPLATE", "")
         ).strip()
         for thermometer in queryset:
-            w1_path = f"/sys/bus/w1/devices/{thermometer.slug}/temperature"
+            w1_path = w1_path_template.format(slug=thermometer.slug)
             i2c_paths = (
                 [i2c_path_template.format(slug=thermometer.slug)]
                 if i2c_path_template

--- a/apps/sensors/admin.py
+++ b/apps/sensors/admin.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from .models import Thermometer, ThermometerReading, UsbTracker
-from .thermometers import read_w1_temperature
+from .thermometers import read_temperature
 
 
 @admin.register(Thermometer)
@@ -39,9 +39,22 @@ class ThermometerAdmin(admin.ModelAdmin):
     def sample_selected_thermometers(self, request, queryset):
         updated_count = 0
         failed_names = []
+        source = str(getattr(settings, "THERMOMETER_SOURCE", "auto")).strip().lower()
+        i2c_path_template = str(
+            getattr(settings, "THERMOMETER_I2C_PATH_TEMPLATE", "")
+        ).strip()
         for thermometer in queryset:
-            device_path = f"/sys/bus/w1/devices/{thermometer.slug}/temperature"
-            reading = read_w1_temperature(paths=[device_path])
+            w1_path = f"/sys/bus/w1/devices/{thermometer.slug}/temperature"
+            i2c_paths = (
+                [i2c_path_template.format(slug=thermometer.slug)]
+                if i2c_path_template
+                else None
+            )
+            reading = read_temperature(
+                source=source,
+                w1_paths=[w1_path],
+                i2c_paths=i2c_paths,
+            )
             if reading is None:
                 failed_names.append(thermometer.name)
                 continue

--- a/apps/sensors/tasks.py
+++ b/apps/sensors/tasks.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
-import re
 
 from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
 
 from .models import Thermometer, UsbTracker
-from .thermometers import read_w1_temperature
+from .thermometers import read_temperature
 
 logger = logging.getLogger(__name__)
 
@@ -54,13 +54,22 @@ def sample_thermometers() -> dict[str, int]:
             skipped += 1
             continue
 
-        path_template = getattr(
+        source = str(getattr(settings, "THERMOMETER_SOURCE", "auto")).strip().lower()
+        w1_path_template = getattr(
             settings,
             "THERMOMETER_PATH_TEMPLATE",
             "/sys/bus/w1/devices/{slug}/temperature",
         )
-        device_path = path_template.format(slug=thermometer.slug)
-        reading = read_w1_temperature(paths=[device_path])
+        w1_paths = [w1_path_template.format(slug=thermometer.slug)]
+        i2c_path_template = str(
+            getattr(settings, "THERMOMETER_I2C_PATH_TEMPLATE", "")
+        ).strip()
+        i2c_paths = (
+            [i2c_path_template.format(slug=thermometer.slug)]
+            if i2c_path_template
+            else None
+        )
+        reading = read_temperature(source=source, w1_paths=w1_paths, i2c_paths=i2c_paths)
         if reading is None:
             failed += 1
             logger.info(

--- a/apps/sensors/tests/test_tasks.py
+++ b/apps/sensors/tests/test_tasks.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from apps.sensors.models import UsbTracker
-from apps.sensors.tasks import scan_usb_trackers
+from apps.sensors.models import Thermometer, UsbTracker
+from apps.sensors.tasks import sample_thermometers, scan_usb_trackers
 
 pytestmark = pytest.mark.django_db
 
@@ -82,3 +82,32 @@ def test_scan_usb_trackers_reports_invalid_regex(settings, tmp_path: Path) -> No
     assert result == {"scanned": 1, "matched": 0, "failed": 1}
     assert "Invalid regex" in tracker.last_error
     assert tracker.last_match_path == ""
+
+
+def test_sample_thermometers_prefers_i2c_source(settings, monkeypatch) -> None:
+    settings.THERMOMETER_SOURCE = "i2c"
+    settings.THERMOMETER_I2C_PATH_TEMPLATE = "/sys/bus/i2c/devices/{slug}/temp1_input"
+    thermometer = Thermometer.objects.create(
+        name="Ambient",
+        slug="1-0048",
+        unit="C",
+        sampling_interval_seconds=60,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_read_temperature(*, source, w1_paths, i2c_paths):
+        captured["source"] = source
+        captured["w1_paths"] = w1_paths
+        captured["i2c_paths"] = i2c_paths
+        return 23
+
+    monkeypatch.setattr("apps.sensors.tasks.read_temperature", fake_read_temperature)
+
+    result = sample_thermometers()
+    thermometer.refresh_from_db()
+
+    assert result == {"sampled": 1, "skipped": 0, "failed": 0}
+    assert captured["source"] == "i2c"
+    assert captured["w1_paths"] == ["/sys/bus/w1/devices/1-0048/temperature"]
+    assert captured["i2c_paths"] == ["/sys/bus/i2c/devices/1-0048/temp1_input"]
+    assert thermometer.last_reading == 23

--- a/apps/sensors/tests/test_thermometers.py
+++ b/apps/sensors/tests/test_thermometers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from apps.sensors import thermometers
+
+
+def test_read_i2c_temperature_empty_paths_skips_global_discovery(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "apps.sensors.thermometers._iter_i2c_paths",
+        lambda: ["/sys/class/hwmon/hwmon0/temp1_input"],
+    )
+
+    assert thermometers.read_i2c_temperature(paths=[]) is None
+
+
+def test_read_temperature_auto_without_i2c_paths_reads_w1_only(monkeypatch) -> None:
+    captured: dict[str, object] = {"i2c_called": False, "w1_paths": None}
+
+    def fake_read_i2c(paths=None):
+        captured["i2c_called"] = True
+        return Decimal("30.1")
+
+    def fake_read_w1(paths=None):
+        captured["w1_paths"] = paths
+        return Decimal("19.7")
+
+    monkeypatch.setattr("apps.sensors.thermometers.read_i2c_temperature", fake_read_i2c)
+    monkeypatch.setattr("apps.sensors.thermometers.read_w1_temperature", fake_read_w1)
+
+    result = thermometers.read_temperature(
+        source="auto",
+        w1_paths=["/sys/bus/w1/devices/28-1/temperature"],
+        i2c_paths=None,
+    )
+
+    assert captured["i2c_called"] is False
+    assert captured["w1_paths"] == ["/sys/bus/w1/devices/28-1/temperature"]
+    assert result == Decimal("19.7")

--- a/apps/sensors/thermometers.py
+++ b/apps/sensors/thermometers.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from decimal import Decimal, InvalidOperation
 from glob import glob
 from pathlib import Path
-from typing import Iterable
-
 
 DEFAULT_SYSFS_GLOB = "/sys/bus/w1/devices/28-*/temperature"
+DEFAULT_I2C_GLOBS = (
+    "/sys/bus/i2c/devices/*/hwmon/hwmon*/temp*_input",
+    "/sys/class/hwmon/hwmon*/temp*_input",
+    "/sys/bus/i2c/devices/*/iio:device*/in_temp_input",
+    "/sys/bus/iio/devices/iio:device*/in_temp_input",
+)
 MILLI_DEGREES_THRESHOLD = Decimal("1000")
 
 
@@ -32,6 +37,53 @@ def read_w1_temperature(
     return None
 
 
+def read_i2c_temperature(
+    paths: Iterable[str | Path] | None = None,
+) -> Decimal | None:
+    candidates = list(paths or _iter_i2c_paths())
+    for candidate in candidates:
+        path = Path(candidate)
+        try:
+            raw = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not raw:
+            continue
+        try:
+            value = Decimal(raw)
+        except (InvalidOperation, ValueError):
+            continue
+        if value.copy_abs() >= MILLI_DEGREES_THRESHOLD:
+            value = value / MILLI_DEGREES_THRESHOLD
+        return value
+    return None
+
+
+def _iter_i2c_paths() -> list[str]:
+    paths: list[str] = []
+    for pattern in DEFAULT_I2C_GLOBS:
+        paths.extend(glob(pattern))
+    return paths
+
+
+def read_temperature(
+    *,
+    source: str = "auto",
+    w1_paths: Iterable[str | Path] | None = None,
+    i2c_paths: Iterable[str | Path] | None = None,
+) -> Decimal | None:
+    normalized = source.strip().lower()
+    if normalized == "i2c":
+        return read_i2c_temperature(i2c_paths)
+    if normalized == "w1":
+        return read_w1_temperature(w1_paths)
+
+    i2c_reading = read_i2c_temperature(i2c_paths)
+    if i2c_reading is not None:
+        return i2c_reading
+    return read_w1_temperature(w1_paths)
+
+
 def format_w1_temperature(
     *,
     precision: int = 1,
@@ -46,4 +98,26 @@ def format_w1_temperature(
     return f"{value}{unit}".strip()
 
 
-__all__ = ["format_w1_temperature", "read_w1_temperature"]
+def format_temperature(
+    *,
+    source: str = "auto",
+    precision: int = 1,
+    unit: str = "C",
+    w1_paths: Iterable[str | Path] | None = None,
+    i2c_paths: Iterable[str | Path] | None = None,
+) -> str | None:
+    reading = read_temperature(source=source, w1_paths=w1_paths, i2c_paths=i2c_paths)
+    if reading is None:
+        return None
+    precision = max(precision, 0)
+    value = f"{reading:.{precision}f}"
+    return f"{value}{unit}".strip()
+
+
+__all__ = [
+    "format_temperature",
+    "format_w1_temperature",
+    "read_i2c_temperature",
+    "read_temperature",
+    "read_w1_temperature",
+]

--- a/apps/sensors/thermometers.py
+++ b/apps/sensors/thermometers.py
@@ -40,7 +40,7 @@ def read_w1_temperature(
 def read_i2c_temperature(
     paths: Iterable[str | Path] | None = None,
 ) -> Decimal | None:
-    candidates = list(paths or _iter_i2c_paths())
+    candidates = list(paths if paths is not None else _iter_i2c_paths())
     for candidate in candidates:
         path = Path(candidate)
         try:
@@ -78,9 +78,10 @@ def read_temperature(
     if normalized == "w1":
         return read_w1_temperature(w1_paths)
 
-    i2c_reading = read_i2c_temperature(i2c_paths)
-    if i2c_reading is not None:
-        return i2c_reading
+    if i2c_paths is not None:
+        i2c_reading = read_i2c_temperature(i2c_paths)
+        if i2c_reading is not None:
+            return i2c_reading
     return read_w1_temperature(w1_paths)
 
 


### PR DESCRIPTION
### Motivation

- Avoid IRQ conflicts with the RFID hardware that share the OneWire GPIO by allowing thermometer reads to move off OneWire and onto I2C.  
- Keep temperature-only behavior for now and avoid adding humidity sensors or related capability in this change.  

### Description

- Add I2C/sysfs discovery and readers in `apps/sensors/thermometers.py` (`read_i2c_temperature`, `_iter_i2c_paths`, `read_temperature`, `format_temperature`) and keep W1 helpers for compatibility.  
- Make sampling and admin actions source-aware by wiring `THERMOMETER_SOURCE` and optional `THERMOMETER_I2C_PATH_TEMPLATE` into `apps/sensors/tasks.py` and `apps/sensors/admin.py` and calling `read_temperature(...)` instead of the W1-only reader.  
- Update the LCD rendering hook in `apps/screens/lcd_screen/rendering.py` to prefer persisted `Thermometer.last_reading` (latest active) and fall back to the source-aware sysfs formatter rather than hardcoded OneWire sysfs reads.  
- Add unit tests: `apps/sensors/tests/test_tasks.py` (I2C source selection) and `apps/screens/tests/test_lcd_rendering_temperature.py` (LCD uses latest active thermometer).  

### Testing

- Bootstrapped environment with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt`.  
- Ran formatter/lint fix: `.venv/bin/ruff check --fix ...` and fixed import ordering issues automatically.  
- Executed targeted tests with `.venv/bin/python manage.py test run -- apps/sensors/tests/test_tasks.py apps/screens/tests/test_lcd_rendering_temperature.py`, and all tests passed (`6 passed`).  
- Sent review notification via `./scripts/review-notify.sh --actor Codex`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9b4668108326b40d13d9d6082786)