### PR TITLE
Harden venv bootstrap for preflight and mypy scripts

### DIFF
--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -146,15 +146,20 @@ fi
 
 if [ ! -f "$PYTHON" ]; then
   if bootstrap_python="$(arthexis_python_bin 2>/dev/null)"; then
-    if "$bootstrap_python" -m venv "$VENV_DIR" >/dev/null 2>&1; then
+    venv_bootstrap_log="$(mktemp)"
+    if "$bootstrap_python" -m venv "$VENV_DIR" >"$venv_bootstrap_log" 2>&1; then
+      rm -f "$venv_bootstrap_log"
       PYTHON="$VENV_DIR/bin/python"
       USE_SYSTEM_PYTHON=0
       FORCE_REQUIREMENTS_INSTALL=1
       echo "Virtual environment not found. Bootstrapping new virtual environment." >&2
     else
+      echo "Virtual environment not found and automatic creation failed. Using system Python." >&2
+      echo "Failed command: $bootstrap_python -m venv $VENV_DIR" >&2
+      sed -e 's/^/venv bootstrap error: /' "$venv_bootstrap_log" >&2
+      rm -f "$venv_bootstrap_log"
       PYTHON="$bootstrap_python"
       USE_SYSTEM_PYTHON=1
-      echo "Virtual environment not found and automatic creation failed. Using system Python." >&2
     fi
   else
     echo "Python interpreter not found. Run ./install.sh first. Skipping." >&2

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -5,6 +5,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_BIN="$BASE_DIR/.venv/bin/python"
 REQUIRED_MODULES=("django")
