### PR TITLE
docs/repos: add GitHub issue/PR viewer in Developer Docs with canned responses

### DIFF
--- a/apps/docs/templates/docs/github_detail.html
+++ b/apps/docs/templates/docs/github_detail.html
@@ -21,17 +21,15 @@
     <p class="text-muted mb-1">
       {% trans "Repository" %}: {{ repository_slug }} · {% trans "State" %}: {{ item.state }}
     </p>
-    <p class="text-muted mb-3">
-      {% trans "Overall checks" %}: <strong>{{ checks_state }}</strong>
-    </p>
+    {% if item.pull_request %}
+      <p class="text-muted mb-3">
+        {% trans "Overall checks" %}: <strong>{{ checks_state }}</strong>
+      </p>
+    {% endif %}
 
     {% if error_message %}
       <div class="alert alert-danger" role="alert">{{ error_message }}</div>
     {% endif %}
-    {% if post_success %}
-      <div class="alert alert-success" role="alert">{{ post_success }}</div>
-    {% endif %}
-
     <h2>{% trans "Description" %}</h2>
     <pre class="border rounded p-3 bg-light" style="white-space: pre-wrap">{{ item.body|default:"" }}</pre>
 
@@ -67,6 +65,8 @@
     {% empty %}
       <p class="text-muted">{% trans "No comments yet." %}</p>
     {% endfor %}
+  {% elif error_message %}
+    <div class="alert alert-danger" role="alert">{{ error_message }}</div>
   {% endif %}
 </div>
 {% endblock %}

