### PR TITLE
preflight-env: auto-bootstrap .venv with env-refresh when Python is missing

### DIFF
--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -32,7 +32,15 @@ fi
 
 if [[ ! -x "$PYTHON_BIN" ]]; then
   echo ".venv/bin/python missing: expected executable at $PYTHON_BIN" >&2
-  echo "Run ./env-refresh.sh --deps-only" >&2
+  echo "Bootstrapping dependencies with ./env-refresh.sh --deps-only" >&2
+  if ! "$BASE_DIR/env-refresh.sh" --deps-only; then
+    echo "Failed to bootstrap environment with ./env-refresh.sh --deps-only" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo ".venv/bin/python still missing after bootstrap: expected executable at $PYTHON_BIN" >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Ensure `./scripts/preflight-env.sh` will automatically attempt to bootstrap the virtualenv dependencies with `./env-refresh.sh --deps-only` when `.venv/bin/python` is missing to avoid a manual refresh step.

### Description
- If `"$PYTHON_BIN"` is not executable the script now runs `"$BASE_DIR/env-refresh.sh" --deps-only`, prints an error and exits if bootstrapping fails, and then re-checks `"$PYTHON_BIN"` before failing; user-facing messages were updated accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ed7b02d883269185ed05087e254e)