### PR TITLE
sites: tighten admin net message spacing on admin dashboard

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -22,9 +22,8 @@
         align-items: center;
         align-content: right;
         gap: 0.5rem;
-        padding-block: 0;
-        padding-inline: 0.65rem;
-        margin-block: 0;
+        padding: 0;
+        margin: 0 0 0.25rem;
         border-radius: 6px;
         background: var(--darkened-bg);
         color: var(--body-fg);

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -23,7 +23,7 @@
         align-content: right;
         gap: 0.5rem;
         padding: 0;
-        margin: 0 0 0.25rem;
+        margin-block: 0 var(--admin-ui-space-1, 0.25rem);
         border-radius: 6px;
         background: var(--darkened-bg);
         color: var(--body-fg);


### PR DESCRIPTION
### Motivation
- Operator feedback requested removing internal padding and broad margins from the admin "net message" row and adding only a slight outer spacing on the bottom to make the message area more compact and visually aligned with other header elements.

### Description
- Updated `apps/sites/static/sites/css/admin/dashboard.css` to replace `padding-block`/`padding-inline` and `margin-block` with `padding: 0;` and `margin: 0 0 0.25rem;` on `.admin-home-net-message` so the container has no internal padding and only a small bottom gap.

### Testing
- Performed environment refresh with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`, then ran ` .venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py` which ran 5 tests and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa00693e483268673bfaefb9d569b)