### PR TITLE
ops: enforce password validation for custom provisioned superuser passwords

### DIFF
--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -123,10 +123,15 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
             return
 
         user_model = get_user_model()
-        user = existing_user or user_model(
-            username=cleaned_data.get("username", ""),
-            email=cleaned_data.get("email", ""),
-        )
+        if existing_user is not None:
+            user = user_model(pk=existing_user.pk)
+            user.username = cleaned_data.get("username", existing_user.username)
+            user.email = cleaned_data.get("email", existing_user.email)
+        else:
+            user = user_model(
+                username=cleaned_data.get("username", ""),
+                email=cleaned_data.get("email", ""),
+            )
         try:
             validate_password(password=password, user=user)
         except ValidationError as exc:

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -7,6 +7,8 @@ import string
 
 from django import forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 
 from apps.groups.models import SecurityGroup
 
@@ -85,6 +87,10 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
             self.add_error(
                 "password", "Provide a password or switch to random generation."
             )
+        self._validate_custom_password(
+            cleaned_data=cleaned_data,
+            existing_user=existing_user,
+        )
         return cleaned_data
 
     def clean_username(self):
@@ -107,6 +113,24 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
     def _is_upgrade_opt_in_requested(self) -> bool:
         value = (self.data.get("upgrade_existing_user") or "").strip().lower()
         return value in {"1", "on", "true", "yes"}
+
+    def _validate_custom_password(self, *, cleaned_data, existing_user) -> None:
+        if cleaned_data.get("password_mode") != "custom":
+            return
+
+        password = cleaned_data.get("password")
+        if not password:
+            return
+
+        user_model = get_user_model()
+        user = existing_user or user_model(
+            username=cleaned_data.get("username", ""),
+            email=cleaned_data.get("email", ""),
+        )
+        try:
+            validate_password(password=password, user=user)
+        except ValidationError as exc:
+            self.add_error("password", exc)
 
     def save(self):
         """Create the superuser, assign groups, and return the account/password tuple."""

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -424,6 +424,52 @@ class OperatorJourneyViewTests(TestCase):
         )
         self.assertContains(response, "Operational superuser upgraded")
 
+    @override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {
+                "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+                "OPTIONS": {"min_length": 16},
+            }
+        ]
+    )
+    def test_provision_step_rejects_custom_password_that_fails_validators(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+
+        response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": "ops-provisioned-weak-password",
+                "email": "ops-provisioned-weak-password@example.com",
+                "security_groups": [self.group.pk],
+                "password_mode": "custom",
+                "password": "too-short",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "This password is too short. It must contain at least 16 characters.",
+        )
+        self.assertFalse(
+            get_user_model()
+            .objects.filter(username="ops-provisioned-weak-password")
+            .exists()
+        )
+
     def test_provision_step_post_rejects_when_not_current_required_step(self):
         blocked_step = OperatorJourneyStep.objects.create(
             journey=self.journey,

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -470,6 +470,58 @@ class OperatorJourneyViewTests(TestCase):
             .exists()
         )
 
+    @override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {
+                "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+            }
+        ]
+    )
+    def test_provision_step_upgrade_validates_password_against_submitted_email(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_1.pk])
+        )
+        self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[self.step_2.pk])
+        )
+        existing_user = get_user_model().objects.create_user(
+            username="existing-ops-user-email-change",
+            email="old-upgrade-email@example.com",
+            password="old-password",
+            is_active=False,
+            is_staff=False,
+            is_superuser=False,
+        )
+
+        response = self.client.post(
+            reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
+            {
+                "username": existing_user.username,
+                "email": "new-upgrade-email@example.com",
+                "security_groups": [self.group.pk],
+                "password_mode": "custom",
+                "password": "new-upgrade-email@example.com",
+                "upgrade_existing_user": "on",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "The password is too similar to the email address.",
+        )
+        existing_user.refresh_from_db()
+        self.assertEqual(existing_user.email, "old-upgrade-email@example.com")
+        self.assertFalse(existing_user.check_password("new-upgrade-email@example.com"))
+
     def test_provision_step_post_rejects_when_not_current_required_step(self):
         blocked_step = OperatorJourneyStep.objects.create(
             journey=self.journey,


### PR DESCRIPTION
### Motivation
- The operator provisioning form accepted a manually entered password without invoking Django's configured `AUTH_PASSWORD_VALIDATORS`, allowing weak superuser passwords to be created.
- Enforce existing password policy to prevent low-entropy credentials and reduce risk of remote brute-force compromise.

### Description
- Call `django.contrib.auth.password_validation.validate_password` for custom passwords and add `ValidationError` handling in `OperatorJourneyProvisionSuperuserForm` (file `apps/ops/forms.py`).
- Introduce a helper method `_validate_custom_password` that validates against the existing user when upgrading or a synthesized user context using the submitted `username`/`email` when creating a new account.
- Invoke the helper from `clean()` so validation errors surface on the form prior to `save()` and prevent creating/upgrading the superuser with an invalid password.
- Add a regression test in `apps/ops/tests/test_operator_journey.py` that sets a strict `MinimumLengthValidator`, submits a weak custom password, asserts the validator error is shown, and verifies no user is created.

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt`.
- Executed targeted test selection with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py -k "provision_step"` and observed the suite complete with `8 passed, 11 deselected`.
- The added test verifies that a custom password failing `AUTH_PASSWORD_VALIDATORS` is rejected and no superuser account is created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda0db18448326b0a23b776af6266c)