### PR TITLE
docs: reinforce Screenshot CI-only guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Agents must run relevant tests after code changes.
 
 * Do **not** take manual screenshots in the agent runtime.
 * The Screenshot CI workflow is the source of truth for previews and artifacts.
-* Leave screenshot generation to Screenshot CI, even when making visual/UI changes, unless a maintainer explicitly asks for a one-off manual capture for a specific debugging need.
+* Leave screenshot generation to Screenshot CI, even when making visual/UI changes; do not use manual capture skills unless a maintainer explicitly asks for a one-off capture for a specific debugging need.
 * If you need extra screenshot coverage, add route paths (one per line) to:
   * `.github/screenshot-paths.authenticated.txt` for pages that require login.
   * `.github/screenshot-paths.public.txt` for public pages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Agents must run relevant tests after code changes.
 
 * Do **not** take manual screenshots in the agent runtime.
 * The Screenshot CI workflow is the source of truth for previews and artifacts.
+* Leave screenshot generation to Screenshot CI, even when making visual/UI changes, unless a maintainer explicitly asks for a one-off manual capture for a specific debugging need.
 * If you need extra screenshot coverage, add route paths (one per line) to:
   * `.github/screenshot-paths.authenticated.txt` for pages that require login.
   * `.github/screenshot-paths.public.txt` for public pages.


### PR DESCRIPTION
### Motivation
- Prevent agents from taking manual screenshots during runtime and centralize visual preview generation in the Screenshot CI workflow.

### Description
- Updated `AGENTS.md` to add an explicit guideline: leave screenshot generation to Screenshot CI even for visual/UI changes, and only take a manual capture when a maintainer explicitly requests a one-off debugging capture.

### Testing
- Executed `./scripts/review-notify.sh --actor Codex`, which ran successfully via the fallback notification path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0559921483269ba74ba4b71a58f8)