### PR TITLE
users: default access point CLI users to AP and gallery groups

### DIFF
--- a/apps/users/management/commands/password.py
+++ b/apps/users/management/commands/password.py
@@ -198,8 +198,7 @@ class Command(BaseCommand):
                 access_point_user=access_point_user,
             )
         if access_point_user:
-            resolved_groups = self._resolve_groups(groups) if groups else []
-            resolved_groups = self._resolve_access_point_groups(resolved_groups)
+            resolved_groups = self._resolve_access_point_groups(groups)
             self._configure_access_point_user(user)
             self._harden_access_point_membership(user, resolved_groups)
             self.stdout.write(self.style.SUCCESS(f"Configured {user.username} as a local access point user."))
@@ -361,13 +360,12 @@ class Command(BaseCommand):
         if groups:
             user.groups.add(*groups)
 
-    def _resolve_access_point_groups(self, explicit_groups: list[Group]) -> list[Group]:
-        ensure_security_groups_exist(self.ACCESS_POINT_DEFAULT_GROUP_NAMES)
-        default_groups = self._resolve_groups(list(self.ACCESS_POINT_DEFAULT_GROUP_NAMES))
+    def _resolve_access_point_groups(self, explicit_group_names: list[str]) -> list[Group]:
+        default_groups = ensure_security_groups_exist(self.ACCESS_POINT_DEFAULT_GROUP_NAMES)
+        explicit_groups = self._resolve_groups(explicit_group_names) if explicit_group_names else []
 
-        groups_by_name: dict[str, Group] = {
-            group.name: group for group in [*default_groups, *explicit_groups]
-        }
+        groups_by_name: dict[str, Group] = {group.name: group for group in explicit_groups}
+        groups_by_name.update(default_groups)
         return [groups_by_name[name] for name in sorted(groups_by_name)]
 
     def _delete_password(self, user) -> None:

--- a/apps/users/management/commands/password.py
+++ b/apps/users/management/commands/password.py
@@ -10,7 +10,9 @@ from django.db.models import Q
 from django.db.utils import OperationalError
 from django.utils import timezone
 
-from apps.groups.security import ensure_default_staff_groups
+from apps.gallery.constants import GALLERY_MANAGER_GROUP_NAME
+from apps.groups.constants import AP_USER_GROUP_NAME
+from apps.groups.security import ensure_default_staff_groups, ensure_security_groups_exist
 from apps.users import temp_passwords
 from apps.users.management.commands.utils import coerce_option_list
 
@@ -21,6 +23,10 @@ class Command(BaseCommand):
     help = (
         "Generate or set temporary/permanent passwords, clear passwords, and "
         "toggle forced password change using username, email, or user id."
+    )
+    ACCESS_POINT_DEFAULT_GROUP_NAMES: tuple[str, ...] = (
+        AP_USER_GROUP_NAME,
+        GALLERY_MANAGER_GROUP_NAME,
     )
 
     def add_arguments(self, parser):
@@ -193,6 +199,7 @@ class Command(BaseCommand):
             )
         if access_point_user:
             resolved_groups = self._resolve_groups(groups) if groups else []
+            resolved_groups = self._resolve_access_point_groups(resolved_groups)
             self._configure_access_point_user(user)
             self._harden_access_point_membership(user, resolved_groups)
             self.stdout.write(self.style.SUCCESS(f"Configured {user.username} as a local access point user."))
@@ -353,6 +360,15 @@ class Command(BaseCommand):
         user.groups.clear()
         if groups:
             user.groups.add(*groups)
+
+    def _resolve_access_point_groups(self, explicit_groups: list[Group]) -> list[Group]:
+        ensure_security_groups_exist(self.ACCESS_POINT_DEFAULT_GROUP_NAMES)
+        default_groups = self._resolve_groups(list(self.ACCESS_POINT_DEFAULT_GROUP_NAMES))
+
+        groups_by_name: dict[str, Group] = {
+            group.name: group for group in [*default_groups, *explicit_groups]
+        }
+        return [groups_by_name[name] for name in sorted(groups_by_name)]
 
     def _delete_password(self, user) -> None:
         user.set_unusable_password()

--- a/apps/users/tests/test_temp_password_command.py
+++ b/apps/users/tests/test_temp_password_command.py
@@ -9,6 +9,7 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 from django.utils import timezone
 
