### PR TITLE
ci: add developer library to screenshot capture and artifact uploads

### DIFF
--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -283,7 +283,7 @@ jobs:
           python <<'PY' > /tmp/authenticated-screenshot-paths.txt
           from pathlib import Path
 
-          defaults = ["/admin/", "/ocpp/cpms/dashboard/"]
+          defaults = ["/admin/", "/ocpp/cpms/dashboard/", "/docs/library/"]
           configured_paths_file = Path(".github/screenshot-paths.authenticated.txt")
           requested_paths_file = Path("/tmp/pr-authenticated-screenshot-paths.txt")
           configured = []
@@ -339,6 +339,14 @@ jobs:
         with:
           name: ocpp-dashboard
           path: artifacts/ocpp-cpms-dashboard-desktop.png
+
+      - name: Upload developer library screenshot for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        id: upload-developer-library
+        uses: actions/upload-artifact@v7
+        with:
+          name: developer-library
+          path: artifacts/docs-library-desktop.png
 
       - name: Upload pull request screenshot bundle
         if: ${{ github.event_name == 'pull_request' }}
@@ -530,6 +538,13 @@ jobs:
         with:
           name: ocpp-dashboard
           path: artifacts/ocpp-cpms-dashboard-desktop.png
+
+      - name: Upload developer library screenshot
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: developer-library
+          path: artifacts/docs-library-desktop.png
 
       - name: Upload EVCS public screenshot
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
### Motivation

- Ensure the developer documentation library (`/docs/library/`) is captured by the screenshot CI flow as the third authenticated screenshot so the public developer site is included in the same visual verification checks as other dashboards.
- Keep the new screenshot subject to the existing artifact upload and verification pipeline so coverage and checklist logic remain unified.

### Description

- Add `/docs/library/` to the authenticated preview defaults so it is captured after `/admin/` and `/ocpp/cpms/dashboard/` by the preview job (`.github/workflows/dashboard-screenshot.yml`).
- Add an artifact upload step for pull requests named `developer-library` that uploads `artifacts/docs-library-desktop.png` into the PR bundle.
- Add a non-pull-request artifact upload step named `developer-library` that uploads `artifacts/docs-library-desktop.png` for scheduled/daily runs.
- Do not change the verification logic; the new artifact is included in the same `artifacts/*.png` bundle and checked by `scripts/verify_screenshot_artifacts.py` and the PR comment generation flow.

### Testing

- Ran `./scripts/review-notify.sh --actor Codex` and it completed successfully via the fallback notifier.
- Inspected the workflow diff with `git diff -- .github/workflows/dashboard-screenshot.yml` to verify the added default path and upload steps were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0078f53c8326af65cb798b7fc6de)