### PR TITLE
ops/sites: auto-complete one-time operator steps and enrich feedback copy

### DIFF
--- a/apps/ops/operator_journey.py
+++ b/apps/ops/operator_journey.py
@@ -11,6 +11,11 @@ from apps.groups.security import ensure_default_staff_groups
 
 from .models import OperatorJourneyStep, OperatorJourneyStepCompletion
 
+ROLE_VALIDATION_STEP_SLUG = "validate-local-node-role"
+PROVISION_SUPERUSER_STEP_SLUG = "provision-ops-superuser"
+ONE_TIME_STEP_SLUGS = {PROVISION_SUPERUSER_STEP_SLUG, ROLE_VALIDATION_STEP_SLUG}
+BOOTSTRAP_ADMIN_USERNAMES = {"admin", "admi"}
+
 
 @dataclass(frozen=True)
 class OperatorJourneyStatus:
@@ -29,7 +34,7 @@ def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
     if not user.is_authenticated:
         return None
 
-    return (
+    remaining_steps = (
         OperatorJourneyStep.objects.filter(
             is_active=True,
             journey__is_active=True,
@@ -38,8 +43,13 @@ def next_step_for_user(*, user: AbstractBaseUser) -> OperatorJourneyStep | None:
         .exclude(completions__user=user)
         .select_related("journey")
         .order_by("journey__priority", "journey__name", "order", "id")
-        .first()
     )
+    for step in remaining_steps:
+        if _step_is_already_satisfied(user=user, step=step):
+            OperatorJourneyStepCompletion.objects.get_or_create(user=user, step=step)
+            continue
+        return step
+    return None
 
 
 def complete_step_for_user(*, user: AbstractBaseUser, step: OperatorJourneyStep) -> bool:
@@ -103,3 +113,33 @@ def _active_security_groups_for_user(user: AbstractBaseUser):
     if user.is_staff:
         ensure_default_staff_groups(user)
     return user.groups.all()
+
+
+def _step_is_already_satisfied(*, user: AbstractBaseUser, step: OperatorJourneyStep) -> bool:
+    """Return whether ``step`` was already completed at node level."""
+
+    if step.slug in ONE_TIME_STEP_SLUGS and step.completions.exists():
+        return True
+    if step.slug == ROLE_VALIDATION_STEP_SLUG:
+        return _local_node_role_is_available()
+    if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
+        return _current_user_is_operational_staff(user=user)
+    return False
+
+
+def _local_node_role_is_available() -> bool:
+    try:
+        from apps.nodes.models import Node
+    except (ImportError, LookupError):
+        return False
+
+    local_node = Node.get_local()
+    return bool(local_node and getattr(local_node, "role_id", None))
+
+
+def _current_user_is_operational_staff(*, user: AbstractBaseUser) -> bool:
+    if not user.is_authenticated or not user.is_staff or user.is_superuser:
+        return False
+    if getattr(user, "is_deleted", False):
+        return False
+    return (user.username or "").strip().lower() not in BOOTSTRAP_ADMIN_USERNAMES

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1,5 +1,7 @@
 """Regression tests for operator journey progression and admin dashboard surfacing."""
 
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.template import Context, Template
@@ -10,7 +12,13 @@ from apps.groups.models import SecurityGroup
 from apps.nodes.models import NodeRole
 from apps.ops.forms import OperatorJourneyProvisionSuperuserForm
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
-from apps.ops.operator_journey import complete_step_for_user, status_for_user
+from apps.ops.operator_journey import (
+    PROVISION_SUPERUSER_STEP_SLUG,
+    ROLE_VALIDATION_STEP_SLUG,
+    complete_step_for_user,
+    next_step_for_user,
+    status_for_user,
+)
 from apps.ops.views import (
     _build_node_role_validation_summary,
     _build_security_group_rows,
@@ -83,6 +91,77 @@ class OperatorJourneyFlowTests(TestCase):
         completed = complete_step_for_user(user=self.user, step=self.step_2)
 
         self.assertFalse(completed)
+
+    @patch("apps.ops.operator_journey._local_node_role_is_available", return_value=True)
+    def test_next_step_skips_provision_for_non_superuser_operational_staff(
+        self, _mock_role_check
+    ):
+        role_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Validate node",
+            slug=ROLE_VALIDATION_STEP_SLUG,
+            instruction="Validate local node role.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create operational superuser",
+            slug=PROVISION_SUPERUSER_STEP_SLUG,
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=4,
+        )
+        follow_up_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Follow-up",
+            slug="follow-up-step",
+            instruction="Continue setup.",
+            iframe_url="/admin/",
+            order=5,
+        )
+        staff_user = get_user_model().objects.create_user(
+            username="existing-operator",
+            password="x",
+            is_staff=True,
+        )
+        staff_user.groups.add(self.group)
+        complete_step_for_user(user=staff_user, step=self.step_1)
+        complete_step_for_user(user=staff_user, step=self.step_2)
+
+        next_step = next_step_for_user(user=staff_user)
+
+        self.assertEqual(next_step, follow_up_step)
+        self.assertTrue(provision_step.completions.filter(user=staff_user).exists())
+        self.assertTrue(role_step.completions.filter(user=staff_user).exists())
+
+    @patch("apps.ops.operator_journey._local_node_role_is_available", return_value=True)
+    def test_next_step_skips_role_validation_when_local_node_role_exists(
+        self, _mock_role_check
+    ):
+        role_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Validate node",
+            slug=ROLE_VALIDATION_STEP_SLUG,
+            instruction="Validate local node role.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        follow_up_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Follow-up",
+            slug="follow-up-step",
+            instruction="Continue setup.",
+            iframe_url="/admin/",
+            order=4,
+        )
+        complete_step_for_user(user=self.user, step=self.step_1)
+        complete_step_for_user(user=self.user, step=self.step_2)
+
+        next_step = next_step_for_user(user=self.user)
+
+        self.assertEqual(next_step, follow_up_step)
+        self.assertTrue(role_step.completions.filter(user=self.user).exists())
 
 
 class OperatorJourneyViewTests(TestCase):