--- a/apps/docs/templates/docs/github_detail.html
+++ b/apps/docs/templates/docs/github_detail.html
@@ -1,0 +1,72 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="markdown-body">
+  {% if viewer_url %}
+    <p><a href="{{ viewer_url }}">← {% trans "Back to GitHub viewer" %}</a></p>
+  {% endif %}
+
+  {% if not github_connected %}
+    <div class="alert alert-info" role="alert">
+      {% trans "GitHub is not connected for the active repository." %}
+    </div>
+  {% elif item %}
+    <h1>
+      {% if item.pull_request %}{% trans "Pull Request" %}{% else %}{% trans "Issue" %}{% endif %}
+      #{{ item.number }}: {{ item.title }}
+    </h1>
+    <p class="text-muted mb-1">
+      {% trans "Repository" %}: {{ repository_slug }} · {% trans "State" %}: {{ item.state }}
+    </p>
+    <p class="text-muted mb-3">
+      {% trans "Overall checks" %}: <strong>{{ checks_state }}</strong>
+    </p>
+
+    {% if error_message %}
+      <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+    {% endif %}
+    {% if post_success %}
+      <div class="alert alert-success" role="alert">{{ post_success }}</div>
+    {% endif %}
+
+    <h2>{% trans "Description" %}</h2>
+    <pre class="border rounded p-3 bg-light" style="white-space: pre-wrap">{{ item.body|default:"" }}</pre>
+
+    <h2>{% trans "Respond" %}</h2>
+    <form method="post" class="mb-4">
+      {% csrf_token %}
+      <div class="mb-3">
+        <label class="form-label" for="template">{% trans "Template" %}</label>
+        <select class="form-select" id="template" name="template">
+          <option value="">{% trans "Custom response" %}</option>
+          {% for template in response_templates %}
+            <option value="{{ template.pk }}">{{ template.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="body">{% trans "Comment body" %}</label>
+        <textarea class="form-control" id="body" name="body" rows="5" placeholder="{% trans 'Optional when a template is selected.' %}"></textarea>
+      </div>
+      <button class="btn btn-primary" type="submit">{% trans "Post response" %}</button>
+    </form>
+
+    <h2>{% trans "Comments" %}</h2>
+    {% for comment in comments %}
+      <div class="card mb-3">
+        <div class="card-header small text-muted">
+          {{ comment.user.login|default:"Unknown" }} · {{ comment.updated_at|default:"" }}
+        </div>
+        <div class="card-body">
+          <pre class="mb-0" style="white-space: pre-wrap">{{ comment.body|default:"" }}</pre>
+        </div>
+      </div>
+    {% empty %}
+      <p class="text-muted">{% trans "No comments yet." %}</p>
+    {% endfor %}
+  {% endif %}
+</div>
+{% endblock %}

--- a/apps/docs/templates/docs/github_viewer.html
+++ b/apps/docs/templates/docs/github_viewer.html
@@ -1,0 +1,54 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="markdown-body">
+  <h1>{{ title }}</h1>
+  {% if not github_connected %}
+    <div class="alert alert-info" role="alert">
+      {% trans "GitHub is not connected for the active repository. Configure an active repository and token to enable this viewer." %}
+    </div>
+  {% else %}
+    <p class="text-muted">{% blocktrans with repository_slug=repository_slug %}Showing all open issues and pull requests for {{ repository_slug }}.{% endblocktrans %}</p>
+    {% if error_message %}
+      <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+    {% endif %}
+    {% if entries %}
+      <div class="table-responsive">
+        <table class="table table-striped align-middle">
+          <thead>
+            <tr>
+              <th>{% trans "Type" %}</th>
+              <th>{% trans "Number" %}</th>
+              <th>{% trans "Title" %}</th>
+              <th>{% trans "Author" %}</th>
+              <th>{% trans "State" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for entry in entries %}
+              <tr>
+                <td>
+                  {% if entry.kind == "pull_request" %}
+                    <span class="badge text-bg-primary">PR</span>
+                  {% else %}
+                    <span class="badge text-bg-secondary">Issue</span>
+                  {% endif %}
+                </td>
+                <td><a href="{{ entry.detail_url }}">#{{ entry.number }}</a></td>
+                <td><a href="{{ entry.detail_url }}">{{ entry.title }}</a></td>
+                <td>{{ entry.author|default:"-" }}</td>
+                <td>{{ entry.state|default:"-" }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p class="text-muted">{% trans "No open issues or pull requests were found." %}</p>
+    {% endif %}
+  {% endif %}
+</div>
+{% endblock %}

--- a/apps/docs/templates/docs/library.html
+++ b/apps/docs/templates/docs/library.html
@@ -84,6 +84,11 @@
         <p class="text-muted small mb-3">
           {% trans "Preview the latest uploads and jump straight to the full gallery." %}
         </p>
+        {% if github_connected %}
+          <p class="mb-3">
+            <a class="btn btn-sm btn-outline-dark" href="{{ github_issue_viewer_url }}">{% trans "Open GitHub issue viewer" %}</a>
+          </p>
+        {% endif %}
         <p class="mb-3">
           {% if is_gallery_manager %}
             <a class="btn btn-sm btn-primary" href="{{ gallery_upload_url }}">{% trans "Create / upload image" %}</a>

--- a/apps/docs/urls.py
+++ b/apps/docs/urls.py
@@ -16,6 +16,12 @@ urlpatterns = [
     path("read/<path:doc>", views.readme, name="readme-document"),
     path("docs/", views.readme, {"prepend_docs": True}, name="docs-index"),
     path("docs/library/", views.document_library, name="docs-library"),
+    path("docs/github/", views.github_issue_viewer, name="docs-github-viewer"),
+    path(
+        "docs/github/<int:number>/",
+        views.github_issue_detail,
+        name="docs-github-item",
+    ),
     path(
         "docs/<path:doc>",
         views.readme,

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -8,8 +8,9 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.db.models import Q
+from django.http import HttpRequest
 from django.http import FileResponse, Http404, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch, reverse
 from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.views.decorators.cache import never_cache
@@ -24,6 +25,10 @@ from apps.groups.decorators import security_group_required
 from apps.modules.models import Module
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
+from apps.repos.models.response_templates import GitHubResponseTemplate
+from apps.repos.models.repositories import GitHubRepository
+from apps.repos.services import github as github_service
+from apps.repos.services.github import GitHubRepositoryError
 from apps.sites.utils import module_pill_link_validation
 
 from . import assets, rendering
@@ -769,6 +774,7 @@ def _render_document_library(
     )
     indexed_groups = _build_indexed_document_groups(request, all_documents)
     is_gallery_manager = can_manage_gallery(request.user)
+    github_connection = _resolve_github_docs_connection()
     gallery_images = _latest_gallery_images_for_user(
         request.user,
         is_gallery_manager=is_gallery_manager,
@@ -784,6 +790,8 @@ def _render_document_library(
         "is_gallery_manager": is_gallery_manager,
         "page_url": request.build_absolute_uri(),
         "sections": sections,
+        "github_connected": github_connection.connected,
+        "github_issue_viewer_url": reverse("docs:docs-github-viewer"),
         "title": "Developer Documents",
     }
     if request.user.is_staff:
@@ -801,6 +809,24 @@ def _render_document_library(
     response = render(request, "docs/library.html", context, status=status)
     patch_vary_headers(response, ["Accept-Language", "Cookie"])
     return response
+
+
+def _resolve_github_docs_connection() -> SimpleNamespace:
+    """Return repository/token context for docs GitHub viewer pages."""
+
+    try:
+        repository = GitHubRepository.resolve_active_repository()
+        token = github_service.get_github_issue_token()
+    except (GitHubRepositoryError, RuntimeError, ValueError):
+        return SimpleNamespace(connected=False, owner="", repo="", slug="", token="")
+
+    return SimpleNamespace(
+        connected=True,
+        owner=repository.owner,
+        repo=repository.name,
+        slug=repository.slug,
+        token=token,
+    )
 
 
 def _canonicalize_docs_host(host: str) -> str:
@@ -898,6 +924,174 @@ def render_readme_page(
     response = render(request, "docs/readme.html", context)
     patch_vary_headers(response, ["Accept-Language", "Cookie"])
     return response
+
+
+def _parse_github_comment_payload(
+    request: HttpRequest,
+) -> tuple[bool, str, str | None]:
+    """Return ``(is_post, body, error)`` for comment submissions."""
+
+    if request.method != "POST":
+        return False, "", None
+
+    template_choice = (request.POST.get("template") or "").strip()
+    if template_choice:
+        template = (
+            GitHubResponseTemplate.objects.filter(
+                user=request.user,
+                pk=template_choice,
+                is_active=True,
+            )
+            .only("body")
+            .first()
+        )
+        if template is None:
+            return True, "", "Selected response template is not available."
+        body = template.body.strip()
+    else:
+        body = (request.POST.get("body") or "").strip()
+
+    if not body:
+        return True, "", "Comment body is required."
+
+    return True, body, None
+
+
+@module_pill_link_validation(_show_docs_navigation_link)
+@security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
+def github_issue_viewer(request):
+    """Render open GitHub issues and pull requests for connected repositories."""
+
+    connection = _resolve_github_docs_connection()
+    entries: list[dict[str, object]] = []
+    error_message = ""
+    if connection.connected:
+        try:
+            for item in github_service.fetch_repository_issues(
+                token=connection.token,
+                owner=connection.owner,
+                name=connection.repo,
+                state="open",
+            ):
+                number = item.get("number")
+                if not isinstance(number, int):
+                    continue
+                is_pull_request = isinstance(item.get("pull_request"), dict)
+                entries.append(
+                    {
+                        "number": number,
+                        "title": str(item.get("title") or ""),
+                        "author": str((item.get("user") or {}).get("login") or ""),
+                        "kind": "pull_request" if is_pull_request else "issue",
+                        "state": str(item.get("state") or ""),
+                        "updated_at": item.get("updated_at"),
+                        "detail_url": reverse(
+                            "docs:docs-github-item", kwargs={"number": number}
+                        ),
+                    }
+                )
+        except GitHubRepositoryError as exc:
+            error_message = str(exc)
+
+    context = {
+        "entries": entries,
+        "error_message": error_message,
+        "github_connected": connection.connected,
+        "repository_slug": connection.slug,
+        "title": "GitHub Issues & Pull Requests",
+    }
+    return render(request, "docs/github_viewer.html", context)
+
+
+@module_pill_link_validation(_show_docs_navigation_link)
+@security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
+def github_issue_detail(request, number: int):
+    """Render issue/PR details including comments and optional response actions."""
+
+    connection = _resolve_github_docs_connection()
+    if not connection.connected:
+        return render(
+            request,
+            "docs/github_detail.html",
+            {
+                "github_connected": False,
+                "item": None,
+                "title": "GitHub Item",
+            },
+        )
+
+    post_error = ""
+    post_success = ""
+    is_post, comment_body, payload_error = _parse_github_comment_payload(request)
+    if is_post and payload_error:
+        post_error = payload_error
+    elif is_post:
+        try:
+            github_service.create_issue_comment(
+                connection.owner,
+                connection.repo,
+                issue_number=number,
+                token=connection.token,
+                body=comment_body,
+            )
+            return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
+        except GitHubRepositoryError as exc:
+            post_error = str(exc)
+        else:  # pragma: no cover - unreachable, redirect above is expected
+            post_success = "Comment posted."
+
+    item = github_service.fetch_issue_or_pull_request(
+        token=connection.token,
+        owner=connection.owner,
+        name=connection.repo,
+        number=number,
+    )
+    is_pull_request = isinstance(item.get("pull_request"), dict)
+    comments = list(
+        github_service.fetch_issue_comments(
+            token=connection.token,
+            owner=connection.owner,
+            name=connection.repo,
+            issue_number=number,
+        )
+    )
+    checks_state = "not_applicable"
+    if is_pull_request:
+        pull = github_service.fetch_pull_request(
+            token=connection.token,
+            owner=connection.owner,
+            name=connection.repo,
+            number=number,
+        )
+        head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
+        if head_sha:
+            status_payload = github_service.fetch_commit_status_summary(
+                token=connection.token,
+                owner=connection.owner,
+                name=connection.repo,
+                sha=head_sha,
+            )
+            checks_state = str(status_payload.get("state") or "unknown")
+        else:
+            checks_state = "unknown"
+
+    response_templates = GitHubResponseTemplate.objects.filter(
+        user=request.user,
+        is_active=True,
+    ).order_by("label")
+    context = {
+        "checks_state": checks_state,
+        "comments": comments,
+        "error_message": post_error,
+        "github_connected": True,
+        "item": item,
+        "post_success": post_success,
+        "repository_slug": connection.slug,
+        "response_templates": response_templates,
+        "title": f"GitHub #{number}",
+        "viewer_url": reverse("docs:docs-github-viewer"),
+    }
+    return render(request, "docs/github_detail.html", context)
 
 
 @module_pill_link_validation(_show_docs_navigation_link)

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -25,8 +25,8 @@ from apps.groups.decorators import security_group_required
 from apps.modules.models import Module
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
-from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.models.repositories import GitHubRepository
+from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.services import github as github_service
 from apps.repos.services.github import GitHubRepositoryError
 from apps.sites.utils import module_pill_link_validation
@@ -817,7 +817,7 @@ def _resolve_github_docs_connection() -> SimpleNamespace:
     try:
         repository = GitHubRepository.resolve_active_repository()
         token = github_service.get_github_issue_token()
-    except (GitHubRepositoryError, RuntimeError, ValueError):
+    except (GitHubRepositoryError, ValueError):
         return SimpleNamespace(connected=False, owner="", repo="", slug="", token="")
 
     return SimpleNamespace(
@@ -936,10 +936,14 @@ def _parse_github_comment_payload(
 
     template_choice = (request.POST.get("template") or "").strip()
     if template_choice:
+        try:
+            template_pk = int(template_choice)
+        except ValueError:
+            return True, "", "Selected response template is not available."
         template = (
             GitHubResponseTemplate.objects.filter(
                 user=request.user,
-                pk=template_choice,
+                pk=template_pk,
                 is_active=True,
             )
             .only("body")
@@ -1021,7 +1025,6 @@ def github_issue_detail(request, number: int):
         )
 
     post_error = ""
-    post_success = ""
     is_post, comment_body, payload_error = _parse_github_comment_payload(request)
     if is_post and payload_error:
         post_error = payload_error
@@ -1037,43 +1040,45 @@ def github_issue_detail(request, number: int):
             return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
         except GitHubRepositoryError as exc:
             post_error = str(exc)
-        else:  # pragma: no cover - unreachable, redirect above is expected
-            post_success = "Comment posted."
-
-    item = github_service.fetch_issue_or_pull_request(
-        token=connection.token,
-        owner=connection.owner,
-        name=connection.repo,
-        number=number,
-    )
-    is_pull_request = isinstance(item.get("pull_request"), dict)
-    comments = list(
-        github_service.fetch_issue_comments(
-            token=connection.token,
-            owner=connection.owner,
-            name=connection.repo,
-            issue_number=number,
-        )
-    )
+    item = None
+    comments = []
     checks_state = "not_applicable"
-    if is_pull_request:
-        pull = github_service.fetch_pull_request(
+    try:
+        item = github_service.fetch_issue_or_pull_request(
             token=connection.token,
             owner=connection.owner,
             name=connection.repo,
             number=number,
         )
-        head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
-        if head_sha:
-            status_payload = github_service.fetch_commit_status_summary(
+        is_pull_request = isinstance(item.get("pull_request"), dict)
+        comments = list(
+            github_service.fetch_issue_comments(
                 token=connection.token,
                 owner=connection.owner,
                 name=connection.repo,
-                sha=head_sha,
+                issue_number=number,
             )
-            checks_state = str(status_payload.get("state") or "unknown")
-        else:
-            checks_state = "unknown"
+        )
+        if is_pull_request:
+            pull = github_service.fetch_pull_request(
+                token=connection.token,
+                owner=connection.owner,
+                name=connection.repo,
+                number=number,
+            )
+            head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
+            if head_sha:
+                status_payload = github_service.fetch_commit_status_summary(
+                    token=connection.token,
+                    owner=connection.owner,
+                    name=connection.repo,
+                    sha=head_sha,
+                )
+                checks_state = str(status_payload.get("state") or "unknown")
+            else:
+                checks_state = "unknown"
+    except GitHubRepositoryError as exc:
+        post_error = post_error or str(exc)
 
     response_templates = GitHubResponseTemplate.objects.filter(
         user=request.user,
@@ -1085,7 +1090,6 @@ def github_issue_detail(request, number: int):
         "error_message": post_error,
         "github_connected": True,
         "item": item,
-        "post_success": post_success,
         "repository_slug": connection.slug,
         "response_templates": response_templates,
         "title": f"GitHub #{number}",

--- a/apps/repos/admin.py
+++ b/apps/repos/admin.py
@@ -15,8 +15,8 @@ from apps.repos.models.events import GitHubEvent
 from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall
 from apps.repos.models.github_tokens import GitHubToken
 from apps.repos.models.issues import RepositoryIssue, RepositoryPullRequest
-from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.models.repositories import GitHubRepository, PackageRepository
+from apps.repos.models.response_templates import GitHubResponseTemplate
 
 
 class FetchFromGitHubMixin(DjangoObjectActions):
@@ -249,6 +249,16 @@ class GitHubResponseTemplateAdmin(OwnableAdminMixin, admin.ModelAdmin):
     list_display = ("label", "user", "is_active")
     list_filter = ("is_active",)
     search_fields = ("label", "body", "user__username")
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        if request.user.is_superuser:
+            return queryset
+        return queryset.filter(user=request.user)
+
+    def save_model(self, request, obj, form, change):
+        obj.user = request.user
+        super().save_model(request, obj, form, change)
 
 
 @admin.register(GitHubApp)

--- a/apps/repos/admin.py
+++ b/apps/repos/admin.py
@@ -15,6 +15,7 @@ from apps.repos.models.events import GitHubEvent
 from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall
 from apps.repos.models.github_tokens import GitHubToken
 from apps.repos.models.issues import RepositoryIssue, RepositoryPullRequest
+from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.models.repositories import GitHubRepository, PackageRepository
 
 
@@ -241,6 +242,13 @@ class GitHubEventAdmin(admin.ModelAdmin):
         "user_agent",
     )
     raw_id_fields = ("repository",)
+
+
+@admin.register(GitHubResponseTemplate)
+class GitHubResponseTemplateAdmin(OwnableAdminMixin, admin.ModelAdmin):
+    list_display = ("label", "user", "is_active")
+    list_filter = ("is_active",)
+    search_fields = ("label", "body", "user__username")
 
 
 @admin.register(GitHubApp)

--- a/apps/repos/migrations/0003_githubresponsetemplate.py
+++ b/apps/repos/migrations/0003_githubresponsetemplate.py
@@ -1,0 +1,53 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("repos", "0002_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GitHubResponseTemplate",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_user_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("label", models.CharField(max_length=120)),
+                ("body", models.TextField()),
+                ("is_active", models.BooleanField(default=True)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        related_name="github_response_templates",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "GitHub Response Template",
+                "verbose_name_plural": "GitHub Response Templates",
+                "ordering": ("user__username", "label"),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="githubresponsetemplate",
+            constraint=models.UniqueConstraint(
+                fields=("user", "label"),
+                name="unique_github_response_template_label_per_user",
+            ),
+        ),
+    ]

--- a/apps/repos/models/__init__.py
+++ b/apps/repos/models/__init__.py
@@ -4,6 +4,7 @@ from apps.repos.models.events import GitHubEvent, RepositoryEvent
 from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall, GitHubWebhook
 from apps.repos.models.github_tokens import GitHubToken
 from apps.repos.models.issues import RepositoryIssue, RepositoryPullRequest
+from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.models.repositories import GitHubRepository, PackageRepository
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "GitHubWebhook",
     "GitHubToken",
     "GitHubRepository",
+    "GitHubResponseTemplate",
     "PackageRepository",
     "RepositoryEvent",
     "RepositoryIssue",

--- a/apps/repos/models/__init__.py
+++ b/apps/repos/models/__init__.py
@@ -4,17 +4,17 @@ from apps.repos.models.events import GitHubEvent, RepositoryEvent
 from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall, GitHubWebhook
 from apps.repos.models.github_tokens import GitHubToken
 from apps.repos.models.issues import RepositoryIssue, RepositoryPullRequest
-from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.repos.models.repositories import GitHubRepository, PackageRepository
+from apps.repos.models.response_templates import GitHubResponseTemplate
 
 __all__ = [
-    "GitHubEvent",
     "GitHubApp",
     "GitHubAppInstall",
-    "GitHubWebhook",
-    "GitHubToken",
+    "GitHubEvent",
     "GitHubRepository",
     "GitHubResponseTemplate",
+    "GitHubToken",
+    "GitHubWebhook",
     "PackageRepository",
     "RepositoryEvent",
     "RepositoryIssue",

--- a/apps/repos/models/response_templates.py
+++ b/apps/repos/models/response_templates.py
@@ -1,0 +1,36 @@
+"""Per-user GitHub response templates for issue and PR workflows."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from apps.core.entity import Entity
+
+
+class GitHubResponseTemplate(Entity):
+    """Reusable canned response text a user can apply to GitHub discussions."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="github_response_templates",
+    )
+    label = models.CharField(max_length=120)
+    body = models.TextField()
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ("user__username", "label")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "label"],
+                name="unique_github_response_template_label_per_user",
+            )
+        ]
+        verbose_name = _("GitHub Response Template")
+        verbose_name_plural = _("GitHub Response Templates")
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.user}: {self.label}"

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -303,6 +303,111 @@ def fetch_repository_pull_requests(
     yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
 
 
+def fetch_issue_comments(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    issue_number: int,
+) -> Iterator[Mapping[str, object]]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/issues/{issue_number}/comments"
+    params: dict[str, RequestParamValue] = {"per_page": 100}
+    yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
+
+
+def fetch_issue_or_pull_request(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    number: int,
+    timeout: int = REQUEST_TIMEOUT,
+) -> Mapping[str, object]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/issues/{number}"
+    headers = build_headers(token)
+    response = None
+    try:
+        response = requests.get(endpoint, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    try:
+        if not (200 <= response.status_code < 300):
+            raise GitHubRepositoryError(_extract_error_message(response))
+
+        payload = _safe_json(response)
+        if isinstance(payload, Mapping):
+            return payload
+        raise GitHubRepositoryError("Unable to decode issue details from GitHub")
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+
+def fetch_commit_status_summary(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    sha: str,
+    timeout: int = REQUEST_TIMEOUT,
+) -> Mapping[str, object]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/commits/{sha}/status"
+    headers = build_headers(token)
+    response = None
+    try:
+        response = requests.get(endpoint, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    try:
+        if not (200 <= response.status_code < 300):
+            raise GitHubRepositoryError(_extract_error_message(response))
+
+        payload = _safe_json(response)
+        if isinstance(payload, Mapping):
+            return payload
+        raise GitHubRepositoryError("Unable to decode commit status from GitHub")
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+
+def fetch_pull_request(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    number: int,
+    timeout: int = REQUEST_TIMEOUT,
+) -> Mapping[str, object]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/pulls/{number}"
+    headers = build_headers(token)
+    response = None
+    try:
+        response = requests.get(endpoint, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    try:
+        if not (200 <= response.status_code < 300):
+            raise GitHubRepositoryError(_extract_error_message(response))
+
+        payload = _safe_json(response)
+        if isinstance(payload, Mapping):
+            return payload
+        raise GitHubRepositoryError("Unable to decode pull request details from GitHub")
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+
 def _ensure_issue_lock_dir() -> None:
     ISSUE_LOCK_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -509,6 +614,52 @@ def create_pull_request_comment(
         owner,
         repository,
         pull_number,
+        response.status_code,
+    )
+    return response
+
+
+def create_issue_comment(
+    owner: str,
+    repository: str,
+    *,
+    issue_number: int,
+    token: str,
+    body: str,
+    timeout: int = REQUEST_TIMEOUT,
+) -> requests.Response:
+    """Post a comment on a specific issue or pull request and return the API response."""
+
+    cleaned_body = body.strip()
+    if not cleaned_body:
+        raise ValueError("Issue comment body must not be empty")
+
+    headers = build_headers(token, user_agent="arthexis-runtime-reporter")
+    url = f"{API_ROOT}/repos/{owner}/{repository}/issues/{issue_number}/comments"
+    response = None
+    try:
+        response = requests.post(
+            url,
+            json={"body": cleaned_body},
+            headers=headers,
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    if not (200 <= response.status_code < 300):
+        try:
+            message = _extract_error_message(response)
+        finally:
+            with contextlib.suppress(Exception):
+                response.close()
+        raise GitHubRepositoryError(message)
+
+    logger.info(
+        "GitHub issue comment created for %s/%s#%s with status %s",
+        owner,
+        repository,
+        issue_number,
         response.status_code,
     )
     return response

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -315,6 +315,36 @@ def fetch_issue_comments(
     yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
 
 
+def _fetch_json_mapping(
+    *,
+    token: str,
+    endpoint: str,
+    timeout: int,
+    decode_error: str,
+) -> Mapping[str, object]:
+    headers = build_headers(token)
+    response = None
+    try:
+        try:
+            response = requests.get(endpoint, headers=headers, timeout=timeout)
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            raise GitHubRepositoryError(str(exc)) from exc
+
+        if not (200 <= response.status_code < 300):
+            raise GitHubRepositoryError(_extract_error_message(response))
+
+        payload = _safe_json(response)
+        if isinstance(payload, Mapping):
+            return payload
+        raise GitHubRepositoryError(decode_error)
+    finally:
+        if response is not None:
+            close = getattr(response, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+
+
 def fetch_issue_or_pull_request(
     *,
     token: str,
@@ -324,26 +354,12 @@ def fetch_issue_or_pull_request(
     timeout: int = REQUEST_TIMEOUT,
 ) -> Mapping[str, object]:
     endpoint = f"{API_ROOT}/repos/{owner}/{name}/issues/{number}"
-    headers = build_headers(token)
-    response = None
-    try:
-        response = requests.get(endpoint, headers=headers, timeout=timeout)
-    except requests.RequestException as exc:  # pragma: no cover - network failure
-        raise GitHubRepositoryError(str(exc)) from exc
-
-    try:
-        if not (200 <= response.status_code < 300):
-            raise GitHubRepositoryError(_extract_error_message(response))
-
-        payload = _safe_json(response)
-        if isinstance(payload, Mapping):
-            return payload
-        raise GitHubRepositoryError("Unable to decode issue details from GitHub")
-    finally:
-        close = getattr(response, "close", None)
-        if callable(close):
-            with contextlib.suppress(Exception):
-                close()
+    return _fetch_json_mapping(
+        token=token,
+        endpoint=endpoint,
+        timeout=timeout,
+        decode_error="Unable to decode issue details from GitHub",
+    )
 
 
 def fetch_commit_status_summary(
@@ -355,26 +371,12 @@ def fetch_commit_status_summary(
     timeout: int = REQUEST_TIMEOUT,
 ) -> Mapping[str, object]:
     endpoint = f"{API_ROOT}/repos/{owner}/{name}/commits/{sha}/status"
-    headers = build_headers(token)
-    response = None
-    try:
-        response = requests.get(endpoint, headers=headers, timeout=timeout)
-    except requests.RequestException as exc:  # pragma: no cover - network failure
-        raise GitHubRepositoryError(str(exc)) from exc
-
-    try:
-        if not (200 <= response.status_code < 300):
-            raise GitHubRepositoryError(_extract_error_message(response))
-
-        payload = _safe_json(response)
-        if isinstance(payload, Mapping):
-            return payload
-        raise GitHubRepositoryError("Unable to decode commit status from GitHub")
-    finally:
-        close = getattr(response, "close", None)
-        if callable(close):
-            with contextlib.suppress(Exception):
-                close()
+    return _fetch_json_mapping(
+        token=token,
+        endpoint=endpoint,
+        timeout=timeout,
+        decode_error="Unable to decode commit status from GitHub",
+    )
 
 
 def fetch_pull_request(
@@ -386,26 +388,12 @@ def fetch_pull_request(
     timeout: int = REQUEST_TIMEOUT,
 ) -> Mapping[str, object]:
     endpoint = f"{API_ROOT}/repos/{owner}/{name}/pulls/{number}"
-    headers = build_headers(token)
-    response = None
-    try:
-        response = requests.get(endpoint, headers=headers, timeout=timeout)
-    except requests.RequestException as exc:  # pragma: no cover - network failure
-        raise GitHubRepositoryError(str(exc)) from exc
-
-    try:
-        if not (200 <= response.status_code < 300):
-            raise GitHubRepositoryError(_extract_error_message(response))
-
-        payload = _safe_json(response)
-        if isinstance(payload, Mapping):
-            return payload
-        raise GitHubRepositoryError("Unable to decode pull request details from GitHub")
-    finally:
-        close = getattr(response, "close", None)
-        if callable(close):
-            with contextlib.suppress(Exception):
-                close()
+    return _fetch_json_mapping(
+        token=token,
+        endpoint=endpoint,
+        timeout=timeout,
+        decode_error="Unable to decode pull request details from GitHub",
+    )
 
 
 def _ensure_issue_lock_dir() -> None:
@@ -478,7 +466,9 @@ def get_github_issue_token() -> str:
         if cleaned:
             return cleaned
 
-    raise RuntimeError(f"GitHub token is not configured; set one via {DEFAULT_PACKAGE.repository_url}")
+    raise GitHubRepositoryError(
+        f"GitHub token is not configured; set one via {DEFAULT_PACKAGE.repository_url}"
+    )
 
 
 def create_issue(

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -28,6 +28,7 @@ from apps.groups.models import SecurityGroup
 from apps.media.utils import create_media_file, ensure_media_bucket
 from apps.modules.models import Module
 from apps.repos.models.response_templates import GitHubResponseTemplate
+from apps.repos.services.github import GitHubRepositoryError
 from apps.sites import context_processors
 from apps.sites.models import Landing, SiteProfile
 from apps.sites.utils import require_site_operator_or_staff
@@ -617,6 +618,86 @@ def test_docs_github_detail_allows_posting_template_response(client, monkeypatch
 
     assert response.status_code == 200
     assert posted["body"] == "Please share reproducible steps."
+
+
+def test_docs_github_detail_rejects_invalid_template_id(client, monkeypatch):
+    user = get_user_model().objects.create_user(
+        username="docs-github-invalid-template-user",
+        email="docs-github-invalid-template-user@example.com",
+        password="secret",
+    )
+    _grant_docs_access(user)
+
+    monkeypatch.setattr(
+        "apps.docs.views._resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="arthexis",
+            repo="arthexis",
+            slug="arthexis/arthexis",
+            token="tok",
+        ),
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 56,
+            "title": "Improve diagnostics",
+            "state": "open",
+            "body": "Detailed description",
+        },
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_comments",
+        lambda **kwargs: iter([]),
+    )
+
+    client.force_login(user)
+    response = client.post(
+        reverse("docs:docs-github-item", kwargs={"number": 56}),
+        data={"template": "abc", "body": ""},
+    )
+
+    assert response.status_code == 200
+    assert "Selected response template is not available." in response.content.decode()
+
+
+def test_docs_github_detail_handles_fetch_errors(client, monkeypatch):
+    user = get_user_model().objects.create_user(
+        username="docs-github-fetch-error-user",
+        email="docs-github-fetch-error-user@example.com",
+        password="secret",
+    )
+    _grant_docs_access(user)
+
+    monkeypatch.setattr(
+        "apps.docs.views._resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="arthexis",
+            repo="arthexis",
+            slug="arthexis/arthexis",
+            token="tok",
+        ),
+    )
+
+    def _raise_fetch_error(**kwargs):
+        raise GitHubRepositoryError("GitHub unavailable")
+
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_or_pull_request",
+        _raise_fetch_error,
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_comments",
+        lambda **kwargs: iter([]),
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("docs:docs-github-item", kwargs={"number": 57}))
+
+    assert response.status_code == 200
+    assert "GitHub unavailable" in response.content.decode()
 
 
 def test_readme_resolves_sigils_for_authenticated_user(client):

--- a/apps/sites/tests/test_public_routes.py
+++ b/apps/sites/tests/test_public_routes.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -26,6 +27,7 @@ from apps.groups.constants import (
 from apps.groups.models import SecurityGroup
 from apps.media.utils import create_media_file, ensure_media_bucket
 from apps.modules.models import Module
+from apps.repos.models.response_templates import GitHubResponseTemplate
 from apps.sites import context_processors
 from apps.sites.models import Landing, SiteProfile
 from apps.sites.utils import require_site_operator_or_staff
@@ -477,6 +479,144 @@ def test_docs_library_shows_gallery_sidebar_with_latest_four_images(client):
     assert "Gallery image 2" in body
     assert "Gallery image 1" in body
     assert "Gallery image 0" not in body
+
+
+def test_docs_library_shows_github_issue_viewer_entry_when_connected(client, monkeypatch):
+    user = get_user_model().objects.create_user(
+        username="docs-github-library-user",
+        email="docs-github-library-user@example.com",
+        password="secret",
+    )
+    _grant_docs_access(user)
+    monkeypatch.setattr(
+        "apps.docs.views._resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="arthexis",
+            repo="arthexis",
+            slug="arthexis/arthexis",
+            token="tok",
+        ),
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("docs:docs-library"))
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "Open GitHub issue viewer" in body
+    assert reverse("docs:docs-github-viewer") in body
+
+
+def test_docs_github_viewer_lists_open_issues_and_pull_requests(client, monkeypatch):
+    user = get_user_model().objects.create_user(
+        username="docs-github-viewer-user",
+        email="docs-github-viewer-user@example.com",
+        password="secret",
+    )
+    _grant_docs_access(user)
+    monkeypatch.setattr(
+        "apps.docs.views._resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="arthexis",
+            repo="arthexis",
+            slug="arthexis/arthexis",
+            token="tok",
+        ),
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_repository_issues",
+        lambda **kwargs: iter(
+            [
+                {
+                    "number": 42,
+                    "title": "Issue title",
+                    "state": "open",
+                    "user": {"login": "octocat"},
+                },
+                {
+                    "number": 43,
+                    "title": "PR title",
+                    "state": "open",
+                    "user": {"login": "hubot"},
+                    "pull_request": {"url": "https://api.github.com/pr/43"},
+                },
+            ]
+        ),
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("docs:docs-github-viewer"))
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "Issue title" in body
+    assert "PR title" in body
+    assert reverse("docs:docs-github-item", kwargs={"number": 42}) in body
+
+
+def test_docs_github_detail_allows_posting_template_response(client, monkeypatch):
+    user = get_user_model().objects.create_user(
+        username="docs-github-detail-user",
+        email="docs-github-detail-user@example.com",
+        password="secret",
+    )
+    _grant_docs_access(user)
+    template = GitHubResponseTemplate.objects.create(
+        user=user,
+        label="Needs reproduction",
+        body="Please share reproducible steps.",
+    )
+
+    monkeypatch.setattr(
+        "apps.docs.views._resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="arthexis",
+            repo="arthexis",
+            slug="arthexis/arthexis",
+            token="tok",
+        ),
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 55,
+            "title": "Improve diagnostics",
+            "state": "open",
+            "body": "Detailed description",
+            "pull_request": {"url": "https://api.github.com/pr/55"},
+        },
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_issue_comments",
+        lambda **kwargs: iter([]),
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_pull_request",
+        lambda **kwargs: {"head": {"sha": "abc123"}},
+    )
+    monkeypatch.setattr(
+        "apps.docs.views.github_service.fetch_commit_status_summary",
+        lambda **kwargs: {"state": "success"},
+    )
+    posted = {}
+
+    def _capture_comment(*args, **kwargs):
+        posted["body"] = kwargs["body"]
+
+    monkeypatch.setattr("apps.docs.views.github_service.create_issue_comment", _capture_comment)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("docs:docs-github-item", kwargs={"number": 55}),
+        data={"template": str(template.pk), "body": ""},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert posted["body"] == "Please share reproducible steps."
 
 
 def test_readme_resolves_sigils_for_authenticated_user(client):


### PR DESCRIPTION
### Motivation
- Provide a developer-facing GitHub Issues/PR viewer from the Developer Documents page so connected repos can be inspected without leaving the suite.
- Allow drilling into an issue/PR to see description, comments, and overall checks status and respond immediately from the UI.
- Let developers send common, prewritten replies via per-user templates to speed triage and ensure consistent responses.

### Description
- Added routes and views: `docs/github/` (list open issues/PRs) and `docs/github/<number>/` (detail, comments, checks, respond) and exposed the viewer from the Developer Documents sidebar.
- Added templates `docs/github_viewer.html` and `docs/github_detail.html` and updated `docs/library.html` to surface the viewer button when GitHub is connected.
- Introduced `GitHubResponseTemplate` model with migration and admin registration to manage per-user canned responses.
- Extended GitHub service helpers (`apps/repos/services/github.py`) with utilities to fetch issue/PR details, comments, pull request data, commit status summaries, and post issue/PR comments used by the new views.

### Testing
- Performed environment refresh: `./env-refresh.sh --deps-only` (completed successfully).
- Verified migrations: `.venv/bin/python manage.py migrations check` (no pending changes after adjustments).
- Installed CI test deps: `.venv/bin/pip install -r requirements-ci.txt` (completed successfully).
- Ran the new/updated route tests: `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py` and all tests passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17fbb2870832683cdaf9bd283e8f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GitHub Issue/PR Viewer with Canned Response Templates

### Overview
Adds a developer-facing GitHub Issues and Pull Requests viewer to the Developer Documents page so connected repositories can be inspected and triaged without leaving the suite. Supports listing open issues/PRs, drilling into an item to view description, comments and checks status, and responding from the UI using per-user canned response templates.

### New Features

- UI and routes
  - New routes: docs/github/ (list) and docs/github/<int:number>/ (detail).
  - Templates: apps/docs/templates/docs/github_viewer.html and apps/docs/templates/docs/github_detail.html render the list and detailed views and surface connection/error states.
  - Adds an "Open GitHub issue viewer" link in apps/docs/templates/docs/library.html (rendered only when a repo/token is connected).
  - Detail view includes description, comments, PR checks summary, and a POST form to submit responses (select a saved template or provide a custom body).

- Views and helpers
  - Views: github_issue_viewer() and github_issue_detail(number) in apps/docs/views.py.
  - _resolve_github_docs_connection() centralizes resolution of active owner/repo/token and exposes github_connected/github_issue_viewer_url in the library context.
  - _parse_github_comment_payload(request) validates POSTed response template selection or custom body and returns explicit errors for invalid/missing input.
  - Detail view supports POST to create issue/PR comments and surfaces upstream errors (renders error_message in the template). For PRs, computes checks_state from commit status summary.

- Response template model & admin
  - New model: GitHubResponseTemplate (apps/repos/models/response_templates.py) with fields user (FK), label, body, is_active; ordering and UniqueConstraint(user, label).
  - Migration: apps/repos/migrations/0003_githubresponsetemplate.py creates the table and uniqueness constraint.
  - Admin: GitHubResponseTemplateAdmin registered (apps/repos/admin.py) with list/search/filter; get_queryset restricts non-superusers to their own templates and save_model assigns the current user to created templates.

- GitHub service helpers
  - Added robust helpers in apps/repos/services/github.py:
    - fetch_issue_or_pull_request()
    - fetch_issue_comments() (paginated iterator)
    - fetch_pull_request()
    - fetch_commit_status_summary()
    - create_issue_comment() — trims/validates body, posts a comment, maps network/errors to GitHubRepositoryError and returns the requests.Response on success.
  - get_github_issue_token() now raises GitHubRepositoryError when token is missing (behavior/signature change to unify error handling).

### Testing and CI
- Environment refresh and CI deps: ./env-refresh.sh --deps-only completed; pip install -r requirements-ci.txt executed.
- Migrations: manage.py migrations check passed (no pending migrations after adjustments).
- Tests: apps/sites/tests/test_public_routes.py extended with coverage for:
  - Library page showing viewer link when connected.
  - Viewer list page rendering issues and PRs from a mocked fetch_repository_issues iterator.
  - Detail page POST flow posting a selected GitHubResponseTemplate body (mocks fetch and create calls and asserts posted payload).
  - Invalid template selection returns 200 with an appropriate error message.
  - Upstream fetch failures render the error message on the detail page (200 status).
- Route tests executed: 37 passed.

### Error handling and behavior notes
- Views and service helpers consistently translate network/request issues and misconfiguration into GitHubRepositoryError so upstream failures render user-facing error messages instead of raising raw exceptions.
- create_issue_comment enforces non-empty trimmed comment body; payload validation also handled in _parse_github_comment_payload.

### DB & exports
- Migration 0003 adds the GitHubResponseTemplate model and uniqueness constraint.
- apps/repos/models/__init__.py exports GitHubResponseTemplate.

### Other
- Commit history includes a follow-up commit addressing review comments and mypy fixes (commit: "docs/repos: address review comments and mypy follow-ups").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->