### PR TITLE
Restrict Raspberry Pi hardware dependencies to supported platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,9 @@ ftp = [
   "pyftpdlib==2.2.0",
 ]
 hardware = [
-  "gpiozero==2.0.1; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\"",
-  "mfrc522==0.0.7; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\" and python_version < \"3.12\"",
-  "smbus2==0.6.0; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\"",
+  "gpiozero==2.0.1; sys_platform == \"linux\" and (platform_machine == \"armv7l\" or platform_machine == \"aarch64\")",
+  "mfrc522==0.0.7; sys_platform == \"linux\" and (platform_machine == \"armv7l\" or platform_machine == \"aarch64\") and python_version < \"3.12\"",
+  "smbus2==0.6.0; sys_platform == \"linux\" and (platform_machine == \"armv7l\" or platform_machine == \"aarch64\")",
 ]
 nodes = [
   "graphviz==0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,9 @@ ftp = [
   "pyftpdlib==2.2.0",
 ]
 hardware = [
-  "gpiozero==2.0.1; sys_platform == \"linux\"",
-  "mfrc522==0.0.7; sys_platform == \"linux\"",
-  "smbus2==0.6.0; sys_platform == \"linux\"",
+  "gpiozero==2.0.1; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\"",
+  "mfrc522==0.0.7; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\" and python_version < \"3.12\"",
+  "smbus2==0.6.0; sys_platform == \"linux\" and platform_machine in \"armv7l,aarch64\"",
 ]
 nodes = [
   "graphviz==0.21",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,14 +39,14 @@ Django==5.2.12
 dnspython==2.7.0
 docutils==0.22.4
 filelock==3.25.2
-gpiozero==2.0.1; sys_platform == "linux"
+gpiozero==2.0.1; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
 graphviz==0.21
 httpx==0.28.1
 import-linter==2.11
 kombu==5.5.4
 Markdown==3.10.2
 mdx_truly_sane_lists==1.3
-mfrc522==0.0.7; sys_platform == "linux"
+mfrc522==0.0.7; sys_platform == "linux" and platform_machine in "armv7l,aarch64" and python_version < "3.12"
 mkdocs==1.6.1
 mypy==1.20.0
 opencv-python==4.13.0.92
@@ -77,7 +77,7 @@ requests==2.33.1
 ruff==0.15.9
 selenium==4.41.0
 setuptools==82.0.1
-smbus2==0.6.0; sys_platform == "linux"
+smbus2==0.6.0; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
 sqlparse==0.5.5
 tablib==3.9.0
 tinycss2==1.5.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -39,14 +39,14 @@ Django==5.2.12
 dnspython==2.7.0
 docutils==0.22.4
 filelock==3.25.2
-gpiozero==2.0.1; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
+gpiozero==2.0.1; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64")
 graphviz==0.21
 httpx==0.28.1
 import-linter==2.11
 kombu==5.5.4
 Markdown==3.10.2
 mdx_truly_sane_lists==1.3
-mfrc522==0.0.7; sys_platform == "linux" and platform_machine in "armv7l,aarch64" and python_version < "3.12"
+mfrc522==0.0.7; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64") and python_version < "3.12"
 mkdocs==1.6.1
 mypy==1.20.0
 opencv-python==4.13.0.92
@@ -77,7 +77,7 @@ requests==2.33.1
 ruff==0.15.9
 selenium==4.41.0
 setuptools==82.0.1
-smbus2==0.6.0; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
+smbus2==0.6.0; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64")
 sqlparse==0.5.5
 tablib==3.9.0
 tinycss2==1.5.1

--- a/requirements-hw.txt
+++ b/requirements-hw.txt
@@ -1,4 +1,4 @@
 # Optional hardware dependencies (GPIO, RFID, LCD).
-gpiozero==2.0.1; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
-mfrc522==0.0.7; sys_platform == "linux" and platform_machine in "armv7l,aarch64" and python_version < "3.12"
-smbus2==0.6.0; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
+gpiozero==2.0.1; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64")
+mfrc522==0.0.7; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64") and python_version < "3.12"
+smbus2==0.6.0; sys_platform == "linux" and (platform_machine == "armv7l" or platform_machine == "aarch64")

--- a/requirements-hw.txt
+++ b/requirements-hw.txt
@@ -1,4 +1,4 @@
 # Optional hardware dependencies (GPIO, RFID, LCD).
-gpiozero==2.0.1; sys_platform == "linux"
-mfrc522==0.0.7; sys_platform == "linux"
-smbus2==0.6.0; sys_platform == "linux"
+gpiozero==2.0.1; sys_platform == "linux" and platform_machine in "armv7l,aarch64"
+mfrc522==0.0.7; sys_platform == "linux" and platform_machine in "armv7l,aarch64" and python_version < "3.12"
+smbus2==0.6.0; sys_platform == "linux" and platform_machine in "armv7l,aarch64"


### PR DESCRIPTION
### Motivation
- Installing optional hardware packages on non-Raspberry Pi/Linux hosts caused resolver failures like `No matching distribution found for RPi.GPIO` during dependency resolution.
- The change ensures hardware-only packages are selected on appropriate ARM Linux targets and avoids pulling `mfrc522`/`RPi.GPIO` on unsupported Python/platform combinations.

### Description
- Narrowed the `hardware` optional dependency markers in `pyproject.toml` so `gpiozero`, `mfrc522`, and `smbus2` are only selected when `sys_platform == "linux"` and `platform_machine` is one of `"armv7l,aarch64"`.
- Added a Python-version guard `python_version < "3.12"` to the `mfrc522` marker to avoid selecting it on newer Python versions that cause transitive `RPi.GPIO` build failures.
- Regenerated `requirements-ci.txt` and updated `requirements-hw.txt` to reflect the same environment markers so CI and developer installs match project metadata.

### Testing
- Ran `python scripts/generate_requirements.py --check`, which reported the requirements files are up to date (success).
- Ran `python -m pip install --dry-run -r requirements-hw.txt`, which completed and correctly ignored the gated hardware packages in this environment (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e025ce076483268408e5075f72dbee)