### PR TITLE
docs: remove static changelog and point to built-in changelog UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## Unreleased
-
-- Removed the legacy Mermaid migration shim package (`config/legacy_mermaid`) after confirming no active migration graph dependencies remain in this repository.

--- a/docs/development/management-command-deprecation-pattern.md
+++ b/docs/development/management-command-deprecation-pattern.md
@@ -5,7 +5,7 @@ When a command is absorbed into a newer surface, keep the compatibility guidance
 
 ## Minimal migration note template
 
-Use a short mapping table in docs/changelog content so operators can update automation scripts:
+Use a short mapping table in the built-in Arthexis changelog/report UI so operators can update automation scripts:
 
 | Removed command | Replacement |
 | --- | --- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 This site aggregates operator guides, architecture notes, and development references for the Arthexis software suite.
 
-Release notes and changelog reporting are maintained in the built-in Arthexis changelog/report UI to avoid duplicate static changelog sources.
+Release notes and changelog reporting are available in the built-in Arthexis changelog UI, accessible via the Admin Dashboard.
 
 In Arthexis terminology, the **suite** is the collection of applications, while the **Constellation** is the fleet of nodes running that suite.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 This site aggregates operator guides, architecture notes, and development references for the Arthexis software suite.
 
+Release notes and changelog reporting are maintained in the built-in Arthexis changelog/report UI to avoid duplicate static changelog sources.
+
 In Arthexis terminology, the **suite** is the collection of applications, while the **Constellation** is the fleet of nodes running that suite.
 
 ## Suite goals


### PR DESCRIPTION
### Motivation
- Remove a duplicated static changelog source and consolidate release notes in the built-in Arthexis changelog/report UI to avoid drift and duplicate maintenance.

### Description
- Deleted `docs/changelog.md` and added a single sentence to `docs/index.md` directing users to the built-in Arthexis changelog/report UI.

### Testing
- Ran `git diff --check` and `./scripts/review-notify.sh --actor Codex`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b753aae083268cf512365d038890)