### PR TITLE
docs: make mypy adoption backlog metrics evergreen

### DIFF
--- a/docs/development/mypy-adoption-checklist.md
+++ b/docs/development/mypy-adoption-checklist.md
@@ -61,15 +61,9 @@ Search these patterns before claiming a package as MyPy-owned:
 - `from typing import Any`
 - unparameterized `list`, `dict`, `set`, and `tuple` annotations
 
-The backlog summaries below are a snapshot taken on 2026-03-21 with `rg` so reviewers can refresh them as coverage expands instead of treating them as evergreen totals.
+Treat backlog counts as on-demand metrics, not fixed targets in this checklist. Recompute them when reviewing rollout scope changes.
 
 ### `apps/protocols/`
-
-Backlog snapshot as of 2026-03-21:
-
-- `TYPE_CHECKING`: 0
-- `from typing import Any`: 0
-- unparameterized collections: 6
 
 Small follow-ups:
 
@@ -77,12 +71,6 @@ Small follow-ups:
 - Replace runtime tuple and set checks in `apps/protocols/registry.py` with narrower aliases where practical.
 
 ### `apps/repos/`
-
-Backlog snapshot as of 2026-03-21 (with `from typing import Any` and unparameterized collection counts manually adjusted after that snapshot to reflect the `release_management.py` rollout):
-
-- `TYPE_CHECKING`: 8
-- `from typing import Any`: 3
-- unparameterized collections: 20
 
 Small follow-ups:
 
@@ -93,18 +81,26 @@ Small follow-ups:
 
 ### Selected `apps/core/` modules
 
-Backlog snapshot as of 2026-03-21 for the current service and registry-heavy targets:
-
-- `TYPE_CHECKING`: 0
-- `from typing import Any`: 2
-- unparameterized collections: 7
-
 Small follow-ups:
 
 - `apps/core/modeling/events.py`
 - `apps/core/modeling/registry.py`
 
 Keep broader `apps/core/system/ui/` rollout tracked separately until translation and uptime helpers are typed cleanly.
+
+### Refresh procedure (on demand)
+
+When maintainers need current backlog counts, run these exact patterns with `rg -n` against the package under review:
+
+- `TYPE_CHECKING`
+- `from typing import Any`
+- `\b(list|dict|set|tuple)\b(?!\s*\[)`
+
+Use this workflow:
+
+1. run the three searches for each target package
+2. count each result set for the current totals
+3. record refreshed totals and the refresh date in the optional history section below, not in the evergreen checklist sections above
 
 ## Regression tracking during rollout
 
@@ -133,3 +129,27 @@ Keep the signal useful after each rollout step:
 4. leave excluded apps out of the blocking workflow until their checklist step is complete
 
 If a warning turns out to be persistent noise, document the exact module and reason next to the corresponding override so later rollout work can remove it deliberately instead of normalizing broad ignores.
+
+## Optional history (point-in-time snapshots)
+
+Use this section for dated snapshots when a review or release needs an auditable before/after comparison. Keep entries date-stamped and append-only.
+
+### Snapshot: 2026-03-21
+
+`apps/protocols/`
+
+- `TYPE_CHECKING`: 0
+- `from typing import Any`: 0
+- unparameterized collections: 6
+
+`apps/repos/`
+
+- `TYPE_CHECKING`: 8
+- `from typing import Any`: 3
+- unparameterized collections: 20
+
+`apps/core/` selected modules
+
+- `TYPE_CHECKING`: 0
+- `from typing import Any`: 2
+- unparameterized collections: 7

--- a/docs/development/mypy-adoption-checklist.md
+++ b/docs/development/mypy-adoption-checklist.md
@@ -90,15 +90,15 @@ Keep broader `apps/core/system/ui/` rollout tracked separately until translation
 
 ### Refresh procedure (on demand)
 
-When maintainers need current backlog counts, run these exact patterns with `rg -n` against the package under review:
+When maintainers need current backlog counts, run these exact patterns against the package under review:
 
 - `TYPE_CHECKING`
 - `from typing import Any`
-- `\b(list|dict|set|tuple)\b(?!\s*\[)`
+- `(?::|->)\s*\b(list|dict|set|tuple)\b(?!\s*\[)` (requires `rg -nP` and shell quoting)
 
 Use this workflow:
 
-1. run the three searches for each target package
+1. run the three searches for each target package (`rg -n` for the first two, `rg -nP '(?::|->)\s*\b(list|dict|set|tuple)\b(?!\s*\[)'` for the third)
 2. count each result set for the current totals
 3. record refreshed totals and the refresh date in the optional history section below, not in the evergreen checklist sections above
 


### PR DESCRIPTION
### Motivation

- Keep the MyPy adoption checklist evergreen by removing date-bound backlog totals that become stale. 
- Ensure maintainers can generate up-to-date backlog counts on demand using the same search patterns already referenced in the document. 

### Description

- Replaced inline snapshot text in `docs/development/mypy-adoption-checklist.md` with guidance that backlog counts are on-demand metrics and should be recomputed when reviewing rollout scope. 
- Added a concise `Refresh procedure (on demand)` subsection with exact `rg -n` search patterns (`TYPE_CHECKING`, `from typing import Any`, and `\b(list|dict|set|tuple)\b(?!\s*\[)`) and a 3-step workflow for recording refreshed totals. 
- Moved the previous point-in-time counts into a new append-only `Optional history (point-in-time snapshots)` section so the main checklist remains evergreen. 

### Testing

- Ran the repository review notifier with `./scripts/review-notify.sh --actor Codex` and the notification step succeeded. 
- This is a documentation-only change and did not require runtime or unit-test updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbca1ffe083269c6e8538a6843d03)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR makes the MyPy adoption checklist evergreen by decoupling backlog metrics from the main guidance document. The changes replace static, dated backlog counts with a process for on-demand recomputation and move historical snapshots into a separate, append-only section.

## Changes made

**docs/development/mypy-adoption-checklist.md**

- Removed inline backlog count totals from the "Annotation backlog before enablement" section (previously listed under `apps/protocols/`, `apps/repos/`, and selected `apps/core/` modules)
- Added guidance clarifying that backlog counts are on-demand metrics to be recomputed when reviewing rollout scope changes
- Introduced a new "Refresh procedure (on demand)" subsection with:
  - Three exact ripgrep search patterns: `TYPE_CHECKING`, `from typing import Any`, and the regex `\b(list|dict|set|tuple)\b(?!\s*\[)` for unparameterized collections
  - A 3-step workflow for recording refreshed totals in the history section with a refresh date
- Added a new "Optional history (point-in-time snapshots)" section containing an append-only dated snapshot from 2026-03-21 that preserves the previously removed counts by module grouping

## Impact

The checklist now remains current without requiring updates to inline metrics, while maintainers can generate up-to-date backlog counts on demand using the specified search patterns. Historical comparisons are preserved in a dedicated history section rather than cluttering the evergreen guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->