### PR TITLE
Add Developer Gallery sidebar to docs library with backend support and tests

### DIFF
--- a/apps/docs/templates/docs/library.html
+++ b/apps/docs/templates/docs/library.html
@@ -96,7 +96,7 @@
           {% for image in gallery_images %}
             <div class="col">
               <a href="{% url 'gallery:detail' slug=image.slug %}" class="text-decoration-none">
-                <img src="{{ image.media_file.file.url }}" alt="{{ image.title }}" class="img-fluid rounded border">
+                <img src="{{ image.media_file.file.url }}" alt="{{ image.title }}" class="img-fluid rounded border" loading="lazy" decoding="async">
                 <div class="small mt-1 text-truncate">{{ image.title }}</div>
               </a>
             </div>

--- a/apps/docs/templates/docs/library.html
+++ b/apps/docs/templates/docs/library.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col-12">
+  <div class="col-12 col-xl-8">
     <div class="markdown-body">
       <h1>{{ title }}</h1>
       <p>{% trans "Browse curated developer references below with quick summaries to help you choose the right guide." %}</p>
@@ -74,5 +74,40 @@
       {% endif %}
     </div>
   </div>
+  <aside class="col-12 col-xl-4 mt-4 mt-xl-0">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h2 class="h5 mb-0">{% trans "Developer Gallery" %}</h2>
+          <a class="btn btn-sm btn-outline-primary" href="{{ gallery_index_url }}">{% trans "Open gallery" %}</a>
+        </div>
+        <p class="text-muted small mb-3">
+          {% trans "Preview the latest uploads and jump straight to the full gallery." %}
+        </p>
+        <p class="mb-3">
+          {% if is_gallery_manager %}
+            <a class="btn btn-sm btn-primary" href="{{ gallery_upload_url }}">{% trans "Create / upload image" %}</a>
+          {% else %}
+            <a class="btn btn-sm btn-outline-secondary" href="{{ gallery_upload_url }}">{% trans "Create / upload image" %}</a>
+            <span class="d-block text-muted small mt-2">{% trans "Upload requires Gallery Manager, staff, or superuser access." %}</span>
+          {% endif %}
+        </p>
+        <div class="row row-cols-2 g-2">
+          {% for image in gallery_images %}
+            <div class="col">
+              <a href="{% url 'gallery:detail' slug=image.slug %}" class="text-decoration-none">
+                <img src="{{ image.media_file.file.url }}" alt="{{ image.title }}" class="img-fluid rounded border">
+                <div class="small mt-1 text-truncate">{{ image.title }}</div>
+              </a>
+            </div>
+          {% empty %}
+            <div class="col-12">
+              <div class="alert alert-light border mb-0">{% trans "No gallery images are visible yet." %}</div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </aside>
 </div>
 {% endblock %}

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -706,22 +706,29 @@ def _get_cached_document_library(
     )
 
 
-def _latest_gallery_images_for_user(user, *, limit: int = 4):
-    queryset = GalleryImage.objects.select_related(
-        "media_file", "owner_user", "owner_group"
-    )
-    if can_manage_gallery(user):
+def _latest_gallery_images_for_user(
+    user, *, limit: int = 4, is_gallery_manager: bool | None = None
+):
+    """Return latest gallery images visible to the user, limited to four by default.
+
+    Gallery managers can see all images. Other users see public images plus images
+    they own and images owned by one of their groups. Results are ordered newest
+    first by media upload time and primary key.
+    """
+
+    queryset = GalleryImage.objects.select_related("media_file")
+    if is_gallery_manager is None:
+        is_gallery_manager = can_manage_gallery(user)
+    if is_gallery_manager:
         return queryset.order_by("-media_file__uploaded_at", "-pk")[:limit]
 
     visibility_filter = Q(include_in_public_gallery=True)
     if getattr(user, "is_authenticated", False):
         visibility_filter |= Q(owner_user=user)
         visibility_filter |= Q(owner_group__in=user.groups.all())
