### PR TITLE
docs(performance): remove speculative public charger optimization notes

### DIFF
--- a/docs/performance/public_charger_optimizations.md
+++ b/docs/performance/public_charger_optimizations.md
@@ -1,9 +1,0 @@
-# Public charger and connector performance notes
-
-## Dashboard view
-- The dashboard view fetches each charger's latest transaction individually when it isn't already cached, leading to an N+1 query pattern across the visible chargers list. Collecting the latest transaction IDs with a subquery or prefetch would trim redundant queries during dashboard refreshes and partial table renders.
-- Per-charger energy stats (`total_kw` and `total_kw_for_range`) are computed inside the dashboard loop. Batch annotations for the current day and lifetime totals (or caching a daily summary) would avoid repeating aggregations for every connector on each request.
-
-## Public charger page and connector overview
-- `_connector_overview` walks every sibling connector and calls the OCPP store plus `_charger_state` for each. Prefetching sibling connectors before rendering the page (or caching the overview payload) would cut repeated ORM hits for chargers with many connectors.
-- The landing page translations are recomputed on every request by iterating through all configured languages and overriding translations. Wrapping the translation catalog in an in-memory cache (for example via `functools.lru_cache`) would eliminate per-request translation churn for the public landing page payload.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,5 @@ nav:
       - Watchtower Attack Simulation: development/watchtower-attack-simulation.md
       - CodeQL Configuration: development/codeql.md
       - CI Troubleshooting: development/ci-troubleshooting.md
-  - Performance:
-      - Public Charger Optimizations: performance/public_charger_optimizations.md
   - Legal:
       - Third-Party Licenses: legal/THIRD_PARTY_LICENSES.md


### PR DESCRIPTION
### Motivation
- Keep the performance docs focused on current, actionable behavior rather than speculative TODOs and move any still-relevant optimization ideas into tracked GitHub issues for follow-up.

### Description
- Removed the speculative notes file `docs/performance/public_charger_optimizations.md` from the repository and committed the deletion; attempted programmatic creation of follow-up issues but the runtime returned `403 Method forbidden` so issue creation was not completed.

### Testing
- No unit or integration tests were required for this documentation-only change; I verified repository state with `git status --short`, committed the removal with `git commit`, and ran `./scripts/review-notify.sh --actor Codex` which completed and reported a skipped notification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22f364c888326b4f4c3c2ae1db97d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes speculative performance optimization documentation to maintain focus on current, actionable behavior in the documentation.

## Changes

**docs/performance/public_charger_optimizations.md**
- Deleted file containing speculative optimization notes for public charger and connector views, including notes about potential N+1 query patterns in dashboard views, repeated data-store lookups in connector overview logic, and translation recomputation behavior.

**mkdocs.yml**
- Removed the `Performance` navigation section entry, including the reference to the deleted `Public Charger Optimizations` page, to keep the documentation navigation consistent with the removed file.

## Context

The removal aligns with the goal of keeping performance documentation focused on current, implemented behavior rather than speculative optimization ideas. Any still-relevant optimization opportunities were intended to be tracked as GitHub issues for follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->