+from apps.gallery.constants import GALLERY_MANAGER_GROUP_NAME
 from apps.groups.constants import AP_USER_GROUP_NAME
 from apps.groups.constants import EXTERNAL_AGENT_GROUP_NAME
 from apps.users import temp_passwords
@@ -183,7 +184,6 @@ class PasswordCommandTests(TestCase):
     def test_configures_access_point_user_mode(self):
         """Access-point mode should disable passwords and keep the user non-staff."""
 
-        Group.objects.create(name=AP_USER_GROUP_NAME)
         user = get_user_model().objects.create_user(
             username="ap-user",
             email="ap-user@example.com",
@@ -198,7 +198,6 @@ class PasswordCommandTests(TestCase):
             user.username,
             update=True,
             access_point_user=True,
-            group=AP_USER_GROUP_NAME,
         )
 
         user.refresh_from_db()
@@ -208,11 +207,11 @@ class PasswordCommandTests(TestCase):
         assert user.allow_local_network_passwordless_login is True
         assert user.force_password_change is False
         assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
+        assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
 
     def test_configures_access_point_user_mode_without_update_flag(self):
         """Access-point mode should demote privileges even without --update."""
 
-        Group.objects.create(name=AP_USER_GROUP_NAME)
         user = get_user_model().objects.create_user(
             username="ap-no-update",
             email="ap-no-update@example.com",
@@ -226,7 +225,6 @@ class PasswordCommandTests(TestCase):
             "password",
             user.username,
             access_point_user=True,
-            group=AP_USER_GROUP_NAME,
         )
 
         user.refresh_from_db()
@@ -236,11 +234,11 @@ class PasswordCommandTests(TestCase):
         assert user.allow_local_network_passwordless_login is True
         assert user.force_password_change is False
         assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
+        assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
 
     def test_configures_access_point_user_mode_clears_existing_groups(self):
         """Access-point mode should drop prior group access before reassignment."""
 
-        Group.objects.create(name=AP_USER_GROUP_NAME)
         legacy_group = Group.objects.create(name="Legacy Admin")
         user = get_user_model().objects.create_user(
             username="ap-groups-clear",
@@ -255,12 +253,12 @@ class PasswordCommandTests(TestCase):
             "password",
             user.username,
             access_point_user=True,
-            group=AP_USER_GROUP_NAME,
         )
 
         user.refresh_from_db()
         assert not user.groups.filter(name=legacy_group.name).exists()
         assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
+        assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
 
     def test_access_point_user_mode_preserves_groups_when_requested_group_is_unknown(self):
         """Failed AP group reassignment should not apply partial account hardening."""
@@ -309,7 +307,6 @@ class PasswordCommandTests(TestCase):
     def test_configures_access_point_user_mode_clears_temporary_credentials(self):
         """Access-point mode should clear temporary-password state for hardened login."""
 
-        Group.objects.create(name=AP_USER_GROUP_NAME)
         user = get_user_model().objects.create_user(
             username="ap-temp-clear",
             email="ap-temp-clear@example.com",
@@ -322,12 +319,26 @@ class PasswordCommandTests(TestCase):
             "password",
             user.username,
             access_point_user=True,
-            group=AP_USER_GROUP_NAME,
         )
 
         user.refresh_from_db()
         assert user.temporary_expires_at is None
         assert temp_passwords.load_temp_password(user.username) is None
+
+    def test_access_point_user_mode_adds_default_groups_without_preexisting_entries(self):
+        """Access-point mode should always include AP visitor and gallery upload groups."""
+
+        user = get_user_model().objects.create_user(
+            username="ap-default-groups",
+            email="ap-default-groups@example.com",
+            password="InitialPassword123",
+        )
+
+        call_command("password", user.username, access_point_user=True)
+
+        user.refresh_from_db()
+        assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
+        assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
 
     def test_access_point_user_mode_rejects_password_argument(self):
         """Access-point mode should reject contradictory password arguments."""

--- a/apps/users/tests/test_temp_password_command.py
+++ b/apps/users/tests/test_temp_password_command.py
@@ -340,6 +340,28 @@ class PasswordCommandTests(TestCase):
         assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
         assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
 
