### PR TITLE
Restrict Developer Documents access to Product Developer and Release Manager SGs

### DIFF
--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -835,7 +835,6 @@ def render_readme_page(
 
 @module_pill_link_validation(_show_docs_navigation_link)
 @security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
-@login_required(login_url="pages:login")
 def document_library(request):
     """Render the developer documentation library index."""
 
@@ -852,7 +851,6 @@ def _render_missing_document(request, *, doc: str | None, prepend_docs: bool) ->
 @module_pill_link_validation(_show_docs_navigation_link)
 @never_cache
 @security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
-@login_required(login_url="pages:login")
 def readme(request, doc=None, prepend_docs: bool = False):
     try:
         return render_readme_page(request, doc=doc, prepend_docs=prepend_docs)

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -13,6 +13,11 @@ from django.urls import NoReverseMatch, reverse
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
+from apps.groups.constants import (
+    PRODUCT_DEVELOPER_GROUP_NAME,
+    RELEASE_MANAGER_GROUP_NAME,
+)
+from apps.groups.decorators import security_group_required
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
 from apps.modules.models import Module
@@ -43,9 +48,20 @@ FULL_CONTENT_DEFAULT_DOCUMENTS = {
 }
 
 
+DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES = (
+    PRODUCT_DEVELOPER_GROUP_NAME,
+    RELEASE_MANAGER_GROUP_NAME,
+)
+
+
 def _show_docs_navigation_link(*, request, landing) -> bool:
     del landing
-    return bool(getattr(request, "user", None) and request.user.is_authenticated)
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    return user.groups.filter(name__in=DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES).exists()
 
 
 def _is_allowed_doc_path(path: Path) -> bool:
@@ -818,6 +834,7 @@ def render_readme_page(
 
 
 @module_pill_link_validation(_show_docs_navigation_link)
+@security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
 @login_required(login_url="pages:login")
 def document_library(request):
     """Render the developer documentation library index."""
@@ -834,6 +851,7 @@ def _render_missing_document(request, *, doc: str | None, prepend_docs: bool) ->
 
 @module_pill_link_validation(_show_docs_navigation_link)
 @never_cache
+@security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
 @login_required(login_url="pages:login")
 def readme(request, doc=None, prepend_docs: bool = False):
     try:

--- a/apps/groups/decorators.py
+++ b/apps/groups/decorators.py
@@ -43,16 +43,18 @@ def security_group_required(*group_names):
 
     required_groups = frozenset(filter(None, group_names))
 
-    def _has_membership(user):
-        if not getattr(user, "is_authenticated", False):
-            return False
-        if not required_groups:
-            return True
-        if getattr(user, "is_superuser", False):
-            return True
-        return user.groups.filter(name__in=required_groups).exists()
-
     def decorator(view_func):
+        def _has_membership(user):
+            if not getattr(user, "is_authenticated", False):
+                return False
+            if not required_groups:
+                return True
+            if getattr(user, "is_superuser", False):
+                return True
+            if user.groups.filter(name__in=required_groups).exists():
+                return True
+            raise PermissionDenied
+
         decorated = user_passes_test(_has_membership)(view_func)
         decorated.login_required = True
         decorated.required_security_groups = required_groups

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -284,12 +284,23 @@ def test_docs_library_and_documents_require_login(client):
     assert apps_document_response.url.startswith(expected_prefix)
 
 
-def test_docs_library_and_documents_require_developer_or_release_manager_group(client):
+@pytest.mark.parametrize(
+    ("group_name", "is_superuser"),
+    [
+        (PRODUCT_DEVELOPER_GROUP_NAME, False),
+        (RELEASE_MANAGER_GROUP_NAME, False),
+        (None, True),
+    ],
+)
+def test_docs_library_and_documents_require_developer_or_release_manager_group(
+    client, group_name, is_superuser
+):
     user = get_user_model().objects.create_user(
-        username="docs-group-user",
-        email="docs-group-user@example.com",
+        username=f"docs-group-user-{group_name or 'superuser'}",
+        email=f"docs-group-user-{group_name or 'superuser'}@example.com",
         password="secret",
         is_staff=True,
+        is_superuser=is_superuser,
     )
     library_url = reverse("docs:docs-library")
     document_url = reverse("docs:docs-document", args=["index.md"])
@@ -297,11 +308,13 @@ def test_docs_library_and_documents_require_developer_or_release_manager_group(c
     library_response = client.get(library_url)
     document_response = client.get(document_url)
 
-    assert library_response.status_code == 302
-    assert document_response.status_code == 302
+    expected_initial_status = 200 if is_superuser else 403
+    assert library_response.status_code == expected_initial_status
+    assert document_response.status_code == expected_initial_status
 
-    developer_group = SecurityGroup.objects.create(name=PRODUCT_DEVELOPER_GROUP_NAME)
-    developer_group.user_set.add(user)
+    if group_name:
+        allowed_group, _ = SecurityGroup.objects.get_or_create(name=group_name)
+        allowed_group.user_set.add(user)
 
     library_response = client.get(library_url)
     document_response = client.get(document_url)
@@ -360,7 +373,9 @@ def test_developers_module_pill_visible_to_release_manager_users():
         email="docs-release-manager@example.com",
         password="secret",
     )
-    release_manager_group = SecurityGroup.objects.create(name=RELEASE_MANAGER_GROUP_NAME)
+    release_manager_group, _ = SecurityGroup.objects.get_or_create(
+        name=RELEASE_MANAGER_GROUP_NAME
+    )
     release_manager_group.user_set.add(user)
     request = RequestFactory().get("/")
     request.user = user

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -16,7 +16,11 @@ from django.utils.http import urlsafe_base64_encode
 from apps.docs.models import DocumentIndex, DocumentIndexAssignment
 from apps.energy.models import ClientReport
 from apps.features.models import Feature
-from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
+from apps.groups.constants import (
+    PRODUCT_DEVELOPER_GROUP_NAME,
+    RELEASE_MANAGER_GROUP_NAME,
+    SITE_OPERATOR_GROUP_NAME,
+)
 from apps.groups.models import SecurityGroup
 from apps.modules.models import Module
 from apps.sites import context_processors
@@ -280,6 +284,32 @@ def test_docs_library_and_documents_require_login(client):
     assert apps_document_response.url.startswith(expected_prefix)
 
 
+def test_docs_library_and_documents_require_developer_or_release_manager_group(client):
+    user = get_user_model().objects.create_user(
+        username="docs-group-user",
+        email="docs-group-user@example.com",
+        password="secret",
+        is_staff=True,
+    )
+    library_url = reverse("docs:docs-library")
+    document_url = reverse("docs:docs-document", args=["index.md"])
+    client.force_login(user)
+    library_response = client.get(library_url)
+    document_response = client.get(document_url)
+
+    assert library_response.status_code == 302
+    assert document_response.status_code == 302
+
+    developer_group = SecurityGroup.objects.create(name=PRODUCT_DEVELOPER_GROUP_NAME)
+    developer_group.user_set.add(user)
+
+    library_response = client.get(library_url)
+    document_response = client.get(document_url)
+
+    assert library_response.status_code == 200
+    assert document_response.status_code == 200
+
+
 def test_developers_module_pill_hidden_from_anonymous_users_when_landing_is_docs_library():
     module = Module.objects.create(path="/docs/", menu="Developers")
     Landing.objects.create(
@@ -294,6 +324,52 @@ def test_developers_module_pill_hidden_from_anonymous_users_when_landing_is_docs
     nav_modules = nav_context["nav_modules"]
 
     assert not any(candidate.path == "/docs/" for candidate in nav_modules)
+
+
+def test_developers_module_pill_hidden_from_non_member_users_when_landing_is_docs_library():
+    module = Module.objects.create(path="/docs/", menu="Developers")
+    Landing.objects.create(
+        module=module,
+        path=reverse("docs:docs-library"),
+        label="Developer Documents",
+    )
+    user = get_user_model().objects.create_user(
+        username="docs-non-member",
+        email="docs-non-member@example.com",
+        password="secret",
+    )
+    request = RequestFactory().get("/")
+    request.user = user
+
+    cache.clear()
+    nav_context = context_processors.nav_links(request)
+    nav_modules = nav_context["nav_modules"]
+
+    assert not any(candidate.path == "/docs/" for candidate in nav_modules)
+
+
+def test_developers_module_pill_visible_to_release_manager_users():
+    module = Module.objects.create(path="/docs/", menu="Developers")
+    Landing.objects.create(
+        module=module,
+        path=reverse("docs:docs-library"),
+        label="Developer Documents",
+    )
+    user = get_user_model().objects.create_user(
+        username="docs-release-manager",
+        email="docs-release-manager@example.com",
+        password="secret",
+    )
+    release_manager_group = SecurityGroup.objects.create(name=RELEASE_MANAGER_GROUP_NAME)
+    release_manager_group.user_set.add(user)
+    request = RequestFactory().get("/")
+    request.user = user
+
+    cache.clear()
+    nav_context = context_processors.nav_links(request)
+    nav_modules = nav_context["nav_modules"]
+
+    assert any(candidate.path == "/docs/" for candidate in nav_modules)
 
 
 def test_docs_library_renders_indexed_documents_before_other_documents(client):


### PR DESCRIPTION
### Motivation

- Developer documentation (the "Developer Documents" module/pill and its readme/doc routes) should only be visible to appropriate product staff; limit exposure to the Product Developer and Release Manager security groups (with superusers still allowed).

### Description

- Added `DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES` and imported `PRODUCT_DEVELOPER_GROUP_NAME` and `RELEASE_MANAGER_GROUP_NAME` in `apps/docs/views.py` and used it to scope allowed users.
- Updated `_show_docs_navigation_link` to return `True` only for superusers or users who belong to the allowed security groups, and return `False` for anonymous users.
- Enforced the same guard on the endpoints by applying `@security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)` to the `document_library` and `readme` views to protect direct URL access.
- Added/updated tests in `apps/sites/tests/test_public_routes.py` to validate the new behavior: `test_docs_library_and_documents_require_developer_or_release_manager_group`, `test_developers_module_pill_hidden_from_non_member_users_when_landing_is_docs_library`, and `test_developers_module_pill_visible_to_release_manager_users`.

### Testing

- Ran the targeted test matrix with `manage.py` after bootstrapping the environment and installing CI test deps; initial run failed due to missing test dependencies, so I executed `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt` to install test requirements.
- Executed the focused tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py -k "docs_library_and_documents_require_login or docs_library_and_documents_require_developer_or_release_manager_group or developers_module_pill_hidden_from_anonymous_users_when_landing_is_docs_library or developers_module_pill_hidden_from_non_member_users_when_landing_is_docs_library or developers_module_pill_visible_to_release_manager_users"` and the selected tests passed (`5 passed`).
- Sent the review notification with `./scripts/review-notify.sh --actor Codex` (succeeded via fallback notification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e007c1e2488326b71720d7b8760912)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Restrict Developer Documents Access to Product Developer and Release Manager Security Groups

### Overview
This PR restricts visibility and access of the Developer Documents module to Product Developer and Release Manager security groups, while preserving access for superusers.

### Changes in apps/docs/views.py
- New imports: PRODUCT_DEVELOPER_GROUP_NAME, RELEASE_MANAGER_GROUP_NAME, and security_group_required.
- New constant: DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES = (PRODUCT_DEVELOPER_GROUP_NAME, RELEASE_MANAGER_GROUP_NAME).
- _show_docs_navigation_link:
  - Returns False for anonymous/unauthenticated users.
  - Returns True for superusers.
  - For authenticated non-superusers, returns True only if the user belongs to at least one group in DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES.
- document_library and readme views:
  - Replaced @login_required with @security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES) to enforce group-based access at the endpoint level (superusers remain allowed via the decorator).

### Changes in apps/groups/decorators.py
- security_group_required: internal membership check (_has_membership) is defined inside the decorator closure and now:
  - Returns False for unauthenticated users (causing a login redirect).
  - Returns True for superusers and when a required group is present.
  - Raises PermissionDenied for authenticated users who are not members of the required groups (causing 403 responses).
- Decorator still exposes login_required and required_security_groups attributes on the wrapped view.

### Changes in apps/sites/tests/test_public_routes.py
- Added imports for PRODUCT_DEVELOPER_GROUP_NAME and RELEASE_MANAGER_GROUP_NAME.
- New/updated tests:
  1. test_docs_library_and_documents_require_developer_or_release_manager_group
     - Confirms unauthenticated users are redirected to login.
     - Confirms authenticated staff users who are not in the required groups receive 403.
     - Confirms superusers receive 200.
     - Confirms adding the user to PRODUCT_DEVELOPER_GROUP_NAME (or RELEASE_MANAGER_GROUP_NAME) grants 200 access.
  2. test_developers_module_pill_hidden_from_non_member_users_when_landing_is_docs_library
     - Verifies the /docs/ navigation module pill is hidden for authenticated users who are not members of the required groups.
  3. test_developers_module_pill_visible_to_release_manager_users
     - Verifies the /docs/ navigation module pill is visible for users in RELEASE_MANAGER_GROUP_NAME.

### Access Control Strategy
- Navigation visibility: controlled via _show_docs_navigation_link to hide the module pill from unauthenticated users and authenticated users not in the allowed groups.
- Direct URL access: enforced via @security_group_required on document_library and readme; unauthenticated users are redirected to login, authenticated non-members receive 403, superusers bypass group checks.

### Tests & Validation
- Targeted tests run locally; relevant tests pass.
- Commit message indicates a fix for a docs auth loop and hardening of access tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->