### PR TITLE
Add shared SWR fetch cache utility for traffic charts and version checks

### DIFF
--- a/apps/core/templates/core/version_check.html
+++ b/apps/core/templates/core/version_check.html
@@ -1,4 +1,4 @@
-{% load i18n version_tags %}
+{% load i18n static version_tags %}
 {% translate "A new version of this site is available." as version_message %}
 {% translate "Refresh" as refresh_label %}
 {% translate "Version" as version_label %}
@@ -7,6 +7,7 @@
   {% if request.user.is_staff %}
     {% version_check_info as local_version_info %}
   {% endif %}
+<script src="{% static 'pages/js/admin_cache.js' %}"></script>
 <script>
 (function () {
   const CHECK_URL = "{% url 'version-info' %}";
@@ -17,7 +18,7 @@
   const LOCAL_VERSION = "{{ local_version_info.version|escapejs }}";
   const LOCAL_REVISION = "{{ local_version_info.revision|escapejs }}";
   const CHECK_INTERVAL = 120000;
-  const REMOTE_CHECK_INTERVAL = 600000;
+  const VERSION_INFO_TTL = 180000;
   const STORAGE_KEY = "version-check-state-v1";
   const LOCK_KEY = "version-check-lock-v1";
   const LOCK_TTL = 15000;
@@ -137,16 +138,6 @@
       }
     }
 
