### PR TITLE
ocpp-simulator: clarify queued cpsim start state in simulator UI

### DIFF
--- a/apps/ocpp/cpsim_service.py
+++ b/apps/ocpp/cpsim_service.py
@@ -14,6 +14,8 @@ from apps.features.utils import is_suite_feature_enabled
 
 CPSIM_FEATURE_SLUG = "ocpp-simulator"
 CPSIM_REQUEST_LOCK_NAME = "cpsim-service.lck"
+CPSIM_START_QUEUED_STATUS = "cpsim-service start queued (awaiting worker)"
+CPSIM_STOP_QUEUED_STATUS = "cpsim-service stop queued (awaiting worker)"
 
 
 def _serialize_params(params: Any) -> dict[str, Any]:
@@ -114,3 +116,9 @@ def get_cpsim_request_metadata(*, base_dir: Path | None = None) -> dict[str, Any
         "queued_at": queued_at,
         "age_seconds": age_seconds,
     }
+
+
+def is_cpsim_start_queued_status(status: str | None) -> bool:
+    """Return whether simulator state reflects a cpsim start queue request."""
+
+    return str(status or "").startswith("cpsim-service start queued")

--- a/apps/ocpp/cpsim_service.py
+++ b/apps/ocpp/cpsim_service.py
@@ -14,6 +14,8 @@ from apps.features.utils import is_suite_feature_enabled
 
 CPSIM_FEATURE_SLUG = "ocpp-simulator"
 CPSIM_REQUEST_LOCK_NAME = "cpsim-service.lck"
+CPSIM_START_QUEUED_PREFIX = "cpsim-service start queued"
+CPSIM_START_REQUESTED_PREFIX = "cpsim-service start requested"
 CPSIM_START_QUEUED_STATUS = "cpsim-service start queued (awaiting worker)"
 CPSIM_STOP_QUEUED_STATUS = "cpsim-service stop queued (awaiting worker)"
 
