### PR TITLE
Add preflight environment check for QA/test command paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -129,6 +130,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 -m "critical and not integration" | tee pytest.log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Install CI dependencies
         run: |
+          ./scripts/preflight-env.sh
           source .venv/bin/activate
           python -m pip install --only-binary=:all: -r requirements-ci.txt
       - name: Verify editable install import
@@ -108,8 +109,8 @@ jobs:
       - name: Validate upgraded migrations
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh
+          source .venv/bin/activate
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -129,8 +130,8 @@ jobs:
       - name: Run critical auto-upgrade checks
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 -m "critical and not integration" | tee pytest.log
 

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -83,6 +83,7 @@ jobs:
           ./install.sh ${{ matrix.install_args }} --no-start
       - name: Install CI dependencies
         run: |
+          ./scripts/preflight-env.sh
           source .venv/bin/activate
           python -m pip install --only-binary=:all: -r requirements-ci.txt
       - name: Verify editable install import
@@ -91,8 +92,8 @@ jobs:
           python scripts/check_editable_install_import.py
       - name: Validate migrations
         run: |
-          source .venv/bin/activate
           ./scripts/preflight-env.sh
+          source .venv/bin/activate
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -113,8 +114,8 @@ jobs:
           python scripts/check_import_resolution.py
       - name: Validate installed app manifests
         run: |
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           manifest_test_file="tests/test_installed_apps_manifests.py"
           if [[ -f "$manifest_test_file" ]]; then
             python -m pytest "$manifest_test_file" -q
