### PR TITLE
sites: remove vertical spacing from admin net message banner

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -22,8 +22,9 @@
         align-items: center;
         align-content: right;
         gap: 0.5rem;
-        padding: 0 0.65rem;
-        margin-bottom: 0.2rem;
+        padding-block: 0;
+        padding-inline: 0.65rem;
+        margin-block: 0;
         border-radius: 6px;
         background: var(--darkened-bg);
         color: var(--body-fg);


### PR DESCRIPTION
### Motivation
- Remove the top and bottom padding/margin on the admin dashboard net-message container so the net message banner has no vertical gap.

### Description
- Modified `apps/sites/static/sites/css/admin/dashboard.css` to replace `padding: 0 0.65rem;` and `margin-bottom: 0.2rem;` with `padding-block: 0; padding-inline: 0.65rem; margin-block: 0;` to eliminate vertical spacing while preserving horizontal padding.

### Testing
- Ran `./env-refresh.sh --deps-only`, `.venv/bin/python manage.py check`, and `./scripts/review-notify.sh --actor Codex`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee63c74888326b2a1a62f4cd503ae)