### PR TITLE
media-gallery: require authentication for persistent media bucket uploads

### DIFF
--- a/apps/media/tests/test_views.py
+++ b/apps/media/tests/test_views.py
@@ -1,0 +1,58 @@
+"""Tests for media upload views."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.media.models import MediaBucket, MediaFile
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _upload_url(bucket: MediaBucket) -> str:
+    return reverse("ocpp:media-bucket-upload", kwargs={"slug": bucket.slug})
+
+
+def _build_upload() -> SimpleUploadedFile:
+    return SimpleUploadedFile("test.txt", b"hello", content_type="text/plain")
+
+
+def test_media_bucket_upload_rejects_anonymous_for_non_expiring_bucket(client) -> None:
+    bucket = MediaBucket.objects.create(slug="persistent-bucket", name="Persistent")
+
+    response = client.post(_upload_url(bucket), {"file": _build_upload()})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "authentication is required for this bucket"
+    assert MediaFile.objects.count() == 0
+
+
+def test_media_bucket_upload_allows_anonymous_for_expiring_bucket(client) -> None:
+    bucket = MediaBucket.objects.create(
+        slug="expiring-bucket",
+        name="Expiring",
+        expires_at=timezone.now() + timedelta(hours=1),
+    )
+
+    response = client.post(_upload_url(bucket), {"file": _build_upload()})
+
+    assert response.status_code == 201
+    assert MediaFile.objects.count() == 1
+
+
+def test_media_bucket_upload_allows_authenticated_for_non_expiring_bucket(client) -> None:
+    user = get_user_model().objects.create_user(username="alice", password="test-pass-123")
+    bucket = MediaBucket.objects.create(slug="auth-bucket", name="Auth")
+    client.force_login(user)
+
+    response = client.post(_upload_url(bucket), {"file": _build_upload()})
+
+    assert response.status_code == 201
+    assert MediaFile.objects.count() == 1

--- a/apps/media/views.py
+++ b/apps/media/views.py
@@ -25,6 +25,12 @@ def media_bucket_upload(request, slug):
     if request.method not in {"POST", "PUT"}:
         return HttpResponseNotAllowed(["POST", "PUT"])
 
+    if bucket.expires_at is None and not request.user.is_authenticated:
+        return JsonResponse(
+            {"detail": "authentication is required for this bucket"},
+            status=403,
+        )
+
     if not request.FILES:
         return JsonResponse({"detail": "file is required"}, status=400)
 

--- a/apps/media/views.py
+++ b/apps/media/views.py
@@ -25,7 +25,7 @@ def media_bucket_upload(request, slug):
     if request.method not in {"POST", "PUT"}:
         return HttpResponseNotAllowed(["POST", "PUT"])
 
-    if bucket.expires_at is None and not request.user.is_authenticated:
+    if bucket.expires_at is None and not (request.user.is_authenticated and request.user.is_active):
         return JsonResponse(
             {"detail": "authentication is required for this bucket"},
             status=403,


### PR DESCRIPTION
### Motivation

- A predictable persistent gallery bucket combined with the CSRF-exempt upload endpoint allowed unauthenticated arbitrary uploads and potential abuse; the change closes this gap while preserving temporary upload workflows.

### Description

- Require authentication in `media_bucket_upload` for buckets that do not have an `expires_at` (persistent buckets) by returning `403` with a clear message for anonymous requests.
- Preserve existing anonymous upload behavior for expiring (temporary) buckets so current flows that rely on short-lived upload endpoints continue to work.
- Add focused tests in `apps/media/tests/test_views.py` that assert anonymous uploads are rejected for persistent buckets, allowed for expiring buckets, and allowed for authenticated users on persistent buckets.
- Files changed: `apps/media/views.py`, `apps/media/tests/test_views.py` (and test package `apps/media/tests/__init__.py`).

### Testing

- Ran `./env-refresh.sh --deps-only` and installed test dependencies required for CI setup; environment prepared successfully.
- Ran `.venv/bin/python manage.py test run -- apps/media/tests/test_views.py` and all tests passed (`3 passed`).
- Ran `.venv/bin/python manage.py migrations check` and received `No changes detected` (migrations OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9eb1e3c083268aea3e2fed2c650f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Fix: Require Authentication for Persistent Media Bucket Uploads

### Problem
A security vulnerability allowed unauthenticated arbitrary uploads to predictable persistent media bucket endpoints when combined with CSRF-exempt upload routes, creating potential for abuse.

### Solution
Added authentication requirement for persistent (non-expiring) media buckets while preserving anonymous upload workflows for temporary (expiring) buckets.

### Implementation Details

**apps/media/views.py** (6 new lines)
- Added authorization check in the media bucket upload view
- When `bucket.expires_at` is `None` (persistent bucket), the request requires an authenticated and active user
- Anonymous requests to persistent buckets receive HTTP 403 with error message: `{"detail": "authentication is required for this bucket"}`
- Check occurs after HTTP method validation but before file processing
- Temporary buckets (with `expires_at` set) remain accessible to anonymous users, preserving existing short-lived upload flows

**apps/media/tests/test_views.py** (58 new lines)
Added three focused tests validating the access control behavior:
- `test_media_bucket_upload_rejects_anonymous_for_non_expiring_bucket`: Anonymous user receives HTTP 403 and no `MediaFile` is created for persistent buckets
- `test_media_bucket_upload_allows_anonymous_for_expiring_bucket`: Anonymous user receives HTTP 201 and `MediaFile` is created when bucket has `expires_at` in the future
- `test_media_bucket_upload_allows_authenticated_for_non_expiring_bucket`: Authenticated user receives HTTP 201 and `MediaFile` is created for persistent buckets

Helper utilities included for test URL generation and test file payload creation.

### Testing
All 3 tests pass with database interaction enabled (`pytest.mark.django_db`). Migration check confirms no database schema changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->