### PR TITLE
sites: persist admin sidebar filter, app collapse state, and recent targets

### DIFF
--- a/apps/sites/templates/admin/base_site.html
+++ b/apps/sites/templates/admin/base_site.html
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', function () {
         recentTargets: `${storagePrefix}.recent_targets`,
     };
     const writeTimers = {};
+    const pendingWrites = {};
     const recentTargetLimit = 12;
 
     function readJson(key, fallback) {
@@ -143,6 +144,37 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
+    function writeStorageNow(key, value) {
+        if (!storage) {
+            return;
+        }
+        if (writeTimers[key]) {
+            window.clearTimeout(writeTimers[key]);
+            delete writeTimers[key];
+        }
+        if (Object.prototype.hasOwnProperty.call(pendingWrites, key)) {
+            delete pendingWrites[key];
+        }
+        try {
+            storage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value));
+        } catch (error) {
+            // Ignore storage quota and serialization errors.
+        }
+    }
+
+    function flushPendingStorageWrites() {
+        Object.keys(writeTimers).forEach(function (key) {
+            if (writeTimers[key]) {
+                window.clearTimeout(writeTimers[key]);
+                delete writeTimers[key];
+            }
+            if (Object.prototype.hasOwnProperty.call(pendingWrites, key)) {
+                writeStorageNow(key, pendingWrites[key]);
+                delete pendingWrites[key];
+            }
+        });
+    }
+
     function writeStorageDebounced(key, value) {
         if (!storage) {
             return;
@@ -152,12 +184,10 @@ document.addEventListener('DOMContentLoaded', function () {
             window.clearTimeout(writeTimers[key]);
         }
 
+        pendingWrites[key] = value;
         writeTimers[key] = window.setTimeout(function () {
-            try {
-                storage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value));
-            } catch (error) {
-                // Ignore storage quota and serialization errors.
-            }
+            writeStorageNow(key, pendingWrites[key]);
+            delete pendingWrites[key];
             delete writeTimers[key];
         }, 150);
     }
