### PR TITLE
Add Evergo top dashboard task with assignment-aware routing

### DIFF
--- a/apps/actions/internal_actions.py
+++ b/apps/actions/internal_actions.py
@@ -55,6 +55,12 @@ INTERNAL_ACTION_SPECS: tuple[InternalActionSpec, ...] = (
         admin_url_name="admin:environment",
     ),
     InternalActionSpec(
+        name="evergo",
+        label="Evergo",
+        description="Open the Evergo contractor setup or order load workspace.",
+        admin_url_name="admin:evergo",
+    ),
+    InternalActionSpec(
         name="groups",
         label="Groups",
         description="Browse the current user's security groups.",

--- a/apps/actions/staff_tasks.py
+++ b/apps/actions/staff_tasks.py
@@ -38,6 +38,13 @@ DEFAULT_STAFF_TASKS: tuple[dict[str, object], ...] = (
         "order": 50,
     },
     {
+        "slug": "evergo",
+        "label": "Evergo",
+        "description": "Open the Evergo contractor setup or order load workspace.",
+        "action_name": "evergo",
+        "order": 52,
+    },
+    {
         "slug": "groups",
         "label": "Groups",
         "description": "Browse the current user's security groups.",

--- a/apps/actions/tests/test_api.py
+++ b/apps/actions/tests/test_api.py
@@ -63,6 +63,7 @@ def test_staff_task_resolves_named_internal_action_for_visible_tasks():
     tasks = visible_staff_tasks_for_user(user)
 
     assert any(task["slug"] == "groups" and task["url"] == "/actions/api/v1/security-groups/" for task in tasks)
+    assert any(task["slug"] == "evergo" and task["url"] == "/admin/evergo/" for task in tasks)
     assert any(
         task["slug"] == "imager"
         and task["url"] == "/admin/imager/raspberrypiimageartifact/create-rpi-image/"

--- a/apps/core/system/admin_views.py
+++ b/apps/core/system/admin_views.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import subprocess
 from urllib.parse import parse_qsl
 from dataclasses import dataclass
+from django.apps import apps
 
 from django.conf import settings
 from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
+from django.db.models import Q
 from django.http import HttpResponseRedirect, JsonResponse
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -79,6 +81,27 @@ def task_panel_route(*, route: str, name: str, group: str = "panels"):
     return decorator
 
 
+def _assigned_evergo_contractor_for_user(user):
+    """Return the first Evergo contractor assigned to the given authenticated user."""
+
+    if not getattr(user, "is_authenticated", False):
+        return None
+
+    evergo_user_model = apps.get_model("evergo", "EvergoUser")
+    if evergo_user_model is None:
+        return None
+
+    group_ids = list(user.groups.values_list("id", flat=True))
+    owner_filter = Q(user=user)
+    if group_ids:
+        owner_filter |= Q(group_id__in=group_ids)
+    owner_filter |= Q(avatar__user=user)
+    if group_ids:
+        owner_filter |= Q(avatar__group_id__in=group_ids)
+
+    return evergo_user_model._default_manager.filter(owner_filter).order_by("pk").first()
+
+
 @task_panel_route(route="system/", name="system", group="panels")
 def _system_view(request):
     ensure_default_staff_tasks_exist()
@@ -136,6 +159,21 @@ def _system_view(request):
         }
     )
     return TemplateResponse(request, "admin/system.html", context)
+
+
+@task_panel_route(route="evergo/", name="evergo", group="panels")
+def _evergo_shortcut_view(request):
+    """Route users to order loading when assigned; otherwise to contractor setup."""
+
+    contractor = _assigned_evergo_contractor_for_user(request.user)
+    if contractor is not None:
+        return HttpResponseRedirect(reverse("admin:evergo_evergocustomer_load_customers"))
+
+    messages.info(
+        request,
+        _("Set up an Evergo contractor first to load and manage assigned orders."),
+    )
+    return HttpResponseRedirect(reverse("admin:evergo_evergouser_login_on_evergo"))
 
 
 def _suite_service_status(base_dir: Path | None = None) -> dict[str, str | bool]:

--- a/apps/core/tests/test_admin_staff_tasks.py
+++ b/apps/core/tests/test_admin_staff_tasks.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from apps.actions.models import StaffTask
 from apps.actions.staff_tasks import ensure_default_staff_tasks_exist
 from apps.core.system.admin_views import TASK_PANEL_ROUTES
+from apps.evergo.models import EvergoUser
 from apps.ocpp.models import Charger
 
 
@@ -156,3 +157,24 @@ class AdminStaffTasksTests(TestCase):
         self.assertEqual(response.status_code, 200)
         mocked_resolver.assert_called_once_with(request=response.wsgi_request)
         self.assertContains(response, "wss://testserver/ws/&lt;charger-id&gt;/")
+
+    def test_evergo_shortcut_redirects_to_login_setup_when_no_assigned_contractor(self):
+        """Evergo shortcut should open setup wizard when user has no assigned contractor."""
+
+        response = self.client.get(reverse("admin:evergo"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:evergo_evergouser_login_on_evergo"))
+
+    def test_evergo_shortcut_redirects_to_order_load_when_contractor_is_assigned(self):
+        """Evergo shortcut should open load-orders workflow for assigned contractor users."""
+
+        EvergoUser.objects.create(
+            user=self.user,
+            evergo_email="assigned-contractor@example.com",
+        )
+
+        response = self.client.get(reverse("admin:evergo"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:evergo_evergocustomer_load_customers"))


### PR DESCRIPTION
### Motivation
- Provide a single top-dashboard action for Evergo that guides administrators to either manage orders or set up a contractor based on whether the current user already has an assigned Evergo contractor.

### Description
- Register a new internal action `evergo` so staff tasks can resolve to the stable admin shortcut named `admin:evergo` by adding an `InternalActionSpec` in `apps/actions/internal_actions.py`.
- Seed a default `evergo` staff task entry in `DEFAULT_STAFF_TASKS` so the button appears with other configurable top dashboard tasks in `apps/actions/staff_tasks.py`.
- Add an assignment-aware admin task-panel route at `/admin/evergo/` in `apps/core/system/admin_views.py` that looks up an assigned `EvergoUser` (direct, group, or avatar ownership) and redirects to the existing load workflow when present or to the contractor setup wizard when not.
- Extend regression tests to assert the new staff task resolves to `/admin/evergo/` and that the shortcut redirects correctly in both assigned and unassigned scenarios by updating `apps/actions/tests/test_api.py` and `apps/core/tests/test_admin_staff_tasks.py`.

### Testing
- Ran environment preparation with `./env-refresh.sh --deps-only` which completed successfully.
- Installed CI test dependencies with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed the targeted test files with `.venv/bin/python manage.py test run -- apps/actions/tests/test_api.py apps/core/tests/test_admin_staff_tasks.py` and observed all tests pass (`13 passed`).
- Sent the review notification via `./scripts/review-notify.sh --actor Codex` as part of the change process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0259e6bdc8326b9b8cb6def5b4f51)