### PR TITLE
Improve Developer Documents folder blurbs with real content summaries

### DIFF
--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -314,47 +314,38 @@ def _build_virtual_root_query_url(parameter: str) -> str:
     return f"{reverse('docs:docs-library')}?{urlencode({parameter: '1'})}"
 
 
-def _build_folder_blurb(files: list[Path], root: Path, folder_prefix: str) -> str:
+def _pluralize(count: int, singular: str) -> str:
+    """Return the singular/plural form for a count."""
+
+    return singular if count == 1 else f"{singular}s"
+
+
+def _preview_files(names: list[str]) -> tuple[str, str]:
+    """Build a deterministic two-item preview and overflow suffix."""
+
+    preview = ", ".join(sorted(names)[:2])
+    suffix = "…" if len(names) > 2 else ""
+    return preview, suffix
+
+
+def _build_folder_blurb(direct_files: list[str], nested_count: int) -> str:
     """Return a short, data-backed summary for a folder entry."""
 
-    folder_root = f"{folder_prefix}/"
-    direct_files: list[str] = []
-    nested_folders: set[str] = set()
-
-    for path in files:
-        relative = path.relative_to(root).as_posix()
-        if not relative.startswith(folder_root):
-            continue
-        scoped_relative = relative.removeprefix(folder_root)
-        if "/" in scoped_relative:
-            nested_folders.add(scoped_relative.split("/", 1)[0])
-            continue
-        if path.stem.lower() == "index":
-            continue
-        direct_files.append(Path(scoped_relative).name)
-
     direct_count = len(direct_files)
-    nested_count = len(nested_folders)
     total_documents = direct_count + nested_count
     if total_documents == 0:
         return "Folder overview and related references."
 
     if direct_count == 0:
-        return (
-            f"{nested_count} nested folder"
-            f"{'' if nested_count == 1 else 's'} with additional documentation."
-        )
+        return f"{nested_count} nested {_pluralize(nested_count, 'folder')} with additional documentation."
 
-    preview_files = sorted(direct_files)[:2]
-    preview = ", ".join(preview_files)
-    suffix = "…" if direct_count > 2 else ""
+    preview, suffix = _preview_files(direct_files)
     if nested_count:
         return (
-            f"{direct_count} doc{'s' if direct_count != 1 else ''} ({preview}{suffix}) "
-            f"and {nested_count} nested folder"
-            f"{'' if nested_count == 1 else 's'}."
+            f"{direct_count} {_pluralize(direct_count, 'doc')} ({preview}{suffix}) "
+            f"and {nested_count} nested {_pluralize(nested_count, 'folder')}."
         )
-    return f"{direct_count} doc{'s' if direct_count != 1 else ''}: {preview}{suffix}."
+    return f"{direct_count} {_pluralize(direct_count, 'doc')}: {preview}{suffix}."
 
 
 def _build_library_section(
@@ -426,6 +417,34 @@ def _build_library_section(
             )
         )
 