+    def test_access_point_user_mode_merges_explicit_groups_with_defaults(self):
+        """Access-point mode should preserve requested groups while ensuring AP defaults."""
+
+        explicit_group = Group.objects.create(name="Gallery Helpers")
+        user = get_user_model().objects.create_user(
+            username="ap-explicit-group-merge",
+            email="ap-explicit-group-merge@example.com",
+            password="InitialPassword123",
+        )
+
+        call_command(
+            "password",
+            user.username,
+            access_point_user=True,
+            group=explicit_group.name,
+        )
+
+        user.refresh_from_db()
+        assert user.groups.filter(name=AP_USER_GROUP_NAME).exists()
+        assert user.groups.filter(name=GALLERY_MANAGER_GROUP_NAME).exists()
+        assert user.groups.filter(name=explicit_group.name).exists()
+
     def test_access_point_user_mode_rejects_password_argument(self):
         """Access-point mode should reject contradictory password arguments."""
 


### PR DESCRIPTION
### Motivation

- When provisioning an access-point user via the CLI, the account should receive the Access Point visitor security group and gallery upload capability by default so visitors can upload to the gallery without requiring manual group assignment.

### Description

- Add `ACCESS_POINT_DEFAULT_GROUP_NAMES` and import `AP_USER_GROUP_NAME` and `GALLERY_MANAGER_GROUP_NAME` to the `password` management command to declare the default AP groups.  
- Introduce `_resolve_access_point_groups` which calls `ensure_security_groups_exist` and merges default AP groups with any explicitly requested `--group` values before membership hardening.  
- Apply `_resolve_access_point_groups` in the `--access-point-user` flow so CLI-created AP users are assigned the AP visitor and gallery manager groups by default.  
- Update `apps/users/tests/test_temp_password_command.py` to assert the new default group behavior and adapt tests to avoid pre-creating AP group fixtures where unnecessary.

### Testing

- Ran environment refresh with `./env-refresh.sh` to ensure dependencies and migrations were applied successfully.  
- Executed ` .venv/bin/python manage.py test run -- apps.users.tests.test_temp_password_command.py` and observed all tests in the file passed (`21 passed, 1 warning`).  
- Sent review notification via `./scripts/review-notify.sh --actor Codex` as part of the rollout steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b3321fbc8326b5bf746277d1b260)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR automatically assigns default security groups to access-point users provisioned via the CLI, ensuring they have Access Point visitor and gallery manager capabilities without manual group assignment.

## Changes

### `apps/users/management/commands/password.py`

Added default group assignment infrastructure for `--access-point-user` mode:

- **Imports**: Added `GALLERY_MANAGER_GROUP_NAME` (from `apps.gallery.constants`) and `AP_USER_GROUP_NAME` (from `apps.groups.constants`); added `ensure_security_groups_exist` (from `apps.groups.security`).
- **Class attribute**: Defined `ACCESS_POINT_DEFAULT_GROUP_NAMES` tuple containing `AP_USER_GROUP_NAME` and `GALLERY_MANAGER_GROUP_NAME`.
- **New method `_resolve_access_point_groups()`**: Ensures the default security groups exist, resolves them to group objects, merges with any explicitly provided groups via `--group`, deduplicates by name, and returns the result in sorted name order.
- **Updated `--access-point-user` flow**: Now calls `_resolve_access_point_groups()` after resolving explicit groups to ensure all default groups are automatically assigned before membership hardening.

### `apps/users/tests/test_temp_password_command.py`

Updated tests to verify automatic default group assignment:

- Removed pre-creation of `AP_USER_GROUP_NAME` from test setup.
- Added assertions verifying both `AP_USER_GROUP_NAME` and `GALLERY_MANAGER_GROUP_NAME` are present after access-point user configuration in `test_configures_access_point_user_mode()`, `test_configures_access_point_user_mode_without_update_flag()`, `test_configures_access_point_user_mode_clears_existing_groups()`, and `test_configures_access_point_user_mode_clears_temporary_credentials()`.
- Tests now validate that default groups are automatically applied regardless of prior group membership state.

## Impact

Access-point users created via the `password` management command now automatically receive the required security groups, eliminating the need for separate group assignment steps. Explicit `--group` values are merged with defaults and deduplicated to avoid conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->