### PR TITLE
Normalize test command guidance around manage.py test run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,10 @@ Agents must run relevant tests after code changes.
 * Execute tests and **fix errors introduced by changes**.
 * Prefer validated repository entrypoints over ad-hoc interpreter calls. Run `./env-refresh.sh --deps-only` before Django or pytest commands when the environment may be unbootstrapped.
 * Use `.venv/bin/python` (or the repo's validated wrapper/management entrypoints) instead of bare `python` when invoking `manage.py` or `pytest` directly.
-* Prefer `.venv/bin/python manage.py test run -- ...` and `.venv/bin/python manage.py migrations check` when those entrypoints cover the task.
+* Canonical app-test command for this repository: `.venv/bin/python manage.py test run -- <target>`.
+* Use direct `pytest` only where this repository already requires it:
+  * CI workflow internals under `.github/workflows/`.
+  * pytest-backed command/helper implementation code (for example `apps/tests/management/commands/test.py` and `utils/devtools/test_server.py`).
 * Use `.venv/bin/python manage.py ...` for development and test workflows; use `./command.sh ...` only for operator-facing runtime actions when applicable.
 * If `.venv/bin/python` is unavailable, use the repository's validated wrapper or management entrypoint.
 * Avoid creating tests for **micro-behaviors** unless:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Agents must run relevant tests after code changes.
 * Execute tests and **fix errors introduced by changes**.
 * Prefer validated repository entrypoints over ad-hoc interpreter calls. Run `./env-refresh.sh --deps-only` before Django or pytest commands when the environment may be unbootstrapped.
 * Use `.venv/bin/python` (or the repo's validated wrapper/management entrypoints) instead of bare `python` when invoking `manage.py` or `pytest` directly.
-* Canonical app-test command for this repository: `.venv/bin/python manage.py test run -- <target>`.
+* Use the canonical app-test command for this repository: `.venv/bin/python manage.py test run -- <target>`.
 * Use direct `pytest` only where this repository already requires it:
   * CI workflow internals under `.github/workflows/`.
   * pytest-backed command/helper implementation code (for example `apps/tests/management/commands/test.py` and `utils/devtools/test_server.py`).

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -18,7 +18,7 @@ from utils.python_env import resolve_project_python
 class Command(BaseCommand):
     """Run local test workflows from a single command entrypoint."""
 
-    help = "Run pytest or launch the long-running VS Code test server."
+    help = "Run suite tests via the canonical manage.py entrypoint or launch the VS Code test server."
 
     def add_arguments(self, parser) -> None:
         """Register command arguments and subcommands."""
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         subparsers = parser.add_subparsers(dest="action")
         parser.set_defaults(action="run", pytest_args=[])
 
-        run_parser = subparsers.add_parser("run", help="Run pytest.")
+        run_parser = subparsers.add_parser("run", help="Run tests (pytest-backed).")
         run_parser.add_argument(
             "pytest_args",
             nargs=argparse.REMAINDER,

--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -20,7 +20,7 @@ Use this as the default in local QA and agent workflows.
 | Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
 | Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
 | CI pipelines | `python -m pytest ...` inside workflow jobs | Valid in CI workflow implementation where jobs already manage interpreter/bootstrap lifecycle. |
-| Troubleshooting missing deps | `./env-refresh.sh --deps-only` then rerun canonical command | Run when environment may be unbootstrapped. |
+| Troubleshooting missing deps | `./env-refresh.sh --deps-only` | Run when environment may be unbootstrapped; then rerun the canonical command. |
 | Troubleshooting command behavior | `.venv/bin/python manage.py test run -- <target> -k <pattern>` | Troubleshoot through the same canonical entrypoint first. |
 | Direct local pytest | `.venv/bin/python -m pytest ...` | Allowed only for low-level debugging of pytest/plugin behavior or when developing pytest-backed helpers. Prefer recording reproductions with the canonical management command in PR notes. |
 

--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -1,0 +1,34 @@
+# Command Matrix
+
+This matrix defines the allowed test and QA command paths for Arthexis contributors and agents.
+
+## Canonical command path
+
+For local app-targeted test runs, use:
+
+```bash
+.venv/bin/python manage.py test run -- <target>
+```
+
+Use this as the default in local QA and agent workflows.
+
+## Allowed commands by context
+
+| Context | Allowed command(s) | Notes |
+| --- | --- | --- |
+| Local QA (app tests) | `.venv/bin/python manage.py test run -- <target>` | Canonical path for app test execution. |
+| Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
+| Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
+| CI pipelines | `python -m pytest ...` inside workflow jobs | Valid in CI workflow implementation where jobs already manage interpreter/bootstrap lifecycle. |
+| Troubleshooting missing deps | `./env-refresh.sh --deps-only` then rerun canonical command | Run when environment may be unbootstrapped. |
+| Troubleshooting command behavior | `.venv/bin/python manage.py test run -- <target> -k <pattern>` | Troubleshoot through the same canonical entrypoint first. |
+| Direct local pytest | `.venv/bin/python -m pytest ...` | Allowed only for low-level debugging of pytest/plugin behavior or when developing pytest-backed helpers. Prefer recording reproductions with the canonical management command in PR notes. |
+
+## Where direct `pytest` is valid
+
+Direct `pytest` remains valid in two places:
+
+1. CI workflow internals under `.github/workflows/`.
+2. Implementation and maintenance of pytest-backed helper tooling (for example `apps/tests/management/commands/test.py` and `utils/devtools/test_server.py`).
+
+Outside those cases, default to `.venv/bin/python manage.py test run -- <target>`.

--- a/docs/development/devtools-entrypoints.md
+++ b/docs/development/devtools-entrypoints.md
@@ -8,3 +8,9 @@ Developer launcher modules under `utils/devtools/` should be invoked through the
 For cron jobs, systemd units, editor tasks, and other non-interactive launchers, set the working directory to the checkout root before calling these commands. The removed `scripts/*.py` shims inferred the repository root automatically, but the module entrypoints require the repository root to already be the current working directory.
 
 Editor configs and shell scripts should target these module entrypoints directly rather than the removed compatibility shims in `scripts/`.
+
+For regular local app-test execution, prefer the canonical command path:
+
+- `.venv/bin/python manage.py test run -- <target>`
+
+Use direct `pytest` only for devtool/helper maintenance where the implementation itself is pytest-backed.

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,7 @@ For release confidence criteria and maturity semantics, see the [Versioning and 
 For targeted notes about notable test-suite decisions and historical changes, see the dedicated testing notes document:
 
 - [Test Suite Notes](../docs/development/testing/test-suite-notes.md)
+- [Command Matrix](../docs/development/command-matrix.md)
 
 ## License and Sponsorship
 


### PR DESCRIPTION
### Motivation

* Consolidate agent-facing guidance and test helpers to a single canonical command to reduce confusion and accidental ad-hoc pytest usage. 
* Ensure agents and contributors use the same validated repository entrypoint for app tests so CI and local workflows are consistent. 
* Document explicit exceptions where direct `pytest` remains valid (CI internals and pytest-backed helper implementations). 
* Provide an easily discoverable "Command Matrix" for local QA, CI, and troubleshooting workflows.

### Description

* Updated `AGENTS.md` to declare the canonical app-test command as `.venv/bin/python manage.py test run -- <target>` and to scope allowed direct-`pytest` usage to CI internals and pytest-backed helper code. 
* Added `docs/development/command-matrix.md` with a concise Command Matrix that enumerates allowed commands by context and documents where direct `pytest` is valid. 
* Aligned developer docs by adding guidance to `docs/development/devtools-entrypoints.md` and linking the new Command Matrix from `tests/README.md`. 
* Tidy change to the test management command help text in `apps/tests/management/commands/test.py` to reflect the canonical entrypoint language while preserving its pytest-backed behavior.

### Testing

* Ran environment bootstrap: `./env-refresh.sh --deps-only` and it completed successfully. 
* Confirmed the management test entrypoint help: `.venv/bin/python manage.py test --help` returned the updated usage text successfully. 
* Executed the review notification helper as required by repository guidance: `./scripts/review-notify.sh --actor Codex` and it ran successfully.
* No unit test suites were executed as part of this change since edits are documentation/help-text and command guidance only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1aae81860832696b696d300ef0b5b)