@@ -587,7 +666,7 @@ class OperatorJourneyViewTests(TestCase):
             get_user_model().objects.filter(username="ops-not-allowed").exists()
         )
 
-    def test_non_superuser_staff_cannot_view_or_submit_provision_step(self):
+    def test_non_superuser_staff_auto_completes_provision_step(self):
         provision_step = OperatorJourneyStep.objects.create(
             journey=self.journey,
             title="Create ops superuser",
@@ -621,7 +700,8 @@ class OperatorJourneyViewTests(TestCase):
         view_response = self.client.get(
             reverse("ops:operator-journey-step", args=[provision_step.pk])
         )
-        self.assertEqual(view_response.status_code, 403)
+        self.assertEqual(view_response.status_code, 200)
+        self.assertContains(view_response, "Operator journey complete")
 
         submit_response = self.client.post(
             reverse("ops:operator-journey-step-complete", args=[provision_step.pk]),
@@ -631,7 +711,8 @@ class OperatorJourneyViewTests(TestCase):
                 "password_mode": "random",
             },
         )
-        self.assertEqual(submit_response.status_code, 403)
+        self.assertEqual(submit_response.status_code, 302)
+        self.assertRedirects(submit_response, reverse("admin:index"))
         self.assertFalse(
             get_user_model().objects.filter(username="ops-should-not-create").exists()
         )

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -246,6 +246,49 @@
     return `In ${pageLabel} (\`${window.location.href}\`)`;
   };
 