@@ -191,7 +221,7 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    function persistCollapsedState() {
+    function persistCollapsedState(immediate) {
         const collapsedMap = {};
         modules.forEach(function (module) {
             const appLabel = getAppLabel(module);
@@ -200,6 +230,10 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             collapsedMap[appLabel] = module.classList.contains('collapsed');
         });
+        if (immediate) {
+            writeStorageNow(keys.collapsed, collapsedMap);
+            return;
+        }
         writeStorageDebounced(keys.collapsed, collapsedMap);
     }
 
@@ -244,7 +278,7 @@ document.addEventListener('DOMContentLoaded', function () {
             .slice(0, recentTargetLimit);
     }
 
-    function persistRecentTarget(url) {
+    function persistRecentTarget(url, immediate) {
         if (!url) {
             return;
         }
@@ -253,6 +287,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 return target !== url;
             });
         dedupedTargets.unshift(url);
+        if (immediate) {
+            writeStorageNow(keys.recentTargets, dedupedTargets.slice(0, recentTargetLimit));
+            return;
+        }
         writeStorageDebounced(keys.recentTargets, dedupedTargets.slice(0, recentTargetLimit));
     }
 
@@ -269,6 +307,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     const restoredFilter = storage ? storage.getItem(keys.filter) : '';
+    const shouldReapplyFilter = typeof restoredFilter === 'string' && Boolean(restoredFilter.trim());
     if (typeof restoredFilter === 'string') {
         nav.value = restoredFilter;
     }
@@ -287,21 +326,21 @@ document.addEventListener('DOMContentLoaded', function () {
 
     sidebar.addEventListener('click', function (event) {
         const link = event.target.closest('a[href]');
-        if (!link || !sidebar.contains(link)) {
-            return;
-        }
-        persistRecentTarget(link.href);
-        if (link.closest('.app-caption')) {
-            return;
-        }
-        window.setTimeout(persistCollapsedState, 0);
-    });
-    sidebar.addEventListener('click', function (event) {
         const toggleButton = event.target.closest('.app-collapse-toggle');
+
+        if (link && sidebar.contains(link)) {
+            persistRecentTarget(link.href, true);
+            persistCollapsedState(true);
+            return;
+        }
+
         if (!toggleButton || !sidebar.contains(toggleButton)) {
             return;
         }
-        window.setTimeout(persistCollapsedState, 0);
+
+        window.setTimeout(function () {
+            persistCollapsedState(true);
+        }, 0);
     });
 
     const observer = new MutationObserver(function (records) {
@@ -309,16 +348,27 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
         records.forEach(function (record) {
-            if (record.type === 'attributes' && record.attributeName === 'class') {
+            if (
+                record.type === 'attributes'
+                && record.attributeName === 'class'
+                && record.target.classList.contains('collapsed')
+            ) {
                 record.target.classList.remove('collapsed');
             }
         });
     });
-    modules.forEach(function (module) {
-        observer.observe(module, { attributes: true, attributeFilter: ['class'] });
-    });
+    observer.observe(sidebar, { attributes: true, attributeFilter: ['class'], subtree: true });
 
-    toggleEmptyGroups();
+    if (storage) {
+        window.addEventListener('pagehide', flushPendingStorageWrites);
+        window.addEventListener('beforeunload', flushPendingStorageWrites);
+    }
+
+    if (shouldReapplyFilter) {
+        nav.dispatchEvent(new Event('input', { bubbles: true }));
+    } else {
+        toggleEmptyGroups();
+    }
 });
 </script>
 <script id="admin-sidebar-collapse-toggle-visibility">

--- a/apps/sites/templates/admin/base_site.html
+++ b/apps/sites/templates/admin/base_site.html
@@ -109,6 +109,99 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     const modules = Array.from(sidebar.querySelectorAll('.module'));
+    const storage = (function resolveStorage() {
+        try {
+            return window.localStorage;
+        } catch (error) {
+            return null;
+        }
+    })();
+    const storagePrefix = [
+        'arthexis',
+        'admin',
+        'sidebar',
+        '{{ current_site_domain|default:"default-site"|escapejs }}',
+        '{{ request.user.pk|default:"anonymous"|escapejs }}',
+    ].join('.');
+    const keys = {
+        filter: `${storagePrefix}.filter`,
+        collapsed: `${storagePrefix}.collapsed`,
+        recentTargets: `${storagePrefix}.recent_targets`,
+    };
+    const writeTimers = {};
+    const recentTargetLimit = 12;
+
+    function readJson(key, fallback) {
+        if (!storage) {
+            return fallback;
+        }
+        try {
+            const value = storage.getItem(key);
+            return value ? JSON.parse(value) : fallback;
+        } catch (error) {
+            return fallback;
+        }
+    }
+
+    function writeStorageDebounced(key, value) {
+        if (!storage) {
+            return;
+        }
+
+        if (writeTimers[key]) {
+            window.clearTimeout(writeTimers[key]);
+        }
+
+        writeTimers[key] = window.setTimeout(function () {
+            try {
+                storage.setItem(key, typeof value === 'string' ? value : JSON.stringify(value));
+            } catch (error) {
+                // Ignore storage quota and serialization errors.
+            }
+            delete writeTimers[key];
+        }, 150);
+    }
+
+    function getAppLabel(module) {
+        if (module.dataset && module.dataset.appLabel) {
+            return module.dataset.appLabel;
+        }
+        const appClass = Array.from(module.classList).find(function (token) {
+            return token.indexOf('app-') === 0;
+        });
+        return appClass ? appClass.replace('app-', '') : null;
+    }
+
+    function getCollapsedMap() {
+        const value = readJson(keys.collapsed, {});
+        return value && typeof value === 'object' ? value : {};
+    }
+
+    function applyCollapsedMap(collapsedMap) {
+        modules.forEach(function (module) {
+            const appLabel = getAppLabel(module);
+            if (!appLabel) {
+                return;
+            }
+            if (collapsedMap[appLabel]) {
+                module.classList.add('collapsed');
+            } else {
+                module.classList.remove('collapsed');
+            }
+        });
+    }
+
+    function persistCollapsedState() {
+        const collapsedMap = {};
+        modules.forEach(function (module) {
+            const appLabel = getAppLabel(module);
+            if (!appLabel) {
+                return;
+            }
+            collapsedMap[appLabel] = module.classList.contains('collapsed');
+        });
+        writeStorageDebounced(keys.collapsed, collapsedMap);
+    }
 
     function toggleEmptyGroups() {
         const query = nav.value.trim().toLowerCase();
@@ -127,15 +220,103 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
 
-        // Ensure modules remain expanded while filtering and during normal navigation.
-        visibleModules.forEach(function (module) {
-            module.classList.remove('collapsed');
+        if (query) {
+            visibleModules.forEach(function (module) {
+                module.classList.remove('collapsed');
+            });
+        } else {
+            applyCollapsedMap(getCollapsedMap());
+        }
+    }
+
+    function persistFilterValue() {
+        writeStorageDebounced(keys.filter, nav.value);
+    }
+
+    function normalizeRecentTargets(value) {
+        if (!Array.isArray(value)) {
+            return [];
+        }
+        return value
+            .filter(function (target) {
+                return typeof target === 'string' && target.length > 0;
+            })
+            .slice(0, recentTargetLimit);
+    }
+
+    function persistRecentTarget(url) {
+        if (!url) {
+            return;
+        }
+        const dedupedTargets = normalizeRecentTargets(readJson(keys.recentTargets, []))
+            .filter(function (target) {
+                return target !== url;
+            });
+        dedupedTargets.unshift(url);
+        writeStorageDebounced(keys.recentTargets, dedupedTargets.slice(0, recentTargetLimit));
+    }
+
+    function prefetchRecentTargets() {
+        const targets = normalizeRecentTargets(readJson(keys.recentTargets, []));
+        window.__adminRecentAppTargets = targets;
+        targets.slice(0, 4).forEach(function (url) {
+            const prefetch = document.createElement('link');
+            prefetch.rel = 'prefetch';
+            prefetch.href = url;
+            prefetch.as = 'document';
+            document.head.appendChild(prefetch);
         });
     }
 
-    nav.addEventListener('change', toggleEmptyGroups);
-    nav.addEventListener('input', toggleEmptyGroups);
+    const restoredFilter = storage ? storage.getItem(keys.filter) : '';
+    if (typeof restoredFilter === 'string') {
+        nav.value = restoredFilter;
+    }
+    applyCollapsedMap(getCollapsedMap());
+    prefetchRecentTargets();
+
+    nav.addEventListener('change', function () {
+        persistFilterValue();
+        toggleEmptyGroups();
+    });
+    nav.addEventListener('input', function () {
+        persistFilterValue();
+        toggleEmptyGroups();
+    });
     nav.addEventListener('keyup', toggleEmptyGroups);
+
+    sidebar.addEventListener('click', function (event) {
+        const link = event.target.closest('a[href]');
+        if (!link || !sidebar.contains(link)) {
+            return;
+        }
+        persistRecentTarget(link.href);
+        if (link.closest('.app-caption')) {
+            return;
+        }
+        window.setTimeout(persistCollapsedState, 0);
+    });
+    sidebar.addEventListener('click', function (event) {
+        const toggleButton = event.target.closest('.app-collapse-toggle');
+        if (!toggleButton || !sidebar.contains(toggleButton)) {
+            return;
+        }
+        window.setTimeout(persistCollapsedState, 0);
+    });
+
+    const observer = new MutationObserver(function (records) {
+        if (!nav.value.trim()) {
+            return;
+        }
+        records.forEach(function (record) {
+            if (record.type === 'attributes' && record.attributeName === 'class') {
+                record.target.classList.remove('collapsed');
+            }
+        });
+    });
+    modules.forEach(function (module) {
+        observer.observe(module, { attributes: true, attributeFilter: ['class'] });
+    });
 
     toggleEmptyGroups();
 });


### PR DESCRIPTION
### Motivation
- Improve admin UX by preserving the sidebar filter input and app group expand/collapse state across page loads and sessions.
- Provide quick-follow navigation by remembering recent app targets and prefetching top candidates to reduce perceived load time.
- Avoid cross-user/site collisions by namespacing stored state per site and user and avoid excess storage churn via debounced writes.

### Description
- Added safe `localStorage` helpers (`readJson`, `writeStorageDebounced`) and a namespaced key prefix using `current_site_domain` and `request.user.pk` to avoid collisions.
- Restore the persisted nav filter on DOM ready and apply a persisted collapsed map for app groups while keeping groups expanded during active filtering.
- Track recent sidebar navigation targets in a deduped, bounded list exposed as `window.__adminRecentAppTargets` and prefetch up to four top candidates on load.
- Added click handlers to capture link/toggle interactions, a `MutationObserver` to avoid accidental re-collapsing during filtering, and a 150ms debounce for storage writes.

### Testing
- `./env-refresh.sh --deps-only` executed successfully to refresh dependencies.
- `.venv/bin/python manage.py migrations check` ran with no changes detected and succeeded.
- `.venv/bin/python manage.py check` ran with system checks passing and succeeded.
- `.venv/bin/python manage.py test run -- apps.sites` was attempted but failed in this environment because pytest/test extras are not installed, so full test-suite verification was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deffaeaba08326ad7592e71e8b380b)