### PR TITLE
docs: remove agent/developer screenshot directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,6 @@ Agents must run relevant tests after code changes.
   * they are security-relevant, or
   * they protect critical logic.
 
----
-
 ### Test Creation Guidelines
 
 * Each **feature should have a test**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,17 +157,6 @@ Agents must run relevant tests after code changes.
   * they are security-relevant, or
   * they protect critical logic.
 
-### Screenshot Capture Policy
-
-* Do **not** take manual screenshots in the agent runtime.
-* The Screenshot CI workflow is the source of truth for previews and artifacts.
-* Leave screenshot generation to Screenshot CI, even when making visual/UI changes; do not use manual capture skills unless a maintainer explicitly asks for a one-off capture for a specific debugging need.
-* If you need extra screenshot coverage, add route paths (one per line) to:
-  * `.github/screenshot-paths.authenticated.txt` for pages that require login.
-  * `.github/screenshot-paths.public.txt` for public pages.
-* Keep entries as URL paths (for example `/admin/` or `/ocpp/c/SIM-CP-1/`).
-* Comments (`# ...`) and blank lines are allowed in the path files.
-
 ---
 
 ### Test Creation Guidelines
@@ -176,8 +165,6 @@ Agents must run relevant tests after code changes.
 * Prefer **quality over quantity** of tests.
 * Do **not create tests solely to validate styling**.
 * Do **not create tests solely to confirm removed features are gone**.
-
-Styling will be validated through previews.
 
 ### Regression Handling
 

--- a/docs/development/admin-ui-framework.md
+++ b/docs/development/admin-ui-framework.md
@@ -60,7 +60,6 @@ These pages now use common panel, stack, action row, and button primitives to el
 - Audit all templates under `apps/*/templates/admin/**` for ad-hoc button/link sizing.
 - Migrate pages incrementally to framework primitives.
 - Introduce new primitives in `admin_ui_framework.css` only when reused by at least two templates.
-- Add visual checks (screenshots) for representative admin pages when changing primitives.
 
 
 ## Enforcement for new changes
@@ -88,5 +87,3 @@ Use the staged rollout below when upgrading legacy admin templates:
    - When two or more apps need the same styling pattern, promote it into `admin_ui_framework.css`.
 5. **Burn down allowlist entries**
    - Remove migrated templates from the legacy allowlist so regressions are prevented automatically.
-6. **Verify visually for high-impact pages**
-   - Capture screenshots of representative admin pages when changing shared primitives.

--- a/docs/development/ci-troubleshooting.md
+++ b/docs/development/ci-troubleshooting.md
@@ -25,25 +25,6 @@ This catches:
 - local app entries in `PROJECT_LOCAL_APPS` that are not importable
 - `apps.*` entries in `INSTALLED_APPS` that are missing from `PROJECT_LOCAL_APPS` and `PROJECT_APPS`
 
-## Screenshot coverage in CI
-
-The screenshot workflow already captures baseline routes. To request additional CI screenshot coverage without taking manual screenshots:
-
-- Add authenticated paths (admin/session-required pages) to `.github/screenshot-paths.authenticated.txt`.
-- Add public paths to `.github/screenshot-paths.public.txt`.
-- Keep one path per line and start with `/` (for example `/admin/links/reference/`).
-- Blank lines and `#` comments are ignored.
-
-These path files are read by `.github/workflows/dashboard-screenshot.yml`, which appends them to the default capture list and uploads the resulting screenshots as workflow artifacts.
-
-### When local preview tooling is unavailable
-
-If local preview generation fails because browser/screenshot tooling is unavailable in the current runtime, do not block on manual capture. Register the route for CI screenshot capture instead:
-
-- Add the route (starting with `/`, one per line) to `.github/screenshot-paths.authenticated.txt` (requires login) or `.github/screenshot-paths.public.txt` (public route).
-- Push the change and rely on the screenshot workflow artifacts as the preview source of truth.
-- Prefer this CI route-registration flow over ad-hoc local browser setup in constrained environments.
-
 ## Debugger/autoreload duplicate startup logs
 
 In this repository, `manage.py runserver` injects `--noreload` by default, so the usual Django watcher/child autoreload duplication is normally disabled.


### PR DESCRIPTION
### Motivation

* Remove guidance that instructs agents and developers to capture or manage screenshots so agents are not directed to perform manual screenshot capture.
* Reduce operational guidance surface that directs repo contributors to register screenshot CI paths or rely on local/manual screenshot tooling.

### Description

* Removed the entire Screenshot Capture Policy section from `AGENTS.md` so agents are no longer instructed to take or manage screenshots.
* Deleted screenshot recommendation bullets from `docs/development/admin-ui-framework.md` rollout guidance so framework changes no longer explicitly ask for visual screenshot checks.
* Removed the Screenshot coverage in CI section from `docs/development/ci-troubleshooting.md` that instructed developers to add entries to `.github/screenshot-paths.*`.

### Testing

* Ran `git diff --check` to validate there are no whitespace/patch issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f7f36a6c8326832852f04eb6fe16)