### PR TITLE
Adjust spacing in admin dashboard CSS

### DIFF
--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -85,10 +85,11 @@
         display: grid;
         row-gap: 0.25rem;
         align-content: start;
+        padding-bottom: 10px;
     }
     .admin-home-operator-journey {
         margin: 0;
-        padding-left: 10px;
+        padding-left: 5px;
         font-size: 0.75rem;
         line-height: 1.05;
         border-radius: 4px;

--- a/apps/sites/static/sites/css/admin/dashboard.css
+++ b/apps/sites/static/sites/css/admin/dashboard.css
@@ -85,11 +85,11 @@
         display: grid;
         row-gap: 0.25rem;
         align-content: start;
-        padding-bottom: 10px;
+        padding-bottom: 0.625rem;
     }
     .admin-home-operator-journey {
         margin: 0;
-        padding-left: 5px;
+        padding-left: 0.3125rem;
         font-size: 0.75rem;
         line-height: 1.05;
         border-radius: 4px;


### PR DESCRIPTION
### Motivation
- Tweak layout spacing for the admin home status and operator journey blocks to improve visual alignment in the dashboard UI.

### Description
- In `apps/sites/static/sites/css/admin/dashboard.css` add `padding-bottom: 10px` to `.admin-home-status` and change `padding-left` on `.admin-home-operator-journey` from `10px` to `5px`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e008df09c08326baa26de6f8fb09f3)