### PR TITLE
netmesh: reclassify transport keys mis-tagged by migration backfill

### DIFF
--- a/apps/netmesh/migrations/0009_reclassify_transport_key_types.py
+++ b/apps/netmesh/migrations/0009_reclassify_transport_key_types.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def _infer_key_type(public_key: str) -> str:
+    normalized_key = (public_key or "").strip()
+    return "x25519" if normalized_key.startswith("x25519:") else "rsa-bootstrap"
+
+
+def _reclassify_transport_key_types(apps, schema_editor):
+    node_key_material_model = apps.get_model("netmesh", "NodeKeyMaterial")
+    for key_material in node_key_material_model.objects.all().only("id", "public_key", "key_type"):
+        expected_key_type = _infer_key_type(key_material.public_key)
+        if key_material.key_type == expected_key_type:
+            continue
+        key_material.key_type = expected_key_type
+        key_material.save(update_fields=["key_type"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netmesh", "0008_remove_nodekeymaterial_netmesh_node_single_active_key_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _reclassify_transport_key_types,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/apps/netmesh/tests/test_migrations.py
+++ b/apps/netmesh/tests/test_migrations.py
@@ -1,0 +1,42 @@
+import importlib
+
+import pytest
+
+from apps.netmesh.models import NodeKeyMaterial
+from apps.nodes.models import Node
+
+
+class _MigrationApps:
+    def get_model(self, app_label: str, model_name: str):
+        assert app_label == "netmesh"
+        assert model_name == "NodeKeyMaterial"
+        return NodeKeyMaterial
+
+
+@pytest.mark.django_db
+def test_reclassify_transport_key_types_keeps_x25519_and_corrects_rsa_pem_keys():
+    migration = importlib.import_module("apps.netmesh.migrations.0009_reclassify_transport_key_types")
+    node = Node.objects.create(hostname="migration-reclassify")
+
+    pem_key = NodeKeyMaterial.objects.create(
+        node=node,
+        key_type=NodeKeyMaterial.KeyType.X25519,
+        key_state=NodeKeyMaterial.KeyState.ACTIVE,
+        public_key="-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest\n-----END PUBLIC KEY-----",
+        key_version=1,
+    )
+    x25519_key = NodeKeyMaterial.objects.create(
+        node=node,
+        key_type=NodeKeyMaterial.KeyType.RSA_BOOTSTRAP,
+        key_state=NodeKeyMaterial.KeyState.RETIRED,
+        public_key="x25519:QUJDREVGR0g=",
+        key_version=2,
+    )
+
+    migration._reclassify_transport_key_types(_MigrationApps(), None)
+
+    pem_key.refresh_from_db()
+    x25519_key.refresh_from_db()
+
+    assert pem_key.key_type == NodeKeyMaterial.KeyType.RSA_BOOTSTRAP
+    assert x25519_key.key_type == NodeKeyMaterial.KeyType.X25519


### PR DESCRIPTION
### Motivation

- The existing backfill migration inferred `NodeKeyMaterial.key_type` by checking for an OpenSSH `"ssh-rsa "` prefix, which mislabels PEM-encoded RSA public keys ("-----BEGIN PUBLIC KEY-----") as X25519 and can cause RSA bootstrap keys to be treated as active transport keys.

### Description

- Add a follow-up data migration `apps/netmesh/migrations/0009_reclassify_transport_key_types.py` that infers key type from the stored public key format and classifies only `x25519:` payloads as X25519 and everything else as `rsa-bootstrap`.
- The migration reclassifies existing rows where the stored `public_key` format does not match the current `key_type` to correct databases already affected by the brittle backfill.
- Add a regression test `apps/netmesh/tests/test_migrations.py` that reproduces a PEM RSA misclassification and verifies that PEM RSA rows are reclassified to `rsa-bootstrap` while `x25519:` payloads remain `x25519`.

### Testing

- Ran unit tests covering the new migration and existing netmesh model behavior with `..venv/bin/python manage.py test run -- apps.netmesh.tests.test_migrations.py apps.netmesh.tests.test_models.py`, which completed successfully with `15 passed`.
- Ran migration consistency check with `..venv/bin/python manage.py migrations check`, which reported `No changes detected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda0db4c50832692c6dab55783763f)