### PR TITLE
sites: block scheme-relative redirects in legacy language route

### DIFF
--- a/apps/sites/routes.py
+++ b/apps/sites/routes.py
@@ -20,7 +20,12 @@ ROOT_URLPATTERNS = [
         name="admin-model-graph",
     ),
     re_path(
-        r"^(?P<lang>[a-z]{2})/(?P<rest>.*)$",
+        r"^(?P<lang>[a-z]{2})/$",
+        RedirectView.as_view(url="/", permanent=True, query_string=True),
+        name="legacy-language-prefix-root-redirect",
+    ),
+    re_path(
+        r"^(?P<lang>[a-z]{2})/(?P<rest>[^/].*)$",
         RedirectView.as_view(url="/%(rest)s", permanent=True, query_string=True),
         name="legacy-language-prefix-redirect",
     ),

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -100,6 +100,15 @@ def test_whatsapp_webhook_requires_post_and_feature_flag(client, settings):
     assert disabled.status_code == 404
 
 @pytest.mark.integration
+def test_legacy_language_redirect_rejects_scheme_relative_targets(client):
+    response = client.get("/en//evil.com", follow=False)
+
+    assert not (
+        response.status_code in {301, 302, 307, 308}
+        and response["Location"].startswith("//")
+    )
+
+@pytest.mark.integration
 @pytest.mark.parametrize(
     ("payload", "expected_status"),
     [

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -100,13 +100,22 @@ def test_whatsapp_webhook_requires_post_and_feature_flag(client, settings):
     assert disabled.status_code == 404
 
 @pytest.mark.integration
-def test_legacy_language_redirect_rejects_scheme_relative_targets(client):
-    response = client.get("/en//evil.com", follow=False)
+@pytest.mark.parametrize(
+    ("path", "expected_status"),
+    [
+        ("/en//evil.com", 404),
+        ("/en///evil.com", 404),
+        (r"/en/\evil.com", 301),
+    ],
+)
+def test_legacy_language_redirect_rejects_scheme_relative_targets(
+    client, path, expected_status
+):
+    response = client.get(path, follow=False)
 
-    assert not (
-        response.status_code in {301, 302, 307, 308}
-        and response["Location"].startswith("//")
-    )
+    assert response.status_code == expected_status
+    if response.status_code in {301, 302, 307, 308}:
+        assert not response["Location"].startswith("//")
 
 @pytest.mark.integration
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The legacy language-prefix redirect allowed the captured `rest` to begin with a leading slash which produced scheme-relative `Location` headers (e.g. `//evil.com`) for paths like `/en//evil.com`, enabling an open redirect vulnerability.

### Description
- Replace the single catch-all legacy redirect with two routes: a root-only redirect `r"^(?P<lang>[a-z]{2})/$" -> "/"` and a content redirect `r"^(?P<lang>[a-z]{2})/(?P<rest>[^/].*)$"` that forbids `rest` starting with `/` to prevent `//` targets, implemented in `apps/sites/routes.py`.
- Add a regression test `test_legacy_language_redirect_rejects_scheme_relative_targets` in `apps/sites/tests/test_public_routes.py` that requests `/en//evil.com` and asserts the response does not produce a scheme-relative redirect `Location`.

### Testing
- Installed dependencies and CI test extras with `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt` and then ran the targeted tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py` which executed `16 passed` for that file.
- Notification helper `./scripts/review-notify.sh --actor Codex` was run as part of the rollout and completed via the fallback notifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda0dc987c8326ae0360fdafd018cc)