### PR TITLE
souls-shop: prevent cross-account soul attachment via email fallback

### DIFF
--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -446,3 +446,20 @@ class ShopSoulSeedPreloadTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(ShopOrderSoulAttachment.objects.count(), 0)
+
+    def test_checkout_does_not_attach_other_users_soul_for_duplicate_email(self):
+        from django.contrib.auth import get_user_model
+
+        self._create_soul_for_email("shared@example.com")
+        user = get_user_model().objects.create_user(
+            username="shared-attacker",
+            email="shared@example.com",
+            password="x",
+        )
+        self.client.force_login(user)
+        self._add_to_cart(self.card_product, quantity=1)
+
+        response = self._checkout("shared@example.com")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ShopOrderSoulAttachment.objects.count(), 0)

--- a/apps/souls/services/checkout.py
+++ b/apps/souls/services/checkout.py
@@ -8,7 +8,6 @@ CHECKOUT_SOUL_KEY = "shop_checkout_soul_id"
 
 
 def _resolve_checkout_soul(*, request: HttpRequest, customer_email: str) -> Soul | None:
-    normalized_email = customer_email.strip().lower()
     soul_id = request.session.get(CHECKOUT_SOUL_KEY)
     if soul_id:
         soul = Soul.objects.filter(pk=soul_id).first()
@@ -21,16 +20,6 @@ def _resolve_checkout_soul(*, request: HttpRequest, customer_email: str) -> Soul
         soul = Soul.objects.filter(user=user).first()
         if soul:
             return soul
-
-        user_email = getattr(user, "email", "").strip().lower()
-        if user_email != normalized_email:
-            return None
-
-        souls = list(
-            Soul.objects.select_related("user").filter(user__email__iexact=normalized_email).order_by("id")[:2]
-        )
-        if len(souls) == 1:
-            return souls[0]
     return None
 
 


### PR DESCRIPTION
### Motivation
- A new email-based fallback in `_resolve_checkout_soul` could attach another account’s `Soul` when duplicate user emails exist, allowing cross-account Soul Seed preload and limited impersonation.

### Description
- Remove the email-matching fallback from `_resolve_checkout_soul` so resolution only uses an explicit session-selected soul or the authenticated user’s own soul.
- Preserve existing behavior where a session `CHECKOUT_SOUL_KEY` or the authenticated user’s `Soul` is used for preload.
- Add a regression test `test_checkout_does_not_attach_other_users_soul_for_duplicate_email` to ensure an authenticated user that shares an email with another account cannot attach the other account’s `Soul` during checkout.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt` and both commands completed successfully.
- Executed the shop preload tests with `.venv/bin/python manage.py test run -- apps/shop/tests/test_checkout.py::ShopSoulSeedPreloadTests` and the test collection for the affected cases passed (`4 passed`).
- Ran the review notifier with `./scripts/review-notify.sh --actor Codex` which completed via the fallback notification path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfca7001148326bba9cf010cf4a9f0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Fix: Prevent Cross-Account Soul Attachment

**Vulnerability Addressed:** An email-based fallback in `_resolve_checkout_soul` could attach another account's Soul to an order when duplicate user emails existed, enabling unintended cross-account Soul Seed preload and limited impersonation.

**Changes Made:**

1. **Modified `apps/souls/services/checkout.py`:** Removed email-matching fallback logic from `_resolve_checkout_soul`. The function now only returns a Soul via two paths:
   - Explicit session-stored soul (CHECKOUT_SOUL_KEY), or
   - The authenticated user's own Soul
   
   Eliminated the previous email normalization, comparison, and database query for candidate Soul records by email.

2. **Added test `test_checkout_does_not_attach_other_users_soul_for_duplicate_email` in `apps/shop/tests/test_checkout.py`:** Regression test verifying that when an authenticated user shares an email with another account, checkout does not attach the other account's Soul. The test confirms the order succeeds (HTTP 200) while no `ShopOrderSoulAttachment` is created.

**Behavior Preservation:** Existing checkout behavior for session-stored CHECKOUT_SOUL_KEY and authenticated-user Soul usage remains unchanged.

**Testing:** All shop preload tests pass (4/4 in ShopSoulSeedPreloadTests).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->