### PR TITLE
docs: clarify default behavior for user-requested removals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,13 @@ When new apps are created:
   * `docs/development/create-local-app.md`
   * `docs/development/app-structure-policy.md`
 
-## Retiring legacy apps
+## Removal requests and legacy app retirement
 
-When retiring an app that still needs migration compatibility, move it to the
-legacy migration-only pattern instead of deleting it in place:
+When a developer asks to remove something, perform an actual removal by default.
+Do not archive, deprecate, or soft-retire the target unless explicitly asked.
+
+If the request is to retire an app that still needs migration compatibility,
+follow this legacy migration-only retirement process instead of hard deletion:
 
 1. Create or reuse `apps/_legacy/<app>_migration_only/` with an `AppConfig`.
 2. Register that config in `LEGACY_MIGRATION_APPS`.
@@ -77,17 +80,9 @@ legacy migration-only pattern instead of deleting it in place:
    historical migrations stay runnable.
 4. Remove the runtime app from normal app discovery/runtime wiring.
 
-This keeps upgrade paths intact now and ensures the retired app is positioned
-to be dropped cleanly on the next **major** version.
-
-## Removal requests
-
-When a user asks to remove something, perform an actual removal by default.
-Do not archive, deprecate, or soft-retire the target unless a developer
-explicitly asks for one of those alternatives.
-
-This policy exists so maintainers can accurately assess merge impact from
-true removals without soft-retirement patterns masking downstream effects.
+This policy keeps merge impact clear for removals while preserving upgrade
+paths for legacy-app retirement, and positions retired apps to be dropped
+cleanly on the next **major** version.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,15 @@ legacy migration-only pattern instead of deleting it in place:
 This keeps upgrade paths intact now and ensures the retired app is positioned
 to be dropped cleanly on the next **major** version.
 
+## Removal requests
+
+When a user asks to remove something, perform an actual removal by default.
+Do not archive, deprecate, or soft-retire the target unless a developer
+explicitly asks for one of those alternatives.
+
+This policy exists so maintainers can accurately assess merge impact from
+true removals without soft-retirement patterns masking downstream effects.
+
 ---
 
 ## Exceptions


### PR DESCRIPTION
### Motivation
- Ensure agents perform actual removals for user requests by default so maintainers can observe true merge impact without soft-retirement patterns masking downstream effects.

### Description
- Added a `Removal requests` section to `AGENTS.md` that instructs agents to perform real removals on user requests and to only archive/deprecate/soft-retire when a developer explicitly asks for those alternatives.

### Testing
- No runtime tests were required for this documentation-only change, and the review notification hook `./scripts/review-notify.sh --actor Codex` was executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9050111883269981931159a188fd)