### PR TITLE
Fix JSON logging formatter import compatibility with Python 3.10

### DIFF
--- a/utils/loggers/json_formatter.py
+++ b/utils/loggers/json_formatter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import socket
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 
 class JSONFormatter(logging.Formatter):
@@ -15,7 +15,9 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         payload = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),


### PR DESCRIPTION
### Motivation
- Resolve a startup/upgrade crash where `utils.loggers.json_formatter` attempted to import `UTC` from the standard `datetime` module (a name not available on Python 3.10), causing Django to fail logging configuration.

### Description
- Replace `from datetime import UTC, datetime` with `from datetime import datetime, timezone` and use `timezone.utc` when constructing the JSON `timestamp`, preserving ISO UTC timestamps while restoring compatibility with Python 3.10.

### Testing
- Prepared the environment and ran `.venv/bin/python manage.py test run -- tests/test_logging_config.py`, which completed successfully (`6 passed`), confirming the formatter output remains correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f154bd008326a7bdbf029a6a2bde)