### PR TITLE
Add 'legacy' importance choice and migration to mark legacy applications

### DIFF
--- a/apps/app/migrations/0002_application_importance_legacy.py
+++ b/apps/app/migrations/0002_application_importance_legacy.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def mark_legacy_applications(apps, schema_editor):
+    Application = apps.get_model("app", "Application")
+    Application.objects.filter(name__icontains="legacy").update(importance="legacy")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="application",
+            name="importance",
+            field=models.CharField(
+                choices=[
+                    ("critical", "Critical"),
+                    ("baseline", "Baseline"),
+                    ("legacy", "Legacy"),
+                    ("prototype", "Prototype"),
+                ],
+                default="baseline",
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(mark_legacy_applications, migrations.RunPython.noop),
+    ]

--- a/apps/app/migrations/0002_application_importance_legacy.py
+++ b/apps/app/migrations/0002_application_importance_legacy.py
@@ -2,8 +2,12 @@ from django.db import migrations, models
 
 
 def mark_legacy_applications(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     Application = apps.get_model("app", "Application")
-    Application.objects.filter(name__icontains="legacy").update(importance="legacy")
+    Application.objects.using(db_alias).filter(
+        name__icontains="legacy",
+        importance="baseline",
+    ).update(importance="legacy")
 
 
 class Migration(migrations.Migration):

--- a/apps/app/models.py
+++ b/apps/app/models.py
@@ -28,6 +28,7 @@ class Application(Entity):
     class Importance(models.TextChoices):
         CRITICAL = "critical", _("Critical")
         BASELINE = "baseline", _("Baseline")
+        LEGACY = "legacy", _("Legacy")
         PROTOTYPE = "prototype", _("Prototype")
 
     name = models.CharField(max_length=100, unique=True, blank=True)

--- a/apps/app/tests/test_importance.py
+++ b/apps/app/tests/test_importance.py
@@ -1,8 +1,49 @@
 """Tests for application importance choices."""
 
+import importlib
+
+from django.apps import apps as django_apps
+
 from apps.app.models import Application
+
+mark_legacy_applications = importlib.import_module(
+    "apps.app.migrations.0002_application_importance_legacy"
+).mark_legacy_applications
 
 
 def test_application_importance_includes_legacy_choice() -> None:
     assert Application.Importance.LEGACY == "legacy"
     assert ("legacy", "Legacy") in Application.Importance.choices
+
+
+class _SchemaEditorStub:
+    def __init__(self, alias: str):
+        self.connection = type("Connection", (), {"alias": alias})()
+
+
+def test_mark_legacy_applications_updates_baseline_only(db) -> None:
+    legacy_baseline = Application.objects.create(
+        name="legacy core",
+        importance=Application.Importance.BASELINE,
+    )
+    legacy_critical = Application.objects.create(
+        name="legacy critical",
+        importance=Application.Importance.CRITICAL,
+    )
+    non_legacy_baseline = Application.objects.create(
+        name="core app",
+        importance=Application.Importance.BASELINE,
+    )
+
+    mark_legacy_applications(
+        django_apps,
+        _SchemaEditorStub(alias=legacy_baseline._state.db),
+    )
+
+    legacy_baseline.refresh_from_db()
+    legacy_critical.refresh_from_db()
+    non_legacy_baseline.refresh_from_db()
+
+    assert legacy_baseline.importance == Application.Importance.LEGACY
+    assert legacy_critical.importance == Application.Importance.CRITICAL
+    assert non_legacy_baseline.importance == Application.Importance.BASELINE

--- a/apps/app/tests/test_importance.py
+++ b/apps/app/tests/test_importance.py
@@ -1,0 +1,8 @@
+"""Tests for application importance choices."""
+
+from apps.app.models import Application
+
+
+def test_application_importance_includes_legacy_choice() -> None:
+    assert Application.Importance.LEGACY == "legacy"
+    assert ("legacy", "Legacy") in Application.Importance.choices


### PR DESCRIPTION
### Motivation

- Introduce a distinct "legacy" importance level for applications and backfill existing records that are clearly legacy by name.

### Description

- Add `LEGACY = "legacy"` to `Application.Importance` and include it in `Importance.choices` in `apps/app/models.py`.
- Add migration `0002_application_importance_legacy.py` which alters the `importance` field to include the new choice and runs `mark_legacy_applications` to set `importance='legacy'` for applications whose `name` contains `"legacy"` (case-insensitive).
- Add unit test `apps/app/tests/test_importance.py` to assert the `legacy` choice is present and has the expected label.

### Testing

- Ran the added unit test `apps/app/tests/test_importance.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fb9de60c8326a82b9e7e1408b1be)