### PR TITLE
sigils/docs: separate window pipeline actions from user-safe instance actions

### DIFF
--- a/apps/sigils/sigil_resolver.py
+++ b/apps/sigils/sigil_resolver.py
@@ -475,11 +475,9 @@ def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None
             raise TokenParseError("FILTER action is missing field/value")
         key = key_head
         param = key_tail
-    elif action_upper in PIPELINE_WINDOW_ACTIONS - {"FILTER"}:
+    elif action_upper in PIPELINE_WINDOW_ACTIONS:
         instance_target = action_payload or ""
         instance_id = f"{instance_target}:{entity_lookup.map_pipeline_action_to_aggregate(action_upper)}"
-    elif action_upper in PIPELINE_INSTANCE_ACTIONS:
-        key = action_payload or None
     else:
         key = action_payload or None
 

--- a/apps/sigils/sigil_resolver.py
+++ b/apps/sigils/sigil_resolver.py
@@ -34,6 +34,8 @@ PIPELINE_FILTER_SENSITIVE_FIELD_TOKENS = (
     "secret",
     "token",
 )
+PIPELINE_INSTANCE_ACTIONS = frozenset({"FIELD", "GET"})
+PIPELINE_WINDOW_ACTIONS = frozenset({"COUNT", "FILTER", "MAX", "MIN", "SUM", "TOTAL"})
 _ATTRIBUTE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
     max_workers=ATTRIBUTE_RESOLUTION_WORKERS,
     thread_name_prefix="sigil-attr",
@@ -179,7 +181,7 @@ def get_user_safe_sigil_actions() -> set[str]:
     ).exists()
     if not has_safe_entity_root:
         return set()
-    return {"COUNT", "FIELD", "FILTER", "GET", "MAX", "MIN", "SUM", "TOTAL"}
+    return set(PIPELINE_INSTANCE_ACTIONS)
 
 
 def _stringify_value(value) -> str:
@@ -473,10 +475,10 @@ def _parse_pipeline_token_parts(token: str) -> tuple[SigilTokenParts, str | None
             raise TokenParseError("FILTER action is missing field/value")
         key = key_head
         param = key_tail
-    elif action_upper in {"COUNT", "MAX", "MIN", "SUM", "TOTAL"}:
+    elif action_upper in PIPELINE_WINDOW_ACTIONS - {"FILTER"}:
         instance_target = action_payload or ""
         instance_id = f"{instance_target}:{entity_lookup.map_pipeline_action_to_aggregate(action_upper)}"
-    elif action_upper in {"GET", "FIELD"}:
+    elif action_upper in PIPELINE_INSTANCE_ACTIONS:
         key = action_payload or None
     else:
         key = action_payload or None

--- a/apps/sigils/tests/test_sigil_resolver.py
+++ b/apps/sigils/tests/test_sigil_resolver.py
@@ -215,6 +215,25 @@ def test_pipeline_v2_user_safe_gating_degrades_disallowed_action(settings, node_
 
 
 @pytest.mark.django_db
+def test_pipeline_v2_filter_is_not_user_safe_action(settings, user_root):
+    settings.SIGILS_PIPELINE_V2_ENABLED = True
+    user_model = get_user_model()
+    user_model.objects.create_user(
+        username="safe-filter-user",
+        email="safe-filter@example.com",
+        password="abc12345",
+    )
+
+    resolved = sigil_resolver.resolve_sigils(
+        "[USR:|FILTER:email:safe-filter@example.com]",
+        allowed_roots={"USR"},
+        allowed_actions=sigil_resolver.get_user_safe_sigil_actions(),
+    )
+
+    assert resolved == "[USR:|FILTER:email:safe-filter@example.com]"
+
+
+@pytest.mark.django_db
 def test_pipeline_v2_feature_flag_can_disable_pipeline_parsing(settings, node_root):
     settings.SIGILS_PIPELINE_V2_ENABLED = False
     role = NodeRole.objects.create(name="Disabled")
@@ -491,8 +510,7 @@ def test_get_user_safe_sigil_actions_requires_safe_entity_root():
     )
 
     actions = sigil_resolver.get_user_safe_sigil_actions()
-    assert "FILTER" in actions
-    assert "COUNT" in actions
+    assert actions == {"FIELD", "GET"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- Close a data-disclosure vector where user-authored docs could use the `FILTER` pipeline action to enumerate multiple records and expose PII from user-safe entity roots.  
- Follow the requirement to differentiate window-style (multi-row/aggregate) actions from instance-style (single-instance) actions so user-facing docs remain restricted to safe single-value substitutions.

### Description
- Introduce `PIPELINE_INSTANCE_ACTIONS` and `PIPELINE_WINDOW_ACTIONS` constants in `apps/sigils/sigil_resolver.py` and centralize action classification.  
- Restrict `get_user_safe_sigil_actions()` to return only instance-style actions (`FIELD`, `GET`) when an entity root is marked `is_user_safe`.  
- Update pipeline parsing to reuse the new action groups and treat window actions (e.g. `COUNT`, `FILTER`, `MAX`, `MIN`, `SUM`, `TOTAL`) separately from instance actions.  
- Add and update tests in `apps/sigils/tests/test_sigil_resolver.py` to assert the tightened user-safe action policy and verify that `FILTER` is rejected under user-safe gating (`test_pipeline_v2_filter_is_not_user_safe_action`).

### Testing
- Ran `./env-refresh.sh --deps-only` to prepare the environment and dependencies, which completed successfully.  
- Installed test tooling with `.venv/bin/pip install pytest==9.0.3 pytest-django==4.12.0 pytest-timeout==2.4.0`, which succeeded.  
- Ran the sigils test suite with `.venv/bin/python manage.py test run -- apps/sigils/tests/test_sigil_resolver.py`, which collected 27 tests and reported `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e406ae66d483268fae160283ff695f)