### PR TITLE
tests/migrations: add deterministic remediation for QA wrapper startup failures

### DIFF
--- a/apps/tests/management/commands/migrations.py
+++ b/apps/tests/management/commands/migrations.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
+
+from utils.qa_remediation import emit_remediation, expected_venv_python
 
 
 class Command(BaseCommand):
@@ -47,6 +51,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options) -> None:
         """Dispatch to the selected migration subcommand."""
+
+        if not expected_venv_python(self._base_dir()).exists():
+            raise CommandError(
+                emit_remediation(
+                    code="missing_venv_python",
+                    command="./install.sh --terminal",
+                    retry=self._retry_command_for_options(options),
+                )
+            )
 
         action = options["action"]
         if action == "run":
@@ -92,7 +105,16 @@ class Command(BaseCommand):
     def _run_migration_server(self, options: dict[str, object]) -> None:
         """Run the VS Code migration server watcher."""
 
-        from utils.devtools import migration_server
+        try:
+            from utils.devtools import migration_server
+        except ModuleNotFoundError as exc:
+            raise CommandError(
+                emit_remediation(
+                    code="missing_dependency",
+                    command="./env-refresh.sh --deps-only",
+                    retry=self._retry_command_for_options(options),
+                )
+            ) from exc
 
         argv = [
             "--watch",
@@ -104,3 +126,27 @@ class Command(BaseCommand):
         exit_code = migration_server.main(argv)
         if exit_code != 0:
             raise CommandError(f"migration server exited with status {exit_code}")
+
+    @staticmethod
+    def _base_dir() -> "Path":
+        """Return the repository root directory."""
+
+        path = Path(__file__).resolve().parent
+        while path != path.parent:
+            if (path / "manage.py").is_file() or (path / "pyproject.toml").is_file():
+                return path
+            path = path.parent
+        raise FileNotFoundError("Repository root not found from command module path.")
+
+    @staticmethod
+    def _retry_command_for_options(options: dict[str, object]) -> str:
+        """Build retry guidance for the current migration subcommand."""
+
+        action = options.get("action") or "run"
+        if action == "check":
+            return ".venv/bin/python manage.py migrations check"
+        if action == "server":
+            return ".venv/bin/python manage.py migrations server"
+        if action == "make":
+            return ".venv/bin/python manage.py migrations make"
+        return ".venv/bin/python manage.py migrations run"

--- a/apps/tests/management/commands/migrations.py
+++ b/apps/tests/management/commands/migrations.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from utils.qa_remediation import emit_remediation, expected_venv_python
+from utils.qa_remediation import (
+    emit_remediation,
+    expected_venv_python,
+    find_repo_root,
+)
 
 
 class Command(BaseCommand):
@@ -131,22 +136,39 @@ class Command(BaseCommand):
     def _base_dir() -> "Path":
         """Return the repository root directory."""
 
-        path = Path(__file__).resolve().parent
-        while path != path.parent:
-            if (path / "manage.py").is_file() or (path / "pyproject.toml").is_file():
-                return path
-            path = path.parent
-        raise FileNotFoundError("Repository root not found from command module path.")
+        return find_repo_root(Path(__file__).resolve().parent)
 
-    @staticmethod
-    def _retry_command_for_options(options: dict[str, object]) -> str:
+    def _retry_command_for_options(self, options: dict[str, object]) -> str:
         """Build retry guidance for the current migration subcommand."""
 
         action = options.get("action") or "run"
-        if action == "check":
-            return ".venv/bin/python manage.py migrations check"
-        if action == "server":
-            return ".venv/bin/python manage.py migrations server"
-        if action == "make":
-            return ".venv/bin/python manage.py migrations make"
-        return ".venv/bin/python manage.py migrations run"
+        base_dir = self._base_dir()
+        venv_rel = expected_venv_python(base_dir).relative_to(base_dir).as_posix()
+        command: list[str] = [venv_rel, "manage.py", "migrations", str(action)]
+
+        if action == "run":
+            app_label = options.get("app_label")
+            migration_name = options.get("migration_name")
+            database = options.get("database", "default")
+            if isinstance(app_label, str) and app_label:
+                command.append(app_label)
+                if isinstance(migration_name, str) and migration_name:
+                    command.append(migration_name)
+            if isinstance(database, str) and database:
+                command.extend(["--database", database])
+        elif action == "make":
+            app_labels = options.get("app_labels")
+            if isinstance(app_labels, list):
+                command.extend(
+                    label for label in app_labels if isinstance(label, str) and label
+                )
+            if options.get("check"):
+                command.append("--check")
+            if options.get("dry_run"):
+                command.append("--dry-run")
+        elif action == "server":
+            interval = options.get("interval", 1.0)
+            debounce = options.get("debounce", 1.0)
+            command.extend(["--interval", str(interval), "--debounce", str(debounce)])
+
+        return shlex.join(command)

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -13,6 +13,7 @@ from django.db import transaction
 from apps.tests.discovery import TestDiscoveryError, discover_suite_tests
 from apps.tests.models import SuiteTest
 from utils.python_env import resolve_project_python
+from utils.qa_remediation import emit_remediation, expected_venv_python
 
 
 class Command(BaseCommand):
@@ -62,6 +63,21 @@ class Command(BaseCommand):
         """Execute pytest as a subprocess."""
 
         base_dir = self._base_dir()
+        venv_python = expected_venv_python(base_dir)
+        args = list(pytest_args)
+        if args and args[0] == "--":
+            args = args[1:]
+        retry_command = ".venv/bin/python manage.py test run"
+        if args:
+            retry_command = f"{retry_command} -- {' '.join(args)}"
+        if not venv_python.exists():
+            raise CommandError(
+                emit_remediation(
+                    code="missing_venv_python",
+                    command="./install.sh --terminal",
+                    retry=retry_command,
+                )
+            )
         python = resolve_project_python(base_dir)
         probe = subprocess.run(
             [
@@ -74,14 +90,13 @@ class Command(BaseCommand):
         )
         if probe.returncode != 0:
             raise CommandError(
-                "pytest is not installed in the active environment. "
-                "Install test dependencies (for example: "
-                "`.venv/bin/pip install -r requirements-ci.txt`) and retry."
+                emit_remediation(
+                    code="missing_dependency",
+                    command="./env-refresh.sh --deps-only",
+                    retry=retry_command,
+                )
             )
 
-        args = list(pytest_args)
-        if args and args[0] == "--":
-            args = args[1:]
         command = [python, "-m", "pytest", *args]
         result = subprocess.run(command, cwd=base_dir, env=os.environ.copy())
         if result.returncode != 0:
@@ -90,9 +105,28 @@ class Command(BaseCommand):
     def _run_test_server(self) -> None:
         """Start the long-running VS Code test server."""
 
+        base_dir = self._base_dir()
+        if not expected_venv_python(base_dir).exists():
+            raise CommandError(
+                emit_remediation(
+                    code="missing_venv_python",
+                    command="./install.sh --terminal",
+                    retry=".venv/bin/python manage.py test server",
+                )
+            )
+
         from utils.devtools import test_server
 
-        exit_code = test_server.main([])
+        try:
+            exit_code = test_server.main([])
+        except ModuleNotFoundError as exc:
+            raise CommandError(
+                emit_remediation(
+                    code="missing_dependency",
+                    command="./env-refresh.sh --deps-only",
+                    retry=".venv/bin/python manage.py test server",
+                )
+            ) from exc
         if exit_code != 0:
             raise CommandError(f"test server exited with status {exit_code}")
 

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -118,9 +118,9 @@ class Command(BaseCommand):
                 )
             )
 
