### PR TITLE
sigils: add pipeline-v2 parsing with uppercase normalization and user-safe action gating

### DIFF
--- a/apps/docs/rendering.py
+++ b/apps/docs/rendering.py
@@ -8,8 +8,11 @@ import bleach
 import markdown
 
 from apps.docs import assets
-from apps.sigils.sigil_resolver import get_user_safe_sigil_roots, resolve_sigils
-
+from apps.sigils.sigil_resolver import (
+    get_user_safe_sigil_actions,
+    get_user_safe_sigil_roots,
+    resolve_sigils,
+)
 
 MARKDOWN_EXTENSIONS = ["toc", "tables", "mdx_truly_sane_lists", "fenced_code"]
 
@@ -71,6 +74,7 @@ def _sanitize_html(html: str) -> str:
         strip=True,
     )
 
+
 MARKDOWN_FILE_EXTENSIONS = {".md", ".markdown"}
 PLAINTEXT_FILE_EXTENSIONS = {".txt", ".text"}
 CSV_FILE_EXTENSIONS = {".csv"}
@@ -111,7 +115,7 @@ def render_csv_document(text: str) -> tuple[str, str]:
         empty_html = (
             '<div class="table-responsive">'
             '<table class="table table-striped table-bordered table-sm reader-table">'
-            "<tbody><tr><td class=\"text-muted\">No data available.</td></tr></tbody>"
+            '<tbody><tr><td class="text-muted">No data available.</td></tr></tbody>'
             "</table></div>"
         )
         return empty_html, ""
@@ -125,7 +129,7 @@ def render_csv_document(text: str) -> tuple[str, str]:
         return normalized
 
     header_cells = "".join(
-        f"<th scope=\"col\">{escape(value)}</th>" for value in _normalize(rows[0])
+        f'<th scope="col">{escape(value)}</th>' for value in _normalize(rows[0])
     )
     header_html = f"<thead><tr>{header_cells}</tr></thead>"
 
@@ -138,9 +142,7 @@ def render_csv_document(text: str) -> tuple[str, str]:
             for row in body_rows
         )
     else:
-        body_html = (
-            f"<tr><td class=\"text-muted\" colspan=\"{column_count}\">No rows available.</td></tr>"
-        )
+        body_html = f'<tr><td class="text-muted" colspan="{column_count}">No rows available.</td></tr>'
     body_html = f"<tbody>{body_html}</tbody>"
 
     table_html = (
@@ -156,7 +158,7 @@ def render_code_document(text: str) -> tuple[str, str]:
 
     html = (
         '<pre class="reader-code-viewer bg-body-tertiary border rounded p-3">'
-        f"<code class=\"font-monospace\">{escape(text)}</code>"
+        f'<code class="font-monospace">{escape(text)}</code>'
         "</pre>"
     )
     return html, ""
@@ -181,7 +183,11 @@ def read_document_text(file_path: Path) -> str:
     """Read ``file_path`` as UTF-8 text, replacing undecodable bytes."""
 
     raw_text = file_path.read_text(encoding="utf-8", errors="replace")
-    return resolve_sigils(raw_text, allowed_roots=get_user_safe_sigil_roots())
+    return resolve_sigils(
+        raw_text,
+        allowed_roots=get_user_safe_sigil_roots(),
+        allowed_actions=get_user_safe_sigil_actions(),
+    )
 
 
 def render_document_file(file_path: Path) -> tuple[str, str]:

--- a/apps/sigils/entity_lookup.py
+++ b/apps/sigils/entity_lookup.py
@@ -11,6 +11,14 @@ from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 from django.db.models import Count, Max, Min, Sum
 
+PIPELINE_AGGREGATE_ACTIONS = {
+    "COUNT": "count",
+    "MAX": "max",
+    "MIN": "min",
+    "SUM": "total",
+    "TOTAL": "total",
+}
+
 
 @lru_cache(maxsize=256)
 def model_field_map(model: type[models.Model]) -> dict[str, models.Field]:
@@ -34,10 +42,22 @@ def parse_aggregate_request(
     normalized_key: str | None,
 ) -> tuple[str | None, str | None]:
     """Parse entity aggregate syntax expressed as ``target:function``."""
-    if filter_field or instance_id is None or normalized_key is not None or ":" not in instance_id:
+    if (
+        filter_field
+        or instance_id is None
+        or normalized_key is not None
+        or ":" not in instance_id
+    ):
         return None, None
     aggregate_target, aggregate_func = instance_id.split(":", 1)
     return aggregate_target, (aggregate_func or "total").replace("-", "_").lower()
+
+
+def map_pipeline_action_to_aggregate(action: str | None) -> str | None:
+    """Map pipeline aggregate actions to entity aggregate function names."""
+    if not action:
+        return None
+    return PIPELINE_AGGREGATE_ACTIONS.get(action.upper())
 
 
 def resolve_entity_lookup(
@@ -77,11 +97,18 @@ def resolve_entity_lookup(
 
     if instance is None and instance_id is not None and not filter_field:
         for field_name in unique_char_fields(model):
-            instance = model.objects.filter(**{f"{field_name}__iexact": instance_id}).first()
+            instance = model.objects.filter(
+                **{f"{field_name}__iexact": instance_id}
+            ).first()
             if instance:
                 break
 
-    if instance is None and instance_id is None and current and isinstance(current, model):
+    if (
+        instance is None
+        and instance_id is None
+        and current
+        and isinstance(current, model)
+    ):
         instance = current
     return instance, invalid_lookup
 

--- a/apps/sigils/entity_lookup.py
+++ b/apps/sigils/entity_lookup.py
@@ -80,7 +80,7 @@ def resolve_entity_lookup(
             except FieldDoesNotExist:
                 invalid_lookup = True
                 field_obj = None
-            if field_obj and isinstance(field_obj, models.CharField):
+            if field_obj and isinstance(field_obj, (models.CharField, models.TextField)):
                 lookup = {f"{field_name}__iexact": instance_id}
             else:
                 lookup = {field_name: instance_id}

--- a/apps/sigils/models.py
+++ b/apps/sigils/models.py
@@ -13,7 +13,7 @@ class SigilRootQuerySet(EntityQuerySet):
 
 class SigilRootManager(EntityManager.from_queryset(SigilRootQuerySet)):
     def get_by_natural_key(self, prefix: str):
-        return self.get(prefix=prefix)
+        return self.get(prefix__iexact=prefix)
 
 
 class SigilRoot(Entity):
@@ -25,9 +25,7 @@ class SigilRoot(Entity):
     prefix = models.CharField(max_length=50, unique=True)
     is_user_safe = models.BooleanField(
         default=False,
-        help_text=_(
-            "Allow this sigil root in user-facing rendering contexts."
-        ),
+        help_text=_("Allow this sigil root in user-facing rendering contexts."),
     )
     context_type = models.CharField(max_length=20, choices=Context.choices)
     content_type = models.ForeignKey(
@@ -35,6 +33,11 @@ class SigilRoot(Entity):
     )
 
     objects = SigilRootManager()
+
+    def save(self, *args, **kwargs):
+        if self.prefix:
+            self.prefix = self.prefix.upper()
+        super().save(*args, **kwargs)
 
     def default_instance(self):
         """Return the preferred instance for this sigil root's model.
@@ -59,14 +62,24 @@ class SigilRoot(Entity):
                 return candidate
             return None
 
-        for attr in ("default_instance", "get_default_instance", "default", "get_default"):
+        for attr in (
+            "default_instance",
+            "get_default_instance",
+            "default",
+            "get_default",
+        ):
             instance = _evaluate(getattr(model, attr, None))
             if instance:
                 return instance
 
         manager = getattr(model, "_default_manager", None)
         if manager:
-            for attr in ("default_instance", "get_default_instance", "default", "get_default"):
+            for attr in (
+                "default_instance",
+                "get_default_instance",
+                "default",
+                "get_default",
+            ):
                 instance = _evaluate(getattr(manager, attr, None))
                 if instance:
                     return instance

--- a/apps/sigils/sigil_resolver.py
+++ b/apps/sigils/sigil_resolver.py
@@ -38,7 +38,9 @@ class SigilTokenParts(tuple):
     __slots__ = ()
 
     def __new__(cls, root_name, filter_field, instance_id, key, param, strict_key):
-        return super().__new__(cls, (root_name, filter_field, instance_id, key, param, strict_key))
+        return super().__new__(
+            cls, (root_name, filter_field, instance_id, key, param, strict_key)
+        )
 
     root_name = property(lambda self: self[0])
     filter_field = property(lambda self: self[1])
@@ -61,6 +63,7 @@ class ResolutionContext:
     original_token: str
     param: str | None
     param_args: tuple[str, ...]
+    pipeline_action: str | None
     raw_key: str | None
     token_parts: SigilTokenParts
 
@@ -106,7 +109,15 @@ def _identifier_variants(name: str | None) -> list[str]:
     normalized = _normalize_name(name)
     dashed = normalized.replace("_", "-")
     variants: list[str] = []
-    for candidate in (name, normalized, dashed, normalized.lower(), normalized.upper(), dashed.lower(), dashed.upper()):
+    for candidate in (
+        name,
+        normalized,
+        dashed,
+        normalized.lower(),
+        normalized.upper(),
+        dashed.lower(),
+        dashed.upper(),
+    ):
         if candidate and candidate not in variants:
             variants.append(candidate)
     return variants
@@ -142,8 +153,21 @@ def get_user_safe_sigil_roots() -> set[str]:
     """Return sigil roots marked safe for user-facing resolution."""
     return {
         _normalize_name(prefix).upper()
-        for prefix in SigilRoot.objects.filter(is_user_safe=True).values_list("prefix", flat=True)
+        for prefix in SigilRoot.objects.filter(is_user_safe=True).values_list(
+            "prefix", flat=True
+        )
     }
+
+
+def get_user_safe_sigil_actions() -> set[str]:
+    """Return user-safe pipeline actions for user-facing resolution."""
+    has_safe_entity_root = SigilRoot.objects.filter(
+        is_user_safe=True,
+        context_type=SigilRoot.Context.ENTITY,
+    ).exists()
+    if not has_safe_entity_root:
+        return set()
+    return {"COUNT", "FIELD", "FILTER", "GET", "MAX", "MIN", "SUM", "TOTAL"}
 
 
 def _stringify_value(value) -> str:
@@ -331,12 +355,16 @@ def _parse_key_segment(token: str, index: int) -> tuple[str | None, bool, int]:
     key, index = _parse_quoted_segment(
         token,
         index,
-        lambda value, offset, depth, in_quotes: depth == 0 and not in_quotes and value[offset] == "=",
+        lambda value, offset, depth, in_quotes: depth == 0
+        and not in_quotes
+        and value[offset] == "=",
     )
     return key, strict_key, index
 
 
-def _parse_key_and_param(token: str, index: int) -> tuple[str | None, str | None, bool, int]:
+def _parse_key_and_param(
+    token: str, index: int
+) -> tuple[str | None, str | None, bool, int]:
     """Parse optional ``.key``/``->key`` and ``=param`` segments from a sigil token.
 
     Args:
@@ -376,6 +404,64 @@ def _parse_token_parts(token: str) -> SigilTokenParts:
     instance_id, index = _parse_instance_id(token, index)
     key, param, strict_key, index = _parse_key_and_param(token, index)
     return SigilTokenParts(root_name, filter_field, instance_id, key, param, strict_key)
+
+
+def _is_pipeline_v2_enabled() -> bool:
+    return bool(getattr(settings, "SIGILS_PIPELINE_V2_ENABLED", False))
+
+
+def _normalize_pipeline_segment(segment: str) -> str:
+    head, separator, tail = segment.partition(":")
+    if not separator:
+        return segment
+    return f"{head.upper()}:{tail}"
+
+
+def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None]:
+    if "|" not in token:
+        raise TokenParseError("Sigil token is not a pipeline token")
+    root_segment, action_segment = token.split("|", 1)
+    normalized_root_segment = _normalize_pipeline_segment(root_segment)
+    normalized_action_segment = _normalize_pipeline_segment(action_segment)
+    root_name, separator, root_payload = normalized_root_segment.partition(":")
+    action_name, action_separator, action_payload = normalized_action_segment.partition(
+        ":"
+    )
+    if not root_name or not separator or not action_name or not action_separator:
+        raise TokenParseError("Sigil pipeline token is malformed")
+
+    filter_field = None
+    instance_id = None
+    key = None
+    param = None
+    strict_key = False
+    payload_head, payload_separator, payload_tail = root_payload.partition(":")
+    if payload_separator:
+        filter_field = payload_head.replace("-", "_")
+        instance_id = payload_tail
+    elif root_payload:
+        instance_id = root_payload
+
+    action_upper = action_name.upper()
+    if action_upper == "FILTER":
+        key_head, key_separator, key_tail = action_payload.partition(":")
+        if not key_separator:
+            raise TokenParseError("FILTER action is missing field/value")
+        key = key_head
+        param = key_tail
+    elif action_upper in {"COUNT", "MAX", "MIN", "SUM", "TOTAL"}:
+        key = action_payload or None
+        instance_target = key or ""
+        instance_id = f"{instance_target}:{entity_lookup.map_pipeline_action_to_aggregate(action_upper)}"
+    elif action_upper in {"GET", "FIELD"}:
+        key = action_payload or None
+    else:
+        key = action_payload or None
+
+    return (
+        SigilTokenParts(root_name, filter_field, instance_id, key, param, strict_key),
+        action_upper,
+    )
 
 
 def _resolve_request_value(request, key: str, param: str) -> str:
@@ -427,7 +513,9 @@ def _resolve_request_value(request, key: str, param: str) -> str:
     return ""
 
 
-def _resolve_instance_value(instance, model, key_name: str, key_lower: str, raw_key: str, param_args: list[str]):
+def _resolve_instance_value(
+    instance, model, key_name: str, key_lower: str, raw_key: str, param_args: list[str]
+):
     """Resolve an instance value via custom resolver, model field, or callable attribute.
 
     Args:
@@ -466,7 +554,13 @@ def _resolve_instance_value(instance, model, key_name: str, key_lower: str, raw_
     return None
 
 
-def _resolve_env_value(normalized_key: str | None, key_upper: str | None, key_lower: str | None, raw_key: str | None, original_token: str) -> str:
+def _resolve_env_value(
+    normalized_key: str | None,
+    key_upper: str | None,
+    key_lower: str | None,
+    raw_key: str | None,
+    original_token: str,
+) -> str:
     """Resolve an ``ENV`` sigil from process environment variables.
 
     Args:
@@ -503,7 +597,9 @@ def _resolve_env_value(normalized_key: str | None, key_upper: str | None, key_lo
     return _failed_resolution(original_token)
 
 
-def _resolve_conf_value(normalized_key: str | None, key_upper: str | None, key_lower: str | None) -> str:
+def _resolve_conf_value(
+    normalized_key: str | None, key_upper: str | None, key_lower: str | None
+) -> str:
     """Resolve a ``CONF`` sigil from Django settings.
 
     Args:
@@ -524,7 +620,12 @@ def _resolve_conf_value(normalized_key: str | None, key_upper: str | None, key_l
     return ""
 
 
-def _resolve_sys_value(normalized_key: str | None, key_upper: str | None, raw_key: str | None, original_token: str) -> str:
+def _resolve_sys_value(
+    normalized_key: str | None,
+    key_upper: str | None,
+    raw_key: str | None,
+    original_token: str,
+) -> str:
     """Resolve a ``SYS`` sigil from cached or computed system metadata.
 
     Args:
@@ -537,7 +638,9 @@ def _resolve_sys_value(normalized_key: str | None, key_upper: str | None, raw_ke
         The resolved system value or the degraded placeholder.
     """
     values = get_system_sigil_values()
-    candidates = [candidate for candidate in [key_upper, (raw_key or "").upper()] if candidate]
+    candidates = [
+        candidate for candidate in [key_upper, (raw_key or "").upper()] if candidate
+    ]
     for candidate in candidates:
         if candidate in values:
             return values[candidate]
@@ -551,7 +654,14 @@ def _resolve_sys_value(normalized_key: str | None, key_upper: str | None, raw_ke
     return _failed_resolution(original_token)
 
 
-def _resolve_config_value(root, normalized_key: str | None, key_upper: str | None, key_lower: str | None, raw_key: str | None, original_token: str) -> str:
+def _resolve_config_value(
+    root,
+    normalized_key: str | None,
+    key_upper: str | None,
+    key_lower: str | None,
+    raw_key: str | None,
+    original_token: str,
+) -> str:
     """Resolve configuration-backed sigils, including ENV, CONF, and SYS namespaces.
 
     Args:
@@ -569,7 +679,9 @@ def _resolve_config_value(root, normalized_key: str | None, key_upper: str | Non
         return ""
     prefix = root.prefix.upper()
     if prefix == "ENV":
-        return _resolve_env_value(normalized_key, key_upper, key_lower, raw_key, original_token)
+        return _resolve_env_value(
+            normalized_key, key_upper, key_lower, raw_key, original_token
+        )
     if prefix == "CONF":
         return _resolve_conf_value(normalized_key, key_upper, key_lower)
     if prefix == "SYS":
@@ -577,7 +689,12 @@ def _resolve_config_value(root, normalized_key: str | None, key_upper: str | Non
     return _failed_resolution(original_token)
 
 
-def _resolve_request_root(normalized_key: str | None, raw_key: str | None, param: str | None, param_args: list[str]) -> str:
+def _resolve_request_root(
+    normalized_key: str | None,
+    raw_key: str | None,
+    param: str | None,
+    param_args: list[str],
+) -> str:
     """Resolve request-context sigils from the current request.
 
     Args:
@@ -632,7 +749,15 @@ def _resolve_dynamic_root(
     return serializers.serialize("json", [instance])
 
 
-def _resolve_entity_instance(model, instance, normalized_key: str | None, key_lower: str | None, raw_key: str | None, param_args: list[str], original_token: str) -> str:
+def _resolve_entity_instance(
+    model,
+    instance,
+    normalized_key: str | None,
+    key_lower: str | None,
+    raw_key: str | None,
+    param_args: list[str],
+    original_token: str,
+) -> str:
     """Resolve a sigil against a specific entity instance or serialize that instance.
 
     Args:
@@ -687,6 +812,24 @@ def _resolve_entity_root(
     if model is None:
         return _failed_resolution(context.original_token)
 
+    if context.pipeline_action == "FILTER":
+        filter_field = (context.normalized_key or "").lower()
+        if not filter_field or context.param is None:
+            return _failed_resolution(context.original_token)
+        try:
+            field_obj = model._meta.get_field(filter_field)
+        except FieldDoesNotExist:
+            return _failed_resolution(context.original_token)
+        if isinstance(field_obj, models.CharField):
+            lookup = {f"{filter_field}__iexact": context.param}
+        else:
+            lookup = {filter_field: context.param}
+        try:
+            qs = model.objects.filter(**lookup)
+        except (FieldError, TypeError, ValueError):
+            return _failed_resolution(context.original_token)
+        return serializers.serialize("json", qs)
+
     aggregate_target, aggregate_func = entity_lookup.parse_aggregate_request(
         context.token_parts.filter_field,
         context.instance_id,
@@ -734,7 +877,9 @@ def _resolve_entity_root(
         else None
     )
     if manager_method_name:
-        found, manager_val = _call_attribute(model.objects, manager_method_name, list(context.param_args))
+        found, manager_val = _call_attribute(
+            model.objects, manager_method_name, list(context.param_args)
+        )
         if found:
             if isinstance(manager_val, models.QuerySet):
                 return serializers.serialize("json", manager_val)
@@ -755,7 +900,11 @@ def _build_resolution_context(
     allowed_roots: set[str] | None = None,
 ) -> ResolutionContext:
     """Build normalized token resolution context from a raw token."""
-    token_parts = _parse_token_parts(token)
+    pipeline_action = None
+    if _is_pipeline_v2_enabled() and "|" in token:
+        token_parts, pipeline_action = _parse_pipeline_token_parts(token)
+    else:
+        token_parts = _parse_token_parts(token)
     normalized_root = _normalize_name(token_parts.root_name)
     lookup_root = normalized_root.upper()
     normalized_key = _normalize_name(token_parts.key) if token_parts.key else None
@@ -782,6 +931,7 @@ def _build_resolution_context(
         original_token=token,
         param=param,
         param_args=param_args,
+        pipeline_action=pipeline_action,
         raw_key=token_parts.key,
         token_parts=token_parts,
     )
@@ -822,6 +972,7 @@ def _resolve_token_with_policy(
     token: str,
     current: models.Model | None = None,
     allowed_roots: set[str] | None = None,
+    allowed_actions: set[str] | None = None,
 ) -> str:
     """Resolve one sigil token while enforcing an optional root allow-list."""
     try:
@@ -830,6 +981,12 @@ def _resolve_token_with_policy(
         return _failed_resolution(token)
 
     if allowed_roots is not None and context.lookup_root not in allowed_roots:
+        return _failed_resolution(context.original_token)
+    if (
+        allowed_actions is not None
+        and context.pipeline_action
+        and context.pipeline_action not in allowed_actions
+    ):
         return _failed_resolution(context.original_token)
 
     if context.lookup_root == "OBJECT" and context.current is not None:
@@ -876,6 +1033,7 @@ def resolve_sigils(
     current: models.Model | None = None,
     *,
     allowed_roots: Collection[str] | None = None,
+    allowed_actions: Collection[str] | None = None,
 ) -> str:
     """Resolve every sigil token found in the given text.
 
@@ -887,17 +1045,23 @@ def resolve_sigils(
         The input text with each recognized sigil token replaced by its resolved value.
     """
     normalized_allowed_roots = _normalize_allowed_roots(allowed_roots)
+    normalized_allowed_actions = (
+        {action.upper() for action in allowed_actions if action}
+        if allowed_actions is not None
+        else None
+    )
     parts: list[str] = []
     cursor = 0
     for span in scan_sigil_tokens(text):
         if span.start > cursor:
-            parts.append(text[cursor:span.start])
+            parts.append(text[cursor : span.start])
         token = text[span.start + 1 : span.end - 1]
         parts.append(
             _resolve_token_with_policy(
                 token,
                 current,
                 allowed_roots=normalized_allowed_roots,
+                allowed_actions=normalized_allowed_actions,
             )
         )
         cursor = span.end
@@ -911,6 +1075,7 @@ def resolve_sigil(
     current: models.Model | None = None,
     *,
     allowed_roots: Collection[str] | None = None,
+    allowed_actions: Collection[str] | None = None,
 ) -> str:
     """Resolve a single sigil-bearing string.
 
@@ -921,4 +1086,9 @@ def resolve_sigil(
     Returns:
         The resolved sigil text.
     """
-    return resolve_sigils(sigil, current, allowed_roots=allowed_roots)
+    return resolve_sigils(
+        sigil,
+        current,
+        allowed_roots=allowed_roots,
+        allowed_actions=allowed_actions,
+    )

--- a/apps/sigils/sigil_resolver.py
+++ b/apps/sigils/sigil_resolver.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 from django.conf import settings
 from django.core import serializers
 from django.core.exceptions import FieldDoesNotExist, FieldError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 from . import entity_lookup
@@ -22,6 +23,17 @@ logger = logging.getLogger(__name__)
 
 ATTRIBUTE_RESOLUTION_TIMEOUT = float(os.environ.get("SIGIL_ATTRIBUTE_TIMEOUT", 2.0))
 ATTRIBUTE_RESOLUTION_WORKERS = int(os.environ.get("SIGIL_ATTRIBUTE_WORKERS", 4)) or 1
+PIPELINE_FILTER_DEFAULT_LIMIT = 50
+PIPELINE_FILTER_MAX_LIMIT = 200
+PIPELINE_FILTER_SENSITIVE_FIELD_TOKENS = (
+    "api_key",
+    "hash",
+    "key",
+    "password",
+    "private",
+    "secret",
+    "token",
+)
 _ATTRIBUTE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
     max_workers=ATTRIBUTE_RESOLUTION_WORKERS,
     thread_name_prefix="sigil-attr",
@@ -417,6 +429,10 @@ def _normalize_pipeline_segment(segment: str) -> str:
     return f"{head.upper()}:{tail}"
 
 
+def _is_valid_pipeline_head(name: str) -> bool:
+    return bool(name) and all(char.isalnum() or char in {"_", "-"} for char in name)
+
+
 def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None]:
     if "|" not in token:
         raise TokenParseError("Sigil token is not a pipeline token")
@@ -424,10 +440,18 @@ def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None
     normalized_root_segment = _normalize_pipeline_segment(root_segment)
     normalized_action_segment = _normalize_pipeline_segment(action_segment)
     root_name, separator, root_payload = normalized_root_segment.partition(":")
+    if not separator:
+        root_name = normalized_root_segment
+        root_payload = ""
     action_name, action_separator, action_payload = normalized_action_segment.partition(
         ":"
     )
-    if not root_name or not separator or not action_name or not action_separator:
+    if not action_separator:
+        action_name = normalized_action_segment
+        action_payload = ""
+    if not _is_valid_pipeline_head(root_name) or not _is_valid_pipeline_head(
+        action_name
+    ):
         raise TokenParseError("Sigil pipeline token is malformed")
 
     filter_field = None
@@ -450,8 +474,7 @@ def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None
         key = key_head
         param = key_tail
     elif action_upper in {"COUNT", "MAX", "MIN", "SUM", "TOTAL"}:
-        key = action_payload or None
-        instance_target = key or ""
+        instance_target = action_payload or ""
         instance_id = f"{instance_target}:{entity_lookup.map_pipeline_action_to_aggregate(action_upper)}"
     elif action_upper in {"GET", "FIELD"}:
         key = action_payload or None
@@ -820,7 +843,7 @@ def _resolve_entity_root(
             field_obj = model._meta.get_field(filter_field)
         except FieldDoesNotExist:
             return _failed_resolution(context.original_token)
-        if isinstance(field_obj, models.CharField):
+        if isinstance(field_obj, (models.CharField, models.TextField)):
             lookup = {f"{filter_field}__iexact": context.param}
         else:
             lookup = {filter_field: context.param}
@@ -828,7 +851,34 @@ def _resolve_entity_root(
             qs = model.objects.filter(**lookup)
         except (FieldError, TypeError, ValueError):
             return _failed_resolution(context.original_token)
-        return serializers.serialize("json", qs)
+        filter_limit = getattr(
+            settings,
+            "SIGILS_PIPELINE_FILTER_LIMIT",
+            PIPELINE_FILTER_DEFAULT_LIMIT,
+        )
+        try:
+            filter_limit = int(filter_limit)
+        except (TypeError, ValueError):
+            filter_limit = PIPELINE_FILTER_DEFAULT_LIMIT
+        filter_limit = max(1, min(filter_limit, PIPELINE_FILTER_MAX_LIMIT))
+
+        safe_fields = []
+        for model_field in model._meta.fields:
+            if model_field.is_relation:
+                continue
+            lower_name = model_field.name.lower()
+            if any(
+                token in lower_name for token in PIPELINE_FILTER_SENSITIVE_FIELD_TOKENS
+            ):
+                continue
+            safe_fields.append(model_field.name)
+        if model._meta.pk.name not in safe_fields:
+            safe_fields.insert(0, model._meta.pk.name)
+        if filter_field not in safe_fields and not field_obj.is_relation:
+            safe_fields.append(filter_field)
+
+        payload = list(qs.values(*safe_fields)[:filter_limit])
+        return json.dumps(payload, cls=DjangoJSONEncoder)
 
     aggregate_target, aggregate_func = entity_lookup.parse_aggregate_request(
         context.token_parts.filter_field,
@@ -902,7 +952,10 @@ def _build_resolution_context(
     """Build normalized token resolution context from a raw token."""
     pipeline_action = None
     if _is_pipeline_v2_enabled() and "|" in token:
-        token_parts, pipeline_action = _parse_pipeline_token_parts(token)
+        try:
+            token_parts, pipeline_action = _parse_pipeline_token_parts(token)
+        except TokenParseError:
+            token_parts = _parse_token_parts(token)
     else:
         token_parts = _parse_token_parts(token)
     normalized_root = _normalize_name(token_parts.root_name)

--- a/apps/sigils/tests/test_sigil_resolver.py
+++ b/apps/sigils/tests/test_sigil_resolver.py
@@ -26,6 +26,19 @@ def user_root():
     return root
 
 
+@pytest.fixture
+def node_root():
+    root, _ = SigilRoot.objects.update_or_create(
+        prefix="CP",
+        defaults={
+            "context_type": SigilRoot.Context.ENTITY,
+            "content_type": ContentType.objects.get_for_model(Node),
+            "is_user_safe": True,
+        },
+    )
+    return root
+
+
 @pytest.mark.django_db
 def test_resolve_sigils_filters_and_fetches_field(user_root):
     user_model = get_user_model()
@@ -35,6 +48,103 @@ def test_resolve_sigils_filters_and_fetches_field(user_root):
 
     assert result == user.email
 
+
+@pytest.mark.django_db
+def test_pipeline_v2_parses_uppercase_pipeline(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="Charging")
+    Node.objects.create(
+        hostname="SIM-CP-1",
+        address="127.0.0.11",
+        mac_address="00:11:22:33:44:12",
+        port=9001,
+        public_endpoint="SIM-CP-1",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[CP:hostname:SIM-CP-1|GET:role]")
+
+    assert resolved == "Charging"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_normalizes_mixed_case_root_and_action(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="Charging")
+    Node.objects.create(
+        hostname="SIM-CP-1",
+        address="127.0.0.12",
+        mac_address="00:11:22:33:44:13",
+        port=9002,
+        public_endpoint="SIM-CP-1",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[cp:hostname:SIM-CP-1|field:role]")
+
+    assert resolved == "Charging"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_coexists_with_dot_and_parenthesis_sigils(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="Router")
+    Node.objects.create(
+        hostname="SIM-CP-2",
+        address="127.0.0.13",
+        mac_address="00:11:22:33:44:14",
+        port=9003,
+        public_endpoint="SIM-CP-2",
+        role=role,
+    )
+    user_model = get_user_model()
+    user_model.objects.create(username="sigiladmin")
+
+    result = sigil_resolver.resolve_sigils(
+        "[USR:username=sigiladmin.username]-[CP:hostname:SIM-CP-2|GET:role]"
+    )
+
+    assert result == "sigiladmin-Router"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_user_safe_gating_degrades_disallowed_action(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="Charging")
+    Node.objects.create(
+        hostname="SIM-CP-3",
+        address="127.0.0.14",
+        mac_address="00:11:22:33:44:15",
+        port=9004,
+        public_endpoint="SIM-CP-3",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils(
+        "[CP:hostname:SIM-CP-3|GET:role]",
+        allowed_roots={"CP"},
+        allowed_actions={"COUNT"},
+    )
+
+    assert resolved == "[CP:hostname:SIM-CP-3|GET:role]"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_feature_flag_can_disable_pipeline_parsing(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = False
+    role = NodeRole.objects.create(name="Disabled")
+    Node.objects.create(
+        hostname="SIM-CP-4",
+        address="127.0.0.15",
+        mac_address="00:11:22:33:44:16",
+        port=9005,
+        public_endpoint="SIM-CP-4",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[CP:hostname:SIM-CP-4|GET:role]")
+
+    assert resolved == "[CP:hostname:SIM-CP-4|GET:role]"
 
 
 @pytest.mark.django_db
@@ -52,9 +162,7 @@ def test_resolve_sigils_request_values():
         assert sigil_resolver.resolve_sigils("[REQ.method]") == "GET"
         assert sigil_resolver.resolve_sigils("[REQ.path]") == "/example/path"
         assert sigil_resolver.resolve_sigils("[REQ.query=foo]") == "bar"
-        assert (
-            sigil_resolver.resolve_sigils("[REQ.header=X-Custom-Header]") == "hello"
-        )
+        assert sigil_resolver.resolve_sigils("[REQ.header=X-Custom-Header]") == "hello"
     finally:
         clear_request()
 
@@ -86,7 +194,9 @@ def test_resolve_sigils_uses_default_entity_instance(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_resolve_sigils_uses_default_entity_instance_with_unrelated_current(monkeypatch):
+def test_resolve_sigils_uses_default_entity_instance_with_unrelated_current(
+    monkeypatch,
+):
     SigilRoot.objects.update_or_create(
         prefix="NODE",
         defaults={
@@ -112,9 +222,10 @@ def test_resolve_sigils_uses_default_entity_instance_with_unrelated_current(monk
     assert result == role.name
 
 
-
 @pytest.mark.django_db
-def test_resolve_sigils_empty_nested_selector_does_not_fall_back_to_default_instance(monkeypatch, user_root):
+def test_resolve_sigils_empty_nested_selector_does_not_fall_back_to_default_instance(
+    monkeypatch, user_root
+):
     SigilRoot.objects.update_or_create(
         prefix="NODE",
         defaults={
@@ -133,7 +244,7 @@ def test_resolve_sigils_empty_nested_selector_does_not_fall_back_to_default_inst
     )
     monkeypatch.setattr(Node, "get_local", classmethod(lambda cls: node))
 
-    result = sigil_resolver.resolve_sigils("[NODE=\"[USR=missing.email]\".role]")
+    result = sigil_resolver.resolve_sigils('[NODE="[USR=missing.email]".role]')
 
     assert result == ""
 
@@ -180,7 +291,9 @@ def test_resolve_sigils_manager_database_errors_propagate(monkeypatch, user_root
         ("[USR=manager_count]", lambda payload: payload == "2"),
     ],
 )
-def test_resolve_sigils_table_driven_manager_method_dispatch(user_root, token, assertion, monkeypatch):
+def test_resolve_sigils_table_driven_manager_method_dispatch(
+    user_root, token, assertion, monkeypatch
+):
     user_model = get_user_model()
     user_model.objects.create(username="manager-alpha")
     user_model.objects.create(username="manager-bravo")
@@ -208,7 +321,9 @@ def test_resolve_sigils_table_driven_aggregate_requests(user_root, token, expect
     user_ids = (first_user.id, second_user.id)
 
     resolved = sigil_resolver.resolve_sigils(token)
-    expected_value = expected if isinstance(expected, str) else expected(baseline_total, user_ids)
+    expected_value = (
+        expected if isinstance(expected, str) else expected(baseline_total, user_ids)
+    )
     assert resolved == expected_value
 
 
@@ -259,7 +374,46 @@ def test_get_user_safe_sigil_roots_normalizes_prefixes():
 
 
 @pytest.mark.django_db
-def test_generate_model_sigils_sets_default_user_safety_for_new_builtin_roots(monkeypatch):
+def test_sigil_root_prefix_persists_uppercase_and_matches_case_insensitively():
+    root, _ = SigilRoot.objects.update_or_create(
+        prefix="xcp",
+        defaults={"context_type": SigilRoot.Context.REQUEST},
+    )
+    fetched = SigilRoot.objects.get(prefix__iexact="XCP")
+
+    assert root.prefix == "XCP"
+    assert fetched.pk == root.pk
+
+
+@pytest.mark.django_db
+def test_get_user_safe_sigil_actions_requires_safe_entity_root():
+    SigilRoot.objects.update_or_create(
+        prefix="REQ",
+        defaults={
+            "context_type": SigilRoot.Context.REQUEST,
+            "is_user_safe": True,
+        },
+    )
+    assert sigil_resolver.get_user_safe_sigil_actions() == set()
+
+    SigilRoot.objects.update_or_create(
+        prefix="CP",
+        defaults={
+            "context_type": SigilRoot.Context.ENTITY,
+            "content_type": ContentType.objects.get_for_model(Node),
+            "is_user_safe": True,
+        },
+    )
+
+    actions = sigil_resolver.get_user_safe_sigil_actions()
+    assert "FILTER" in actions
+    assert "COUNT" in actions
+
+
+@pytest.mark.django_db
+def test_generate_model_sigils_sets_default_user_safety_for_new_builtin_roots(
+    monkeypatch,
+):
     monkeypatch.setattr(
         "apps.sigils.sigil_builder.BUILTIN_SIGIL_POLICIES",
         {
@@ -270,7 +424,7 @@ def test_generate_model_sigils_sets_default_user_safety_for_new_builtin_roots(mo
             "REQ_UNSAFE": {
                 "context_type": SigilRoot.Context.REQUEST,
                 "is_user_safe": False,
-            }
+            },
         },
     )
 

--- a/apps/sigils/tests/test_sigil_resolver.py
+++ b/apps/sigils/tests/test_sigil_resolver.py
@@ -108,6 +108,91 @@ def test_pipeline_v2_coexists_with_dot_and_parenthesis_sigils(settings, node_roo
 
 
 @pytest.mark.django_db
+def test_pipeline_v2_aggregate_action_payload_resolves(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="Counter")
+    Node.objects.create(
+        hostname="SIM-CP-AGG-1",
+        address="127.0.1.1",
+        mac_address="00:11:22:33:44:31",
+        port=9011,
+        public_endpoint="SIM-CP-AGG-1",
+        role=role,
+    )
+    Node.objects.create(
+        hostname="SIM-CP-AGG-2",
+        address="127.0.1.2",
+        mac_address="00:11:22:33:44:32",
+        port=9012,
+        public_endpoint="SIM-CP-AGG-2",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[CP:|COUNT:port]")
+
+    assert resolved == "2"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_root_and_action_can_omit_colons(settings, node_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    role = NodeRole.objects.create(name="No-Colon")
+    Node.objects.create(
+        hostname="SIM-CP-NC-1",
+        address="127.0.1.3",
+        mac_address="00:11:22:33:44:33",
+        port=9013,
+        public_endpoint="SIM-CP-NC-1",
+        role=role,
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[CP|COUNT:port]")
+
+    assert resolved == "1"
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_filter_uses_safe_bounded_serialization(settings, user_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    settings.SIGILS_PIPELINE_FILTER_LIMIT = 1
+    user_model = get_user_model()
+    user_model.objects.create_user(
+        username="filter-a",
+        email="filter@example.com",
+        password="abc12345",
+    )
+    user_model.objects.create_user(
+        username="filter-b",
+        email="filter@example.com",
+        password="abc12345",
+    )
+
+    resolved = sigil_resolver.resolve_sigils("[USR:|FILTER:email:filter@example.com]")
+    payload = json.loads(resolved)
+
+    assert len(payload) == 1
+    assert payload[0]["email"] == "filter@example.com"
+    assert "password" not in payload[0]
+
+
+@pytest.mark.django_db
+def test_pipeline_v2_falls_back_to_legacy_parser_for_pipe_parameters(settings):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    SigilRoot.objects.update_or_create(
+        prefix="REQ", defaults={"context_type": SigilRoot.Context.REQUEST}
+    )
+    factory = RequestFactory()
+    request = factory.get("/example/path?foo%7Cbar=baz")
+    set_request(request)
+    try:
+        resolved = sigil_resolver.resolve_sigils("[REQ.query=foo|bar]")
+    finally:
+        clear_request()
+
+    assert resolved == "baz"
+
+
+@pytest.mark.django_db
 def test_pipeline_v2_user_safe_gating_degrades_disallowed_action(settings, node_root):
     settings.SIGILS_PIPELINE_V2_ENABLED = True
     role = NodeRole.objects.create(name="Charging")


### PR DESCRIPTION
### Motivation

- Introduce a feature-flagged pipeline syntax that allows expressions shaped like `ROOT:...|ACTION:...` while keeping existing dot/parenthesis parser behavior as a safe fallback. 
- Normalize pipeline heads (root/action) to uppercase for consistent canonical display while preserving value case for lookups. 
- Enable mapping of common uppercase actions (`FILTER`, `COUNT`, `SUM`, `MIN`, `MAX`, `TOTAL`, etc.) into existing entity lookup/aggregate logic so pipeline expressions reuse current model/query machinery. 
- Gate user-facing resolution by action as well as root so only whitelisted actions are allowed in untrusted contexts and enable staged rollout via a feature flag.

### Description

- Added feature flag `SIGILS_PIPELINE_V2_ENABLED` and a pipeline parsing branch in `apps/sigils/sigil_resolver.py` with helpers `_is_pipeline_v2_enabled`, `_normalize_pipeline_segment`, and `_parse_pipeline_token_parts`, and threaded a `pipeline_action` into `ResolutionContext` for execution-time decisioning. 
- Implemented uppercase-normalization of pipeline root/action heads while preserving payload case and mapped aggregate actions to existing entity aggregate logic by adding `map_pipeline_action_to_aggregate` and `PIPELINE_AGGREGATE_ACTIONS` in `apps/sigils/entity_lookup.py`. 
- Extended resolver execution to handle `FILTER` pipeline actions (runs a queryset filter and serializes results) and to map uppercase actions (`COUNT`, `SUM`, `MIN`, `MAX`, `TOTAL`, `GET`, `FIELD`) onto existing lookup/aggregate/attribute resolution paths in `apps/sigils/sigil_resolver.py`. 
- Added strict context gating so `_resolve_token_with_policy` enforces an `allowed_actions` set (normalized to uppercase) in addition to `allowed_roots`, plus `get_user_safe_sigil_actions()` to produce a user-safe action whitelist; wired docs rendering (`apps/docs/rendering.py`) to pass both allowed roots and allowed actions. 
- Enforced canonical uppercase persistence/display for `SigilRoot.prefix` (saved uppercase) and made natural-key/narrow lookups case-insensitive (`prefix__iexact`) in `apps/sigils/models.py`. 
- Added tests in `apps/sigils/tests/test_sigil_resolver.py` to cover uppercase pipeline parsing, mixed-case normalization, coexistence with existing sigil forms, feature-flag disable behavior, user-safe action gating and prefix persistence; adjusted existing tests formatting where needed.

### Testing

- Bootstrapped environment and dependencies with `./env-refresh.sh --deps-only` and installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt`. 
- Ran the focused test set with `.venv/bin/python manage.py test run -- apps/sigils/tests/test_sigil_resolver.py apps/docs/tests/test_rendering.py` and observed all tests pass (`24 passed`). 
- Verified migrations with `.venv/bin/python manage.py migrations check` which reported no changes. 
- Sent review notification using `./scripts/review-notify.sh --actor Codex` as part of the rollout workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1800e2abc8326b76a63e41ac3f8ac)