### PR TITLE
env-refresh: fail fast when venv python is missing or non-executable

### DIFF
--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -144,7 +144,7 @@ if [ "$DEPS_ONLY" -eq 1 ] && [ "$INSTALL_AND_REFRESH" -eq 1 ]; then
   exit 1
 fi
 
-if [ ! -f "$PYTHON" ]; then
+if [ ! -x "$PYTHON" ]; then
   if bootstrap_python="$(arthexis_python_bin 2>/dev/null)"; then
     if "$bootstrap_python" -m venv "$VENV_DIR" >/dev/null 2>&1; then
       PYTHON="$VENV_DIR/bin/python"
@@ -152,9 +152,9 @@ if [ ! -f "$PYTHON" ]; then
       FORCE_REQUIREMENTS_INSTALL=1
       echo "Virtual environment not found. Bootstrapping new virtual environment." >&2
     else
-      PYTHON="$bootstrap_python"
-      USE_SYSTEM_PYTHON=1
-      echo "Virtual environment not found and automatic creation failed. Using system Python." >&2
+      echo "Virtual environment not found and automatic creation failed." >&2
+      echo "Ensure venv support is installed (for example: sudo apt install python3-venv) and rerun ./install.sh." >&2
+      exit 1
     fi
   else
     echo "Python interpreter not found. Run ./install.sh first. Skipping." >&2


### PR DESCRIPTION
### Motivation

* CI and tooling (for example `./scripts/preflight-env.sh` and `./scripts/run_mypy.sh`) expect `.venv/bin/python` to exist and be runnable, but stale cached venvs or non-executable files allowed the script to continue and caused later failures.

### Description

* Require an executable venv Python by checking `-x` for `.venv/bin/python` and remove the silent fallback to the system Python; if venv bootstrap fails the script emits a clear remediation message and exits with non-zero status.

### Testing

* Ran `./env-refresh.sh --deps-only` which successfully bootstrapped a venv and installed dependencies (success).
* Ran `./scripts/preflight-env.sh` which passed (success).
* Ran `bash -n env-refresh.sh` to validate syntax (success).
* Ran `./scripts/review-notify.sh --actor Codex` to exercise notification paths (success).
* `./scripts/preflight-env.sh --pytest` / `./scripts/run_mypy.sh` failed in this environment due to missing optional tooling (`pytest`/`mypy`) and not because of the venv bootstrap change (expected failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e391d2b5c88326a7a905487225a4fe)