+    folder_direct_files: dict[str, list[str]] = {}
+    folder_nested_folders: dict[str, dict[str, bool]] = {}
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        if prefix:
+            prefix_root = f"{prefix}/"
+            if not relative.startswith(prefix_root):
+                continue
+            scoped_relative = relative.removeprefix(prefix_root)
+        else:
+            scoped_relative = relative
+        if "/" not in scoped_relative:
+            continue
+
+        folder, remainder = scoped_relative.split("/", 1)
+        direct_files = folder_direct_files.setdefault(folder, [])
+        nested_folders = folder_nested_folders.setdefault(folder, {})
+        if "/" in remainder:
+            nested_folder = remainder.split("/", 1)[0]
+            if Path(remainder).stem.lower() != "index":
+                nested_folders[nested_folder] = True
+            else:
+                nested_folders.setdefault(nested_folder, False)
+            continue
+        if path.stem.lower() == "index":
+            continue
+        direct_files.append(Path(remainder).name)
+
     folder_items = [
         {
             "kind": "folder",
@@ -435,9 +454,8 @@ def _build_library_section(
                 f"{prefix}/{folder}" if prefix else folder,
             ),
             "description": _build_folder_blurb(
-                files,
-                root,
-                f"{prefix}/{folder}" if prefix else folder,
+                folder_direct_files.get(folder, []),
+                sum(folder_nested_folders.get(folder, {}).values()),
             ),
         }
         for folder in sorted(folders)

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -314,6 +314,49 @@ def _build_virtual_root_query_url(parameter: str) -> str:
     return f"{reverse('docs:docs-library')}?{urlencode({parameter: '1'})}"
 
 
+def _build_folder_blurb(files: list[Path], root: Path, folder_prefix: str) -> str:
+    """Return a short, data-backed summary for a folder entry."""
+
+    folder_root = f"{folder_prefix}/"
+    direct_files: list[str] = []
+    nested_folders: set[str] = set()
+
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        if not relative.startswith(folder_root):
+            continue
+        scoped_relative = relative.removeprefix(folder_root)
+        if "/" in scoped_relative:
+            nested_folders.add(scoped_relative.split("/", 1)[0])
+            continue
+        if path.stem.lower() == "index":
+            continue
+        direct_files.append(Path(scoped_relative).name)
+
+    direct_count = len(direct_files)
+    nested_count = len(nested_folders)
+    total_documents = direct_count + nested_count
+    if total_documents == 0:
+        return "Folder overview and related references."
+
+    if direct_count == 0:
+        return (
+            f"{nested_count} nested folder"
+            f"{'' if nested_count == 1 else 's'} with additional documentation."
+        )
+
+    preview_files = sorted(direct_files)[:2]
+    preview = ", ".join(preview_files)
+    suffix = "…" if direct_count > 2 else ""
+    if nested_count:
+        return (
+            f"{direct_count} doc{'s' if direct_count != 1 else ''} ({preview}{suffix}) "
+            f"and {nested_count} nested folder"
+            f"{'' if nested_count == 1 else 's'}."
+        )
+    return f"{direct_count} doc{'s' if direct_count != 1 else ''}: {preview}{suffix}."
+
+
 def _build_library_section(
     files: list[Path],
     *,
@@ -391,7 +434,11 @@ def _build_library_section(
                 parameter,
                 f"{prefix}/{folder}" if prefix else folder,
             ),
-            "description": f"Browse documents in {folder}.",
+            "description": _build_folder_blurb(
+                files,
+                root,
+                f"{prefix}/{folder}" if prefix else folder,
+            ),
         }
         for folder in sorted(folders)
     ]

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -507,3 +507,32 @@ def test_docs_library_folder_view_includes_file_matching_prefix_exactly(client):
         assert "library-prefix-match.md" in response.content.decode()
     finally:
         prefixed_document.unlink(missing_ok=True)
