### PR TITLE
screens: mirror queued HI payloads into empty LO slot

### DIFF
--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -127,6 +127,8 @@ class LCDRunner:
         default_factory=lambda: ThreadPoolExecutor(max_workers=1, thread_name_prefix="lcd-cycle")
     )
     cycle_state_lock: threading.Lock = field(default_factory=threading.Lock)
+    high_repeat_signature: tuple[tuple[int, float], ...] | None = None
+    high_repeat_count: int = 0
 
     def __post_init__(self) -> None:
         """Initialize the fallback frame writer."""
@@ -252,8 +254,22 @@ class LCDRunner:
                 return None
             return cycle.payloads[cycle.index % len(cycle.payloads)]
 
+        def _high_payload(cycle: ChannelCycle | None) -> locks.LockPayload | None:
+            if cycle is None or not cycle.payloads:
+                return None
+            if self.high_repeat_signature != cycle.signature:
+                self.high_repeat_signature = cycle.signature
+                self.high_repeat_count = 0
+            payload = cycle.payloads[cycle.index % len(cycle.payloads)]
+            if advance:
+                self.high_repeat_count += 1
+                if self.high_repeat_count >= 3:
+                    self.high_repeat_count = 0
+                    cycle.index = (cycle.index + 1) % len(cycle.payloads)
+            return payload
+
         if state_label == "high" and channel_state:
-            payload = _peek_payload(channel_state)
+            payload = _high_payload(channel_state)
             return payload or locks.LockPayload("", "", locks.DEFAULT_SCROLL_MS)
         if state_label in {"low", "uptime"} and channel_state:
             payload = _peek_payload(channel_state)
@@ -266,8 +282,8 @@ class LCDRunner:
                 refreshed = _refresh_uptime_payload(payload, base_dir=BASE_DIR, now=now_dt)
                 return self.apply_relief_if_needed("low", refreshed, base_payload, now_dt)
             high_state = channel_info.get("high")
-            if high_state and len(high_state.payloads) >= 2:
-                high_payload = _peek_payload(high_state)
+            if "high" in state_order and high_state and len(high_state.payloads) >= 2:
+                high_payload = _high_payload(high_state)
                 if high_payload and _payload_has_text(high_payload):
                     self.reset_relief_state("low")
                     return high_payload

--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -260,6 +260,7 @@ class LCDRunner:
             if self.high_repeat_signature != cycle.signature:
                 self.high_repeat_signature = cycle.signature
                 self.high_repeat_count = 0
+                cycle.index = 0
             payload = cycle.payloads[cycle.index % len(cycle.payloads)]
             if advance:
                 self.high_repeat_count += 1

--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -265,6 +265,12 @@ class LCDRunner:
             if payload and _payload_has_text(payload):
                 refreshed = _refresh_uptime_payload(payload, base_dir=BASE_DIR, now=now_dt)
                 return self.apply_relief_if_needed("low", refreshed, base_payload, now_dt)
+            high_state = channel_info.get("high")
+            if high_state and len(high_state.payloads) >= 2:
+                high_payload = _peek_payload(high_state)
+                if high_payload and _payload_has_text(high_payload):
+                    self.reset_relief_state("low")
+                    return high_payload
             self.reset_relief_state("low")
             return base_payload
         if state_label == "clock":

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -347,6 +347,20 @@ def test_high_payloads_repeat_three_times_across_high_and_low_slots(monkeypatch)
 
     assert seen == ["HI-1", "HI-1", "HI-1", "HI-2", "HI-2", "HI-2", "HI-1"]
 
+    high_cycle.signature = ((10, 0.0), (11, 0.0))
+    high_cycle.payloads = [
+        runner.locks.LockPayload("HI-NEW-1", "", 0),
+        runner.locks.LockPayload("HI-NEW-2", "", 0),
+    ]
+    high_cycle.index = 1
+
+    churn_seen = [
+        coordinator.payload_for_state(("high", "low"), slot, channel_info, channel_text, now_dt).line1
+        for slot in (0, 1, 0, 1)
+    ]
+
+    assert churn_seen == ["HI-NEW-1", "HI-NEW-1", "HI-NEW-1", "HI-NEW-2"]
+
 
 def test_low_slot_keeps_default_when_only_one_high_payload_exists(monkeypatch):
     """Low slot should show its default base payload when only one HI payload exists."""
@@ -429,3 +443,5 @@ def test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high(monkeyp
     )
 
     assert low_payload.line1 == "LO BASE"
