### PR TITLE
license: add sponsorship as a good-faith contribution option

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,8 @@ modify, and distribute the Software, subject to the conditions below.
       security fixes;
    b. documentation improvements, operational guidance, or issue triage;
    c. review, maintenance, or other concrete project work accepted by the
-      maintainers.
+      maintainers;
+   d. sponsoring the Arthexis GitHub repository or one of its dependencies.
 
 3. Timing of contributions.
    Required contributions under Section 2 must be offered to the upstream

--- a/LICENSE
+++ b/LICENSE
@@ -23,7 +23,7 @@ modify, and distribute the Software, subject to the conditions below.
    b. documentation improvements, operational guidance, or issue triage;
    c. review, maintenance, or other concrete project work accepted by the
       maintainers;
-   d. sponsoring the Arthexis GitHub repository or one of its dependencies.
+   d. sponsoring the Arthexis project or one of its dependencies.
 
 3. Timing of contributions.
    Required contributions under Section 2 must be offered to the upstream


### PR DESCRIPTION
### Motivation
- Make sponsorship an explicit acceptable form of good-faith contribution by adding it as item `d` to the license's contribution examples.

### Description
- Add the line `d. sponsoring the Arthexis GitHub repository or one of its dependencies.` to the `LICENSE` file and adjust punctuation to preserve list formatting.

### Testing
- No runtime code changes; ran `./scripts/review-notify.sh --actor Codex` and committed the documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded3d6291883268a612f930d7d8881)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## LICENSE File Updates for Sponsorship as Good-Faith Contribution

The LICENSE file (Arthexis Reciprocity General License 1.0) was updated to formally recognize sponsorship as an acceptable form of good-faith contribution.

**Key Changes:**
- Added item `d` to Section 2 ("Share improvements"), explicitly listing "sponsoring the Arthexis project or one of its dependencies" as a valid good-faith contribution option alongside code improvements, documentation, and project work.
- Section 11 ("Forms of contribution") clarifies that sponsoring the project and supporting its open-source dependencies constitute valid contributions when proportionate to the licensee's use or extension of the Software.
- Sponsorship language was generalized (platform-neutral) to encompass all forms of financial and volunteer support rather than platform-specific mechanisms.

**Impact:**
- Documentation-only change; no code modifications
- Low review effort

<!-- end of auto-generated comment: release notes by coderabbit.ai -->