### PR TITLE
docs/sites: fix Developer Documents ordering and folder navigation

### DIFF
--- a/apps/docs/templates/docs/library.html
+++ b/apps/docs/templates/docs/library.html
@@ -18,30 +18,14 @@
           {% blocktrans with missing_document=missing_document %}The requested document "{{ missing_document }}" was not found. Choose one of the available documents below.{% endblocktrans %}
         </div>
       {% endif %}
-      {% if sections %}
-        <h2>{% trans "Browse by Folder" %}</h2>
-        {% for section in sections %}
-          <h3 class="h5">{{ section.title }}</h3>
-          {% if section.current_prefix and section.parent_url %}
-            <p class="mb-2"><a href="{{ section.parent_url }}">← {% trans "Up one level" %}</a></p>
-          {% endif %}
-          {% if section.items %}
-            <ul class="list-unstyled mb-4">
-              {% for item in section.items %}
-                <li class="mb-2">
-                  <a href="{{ item.url }}">{{ item.label }}</a>
-                  {% if item.description %}
-                    <div class="text-muted small">{{ item.description }}</div>
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="text-muted">{% trans "No documents available in this folder." %}</p>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
       <h2>{% trans "Indexed Documents" %}</h2>
+      {% if document_index_admin_changelist_url and document_index_admin_add_url %}
+        <p class="small mb-3">
+          <a href="{{ document_index_admin_changelist_url }}">{% trans "Manage indexed documents" %}</a>
+          ·
+          <a href="{{ document_index_admin_add_url }}">{% trans "Create indexed document" %}</a>
+        </p>
+      {% endif %}
       {% if indexed_groups %}
         {% for group in indexed_groups %}
           <h3 class="h5">{{ group.title }}</h3>
@@ -64,21 +48,31 @@
       {% endif %}
 
       <h2>{% trans "Other Documents" %}</h2>
-      {% if other_documents %}
-        <div class="row row-cols-1 row-cols-lg-2 g-3 mb-4">
-          {% for item in other_documents %}
-            <div class="col">
-              <div class="card h-100 shadow-sm">
-                <div class="card-body">
-                  <h3 class="h5 mb-2"><a href="{{ item.url }}">{{ item.label }}</a></h3>
-                  <p class="mb-0 text-muted">{{ item.description }}</p>
-                </div>
-              </div>
-            </div>
-          {% endfor %}
-        </div>
+      {% if sections %}
+        {% for section in sections %}
+          <h3 class="h5">{{ section.title }}</h3>
+          {% if section.current_prefix and section.parent_url %}
+            <p class="mb-2"><a href="{{ section.parent_url }}">← {% trans "Up one level" %}</a></p>
+          {% endif %}
+          {% if section.items %}
+            <ul class="list-unstyled mb-4">
+              {% for item in section.items %}
+                {% if section.current_prefix or item.kind == "folder" %}
+                  <li class="mb-2">
+                    <a href="{{ item.url }}">{{ item.label }}</a>
+                    {% if item.description %}
+                      <div class="text-muted small">{{ item.description }}</div>
+                    {% endif %}
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted">{% trans "No document folders are available." %}</p>
+          {% endif %}
+        {% endfor %}
       {% else %}
-        <p class="text-muted">{% trans "No other documents are available." %}</p>
+        <p class="text-muted">{% trans "No document folders are available." %}</p>
       {% endif %}
     </div>
   </div>

--- a/apps/docs/templates/docs/library.html
+++ b/apps/docs/templates/docs/library.html
@@ -57,14 +57,12 @@
           {% if section.items %}
             <ul class="list-unstyled mb-4">
               {% for item in section.items %}