+ENV_REFRESH_CMD=("$BASE_DIR/env-refresh.sh" "--deps-only")
+
+ensure_venv_python() {
+  local needs_refresh=0
+
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    needs_refresh=1
+  elif ! "$PYTHON_BIN" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
+    needs_refresh=1
+  fi
+
+  if [[ "$needs_refresh" -eq 0 ]]; then
+    return 0
+  fi
+
+  echo ".venv/bin/python missing or unusable at $PYTHON_BIN; running ${ENV_REFRESH_CMD[*]}" >&2
+  "${ENV_REFRESH_CMD[@]}"
+}
 
 if [[ $# -gt 1 ]]; then
   echo "Too many arguments provided." >&2
@@ -30,8 +48,16 @@ elif [[ $# -gt 0 ]]; then
   exit 1
 fi
 
+ensure_venv_python
+
 if [[ ! -x "$PYTHON_BIN" ]]; then
-  echo ".venv/bin/python missing: expected executable at $PYTHON_BIN" >&2
+  echo ".venv/bin/python missing: expected executable at $PYTHON_BIN after ${ENV_REFRESH_CMD[*]}" >&2
+  echo "Run ./env-refresh.sh --deps-only" >&2
+  exit 1
+fi
+
+if ! "$PYTHON_BIN" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
+  echo ".venv/bin/python is not runnable at $PYTHON_BIN after ${ENV_REFRESH_CMD[*]}" >&2
   echo "Run ./env-refresh.sh --deps-only" >&2
   exit 1
 fi

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -4,24 +4,33 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_BIN="$BASE_DIR/.venv/bin/python"
+PYTHON_LABEL=".venv/bin/python"
+if [[ "${OSTYPE:-}" == "msys" || "${OSTYPE:-}" == "cygwin" || "${OSTYPE:-}" == "win32" ]]; then
+  PYTHON_BIN="$BASE_DIR/.venv/Scripts/python.exe"
+  PYTHON_LABEL=".venv/Scripts/python.exe"
+fi
 REQUIRED_MODULES=("django")
 ENV_REFRESH_CMD=("$BASE_DIR/env-refresh.sh" "--deps-only")
 
+python_is_usable() {
+  [[ -x "$PYTHON_BIN" ]] && "$PYTHON_BIN" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1
+}
+
 ensure_venv_python() {
-  local needs_refresh=0
-
-  if [[ ! -x "$PYTHON_BIN" ]]; then
-    needs_refresh=1
-  elif ! "$PYTHON_BIN" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
-    needs_refresh=1
-  fi
-
-  if [[ "$needs_refresh" -eq 0 ]]; then
+  if python_is_usable; then
     return 0
   fi
 
-  echo ".venv/bin/python missing or unusable at $PYTHON_BIN; running ${ENV_REFRESH_CMD[*]}" >&2
+  echo "$PYTHON_LABEL missing or unusable at $PYTHON_BIN; running ${ENV_REFRESH_CMD[*]}" >&2
   "${ENV_REFRESH_CMD[@]}"
+
+  if python_is_usable; then
+    return 0
+  fi
+
+  echo "$PYTHON_LABEL missing: expected executable at $PYTHON_BIN after ${ENV_REFRESH_CMD[*]}" >&2
+  echo "Run ./env-refresh.sh --deps-only" >&2
+  return 1
 }
 
 if [[ $# -gt 1 ]]; then
@@ -48,17 +57,7 @@ elif [[ $# -gt 0 ]]; then
   exit 1
 fi
 
-ensure_venv_python
-
-if [[ ! -x "$PYTHON_BIN" ]]; then
-  echo ".venv/bin/python missing: expected executable at $PYTHON_BIN after ${ENV_REFRESH_CMD[*]}" >&2
-  echo "Run ./env-refresh.sh --deps-only" >&2
-  exit 1
-fi
-
-if ! "$PYTHON_BIN" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
-  echo ".venv/bin/python is not runnable at $PYTHON_BIN after ${ENV_REFRESH_CMD[*]}" >&2
-  echo "Run ./env-refresh.sh --deps-only" >&2
+if ! ensure_venv_python; then
   exit 1
 fi
 

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -21,9 +21,7 @@ emit_remediation() {
   printf '{"code":"%s","command":"%s","event":"arthexis.qa.remediation","retry":"%s"}\n' "$code" "$command" "$retry" >&2
 }
 
-"$SCRIPT_DIR/preflight-env.sh"
-
-if [ ! -x "$PYTHON_BIN" ]; then
+if ! "$SCRIPT_DIR/preflight-env.sh"; then
   emit_remediation "missing_venv_python" "./env-refresh.sh --deps-only" "./scripts/run_mypy.sh"
   exit 1
 fi

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -8,10 +8,11 @@ export DEBUG="${DEBUG:-0}"
 export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-PYTHON_BIN=".venv/bin/python"
+PYTHON_BIN="$BASE_DIR/.venv/bin/python"
 if [[ "${OSTYPE:-}" == "msys" || "${OSTYPE:-}" == "cygwin" || "${OSTYPE:-}" == "win32" ]]; then
-  PYTHON_BIN=".venv/Scripts/python.exe"
+  PYTHON_BIN="$BASE_DIR/.venv/Scripts/python.exe"
 fi
 emit_remediation() {
   local code="$1"
@@ -20,8 +21,10 @@ emit_remediation() {
   printf '{"code":"%s","command":"%s","event":"arthexis.qa.remediation","retry":"%s"}\n' "$code" "$command" "$retry" >&2
 }
 
+"$SCRIPT_DIR/preflight-env.sh"
+
 if [ ! -x "$PYTHON_BIN" ]; then
-  emit_remediation "missing_venv_python" "./install.sh --terminal" "./scripts/run_mypy.sh"
+  emit_remediation "missing_venv_python" "./env-refresh.sh --deps-only" "./scripts/run_mypy.sh"
   exit 1
 fi
 
@@ -29,8 +32,6 @@ if ! "$PYTHON_BIN" -c "import importlib.util,sys;sys.exit(0 if importlib.util.fi
   emit_remediation "missing_dependency" "./env-refresh.sh --deps-only" "./scripts/run_mypy.sh"
   exit 1
 fi
-
-"$SCRIPT_DIR/preflight-env.sh"
 
 mypy_output="$(mktemp)"
 cleanup() {


### PR DESCRIPTION
### Motivation
- CI and typing flows can fail when `.venv/bin/python` is missing, stale, or contains a broken interpreter shim, so preflight and mypy wrappers must recover or point to the correct lightweight remediation before erroring.
- Ensure a single, predictable recovery path (`./env-refresh.sh --deps-only`) is used by preflight and mypy flows to reduce duplicated guidance and flaky failures.

### Description
- Add `ensure_venv_python()` to `scripts/preflight-env.sh` that checks `.venv/bin/python` for existence and runtime suitability and automatically runs `./env-refresh.sh --deps-only` when the venv is missing or unusable.
- Add an explicit runnable-interpreter validation in `scripts/preflight-env.sh` so stale/broken venv interpreters are treated the same as missing ones and fail with a clear remediation message.
- Update `scripts/run_mypy.sh` to resolve `.venv` paths relative to the repository root, invoke the preflight script before running MyPy, and change missing-venv remediation to `./env-refresh.sh --deps-only`.

### Testing
- Ran `./scripts/preflight-env.sh` and it successfully bootstrapped the venv by invoking `./env-refresh.sh --deps-only` when needed.
- Installed CI typing deps with `.venv/bin/python -m pip install --only-binary=:all: -r requirements-ci.txt` which completed successfully after the bootstrapped venv.
- Ran `./scripts/preflight-env.sh --pytest` which completed without error.
- Ran `./scripts/run_mypy.sh --version` which returned `mypy 1.20.0` indicating the mypy runner and preflight checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e391d2b5c88326a7a905487225a4fe)