-    return (
-        queryset.filter(visibility_filter)
-        .distinct()
-        .order_by("-media_file__uploaded_at", "-pk")[:limit]
-    )
+    return queryset.filter(visibility_filter).order_by("-media_file__uploaded_at", "-pk")[
+        :limit
+    ]
 
 
 def _render_document_library(
@@ -761,7 +768,11 @@ def _render_document_library(
         doc_path_prefix="apps/docs/",
     )
     indexed_groups = _build_indexed_document_groups(request, all_documents)
-    gallery_images = _latest_gallery_images_for_user(request.user)
+    is_gallery_manager = can_manage_gallery(request.user)
+    gallery_images = _latest_gallery_images_for_user(
+        request.user,
+        is_gallery_manager=is_gallery_manager,
+    )
     context = {
         "canonical_url": _build_canonical_url(request),
         "document_index_admin_add_url": "",
@@ -770,7 +781,7 @@ def _render_document_library(
         "gallery_index_url": reverse("gallery:index"),
         "gallery_upload_url": reverse("gallery:upload"),
         "indexed_groups": indexed_groups,
-        "is_gallery_manager": can_manage_gallery(request.user),
+        "is_gallery_manager": is_gallery_manager,
         "page_url": request.build_absolute_uri(),
         "sections": sections,
         "title": "Developer Documents",

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -7,25 +7,27 @@ from urllib.parse import urlencode, urlunsplit
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.utils.cache import patch_cache_control, patch_vary_headers
+from django.db.models import Q
 from django.http import FileResponse, Http404, HttpResponse
-from django.urls import NoReverseMatch, reverse
 from django.shortcuts import render
+from django.urls import NoReverseMatch, reverse
+from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.views.decorators.cache import never_cache
 
+from apps.gallery.models import GalleryImage
+from apps.gallery.permissions import can_manage_gallery
 from apps.groups.constants import (
     PRODUCT_DEVELOPER_GROUP_NAME,
     RELEASE_MANAGER_GROUP_NAME,
 )
 from apps.groups.decorators import security_group_required
+from apps.modules.models import Module
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
-from apps.modules.models import Module
 from apps.sites.utils import module_pill_link_validation
 
-from .models import DocumentIndex
 from . import assets, rendering
-
+from .models import DocumentIndex
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,9 @@ def _show_docs_navigation_link(*, request, landing) -> bool:
         return False
     if user.is_superuser:
         return True
-    return user.groups.filter(name__in=DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES).exists()
+    return user.groups.filter(
+        name__in=DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES
+    ).exists()
 
 
 def _is_allowed_doc_path(path: Path) -> bool:
@@ -115,7 +119,9 @@ def _locate_readme_document(role, doc: str | None, lang: str) -> SimpleNamespace
                     add_candidate(path.with_name(f"{path.stem}.{lang}{path.suffix}"))
                     short = lang.split("-")[0]
                     if short and short != lang:
-                        add_candidate(path.with_name(f"{path.stem}.{short}{path.suffix}"))
+                        add_candidate(
+                            path.with_name(f"{path.stem}.{short}{path.suffix}")
+                        )
             add_candidate(path)
 
         add_localized_candidates(doc_path)
@@ -179,7 +185,11 @@ def _locate_readme_document(role, doc: str | None, lang: str) -> SimpleNamespace
             candidates.append(root_default)
 
     readme_file = next(
-        (p for p in candidates if p.exists() and p.is_file() and _is_allowed_doc_path(p)),
+        (
+            p
+            for p in candidates
+            if p.exists() and p.is_file() and _is_allowed_doc_path(p)
+        ),
         None,
     )
     if readme_file is None:
@@ -323,7 +333,11 @@ def _normalize_library_prefix(prefix: str | None) -> str:
 
 def _build_library_query_url(parameter: str, prefix: str) -> str:
     query = urlencode({parameter: prefix}) if prefix else ""
-    return f"{reverse('docs:docs-library')}?{query}" if query else reverse("docs:docs-library")
+    return (
+        f"{reverse('docs:docs-library')}?{query}"
+        if query
+        else reverse("docs:docs-library")
+    )
 
 
 def _build_virtual_root_query_url(parameter: str) -> str:
@@ -482,7 +496,9 @@ def _build_library_section(
             {
                 "kind": "folder",
                 "label": f"{LIBRARY_ROOT_FOLDER_LABEL}/",
-                "url": _build_virtual_root_query_url(f"{parameter}_{LIBRARY_ROOT_QUERY_PARAMETER}"),
+                "url": _build_virtual_root_query_url(
+                    f"{parameter}_{LIBRARY_ROOT_QUERY_PARAMETER}"
+                ),
                 "description": "Browse root-level documents.",
             },
         )
@@ -523,7 +539,9 @@ def _collect_document_library(
     apps_docs_root = root_base / "apps" / "docs"
     sections: list[dict[str, object]] = []
 
-    docs_files = docs_files if docs_files is not None else _iter_document_paths(docs_root)
+    docs_files = (
+        docs_files if docs_files is not None else _iter_document_paths(docs_root)
+    )
     if docs_files:
         sections.append(
             _build_library_section(
@@ -539,7 +557,9 @@ def _collect_document_library(
         )
 
     apps_docs_files = (
-        apps_docs_files if apps_docs_files is not None else _iter_document_paths(apps_docs_root)
+        apps_docs_files
+        if apps_docs_files is not None
+        else _iter_document_paths(apps_docs_root)
     )
     if apps_docs_files:
         sections.append(
@@ -583,7 +603,9 @@ def _build_library_documents(
     return [item for item in documents if item["url"]]
 
 
-def _build_indexed_document_groups(request, documents: list[dict[str, str]]) -> list[dict[str, object]]:
+def _build_indexed_document_groups(
+    request, documents: list[dict[str, str]]
+) -> list[dict[str, object]]:
     """Group indexed documents by security-group course (and listable catch-all)."""
 
     document_by_path = {item["doc_path"]: item for item in documents}
@@ -630,10 +652,14 @@ def _build_indexed_document_groups(request, documents: list[dict[str, str]]) -> 
             group = ensure_group("Listable", description="General")
             group["items"].append({**item, "access": "Available"})
 
-    return [value for _, value in sorted(grouped.items(), key=lambda pair: pair[0].lower())]
+    return [
+        value for _, value in sorted(grouped.items(), key=lambda pair: pair[0].lower())
+    ]
 
 
-def _get_cached_document_library_paths(root_base: Path) -> tuple[list[Path], list[Path]]:
+def _get_cached_document_library_paths(
+    root_base: Path,
+) -> tuple[list[Path], list[Path]]:
     """Return cached document path lists to avoid repeated filesystem scans."""
 
     cache_key = f"{DOCUMENT_LIBRARY_CACHE_KEY}:paths:{root_base.as_posix()}"
@@ -680,6 +706,24 @@ def _get_cached_document_library(
     )
 
 
+def _latest_gallery_images_for_user(user, *, limit: int = 4):
+    queryset = GalleryImage.objects.select_related(
+        "media_file", "owner_user", "owner_group"
+    )
+    if can_manage_gallery(user):
+        return queryset.order_by("-media_file__uploaded_at", "-pk")[:limit]
+
+    visibility_filter = Q(include_in_public_gallery=True)
+    if getattr(user, "is_authenticated", False):
+        visibility_filter |= Q(owner_user=user)
+        visibility_filter |= Q(owner_group__in=user.groups.all())
+    return (
+        queryset.filter(visibility_filter)
+        .distinct()
+        .order_by("-media_file__uploaded_at", "-pk")[:limit]
+    )
+
+
 def _render_document_library(
     request,
     *,
@@ -691,7 +735,9 @@ def _render_document_library(
     root_base = Path(settings.BASE_DIR).resolve()
     docs_prefix = request.GET.get("docs_path", "")
     apps_docs_prefix = request.GET.get("apps_docs_path", "")
-    docs_virtual_root_selected = request.GET.get(f"docs_path_{LIBRARY_ROOT_QUERY_PARAMETER}") == "1"
+    docs_virtual_root_selected = (
+        request.GET.get(f"docs_path_{LIBRARY_ROOT_QUERY_PARAMETER}") == "1"
+    )
     apps_docs_virtual_root_selected = (
         request.GET.get(f"apps_docs_path_{LIBRARY_ROOT_QUERY_PARAMETER}") == "1"
     )
@@ -715,11 +761,16 @@ def _render_document_library(
         doc_path_prefix="apps/docs/",
     )
     indexed_groups = _build_indexed_document_groups(request, all_documents)
+    gallery_images = _latest_gallery_images_for_user(request.user)
     context = {
         "canonical_url": _build_canonical_url(request),
         "document_index_admin_add_url": "",
         "document_index_admin_changelist_url": "",
+        "gallery_images": gallery_images,
+        "gallery_index_url": reverse("gallery:index"),
+        "gallery_upload_url": reverse("gallery:upload"),
         "indexed_groups": indexed_groups,
+        "is_gallery_manager": can_manage_gallery(request.user),
         "page_url": request.build_absolute_uri(),
         "sections": sections,
         "title": "Developer Documents",
@@ -729,7 +780,9 @@ def _render_document_library(
             context["document_index_admin_changelist_url"] = reverse(
                 "admin:docs_documentindex_changelist"
             )
-            context["document_index_admin_add_url"] = reverse("admin:docs_documentindex_add")
+            context["document_index_admin_add_url"] = reverse(
+                "admin:docs_documentindex_add"
+            )
         except NoReverseMatch:
             pass
     if missing_document:
@@ -796,7 +849,10 @@ def render_readme_page(
         initial_content = html
         remaining_content = ""
 
-    if request.headers.get("HX-Request") == "true" and request.GET.get("fragment") == "remaining":
+    if (
+        request.headers.get("HX-Request") == "true"
+        and request.GET.get("fragment") == "remaining"
+    ):
         response = HttpResponse(remaining_content)
         patch_vary_headers(response, ["Accept-Language", "Cookie"])
         return response
@@ -841,7 +897,9 @@ def document_library(request):
     return _render_document_library(request)
 
 
-def _render_missing_document(request, *, doc: str | None, prepend_docs: bool) -> HttpResponse:
+def _render_missing_document(
+    request, *, doc: str | None, prepend_docs: bool
+) -> HttpResponse:
     """Render a helpful fallback page when a documentation path is missing."""
 
     missing_path = _normalize_docs_path(doc, prepend_docs) or ""

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -6,8 +6,9 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
 from django.contrib.sites.models import Site
-from django.core.exceptions import PermissionDenied
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.encoding import force_bytes
@@ -16,12 +17,14 @@ from django.utils.http import urlsafe_base64_encode
 from apps.docs.models import DocumentIndex, DocumentIndexAssignment
 from apps.energy.models import ClientReport
 from apps.features.models import Feature
+from apps.gallery.models import GalleryImage
 from apps.groups.constants import (
     PRODUCT_DEVELOPER_GROUP_NAME,
     RELEASE_MANAGER_GROUP_NAME,
     SITE_OPERATOR_GROUP_NAME,
 )
 from apps.groups.models import SecurityGroup
+from apps.media.utils import create_media_file, ensure_media_bucket
 from apps.modules.models import Module
 from apps.sites import context_processors
 from apps.sites.models import Landing, SiteProfile
@@ -29,7 +32,10 @@ from apps.sites.utils import require_site_operator_or_staff
 
 pytestmark = [pytest.mark.django_db]
 
-def test_client_report_download_enforces_login_and_ownership(client, monkeypatch, tmp_path):
+
+def test_client_report_download_enforces_login_and_ownership(
+    client, monkeypatch, tmp_path
+):
     user_model = get_user_model()
     owner = user_model.objects.create_user(
         username="report-owner", email="owner@example.com", password="secret"
@@ -70,6 +76,7 @@ def test_client_report_download_enforces_login_and_ownership(client, monkeypatch
     assert staff_response.status_code == 200
     assert staff_response["Content-Type"] == "application/pdf"
 
+
 def test_invitation_login_invalid_tokens_are_handled_safely(client):
     user_model = get_user_model()
     user = user_model.objects.create_user(
@@ -89,6 +96,7 @@ def test_invitation_login_invalid_tokens_are_handled_safely(client):
     )
     assert malformed_uid_response.status_code == 400
 
+
 @pytest.mark.integration
 def test_whatsapp_webhook_requires_post_and_feature_flag(client, settings):
     url = reverse("pages:whatsapp-webhook")
@@ -105,6 +113,7 @@ def test_whatsapp_webhook_requires_post_and_feature_flag(client, settings):
         content_type="application/json",
     )
     assert disabled.status_code == 404
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -123,6 +132,7 @@ def test_legacy_language_redirect_rejects_scheme_relative_targets(
     assert response.status_code == expected_status
     if response.status_code in {301, 302, 307, 308}:
         assert not response["Location"].startswith("//")
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -146,6 +156,7 @@ def test_whatsapp_webhook_post_payload_validation(
     assert response.status_code == expected_status
     if expected_status == 201:
         assert response.json()["status"] == "ok"
+
 
 @pytest.mark.critical
 def test_require_site_operator_or_staff_enforces_admin_operator_boundary(rf):
@@ -213,6 +224,7 @@ def test_charge_points_module_hides_dashboard_and_simulator_links_from_anonymous
     nav_modules = nav_context["nav_modules"]
     assert not any(module.path == "/charge-points/" for module in nav_modules)
 
+
 def test_charge_points_module_shows_dashboard_and_simulator_links_to_site_operators():
     module = Module.objects.create(path="/charge-points/", menu="Charge Points")
     Landing.objects.create(
@@ -245,6 +257,7 @@ def test_charge_points_module_shows_dashboard_and_simulator_links_to_site_operat
         reverse("ocpp:ocpp-dashboard"),
         reverse("ocpp:cp-simulator"),
     }.issubset(visible_paths)
+
 
 def test_charge_points_module_hides_operator_only_map_link_from_anonymous_users():
     module = Module.objects.create(path="/charge-points/", menu="Charge Points")
@@ -420,6 +433,46 @@ def test_docs_library_renders_indexed_documents_before_other_documents(client):
     assert "Create indexed document" in body
 
 
+def test_docs_library_shows_gallery_sidebar_with_latest_four_images(client):
+    user = get_user_model().objects.create_user(
+        username="docs-gallery-sidebar-user",
+        email="docs-gallery-sidebar-user@example.com",
+        password="secret",
+    )
+    developer_group, _ = SecurityGroup.objects.get_or_create(
+        name=PRODUCT_DEVELOPER_GROUP_NAME
+    )
+    developer_group.user_set.add(user)
+    bucket = ensure_media_bucket(slug="gallery-images", name="Gallery Images")
+    for index in range(5):
+        upload = SimpleUploadedFile(
+            f"gallery-{index}.png",
+            b"\x89PNG\r\n\x1a\n",
+            content_type="image/png",
+        )
+        media_file = create_media_file(bucket=bucket, uploaded_file=upload)
+        GalleryImage.objects.create(
+            media_file=media_file,
+            title=f"Gallery image {index}",
+            include_in_public_gallery=True,
+            owner_user=user,
+        )
+
+    client.force_login(user)
+    response = client.get(reverse("docs:docs-library"))
+    body = response.content.decode()
+
+    assert response.status_code == 200
+    assert "Developer Gallery" in body
+    assert reverse("gallery:index") in body
+    assert reverse("gallery:upload") in body
+    assert "Gallery image 4" in body
+    assert "Gallery image 3" in body
+    assert "Gallery image 2" in body
+    assert "Gallery image 1" in body
+    assert "Gallery image 0" not in body
+
+
 def test_readme_resolves_sigils_for_authenticated_user(client):
     user = get_user_model().objects.create_user(
         username="docs-sigil-user",
@@ -507,13 +560,17 @@ def test_docs_library_keeps_nested_docs_visible_and_shows_parent_navigation(clie
     )
     nested_document = Path("docs/library-test/subfolder/nested-visibility-test.md")
     nested_document.parent.mkdir(parents=True, exist_ok=True)
-    nested_document.write_text("# Nested visibility\n\nNested document.\n", encoding="utf-8")
+    nested_document.write_text(
+        "# Nested visibility\n\nNested document.\n", encoding="utf-8"
+    )
 
     client.force_login(user)
     try:
         cache.clear()
         root_response = client.get(reverse("docs:docs-library"))
-        folder_response = client.get(reverse("docs:docs-library"), {"docs_path": "library-test/subfolder"})
+        folder_response = client.get(
+            reverse("docs:docs-library"), {"docs_path": "library-test/subfolder"}
+        )
 
         assert root_response.status_code == 200
         assert "library-test/" in root_response.content.decode()
@@ -550,7 +607,9 @@ def test_docs_library_groups_root_documents_into_root_folder(client):
         assert "root/" in root_response.content.decode()
         assert "library-root-visibility-test.md" not in root_response.content.decode()
         assert virtual_root_response.status_code == 200
-        assert "library-root-visibility-test.md" in virtual_root_response.content.decode()
+        assert (
+            "library-root-visibility-test.md" in virtual_root_response.content.decode()
+        )
     finally:
         root_document.unlink(missing_ok=True)
 
@@ -569,7 +628,9 @@ def test_docs_library_virtual_root_does_not_collide_with_real_root_named_folder(
     client.force_login(user)
     try:
         cache.clear()
-        folder_response = client.get(reverse("docs:docs-library"), {"docs_path": "__root__"})
+        folder_response = client.get(
+            reverse("docs:docs-library"), {"docs_path": "__root__"}
+        )
 
         assert folder_response.status_code == 200
         assert "folder-navigation-test.md" in folder_response.content.decode()
@@ -587,12 +648,16 @@ def test_docs_library_folder_view_includes_file_matching_prefix_exactly(client):
         is_staff=True,
     )
     prefixed_document = Path("docs/library-prefix-match.md")
-    prefixed_document.write_text("# Prefix match\n\nExact path document.\n", encoding="utf-8")
+    prefixed_document.write_text(
+        "# Prefix match\n\nExact path document.\n", encoding="utf-8"
+    )
 
     client.force_login(user)
     try:
         cache.clear()
-        response = client.get(reverse("docs:docs-library"), {"docs_path": "library-prefix-match.md"})
+        response = client.get(
+            reverse("docs:docs-library"), {"docs_path": "library-prefix-match.md"}
+        )
 
         assert response.status_code == 200
         assert "library-prefix-match.md" in response.content.decode()
@@ -642,7 +707,9 @@ def test_docs_library_folder_blurb_ignores_index_only_nested_folders(client):
     parent_document.parent.mkdir(parents=True, exist_ok=True)
     nested_index_document.parent.mkdir(parents=True, exist_ok=True)
     parent_document.write_text("# Direct\n\nTop-level document.\n", encoding="utf-8")
-    nested_index_document.write_text("# Index\n\nHidden nested index.\n", encoding="utf-8")
+    nested_index_document.write_text(
+        "# Index\n\nHidden nested index.\n", encoding="utf-8"
+    )
 
     client.force_login(user)
     try:


### PR DESCRIPTION
### Motivation
- Surface recent gallery images on the Developer Documents library page to make visual assets discoverable and provide quick access to the full gallery and upload actions.
- Enforce gallery visibility rules so users only see images they are allowed to view while showing managers full results.

### Description
- Added an aside card to `apps/docs/templates/docs/library.html` to render a "Developer Gallery" sidebar with preview images, links to the gallery index and upload page, and contextual upload button state for gallery managers.
- Extended `apps/docs/views.py` to import `GalleryImage` and `can_manage_gallery`, implemented `_latest_gallery_images_for_user` to select the latest visible images (or manager view), and added gallery-related context keys (`gallery_images`, `gallery_index_url`, `gallery_upload_url`, `is_gallery_manager`) to `_render_document_library`.
- Included visibility-aware query construction for authenticated and anonymous users and preserved ordering by upload time with a limit of 4 images.
- Minor formatting and whitespace cleanups across `views.py` and some test file line-wrapping adjustments.
- Added `test_docs_library_shows_gallery_sidebar_with_latest_four_images` to `apps/sites/tests/test_public_routes.py` which creates media files and gallery images and asserts the sidebar shows only the latest four images and includes gallery links.

### Testing
- Ran the apps' test suite for the affected modules with `pytest`, including the newly added `test_docs_library_shows_gallery_sidebar_with_latest_four_images`, and existing docs/library tests; all executed tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f66f260483269c166da57e8744a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR integrates a "Developer Gallery" sidebar into the docs library page, allowing users to preview the latest uploaded gallery images directly within the documentation interface. The feature includes role-based access controls, visibility filtering, and comprehensive test coverage.

## Changes

### Template (apps/docs/templates/docs/library.html)
- Adjusted the main content column from `col-12` to `col-12 col-xl-8` to enable a two-column layout on extra-large screens
- Added a new `<aside>` sidebar (`col-12 col-xl-4`) containing a "Developer Gallery" card that displays:
  - An "Open gallery" link to the full gallery index
  - A role-based call-to-action button: 
    - Primary "Create / upload image" button for gallery managers
    - Outline button with access-warning message for non-managers
  - A responsive grid preview of the latest gallery images (each linked to its detail page by slug, displaying the image and title)
  - An empty state fallback alert when no images are available

### Views (apps/docs/views.py)
- Added `_latest_gallery_images_for_user()` function that:
  - Retrieves gallery images with a configurable limit (defaults to 4)
  - Implements visibility-aware filtering: gallery managers see all images ordered by upload timestamp; non-managers see only images marked for public inclusion, plus their own and their group-owned images
  - Uses `distinct()` to handle group membership queries and orders results by `-media_file__uploaded_at` and `-pk` for consistent newest-first ordering
- Updated `_render_document_library()` to populate the template context with:
  - `gallery_images`: the filtered gallery image queryset
  - `gallery_index_url`: reverse URL for `gallery:index`
  - `gallery_upload_url`: reverse URL for `gallery:upload`
  - `is_gallery_manager`: boolean indicating if the current user can manage gallery uploads
- Updated imports to include `GalleryImage`, `can_manage_gallery`, and `Q`

### Tests (apps/sites/tests/test_public_routes.py)
- Added `test_docs_library_shows_gallery_sidebar_with_latest_four_images()` which:
  - Creates a test user with developer group access
  - Creates a media bucket and uploads 5 PNG media files via `SimpleUploadedFile`
  - Creates corresponding `GalleryImage` records flagged as public
  - Verifies the docs library page renders the "Developer Gallery" sidebar with proper links to the gallery index and upload pages
  - Asserts that only the latest 4 images are displayed (images 4, 3, 2, 1) while the oldest image (image 0) is excluded
- Updated imports to support the new test: added `SimpleUploadedFile`, `GalleryImage`, and media helper utilities (`create_media_file`, `ensure_media_bucket`)

## Implementation Notes
- Gallery visibility respects user permissions: authenticated users see public images plus content they own or manage
- The latest 4 images are selected by upload timestamp and secondary sort by primary key to ensure stable ordering
- The test validates both the presence of gallery UI elements and the correct limiting/ordering behavior of the gallery image query

<!-- end of auto-generated comment: release notes by coderabbit.ai -->