-    function shouldSkipRemoteFetch() {
-      const stored = readStoredState();
-      if (!stored) {
-        return false;
-      }
-      syncWithStoredState(stored);
-      const age = Date.now() - stored.checkedAt;
-      return age < REMOTE_CHECK_INTERVAL;
-    }
-
     function acquireLock() {
       try {
         const now = Date.now();
@@ -221,38 +212,52 @@
       return banner;
     }
 
-    async function fetchInfo() {
-      if (document.visibilityState === "hidden") {
+    function applyRemoteState(data) {
+      if (!data || typeof data !== "object") {
         return;
       }
-      if (shouldSkipRemoteFetch()) {
+      const version = typeof data.version === "string" ? data.version : "";
+      const revision = typeof data.revision === "string" ? data.revision : "";
+      writeStoredState({ version, revision });
+      if (currentVersion === null && currentRevision === null) {
+        currentVersion = version;
+        currentRevision = revision;
+        return;
+      }
+      if (version !== currentVersion || revision !== currentRevision) {
+        currentVersion = version;
+        currentRevision = revision;
+        updateBanner({ version, revision });
+      }
+    }
+
+    async function fetchInfo() {
+      if (document.visibilityState === "hidden") {
         return;
       }
       if (!acquireLock()) {
         return;
       }
       try {
-        const response = await fetch(CHECK_URL, {
-          credentials: "same-origin",
-          cache: "no-store",
+        const cacheClient = window.ArthexisAdminCache;
+        if (!cacheClient || typeof cacheClient.fetchJSON !== "function") {
+          return;
+        }
+        const result = await cacheClient.fetchJSON(CHECK_URL, {
+          maxPayloadBytes: 32768,
+          onRevalidate: (nextData, state) => {
+            if (state.changed) {
+              applyRemoteState(nextData);
+            }
+          },
+          requestInit: {
+            credentials: "same-origin",
+            headers: { Accept: "application/json" },
+          },
+          staleWhileRevalidate: true,
+          ttlMs: VERSION_INFO_TTL,
         });
-        if (!response.ok) {
-          return;
-        }
-        const data = await response.json();
-        const version = typeof data.version === "string" ? data.version : "";
-        const revision = typeof data.revision === "string" ? data.revision : "";
-        writeStoredState({ version, revision });
-        if (currentVersion === null && currentRevision === null) {
-          currentVersion = version;
-          currentRevision = revision;
-          return;
-        }
-        if (version !== currentVersion || revision !== currentRevision) {
-          currentVersion = version;
-          currentRevision = revision;
-          updateBanner({ version, revision });
-        }
+        applyRemoteState(result.data);
       } catch (error) {
         // Network issues are ignored to avoid interrupting the user experience.
       }

--- a/apps/sites/static/pages/js/admin_cache.js
+++ b/apps/sites/static/pages/js/admin_cache.js
@@ -63,27 +63,57 @@
 
   const storeEntry = (cacheKey, entry, maxPayloadBytes) => {
     try {
-      const payload = JSON.stringify(entry.data);
+      const serialized = JSON.stringify(entry);
       if (
         typeof maxPayloadBytes === "number" &&
         maxPayloadBytes > 0 &&
-        new TextEncoder().encode(payload).length > maxPayloadBytes
+        new TextEncoder().encode(serialized).length > maxPayloadBytes
       ) {
         return;
       }
       memoryCache.set(cacheKey, entry);
-      window.localStorage.setItem(cacheKey, JSON.stringify(entry));
+      window.localStorage.setItem(cacheKey, serialized);
     } catch (error) {
       // Ignore serialization and storage failures.
     }
   };
 
+  const isPlainObject = (value) =>
+    Object.prototype.toString.call(value) === "[object Object]";
+
   const sameData = (first, second) => {
-    try {
-      return JSON.stringify(first) === JSON.stringify(second);
-    } catch (error) {
+    if (Object.is(first, second)) {
+      return true;
+    }
+
+    if (typeof first !== typeof second || first == null || second == null) {
       return false;
     }
+
+    if (Array.isArray(first)) {
+      if (!Array.isArray(second) || first.length !== second.length) {
+        return false;
+      }
+      return first.every((value, index) => sameData(value, second[index]));
+    }
+
+    if (isPlainObject(first)) {
+      if (!isPlainObject(second)) {
+        return false;
+      }
+
+      const firstKeys = Object.keys(first).sort();
+      const secondKeys = Object.keys(second).sort();
+      if (firstKeys.length !== secondKeys.length) {
+        return false;
+      }
+
+      return firstKeys.every(
+        (key, index) => key === secondKeys[index] && sameData(first[key], second[key]),
+      );
+    }
+
+    return false;
   };
 
   const fetchNetworkData = (url, requestInit) =>
@@ -142,7 +172,9 @@
     }
 
     if (staleWhileRevalidate) {
-      void revalidate();
+      if (isExpired) {
+        void revalidate().catch(() => {});
+      }
     } else if (isExpired) {
       return revalidate().then((data) => ({
         data,

--- a/apps/sites/static/pages/js/admin_cache.js
+++ b/apps/sites/static/pages/js/admin_cache.js
@@ -1,0 +1,164 @@
+(() => {
+  const CACHE_PREFIX = "arthexis-admin-cache-v1:";
+  const memoryCache = new Map();
+  const inFlightRequests = new Map();
+
+  const toAbsoluteUrl = (url) => new URL(url, window.location.origin);
+
+  const stableParams = (urlObject, keyParams) => {
+    const params = new URLSearchParams();
+    if (Array.isArray(keyParams) && keyParams.length) {
+      keyParams
+        .slice()
+        .sort()
+        .forEach((name) => {
+          urlObject.searchParams.getAll(name).forEach((value) => {
+            params.append(name, value);
+          });
+        });
+      return params;
+    }
+
+    Array.from(urlObject.searchParams.entries())
+      .sort(([aName, aValue], [bName, bValue]) => {
+        if (aName === bName) {
+          return aValue.localeCompare(bValue);
+        }
+        return aName.localeCompare(bName);
+      })
+      .forEach(([name, value]) => {
+        params.append(name, value);
+      });
+    return params;
+  };
+
+  const buildCacheKey = (url, keyParams) => {
+    const absolute = toAbsoluteUrl(url);
+    const params = stableParams(absolute, keyParams);
+    const keyUrl = `${absolute.origin}${absolute.pathname}`;
+    const query = params.toString();
+    return `${CACHE_PREFIX}${query ? `${keyUrl}?${query}` : keyUrl}`;
+  };
+
+  const readStoredEntry = (cacheKey) => {
+    if (memoryCache.has(cacheKey)) {
+      return memoryCache.get(cacheKey);
+    }
+
+    try {
+      const raw = window.localStorage.getItem(cacheKey);
+      if (!raw) {
+        return null;
+      }
+      const entry = JSON.parse(raw);
+      if (!entry || typeof entry !== "object" || !("data" in entry)) {
+        return null;
+      }
+      memoryCache.set(cacheKey, entry);
+      return entry;
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const storeEntry = (cacheKey, entry, maxPayloadBytes) => {
+    try {
+      const payload = JSON.stringify(entry.data);
+      if (
+        typeof maxPayloadBytes === "number" &&
+        maxPayloadBytes > 0 &&
+        new TextEncoder().encode(payload).length > maxPayloadBytes
+      ) {
+        return;
+      }
+      memoryCache.set(cacheKey, entry);
+      window.localStorage.setItem(cacheKey, JSON.stringify(entry));
+    } catch (error) {
+      // Ignore serialization and storage failures.
+    }
+  };
+
+  const sameData = (first, second) => {
+    try {
+      return JSON.stringify(first) === JSON.stringify(second);
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const fetchNetworkData = (url, requestInit) =>
+    fetch(url, requestInit).then((response) => {
+      if (!response.ok) {
+        throw new Error(`Fetch failed with status ${response.status}`);
+      }
+      return response.json();
+    });
+
+  const fetchJSON = (url, options = {}) => {
+    const {
+      keyParams = [],
+      ttlMs = 60_000,
+      staleWhileRevalidate = true,
+      maxPayloadBytes,
+      requestInit = {},
+      onRevalidate,
+    } = options;
+
+    const cacheKey = buildCacheKey(url, keyParams);
+    const entry = readStoredEntry(cacheKey);
+    const now = Date.now();
+    const isExpired = !entry || now - (entry.fetchedAt || 0) > ttlMs;
+
+    const revalidate = () => {
+      if (inFlightRequests.has(cacheKey)) {
+        return inFlightRequests.get(cacheKey);
+      }
+
+      const pending = fetchNetworkData(url, requestInit)
+        .then((data) => {
+          const previous = readStoredEntry(cacheKey);
+          const changed = !previous || !sameData(previous.data, data);
+          const nextEntry = { data, fetchedAt: Date.now() };
+          storeEntry(cacheKey, nextEntry, maxPayloadBytes);
+          if (typeof onRevalidate === "function") {
+            onRevalidate(data, { changed, cacheKey });
+          }
+          return data;
+        })
+        .finally(() => {
+          inFlightRequests.delete(cacheKey);
+        });
+
+      inFlightRequests.set(cacheKey, pending);
+      return pending;
+    };
+
+    if (!entry) {
+      return revalidate().then((data) => ({
+        data,
+        fromCache: false,
+        isStale: false,
+      }));
+    }
+
+    if (staleWhileRevalidate) {
+      void revalidate();
+    } else if (isExpired) {
+      return revalidate().then((data) => ({
+        data,
+        fromCache: false,
+        isStale: false,
+      }));
+    }
+
+    return Promise.resolve({
+      data: entry.data,
+      fromCache: true,
+      isStale: isExpired,
+    });
+  };
+
+  window.ArthexisAdminCache = {
+    fetchJSON,
+  };
+})();

--- a/apps/sites/templates/admin/pages/viewhistory/traffic_graph.html
+++ b/apps/sites/templates/admin/pages/viewhistory/traffic_graph.html
@@ -5,6 +5,7 @@
 
 {% block extrahead %}
   {{ block.super }}
+  <script src="{% static 'pages/js/admin_cache.js' %}"></script>
   <script src="{% static 'core/vendor/chart.umd.min.js' %}" data-chartjs="true"></script>
   <style>
     #viewhistory-graph-module {
@@ -117,82 +118,110 @@
 
       const chartEndpoint = new URL('{{ chart_endpoint }}', window.location);
 
-      const fetchData = () =>
-        fetch(chartEndpoint.toString(), {
-          headers: { Accept: 'application/json' },
-          credentials: 'same-origin',
-        }).then((response) => (response.ok ? response.json() : Promise.reject()));
+      let chart;
+
+      const applyData = (Chart, data) => {
+        if (!data || !Array.isArray(data.labels) || !Array.isArray(data.datasets)) {
+          throw new Error('Invalid chart data');
+        }
+        if (!data.datasets.length) {
+          if (chart) {
+            chart.destroy();
+            chart = null;
+          }
+          canvas.hidden = true;
+          emptyLabel.hidden = false;
+          return;
+        }
+        if (data.meta && metaLabel) {
+          const start = data.meta.start || '';
+          const end = data.meta.end || '';
+          const pages = Array.isArray(data.meta.pages) ? data.meta.pages : [];
+          const summary = [];
+          if (start && end) {
+            summary.push(`{% translate "Range" %}: ${start} – ${end}`);
+          }
+          if (pages.length) {
+            summary.push(`{% translate "Pages" %}: ${pages.join(', ')}`);
+          }
+          metaLabel.textContent = summary.join(' \u2022 ');
+        }
+        emptyLabel.hidden = true;
+        canvas.hidden = false;
+        const nextData = {
+          labels: data.labels,
+          datasets: data.datasets.map((dataset) => ({
+            ...dataset,
+            pointRadius: 3,
+            pointHoverRadius: 5,
+          })),
+        };
+        if (chart) {
+          chart.data = nextData;
+          chart.update();
+          return;
+        }
+        const context = canvas.getContext('2d');
+        chart = new Chart(context, {
+          type: 'line',
+          data: nextData,
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                title: {
+                  display: true,
+                  text: '{% translate "Date" %}',
+                },
+              },
+              y: {
+                beginAtZero: true,
+                title: {
+                  display: true,
+                  text: '{% translate "Visits" %}',
+                },
+              },
+            },
+            plugins: {
+              legend: {
+                position: 'bottom',
+              },
+              tooltip: {
+                mode: 'nearest',
+                intersect: false,
+              },
+            },
+          },
+        });
+      };
+
+      const fetchData = (Chart) =>
+        window.ArthexisAdminCache.fetchJSON(chartEndpoint.toString(), {
+          keyParams: ['days', 'page', 'pages'],
+          maxPayloadBytes: 262144,
+          onRevalidate: (nextData, state) => {
+            if (state.changed) {
+              applyData(Chart, nextData);
+            }
+          },
+          requestInit: {
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+          },
+          staleWhileRevalidate: true,
+          ttlMs: 60000,
+        }).then((result) => result.data);
 
       ensureChartJs()
         .then((Chart) => {
           if (!Chart && !waitForChart(() => {})) {
             throw new Error('Chart.js unavailable');
           }
-          return fetchData().then((data) => ({ Chart: window.Chart, data }));
+          return fetchData(window.Chart).then((data) => ({ Chart: window.Chart, data }));
         })
         .then(({ Chart, data }) => {
-          if (!data || !Array.isArray(data.labels) || !Array.isArray(data.datasets)) {
-            throw new Error('Invalid chart data');
-          }
-          if (!data.datasets.length) {
-            canvas.hidden = true;
-            emptyLabel.hidden = false;
-            return;
-          }
-          if (data.meta && metaLabel) {
-            const start = data.meta.start || '';
-            const end = data.meta.end || '';
-            const pages = Array.isArray(data.meta.pages) ? data.meta.pages : [];
-            const summary = [];
-            if (start && end) {
-              summary.push(`{% translate "Range" %}: ${start} – ${end}`);
-            }
-            if (pages.length) {
-              summary.push(`{% translate "Pages" %}: ${pages.join(', ')}`);
-            }
-            metaLabel.textContent = summary.join(' \u2022 ');
-          }
-          emptyLabel.hidden = true;
-          const context = canvas.getContext('2d');
-          new Chart(context, {
-            type: 'line',
-            data: {
-              labels: data.labels,
-              datasets: data.datasets.map((dataset) => ({
-                ...dataset,
-                pointRadius: 3,
-                pointHoverRadius: 5,
-              })),
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              scales: {
-                x: {
-                  title: {
-                    display: true,
-                    text: '{% translate "Date" %}',
-                  },
-                },
-                y: {
-                  beginAtZero: true,
-                  title: {
-                    display: true,
-                    text: '{% translate "Visits" %}',
-                  },
-                },
-              },
-              plugins: {
-                legend: {
-                  position: 'bottom',
-                },
-                tooltip: {
-                  mode: 'nearest',
-                  intersect: false,
-                },
-              },
-            },
-          });
+          applyData(Chart, data);
         })
         .catch(() => {
           canvas.hidden = true;

--- a/apps/sites/templates/widgets/public_site_traffic.html
+++ b/apps/sites/templates/widgets/public_site_traffic.html
@@ -7,6 +7,7 @@
   </div>
   <p class="chart-link"><a id="viewhistory-mini-link" href="{% url 'admin:pages_viewhistory_traffic_graph' %}">{% translate 'Open full report' %}</a></p>
 </div>
+<script src="{% static 'pages/js/admin_cache.js' %}"></script>
 <script>
   const initializeMiniTrafficChart = () => {
     const canvas = document.getElementById('viewhistory-mini-chart');
@@ -95,66 +96,91 @@
     );
     chartDataUrl.searchParams.set('days', '7');
 
-    const fetchData = () =>
-      fetch(chartDataUrl.toString(), {
-        headers: { Accept: 'application/json' },
-      }).then((response) => (response.ok ? response.json() : Promise.reject()));
+    const applyData = (Chart, data) => {
+      if (!data || !Array.isArray(data.datasets) || !data.datasets.length) {
+        if (canvas.chart) {
+          canvas.chart.destroy();
+          delete canvas.chart;
+        }
+        canvas.hidden = true;
+        if (emptyLabel) {
+          emptyLabel.hidden = false;
+          emptyLabel.textContent = '{% translate "No visit data yet." %}';
+        }
+        return;
+      }
+
+      if (emptyLabel) {
+        emptyLabel.hidden = true;
+      }
+      canvas.hidden = false;
+      const nextData = {
+        labels: data.labels,
+        datasets: data.datasets.map((dataset) => ({
+          ...dataset,
+          pointRadius: 0,
+          pointHoverRadius: 3,
+          borderWidth: 2,
+        })),
+      };
+      if (canvas.chart) {
+        canvas.chart.data = nextData;
+        canvas.chart.update();
+        return;
+      }
+
+      const context = canvas.getContext('2d');
+      canvas.chart = new Chart(context, {
+        type: 'line',
+        data: nextData,
+        options: {
+          animation: false,
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              mode: 'nearest',
+              intersect: false,
+            },
+          },
+          elements: {
+            line: { tension: 0.3 },
+          },
+          scales: {
+            x: {
+              ticks: { autoSkip: true, maxTicksLimit: 7 },
+            },
+          },
+        },
+      });
+    };
+
+    const fetchData = (Chart) =>
+      window.ArthexisAdminCache.fetchJSON(chartDataUrl.toString(), {
+        keyParams: ['days', 'page', 'pages'],
+        maxPayloadBytes: 196608,
+        onRevalidate: (nextData, state) => {
+          if (state.changed) {
+            applyData(Chart, nextData);
+          }
+        },
+        requestInit: {
+          headers: { Accept: 'application/json' },
+        },
+        staleWhileRevalidate: true,
+        ttlMs: 45000,
+      }).then((result) => result.data);
 
     ensureChartJs()
       .then((Chart) => {
         if (!Chart) {
           throw new Error('chartjs');
         }
-        return fetchData().then((data) => ({ Chart, data }));
+        return fetchData(Chart).then((data) => ({ Chart, data }));
       })
       .then(({ Chart, data }) => {
-        if (!data || !Array.isArray(data.datasets) || !data.datasets.length) {
-          canvas.hidden = true;
-          if (emptyLabel) {
-            emptyLabel.hidden = false;
-            emptyLabel.textContent = '{% translate "No visit data yet." %}';
-          }
-          return;
-        }
-
-        if (emptyLabel) {
-          emptyLabel.hidden = true;
-        }
-        canvas.hidden = false;
-        const context = canvas.getContext('2d');
-        const chart = new Chart(context, {
-          type: 'line',
-          data: {
-            labels: data.labels,
-            datasets: data.datasets.map((dataset) => ({
-              ...dataset,
-              pointRadius: 0,
-              pointHoverRadius: 3,
-              borderWidth: 2,
-            })),
-          },
-          options: {
-            animation: false,
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                mode: 'nearest',
-                intersect: false,
-              },
-            },
-            elements: {
-              line: { tension: 0.3 },
-            },
-            scales: {
-              x: {
-                ticks: { autoSkip: true, maxTicksLimit: 7 },
-              },
-            },
-          },
-        });
-        canvas.chart = chart;
+        applyData(Chart, data);
       })
       .catch(() => {
         canvas.hidden = true;


### PR DESCRIPTION
### Motivation
- Reduce redundant network requests and make traffic/version UIs render immediately by returning cached JSON when available and refreshing in the background. 
- Provide a single, small client-side utility to standardize cache key building, TTLs, stale-while-revalidate behavior, and payload-size guarding. 
- Replace a strict `cache: "no-store"` pattern for version checks with a conservative short-TTL SWR approach to keep admin UX responsive without sacrificing freshness. 

### Description
- Add `apps/sites/static/pages/js/admin_cache.js` which exposes `window.ArthexisAdminCache.fetchJSON` and implements deterministic cache keys (URL + selected query params), an in-memory + `localStorage` backing store, in-flight request deduplication, TTL checks, stale-while-revalidate background revalidation, `onRevalidate` callbacks, and an optional `maxPayloadBytes` guard. 
- Integrate the cache into the admin traffic graph at `apps/sites/templates/admin/pages/viewhistory/traffic_graph.html` so the page renders cached data immediately and then revalidates in background with `ttlMs: 60000` and `maxPayloadBytes: 262144`, updating the chart and metadata in-place when data changes. 
- Integrate the cache into the public mini-traffic widget at `apps/sites/templates/widgets/public_site_traffic.html` so the mini-chart uses cached data first and background-refreshes with `ttlMs: 45000` and `maxPayloadBytes: 196608`, updating the existing chart instance when payloads differ. 
- Replace the version-check `fetch(..., cache: 'no-store')` with `ArthexisAdminCache.fetchJSON` in `apps/core/templates/core/version_check.html`, using `ttlMs: 180000` and `maxPayloadBytes: 32768` and preserving banner/state update logic via the `onRevalidate` callback. 

### Testing
- Ran environment setup with `./env-refresh.sh --deps-only`, which completed successfully. 
- Verified migrations with `.venv/bin/python manage.py migrations check`, which reported no changes. 
- Installed CI test dependencies with `.venv/bin/pip install -r requirements-ci.txt`, which completed successfully. 
- Executed the targeted test subset with `.venv/bin/python manage.py test run -- apps/sites/tests/test_view_history_middleware.py apps/sites/tests/test_view_history_maintenance.py apps/core/tests/test_admin_staff_tasks.py`, which passed (16 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deff77a440832682586e116c1af481)