### PR TITLE
docs: move OCPP legacy migration notes into dedicated history doc

### DIFF
--- a/docs/development/ocpp-migration-history.md
+++ b/docs/development/ocpp-migration-history.md
@@ -56,21 +56,21 @@ For shell migration, a direct one-time update can be done with substitutions lik
 ```bash
 # GNU sed
 sed -i \
-  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
-  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
-  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
-  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
+  -e 's|manage.py coverage_ocpp16|manage.py ocpp coverage --version 1.6|g' \
+  -e 's|manage.py coverage_ocpp201|manage.py ocpp coverage --version 2.0.1|g' \
+  -e 's|manage.py coverage_ocpp21|manage.py ocpp coverage --version 2.1|g' \
+  -e 's|manage.py import_transactions|manage.py ocpp transactions import|g' \
+  -e 's|manage.py export_transactions|manage.py ocpp transactions export|g' \
+  -e 's|manage.py ocpp_replay|manage.py ocpp trace replay|g' \
   path/to/ops-script.sh
 
 # BSD/macOS sed
 sed -i '' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
-  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
-  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
-  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
+  -e 's|manage.py coverage_ocpp16|manage.py ocpp coverage --version 1.6|g' \
+  -e 's|manage.py coverage_ocpp201|manage.py ocpp coverage --version 2.0.1|g' \
+  -e 's|manage.py coverage_ocpp21|manage.py ocpp coverage --version 2.1|g' \
+  -e 's|manage.py import_transactions|manage.py ocpp transactions import|g' \
+  -e 's|manage.py export_transactions|manage.py ocpp transactions export|g' \
+  -e 's|manage.py ocpp_replay|manage.py ocpp trace replay|g' \
   path/to/ops-script.sh
 ```

--- a/docs/development/ocpp-migration-history.md
+++ b/docs/development/ocpp-migration-history.md
@@ -1,0 +1,76 @@
+# OCPP migration history
+
+This document keeps historical OCPP migration notes for teams upgrading older Arthexis releases.
+
+## Deprecated command removal
+
+Legacy single-purpose commands (`coverage_ocpp16`, `coverage_ocpp201`, `coverage_ocpp21`, `import_transactions`, `export_transactions`, and `ocpp_replay`) were removed in favor of the unified `ocpp` command surface.
+
+If automation still calls legacy entrypoints, update scripts to the canonical `ocpp` subcommands:
+
+| Removed command | Replacement |
+| --- | --- |
+| `.venv/bin/python manage.py coverage_ocpp16` | `.venv/bin/python manage.py ocpp coverage --version 1.6` |
+| `.venv/bin/python manage.py coverage_ocpp201` | `.venv/bin/python manage.py ocpp coverage --version 2.0.1` |
+| `.venv/bin/python manage.py coverage_ocpp21` | `.venv/bin/python manage.py ocpp coverage --version 2.1` |
+| `.venv/bin/python manage.py import_transactions <input.json>` | `.venv/bin/python manage.py ocpp transactions import <input.json>` |
+| `.venv/bin/python manage.py export_transactions <output.json> [--start ... --end ... --chargers ...]` | `.venv/bin/python manage.py ocpp transactions export <output.json> [--start ... --end ... --chargers ...]` |
+| `.venv/bin/python manage.py ocpp_replay <extract.json>` | `.venv/bin/python manage.py ocpp trace replay <extract.json>` |
+
+## Forwarder import path removal
+
+The compatibility shim at `apps.ocpp.forwarder` was removed.
+
+If integration code still imports the legacy path, switch to `apps.forwarder.ocpp`:
+
+```python
+# from apps.ocpp.forwarder import Forwarder, ForwardingSession, forwarder
+from apps.forwarder.ocpp import Forwarder, ForwardingSession, forwarder
+```
+
+## Simulator import path removal
+
+The compatibility package at `apps.ocpp.simulator` was removed.
+
+If external integrations still import the legacy module path, update imports to `apps.simulators`:
+
+| Removed import path | Replacement import path |
+| --- | --- |
+| `from apps.ocpp.simulator import ChargePointSimulator, SimulatorConfig` | `from apps.simulators import ChargePointSimulator, SimulatorConfig` |
+
+## EVCS wrapper removal
+
+The compatibility wrapper module at `apps.ocpp.evcs` was removed.
+
+External plugin maintainers should update imports to use `apps.simulators.evcs` directly:
+
+| Removed import path | Replacement import path |
+| --- | --- |
+| `from apps.ocpp.evcs import simulate, simulate_cp, view_simulator, view_cp_simulator` | `from apps.simulators.evcs import simulate, simulate_cp, view_simulator, view_cp_simulator` |
+| `from apps.ocpp.evcs import _simulator_status_json, _start_simulator, _stop_simulator, get_simulator_state, parse_repeat` | `from apps.simulators.evcs import _simulator_status_json, _start_simulator, _stop_simulator, get_simulator_state, parse_repeat` |
+
+## One-time shell migration example
+
+For shell migration, a direct one-time update can be done with substitutions like:
+
+```bash
+# GNU sed
+sed -i \
+  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
+  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
+  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
+  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
+  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
+  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
+  path/to/ops-script.sh
+
+# BSD/macOS sed
+sed -i '' \
+  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
+  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
+  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
+  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
+  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
+  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
+  path/to/ops-script.sh
+```

--- a/docs/development/ocpp-user-manual.md
+++ b/docs/development/ocpp-user-manual.md
@@ -2,6 +2,8 @@
 
 This manual documents how the Arthexis control system implements each Open Charge Point Protocol (OCPP) 1.6 call that is currently supported. The focus is on the behaviour of the WebSocket consumer that represents our central system (CSMS) and the HTTP endpoints that emit CSMS initiated calls.
 
