### PR TITLE
widgets: remove required feature changelist filter

### DIFF
--- a/apps/widgets/admin.py
+++ b/apps/widgets/admin.py
@@ -28,6 +28,7 @@ class WidgetAdmin(EntityModelAdmin):
         "priority",
     )
     list_filter = ("zone", "is_enabled")
+    list_select_related = ("zone", "required_feature")
     search_fields = ("name", "slug", "renderer_path")
     ordering = ("priority", "name")
 

--- a/apps/widgets/admin.py
+++ b/apps/widgets/admin.py
@@ -27,7 +27,7 @@ class WidgetAdmin(EntityModelAdmin):
         "visibility_for_current_user",
         "priority",
     )
-    list_filter = ("zone", "required_feature", "is_enabled")
+    list_filter = ("zone", "is_enabled")
     search_fields = ("name", "slug", "renderer_path")
     ordering = ("priority", "name")
 

--- a/apps/widgets/tests/test_admin.py
+++ b/apps/widgets/tests/test_admin.py
@@ -1,5 +1,11 @@
+from django.contrib import admin
+
 from apps.widgets.admin import WidgetAdmin
+from apps.widgets.models import Widget
 
 
-def test_widget_admin_filters_hide_required_feature_filter():
-    assert WidgetAdmin.list_filter == ("zone", "is_enabled")
+def test_widget_admin_registration_and_filters():
+    model_admin = admin.site._registry.get(Widget)
+
+    assert isinstance(model_admin, WidgetAdmin)
+    assert model_admin.list_filter == ("zone", "is_enabled")

--- a/apps/widgets/tests/test_admin.py
+++ b/apps/widgets/tests/test_admin.py
@@ -1,0 +1,5 @@
+from apps.widgets.admin import WidgetAdmin
+
+
+def test_widget_admin_filters_hide_required_feature_filter():
+    assert WidgetAdmin.list_filter == ("zone", "is_enabled")


### PR DESCRIPTION
### Motivation
- Remove the `By required feature` filter from the widgets changelist so the admin view for `Widget` no longer exposes the `required_feature` filter column in the sidebar.

### Description
- Remove `required_feature` from `WidgetAdmin.list_filter` in `apps/widgets/admin.py` and add a small regression test asserting `WidgetAdmin.list_filter` is `("zone", "is_enabled")` in `apps/widgets/tests/test_admin.py`.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only`, installed CI test deps with `.venv/bin/pip install -r requirements-ci.txt`, and ran `./.venv/bin/python manage.py test run -- apps/widgets/tests/test_admin.py apps/widgets/tests/test_services.py`, which completed with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19e3d0900832693ea55677ba14678)