### PR TITLE
ops: improve security-group table details and checkbox usability in operator journey

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -200,29 +200,29 @@
         }
         .operator-journey-sg-table td:first-child,
         .operator-journey-sg-table th:first-child {
-          width: 84px;
+          width: calc(var(--admin-ui-control-height, 2.5rem) + var(--admin-ui-space-4, 1rem));
         }
         .operator-journey-checkbox {
-          block-size: 1.35rem;
+          block-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-3, 0.75rem));
           cursor: pointer;
-          inline-size: 1.35rem;
+          inline-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-3, 0.75rem));
           margin: 0;
         }
         .operator-journey-checkbox-hitarea {
           align-items: center;
-          border: 1px solid var(--hairline-color);
-          border-radius: 999px;
+          border: 1px solid var(--admin-ui-border-color, var(--hairline-color));
+          border-radius: var(--admin-ui-radius-md, 0.5rem);
           cursor: pointer;
           display: inline-flex;
           justify-content: center;
-          min-height: 2rem;
-          min-width: 2rem;
-          padding: 0.2rem;
+          min-height: var(--admin-ui-control-height-sm, 2.125rem);
+          min-width: var(--admin-ui-control-height-sm, 2.125rem);
+          padding: var(--admin-ui-space-1, 0.25rem);
         }
         .operator-journey-primary-button {
           font-size: 0.95rem;
-          min-height: 2.25rem;
-          padding: 0.55rem 1.1rem;
+          min-height: var(--admin-ui-control-height-sm, 2.125rem);
+          padding: 0 var(--admin-ui-control-padding-x, 0.875rem);
         }
         @media (max-width: 980px) {
           .operator-journey-provision-layout {

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -200,11 +200,24 @@
         }
         .operator-journey-sg-table td:first-child,
         .operator-journey-sg-table th:first-child {
-          width: 72px;
+          width: 84px;
         }
         .operator-journey-checkbox {
-          block-size: 1.15rem;
-          inline-size: 1.15rem;
+          block-size: 1.35rem;
+          cursor: pointer;
+          inline-size: 1.35rem;
+          margin: 0;
+        }
+        .operator-journey-checkbox-hitarea {
+          align-items: center;
+          border: 1px solid var(--hairline-color);
+          border-radius: 999px;
+          cursor: pointer;
+          display: inline-flex;
+          justify-content: center;
+          min-height: 2rem;
+          min-width: 2rem;
+          padding: 0.2rem;
         }
         .operator-journey-primary-button {
           font-size: 0.95rem;
@@ -238,23 +251,26 @@
                 <tr>
                   <th>{% translate "Select" %}</th>
                   <th>{% translate "Security group" %}</th>
-                  <th>{% translate "Short description" %}</th>
+                  <th>{% translate "Staff" %}</th>
+                  <th>{% translate "Apps" %}</th>
                 </tr>
               </thead>
               <tbody>
                 {% for row in security_group_rows %}
                   <tr>
                     <td>
-                      <input class="operator-journey-checkbox" id="id_security_groups_{{ row.id }}" type="checkbox" name="security_groups" value="{{ row.id }}" {% if row.selected %}checked{% endif %}>
+                      <label class="operator-journey-checkbox-hitarea" for="id_security_groups_{{ row.id }}">
+                        <input class="operator-journey-checkbox" id="id_security_groups_{{ row.id }}" type="checkbox" name="security_groups" value="{{ row.id }}" {% if row.selected %}checked{% endif %}>
+                      </label>
                     </td>
                     <td>
                       <label for="id_security_groups_{{ row.id }}"><strong>{{ row.name }}</strong></label>
                     </td>
                     <td>
-                      {{ row.security_model_label }}
-                      {% if row.app %}
-                        <br><span class="help">{% translate "App:" %} {{ row.app }}</span>
-                      {% endif %}
+                      {% if row.is_staff_group %}{% translate "Yes" %}{% else %}{% translate "No" %}{% endif %}
+                    </td>
+                    <td>
+                      {{ row.apps }}
                     </td>
                   </tr>
                 {% endfor %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -266,7 +266,8 @@ class OperatorJourneyViewTests(TestCase):
 
         self.assertContains(response, "Create account and complete step")
         self.assertContains(response, "Security group")
-        self.assertContains(response, "Short description")
+        self.assertContains(response, "Staff")
+        self.assertContains(response, "Apps")
         self.assertContains(response, "User details")
         self.assertContains(response, "id=\"nav-sidebar\"", html=False)
         self.assertNotContains(response, "<iframe", html=False)
@@ -302,6 +303,22 @@ class OperatorJourneyViewTests(TestCase):
             row["id"] for row in security_group_rows if row.get("selected") is True
         }
         self.assertSetEqual(selected_ids, {extra_group.pk})
+
+    def test_security_group_rows_include_staff_flag_and_apps(self):
+        SecurityGroup.objects.create(name=SITE_OPERATOR_GROUP_NAME)
+        SecurityGroup.objects.create(
+            app="billing",
+            name="Custom app group",
+        )
+        provision_form = OperatorJourneyProvisionSuperuserForm()
+
+        security_group_rows = _build_security_group_rows(provision_form)
+
+        rows_by_name = {row["name"]: row for row in security_group_rows}
+        self.assertTrue(rows_by_name[SITE_OPERATOR_GROUP_NAME]["is_staff_group"])
+        self.assertEqual(rows_by_name[SITE_OPERATOR_GROUP_NAME]["apps"], "—")
+        self.assertFalse(rows_by_name["Custom app group"]["is_staff_group"])
+        self.assertEqual(rows_by_name["Custom app group"]["apps"], "billing")
 
     def test_provision_step_creates_superuser_with_assigned_groups(self):
         provision_step = OperatorJourneyStep.objects.create(

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -68,13 +68,24 @@ def _build_security_group_rows(
             }
 
     rows: list[dict[str, object]] = []
-    for group in provision_superuser_form.fields["security_groups"].queryset:
+    for group in (
+        provision_superuser_form.fields["security_groups"]
+        .queryset.prefetch_related("permissions__content_type")
+    ):
+        app_labels = {
+            permission.content_type.app_label
+            for permission in group.permissions.all()
+            if permission.content_type.app_label
+        }
+        if group.app:
+            app_labels.add(group.app)
+        app_names = ", ".join(sorted(app_labels)) if app_labels else "—"
         rows.append(
             {
                 "id": group.pk,
+                "apps": app_names,
+                "is_staff_group": group.is_canonical_staff_group,
                 "name": group.name,
-                "app": group.app,
-                "security_model_label": group.security_model_label,
                 "selected": str(group.pk) in selected_group_ids,
             }
         )


### PR DESCRIPTION
### Motivation

- Replace the prior ambiguous "Short description" SG column with clearer operator-facing data: whether the group is a canonical staff group and which apps are related.  
- Improve the checkbox look and feel and hit area so selecting security groups is more obvious and accessible.  
- Keep operator journey provisioning clearer and reduce follow-up questions when assigning groups during onboarding.

### Description

- Updated `_build_security_group_rows` to prefetch `permissions__content_type` and compute `apps` (comma-separated app labels from permissions + `group.app`) and `is_staff_group` (canonical staff flag).  
- Replaced the template column `Short description` with two columns, `Staff` and `Apps`, rendered as `Yes`/`No` and the comma-separated app list respectively in `operator_journey_step.html`.  
- Improved checkbox UX by increasing checkbox size and wrapping it in a rounded hit-area element with CSS to make it more clickable.  
- Updated tests in `apps.ops.tests.test_operator_journey` to assert the new headings and validate the computed `is_staff_group` and `apps` fields returned by `_build_security_group_rows`.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` which completed successfully.  
- Installed CI test requirements with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.  
- Ran the operator-journey test suite with `.venv/bin/python manage.py test run -- apps.ops.tests.test_operator_journey.py` and observed `23 passed` (all tests in that module passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19c189dc0832695029d43af626ff6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Improve security-group table details and checkbox usability in operator journey

Enhances the operator journey's security-group selection interface to surface operator-relevant data and improve form control accessibility.

### Changes

**Backend logic (`views.py`)**
- Updated `_build_security_group_rows` to prefetch `permissions__content_type` and compute two new fields per security group:
  - `is_staff_group`: Boolean flag indicating whether the group is a canonical staff group
  - `apps`: Comma-separated list of app labels derived from the group's permissions' content types and the group's `app` field; defaults to an em dash (`"—"`) when empty
- Removed `app` and `security_model_label` fields from row data

**Template and UI (`operator_journey_step.html`)**
- Replaced the "Short description" column with two new columns: "Staff" (displays "Yes"/"No" based on `is_staff_group`) and "Apps" (displays comma-separated app list)
- Enhanced checkbox usability by wrapping the checkbox input in a `<label>` element with a new `.operator-journey-checkbox-hitarea` class that provides a rounded, bordered clickable region with improved hit area
- Updated button and checkbox sizing to use admin UI design tokens for consistency, replacing fixed pixel values

**Tests (`test_operator_journey.py`)**
- Updated existing assertions to expect "Staff" and "Apps" table headers instead of "Short description"
- Added regression test validating:
  - Staff operator security groups display `is_staff_group=True` with `apps="—"`
  - Custom app-backed security groups display `is_staff_group=False` with the corresponding app label in the `apps` field

### Testing
- All 23 tests in `apps.ops.tests.test_operator_journey` pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->