-                {% if section.current_prefix or item.kind == "folder" %}
-                  <li class="mb-2">
-                    <a href="{{ item.url }}">{{ item.label }}</a>
-                    {% if item.description %}
-                      <div class="text-muted small">{{ item.description }}</div>
-                    {% endif %}
-                  </li>
-                {% endif %}
+                <li class="mb-2">
+                  <a href="{{ item.url }}">{{ item.label }}</a>
+                  {% if item.description %}
+                    <div class="text-muted small">{{ item.description }}</div>
+                  {% endif %}
+                </li>
               {% endfor %}
             </ul>
           {% else %}

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -37,7 +37,7 @@ DOCS_CANONICAL_HOST_OVERRIDES = {
     "m.arthexis.com": "arthexis.com",
 }
 LIBRARY_ROOT_FOLDER_LABEL = "root"
-LIBRARY_ROOT_FOLDER_SENTINEL = "__root__"
+LIBRARY_ROOT_QUERY_PARAMETER = "virtual_root"
 FULL_CONTENT_DEFAULT_DOCUMENTS = {
     "docs/development/install-lifecycle-scripts-manual.md",
 }
@@ -310,6 +310,10 @@ def _build_library_query_url(parameter: str, prefix: str) -> str:
     return f"{reverse('docs:docs-library')}?{query}" if query else reverse("docs:docs-library")
 
 