+
+
+def test_docs_library_folder_entries_include_content_blurbs(client):
+    user = get_user_model().objects.create_user(
+        username="docs-folder-blurb-user",
+        email="docs-folder-blurb-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    first_document = Path("docs/library-blurb-test/alpha.md")
+    second_document = Path("docs/library-blurb-test/beta.md")
+    first_document.parent.mkdir(parents=True, exist_ok=True)
+    first_document.write_text("# Alpha\n\nFolder blurb alpha.\n", encoding="utf-8")
+    second_document.write_text("# Beta\n\nFolder blurb beta.\n", encoding="utf-8")
+
+    client.force_login(user)
+    try:
+        cache.clear()
+        response = client.get(reverse("docs:docs-library"))
+        body = response.content.decode()
+
+        assert response.status_code == 200
+        assert "library-blurb-test/" in body
+        assert "2 docs: alpha.md, beta.md." in body
+    finally:
+        first_document.unlink(missing_ok=True)
+        second_document.unlink(missing_ok=True)
+        if first_document.parent.exists():
+            first_document.parent.rmdir()

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -536,3 +536,38 @@ def test_docs_library_folder_entries_include_content_blurbs(client):
         second_document.unlink(missing_ok=True)
         if first_document.parent.exists():
             first_document.parent.rmdir()
+        cache.clear()
+
+
+def test_docs_library_folder_blurb_ignores_index_only_nested_folders(client):
+    user = get_user_model().objects.create_user(
+        username="docs-folder-blurb-index-user",
+        email="docs-folder-blurb-index-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    parent_document = Path("docs/library-blurb-parent/direct.md")
+    nested_index_document = Path("docs/library-blurb-parent/child/index.md")
+    parent_document.parent.mkdir(parents=True, exist_ok=True)
+    nested_index_document.parent.mkdir(parents=True, exist_ok=True)
+    parent_document.write_text("# Direct\n\nTop-level document.\n", encoding="utf-8")
+    nested_index_document.write_text("# Index\n\nHidden nested index.\n", encoding="utf-8")
+
+    client.force_login(user)
+    try:
+        cache.clear()
+        response = client.get(reverse("docs:docs-library"))
+        body = response.content.decode()
+
+        assert response.status_code == 200
+        assert "library-blurb-parent/" in body
+        assert "1 doc: direct.md." in body
+        assert "nested folder with additional documentation" not in body
+    finally:
+        nested_index_document.unlink(missing_ok=True)
+        parent_document.unlink(missing_ok=True)
+        if nested_index_document.parent.exists():
+            nested_index_document.parent.rmdir()
+        if parent_document.parent.exists():
+            parent_document.parent.rmdir()
+        cache.clear()


### PR DESCRIPTION
### Motivation

- Replace the generic folder description in the Developer Documents library with short, data-driven blurbs that give immediate, useful info about each folder's contents.
- Help users and maintainers choose documents faster by surfacing document counts, sample filenames, and nested-folder presence in the folder card text.

### Description

- Added a new helper `_build_folder_blurb(files, root, folder_prefix)` in `apps/docs/views.py` that summarizes a folder by counting direct documents, enumerating up to two preview filenames, and reporting nested folder counts.
- Wired the folder cards in `_build_library_section` to use the new `_build_folder_blurb` instead of the static `"Browse documents in …"` text in `apps/docs/views.py`.
- Added a regression test `test_docs_library_folder_entries_include_content_blurbs` in `apps/sites/tests/test_public_routes.py` that creates a temporary docs folder and asserts the library page renders the generated blurb string.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` before running tests.
- Ran the new test with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py::test_docs_library_folder_entries_include_content_blurbs` and it passed.
- Re-ran a related existing docs test with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py::test_docs_library_keeps_nested_docs_visible_and_shows_parent_navigation` and it also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9ecf6f188326b523eaca681de45a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Replaces generic folder descriptions in the Developer Documents library with data-driven content summaries that display document counts, deterministic sample filenames, and nested-folder counts so users can assess a folder’s contents at a glance.

### Changes

**`apps/docs/views.py`**
- Added helper functions:
  - `_pluralize(count, singular)` — returns correct singular/plural word.
  - `_preview_files(names)` — deterministic two-item preview plus overflow suffix.
  - `_build_folder_blurb(direct_files, nested_count)` — composes a short folder blurb:
    - Empty folders → "Folder overview and related references."
    - Only nested folders → "{N} nested folder(s) with additional documentation."
    - Only documents → "{N} doc(s): name1, name2…" (up to 2 previews)
    - Documents + nested folders → "{N} doc(s) (previews) and {M} nested folder(s)."
- Updated `_build_library_section()` to compute per-folder direct filenames and nested-folder counts and to use `_build_folder_blurb()` for each folder entry’s description instead of the previous static "Browse documents in …" text.
- Fixes included to avoid counting index-only nested folders as containing additional documentation.

**`apps/sites/tests/test_public_routes.py`**
- Added `test_docs_library_folder_entries_include_content_blurbs`:
  - Creates two markdown files in a temporary docs folder, clears cache, requests the docs library, and asserts the generated blurb with both filenames appears in the rendered output; cleans up after.
- Added `test_docs_library_folder_blurb_ignores_index_only_nested_folders`:
  - Creates a direct document and a nested child folder containing only `index.md`, then asserts the parent folder’s blurb reflects only the direct document (i.e., index-only nested folders do not count as nested documentation).

### Testing

- New regression tests run successfully (per PR description). Commit message indicates an explicit fix for index-only nested counts to ensure blurbs accurately reflect nested documentation presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->