@@ -143,16 +144,16 @@ jobs:
       - name: Run install smoke tests
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 --junitxml=pytest-junit.xml -m "not critical and not slow and not integration" | tee pytest.log
       - name: Run install critical smoke tests
         if: always()
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           critical_smoke_tests=(
             "apps/netmesh/tests/test_api.py::test_netmesh_token_lifecycle_errors_are_stable"
             "apps/ocpp/tests/test_charger_status_polling.py::test_dedupe_event_rows_keeps_newest_status_for_out_of_order_retry_collisions"

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Validate migrations
         run: |
           source .venv/bin/activate
+          ./scripts/preflight-env.sh
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -113,6 +114,7 @@ jobs:
       - name: Validate installed app manifests
         run: |
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           manifest_test_file="tests/test_installed_apps_manifests.py"
           if [[ -f "$manifest_test_file" ]]; then
             python -m pytest "$manifest_test_file" -q
@@ -142,6 +144,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 --junitxml=pytest-junit.xml -m "not critical and not slow and not integration" | tee pytest.log
       - name: Run install critical smoke tests
@@ -149,6 +152,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           critical_smoke_tests=(
             "apps/netmesh/tests/test_api.py::test_netmesh_token_lifecycle_errors_are_stable"
             "apps/ocpp/tests/test_charger_status_polling.py::test_dedupe_event_rows_keeps_newest_status_for_out_of_order_retry_collisions"

--- a/.github/workflows/pr-critical.yml
+++ b/.github/workflows/pr-critical.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -109,6 +110,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 -m "critical and not integration" | tee pytest.log
 

--- a/.github/workflows/pr-critical.yml
+++ b/.github/workflows/pr-critical.yml
@@ -82,14 +82,15 @@ jobs:
 
       - name: Install CI dependencies
         run: |
+          ./scripts/preflight-env.sh
           source .venv/bin/activate
           python -m pip install --only-binary=:all: -r requirements-ci.txt
 
       - name: Validate migrations
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh
+          source .venv/bin/activate
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -109,8 +110,8 @@ jobs:
       - name: Run critical tests
         run: |
           set -Eeuo pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 -m "critical and not integration" | tee pytest.log
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,20 +54,21 @@ jobs:
           ./install.sh --no-start
       - name: Validate migrations
         run: |
-          source .venv/bin/activate
           ./scripts/preflight-env.sh
+          source .venv/bin/activate
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
       - name: Install CI dependencies
         run: |
+          ./scripts/preflight-env.sh
           source .venv/bin/activate
           python -m pip install --only-binary=:all: -r requirements-ci.txt
       - name: Run tests
         run: |
           set -o pipefail
-          source .venv/bin/activate
           ./scripts/preflight-env.sh --pytest
+          source .venv/bin/activate
           python -m pytest --maxfail=1 --disable-warnings -q --timeout=180 | tee pytest.log
       - name: Upload pytest log
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Validate migrations
         run: |
           source .venv/bin/activate
+          ./scripts/preflight-env.sh
           python scripts/check_migration_conflicts.py
           python manage.py migrations check
           python manage.py migrate --noinput --database default
@@ -66,6 +67,7 @@ jobs:
         run: |
           set -o pipefail
           source .venv/bin/activate
+          ./scripts/preflight-env.sh --pytest
           python -m pytest --maxfail=1 --disable-warnings -q --timeout=180 | tee pytest.log
       - name: Upload pytest log
         if: always()

--- a/docs/development/ci-troubleshooting.md
+++ b/docs/development/ci-troubleshooting.md
@@ -17,6 +17,7 @@ Arthexis keeps settings module import lean by validating `PROJECT_LOCAL_APPS` wi
 Run this check locally before opening a PR and in CI guardrail steps:
 
 ```bash
+./scripts/preflight-env.sh
 .venv/bin/python manage.py check --tag core
 ```
 

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -6,6 +6,11 @@ BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_BIN="$BASE_DIR/.venv/bin/python"
 REQUIRED_MODULES=("django")
 
+if [[ $# -gt 1 ]]; then
+  echo "Too many arguments provided." >&2
+  exit 1
+fi
+
 if [[ "${1:-}" == "--pytest" ]]; then
   REQUIRED_MODULES+=("pytest")
 elif [[ "${1:-}" == "--help" ]]; then
@@ -34,11 +39,16 @@ fi
 if ! "$PYTHON_BIN" - "${REQUIRED_MODULES[@]}" <<'PY'
 from __future__ import annotations
 
-import importlib.util
+import importlib
 import sys
 
 required_modules = tuple(sys.argv[1:])
-missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
+missing = []
+for name in required_modules:
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        missing.append(name)
 if missing:
     print(
         "Required Python tooling not importable: "

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_BIN="$BASE_DIR/.venv/bin/python"
+REQUIRED_MODULES=("django")
+
+if [[ "${1:-}" == "--pytest" ]]; then
+  REQUIRED_MODULES+=("pytest")
+elif [[ "${1:-}" == "--help" ]]; then
+  cat <<'USAGE'
+Usage: ./scripts/preflight-env.sh [--pytest]
+
+Checks that:
+  - .venv/bin/python exists and is executable
+  - required Python tooling is importable for Arthexis entrypoints
+
+Options:
+  --pytest  additionally require pytest to be importable
+USAGE
+  exit 0
+elif [[ $# -gt 0 ]]; then
+  echo "Unknown option: $1" >&2
+  exit 1
+fi
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo ".venv/bin/python missing: expected executable at $PYTHON_BIN" >&2
+  echo "Run ./env-refresh.sh --deps-only" >&2
+  exit 1
+fi
+
+if ! "$PYTHON_BIN" - "${REQUIRED_MODULES[@]}" <<'PY'
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+required_modules = tuple(sys.argv[1:])
+missing = [name for name in required_modules if importlib.util.find_spec(name) is None]
+if missing:
+    print(
+        "Required Python tooling not importable: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+then
+  echo "Run ./env-refresh.sh --deps-only" >&2
+  exit 1
+fi

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -7,7 +7,8 @@ export CELERY_LOG_LEVEL="${CELERY_LOG_LEVEL:-WARNING}"
 export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
-./scripts/preflight-env.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/preflight-env.sh"
 
 PYTHON_BIN=".venv/bin/python"
 mypy_output="$(mktemp)"

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -7,6 +7,8 @@ export CELERY_LOG_LEVEL="${CELERY_LOG_LEVEL:-WARNING}"
 export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
+./scripts/preflight-env.sh
+
 PYTHON_BIN=".venv/bin/python"
 mypy_output="$(mktemp)"
 cleanup() {


### PR DESCRIPTION
### Motivation

- Prevent long-running CI steps and confusing failures by validating the local Python runtime and required tooling before running QA/test entrypoints. 
- Provide clear, searchable failure markers so missing-venv and missing-deps failures are self-explanatory in CI logs. 
- Keep default checks lightweight for most commands while allowing stricter checks for test runs that need `pytest`.

### Description

- Add `scripts/preflight-env.sh`, a small shell gate that ensures `.venv/bin/python` is executable and validates importability of required Python modules, emitting `.venv/bin/python missing` and `Run ./env-refresh.sh --deps-only` on failure. 
- Make the script accept `--pytest` to require `pytest` in addition to `django`, and provide `--help` usage text. 
- Invoke the preflight from `scripts/run_mypy.sh` so static checks fail fast when the environment is not ready. 
- Wire the preflight into CI/test workflows by calling `./scripts/preflight-env.sh` (or `--pytest` where appropriate) in `.github/workflows/ci.yml`, `.github/workflows/pr-critical.yml`, `.github/workflows/install-hourly.yml`, and `.github/workflows/publish.yml`, and update `docs/development/ci-troubleshooting.md` to show the preflight-first command pattern.

### Testing

- Ran environment bootstrap: `./env-refresh.sh --deps-only` (succeeded). 
- Verified the preflight gate locally: `./scripts/preflight-env.sh` and `./scripts/preflight-env.sh --pytest` after installing CI deps (succeeded). 
- Performed syntax checks: `bash -n scripts/preflight-env.sh scripts/run_mypy.sh` (succeeded). 
- Executed the downstream commands used in validation: `.venv/bin/python -m pip install --only-binary=:all: -r requirements-ci.txt`, `./scripts/run_mypy.sh --version`, and `./scripts/review-notify.sh --actor Codex` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1aae0493483268d9e0ca8d8294321)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces a preflight environment verification script that performs fast-fail checks on the Python virtual environment and required dependencies before running CI/QA commands. The script is integrated into CI workflows and local development scripts to catch missing virtualenv or dependencies early, avoiding long CI runs with unclear failure messages.

## New Script: `scripts/preflight-env.sh`
Added a new Bash script that:
- Verifies `.venv/bin/python` is executable, with clear guidance to run `./env-refresh.sh --deps-only` if missing
- Validates importability of required Python modules (`django`, and optionally `pytest`)
- Supports `--pytest` flag to add pytest to the required imports
- Supports `--help` flag for usage information
- Exits with status 1 on any validation failure

## Integration Points
**CI Workflows:** Added preflight checks to:
- `.github/workflows/ci.yml` (3 steps: installing CI deps, validating migrations, running critical pytest)
- `.github/workflows/install-hourly.yml` (5 steps: dependencies, migration checks, manifest validation, smoke tests)
- `.github/workflows/pr-critical.yml` (3 steps: dependencies, migrations, critical tests)
- `.github/workflows/publish.yml` (test job: migrations, dependencies, pytest)

Each integration invokes the preflight script (with `--pytest` where appropriate) before virtualenv activation and dependency installation.

**Local Scripts:**
- `scripts/run_mypy.sh`: Now sources the preflight script before running mypy

**Documentation:**
- `docs/development/ci-troubleshooting.md`: Updated to document the preflight-first pattern in command sequences

## Testing
Local verification performed: environment refresh, preflight script execution with/without `--pytest`, bash syntax checking, and downstream command execution (`run_mypy --version`, pip operations, review-notify).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->