### PR TITLE
scripts: auto-bootstrap .venv and CI dependencies in preflight

### DIFF
--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -4,7 +4,57 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_BIN="$BASE_DIR/.venv/bin/python"
+ENV_REFRESH_CMD=("$BASE_DIR/env-refresh.sh" "--deps-only")
+CI_REQUIREMENTS_FILE="$BASE_DIR/requirements-ci.txt"
 REQUIRED_MODULES=("django")
+
+check_required_modules() {
+  "$PYTHON_BIN" - "${REQUIRED_MODULES[@]}" <<'PY'
+from __future__ import annotations
+
+import importlib
+import sys
+
+required_modules = tuple(sys.argv[1:])
+missing = []
+for name in required_modules:
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        missing.append(name)
+if missing:
+    print(
+        "Required Python tooling not importable: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+}
+
+try_env_refresh() {
+  if [[ ! -x "${ENV_REFRESH_CMD[0]}" ]]; then
+    echo "Cannot auto-refresh dependencies: missing ${ENV_REFRESH_CMD[0]}" >&2
+    return 1
+  fi
+
+  echo "Attempting dependency bootstrap via: ${ENV_REFRESH_CMD[*]}" >&2
+  "${ENV_REFRESH_CMD[@]}"
+}
+
+try_install_ci_requirements() {
+  if [[ ! -f "$CI_REQUIREMENTS_FILE" ]]; then
+    echo "Cannot auto-install CI requirements: missing $CI_REQUIREMENTS_FILE" >&2
+    return 1
+  fi
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    echo "Cannot auto-install CI requirements: missing python executable at $PYTHON_BIN" >&2
+    return 1
+  fi
+
+  echo "Attempting CI dependency bootstrap via: $PYTHON_BIN -m pip install --only-binary=:all: -r $CI_REQUIREMENTS_FILE" >&2
+  "$PYTHON_BIN" -m pip install --only-binary=:all: -r "$CI_REQUIREMENTS_FILE"
+}
 
 if [[ $# -gt 1 ]]; then
   echo "Too many arguments provided." >&2
@@ -32,32 +82,23 @@ fi
 
 if [[ ! -x "$PYTHON_BIN" ]]; then
   echo ".venv/bin/python missing: expected executable at $PYTHON_BIN" >&2
-  echo "Run ./env-refresh.sh --deps-only" >&2
-  exit 1
+  if ! try_env_refresh || [[ ! -x "$PYTHON_BIN" ]]; then
+    echo "Run ./env-refresh.sh --deps-only" >&2
+    exit 1
+  fi
 fi
 
-if ! "$PYTHON_BIN" - "${REQUIRED_MODULES[@]}" <<'PY'
-from __future__ import annotations
-
-import importlib
-import sys
-
-required_modules = tuple(sys.argv[1:])
-missing = []
-for name in required_modules:
-    try:
-        importlib.import_module(name)
-    except ImportError:
-        missing.append(name)
-if missing:
-    print(
-        "Required Python tooling not importable: "
-        + ", ".join(missing),
-        file=sys.stderr,
-    )
-    raise SystemExit(1)
-PY
+if ! check_required_modules
 then
-  echo "Run ./env-refresh.sh --deps-only" >&2
-  exit 1
+  if ! try_env_refresh; then
+    echo "Run ./env-refresh.sh --deps-only" >&2
+    exit 1
+  fi
+  if ! check_required_modules; then
+    if [[ " ${REQUIRED_MODULES[*]} " == *" pytest "* ]] && try_install_ci_requirements && check_required_modules; then
+      exit 0
+    fi
+    echo "Run ./env-refresh.sh --deps-only" >&2
+    exit 1
+  fi
 fi


### PR DESCRIPTION
### Motivation

- Preflight was failing in CI and local runs when `.venv/bin/python` or `pytest` were missing, forcing manual remediation and blocking PRs. 
- The change aims to make `preflight-env.sh` resilient by attempting automated remediation before emitting the existing guidance to run `./env-refresh.sh --deps-only`.

### Description

- Added an `ENV_REFRESH_CMD` and `CI_REQUIREMENTS_FILE` and a `check_required_modules` helper to centralize import checks via the `.venv` Python interpreter. 
- Implemented `try_env_refresh()` to automatically run `./env-refresh.sh --deps-only` when the virtualenv Python is missing. 
- Implemented `try_install_ci_requirements()` to install `requirements-ci.txt` into the `.venv` when `--pytest` tooling is missing. 
- Updated control flow in `preflight-env.sh` so it attempts the above remediation steps before failing and still emits the original remediation message if automated steps do not complete.

### Testing

- Ran `./scripts/preflight-env.sh --help` which displayed usage and exited successfully. 
- Ran `./scripts/preflight-env.sh` which auto-bootstrapped a missing virtualenv by running `./env-refresh.sh --deps-only` and completed successfully. 
- Ran `./scripts/preflight-env.sh --pytest` which triggered the env refresh and then installed `requirements-ci.txt` into `.venv` to satisfy `pytest`, and the command completed successfully. 
- Ran `./scripts/review-notify.sh --actor Codex` as the final validation step and it executed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2697102288326b4a76c697902816d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Enhanced `scripts/preflight-env.sh` to automatically remediate missing Python dependencies before requiring manual user intervention. The script now implements a staged bootstrap approach to improve CI and local development workflows.

## Changes

**New Helper Functions:**
- `check_required_modules()`: Centralizes Python module importability checks by invoking the `.venv` Python interpreter to validate that required modules (django, and optionally pytest) can be imported
- `try_env_refresh()`: Executes `./env-refresh.sh --deps-only` to rebuild the virtualenv when the Python executable is missing
- `try_install_ci_requirements()`: Installs `requirements-ci.txt` into the virtualenv using `pip install --only-binary=:all:` to satisfy pytest and CI tooling dependencies

**Configuration:**
- Added `ENV_REFRESH_CMD` and `CI_REQUIREMENTS_FILE` variables to externalize command paths and requirements file location

**Control Flow Restructuring:**
- When `.venv/bin/python` is missing, the script now attempts `try_env_refresh()` before failing with the manual remediation message
- When required module imports fail, the script attempts `try_env_refresh()` first; if imports still fail and `pytest` is among the required modules, it additionally attempts to install CI requirements before failing
- The script exits successfully only after all staged remediation attempts complete and module checks pass

**Command-Line Interface:**
- Added `--help` option displaying usage information
- `--pytest` option now triggers both virtualenv refresh and CI requirements installation if needed

## Behavior Changes

The script's behavior is now conditional on staged auto-bootstrap attempts rather than immediately requiring manual refresh. Users running `./scripts/preflight-env.sh` in environments with missing dependencies will benefit from automated recovery instead of facing immediate failures that require manual intervention.

## Testing

Validated in local and CI scenarios:
- Help output displays correctly and exits successfully
- Missing virtualenv is auto-bootstrapped via `env-refresh.sh --deps-only`
- `--pytest` flag triggers both virtualenv refresh and CI requirements installation as needed
- Related scripts like `review-notify.sh` continue to function without errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->