+  const getAdminDashboardNextTask = () => {
+    const nextTaskNode = document.querySelector(
+      '.admin-home-operator-journey__link, .admin-home-operator-journey__text',
+    );
+    if (!nextTaskNode) {
+      return '';
+    }
+    return nextTaskNode.textContent.replace(/\s+/g, ' ').trim();
+  };
+
+  const getAdminDashboardNetMessage = () => {
+    const netMessageNode = document.querySelector('.admin-home-net-message__content');
+    if (!netMessageNode) {
+      return '';
+    }
+    return netMessageNode.textContent.replace(/\s+/g, ' ').trim();
+  };
+
+  const getRoleSiteNodeSummary = () => {
+    const badgeNodes = document.querySelectorAll('#site-badges .badge');
+    if (!badgeNodes.length) {
+      return '';
+    }
+    const valuesByLabel = {};
+    badgeNodes.forEach(badgeNode => {
+      const labelNode = badgeNode.querySelector('.badge-link');
+      const valueNode = badgeNode.querySelector('.badge-link-value');
+      if (!labelNode || !valueNode) {
+        return;
+      }
+      const normalizedLabel = labelNode.textContent.replace(':', '').trim().toLowerCase();
+      const badgeValue = valueNode.textContent.replace(/\s+/g, ' ').trim();
+      if (normalizedLabel && badgeValue) {
+        valuesByLabel[normalizedLabel] = badgeValue;
+      }
+    });
+    const role = valuesByLabel.role || '';
+    const site = valuesByLabel.site || '';
+    const node = valuesByLabel.node || '';
+    const summaryParts = [role, site, node].filter(Boolean);
+    return summaryParts.join(' / ');
+  };
+
   const getFieldLabel = fieldName => {
     if (fieldName === 'rating') {
       const ratingLabel = document.getElementById('user-story-rating-group-label');
@@ -326,6 +369,18 @@
       return baseValue;
     }
     const details = getFormDetails();
+    const nextOpsTask = getAdminDashboardNextTask();
+    const netMessage = getAdminDashboardNetMessage();
+    const roleSiteNode = getRoleSiteNodeSummary();
+    if (nextOpsTask) {
+      details.push(`Next: ${nextOpsTask}`);
+    }
+    if (netMessage) {
+      details.push(`Net Message: ${netMessage}`);
+    }
+    if (roleSiteNode) {
+      details.push(`Role / Site / Node: ${roleSiteNode}`);
+    }
     if (securityGroups) {
       details.push(`Security groups: ${securityGroups}`);
     }


### PR DESCRIPTION
### Motivation

- Avoid repeatedly asking admins to redo operator onboarding tasks that are once-per-node or already satisfied by the local environment.
- Improve feedback payloads so staff can copy context-rich details from the admin dashboard (next ops task, current Net Message, role/site/node summary) into feedback submissions.

### Description

- Add auto-completion checks in `apps/ops/operator_journey.py` to skip or mark as satisfied steps that are one-time or already satisfied: `validate-local-node-role` and `provision-ops-superuser`, plus a small set of bootstrap username guards (`BOOTSTRAP_ADMIN_USERNAMES`).
- Auto-record completions for seeded one-time steps when they are already satisfied at the node/user level via `_step_is_already_satisfied`, `_local_node_role_is_available`, and `_current_user_is_operational_staff` helpers.
- Update operator-journey tests in `apps/ops/tests/test_operator_journey.py` to exercise the new auto-complete behavior and to adjust expectations for non-superuser staff flows.
- Enhance feedback copy generation in `apps/sites/static/pages/js/user_story_feedback.js` to include `Next: <Ops task>`, `Net Message: <current net message>`, and `Role / Site / Node: <badge summary>` when available and when staff details may be copied.

### Testing

- Ran the operator-journey and feedback form tests with `./env-refresh.sh --deps-only` then `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py apps/sites/tests/test_user_story_feedback_form.py`, which passed (`29 passed`).
- Verified migrations with `.venv/bin/python manage.py migrations check` (no changes detected). 
- Installed CI dependencies with `.venv/bin/pip install -r requirements-ci.txt` and executed review notification with `./scripts/review-notify.sh --actor Codex`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19dfbe2d88326a0bd37f3212b0cc1)