### PR TITLE
Defer RFID scanner auto-detection to explicit scanner workflows

### DIFF
--- a/apps/nodes/models/features.py
+++ b/apps/nodes/models/features.py
@@ -324,6 +324,7 @@ class NodeFeatureMixin:
             self.sync_feature_tasks()
             return
         managed_slugs = self.AUTO_MANAGED_FEATURES - self.LAZY_AUTO_DETECTION_FEATURE_SLUGS
+        reconciliation_slugs = self.AUTO_MANAGED_FEATURES
         detected_slugs = set()
         base_path = self.get_base_path()
         base_dir = Path(settings.BASE_DIR)
@@ -337,7 +338,7 @@ class NodeFeatureMixin:
                 logger.exception("Automatic detection failed for feature %s", slug)
         current_slugs = set(
             self.features.filter(
-                slug__in=managed_slugs,
+                slug__in=reconciliation_slugs,
                 footprint=self.AUTO_ENABLE_FOOTPRINT,
             ).values_list("slug", flat=True)
         )

--- a/apps/nodes/models/features.py
+++ b/apps/nodes/models/features.py
@@ -219,6 +219,7 @@ class NodeFeatureMixin:
         "playwright-browser-webkit",
         "video-cam",
     }
+    LAZY_AUTO_DETECTION_FEATURE_SLUGS = {"rfid-scanner"}
     MANUAL_FEATURE_SLUGS = {"screenshot-poll"}
     ROLE_AUTO_FEATURE_SLUGS: set[str] = set()
     AUTO_ENABLE_FOOTPRINT = NodeFeature.Footprint.LIGHT
@@ -322,10 +323,11 @@ class NodeFeatureMixin:
         if not self.is_local:
             self.sync_feature_tasks()
             return
+        managed_slugs = self.AUTO_MANAGED_FEATURES - self.LAZY_AUTO_DETECTION_FEATURE_SLUGS
         detected_slugs = set()
         base_path = self.get_base_path()
         base_dir = Path(settings.BASE_DIR)
