### PR TITLE
sites/ops: replace operator journey age with "Next:" label on admin home

### DIFF
--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from django.contrib.auth.models import AbstractBaseUser
-from django.db.models import Q
 from django.urls import reverse
-from django.utils import timezone
 
 from apps.groups.security import ensure_default_staff_groups
 
@@ -24,7 +21,6 @@ class OperatorJourneyStatus:
     message: str
     task_title: str
     url: str
-    available_since: datetime | None = None
 
 
 def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
@@ -100,27 +96,7 @@ def status_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStatus:
         message=next_step.title,
         task_title=next_step.title,
         url=reverse("ops:operator-journey-step", args=[next_step.pk]),
-        available_since=_first_available_at(user=user, next_step=next_step),
     )
-
-
-def _first_available_at(*, user: AbstractBaseUser, next_step: OperatorJourneyStep) -> datetime:
-    fallback_available_at = getattr(user, "date_joined", timezone.localtime())
-    previous_step = (
-        OperatorJourneyStep.objects.filter(journey=next_step.journey, is_active=True)
-        .exclude(pk=next_step.pk)
-        .filter(Q(order__lt=next_step.order) | Q(order=next_step.order, id__lt=next_step.id))
-        .order_by("-order", "-id")
-        .first()
-    )
-
-    if previous_step is None:
-        return fallback_available_at
-
-    completion = OperatorJourneyStepCompletion.objects.filter(user=user, step=previous_step).first()
-    if completion is None:
-        return fallback_available_at
-    return completion.completed_at
 
 
 def _active_security_groups_for_user(user: AbstractBaseUser):

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -52,16 +52,11 @@ class OperatorJourneyFlowTests(TestCase):
         status = status_for_user(user=self.user)
         self.assertEqual(status.message, "Step 1")
         self.assertEqual(status.task_title, "Step 1")
-        self.assertEqual(status.available_since, self.user.date_joined)
 
         self.assertTrue(complete_step_for_user(user=self.user, step=self.step_1))
         status = status_for_user(user=self.user)
         self.assertEqual(status.message, "Step 2")
         self.assertEqual(status.task_title, "Step 2")
-        self.assertEqual(
-            status.available_since,
-            self.user.operator_journey_step_completions.first().completed_at,
-        )
 
         self.assertTrue(complete_step_for_user(user=self.user, step=self.step_2))
         status = status_for_user(user=self.user)

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -129,7 +129,9 @@ class OperatorJourneyViewTests(TestCase):
     def test_dashboard_shows_operator_journey_link(self):
         response = self.client.get(reverse("admin:index"))
 
+        self.assertContains(response, "Next:")
         self.assertContains(response, "Validate role")
+        self.assertNotContains(response, "admin-home-operator-journey__age")
         self.assertContains(
             response,
             reverse("ops:operator-journey-step", args=[self.step_1.pk]),

--- a/apps/sites/templates/admin/index.html
+++ b/apps/sites/templates/admin/index.html
@@ -20,12 +20,8 @@
     {% if operator_journey.has_journey %}
       <div class="admin-home-operator-journey" role="status" aria-live="polite">
         {% if operator_journey.url %}
+          <span class="admin-home-operator-journey__label">{% translate "Next:" %}</span>
           <a class="admin-home-operator-journey__link" href="{{ operator_journey.url }}">{{ operator_journey.task_title|default:operator_journey.message }}</a>
-          {% if operator_journey.available_since %}
-            <span class="admin-home-operator-journey__age">
-              {% blocktrans trimmed with age=operator_journey.available_since|timesince %} · {{ age }} ago{% endblocktrans %}
-            </span>
-          {% endif %}
         {% else %}
           <span class="admin-home-operator-journey__text">{{ operator_journey.message }}</span>
         {% endif %}


### PR DESCRIPTION
### Motivation
- Simplify the admin home operator journey display by removing the date/age indicator and showing a concise `Next:` label before the task link as requested by site administration feedback.

### Description
- Updated `apps/sites/templates/admin/index.html` to insert a `<span class="admin-home-operator-journey__label">Next:</span>` before the operator journey link and removed the `available_since`/`timesince` age rendering.
- Updated `apps/ops/tests/test_operator_journey.py` to assert the new `Next:` label and assert the old age element (`admin-home-operator-journey__age`) is not present.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`.
- Ran the targeted unit test `apps.ops.tests.test_operator_journey.OperatorJourneyViewTests.test_dashboard_shows_operator_journey_link` via `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py::OperatorJourneyViewTests::test_dashboard_shows_operator_journey_link`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa0a66d44832683d894e93b16aae6)