### PR TITLE
docs: add UI design guidance for touch targets in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,16 @@ Code within test modules is exempt unless a comment or docstring is needed to cl
 
 ---
 
+## UI Design Notes
+
+When implementing UI updates for Arthexis:
+
+* Avoid hardcoded `rem` values for touch target sizing.
+* Prefer shared CSS variables (design tokens) from the admin UI framework to keep sizing and spacing consistent across the suite.
+* Keep design choices aligned with Arthexis admin usability and consistency needs, prioritizing cohesive behavior across apps over one-off local styling.
+
+---
+
 # Testing Policy
 
 Agents must run relevant tests after code changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,9 +130,10 @@ Code within test modules is exempt unless a comment or docstring is needed to cl
 
 When implementing UI updates for Arthexis:
 
-* Avoid hardcoded `rem` values for touch target sizing.
+* Avoid hardcoded values (for example `rem` or `px`) for UI styling, especially touch target sizing.
 * Prefer shared CSS variables (design tokens) from the admin UI framework to keep sizing and spacing consistent across the suite.
 * Keep design choices aligned with Arthexis admin usability and consistency needs, prioritizing cohesive behavior across apps over one-off local styling.
+* Prioritize clarity over conciseness for UI labels; prefer descriptive labels over ambiguous short toggles when possible.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Capture repository-wide UI guidance so Arthexis UI updates avoid hardcoded `rem` touch targets and use shared design tokens for consistent admin UX.

### Description

- Add a new `UI Design Notes` section to `AGENTS.md` that advises avoiding hardcoded `rem` values for touch target sizing, preferring shared CSS variables (design tokens) from the admin UI framework, and keeping UI decisions aligned with suite-wide admin consistency.

### Testing

- Ran `git diff --check` with no issues found. 
- Ran `./scripts/review-notify.sh --actor Codex` which exited with a "Skipped review notification: no reviewable git changes detected" message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a1078da48326bbd6d27bfecea527)