### PR TITLE
Add 'Operations' staff task and "My Ops Tasks" view to list operator journey items

### DIFF
--- a/apps/actions/internal_actions.py
+++ b/apps/actions/internal_actions.py
@@ -73,6 +73,12 @@ INTERNAL_ACTION_SPECS: tuple[InternalActionSpec, ...] = (
         admin_url_name="admin:log_viewer",
     ),
     InternalActionSpec(
+        name="operations",
+        label="Operations",
+        description="Review and continue assigned operator journey tasks.",
+        admin_url_name="ops:my-tasks",
+    ),
+    InternalActionSpec(
         name="reports",
         label="Reports",
         description="Run system reports and provide query parameters.",

--- a/apps/actions/staff_tasks.py
+++ b/apps/actions/staff_tasks.py
@@ -59,6 +59,13 @@ DEFAULT_STAFF_TASKS: tuple[dict[str, object], ...] = (
         "order": 60,
     },
     {
+        "slug": "operations",
+        "label": "Operations",
+        "description": "Review and continue assigned operator journey tasks.",
+        "action_name": "operations",
+        "order": 65,
+    },
+    {
         "slug": "rules",
         "label": "Rules",
         "description": "Review dashboard rule evaluation outcomes.",

--- a/apps/actions/tests/test_api.py
+++ b/apps/actions/tests/test_api.py
@@ -68,6 +68,7 @@ def test_staff_task_resolves_named_internal_action_for_visible_tasks():
         and task["url"] == "/admin/imager/raspberrypiimageartifact/create-rpi-image/"
         for task in tasks
     )
+    assert any(task["slug"] == "operations" and task["url"] == "/ops/my-tasks/" for task in tasks)
     assert StaffTask.objects.filter(slug="actions").exists() is False
 
 

--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -27,6 +27,17 @@ class OperatorJourneyStatus:
     available_since: datetime | None = None
 
 
+@dataclass(frozen=True)
+class OperatorJourneyTaskItem:
+    """Template-friendly task item for the user's eligible operator steps."""
+
+    step: OperatorJourneyStep
+    is_completed: bool
+    is_next: bool
+    is_locked: bool
+    completed_at: datetime | None = None
+
+
 def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
     """Return the next required step for a user across active journey assignments."""
 
@@ -121,6 +132,49 @@ def _first_available_at(*, user: AbstractBaseUser, next_step: OperatorJourneySte
     if completion is None:
         return fallback_available_at
     return completion.completed_at
+
+
+def task_items_for_user(*, user: AbstractBaseUser) -> list[OperatorJourneyTaskItem]:
+    """Return ordered eligible steps with completion and lock state metadata."""
+
+    if not user.is_authenticated:
+        return []
+
+    steps = list(
+        OperatorJourneyStep.objects.filter(
+            is_active=True,
+            journey__is_active=True,
+            journey__security_group__in=_active_security_groups_for_user(user),
+        )
+        .select_related("journey")
+        .order_by("journey__priority", "journey__name", "order", "id")
+    )
+    if not steps:
+        return []
+
+    completion_map = {
+        completion.step_id: completion.completed_at
+        for completion in OperatorJourneyStepCompletion.objects.filter(
+            user=user,
+            step__in=steps,
+        )
+    }
+    next_step = next_step_for_user(user=user)
+    items: list[OperatorJourneyTaskItem] = []
+    for step in steps:
+        completed_at = completion_map.get(step.pk)
+        is_completed = completed_at is not None
+        is_next = bool(next_step and next_step.pk == step.pk)
+        items.append(
+            OperatorJourneyTaskItem(
+                step=step,
+                is_completed=is_completed,
+                is_next=is_next,
+                is_locked=not is_completed and not is_next,
+                completed_at=completed_at,
+            )
+        )
+    return items
 
 
 def _active_security_groups_for_user(user: AbstractBaseUser):

--- a/apps/ops/templates/admin/ops/my_ops_tasks.html
+++ b/apps/ops/templates/admin/ops/my_ops_tasks.html
@@ -1,0 +1,64 @@
+{% extends "admin/base_site.html" %}
+{% load i18n tz %}
+
+{% block bodyclass %}{{ block.super }} app-ops model-operatorjourneystep{% endblock %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate "Home" %}</a>
+    &rsaquo; {% translate "My Ops Tasks" %}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    <h1>{% translate "My Ops Tasks" %}</h1>
+
+    {% if task_items %}
+      <table id="result_list" class="adminlist">
+        <thead>
+          <tr>
+            <th>{% translate "Journey" %}</th>
+            <th>{% translate "Task" %}</th>
+            <th>{% translate "Status" %}</th>
+            <th>{% translate "Completed" %}</th>
+            <th>{% translate "Action" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in task_items %}
+            <tr>
+              <td>{{ item.step.journey.name }}</td>
+              <td>{{ item.step.title }}</td>
+              <td>
+                {% if item.is_completed %}
+                  {% translate "Completed" %}
+                {% elif item.is_next %}
+                  {% translate "Ready" %}
+                {% else %}
+                  {% translate "Locked" %}
+                {% endif %}
+              </td>
+              <td>
+                {% if item.completed_at %}
+                  {{ item.completed_at|localtime|date:"Y-m-d H:i" }}
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+              <td>
+                {% if item.is_next %}
+                  <a class="button" href="{% url 'ops:operator-journey-step' item.step.pk %}">{% translate "Open next task" %}</a>
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>{% translate "No operator tasks are currently assigned to your account." %}</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -135,6 +135,38 @@ class OperatorJourneyViewTests(TestCase):
             reverse("ops:operator-journey-step", args=[self.step_1.pk]),
         )
 
+    def test_my_ops_tasks_lists_all_eligible_steps_with_next_action_only(self):
+        response = self.client.get(reverse("ops:my-tasks"))
+
+        self.assertContains(response, "My Ops Tasks")
+        self.assertContains(response, "Validate role")
+        self.assertContains(response, "Confirm restart")
+        self.assertContains(
+            response,
+            reverse("ops:operator-journey-step", args=[self.step_1.pk]),
+        )
+        self.assertNotContains(
+            response,
+            reverse("ops:operator-journey-step", args=[self.step_2.pk]),
+        )
+
+    def test_my_ops_tasks_advances_clickable_step_after_completion(self):
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+
+        response = self.client.get(reverse("ops:my-tasks"))
+
+        self.assertContains(response, "Completed")
+        self.assertContains(
+            response,
+            reverse("ops:operator-journey-step", args=[self.step_2.pk]),
+        )
+        self.assertNotContains(
+            response,
+            reverse("ops:operator-journey-step", args=[self.step_1.pk]),
+        )
+
     def test_step_view_redirects_when_opening_future_step(self):
         response = self.client.get(
             reverse("ops:operator-journey-step", args=[self.step_2.pk])

--- a/apps/ops/urls.py
+++ b/apps/ops/urls.py
@@ -8,6 +8,7 @@ app_name = "ops"
 
 urlpatterns = [
     path("clear-active/", views.clear_active_operation, name="clear-active"),
+    path("my-tasks/", views.my_ops_tasks, name="my-tasks"),
     path(
         "operator-journey/steps/<int:step_id>/",
         views.operator_journey_step,

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -16,7 +16,7 @@ OPERATOR_JOURNEY_STEP_URL_NAME = "ops:operator-journey-step"
 
 from .forms import OperatorJourneyProvisionSuperuserForm
 from .models import OperatorJourneyStep
-from .operator_journey import complete_step_for_user, next_step_for_user
+from .operator_journey import complete_step_for_user, next_step_for_user, task_items_for_user
 from .redirects import safe_host_redirect
 from .status_surface import build_status_surface, scoped_log_excerpts
 
@@ -151,6 +151,21 @@ def status_log_excerpts(request: HttpRequest) -> JsonResponse:
     """Return only scoped log excerpts for clients polling the status surface."""
 
     return JsonResponse({"log_excerpts": scoped_log_excerpts(user=request.user)})
+
+
+@staff_member_required
+def my_ops_tasks(request: HttpRequest):
+    """Render all operator journey tasks assigned to the current staff user."""
+
+    items = task_items_for_user(user=request.user)
+    return render(
+        request,
+        "admin/ops/my_ops_tasks.html",
+        {
+            "title": "My Ops Tasks",
+            "task_items": items,
+        },
+    )
 
 
 @staff_member_required


### PR DESCRIPTION
### Motivation

- Make operator journey work visible and actionable from the admin by adding an "Operations" staff task and a dedicated listing of assigned operator steps. 
- Provide a template-friendly representation of eligible operator steps so the UI can show completion, locked and next-state metadata.

### Description

- Added an `InternalActionSpec` for `operations` and a corresponding seeded staff task in `internal_actions.py` and `staff_tasks.py` so the Operations link appears in default staff tasks. 
- Implemented `OperatorJourneyTaskItem` and `task_items_for_user` in `apps/ops/operator_journey.py` to return ordered eligible steps with completion and lock state metadata. 
- Added a `my_ops_tasks` view in `apps/ops/views.py`, a URL route `ops:my-tasks` in `apps/ops/urls.py`, and the admin template `apps/ops/templates/admin/ops/my_ops_tasks.html` to render the task list with actions. 
- Updated imports to use `task_items_for_user` where needed and added tests that assert the new staff task resolves and the new view behavior. 

### Testing

- Ran `pytest` for modified modules and targeted tests including `apps/actions/tests/test_api.py::test_staff_task_resolves_named_internal_action_for_visible_tasks`, and the new `apps/ops/tests/test_operator_journey.py` tests for `my_ops_tasks` listing and advancement. 
- All exercised tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded201dec48326bc5da226dea72c52)