### PR TITLE
imager: remove duplicate Create RPI image dashboard action

### DIFF
--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -234,7 +234,6 @@ class RaspberryPiImageArtifactAdmin(DjangoObjectActions, admin.ModelAdmin):
 
     change_list_template = "django_object_actions/change_list.html"
     changelist_actions = ("create_rpi_image",)
-    dashboard_actions = ("create_rpi_image_dashboard_action",)
     list_display = ("name", "target", "output_filename", "download_uri", "created_at")
     list_filter = ("target", "created_at")
     search_fields = ("name", "target", "output_filename", "download_uri", "base_image_uri")
@@ -258,9 +257,6 @@ class RaspberryPiImageArtifactAdmin(DjangoObjectActions, admin.ModelAdmin):
     def get_changelist_actions(self, request):
         return list(self.changelist_actions)
 
-    def get_dashboard_actions(self, request):
-        return list(self.dashboard_actions)
-
     def create_rpi_image(self, request, queryset=None):
         return HttpResponseRedirect(reverse("admin:imager_raspberrypiimageartifact_create_rpi_image"))
 
@@ -268,14 +264,6 @@ class RaspberryPiImageArtifactAdmin(DjangoObjectActions, admin.ModelAdmin):
     create_rpi_image.short_description = _("Create RPI image")
     create_rpi_image.changelist = True
     create_rpi_image.requires_queryset = False
-
-    def create_rpi_image_dashboard_action(self, request, queryset=None):
-        return self.create_rpi_image(request, queryset)
-
-    create_rpi_image_dashboard_action.label = _("Create RPI image")
-    create_rpi_image_dashboard_action.short_description = _("Create RPI image")
-    create_rpi_image_dashboard_action.requires_queryset = False
-    create_rpi_image_dashboard_action.dashboard_url = "admin:imager_raspberrypiimageartifact_create_rpi_image"
 
     def create_rpi_image_view(self, request: HttpRequest) -> HttpResponse:
         if not self.has_add_permission(request):

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -4,11 +4,23 @@ from unittest.mock import patch
 from urllib.error import HTTPError
 
 import pytest
+from django.contrib import admin
 from django.test import override_settings
 from django.urls import reverse
 
 from apps.imager.admin import _probe_download_url
 from apps.imager.models import RaspberryPiImageArtifact
+
+
+@pytest.mark.django_db
+def test_imager_admin_has_no_duplicate_dashboard_create_action():
+    """Regression: dashboard action wiring should not duplicate the create-image shortcut."""
+
+    model_admin = admin.site._registry[RaspberryPiImageArtifact]
+
+    assert not hasattr(model_admin, "dashboard_actions")
+    assert not hasattr(model_admin, "create_rpi_image_dashboard_action")
+
 
 class _ProbeResponse:
     headers: dict[str, str] = {}


### PR DESCRIPTION
### Motivation
- The Raspberry Pi imager admin registered the same "Create RPI image" shortcut twice (a changelist object action plus an explicit dashboard action), which caused duplicate UI links.

### Description
- Removed the `dashboard_actions` attribute and the `get_dashboard_actions` method from `RaspberryPiImageArtifactAdmin` in `apps/imager/admin.py` to stop registering the duplicate dashboard shortcut.
- Removed the `create_rpi_image_dashboard_action` method and its attribute wiring so the changelist object action remains the single entry point for the create-image workflow.
- Added a regression test `test_imager_admin_has_no_duplicate_dashboard_create_action` in `apps/imager/tests/test_admin.py` that asserts the registered admin for `RaspberryPiImageArtifact` no longer exposes `dashboard_actions` or `create_rpi_image_dashboard_action`.

### Testing
- Ran environment setup: `./env-refresh.sh --deps-only` and installed CI deps with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed the imager admin tests with `.venv/bin/python manage.py test run -- apps.imager.tests.test_admin.py` and received `10 passed`.
- Verified migrations with `.venv/bin/python manage.py migrations check`, which reported no changes detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa26424948326a24db70fd9d83ae5)