### PR TITLE
sites: fix admin username profile link fallback

### DIFF
--- a/apps/sites/templatetags/admin_extras.py
+++ b/apps/sites/templatetags/admin_extras.py
@@ -207,7 +207,9 @@ def admin_profile_url(context, user) -> str:
         pass
 
     if teams_user and teams_user in admin.site._registry:
-        return model_profile_url(teams_user)
+        teams_url = model_profile_url(teams_user)
+        if teams_url:
+            return teams_url
 
     candidate_models = (
         ("core", "User"),

--- a/apps/sites/tests/test_admin_profile_url.py
+++ b/apps/sites/tests/test_admin_profile_url.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from apps.sites.templatetags import admin_extras
+
+
+class _Model:
+    def __init__(self, app_label, model_name):
+        self._meta = SimpleNamespace(app_label=app_label, model_name=model_name)
+
+
+class _ModelAdmin:
+    def __init__(self, model):
+        self.model = model
+
+
+def test_admin_profile_url_falls_back_when_teams_user_not_resolvable(monkeypatch):
+    teams_model = _Model("teams", "user")
+    core_model = _Model("core", "user")
+    user = SimpleNamespace(pk=42)
+
+    registry = {
+        teams_model: _ModelAdmin(teams_model),
+        core_model: _ModelAdmin(core_model),
+    }
+
+    def fake_get_model(app_label, model_name):
+        if (app_label, model_name) == ("teams", "User"):
+            return teams_model
+        if (app_label, model_name) == ("core", "User"):
+            return core_model
+        raise LookupError
+
+    def fake_admin_model_instance(model_admin, request, candidate_user):
+        if model_admin.model is teams_model:
+            return None
+        return candidate_user
+
+    monkeypatch.setattr(admin_extras.apps, "get_model", fake_get_model)
+    monkeypatch.setattr(admin_extras.admin.site, "_registry", registry)
+    monkeypatch.setattr(admin_extras, "_admin_model_instance", fake_admin_model_instance)
+    monkeypatch.setattr(admin_extras, "_admin_has_access", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        admin_extras,
+        "_admin_change_url",
+        lambda model, candidate_user: f"/admin/{model._meta.app_label}/{model._meta.model_name}/{candidate_user.pk}/change/",
+    )
+
+    url = admin_extras.admin_profile_url({"request": object()}, user)
+
+    assert url == "/admin/core/user/42/change/"


### PR DESCRIPTION
### Motivation

- The admin username/profile link could be missing when a `teams.User` admin is registered in `admin.site._registry` but does not resolve for the current user, preventing clickable access to the user change view.

### Description

- Change `admin_profile_url` in `apps/sites/templatetags/admin_extras.py` to return the `teams.User` change URL only when it actually resolves, and otherwise continue to fall back to `core.User` and `auth.User`.
- Add a regression test `apps/sites/tests/test_admin_profile_url.py` that simulates a registered `teams.User` admin entry which does not resolve and asserts the helper falls back to the `core.User` change URL.

### Testing

- Ran the new unit test with `.venv/bin/python manage.py test run -- apps/sites/tests/test_admin_profile_url.py`, which initially failed due to missing `pytest` but passed after installing test dependencies; final result: test passed.
- The test run covering the change succeeded: `1 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a20b08b88326b0a6e21ea83a2433)