### PR TITLE
ci: refresh dependency submission action pin

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Submit dependency snapshot (attempt 1)
         id: submit_snapshot_attempt_1
         continue-on-error: true
-        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
+        uses: advanced-security/component-detection-dependency-submission-action@7c766a0966c66533ae37f76556cf9a33be50e5f8
         with:
           detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
@@ -49,7 +49,7 @@ jobs:
         id: submit_snapshot_attempt_2
         if: steps.submit_snapshot_attempt_1.outcome == 'failure'
         continue-on-error: true
-        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
+        uses: advanced-security/component-detection-dependency-submission-action@7c766a0966c66533ae37f76556cf9a33be50e5f8
         with:
           detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
@@ -61,7 +61,7 @@ jobs:
         id: submit_snapshot_attempt_3
         if: steps.submit_snapshot_attempt_2.outcome == 'failure'
         continue-on-error: true
-        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927
+        uses: advanced-security/component-detection-dependency-submission-action@7c766a0966c66533ae37f76556cf9a33be50e5f8
         with:
           detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 


### PR DESCRIPTION
### Motivation
- Mitigate transient Dependency Graph/API errors observed in the dependency snapshot submission step by advancing the pinned upstream action to a newer commit.

### Description
- Updated `.github/workflows/dependency-submission.yml` to pin `advanced-security/component-detection-dependency-submission-action` to `7c766a0966c66533ae37f76556cf9a33be50e5f8` for all three retry attempts.

### Testing
- Parsed the workflow YAML with `python`/`yaml.safe_load` to confirm the workflow file still parses successfully and it passed.
- Ran `./scripts/review-notify.sh --actor Codex` to exercise the repo notification path and it completed via the fallback notifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa68070b8832690938780e162a687)