### PR TITLE
evergo: enrich login wizard feedback with linked admin messages

### DIFF
--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -23,6 +23,8 @@ from .exceptions import EvergoAPIError
 from .forms import EvergoContractorLoginWizardForm, EvergoLoadCustomersForm, EvergoUserAdminForm
 from .models import EvergoArtifact, EvergoCustomer, EvergoOrder, EvergoOrderFieldValue, EvergoUser
 
+LOADED_ENTITIES_LINK_ID_LIMIT = 100
+
 
 def _parse_selected_ids_query_param(request) -> list[int]:
     """Return validated integer IDs from a comma-separated ``id__in`` query parameter."""
@@ -72,8 +74,8 @@ def _message_user_with_feedback(admin_instance, request, setup_results, message,
 
 def _build_loaded_entities_links(summary: dict[str, list[int]]) -> str:
     """Build customer/order changelist links for the imported entities."""
-    customer_ids = [str(value) for value in summary.get("loaded_customer_ids", [])]
-    order_ids = [str(value) for value in summary.get("loaded_order_ids", [])]
+    customer_ids = [str(value) for value in summary.get("loaded_customer_ids", [])[:LOADED_ENTITIES_LINK_ID_LIMIT]]
+    order_ids = [str(value) for value in summary.get("loaded_order_ids", [])[:LOADED_ENTITIES_LINK_ID_LIMIT]]
     links: list[tuple[str, str]] = []
     if customer_ids:
         customers_url = reverse("admin:evergo_evergocustomer_changelist")

--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -41,7 +41,53 @@ def _parse_selected_ids_query_param(request) -> list[int]:
 
 def _initialize_contract_login_results(saved_contractor):
     """Return the default result payload shown after wizard validation attempts."""
-    return {"contractor": saved_contractor, "validated": None, "loaded": None}
+    return {"admin_messages": [], "contractor": saved_contractor, "validated": None, "loaded": None}
+
+
+def _message_level_label(level: int) -> str:
+    """Return a stable status label for Django admin message levels."""
+    if level >= messages.ERROR:
+        return "error"
+    if level >= messages.WARNING:
+        return "warning"
+    if level >= messages.SUCCESS:
+        return "success"
+    if level >= messages.INFO:
+        return "info"
+    return "debug"
+
+
+def _message_user_with_feedback(admin_instance, request, setup_results, message, *, level: int):
+    """Emit a Django admin message and mirror it into setup feedback data when available."""
+    admin_instance.message_user(request, message, level=level)
+    if setup_results is None:
+        return
+    setup_results["admin_messages"].append(
+        {
+            "message": message,
+            "status": _message_level_label(level),
+        }
+    )
+
+
+def _build_loaded_entities_links(summary: dict[str, list[int]]) -> str:
+    """Build customer/order changelist links for the imported entities."""
+    customer_ids = [str(value) for value in summary.get("loaded_customer_ids", [])]
+    order_ids = [str(value) for value in summary.get("loaded_order_ids", [])]
+    customers_url = reverse("admin:evergo_evergocustomer_changelist")
+    orders_url = reverse("admin:evergo_evergoorder_changelist")
+    if customer_ids:
+        customers_url = f"{customers_url}?id__in={','.join(customer_ids)}"
+    if order_ids:
+        orders_url = f"{orders_url}?id__in={','.join(order_ids)}"
+    return format_html(
+        '{} <a href="{}">{}</a> | <a href="{}">{}</a>',
+        _("View loaded items:"),
+        customers_url,
+        _("Customers"),
+        orders_url,
+        _("Orders"),
+    )
 
 
 def _run_contract_login_validation(admin_instance, request, form, contractor, *, show_setup_results: bool):
@@ -54,7 +100,13 @@ def _run_contract_login_validation(admin_instance, request, form, contractor, *,
     success_message = _(
         "Evergo login succeeded for %(contractor)s (status %(status)s)."
     ) % {"contractor": str(contractor), "status": login_result.response_code}
-    admin_instance.message_user(request, success_message, level=messages.SUCCESS)
+    _message_user_with_feedback(
+        admin_instance,
+        request,
+        setup_results,
+        success_message,
+        level=messages.SUCCESS,
+    )
     if setup_results is not None:
         setup_results["validated"] = {"ok": True, "message": success_message}
 
@@ -67,14 +119,19 @@ def _run_contract_login_validation(admin_instance, request, form, contractor, *,
             raw_queries="" if form.cleaned_data.get("load_all_customers") else order_numbers
         )
     except EvergoAPIError as exc:
-        admin_instance.message_user(
+        error_message = _("Customer load failed for %(contractor)s: %(error)s") % {
+            "contractor": str(contractor),
+            "error": exc,
+        }
+        _message_user_with_feedback(
+            admin_instance,
             request,
-            _("Customer load failed for %(contractor)s: %(error)s")
-            % {"contractor": str(contractor), "error": exc},
+            setup_results,
+            error_message,
             level=messages.ERROR,
         )
         if setup_results is not None:
-            setup_results["loaded"] = {"ok": False, "message": str(exc)}
+            setup_results["loaded"] = {"ok": False, "message": error_message}
         return setup_results
 
     load_label = _("Full load completed") if form.cleaned_data.get("load_all_customers") else _("Order load completed")
@@ -89,9 +146,16 @@ def _run_contract_login_validation(admin_instance, request, form, contractor, *,
         "updated": summary["orders_updated"],
         "placeholders": summary["placeholders_created"],
     }
-    admin_instance.message_user(request, load_message, level=messages.SUCCESS)
+    load_message_with_links = format_html("{} {}", load_message, _build_loaded_entities_links(summary))
+    _message_user_with_feedback(
+        admin_instance,
+        request,
+        setup_results,
+        load_message_with_links,
+        level=messages.SUCCESS,
+    )
     if setup_results is not None:
-        setup_results["loaded"] = {"ok": True, "message": load_message, "summary": summary}
+        setup_results["loaded"] = {"ok": True, "message": load_message_with_links, "summary": summary}
     return setup_results
 
 
@@ -120,16 +184,20 @@ def _save_contractor_and_maybe_validate(admin_instance, request, form, profile):
         else:
             contractor.pk = None
             contractor._state.adding = True
-        admin_instance.message_user(
+        setup_results = _initialize_contract_login_results(contractor) if show_setup_results else None
+        if setup_results is not None:
+            setup_results["validated"] = {"ok": False, "message": str(exc)}
+        error_message = _("Evergo validation failed for %(contractor)s: %(error)s") % {
+            "contractor": str(contractor),
+            "error": exc,
+        }
+        _message_user_with_feedback(
+            admin_instance,
             request,
-            _("Evergo validation failed for %(contractor)s: %(error)s")
-            % {"contractor": str(contractor), "error": exc},
+            setup_results,
+            error_message,
             level=messages.ERROR,
         )
-        setup_results = None
-        if show_setup_results:
-            setup_results = _initialize_contract_login_results(contractor)
-            setup_results["validated"] = {"ok": False, "message": str(exc)}
         return contractor, setup_results
 
     return contractor, setup_results

--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -8,7 +8,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import CharField, Prefetch, Q, Value
 from django.db.models.functions import Coalesce, NullIf
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.http import HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import path, reverse
@@ -74,19 +74,19 @@ def _build_loaded_entities_links(summary: dict[str, list[int]]) -> str:
     """Build customer/order changelist links for the imported entities."""
     customer_ids = [str(value) for value in summary.get("loaded_customer_ids", [])]
     order_ids = [str(value) for value in summary.get("loaded_order_ids", [])]
-    customers_url = reverse("admin:evergo_evergocustomer_changelist")
-    orders_url = reverse("admin:evergo_evergoorder_changelist")
+    links: list[tuple[str, str]] = []
     if customer_ids:
-        customers_url = f"{customers_url}?id__in={','.join(customer_ids)}"
+        customers_url = reverse("admin:evergo_evergocustomer_changelist")
+        links.append((f"{customers_url}?id__in={','.join(customer_ids)}", _("Customers")))
     if order_ids:
-        orders_url = f"{orders_url}?id__in={','.join(order_ids)}"
+        orders_url = reverse("admin:evergo_evergoorder_changelist")
+        links.append((f"{orders_url}?id__in={','.join(order_ids)}", _("Orders")))
+    if not links:
+        return ""
     return format_html(
-        '{} <a href="{}">{}</a> | <a href="{}">{}</a>',
+        "{} {}",
         _("View loaded items:"),
-        customers_url,
-        _("Customers"),
-        orders_url,
-        _("Orders"),
+        format_html_join(" | ", '<a href="{}">{}</a>', links),
     )
 
 
@@ -146,7 +146,8 @@ def _run_contract_login_validation(admin_instance, request, form, contractor, *,
         "updated": summary["orders_updated"],
         "placeholders": summary["placeholders_created"],
     }
-    load_message_with_links = format_html("{} {}", load_message, _build_loaded_entities_links(summary))
+    loaded_entities_links = _build_loaded_entities_links(summary)
+    load_message_with_links = format_html("{} {}", load_message, loaded_entities_links) if loaded_entities_links else load_message
     _message_user_with_feedback(
         admin_instance,
         request,

--- a/apps/evergo/templates/admin/evergo/contractor_login_wizard.html
+++ b/apps/evergo/templates/admin/evergo/contractor_login_wizard.html
@@ -97,7 +97,7 @@
           <li>
             <strong>{% translate "Credential validation" %}:</strong>
             {% if setup_results.validated %}
-              {{ setup_results.validated.message|safe }}
+              {{ setup_results.validated.message }}
             {% else %}
               {% translate "Skipped." %}
             {% endif %}
@@ -105,7 +105,7 @@
           <li>
             <strong>{% translate "Customer load" %}:</strong>
             {% if setup_results.loaded %}
-              {{ setup_results.loaded.message|safe }}
+              {{ setup_results.loaded.message }}
             {% else %}
               {% translate "Skipped." %}
             {% endif %}
@@ -115,7 +115,7 @@
               <strong>{% translate "Admin Messages" %}:</strong>
               <ul>
                 {% for entry in setup_results.admin_messages %}
-                  <li><strong>{{ entry.status }}:</strong> {{ entry.message|safe }}</li>
+                  <li><strong>{{ entry.status }}:</strong> {{ entry.message }}</li>
                 {% endfor %}
               </ul>
             </li>

--- a/apps/evergo/templates/admin/evergo/contractor_login_wizard.html
+++ b/apps/evergo/templates/admin/evergo/contractor_login_wizard.html
@@ -97,7 +97,7 @@
           <li>
             <strong>{% translate "Credential validation" %}:</strong>
             {% if setup_results.validated %}
-              {{ setup_results.validated.message }}
+              {{ setup_results.validated.message|safe }}
             {% else %}
               {% translate "Skipped." %}
             {% endif %}
@@ -105,11 +105,21 @@
           <li>
             <strong>{% translate "Customer load" %}:</strong>
             {% if setup_results.loaded %}
-              {{ setup_results.loaded.message }}
+              {{ setup_results.loaded.message|safe }}
             {% else %}
               {% translate "Skipped." %}
             {% endif %}
           </li>
+          {% if setup_results.admin_messages %}
+            <li>
+              <strong>{% translate "Admin Messages" %}:</strong>
+              <ul>
+                {% for entry in setup_results.admin_messages %}
+                  <li><strong>{{ entry.status }}:</strong> {{ entry.message|safe }}</li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% endif %}
         </ul>
         {% if setup_results.loaded.summary and setup_results.loaded.summary.unresolved %}
           <p>

--- a/apps/evergo/tests/test_admin_wizard.py
+++ b/apps/evergo/tests/test_admin_wizard.py
@@ -118,6 +118,8 @@ def test_run_contract_login_validation_uses_order_numbers_when_full_load_disable
         captured_queries.append(raw_queries)
         return {
             "customers_loaded": 1,
+            "loaded_customer_ids": [11],
+            "loaded_order_ids": [22],
             "orders_created": 1,
             "orders_updated": 0,
             "placeholders_created": 0,
@@ -143,3 +145,8 @@ def test_run_contract_login_validation_uses_order_numbers_when_full_load_disable
 
     assert result is not None
     assert captured_queries == ["J00123, J00456"]
+    assert len(messages) == 2
+    assert "id__in=11" in messages[1][1]
+    assert "id__in=22" in messages[1][1]
+    assert result["admin_messages"][0]["status"] == "success"
+    assert result["admin_messages"][1]["status"] == "success"

--- a/apps/evergo/tests/test_admin_wizard.py
+++ b/apps/evergo/tests/test_admin_wizard.py
@@ -9,7 +9,11 @@ from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 
 from apps.chats.models import ChatAvatar
-from apps.evergo.admin import _build_loaded_entities_links, _run_contract_login_validation
+from apps.evergo.admin import (
+    LOADED_ENTITIES_LINK_ID_LIMIT,
+    _build_loaded_entities_links,
+    _run_contract_login_validation,
+)
 from apps.evergo.forms import EvergoContractorLoginWizardForm
 from apps.evergo.models import EvergoUser
 from apps.groups.models import SecurityGroup
@@ -178,3 +182,17 @@ def test_build_loaded_entities_links_returns_empty_when_no_entities_loaded():
     )
 
     assert links == ""
+
+
+@pytest.mark.django_db
+def test_build_loaded_entities_links_limits_query_ids_to_prevent_overlong_urls():
+    """Link helper should cap IDs so large imports do not emit overlong changelist URLs."""
+    links = _build_loaded_entities_links(
+        {
+            "loaded_customer_ids": list(range(1, LOADED_ENTITIES_LINK_ID_LIMIT + 50)),
+            "loaded_order_ids": [],
+        }
+    )
+
+    assert f",{LOADED_ENTITIES_LINK_ID_LIMIT}" in links
+    assert f",{LOADED_ENTITIES_LINK_ID_LIMIT + 1}" not in links

--- a/apps/evergo/tests/test_admin_wizard.py
+++ b/apps/evergo/tests/test_admin_wizard.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 
 from apps.chats.models import ChatAvatar
-from apps.evergo.admin import _run_contract_login_validation
+from apps.evergo.admin import _build_loaded_entities_links, _run_contract_login_validation
 from apps.evergo.forms import EvergoContractorLoginWizardForm
 from apps.evergo.models import EvergoUser
 from apps.groups.models import SecurityGroup
@@ -150,3 +150,31 @@ def test_run_contract_login_validation_uses_order_numbers_when_full_load_disable
     assert "id__in=22" in messages[1][1]
     assert result["admin_messages"][0]["status"] == "success"
     assert result["admin_messages"][1]["status"] == "success"
+
+
+@pytest.mark.django_db
+def test_build_loaded_entities_links_only_includes_present_entities():
+    """Link helper should omit entity links when no IDs were loaded for that entity type."""
+    links = _build_loaded_entities_links(
+        {
+            "loaded_customer_ids": [11],
+            "loaded_order_ids": [],
+        }
+    )
+
+    assert "id__in=11" in links
+    assert "Customers" in links
+    assert "Orders" not in links
+
+
+@pytest.mark.django_db
+def test_build_loaded_entities_links_returns_empty_when_no_entities_loaded():
+    """Link helper should not render generic changelist links when nothing was loaded."""
+    links = _build_loaded_entities_links(
+        {
+            "loaded_customer_ids": [],
+            "loaded_order_ids": [],
+        }
+    )
+
+    assert links == ""


### PR DESCRIPTION
### Motivation

- Improve operator feedback from the Evergo "Login on Evergo" wizard by capturing admin toasts in the wizard feedback structure and making success messages actionable.  

### Description

- Add `setup_results["admin_messages"]` to the wizard payload and introduce `_message_user_with_feedback` to mirror every admin message into that list with a normalized status label provided by `_message_level_label`.  
- Append customer/order changelist links to successful load messages via `_build_loaded_entities_links` and use the enriched HTML message both for admin toasts and in `setup_results`.  
- Initialize `setup_results` on validation/save error paths so the form always returns feedback when `show_setup_results` is requested.  
- Update the wizard template to render `validated`/`loaded` messages as safe HTML and add a conditional "Admin Messages" section that lists mirrored admin messages and their status.  
- Extend unit tests to assert that load messages contain `id__in` filters and that admin messages are mirrored with `success` status.  

### Testing

- Bootstrapped environment with `./env-refresh.sh --deps-only` and installed test tooling (`pytest`, `pytest-django`, `pytest-timeout`).  
- Ran the app test suite for the changed unit file with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_admin_wizard.py` and received `4 passed` (no failures).  
- All automated tests exercised for this change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f19ed7408326acdff45a5f011724)