+    assert high_cycle.index == 0
+    assert coordinator.high_repeat_count == 0

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -312,3 +312,93 @@ def test_render_event_frame_refreshes_static_event_periodically(monkeypatch):
     assert coordinator.scroll_scheduler.actions == [("sleep", None), ("advance", 0.5)]
 
 
+def test_low_slot_uses_second_high_payload_when_low_is_empty(monkeypatch):
+    """Low slot should borrow from HI queue when two or more HI payloads exist."""
+
+    coordinator = runner.LCDRunner()
+    now_dt = datetime(2026, 3, 20, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        runner,
+        "_select_low_payload",
+        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+    )
+
+    high_cycle = runner.ChannelCycle(
+        payloads=[
+            runner.locks.LockPayload("HI-1", "", 0),
+            runner.locks.LockPayload("HI-2", "", 0),
+        ],
+        signature=((0, 0.0), (1, 0.0)),
+        index=0,
+    )
+    low_cycle = runner.ChannelCycle(
+        payloads=[runner.locks.LockPayload("", "", 0)],
+        signature=((0, 0.0),),
+        index=0,
+    )
+    channel_info = {"high": high_cycle, "low": low_cycle}
+    channel_text = {"high": True, "low": False}
+
+    high_payload = coordinator.payload_for_state(
+        ("high", "low"),
+        0,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+    low_payload = coordinator.payload_for_state(
+        ("high", "low"),
+        1,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+
+    assert high_payload.line1 == "HI-1"
+    assert low_payload.line1 == "HI-2"
+
+
+def test_low_slot_keeps_default_when_only_one_high_payload_exists(monkeypatch):
+    """Low slot should show its default base payload when only one HI payload exists."""
+
+    coordinator = runner.LCDRunner()
+    now_dt = datetime(2026, 3, 20, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        runner,
+        "_select_low_payload",
+        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+    )
+
+    high_cycle = runner.ChannelCycle(
+        payloads=[runner.locks.LockPayload("HI-1", "", 0)],
+        signature=((0, 0.0),),
+        index=0,
+    )
+    low_cycle = runner.ChannelCycle(
+        payloads=[runner.locks.LockPayload("", "", 0)],
+        signature=((0, 0.0),),
+        index=0,
+    )
+    channel_info = {"high": high_cycle, "low": low_cycle}
+    channel_text = {"high": True, "low": False}
+
+    high_payload = coordinator.payload_for_state(
+        ("high", "low"),
+        0,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+    low_payload = coordinator.payload_for_state(
+        ("high", "low"),
+        1,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+
+    assert high_payload.line1 == "HI-1"
+    assert low_payload.line1 == "LO BASE"
+

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -312,8 +312,8 @@ def test_render_event_frame_refreshes_static_event_periodically(monkeypatch):
     assert coordinator.scroll_scheduler.actions == [("sleep", None), ("advance", 0.5)]
 
 
-def test_low_slot_uses_second_high_payload_when_low_is_empty(monkeypatch):
-    """Low slot should borrow from HI queue when two or more HI payloads exist."""
+def test_high_payloads_repeat_three_times_across_high_and_low_slots(monkeypatch):
+    """HI payloads should display three times before advancing to the next payload."""
 
     coordinator = runner.LCDRunner()
     now_dt = datetime(2026, 3, 20, tzinfo=timezone.utc)
@@ -340,23 +340,12 @@ def test_low_slot_uses_second_high_payload_when_low_is_empty(monkeypatch):
     channel_info = {"high": high_cycle, "low": low_cycle}
     channel_text = {"high": True, "low": False}
 
-    high_payload = coordinator.payload_for_state(
-        ("high", "low"),
-        0,
-        channel_info,
-        channel_text,
-        now_dt,
-    )
-    low_payload = coordinator.payload_for_state(
-        ("high", "low"),
-        1,
-        channel_info,
-        channel_text,
-        now_dt,
-    )
+    seen = [
+        coordinator.payload_for_state(("high", "low"), slot, channel_info, channel_text, now_dt).line1
+        for slot in (0, 1, 0, 1, 0, 1, 0)
+    ]
 
-    assert high_payload.line1 == "HI-1"
-    assert low_payload.line1 == "HI-2"
+    assert seen == ["HI-1", "HI-1", "HI-1", "HI-2", "HI-2", "HI-2", "HI-1"]
 
 
 def test_low_slot_keeps_default_when_only_one_high_payload_exists(monkeypatch):
@@ -402,3 +391,41 @@ def test_low_slot_keeps_default_when_only_one_high_payload_exists(monkeypatch):
     assert high_payload.line1 == "HI-1"
     assert low_payload.line1 == "LO BASE"
 
+
+def test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high(monkeypatch):
+    """LO slot should respect configured channel order that excludes HI."""
+
+    coordinator = runner.LCDRunner()
+    now_dt = datetime(2026, 3, 20, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        runner,
+        "_select_low_payload",
+        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+    )
+
+    high_cycle = runner.ChannelCycle(
+        payloads=[
+            runner.locks.LockPayload("HI-1", "", 0),
+            runner.locks.LockPayload("HI-2", "", 0),
+        ],
+        signature=((0, 0.0), (1, 0.0)),
+        index=0,
+    )
+    low_cycle = runner.ChannelCycle(
+        payloads=[runner.locks.LockPayload("", "", 0)],
+        signature=((0, 0.0),),
+        index=0,
+    )
+    channel_info = {"high": high_cycle, "low": low_cycle}
+    channel_text = {"high": True, "low": False}
+
+    low_payload = coordinator.payload_for_state(
+        ("low", "stats", "clock"),
+        0,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+
+    assert low_payload.line1 == "LO BASE"


### PR DESCRIPTION
### Motivation

- Ensure the LCD displays HI messages on the LO slot when LO has no visible payload and there are multiple HI messages queued so each window shows one HI message instead of the LO default. 
- Preserve existing behavior when only a single HI payload exists so the HI message shows once and the LO default remains.

### Description

- Update `LCDRunner.payload_for_state` to, when resolving the `low`/`uptime` slot, check the `high` channel and if `high` has two or more queued payloads, return the next HI payload for the LO slot and reset relief state. 
- Keep the existing low fallback via `_select_low_payload` when HI does not have 2+ payloads or the HI payload is empty. 
- Add two focused unit tests in `apps/screens/tests/test_lcd_runner.py` that verify (1) LO borrows the second HI payload when two HI messages are queued and (2) LO keeps its default when only one HI payload exists.

### Testing

- Bootstrapped the test environment with `./env-refresh.sh --deps-only` and installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`.
- Ran the LCD runner unit tests with `.venv/bin/python manage.py test run -- apps/screens/tests/test_lcd_runner.py` and the test suite succeeded with `8 passed` (no failures).
- Added tests cover the new behaviors and passed on the CI-local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1639a84088326a549b9a8ff50f86a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements a display rotation enhancement for the LCD screen service that mirrors high-priority ("high" channel) messages into the low-priority display slot when multiple high messages are queued, ensuring each window shows one high message instead of defaulting to the low slot default.

## Changes

**apps/screens/lcd_screen/runner.py:**
- Added two new instance fields to `LCDRunner` for tracking high-channel payload repetition:
  - `high_repeat_signature: tuple[tuple[int, float], ...] | None` to detect payload sequence changes
  - `high_repeat_count: int` to count consecutive displays of the same payload
- Introduced `_high_payload()` helper method within `payload_for_state()` that:
  - Resets the repeat counter when the payload sequence (signature) changes
  - Enforces a 3-rotation minimum before advancing to the next high payload by incrementing `cycle.index` only after the third selection
  - Maintains signature and repeat state tracking even when `advance=False` during prefetching
- Updated control flow in `payload_for_state()`:
  - "high" state selection now uses `_high_payload()` instead of `_peek_payload()`
  - "low" and "uptime" state resolution now checks if high channel exists with 2+ payloads; if so and high has displayable text, returns the high payload and resets low relief state. Falls back to base low payload otherwise.
  - Respects rotation order by only mirroring when "high" is present in the configured `state_order`

**apps/screens/tests/test_lcd_runner.py:**
- Added three focused unit tests:
  - `test_high_payloads_repeat_three_times_across_high_and_low_slots()`: Validates that HI payloads repeat exactly 3 times before advancing to the next one, confirming the rotation sequence works across alternating high/low slot selections
  - `test_low_slot_keeps_default_when_only_one_high_payload_exists()`: Confirms that low slot shows its configured base payload when only a single high payload exists, preserving existing behavior for single-message scenarios
  - `test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high()`: Ensures that when rotation order is configured without the high channel, the low slot does not mirror high payloads and remains with its base default

## Design

The implementation enforces a 3-rotation display minimum for high-priority messages by tracking the payload sequence signature and repeat count. When the signature changes (indicating new payloads), the counter resets. The mirroring logic is conservative: it only activates when at least 2 high payloads exist and high is included in the rotation order, ensuring the low slot only borrows messages when intentional plurality is detected. The solution maintains backward compatibility by preserving the base low payload default when these conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->