### PR TITLE
evergo: disable manual EvergoCustomer creation in admin

### DIFF
--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -993,6 +993,10 @@ class EvergoCustomerAdmin(DjangoObjectActions, admin.ModelAdmin):
             return queryset
         return queryset.filter(user__user=request.user)
 
+    def has_add_permission(self, request):
+        """Disallow manual admin creation; customers are synchronized from Evergo."""
+        return False
+
     def get_urls(self):
         """Register custom admin routes for Evergo customer tools."""
         urls = super().get_urls()

--- a/apps/evergo/tests/test_admin_customers.py
+++ b/apps/evergo/tests/test_admin_customers.py
@@ -34,3 +34,19 @@ def test_evergo_customer_changelist_renders_with_json_brand_payload(client):
 
     assert response.status_code == 200
     assert b"Customer With Brand" in response.content
+
+
+@pytest.mark.django_db
+def test_evergo_customer_add_view_is_disabled(client):
+    """Customer add view should be unavailable because records come from Evergo sync."""
+    User = get_user_model()
+    admin_user = User.objects.create_superuser(
+        username="evergo-admin-2",
+        email="evergo-admin-2@example.com",
+        password="top-secret",  # noqa: S106
+    )
+
+    client.force_login(admin_user)
+    response = client.get(reverse("admin:evergo_evergocustomer_add"))
+
+    assert response.status_code == 403


### PR DESCRIPTION
### Motivation

- Prevent manual creation of `EvergoCustomer` records via the admin so customer snapshots are sourced only from the Evergo API sync/load flow. 
- Align admin behavior with existing Evergo workflows and reduce accidental or unsupported manual edits.

### Description

- Added `has_add_permission()` to `EvergoCustomerAdmin` to always return `False`, disallowing admin add operations for customers (`apps/evergo/admin.py`).
- Added a regression test `test_evergo_customer_add_view_is_disabled` that asserts the admin add view returns HTTP `403` for `EvergoCustomer` (`apps/evergo/tests/test_admin_customers.py`).
- Kept changelist and custom loading workflows intact; only manual add capability was disabled.

### Testing

- Ran the app-level test: `.venv/bin/python manage.py test run -- apps/evergo/tests/test_admin_customers.py` and observed `2 passed` for the modified test module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f861c3688326b3dc6d3bb217403b)