### PR TITLE
Demote several apps.repos tests from `critical` and document the change

### DIFF
--- a/apps/repos/tests/test_github_issue_reporting.py
+++ b/apps/repos/tests/test_github_issue_reporting.py
@@ -37,7 +37,6 @@ def _build_request():
     return request
 
 
-@pytest.mark.critical
 def test_request_exceptions_do_not_enqueue_github_reporting_when_feature_disabled(
     db, monkeypatch, settings, tmp_path
 ):
@@ -96,7 +95,6 @@ def test_request_exceptions_enqueue_github_reporting_when_feature_enabled(
     assert (Path(tmp_path) / ".locks" / "github-issues" / payload["fingerprint"]).exists()
 
 
-@pytest.mark.critical
 def test_duplicate_exception_cooldown_still_blocks_repeated_reporting(
     db, monkeypatch, settings, tmp_path
 ):

--- a/apps/repos/tests/test_release_management.py
+++ b/apps/repos/tests/test_release_management.py
@@ -15,7 +15,6 @@ from apps.repos.release_management import (
 
 
 @pytest.mark.django_db
-@pytest.mark.critical
 def test_release_management_uses_suite_api_by_default(monkeypatch):
     """Default suite mode should use API calls when token resolution succeeds."""
 

--- a/apps/repos/tests/test_webhooks.py
+++ b/apps/repos/tests/test_webhooks.py
@@ -14,7 +14,6 @@ from apps.repos.models.repositories import GitHubRepository
 
 
 @pytest.mark.django_db
-@pytest.mark.critical
 def test_github_webhook_form_payload_array_is_preserved(client):
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
 
@@ -37,7 +36,6 @@ def test_github_webhook_form_payload_array_is_preserved(client):
 
 
 @pytest.mark.django_db
-@pytest.mark.critical
 def test_github_webhook_header_lookup_is_case_insensitive(client):
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
     url = reverse("repos:github-webhook")

--- a/docs/development/testing/test-suite-notes.md
+++ b/docs/development/testing/test-suite-notes.md
@@ -6,3 +6,7 @@ This document tracks focused test-suite decisions that are too specific for `tes
 
 - The env refresh integration test was retired because CI and local workflows already run environment refresh before test execution, so failures now surface earlier.
 - Document rendering integration coverage moved to higher-level doc generation checks and manual QA for end-to-end output, while unit coverage retains critical HTML escaping checks for plain text.
+
+## Marker change ledger
+
+- 2026-04-16: Demoted five `apps.repos` tests from `critical` to the default tier because they cover webhook compatibility and GitHub reporting/release-routing behavior rather than install/upgrade or safety-sensitive gates. Remaining critical coverage in the same areas still protects signature validation and other boundary checks.


### PR DESCRIPTION
### Motivation

- Reduce the number of tests marked as `critical` where they cover compatibility and operational behaviors rather than install/upgrade or safety-sensitive gates.
- Record the marker change in test-suite notes so maintainers can track why these tests were demoted.

### Description

- Remove the `@pytest.mark.critical` marker from five tests in `apps.repos` across `test_github_issue_reporting.py`, `test_release_management.py`, and `test_webhooks.py`.
- Add a `Marker change ledger` entry to `docs/development/testing/test-suite-notes.md` documenting the demotion and rationale with a dated note.
- No functional production code was changed; only test metadata and documentation were modified.

### Testing

- Ran the modified test modules with `pytest` targeting `apps.repos.tests.test_github_issue_reporting`, `apps.repos.tests.test_release_management`, and `apps.repos.tests.test_webhooks`, and they completed successfully.
- Full test-suite results were consistent with expectations for a metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02c711b508326afd723c14abd58d7)