### PR TITLE
core/energy: migrate beat maintenance tasks to canonical Celery names

### DIFF
--- a/apps/core/apps.py
+++ b/apps/core/apps.py
@@ -369,6 +369,39 @@ def _configure_lock_dependent_tasks(config):
         except (OperationalError, ProgrammingError):
             return
 
+    def migrate_maintenance_task_names(**kwargs):
+        del kwargs
+        try:  # pragma: no cover - optional dependency
+            from django_celery_beat.models import PeriodicTask, PeriodicTasks
+        except ImportError:
+            return
+
+        legacy_to_canonical_task_names = {
+            "apps.core.tasks.poll_emails": "apps.core.tasks.maintenance._poll_emails",
+            "apps.core.tasks.run_client_report_schedule": "apps.core.tasks.maintenance._run_client_report_schedule",
+            "apps.core.tasks.run_release_data_transform": "apps.core.tasks.maintenance._run_release_data_transform",
+            "apps.core.tasks.run_scheduled_release": "apps.core.tasks.maintenance._run_scheduled_release",
+            "apps.core.tasks.maintenance.poll_emails": "apps.core.tasks.maintenance._poll_emails",
+            "apps.core.tasks.maintenance.run_client_report_schedule": "apps.core.tasks.maintenance._run_client_report_schedule",
+            "apps.core.tasks.maintenance.run_release_data_transform": "apps.core.tasks.maintenance._run_release_data_transform",
+            "apps.core.tasks.maintenance.run_scheduled_release": "apps.core.tasks.maintenance._run_scheduled_release",
+        }
+
+        try:
+            updated = False
+            for legacy_name, canonical_name in legacy_to_canonical_task_names.items():
+                if (
+                    PeriodicTask.objects.filter(task=legacy_name).update(
+                        task=canonical_name
+                    )
+                    > 0
+                ):
+                    updated = True
+            if updated:
+                PeriodicTasks.update_changed()
+        except (OperationalError, ProgrammingError):
+            return
+
     def ensure_email_collector_task(**kwargs):
         try:  # pragma: no cover - optional dependency
             from django_celery_beat.models import IntervalSchedule, PeriodicTask
@@ -388,7 +421,7 @@ def _configure_lock_dependent_tasks(config):
                 name=task_name,
                 defaults={
                     "interval": schedule,
-                    "task": "apps.core.tasks.maintenance.poll_emails",
+                    "task": "apps.core.tasks.maintenance._poll_emails",
                 },
             )
         except (OperationalError, ProgrammingError):
@@ -396,6 +429,7 @@ def _configure_lock_dependent_tasks(config):
 
     post_migrate.connect(ensure_email_collector_task, sender=config)
     post_migrate.connect(migrate_legacy_heartbeat_task, sender=config)
+    post_migrate.connect(migrate_maintenance_task_names, sender=config)
     post_migrate.connect(ensure_auto_upgrade_periodic_task, sender=config)
 
     auto_upgrade_dispatch_uid = "apps.core.apps.ensure_auto_upgrade_periodic_task"
@@ -412,6 +446,7 @@ def _configure_lock_dependent_tasks(config):
         try:
             ensure_auto_upgrade_periodic_task()
             migrate_legacy_heartbeat_task()
+            migrate_maintenance_task_names()
         finally:
             connection_created.disconnect(
                 receiver=ensure_auto_upgrade_on_connection,

--- a/apps/core/apps.py
+++ b/apps/core/apps.py
@@ -388,6 +388,11 @@ def _configure_lock_dependent_tasks(config):
         }
 
         try:
+            if not PeriodicTask.objects.filter(
+                task__in=legacy_to_canonical_task_names
+            ).exists():
+                return
+
             updated = False
             for legacy_name, canonical_name in legacy_to_canonical_task_names.items():
                 if (

--- a/apps/core/migrations/0004_migrate_maintenance_task_names.py
+++ b/apps/core/migrations/0004_migrate_maintenance_task_names.py
@@ -20,11 +20,22 @@ def migrate_maintenance_task_names(apps, schema_editor):
 
     try:
         PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+        PeriodicTasks = apps.get_model("django_celery_beat", "PeriodicTasks")
     except LookupError:
         return
 
+    from django.utils import timezone
+
+    updated = False
     for legacy_name, canonical_name in LEGACY_TO_CANONICAL_TASK_NAMES.items():
-        PeriodicTask.objects.filter(task=legacy_name).update(task=canonical_name)
+        if PeriodicTask.objects.filter(task=legacy_name).update(task=canonical_name) > 0:
+            updated = True
+
+    if updated:
+        PeriodicTasks.objects.update_or_create(
+            ident=1,
+            defaults={"last_update": timezone.now()},
+        )
 
 
 class Migration(migrations.Migration):

--- a/apps/core/migrations/0004_migrate_maintenance_task_names.py
+++ b/apps/core/migrations/0004_migrate_maintenance_task_names.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+LEGACY_TO_CANONICAL_TASK_NAMES = {
+    "apps.core.tasks.poll_emails": "apps.core.tasks.maintenance._poll_emails",
+    "apps.core.tasks.run_client_report_schedule": "apps.core.tasks.maintenance._run_client_report_schedule",
+    "apps.core.tasks.run_release_data_transform": "apps.core.tasks.maintenance._run_release_data_transform",
+    "apps.core.tasks.run_scheduled_release": "apps.core.tasks.maintenance._run_scheduled_release",
+    "apps.core.tasks.maintenance.poll_emails": "apps.core.tasks.maintenance._poll_emails",
+    "apps.core.tasks.maintenance.run_client_report_schedule": "apps.core.tasks.maintenance._run_client_report_schedule",
+    "apps.core.tasks.maintenance.run_release_data_transform": "apps.core.tasks.maintenance._run_release_data_transform",
+    "apps.core.tasks.maintenance.run_scheduled_release": "apps.core.tasks.maintenance._run_scheduled_release",
+}
+
+
+def migrate_maintenance_task_names(apps, schema_editor):
+    del schema_editor
+
+    try:
+        PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    except LookupError:
+        return
+
+    for legacy_name, canonical_name in LEGACY_TO_CANONICAL_TASK_NAMES.items():
+        PeriodicTask.objects.filter(task=legacy_name).update(task=canonical_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0003_adminnotice_trigger_upgrade_permission"),
+        ("django_celery_beat", "0020_googlecalendarprofile"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_maintenance_task_names,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/apps/core/tasks/maintenance.py
+++ b/apps/core/tasks/maintenance.py
@@ -24,7 +24,6 @@ def _poll_emails() -> None:
 
 
 poll_emails = shared_task(_poll_emails)
-poll_emails_legacy = shared_task(name="apps.core.tasks.poll_emails")(_poll_emails)
 
 
 def execute_scheduled_release(release_id: int) -> None:
@@ -53,9 +52,6 @@ def _run_scheduled_release(release_id: int) -> None:
 
 
 run_scheduled_release = shared_task(_run_scheduled_release)
-run_scheduled_release_legacy = shared_task(
-    name="apps.core.tasks.run_scheduled_release"
-)(_run_scheduled_release)
 
 
 def _run_client_report_schedule(schedule_id: int) -> None:
@@ -76,9 +72,6 @@ def _run_client_report_schedule(schedule_id: int) -> None:
 
 
 run_client_report_schedule = shared_task(_run_client_report_schedule)
-run_client_report_schedule_legacy = shared_task(
-    name="apps.core.tasks.run_client_report_schedule"
-)(_run_client_report_schedule)
 
 
 def _run_release_data_transform(transform_name: str) -> None:
@@ -102,6 +95,3 @@ def _run_release_data_transform(transform_name: str) -> None:
 
 
 run_release_data_transform = shared_task(_run_release_data_transform)
-run_release_data_transform_legacy = shared_task(
-    name="apps.core.tasks.run_release_data_transform"
-)(_run_release_data_transform)

--- a/apps/core/tests/test_maintenance_tasks.py
+++ b/apps/core/tests/test_maintenance_tasks.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
+
 from celery import current_app
+
+migrate_maintenance_task_names_module = importlib.import_module(
+    "apps.core.migrations.0004_migrate_maintenance_task_names"
+)
 
 
 def test_maintenance_tasks_register_only_canonical_names():
@@ -40,3 +46,77 @@ def test_maintenance_tasks_register_only_canonical_names():
         "apps.core.tasks.maintenance.run_release_data_transform"
         not in registered_task_names
     )
+
+
+class _FakeQuerySet:
+    def __init__(self, updates_by_task, task):
+        self._task = task
+        self._updates_by_task = updates_by_task
+
+    def update(self, **kwargs):
+        del kwargs
+        return self._updates_by_task.get(self._task, 0)
+
+
+class _FakePeriodicTaskManager:
+    def __init__(self, updates_by_task):
+        self._updates_by_task = updates_by_task
+
+    def filter(self, **kwargs):
+        return _FakeQuerySet(self._updates_by_task, kwargs["task"])
+
+
+class _FakePeriodicTasksManager:
+    def __init__(self):
+        self.calls = []
+
+    def update_or_create(self, **kwargs):
+        self.calls.append(kwargs)
+        return object(), True
+
+
+class _FakeModelRegistry:
+    def __init__(self, updates_by_task):
+        self.periodic_tasks_manager = _FakePeriodicTasksManager()
+        self.periodic_task_model = type(
+            "PeriodicTask",
+            (),
+            {"objects": _FakePeriodicTaskManager(updates_by_task)},
+        )
+        self.periodic_tasks_model = type(
+            "PeriodicTasks",
+            (),
+            {"objects": self.periodic_tasks_manager},
+        )
+
+    def get_model(self, app_label, model_name):
+        model_map = {
+            ("django_celery_beat", "PeriodicTask"): self.periodic_task_model,
+            ("django_celery_beat", "PeriodicTasks"): self.periodic_tasks_model,
+        }
+        return model_map[(app_label, model_name)]
+
+
+def test_migration_updates_periodic_tasks_change_tracker():
+    fake_apps = _FakeModelRegistry(
+        {"apps.core.tasks.poll_emails": 1},
+    )
+
+    migrate_maintenance_task_names_module.migrate_maintenance_task_names(
+        fake_apps, schema_editor=None
+    )
+
+    assert len(fake_apps.periodic_tasks_manager.calls) == 1
+    change_tracker_call = fake_apps.periodic_tasks_manager.calls[0]
+    assert change_tracker_call["ident"] == 1
+    assert "last_update" in change_tracker_call["defaults"]
+
+
+def test_migration_skips_change_tracker_when_no_rows_are_updated():
+    fake_apps = _FakeModelRegistry({})
+
+    migrate_maintenance_task_names_module.migrate_maintenance_task_names(
+        fake_apps, schema_editor=None
+    )
+
+    assert fake_apps.periodic_tasks_manager.calls == []

--- a/apps/core/tests/test_maintenance_tasks.py
+++ b/apps/core/tests/test_maintenance_tasks.py
@@ -1,0 +1,42 @@
+"""Task registration and compatibility coverage for core maintenance tasks."""
+
+from __future__ import annotations
+
+from celery import current_app
+
+
+def test_maintenance_tasks_register_only_canonical_names():
+    """Maintenance tasks should be registered only under canonical task names."""
+
+    from apps.core.tasks import maintenance as _maintenance
+
+    del _maintenance
+
+    registered_task_names = set(current_app.tasks.keys())
+
+    assert "apps.core.tasks.maintenance._poll_emails" in registered_task_names
+    assert "apps.core.tasks.maintenance._run_scheduled_release" in registered_task_names
+    assert (
+        "apps.core.tasks.maintenance._run_client_report_schedule"
+        in registered_task_names
+    )
+    assert (
+        "apps.core.tasks.maintenance._run_release_data_transform"
+        in registered_task_names
+    )
+
+    assert "apps.core.tasks.poll_emails" not in registered_task_names
+    assert "apps.core.tasks.run_scheduled_release" not in registered_task_names
+    assert "apps.core.tasks.run_client_report_schedule" not in registered_task_names
+    assert "apps.core.tasks.run_release_data_transform" not in registered_task_names
+
+    assert "apps.core.tasks.maintenance.poll_emails" not in registered_task_names
+    assert "apps.core.tasks.maintenance.run_scheduled_release" not in registered_task_names
+    assert (
+        "apps.core.tasks.maintenance.run_client_report_schedule"
+        not in registered_task_names
+    )
+    assert (
+        "apps.core.tasks.maintenance.run_release_data_transform"
+        not in registered_task_names
+    )

--- a/apps/energy/models/scheduling.py
+++ b/apps/energy/models/scheduling.py
@@ -177,7 +177,7 @@ class ClientReportSchedule(Entity):
         name = normalize_periodic_task_name(PeriodicTask.objects, raw_name)
         defaults = {
             "crontab": schedule,
-            "task": "apps.core.tasks.maintenance.run_client_report_schedule",
+            "task": "apps.core.tasks.maintenance._run_client_report_schedule",
             "kwargs": _json.dumps({"schedule_id": self.pk}),
             "enabled": True,
         }


### PR DESCRIPTION
### Motivation

- Normalize periodic task names so django-celery-beat schedules use the canonical maintenance task registrations (the underscore-prefixed functions) and remove legacy alias registrations.
- Prevent mismatches between deployed schedules and the actual registered Celery task names so periodic jobs continue to execute reliably.

### Description

- Removed legacy shared-task aliases from `apps/core/tasks/maintenance.py` for `apps.core.tasks.poll_emails`, `apps.core.tasks.run_scheduled_release`, `apps.core.tasks.run_client_report_schedule`, and `apps.core.tasks.run_release_data_transform`, keeping the canonical registrations unchanged.
- Added startup migration logic in `apps/core/apps.py` (post-migrate and connection bootstrap) to rewrite `django_celery_beat.PeriodicTask.task` values from legacy/non-canonical names to canonical names and call `PeriodicTasks.update_changed()` when updates occur.
- Added a data migration `apps/core/migrations/0004_migrate_maintenance_task_names.py` to update existing database rows in-place from legacy/non-canonical task names to the canonical names.
- Updated default schedule creation to point at canonical task names (`_poll_emails` and `_run_client_report_schedule`) in `apps/core/apps.py` and `apps/energy/models/scheduling.py`, and added a regression test `apps/core/tests/test_maintenance_tasks.py` that asserts only canonical names are registered.

### Testing

- Ran `./env-refresh.sh --deps-only` successfully to ensure environment deps are present. (success)
- Executed the new unit test with `.venv/bin/python manage.py test run -- apps.core/tests/test_maintenance_tasks.py` and it passed (`1 passed`). (success)
- Ran `.venv/bin/python manage.py migrations check` and it reported no pending changes. (success)
- Added the data migration `0004_migrate_maintenance_task_names.py` and wired runtime startup migration; `./scripts/review-notify.sh --actor Codex` was invoked to surface the changes. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02ca38f4883269d0c76edec6e0ea9)