@@ -121,4 +123,7 @@ def get_cpsim_request_metadata(*, base_dir: Path | None = None) -> dict[str, Any
 def is_cpsim_start_queued_status(status: str | None) -> bool:
     """Return whether simulator state reflects a cpsim start queue request."""
 
-    return str(status or "").startswith("cpsim-service start queued")
+    status_text = status or ""
+    return status_text.startswith(
+        (CPSIM_START_QUEUED_PREFIX, CPSIM_START_REQUESTED_PREFIX)
+    )

--- a/apps/ocpp/templates/ocpp/cp_simulator_block.html
+++ b/apps/ocpp/templates/ocpp/cp_simulator_block.html
@@ -126,6 +126,7 @@
               </div>
               {% endif %}
               <div class="small mb-0">
+                No websocket will open until a cpsim worker consumes this queue entry.
                 If this stays in Service phase, start or restart the cpsim worker and
                 {% if simulator_log_url %}
                 <a href="{{ simulator_log_url }}">check simulator logs</a>.

--- a/apps/ocpp/tests/test_cp_simulator_view.py
+++ b/apps/ocpp/tests/test_cp_simulator_view.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 
+from apps.ocpp.cpsim_service import CPSIM_START_QUEUED_STATUS
+
 
 @pytest.mark.django_db
 @patch("apps.ocpp.views.simulator._start_simulator")
@@ -22,6 +24,7 @@ def test_cp_simulator_start_posts_selected_backend(
     start_simulator,
     admin_client,
 ):
+    start_simulator.return_value = (True, "started", "/tmp/simulator.log")
     response = admin_client.post(
         reverse("ocpp:cp-simulator"),
         {
@@ -47,3 +50,45 @@ def test_cp_simulator_start_posts_selected_backend(
     start_simulator.assert_called_once()
     sim_params = start_simulator.call_args.args[0]
     assert sim_params["simulator_backend"] == "arthexis"
+
+
+@pytest.mark.django_db
+@patch("apps.ocpp.views.simulator._start_simulator")
+@patch(
+    "apps.ocpp.views.simulator.get_cpsim_request_metadata",
+    return_value={"queued": True, "lock_path": "/tmp/.locks/cpsim-service.lck"},
+)
+@patch(
+    "apps.ocpp.views.simulator.get_simulator_backend_choices",
+    return_value=(("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse")),
+)
+def test_cp_simulator_start_reports_cpsim_queue_status(
+    _request_metadata,
+    _backend_choices,
+    start_simulator,
+    admin_client,
+):
+    start_simulator.return_value = (True, CPSIM_START_QUEUED_STATUS, "/tmp/simulator.log")
+    response = admin_client.post(
+        reverse("ocpp:cp-simulator"),
+        {
+            "action": "start",
+            "host": "localhost:8888",
+            "cp_path": "CP2",
+            "serial_number": "CP2",
+            "connector_id": "1",
+            "rfid": "FFFFFFFF",
+            "vin": "WP0ZZZ00000000000",
+            "duration": "600",
+            "interval": "5",
+            "pre_charge_delay": "0",
+            "average_kwh": "60",
+            "amperage": "90",
+            "repeat": "False",
+            "simulator_backend": "arthexis",
+        },
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert "Simulator start queued for cpsim-service" in response.content.decode("utf-8")

--- a/apps/ocpp/tests/test_cpsim_service_feature.py
+++ b/apps/ocpp/tests/test_cpsim_service_feature.py
@@ -10,9 +10,11 @@ from apps.features.models import Feature
 from apps.nodes.models import Node
 from apps.ocpp.cpsim_service import (
     CPSIM_FEATURE_SLUG,
-    get_cpsim_request_metadata,
-    queue_cpsim_request,
+    CPSIM_START_QUEUED_STATUS,
     cpsim_service_enabled,
+    get_cpsim_request_metadata,
+    is_cpsim_start_queued_status,
+    queue_cpsim_request,
 )
 
 
@@ -98,3 +100,17 @@ def test_get_cpsim_request_metadata_handles_unreadable_lock_path(monkeypatch):
         "queued": False,
         "lock_path": "/workspace/arthexis/.locks/cpsim-service.lck",
     }
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (CPSIM_START_QUEUED_STATUS, True),
+        ("cpsim-service start requested", True),
+        ("cpsim-service start requested (awaiting worker)", True),
+        ("running", False),
+        (None, False),
+    ],
+)
+def test_is_cpsim_start_queued_status_supports_legacy_prefix(status, expected):
+    assert is_cpsim_start_queued_status(status) is expected

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -4,11 +4,7 @@ import ipaddress
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from ..cpsim_service import (
-    CPSIM_START_QUEUED_STATUS,
-    get_cpsim_request_metadata,
-    is_cpsim_start_queued_status,
-)
+from ..cpsim_service import get_cpsim_request_metadata, is_cpsim_start_queued_status
 from ..utils import resolve_ws_scheme
 from apps.core.notifications import LcdChannel
 from apps.screens.startup_notifications import format_lcd_lines
@@ -371,7 +367,7 @@ def cp_simulator(request):
                 lcd_channel_type=LcdChannel.LOW.value,
             )
             message = _("Simulator start requested")
-            if status == CPSIM_START_QUEUED_STATUS:
+            if is_cpsim_start_queued_status(status):
                 message = _("Simulator start queued for cpsim-service")
             if sim_params["demo_mode"]:
                 dashboard_link = reverse("ocpp:ocpp-dashboard")

--- a/apps/ocpp/views/simulator.py
+++ b/apps/ocpp/views/simulator.py
@@ -4,7 +4,11 @@ import ipaddress
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from ..cpsim_service import get_cpsim_request_metadata
+from ..cpsim_service import (
+    CPSIM_START_QUEUED_STATUS,
+    get_cpsim_request_metadata,
+    is_cpsim_start_queued_status,
+)
 from ..utils import resolve_ws_scheme
 from apps.core.notifications import LcdChannel
 from apps.screens.startup_notifications import format_lcd_lines
@@ -358,7 +362,7 @@ def cp_simulator(request):
             sim_params["meter_interval"] = _cast_value(
                 request.POST.get("meter_interval"), float, default_params["interval"]
             )
-            _start_simulator(sim_params, cp=simulator_slot)
+            status = _start_simulator(sim_params, cp=simulator_slot)[1]
             subject, body = _lcd_simulator_lines(name, sim_params)
             NetMessage.broadcast(
                 subject=subject,
@@ -367,6 +371,8 @@ def cp_simulator(request):
                 lcd_channel_type=LcdChannel.LOW.value,
             )
             message = _("Simulator start requested")
+            if status == CPSIM_START_QUEUED_STATUS:
+                message = _("Simulator start queued for cpsim-service")
             if sim_params["demo_mode"]:
                 dashboard_link = reverse("ocpp:ocpp-dashboard")
             if sim_params.get("delay"):
@@ -426,7 +432,7 @@ def cp_simulator(request):
     is_service_queued = (
         state.get("running")
         and state.get("phase") == "Service"
-        and str(state.get("last_status") or "").startswith("cpsim-service start requested")
+        and is_cpsim_start_queued_status(state.get("last_status"))
     )
     cpsim_request = {"queued": False}
     if is_service_queued:

--- a/apps/simulators/evcs.py
+++ b/apps/simulators/evcs.py
@@ -46,7 +46,12 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 
 from apps.ocpp import store
-from apps.ocpp.cpsim_service import cpsim_service_enabled, queue_cpsim_request
+from apps.ocpp.cpsim_service import (
+    CPSIM_START_QUEUED_STATUS,
+    CPSIM_STOP_QUEUED_STATUS,
+    cpsim_service_enabled,
+    queue_cpsim_request,
+)
 from apps.simulators.runtime import ChargePointRuntime, ChargePointRuntimeConfig
 from apps.simulators.evcs_mobilityhouse import MobilityHouseChargePointAdapter
 from apps.simulators.network import validate_simulator_endpoint
@@ -590,7 +595,7 @@ def _start_simulator(
             name=str(state.params.get("name") or f"Simulator {cp}"),
             source="landing",
         )
-        state.last_status = "cpsim-service start requested"
+        state.last_status = CPSIM_START_QUEUED_STATUS
         state.phase = "Service"
         _save_state_file(_simulators)
         return True, state.last_status, log_file
@@ -676,7 +681,7 @@ def _stop_simulator(cp: int = 1) -> bool:
             source="landing",
             params=state.params,
         )
