### PR TITLE
tests: add QA readiness preflight before pytest runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,13 @@ Install test dependencies, then run tests before opening a PR:
 ./.venv/bin/python manage.py test run
 ```
 
+`manage.py test run` now begins with a QA readiness step before any targeted pytest execution. It reports:
+- virtualenv presence,
+- the Python executable path used for the run,
+- core test dependency availability (`pytest`, `pytest-django`, `pytest-timeout`).
+
+If any core dependency is missing, the command fails fast before attempting any tests.
+
 `requirements.txt` is intentionally runtime-only, so `pytest` may be missing until the QA extras are installed. See [Dependency management](docs/development/dependency-management.md) for details.
 
 Useful subsets:

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -63,20 +64,20 @@ class Command(BaseCommand):
 
         base_dir = self._base_dir()
         python = resolve_project_python(base_dir)
-        probe = subprocess.run(
-            [
-                python,
-                "-c",
-                "import importlib.util,sys;sys.exit(0 if importlib.util.find_spec('pytest') else 1)",
-            ],
-            cwd=base_dir,
-            env=os.environ.copy(),
-        )
-        if probe.returncode != 0:
+        readiness = self._run_readiness_probe(base_dir, python)
+        self._write_readiness_report(readiness)
+
+        missing_dependencies = [
+            dependency
+            for dependency, available in readiness["dependencies"].items()
+            if not available
+        ]
+        if missing_dependencies:
+            dependency_list = ", ".join(missing_dependencies)
             raise CommandError(
-                "pytest is not installed in the active environment. "
-                "Install test dependencies (for example: "
-                "`.venv/bin/pip install -r requirements-ci.txt`) and retry."
+                "Core test dependencies are missing in the active environment: "
+                f"{dependency_list}. Install QA dependencies (for example: "
+                "`.venv/bin/pip install '.[qa]'`) and retry."
             )
 
         args = list(pytest_args)
@@ -86,6 +87,63 @@ class Command(BaseCommand):
         result = subprocess.run(command, cwd=base_dir, env=os.environ.copy())
         if result.returncode != 0:
             raise CommandError(f"pytest exited with status {result.returncode}")
+
+    def _run_readiness_probe(self, base_dir: Path, python: str) -> dict[str, object]:
+        """Collect QA readiness details from the selected Python interpreter."""
+
+        probe = subprocess.run(
+            [
+                python,
+                "-c",
+                (
+                    "import importlib.util,json,os,sys;"
+                    "deps=('pytest','pytest_django','pytest_timeout');"
+                    "print(json.dumps({"
+                    "'python_executable':sys.executable,"
+                    "'virtualenv_active':bool(os.environ.get('VIRTUAL_ENV')) "
+                    "or sys.prefix!=getattr(sys,'base_prefix',sys.prefix),"
+                    "'virtualenv_path':os.environ.get('VIRTUAL_ENV'),"
+                    "'dependencies':{dep:bool(importlib.util.find_spec(dep)) "
+                    "for dep in deps}}))"
+                ),
+            ],
+            capture_output=True,
+            check=False,
+            cwd=base_dir,
+            env=os.environ.copy(),
+            text=True,
+        )
+        if probe.returncode != 0:
+            raise CommandError("Unable to run QA readiness probe for test execution.")
+        try:
+            readiness = json.loads(probe.stdout.strip())
+        except json.JSONDecodeError as exc:
+            raise CommandError("QA readiness probe returned invalid output.") from exc
+        if not isinstance(readiness, dict):
+            raise CommandError("QA readiness probe returned malformed output.")
+        return readiness
+
+    def _write_readiness_report(self, readiness: dict[str, object]) -> None:
+        """Print a compact readiness report before any pytest execution."""
+
+        dependencies = readiness.get("dependencies", {})
+        if not isinstance(dependencies, dict):
+            dependencies = {}
+        dependency_report = ", ".join(
+            f"{dependency}={'yes' if bool(available) else 'no'}"
+            for dependency, available in dependencies.items()
+        )
+        if not dependency_report:
+            dependency_report = "none detected"
+
+        self.stdout.write("QA readiness:")
+        self.stdout.write(
+            f"- virtualenv active: {'yes' if readiness.get('virtualenv_active') else 'no'}"
+        )
+        self.stdout.write(
+            f"- python executable: {readiness.get('python_executable', 'unknown')}"
+        )
+        self.stdout.write(f"- core test dependencies: {dependency_report}")
 
     def _run_test_server(self) -> None:
         """Start the long-running VS Code test server."""

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -97,14 +97,15 @@ class Command(BaseCommand):
                 "-c",
                 (
                     "import importlib.util,json,os,sys;"
-                    "deps=('pytest','pytest_django','pytest_timeout');"
+                    "deps={'pytest':'pytest','pytest-django':'pytest_django',"
+                    "'pytest-timeout':'pytest_timeout'};"
                     "print(json.dumps({"
                     "'python_executable':sys.executable,"
                     "'virtualenv_active':bool(os.environ.get('VIRTUAL_ENV')) "
                     "or sys.prefix!=getattr(sys,'base_prefix',sys.prefix),"
                     "'virtualenv_path':os.environ.get('VIRTUAL_ENV'),"
-                    "'dependencies':{dep:bool(importlib.util.find_spec(dep)) "
-                    "for dep in deps}}))"
+                    "'dependencies':{pkg:bool(importlib.util.find_spec(mod)) "
+                    "for pkg, mod in deps.items()}}))"
                 ),
             ],
             capture_output=True,
@@ -116,7 +117,10 @@ class Command(BaseCommand):
         if probe.returncode != 0:
             raise CommandError("Unable to run QA readiness probe for test execution.")
         try:
-            readiness = json.loads(probe.stdout.strip())
+            lines = probe.stdout.strip().splitlines()
+            if not lines:
+                raise CommandError("QA readiness probe produced no output.")
+            readiness = json.loads(lines[-1])
         except json.JSONDecodeError as exc:
             raise CommandError("QA readiness probe returned invalid output.") from exc
         if not isinstance(readiness, dict):

--- a/apps/tests/test_test_command.py
+++ b/apps/tests/test_test_command.py
@@ -21,8 +21,8 @@ def test_run_pytest_prints_readiness_before_execution(monkeypatch, tmp_path, cap
         "virtualenv_path": "/workspace/arthexis/.venv",
         "dependencies": {
             "pytest": True,
-            "pytest_django": True,
-            "pytest_timeout": True,
+            "pytest-django": True,
+            "pytest-timeout": True,
         },
     }
 
@@ -60,8 +60,8 @@ def test_run_pytest_fails_before_pytest_when_dependency_missing(monkeypatch, tmp
         "virtualenv_path": "/workspace/arthexis/.venv",
         "dependencies": {
             "pytest": True,
-            "pytest_django": False,
-            "pytest_timeout": True,
+            "pytest-django": False,
+            "pytest-timeout": True,
         },
     }
 
@@ -77,5 +77,5 @@ def test_run_pytest_fails_before_pytest_when_dependency_missing(monkeypatch, tmp
         command._run_pytest(["--", "apps/tests/test_test_command.py"])
 
     assert "Core test dependencies are missing" in str(exc.value)
-    assert "pytest_django" in str(exc.value)
+    assert "pytest-django" in str(exc.value)
     assert len(calls) == 1

--- a/apps/tests/test_test_command.py
+++ b/apps/tests/test_test_command.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+from django.core.management.base import CommandError
+
+from apps.tests.management.commands import test as test_command
+
+
+def test_run_pytest_prints_readiness_before_execution(monkeypatch, tmp_path, capsys):
+    command = test_command.Command()
+
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    monkeypatch.setattr(test_command, "resolve_project_python", lambda _base_dir: "python")
+
+    probe_payload = {
+        "python_executable": "/workspace/arthexis/.venv/bin/python",
+        "virtualenv_active": True,
+        "virtualenv_path": "/workspace/arthexis/.venv",
+        "dependencies": {
+            "pytest": True,
+            "pytest_django": True,
+            "pytest_timeout": True,
+        },
+    }
+
+    calls: list[list[str]] = []
+
+    def fake_run(command_args, **kwargs):
+        calls.append(command_args)
+        if command_args[:2] == ["python", "-c"]:
+            return subprocess.CompletedProcess(command_args, 0, stdout=json.dumps(probe_payload))
+        return subprocess.CompletedProcess(command_args, 0)
+
+    monkeypatch.setattr(test_command.subprocess, "run", fake_run)
+
+    command._run_pytest(["--", "apps/tests/test_test_command.py"])
+
+    captured = capsys.readouterr().out
+    assert "QA readiness:" in captured
+    assert "virtualenv active: yes" in captured
+    assert "python executable: /workspace/arthexis/.venv/bin/python" in captured
+    assert "core test dependencies: pytest=yes" in captured
+
+    assert calls[0][:2] == ["python", "-c"]
+    assert calls[1] == ["python", "-m", "pytest", "apps/tests/test_test_command.py"]
+
+
+def test_run_pytest_fails_before_pytest_when_dependency_missing(monkeypatch, tmp_path):
+    command = test_command.Command()
+
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    monkeypatch.setattr(test_command, "resolve_project_python", lambda _base_dir: "python")
+
+    probe_payload = {
+        "python_executable": "/workspace/arthexis/.venv/bin/python",
+        "virtualenv_active": True,
+        "virtualenv_path": "/workspace/arthexis/.venv",
+        "dependencies": {
+            "pytest": True,
+            "pytest_django": False,
+            "pytest_timeout": True,
+        },
+    }
+
+    calls: list[list[str]] = []
+
+    def fake_run(command_args, **kwargs):
+        calls.append(command_args)
+        return subprocess.CompletedProcess(command_args, 0, stdout=json.dumps(probe_payload))
+
+    monkeypatch.setattr(test_command.subprocess, "run", fake_run)
+
+    with pytest.raises(CommandError) as exc:
+        command._run_pytest(["--", "apps/tests/test_test_command.py"])
+
+    assert "Core test dependencies are missing" in str(exc.value)
+    assert "pytest_django" in str(exc.value)
+    assert len(calls) == 1

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -8,6 +8,13 @@ export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
 PYTHON_BIN=".venv/bin/python"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="$(command -v python3 || true)"
+fi
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Error: no Python interpreter found (.venv/bin/python or python3)." >&2
+  exit 127
+fi
 mypy_output="$(mktemp)"
 cleanup() {
   rm -f "$mypy_output"


### PR DESCRIPTION
### Motivation
- Prevent partial or confusing test runs by failing fast when QA prerequisites are missing. 
- Make test entrypoints clearer by reporting interpreter and virtualenv context before any pytest invocation. 
- Reduce wasted CI/dev time by surfacing missing core test packages early.

### Description
- Add a QA readiness probe to the `manage.py test run` flow in `apps/tests/management/commands/test.py` that reports virtualenv presence, the Python executable path, and availability of core test dependencies (`pytest`, `pytest_django`, `pytest_timeout`) and fails early if any are missing.
- Emit a compact, human-readable readiness report via `_write_readiness_report` before launching pytest.
- Add focused unit tests in `apps/tests/test_test_command.py` verifying readiness output ordering and fail-fast behavior when dependencies are missing.
- Update `CONTRIBUTING.md` to document the new readiness preflight and its behaviour.

### Testing
- Ran the new command tests with: `python3 manage.py test run -- apps/tests/test_test_command.py`, which initially failed fast as expected in an environment missing QA extras and printed the readiness report (missing `pytest_django`, `pytest_timeout`).
- Installed QA extras with `python3 -m pip install '.[qa]'` and re-ran `python3 manage.py test run -- apps/tests/test_test_command.py`, resulting in `2 passed` for the new tests.
- Ran the repository review notifier: `./scripts/review-notify.sh --actor Codex` which completed (fallback notification used).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1aafe76bc8326ac631e9e2d165585)