-        from utils.devtools import test_server
-
         try:
+            from utils.devtools import test_server
+
             exit_code = test_server.main([])
         except ModuleNotFoundError as exc:
             raise CommandError(

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -13,7 +14,7 @@ from django.db import transaction
 from apps.tests.discovery import TestDiscoveryError, discover_suite_tests
 from apps.tests.models import SuiteTest
 from utils.python_env import resolve_project_python
-from utils.qa_remediation import emit_remediation, expected_venv_python
+from utils.qa_remediation import emit_remediation, expected_venv_python, find_repo_root
 
 
 class Command(BaseCommand):
@@ -64,12 +65,13 @@ class Command(BaseCommand):
 
         base_dir = self._base_dir()
         venv_python = expected_venv_python(base_dir)
+        venv_rel = venv_python.relative_to(base_dir).as_posix()
         args = list(pytest_args)
         if args and args[0] == "--":
             args = args[1:]
-        retry_command = ".venv/bin/python manage.py test run"
+        retry_command = f"{venv_rel} manage.py test run"
         if args:
-            retry_command = f"{retry_command} -- {' '.join(args)}"
+            retry_command = f"{retry_command} -- {shlex.join(args)}"
         if not venv_python.exists():
             raise CommandError(
                 emit_remediation(
@@ -106,12 +108,13 @@ class Command(BaseCommand):
         """Start the long-running VS Code test server."""
 
         base_dir = self._base_dir()
+        venv_rel = expected_venv_python(base_dir).relative_to(base_dir).as_posix()
         if not expected_venv_python(base_dir).exists():
             raise CommandError(
                 emit_remediation(
                     code="missing_venv_python",
                     command="./install.sh --terminal",
-                    retry=".venv/bin/python manage.py test server",
+                    retry=f"{venv_rel} manage.py test server",
                 )
             )
 
@@ -124,7 +127,7 @@ class Command(BaseCommand):
                 emit_remediation(
                     code="missing_dependency",
                     command="./env-refresh.sh --deps-only",
-                    retry=".venv/bin/python manage.py test server",
+                    retry=f"{venv_rel} manage.py test server",
                 )
             ) from exc
         if exit_code != 0:
@@ -151,9 +154,4 @@ class Command(BaseCommand):
     def _base_dir() -> Path:
         """Return the repository root directory."""
 
-        path = Path(__file__).resolve().parent
-        while path != path.parent:
-            if (path / "manage.py").is_file() or (path / "pyproject.toml").is_file():
-                return path
-            path = path.parent
-        raise FileNotFoundError("Repository root not found from command module path.")
+        return find_repo_root(Path(__file__).resolve().parent)

--- a/apps/tests/tests/test_local_qa_remediation.py
+++ b/apps/tests/tests/test_local_qa_remediation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.core.management.base import CommandError
+
+from apps.tests.management.commands.migrations import Command as MigrationsCommand
+from apps.tests.management.commands.test import Command as TestCommand
+
+
+def test_test_command_emits_bootstrap_remediation_when_venv_python_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    command = TestCommand()
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        command._run_pytest([])
+
+    payload = json.loads(str(excinfo.value))
+    assert payload == {
+        "code": "missing_venv_python",
+        "command": "./install.sh --terminal",
+        "event": "arthexis.qa.remediation",
+        "retry": ".venv/bin/python manage.py test run",
+    }
+
+
+def test_test_command_emits_dependency_refresh_remediation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    command = TestCommand()
+    fake_venv_python = tmp_path / ".venv" / "bin" / "python"
+    fake_venv_python.parent.mkdir(parents=True)
+    fake_venv_python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+
+    class _ProbeResult:
+        returncode = 1
+
+    monkeypatch.setattr(
+        "apps.tests.management.commands.test.subprocess.run",
+        lambda *args, **kwargs: _ProbeResult(),
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        command._run_pytest(["--", "apps/core/tests/test_doctor_command.py"])
+
+    payload = json.loads(str(excinfo.value))
+    assert payload == {
+        "code": "missing_dependency",
+        "command": "./env-refresh.sh --deps-only",
+        "event": "arthexis.qa.remediation",
+        "retry": ".venv/bin/python manage.py test run -- apps/core/tests/test_doctor_command.py",
+    }
+
+
+def test_migrations_command_emits_bootstrap_remediation_when_venv_python_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    command = MigrationsCommand()
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+
+    with pytest.raises(CommandError) as excinfo:
+        command.handle(
+            action="check",
+            database="default",
+            app_label=None,
+            migration_name=None,
+        )
+
+    payload = json.loads(str(excinfo.value))
+    assert payload == {
+        "code": "missing_venv_python",
+        "command": "./install.sh --terminal",
+        "event": "arthexis.qa.remediation",
+        "retry": ".venv/bin/python manage.py migrations check",
+    }

--- a/apps/tests/tests/test_local_qa_remediation.py
+++ b/apps/tests/tests/test_local_qa_remediation.py
@@ -8,6 +8,7 @@ from django.core.management.base import CommandError
 
 from apps.tests.management.commands.migrations import Command as MigrationsCommand
 from apps.tests.management.commands.test import Command as TestCommand
+from utils.qa_remediation import expected_venv_python
 
 
 def test_test_command_emits_bootstrap_remediation_when_venv_python_missing(
@@ -16,6 +17,7 @@ def test_test_command_emits_bootstrap_remediation_when_venv_python_missing(
 ) -> None:
     command = TestCommand()
     monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    retry_command = f"{expected_venv_python(tmp_path).relative_to(tmp_path).as_posix()} manage.py test run"
     with pytest.raises(CommandError) as excinfo:
         command._run_pytest([])
 
@@ -24,7 +26,7 @@ def test_test_command_emits_bootstrap_remediation_when_venv_python_missing(
         "code": "missing_venv_python",
         "command": "./install.sh --terminal",
         "event": "arthexis.qa.remediation",
-        "retry": ".venv/bin/python manage.py test run",
+        "retry": retry_command,
     }
 
 
@@ -32,7 +34,7 @@ def test_test_command_emits_dependency_refresh_remediation(
     monkeypatch, tmp_path: Path
 ) -> None:
     command = TestCommand()
-    fake_venv_python = tmp_path / ".venv" / "bin" / "python"
+    fake_venv_python = expected_venv_python(tmp_path)
     fake_venv_python.parent.mkdir(parents=True)
     fake_venv_python.write_text("", encoding="utf-8")
     monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
@@ -46,14 +48,20 @@ def test_test_command_emits_dependency_refresh_remediation(
     )
 
     with pytest.raises(CommandError) as excinfo:
-        command._run_pytest(["--", "apps/core/tests/test_doctor_command.py"])
+        command._run_pytest(
+            ["--", "-k", "smoke and not slow", "apps/core/tests/test_doctor_command.py"]
+        )
 
     payload = json.loads(str(excinfo.value))
+    retry_prefix = expected_venv_python(tmp_path).relative_to(tmp_path).as_posix()
     assert payload == {
         "code": "missing_dependency",
         "command": "./env-refresh.sh --deps-only",
         "event": "arthexis.qa.remediation",
-        "retry": ".venv/bin/python manage.py test run -- apps/core/tests/test_doctor_command.py",
+        "retry": (
+            f"{retry_prefix} manage.py test run -- -k 'smoke and not slow' "
+            "apps/core/tests/test_doctor_command.py"
+        ),
     }
 
 
@@ -62,6 +70,10 @@ def test_migrations_command_emits_bootstrap_remediation_when_venv_python_missing
 ) -> None:
     command = MigrationsCommand()
     monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    retry_command = (
+        f"{expected_venv_python(tmp_path).relative_to(tmp_path).as_posix()} "
+        "manage.py migrations check"
+    )
 
     with pytest.raises(CommandError) as excinfo:
         command.handle(
@@ -76,5 +88,27 @@ def test_migrations_command_emits_bootstrap_remediation_when_venv_python_missing
         "code": "missing_venv_python",
         "command": "./install.sh --terminal",
         "event": "arthexis.qa.remediation",
-        "retry": ".venv/bin/python manage.py migrations check",
+        "retry": retry_command,
     }
+
+
+def test_migrations_retry_command_preserves_requested_options(
+    monkeypatch, tmp_path: Path
+) -> None:
+    command = MigrationsCommand()
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+
+    retry = command._retry_command_for_options(
+        {
+            "action": "run",
+            "app_label": "billing",
+            "migration_name": "0012_auto",
+            "database": "reports replica",
+        }
+    )
+
+    retry_prefix = expected_venv_python(tmp_path).relative_to(tmp_path).as_posix()
+    assert retry == (
+        f"{retry_prefix} manage.py migrations run billing 0012_auto "
+        "--database 'reports replica'"
+    )

--- a/apps/tests/tests/test_local_qa_remediation.py
+++ b/apps/tests/tests/test_local_qa_remediation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import builtins
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -112,3 +114,34 @@ def test_migrations_retry_command_preserves_requested_options(
         f"{retry_prefix} manage.py migrations run billing 0012_auto "
         "--database 'reports replica'"
     )
+
+
+def test_test_server_emits_dependency_remediation_when_import_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    command = TestCommand()
+    fake_venv_python = expected_venv_python(tmp_path)
+    fake_venv_python.parent.mkdir(parents=True)
+    fake_venv_python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    original_import = builtins.__import__
+
+    def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "utils.devtools":
+            raise ModuleNotFoundError("No module named 'utils.devtools'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    sys.modules.pop("utils.devtools", None)
+
+    with pytest.raises(CommandError) as excinfo:
+        command._run_test_server()
+
+    payload = json.loads(str(excinfo.value))
+    retry_prefix = expected_venv_python(tmp_path).relative_to(tmp_path).as_posix()
+    assert payload == {
+        "code": "missing_dependency",
+        "command": "./env-refresh.sh --deps-only",
+        "event": "arthexis.qa.remediation",
+        "retry": f"{retry_prefix} manage.py test server",
+    }

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -8,6 +8,23 @@ export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
 PYTHON_BIN=".venv/bin/python"
+emit_remediation() {
+  local code="$1"
+  local command="$2"
+  local retry="$3"
+  printf '{"code":"%s","command":"%s","event":"arthexis.qa.remediation","retry":"%s"}\n' "$code" "$command" "$retry" >&2
+}
+
+if [ ! -x "$PYTHON_BIN" ]; then
+  emit_remediation "missing_venv_python" "./install.sh --terminal" "./scripts/run_mypy.sh"
+  exit 1
+fi
+
+if ! "$PYTHON_BIN" -c "import importlib.util,sys;sys.exit(0 if importlib.util.find_spec('mypy') else 1)" >/dev/null 2>&1; then
+  emit_remediation "missing_dependency" "./env-refresh.sh --deps-only" "./scripts/run_mypy.sh"
+  exit 1
+fi
+
 mypy_output="$(mktemp)"
 cleanup() {
   rm -f "$mypy_output"

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -8,6 +8,9 @@ export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
 PYTHON_BIN=".venv/bin/python"
+if [[ "${OSTYPE:-}" == "msys" || "${OSTYPE:-}" == "cygwin" || "${OSTYPE:-}" == "win32" ]]; then
+  PYTHON_BIN=".venv/Scripts/python.exe"
+fi
 emit_remediation() {
   local code="$1"
   local command="$2"

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -8,7 +8,6 @@ export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/preflight-env.sh"
 
 PYTHON_BIN=".venv/bin/python"
 if [[ "${OSTYPE:-}" == "msys" || "${OSTYPE:-}" == "cygwin" || "${OSTYPE:-}" == "win32" ]]; then
@@ -30,6 +29,8 @@ if ! "$PYTHON_BIN" -c "import importlib.util,sys;sys.exit(0 if importlib.util.fi
   emit_remediation "missing_dependency" "./env-refresh.sh --deps-only" "./scripts/run_mypy.sh"
   exit 1
 fi
+
+"$SCRIPT_DIR/preflight-env.sh"
 
 mypy_output="$(mktemp)"
 cleanup() {

--- a/utils/qa_remediation.py
+++ b/utils/qa_remediation.py
@@ -4,12 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 
 
 def expected_venv_python(base_dir: Path) -> Path:
     """Return the expected repository virtualenv interpreter path."""
 
-    return base_dir / ".venv" / "bin" / "python"
+    suffix = (
+        Path("Scripts/python.exe") if sys.platform == "win32" else Path("bin/python")
+    )
+    return base_dir / ".venv" / suffix
+
+
+def find_repo_root(start: Path) -> Path:
+    """Return the repository root from ``start`` by searching parent directories."""
+
+    path = start
+    while path != path.parent:
+        if (path / "manage.py").is_file() or (path / "pyproject.toml").is_file():
+            return path
+        path = path.parent
+    raise FileNotFoundError("Repository root not found from command module path.")
 
 
 def emit_remediation(

--- a/utils/qa_remediation.py
+++ b/utils/qa_remediation.py
@@ -1,0 +1,31 @@
+"""Deterministic remediation hints for local QA/test command wrappers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def expected_venv_python(base_dir: Path) -> Path:
+    """Return the expected repository virtualenv interpreter path."""
+
+    return base_dir / ".venv" / "bin" / "python"
+
+
+def emit_remediation(
+    *,
+    code: str,
+    command: str,
+    retry: str,
+) -> str:
+    """Return a single-line machine-parseable remediation message."""
+
+    return json.dumps(
+        {
+            "event": "arthexis.qa.remediation",
+            "code": code,
+            "command": command,
+            "retry": retry,
+        },
+        sort_keys=True,
+    )


### PR DESCRIPTION
### Motivation

- Provide concise, machine-parseable remediation hints when local QA/test launchers fail to start so automated agents can auto-recover in one pass. 
- Intercept the two most common startup failure modes (missing `.venv/bin/python` and missing runtime/test tooling) and return exact bootstrap/refresh commands plus a retry command.

### Description

- Add `utils/qa_remediation.py` which emits a single-line JSON remediation payload with `event`, `code`, `command`, and `retry` fields.
- Update test wrapper (`apps/tests/management/commands/test.py`) to check for the repo venv (`.venv/bin/python`) and emit `missing_venv_python` remediation, and to detect missing `pytest` and emit `missing_dependency` remediation with exact retry guidance.
- Harden the test server path in `apps/tests/management/commands/test.py` to emit deterministic remediation when the venv is missing or when the test-server import fails.
- Update migrations wrapper (`apps/tests/management/commands/migrations.py`) to emit deterministic `missing_venv_python` remediation up front and `missing_dependency` remediation when the migration server import fails, and to provide action-specific retry guidance.
- Add deterministic checks to `scripts/run_mypy.sh` that print the remediation JSON and exit when the venv Python or `mypy` are missing.
- Add unit tests `apps/tests/tests/test_local_qa_remediation.py` that validate the emitted remediation payloads for the `test` and `migrations` command wrappers.

### Testing

- Attempted `python manage.py test run -- apps/tests/tests/test_local_qa_remediation.py` in this environment and it failed as expected because `.venv/bin/python` is not present; the command now raises a `CommandError` containing the deterministic remediation JSON (behavior verified).
- Compiled changed modules with `python -m compileall apps/tests/management/commands/test.py apps/tests/management/commands/migrations.py utils/qa_remediation.py apps/tests/tests/test_local_qa_remediation.py`, which succeeded.
- Ran review notification `./scripts/review-notify.sh --actor Codex`, which completed successfully and recorded the workspace changes.

Files changed: `utils/qa_remediation.py`, `apps/tests/management/commands/test.py`, `apps/tests/management/commands/migrations.py`, `scripts/run_mypy.sh`, and tests `apps/tests/tests/test_local_qa_remediation.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1aaf181cc83268eb1628ca0dcc5d3)