+For upgrade guidance from older releases (including removed wrappers and deprecated command/import migrations), see [OCPP migration history](./ocpp-migration-history.md).
+
 ## Charge point → CSMS calls
 
 ### BootNotification
@@ -85,71 +87,3 @@ Use the unified `ocpp` management command for operational workflows:
 - Trace tools:
   - `.venv/bin/python manage.py ocpp trace extract [--txn ... --out ... --log ...]`
   - `.venv/bin/python manage.py ocpp trace replay <extract.json>`
-
-Legacy single-purpose commands (`coverage_ocpp16`, `coverage_ocpp201`, `coverage_ocpp21`, `import_transactions`, `export_transactions`, and `ocpp_replay`) have been removed; use the unified `ocpp` command surface above.
-
-### Release migration notes (deprecated command removal)
-If your automation still calls legacy entrypoints, update scripts to the canonical `ocpp` subcommands:
-
-| Removed command | Replacement |
-| --- | --- |
-| `.venv/bin/python manage.py coverage_ocpp16` | `.venv/bin/python manage.py ocpp coverage --version 1.6` |
-| `.venv/bin/python manage.py coverage_ocpp201` | `.venv/bin/python manage.py ocpp coverage --version 2.0.1` |
-| `.venv/bin/python manage.py coverage_ocpp21` | `.venv/bin/python manage.py ocpp coverage --version 2.1` |
-| `.venv/bin/python manage.py import_transactions <input.json>` | `.venv/bin/python manage.py ocpp transactions import <input.json>` |
-| `.venv/bin/python manage.py export_transactions <output.json> [--start ... --end ... --chargers ...]` | `.venv/bin/python manage.py ocpp transactions export <output.json> [--start ... --end ... --chargers ...]` |
-| `.venv/bin/python manage.py ocpp_replay <extract.json>` | `.venv/bin/python manage.py ocpp trace replay <extract.json>` |
-
-
-### Release migration notes (forwarder import path removal)
-The compatibility shim at `apps.ocpp.forwarder` has been removed.
-
-If integration code still imports the legacy path, switch to `apps.forwarder.ocpp`:
-
-```python
-# from apps.ocpp.forwarder import Forwarder, ForwardingSession, forwarder
-from apps.forwarder.ocpp import Forwarder, ForwardingSession, forwarder
-```
-
-### Release migration notes (simulator import path removal)
-The compatibility package at `apps.ocpp.simulator` has been removed.
-
-If external integrations still import the legacy module path, update imports to `apps.simulators`:
-
-| Removed import path | Replacement import path |
-| --- | --- |
-| `from apps.ocpp.simulator import ChargePointSimulator, SimulatorConfig` | `from apps.simulators import ChargePointSimulator, SimulatorConfig` |
-
-### Release migration notes (EVCS wrapper removal)
-The compatibility wrapper module at `apps.ocpp.evcs` has been removed.
-
-External plugin maintainers should update imports to use `apps.simulators.evcs` directly:
-
-| Removed import path | Replacement import path |
-| --- | --- |
-| `from apps.ocpp.evcs import simulate, simulate_cp, view_simulator, view_cp_simulator` | `from apps.simulators.evcs import simulate, simulate_cp, view_simulator, view_cp_simulator` |
-| `from apps.ocpp.evcs import _simulator_status_json, _start_simulator, _stop_simulator, get_simulator_state, parse_repeat` | `from apps.simulators.evcs import _simulator_status_json, _start_simulator, _stop_simulator, get_simulator_state, parse_repeat` |
-
-For shell migration, a direct one-time update can be done with substitutions like:
-
-```bash
-# GNU sed
-sed -i \
-  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
-  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
-  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
-  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
-  path/to/ops-script.sh
-
-# BSD/macOS sed
-sed -i '' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp16|.venv/bin/python manage.py ocpp coverage --version 1.6|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp201|.venv/bin/python manage.py ocpp coverage --version 2.0.1|g' \
-  -e 's|.venv/bin/python manage.py coverage_ocpp21|.venv/bin/python manage.py ocpp coverage --version 2.1|g' \
-  -e 's|.venv/bin/python manage.py import_transactions|.venv/bin/python manage.py ocpp transactions import|g' \
-  -e 's|.venv/bin/python manage.py export_transactions|.venv/bin/python manage.py ocpp transactions export|g' \
-  -e 's|.venv/bin/python manage.py ocpp_replay|.venv/bin/python manage.py ocpp trace replay|g' \
-  path/to/ops-script.sh
-```


### PR DESCRIPTION
### Motivation

- Keep the OCPP user manual focused on current CSMS/CP behaviour and the active `ocpp` command surface.
- Make legacy upgrade guidance (removed wrappers and deprecated commands/imports) easier to find and maintain by placing it in a separate migration-history document.

### Description

- Remove legacy migration sections from `docs/development/ocpp-user-manual.md` and add a brief pointer to the new history doc.
- Add `docs/development/ocpp-migration-history.md` containing deprecated command mappings, removed-compatibility import path replacements, and a one-time shell substitution example.
- No runtime or API code changes were made; this PR only reorganises documentation to separate current behaviour from historical migration notes.

### Testing

- Ran `git diff --check` which reported no whitespace or diff issues and succeeded.
- Searched the docs with `rg -n "migration history|Release migration notes|Legacy single-purpose commands"` to validate the content moved and the pointer is present, which returned expected matches.
- Executed `./scripts/review-notify.sh --actor Codex` to emit the review notification, which completed successfully using the fallback notifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbcae306883268c2cad1a7f6e1a32)