-        for slug in self.AUTO_MANAGED_FEATURES:
+        for slug in managed_slugs:
             try:
                 if self._detect_auto_feature(
                     slug, base_dir=base_dir, base_path=base_path
@@ -335,7 +337,7 @@ class NodeFeatureMixin:
                 logger.exception("Automatic detection failed for feature %s", slug)
         current_slugs = set(
             self.features.filter(
-                slug__in=self.AUTO_MANAGED_FEATURES,
+                slug__in=managed_slugs,
                 footprint=self.AUTO_ENABLE_FOOTPRINT,
             ).values_list("slug", flat=True)
         )

--- a/apps/nodes/tests/test_models_split.py
+++ b/apps/nodes/tests/test_models_split.py
@@ -1,9 +1,11 @@
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
 from django.contrib.sites.models import Site
 
 from apps.features.models import Feature
+from apps.nodes import utils as nodes_utils
 from apps.nodes.feature_detection import node_feature_detection_registry
 from apps.nodes.models import Node, NodeFeature
 from apps.nodes.models import utils as node_utils
@@ -168,6 +170,59 @@ def test_refresh_features_auto_enables_when_linked_suite_feature_enabled(
 
     node.refresh_features()
 
+    assert node.features.filter(pk=feature.pk).exists()
+
+
+@pytest.mark.django_db
+def test_refresh_features_skips_lazy_rfid_auto_detection(monkeypatch, tmp_path):
+    """Feature refresh should not probe lazy RFID scanner auto-detection."""
+
+    node = Node.objects.create(
+        hostname="lazy-rfid-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="lazy-rfid-node",
+        base_path=str(tmp_path),
+    )
+    feature = NodeFeature.objects.create(slug="rfid-scanner", display="RFID Scanner")
+    calls: list[str] = []
+
+    def _detect(slug: str, *, base_dir: Path, base_path: Path) -> bool:
+        calls.append(slug)
+        if slug == "rfid-scanner":
+            raise AssertionError("rfid-scanner should be lazily detected")
+        return False
+
+    monkeypatch.setattr(node, "_detect_auto_feature", _detect)
+
+    node.refresh_features()
+
+    assert "rfid-scanner" not in calls
+    assert not node.features.filter(pk=feature.pk).exists()
+
+
+@pytest.mark.django_db
+def test_ensure_feature_enabled_lazily_detects_rfid(monkeypatch, tmp_path):
+    """On-demand feature checks should detect and assign RFID scanner when needed."""
+
+    node = Node.objects.create(
+        hostname="ensure-rfid-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="ensure-rfid-node",
+        base_path=str(tmp_path),
+    )
+    feature = NodeFeature.objects.create(slug="rfid-scanner", display="RFID Scanner")
+    calls: list[str] = []
+
+    def _detect(slug: str, *, base_dir: Path, base_path: Path) -> bool:
+        calls.append(slug)
+        return slug == "rfid-scanner"
+
+    monkeypatch.setattr(node, "_detect_auto_feature", _detect)
+
+    assert nodes_utils.ensure_feature_enabled("rfid-scanner", node=node) is True
+    assert calls == ["rfid-scanner"]
     assert node.features.filter(pk=feature.pk).exists()
 
 

--- a/apps/nodes/tests/test_models_split.py
+++ b/apps/nodes/tests/test_models_split.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -202,6 +203,25 @@ def test_refresh_features_skips_lazy_rfid_auto_detection(monkeypatch, tmp_path):
 
 
 @pytest.mark.django_db
+def test_refresh_features_reconciles_existing_lazy_rfid_assignment(tmp_path):
+    """Feature refresh should clear stale lazy assignments without probing hardware."""
+
+    node = Node.objects.create(
+        hostname="lazy-rfid-stale-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="lazy-rfid-stale-node",
+        base_path=str(tmp_path),
+    )
+    feature = NodeFeature.objects.create(slug="rfid-scanner", display="RFID Scanner")
+    node.features.add(feature)
+
+    node.refresh_features()
+
+    assert not node.features.filter(pk=feature.pk).exists()
+
+
+@pytest.mark.django_db
 def test_ensure_feature_enabled_lazily_detects_rfid(monkeypatch, tmp_path):
     """On-demand feature checks should detect and assign RFID scanner when needed."""
 
@@ -224,6 +244,60 @@ def test_ensure_feature_enabled_lazily_detects_rfid(monkeypatch, tmp_path):
     assert nodes_utils.ensure_feature_enabled("rfid-scanner", node=node) is True
     assert calls == ["rfid-scanner"]
     assert node.features.filter(pk=feature.pk).exists()
+
+
+@pytest.mark.django_db
+def test_ensure_feature_enabled_does_not_probe_lazy_feature_on_remote_node(
+    monkeypatch, tmp_path
+):
+    """Remote nodes should not probe local hardware for lazy feature detection."""
+
+    node = Node.objects.create(
+        hostname="ensure-rfid-remote-node",
+        mac_address=Node.get_current_mac(),
+        public_endpoint="ensure-rfid-remote-node",
+        base_path=str(tmp_path),
+    )
+    NodeFeature.objects.create(slug="rfid-scanner", display="RFID Scanner")
+    monkeypatch.setattr(Node, "is_local", property(lambda self: False))
+    calls: list[str] = []
+
+    def _detect(*args, **kwargs):
+        calls.append("called")
+        return True
+
+    monkeypatch.setattr(node, "_detect_auto_feature", _detect)
+
+    assert nodes_utils.ensure_feature_enabled("rfid-scanner", node=node) is False
+    assert calls == []
+
+
+@pytest.mark.django_db
+def test_ensure_feature_enabled_handles_lazy_detection_exception(
+    monkeypatch, tmp_path
+):
+    """Lazy detection exceptions should be treated as unavailable features."""
+
+    node = Node.objects.create(
+        hostname="ensure-rfid-exception-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="ensure-rfid-exception-node",
+        base_path=str(tmp_path),
+    )
+    NodeFeature.objects.create(slug="rfid-scanner", display="RFID Scanner")
+    logger = mock.Mock()
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("detector unavailable")
+
+    monkeypatch.setattr(node, "_detect_auto_feature", _raise)
+
+    assert (
+        nodes_utils.ensure_feature_enabled("rfid-scanner", node=node, logger=logger)
+        is False
+    )
+    logger.exception.assert_called_once()
 
 
 @pytest.fixture

--- a/apps/nodes/utils.py
+++ b/apps/nodes/utils.py
@@ -1,10 +1,11 @@
 import logging
 from pathlib import Path
 
+from django.conf import settings
 from django.db.utils import OperationalError, ProgrammingError
 
 from apps.content import utils as content_utils
-from apps.nodes.models import Node, NodeFeature
+from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
 
 SCREENSHOT_DIR = content_utils.SCREENSHOT_DIR
 DEFAULT_SCREENSHOT_RESOLUTION = content_utils.DEFAULT_SCREENSHOT_RESOLUTION
@@ -47,6 +48,15 @@ def ensure_feature_enabled(
 
     if target.has_feature(slug):
         return True
+
+    lazy_slugs = getattr(target, "LAZY_AUTO_DETECTION_FEATURE_SLUGS", set())
+    if slug in lazy_slugs:
+        base_dir = Path(settings.BASE_DIR)
+        base_path = target.get_base_path()
+        if target._detect_auto_feature(slug, base_dir=base_dir, base_path=base_path):
+            NodeFeatureAssignment.objects.update_or_create(node=target, feature=feature)
+            return True
+        return False
 
     try:
         target.refresh_features()

--- a/apps/nodes/utils.py
+++ b/apps/nodes/utils.py
@@ -50,12 +50,18 @@ def ensure_feature_enabled(
         return True
 
     lazy_slugs = getattr(target, "LAZY_AUTO_DETECTION_FEATURE_SLUGS", set())
-    if slug in lazy_slugs:
-        base_dir = Path(settings.BASE_DIR)
-        base_path = target.get_base_path()
-        if target._detect_auto_feature(slug, base_dir=base_dir, base_path=base_path):
-            NodeFeatureAssignment.objects.update_or_create(node=target, feature=feature)
-            return True
+    if target.is_local and slug in lazy_slugs:
+        try:
+            base_dir = Path(settings.BASE_DIR)
+            base_path = target.get_base_path()
+            if target._detect_auto_feature(slug, base_dir=base_dir, base_path=base_path):
+                NodeFeatureAssignment.objects.update_or_create(
+                    node=target, feature=feature
+                )
+                return True
+        except Exception:
+            if logger:
+                logger.exception("Unable to lazily detect feature %s", slug)
         return False
 
     try:


### PR DESCRIPTION
### Motivation
- Avoid probing RFID scanner hardware during broad node refresh cycles and only detect the scanner when an admin view or CLI command explicitly requires it.
- Reduce unexpected side-effects and unnecessary runtime checks during unrelated feature refreshes.

### Description
- Introduce `LAZY_AUTO_DETECTION_FEATURE_SLUGS = {"rfid-scanner"}` and exclude those slugs from `NodeFeatureMixin.refresh_features()` so `rfid-scanner` is skipped during generic detection sweeps.
- Update `ensure_feature_enabled()` to perform on-demand detection for lazy features and persist a `NodeFeatureAssignment` when the explicit detection succeeds.
- Add regression tests verifying that `refresh_features()` does not trigger RFID detection and that `ensure_feature_enabled()` still detects and assigns the RFID scanner on demand.
- Minor test import fix to reference `apps.nodes.utils` where appropriate.

### Testing
- Ran environment dependency refresh with `./env-refresh.sh --deps-only` successfully.
- Installed test dependencies with `.venv/bin/python -m pip install pytest pytest-django pytest-timeout` successfully.
- Executed `.venv/bin/python manage.py test run -- apps/nodes/tests/test_models_split.py` and observed all tests in that module pass (`17 passed`).
- Executed `.venv/bin/python manage.py test run -- apps/cards/tests/test_rfid_service_command.py` and observed all tests in that module pass (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2eb1e51248326b3145eed82f242d8)