-        state.last_status = "cpsim-service stop requested"
+        state.last_status = CPSIM_STOP_QUEUED_STATUS
         state.phase = "Service"
         _save_state_file(_simulators)
     return True
@@ -761,7 +766,6 @@ __all__ = [
     "view_cp_simulator",
     "view_simulator",
 ]
-
 
 
 


### PR DESCRIPTION
### Motivation
- Make the UI and runtime status messaging explicit about cpsim queue behavior so users are not misled into thinking a websocket was opened when start requests are only queued.
- Centralize queued-start detection to avoid repeated ad-hoc string checks and make future changes simpler.

### Description
- Added explicit status constants `CPSIM_START_QUEUED_STATUS` and `CPSIM_STOP_QUEUED_STATUS` and a helper `is_cpsim_start_queued_status` in `apps/ocpp/cpsim_service.py` to represent queued service requests.
- Updated simulator runtime in `apps/simulators/evcs.py` to write the clearer queued wording into `state.last_status` when `cpsim_service_enabled()` is true and a start/stop is queued.
- Updated the simulator landing view `apps/ocpp/views/simulator.py` to inspect the helper and the `start` result, and display `"Simulator start queued for cpsim-service"` when appropriate instead of implying an active connection.
- Clarified the simulator panel copy in `apps/ocpp/templates/ocpp/cp_simulator_block.html` to state that no websocket will open until a cpsim worker consumes the queue entry.
- Added/updated tests in `apps/ocpp/tests/test_cp_simulator_view.py` to cover propagation of backend selection and the new queued-start message.

### Testing
- Ran `python -m pytest apps/ocpp/tests/test_cp_simulator_view.py apps/ocpp/tests/test_cpsim_service_feature.py` and the test suite for these files passed (`8 passed, 1 warning`).
- The repository environment was refreshed prior to test execution using `./env-refresh.sh --deps-only` to install required dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e513a0148326b0ab8f3c0923d009)