+def _build_virtual_root_query_url(parameter: str) -> str:
+    return f"{reverse('docs:docs-library')}?{urlencode({parameter: '1'})}"
+
+
 def _build_library_section(
     files: list[Path],
     *,
@@ -319,6 +323,7 @@ def _build_library_section(
     title: str,
     prefix: str,
     parameter: str,
+    virtual_root_selected: bool,
 ) -> dict[str, object]:
     """Build a section index scoped to one folder level."""
 
@@ -326,7 +331,7 @@ def _build_library_section(
     items: list[dict[str, str]] = []
     root_items: list[dict[str, str]] = []
     show_root_folder = prefix == ""
-    in_virtual_root_folder = prefix == LIBRARY_ROOT_FOLDER_SENTINEL
+    in_virtual_root_folder = virtual_root_selected and prefix == ""
 
     for path in files:
         relative = path.relative_to(root).as_posix()
@@ -396,14 +401,13 @@ def _build_library_section(
             {
                 "kind": "folder",
                 "label": f"{LIBRARY_ROOT_FOLDER_LABEL}/",
-                "url": _build_library_query_url(parameter, LIBRARY_ROOT_FOLDER_SENTINEL),
+                "url": _build_virtual_root_query_url(f"{parameter}_{LIBRARY_ROOT_QUERY_PARAMETER}"),
                 "description": "Browse root-level documents.",
             },
         )
 
-    if in_virtual_root_folder:
-        folder_items.extend(item for item in items if item["url"])
-    else:
+    folder_items.extend(item for item in items if item["url"])
+    if prefix != "":
         folder_items.extend(item for item in root_items if item["url"])
 
     section: dict[str, object] = {
@@ -416,6 +420,9 @@ def _build_library_section(
             parent_prefix = ""
         section["current_prefix"] = prefix
         section["parent_url"] = _build_library_query_url(parameter, parent_prefix)
+    elif in_virtual_root_folder:
+        section["current_prefix"] = LIBRARY_ROOT_FOLDER_LABEL
+        section["parent_url"] = _build_library_query_url(parameter, "")
     return section
 
 
@@ -424,6 +431,8 @@ def _collect_document_library(
     *,
     docs_prefix: str = "",
     apps_docs_prefix: str = "",
+    docs_virtual_root_selected: bool = False,
+    apps_docs_virtual_root_selected: bool = False,
     docs_files: list[Path] | None = None,
     apps_docs_files: list[Path] | None = None,
 ) -> list[dict[str, object]]:
@@ -444,6 +453,7 @@ def _collect_document_library(
                 title="Documentation",
                 prefix=_normalize_library_prefix(docs_prefix),
                 parameter="docs_path",
+                virtual_root_selected=docs_virtual_root_selected,
             )
         )
 
@@ -460,6 +470,7 @@ def _collect_document_library(
                 title="Application Docs",
                 prefix=_normalize_library_prefix(apps_docs_prefix),
                 parameter="apps_docs_path",
+                virtual_root_selected=apps_docs_virtual_root_selected,
             )
         )
 
@@ -571,6 +582,8 @@ def _get_cached_document_library(
     *,
     docs_prefix: str = "",
     apps_docs_prefix: str = "",
+    docs_virtual_root_selected: bool = False,
+    apps_docs_virtual_root_selected: bool = False,
 ) -> list[dict[str, object]]:
     """Return a cached library index to avoid repeated filesystem scans."""
 
@@ -579,6 +592,8 @@ def _get_cached_document_library(
         root_base,
         docs_prefix=docs_prefix,
         apps_docs_prefix=apps_docs_prefix,
+        docs_virtual_root_selected=docs_virtual_root_selected,
+        apps_docs_virtual_root_selected=apps_docs_virtual_root_selected,
         docs_files=docs_paths,
         apps_docs_files=apps_docs_paths,
     )
@@ -595,10 +610,16 @@ def _render_document_library(
     root_base = Path(settings.BASE_DIR).resolve()
     docs_prefix = request.GET.get("docs_path", "")
     apps_docs_prefix = request.GET.get("apps_docs_path", "")
+    docs_virtual_root_selected = request.GET.get(f"docs_path_{LIBRARY_ROOT_QUERY_PARAMETER}") == "1"
+    apps_docs_virtual_root_selected = (
+        request.GET.get(f"apps_docs_path_{LIBRARY_ROOT_QUERY_PARAMETER}") == "1"
+    )
     sections = _get_cached_document_library(
         root_base,
         docs_prefix=docs_prefix,
         apps_docs_prefix=apps_docs_prefix,
+        docs_virtual_root_selected=docs_virtual_root_selected,
+        apps_docs_virtual_root_selected=apps_docs_virtual_root_selected,
     )
     docs_paths, apps_docs_paths = _get_cached_document_library_paths(root_base)
     all_documents = _build_library_documents(

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -36,6 +36,8 @@ DOCUMENT_LIBRARY_CACHE_TIMEOUT = 300
 DOCS_CANONICAL_HOST_OVERRIDES = {
     "m.arthexis.com": "arthexis.com",
 }
+LIBRARY_ROOT_FOLDER_LABEL = "root"
+LIBRARY_ROOT_FOLDER_SENTINEL = "__root__"
 FULL_CONTENT_DEFAULT_DOCUMENTS = {
     "docs/development/install-lifecycle-scripts-manual.md",
 }
@@ -322,9 +324,25 @@ def _build_library_section(
 
     folders: set[str] = set()
     items: list[dict[str, str]] = []
+    root_items: list[dict[str, str]] = []
+    show_root_folder = prefix == ""
+    in_virtual_root_folder = prefix == LIBRARY_ROOT_FOLDER_SENTINEL
 
     for path in files:
         relative = path.relative_to(root).as_posix()
+        if in_virtual_root_folder:
+            if "/" in relative or path.stem.lower() == "index":
+                continue
+            items.append(
+                _build_library_item(
+                    path,
+                    root,
+                    route_name,
+                    doc_path_prefix=doc_path_prefix,
+                    label=Path(relative).name,
+                )
+            )
+            continue
         if prefix:
             if relative == prefix:
                 if path.stem.lower() == "index":
@@ -350,7 +368,7 @@ def _build_library_section(
             continue
         if path.stem.lower() == "index":
             continue
-        items.append(
+        root_items.append(
             _build_library_item(
                 path,
                 root,
@@ -372,7 +390,21 @@ def _build_library_section(
         }
         for folder in sorted(folders)
     ]
-    folder_items.extend(item for item in items if item["url"])
+    if show_root_folder and root_items:
+        folder_items.insert(
+            0,
+            {
+                "kind": "folder",
+                "label": f"{LIBRARY_ROOT_FOLDER_LABEL}/",
+                "url": _build_library_query_url(parameter, LIBRARY_ROOT_FOLDER_SENTINEL),
+                "description": "Browse root-level documents.",
+            },
+        )
+
+    if in_virtual_root_folder:
+        folder_items.extend(item for item in items if item["url"])
+    else:
+        folder_items.extend(item for item in root_items if item["url"])
 
     section: dict[str, object] = {
         "title": title,
@@ -380,6 +412,8 @@ def _build_library_section(
     }
     if prefix:
         parent_prefix = prefix.rsplit("/", 1)[0] if "/" in prefix else ""
+        if in_virtual_root_folder:
+            parent_prefix = ""
         section["current_prefix"] = prefix
         section["parent_url"] = _build_library_query_url(parameter, parent_prefix)
     return section
@@ -579,22 +613,23 @@ def _render_document_library(
         doc_path_prefix="apps/docs/",
     )
     indexed_groups = _build_indexed_document_groups(request, all_documents)
-    indexed_doc_paths = {
-        assignment_item["doc_path"]
-        for group in indexed_groups
-        for assignment_item in group["items"]
-    }
-    other_documents = [
-        item for item in all_documents if item["doc_path"] not in indexed_doc_paths
-    ]
     context = {
         "canonical_url": _build_canonical_url(request),
+        "document_index_admin_add_url": "",
+        "document_index_admin_changelist_url": "",
         "indexed_groups": indexed_groups,
-        "other_documents": other_documents,
         "page_url": request.build_absolute_uri(),
         "sections": sections,
         "title": "Developer Documents",
     }
+    if request.user.is_staff:
+        try:
+            context["document_index_admin_changelist_url"] = reverse(
+                "admin:docs_documentindex_changelist"
+            )
+            context["document_index_admin_add_url"] = reverse("admin:docs_documentindex_add")
+        except NoReverseMatch:
+            pass
     if missing_document:
         context["missing_document"] = missing_document
     response = render(request, "docs/library.html", context, status=status)

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -434,7 +434,7 @@ def test_docs_library_groups_root_documents_into_root_folder(client):
         root_response = client.get(reverse("docs:docs-library"))
         virtual_root_response = client.get(
             reverse("docs:docs-library"),
-            {"docs_path": "__root__"},
+            {"docs_path_virtual_root": "1"},
         )
 
         assert root_response.status_code == 200
@@ -444,3 +444,48 @@ def test_docs_library_groups_root_documents_into_root_folder(client):
         assert "library-root-visibility-test.md" in virtual_root_response.content.decode()
     finally:
         root_document.unlink(missing_ok=True)
+
+
+def test_docs_library_virtual_root_does_not_collide_with_real_root_named_folder(client):
+    user = get_user_model().objects.create_user(
+        username="docs-root-collision-user",
+        email="docs-root-collision-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    nested_document = Path("docs/__root__/folder-navigation-test.md")
+    nested_document.parent.mkdir(parents=True, exist_ok=True)
+    nested_document.write_text("# Root folder\n\nFolder document.\n", encoding="utf-8")
+
+    client.force_login(user)
+    try:
+        cache.clear()
+        folder_response = client.get(reverse("docs:docs-library"), {"docs_path": "__root__"})
+
+        assert folder_response.status_code == 200
+        assert "folder-navigation-test.md" in folder_response.content.decode()
+    finally:
+        nested_document.unlink(missing_ok=True)
+        if nested_document.parent.exists():
+            nested_document.parent.rmdir()
+
+
+def test_docs_library_folder_view_includes_file_matching_prefix_exactly(client):
+    user = get_user_model().objects.create_user(
+        username="docs-prefix-file-user",
+        email="docs-prefix-file-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    prefixed_document = Path("docs/library-prefix-match.md")
+    prefixed_document.write_text("# Prefix match\n\nExact path document.\n", encoding="utf-8")
+
+    client.force_login(user)
+    try:
+        cache.clear()
+        response = client.get(reverse("docs:docs-library"), {"docs_path": "library-prefix-match.md"})
+
+        assert response.status_code == 200
+        assert "library-prefix-match.md" in response.content.decode()
+    finally:
+        prefixed_document.unlink(missing_ok=True)

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -305,7 +305,10 @@ def test_docs_library_renders_indexed_documents_before_other_documents(client):
     assert response.status_code == 200
     assert "Indexed Documents" in body
     assert "Other Documents" in body
+    assert body.index("Indexed Documents") < body.index("Other Documents")
     assert "security-model.md" in body
+    assert "Manage indexed documents" in body
+    assert "Create indexed document" in body
 
 
 def test_readme_resolves_sigils_for_authenticated_user(client):
@@ -404,7 +407,8 @@ def test_docs_library_keeps_nested_docs_visible_and_shows_parent_navigation(clie
         folder_response = client.get(reverse("docs:docs-library"), {"docs_path": "library-test/subfolder"})
 
         assert root_response.status_code == 200
-        assert "nested-visibility-test.md" in root_response.content.decode()
+        assert "library-test/" in root_response.content.decode()
+        assert "nested-visibility-test.md" not in root_response.content.decode()
         assert folder_response.status_code == 200
         assert "Up one level" in folder_response.content.decode()
     finally:
@@ -412,3 +416,31 @@ def test_docs_library_keeps_nested_docs_visible_and_shows_parent_navigation(clie
         for parent in (nested_document.parent, nested_document.parent.parent):
             if parent.exists():
                 parent.rmdir()
+
+
+def test_docs_library_groups_root_documents_into_root_folder(client):
+    user = get_user_model().objects.create_user(
+        username="docs-root-folder-user",
+        email="docs-root-folder-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    root_document = Path("docs/library-root-visibility-test.md")
+    root_document.write_text("# Root visibility\n\nRoot document.\n", encoding="utf-8")
+
+    client.force_login(user)
+    try:
+        cache.clear()
+        root_response = client.get(reverse("docs:docs-library"))
+        virtual_root_response = client.get(
+            reverse("docs:docs-library"),
+            {"docs_path": "__root__"},
+        )
+
+        assert root_response.status_code == 200
+        assert "root/" in root_response.content.decode()
+        assert "library-root-visibility-test.md" not in root_response.content.decode()
+        assert virtual_root_response.status_code == 200
+        assert "library-root-visibility-test.md" in virtual_root_response.content.decode()
+    finally:
+        root_document.unlink(missing_ok=True)


### PR DESCRIPTION
### Motivation

- The Developer Documents library page combined and repeated root-level documents and listed sections in the wrong order, making discovery confusing. 
- The goal is to show `Indexed Documents` before folder listings, keep the root page clean by grouping root-level files into a discoverable `root/` folder, and give staff quick admin links for managing indexed documents.

### Description

- Reordered the library rendering so `Indexed Documents` is rendered before the other-document folders and added staff-only admin shortcut links by updating `apps/docs/templates/docs/library.html` and the view context in `apps/docs/views.py`.
- Introduced `LIBRARY_ROOT_FOLDER_LABEL` and `LIBRARY_ROOT_FOLDER_SENTINEL` and changed `_build_library_section` in `apps/docs/views.py` to group root-level files under a virtual `root/` folder and avoid repeating full file listings at the top level. 
- Adjusted template logic in `apps/docs/templates/docs/library.html` to present folders (and folder navigation) under the `Other Documents` section and to show the admin add/changelist links only for staff. 
- Updated and added tests in `apps/sites/tests/test_public_routes.py` to assert section ordering, presence of the staff admin links, nested-folder navigation behavior, and that root documents appear under the virtual `root/` folder view.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed test deps with `.venv/bin/pip install -r requirements-ci.txt` which succeeded. 
- Ran the repository test entrypoint for the affected cases with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py::test_docs_library_renders_indexed_documents_before_other_documents apps/sites/tests/test_public_routes.py::test_docs_library_keeps_nested_docs_visible_and_shows_parent_navigation apps/sites/tests/test_public_routes.py::test_docs_library_groups_root_documents_into_root_folder` and all three tests passed. 
- A review notification was issued via `./scripts/review-notify.sh --actor Codex` after tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee4f81b4083269abf7ec25e65c1cd)