### PR TITLE
Remove placeholder admin.py modules with no registrations

### DIFF
--- a/apps/app/admin.py
+++ b/apps/app/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/base/admin.py
+++ b/apps/base/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/flows/admin.py
+++ b/apps/flows/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/forwarder/ocpp/admin.py
+++ b/apps/forwarder/ocpp/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/leads/admin.py
+++ b/apps/leads/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/locale/admin.py
+++ b/apps/locale/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/payments/admin.py
+++ b/apps/payments/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/protocols/admin.py
+++ b/apps/protocols/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]

--- a/apps/rates/admin.py
+++ b/apps/rates/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-__all__ = ["admin"]


### PR DESCRIPTION
### Motivation
- Clean up apps that contained placeholder `admin.py` modules that only imported `django.contrib.admin` and exported `__all__`, because they add noise and no runtime value.
- Ensure removing these stubs does not break admin autodiscovery or import-time expectations.

### Description
- Deleted nine placeholder modules: `apps/app/admin.py`, `apps/base/admin.py`, `apps/flows/admin.py`, `apps/forwarder/ocpp/admin.py`, `apps/leads/admin.py`, `apps/locale/admin.py`, `apps/payments/admin.py`, `apps/protocols/admin.py`, and `apps/rates/admin.py` because each file only contained a boilerplate import and `__all__` with no model registrations.
- Searched the codebase for direct imports of `apps.<app>.admin` for the affected apps and found none, so no compatibility shim was required.
- Kept changes minimal and aligned with existing admin discovery patterns to avoid behavioral changes.

### Testing
- Ran `rg` searches to confirm each removed file only contained the boilerplate import and `__all__`, and no other code references to `apps.<app>.admin` were found, which succeeded.
- Executed `./env-refresh.sh --deps-only` to provision the virtualenv and dependencies, which completed successfully (Playwright host-deps install was long but not required for this backend cleanup).
- Ran `.venv/bin/python manage.py check` and it completed with no issues detected.
- Ran `.venv/bin/python manage.py shell -c "from django.contrib import admin; admin.autodiscover(); print('admin autodiscover ok')"` and it printed `admin autodiscover ok`, confirming admin autodiscovery imports cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e3c02a5483268efd1c1597fdbf2c)