### PR TITLE
core: add startup timing breakdown

### DIFF
--- a/apps/core/management/commands/startup.py
+++ b/apps/core/management/commands/startup.py
@@ -1,9 +1,45 @@
+import json
 from pathlib import Path
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from apps.core.system_ui import read_startup_report
+
+
+def _read_timing_lock(path: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _phase_timings(payload: dict[str, object] | None) -> list[dict[str, object]]:
+    if not isinstance(payload, dict):
+        return []
+    phases = payload.get("phase_timings")
+    if not isinstance(phases, list):
+        return []
+    return [phase for phase in phases if isinstance(phase, dict)]
+
+
+def _format_duration_seconds(value: object) -> str:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return "unknown"
+    return f"{seconds:.3f}s"
+
+
+def _format_duration_ms(value: object) -> str:
+    try:
+        milliseconds = int(value)
+    except (TypeError, ValueError):
+        return "unknown"
+    return f"{milliseconds / 1000:.3f}s"
 
 
 class Command(BaseCommand):
@@ -22,8 +58,17 @@ class Command(BaseCommand):
                 "(default: 10)."
             ),
         )
+        parser.add_argument(
+            "--timings",
+            action="store_true",
+            help="Show the most recent startup timing breakdown from lock files.",
+        )
 
     def handle(self, *args, **options):  # noqa: D401 - inherited docstring
+        if options.get("timings"):
+            self._handle_timings()
+            return
+
         limit = options["limit"]
         if limit < 1:
             limit = 10
@@ -57,3 +102,62 @@ class Command(BaseCommand):
             if detail:
                 message = f"{message} — {detail}"
             self.stdout.write(message)
+
+    def _handle_timings(self) -> None:
+        base_dir = Path(settings.BASE_DIR)
+        lock_dir = base_dir / ".locks"
+        startup_payload = _read_timing_lock(lock_dir / "startup_duration.lck")
+        orchestration_payload = _read_timing_lock(lock_dir / "startup_orchestrate_status.lck")
+        if not startup_payload and not orchestration_payload:
+            self.stdout.write("No startup timing data has been recorded yet.")
+            return
+
+        if startup_payload:
+            status_value = "ok" if int(startup_payload.get("status") or 0) == 0 else "error"
+            self.stdout.write("Startup timing summary:")
+            self.stdout.write(
+                f"  Measured readiness window: {_format_duration_seconds(startup_payload.get('duration_seconds'))}"
+            )
+            self.stdout.write(f"  Status: {status_value}")
+            self.stdout.write(f"  Started at: {startup_payload.get('started_at') or 'unknown'}")
+            self.stdout.write(f"  Finished at: {startup_payload.get('finished_at') or 'unknown'}")
+            if startup_payload.get("port"):
+                self.stdout.write(f"  Port: {startup_payload.get('port')}")
+
+            phase_timings = _phase_timings(startup_payload)
+            if phase_timings:
+                self.stdout.write("")
+                self.stdout.write("Service-start phases:")
+                for phase in phase_timings:
+                    message = (
+                        f"  - {phase.get('name') or 'phase'}: "
+                        f"{_format_duration_ms(phase.get('duration_ms'))} "
+                        f"[{phase.get('status') or 'unknown'}]"
+                    )
+                    self.stdout.write(message)
+
+        orchestration_phases = _phase_timings(orchestration_payload)
+        if orchestration_payload:
+            self.stdout.write("")
+            self.stdout.write("Orchestration phase:")
+            self.stdout.write(
+                f"  Total: {_format_duration_seconds(orchestration_payload.get('duration_seconds'))}"
+            )
+            self.stdout.write(
+                f"  Started at: {orchestration_payload.get('started_at') or 'unknown'}"
+            )
+            self.stdout.write(
+                f"  Finished at: {orchestration_payload.get('finished_at') or 'unknown'}"
+            )
+            if orchestration_phases:
+                self.stdout.write("  Steps:")
+                for phase in orchestration_phases:
+                    detail = phase.get("detail") or ""
+                    message = (
+                        f"    - {phase.get('name') or 'phase'}: "
+                        f"{_format_duration_ms(phase.get('duration_ms'))} "
+                        f"[{phase.get('status') or 'unknown'}]"
+                    )
+                    if detail:
+                        message = f"{message} — {detail}"
+                    self.stdout.write(message)

--- a/apps/core/management/commands/startup_orchestrate.py
+++ b/apps/core/management/commands/startup_orchestrate.py
@@ -129,12 +129,15 @@ class Command(BaseCommand):
                 orchestrate_started_monotonic=started_monotonic,
             )
         else:
+            phase_started_monotonic = time.monotonic()
+            phase_finished_monotonic = time.monotonic()
             startup_message_timing = self._build_phase_timing(
                 name="startup_message",
                 detail=startup_message_status,
                 phase_started_epoch=time.time(),
                 phase_finished_epoch=time.time(),
-                phase_started_monotonic=time.monotonic(),
+                phase_started_monotonic=phase_started_monotonic,
+                phase_finished_monotonic=phase_finished_monotonic,
                 orchestrate_started_monotonic=started_monotonic,
                 status="skipped",
             )
@@ -244,6 +247,7 @@ class Command(BaseCommand):
         phase_started_epoch = time.time()
         detail = self._queue_startup_message(port)
         phase_finished_epoch = time.time()
+        phase_finished_monotonic = time.monotonic()
         status = "error" if str(detail).startswith("error:") else "ok"
         return detail, self._build_phase_timing(
             name="startup_message",
@@ -251,6 +255,7 @@ class Command(BaseCommand):
             phase_started_epoch=phase_started_epoch,
             phase_finished_epoch=phase_finished_epoch,
             phase_started_monotonic=phase_started_monotonic,
+            phase_finished_monotonic=phase_finished_monotonic,
             orchestrate_started_monotonic=orchestrate_started_monotonic,
             status=status,
         )
@@ -266,6 +271,7 @@ class Command(BaseCommand):
         phase_started_epoch = time.time()
         ok, status = callback()
         phase_finished_epoch = time.time()
+        phase_finished_monotonic = time.monotonic()
         status_payload = dict(status)
         status_payload.update(
             self._build_phase_timing(
@@ -274,6 +280,7 @@ class Command(BaseCommand):
                 phase_started_epoch=phase_started_epoch,
                 phase_finished_epoch=phase_finished_epoch,
                 phase_started_monotonic=phase_started_monotonic,
+                phase_finished_monotonic=phase_finished_monotonic,
                 orchestrate_started_monotonic=orchestrate_started_monotonic,
                 status=str(status.get("status") or ("ok" if ok else "error")),
             )
@@ -288,10 +295,11 @@ class Command(BaseCommand):
         phase_started_epoch: float,
         phase_finished_epoch: float,
         phase_started_monotonic: float,
+        phase_finished_monotonic: float,
         orchestrate_started_monotonic: float,
         status: str,
     ) -> dict[str, object]:
-        duration_ms = max(int(round((phase_finished_epoch - phase_started_epoch) * 1000)), 0)
+        duration_ms = max(int(round((phase_finished_monotonic - phase_started_monotonic) * 1000)), 0)
         started_offset_ms = max(
             int(round((phase_started_monotonic - orchestrate_started_monotonic) * 1000)),
             0,

--- a/apps/core/management/commands/startup_orchestrate.py
+++ b/apps/core/management/commands/startup_orchestrate.py
@@ -58,6 +58,7 @@ class Command(BaseCommand):
         started_monotonic = time.monotonic()
         started_at_epoch = int(time.time())
         started_at_iso = datetime.now(timezone.utc).isoformat()
+        phase_timings: list[dict[str, object]] = []
 
         base_dir = Path(settings.BASE_DIR)
         lock_dir = Path(options.get("lock_dir") or (base_dir / ".locks"))
@@ -105,16 +106,40 @@ class Command(BaseCommand):
 
         self._write_startup_started_lock(startup_started_lock, started_at_epoch)
 
-        preflight_ok, preflight_status = self._run_preflight(lock_dir=lock_dir, base_dir=base_dir)
+        preflight_ok, preflight_status = self._timed_step(
+            "runserver_preflight",
+            lambda: self._run_preflight(lock_dir=lock_dir, base_dir=base_dir),
+            orchestrate_started_monotonic=started_monotonic,
+        )
         payload["checks"].append(preflight_status)
+        phase_timings.append(preflight_status)
 
-        maintenance_ok, maintenance_status = self._run_startup_maintenance()
+        maintenance_ok, maintenance_status = self._timed_step(
+            "startup_maintenance",
+            self._run_startup_maintenance,
+            orchestrate_started_monotonic=started_monotonic,
+        )
         payload["checks"].append(maintenance_status)
+        phase_timings.append(maintenance_status)
 
         startup_message_status = "skipped:lcd-disabled"
         if lcd_enabled:
-            startup_message_status = self._queue_startup_message(str(options["port"]))
+            startup_message_status, startup_message_timing = self._timed_startup_message(
+                port=str(options["port"]),
+                orchestrate_started_monotonic=started_monotonic,
+            )
+        else:
+            startup_message_timing = self._build_phase_timing(
+                name="startup_message",
+                detail=startup_message_status,
+                phase_started_epoch=time.time(),
+                phase_finished_epoch=time.time(),
+                phase_started_monotonic=time.monotonic(),
+                orchestrate_started_monotonic=started_monotonic,
+                status="skipped",
+            )
         payload["startup_message_status"] = startup_message_status
+        phase_timings.append(startup_message_timing)
 
         celery_embedded = self._resolve_celery_embedded(
             celery_mode=celery_mode,
@@ -131,6 +156,7 @@ class Command(BaseCommand):
             "lcd_embedded": lcd_enabled and lcd_target_mode == ARTHEXIS_SERVICE_MODE_EMBEDDED,
             "lcd_target_mode": lcd_target_mode,
         }
+        payload["phase_timings"] = phase_timings
 
         if not preflight_ok or not maintenance_ok:
             payload["status"] = "error"
@@ -143,6 +169,7 @@ class Command(BaseCommand):
             status=0 if payload["status"] == "ok" else 1,
             phase="orchestration",
             port=str(options["port"]),
+            phase_timings=phase_timings,
         )
         self.stdout.write(json.dumps(payload, sort_keys=True))
 
@@ -207,6 +234,78 @@ class Command(BaseCommand):
         except Exception as exc:
             return f"error:{exc}"
 
+    def _timed_startup_message(
+        self,
+        *,
+        port: str,
+        orchestrate_started_monotonic: float,
+    ) -> tuple[str, dict[str, object]]:
+        phase_started_monotonic = time.monotonic()
+        phase_started_epoch = time.time()
+        detail = self._queue_startup_message(port)
+        phase_finished_epoch = time.time()
+        status = "error" if str(detail).startswith("error:") else "ok"
+        return detail, self._build_phase_timing(
+            name="startup_message",
+            detail=detail,
+            phase_started_epoch=phase_started_epoch,
+            phase_finished_epoch=phase_finished_epoch,
+            phase_started_monotonic=phase_started_monotonic,
+            orchestrate_started_monotonic=orchestrate_started_monotonic,
+            status=status,
+        )
+
+    def _timed_step(
+        self,
+        name: str,
+        callback,
+        *,
+        orchestrate_started_monotonic: float,
+    ) -> tuple[bool, dict[str, object]]:
+        phase_started_monotonic = time.monotonic()
+        phase_started_epoch = time.time()
+        ok, status = callback()
+        phase_finished_epoch = time.time()
+        status_payload = dict(status)
+        status_payload.update(
+            self._build_phase_timing(
+                name=name,
+                detail=str(status.get("detail") or ""),
+                phase_started_epoch=phase_started_epoch,
+                phase_finished_epoch=phase_finished_epoch,
+                phase_started_monotonic=phase_started_monotonic,
+                orchestrate_started_monotonic=orchestrate_started_monotonic,
+                status=str(status.get("status") or ("ok" if ok else "error")),
+            )
+        )
+        return ok, status_payload
+
+    @staticmethod
+    def _build_phase_timing(
+        *,
+        name: str,
+        detail: str,
+        phase_started_epoch: float,
+        phase_finished_epoch: float,
+        phase_started_monotonic: float,
+        orchestrate_started_monotonic: float,
+        status: str,
+    ) -> dict[str, object]:
+        duration_ms = max(int(round((phase_finished_epoch - phase_started_epoch) * 1000)), 0)
+        started_offset_ms = max(
+            int(round((phase_started_monotonic - orchestrate_started_monotonic) * 1000)),
+            0,
+        )
+        return {
+            "name": name,
+            "detail": detail,
+            "status": status,
+            "duration_ms": duration_ms,
+            "started_offset_ms": started_offset_ms,
+            "started_at": datetime.fromtimestamp(phase_started_epoch, tz=timezone.utc).isoformat(),
+            "finished_at": datetime.fromtimestamp(phase_finished_epoch, tz=timezone.utc).isoformat(),
+        }
+
     @staticmethod
     def _read_lock_line(path: Path) -> str:
         try:
@@ -267,6 +366,7 @@ class Command(BaseCommand):
         status: int,
         phase: str,
         port: str,
+        phase_timings: list[dict[str, object]] | None = None,
     ) -> None:
         finished_at_epoch = int(time.time())
         payload = {
@@ -276,5 +376,6 @@ class Command(BaseCommand):
             "status": status,
             "phase": phase,
             "port": port,
+            "phase_timings": phase_timings or [],
         }
         lock_path.write_text(json.dumps(payload), encoding="utf-8")

--- a/apps/core/tests/test_startup_command.py
+++ b/apps/core/tests/test_startup_command.py
@@ -1,0 +1,80 @@
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import override_settings
+
+
+def test_startup_command_reports_timing_breakdown(tmp_path):
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    (lock_dir / "startup_duration.lck").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-04-18T17:03:53+00:00",
+                "finished_at": "2026-04-18T17:04:46+00:00",
+                "duration_seconds": 53,
+                "status": 0,
+                "port": "8888",
+                "phase_timings": [
+                    {
+                        "name": "runtime_bootstrap",
+                        "duration_ms": 950,
+                        "status": "completed",
+                    },
+                    {
+                        "name": "startup_orchestrate",
+                        "duration_ms": 15123,
+                        "status": "completed",
+                    },
+                    {
+                        "name": "readiness_wait",
+                        "duration_ms": 36750,
+                        "status": "completed",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (lock_dir / "startup_orchestrate_status.lck").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-04-18T17:03:53+00:00",
+                "finished_at": "2026-04-18T17:04:08+00:00",
+                "duration_seconds": 15,
+                "status": 0,
+                "phase": "orchestration",
+                "port": "8888",
+                "phase_timings": [
+                    {
+                        "name": "runserver_preflight",
+                        "duration_ms": 14250,
+                        "status": "ok",
+                        "detail": "Database matches cached migrations fingerprint; skipping migration checks.",
+                    },
+                    {
+                        "name": "startup_maintenance",
+                        "duration_ms": 110,
+                        "status": "ok",
+                        "detail": "ok",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    stdout = StringIO()
+    with override_settings(BASE_DIR=str(tmp_path)):
+        call_command("startup", "--timings", stdout=stdout)
+
+    output = stdout.getvalue()
+    assert "Startup timing summary:" in output
+    assert "Measured readiness window: 53.000s" in output
+    assert "Service-start phases:" in output
+    assert "runtime_bootstrap: 0.950s [completed]" in output
+    assert "startup_orchestrate: 15.123s [completed]" in output
+    assert "Orchestration phase:" in output
+    assert "runserver_preflight: 14.250s [ok]" in output

--- a/apps/core/tests/test_startup_orchestrate_command.py
+++ b/apps/core/tests/test_startup_orchestrate_command.py
@@ -69,6 +69,11 @@ def test_startup_orchestrate_outputs_json_contract_and_writes_locks(tmp_path, mo
     assert payload["launch"]["celery_embedded"] is True
     assert payload["launch"]["lcd_embedded"] is True
     assert payload["startup_message_status"] == "queued:8899"
+    assert [phase["name"] for phase in payload["phase_timings"]] == [
+        "runserver_preflight",
+        "startup_maintenance",
+        "startup_message",
+    ]
 
     started_at = (lock_dir / "startup_started_at.lck").read_text(encoding="utf-8").strip()
     assert started_at.isdigit()
@@ -76,6 +81,11 @@ def test_startup_orchestrate_outputs_json_contract_and_writes_locks(tmp_path, mo
     duration_payload = json.loads((lock_dir / "startup_orchestrate_status.lck").read_text(encoding="utf-8"))
     assert duration_payload["phase"] == "orchestration"
     assert duration_payload["status"] == 0
+    assert [phase["name"] for phase in duration_payload["phase_timings"]] == [
+        "runserver_preflight",
+        "startup_maintenance",
+        "startup_message",
+    ]
 
 
 def test_startup_orchestrate_uses_systemd_decisions_when_requested(tmp_path, monkeypatch):

--- a/apps/core/tests/test_startup_orchestrate_command.py
+++ b/apps/core/tests/test_startup_orchestrate_command.py
@@ -143,3 +143,19 @@ def test_run_preflight_passes_current_python_to_helper(tmp_path, monkeypatch):
     assert ok is True
     assert status["status"] == "ok"
     assert captured["env"]["ARTHEXIS_PYTHON_BIN"] == sys.executable
+
+
+def test_build_phase_timing_uses_monotonic_duration():
+    payload = Command._build_phase_timing(
+        name="startup_message",
+        detail="ok",
+        phase_started_epoch=200.0,
+        phase_finished_epoch=199.0,
+        phase_started_monotonic=300.5,
+        phase_finished_monotonic=300.9,
+        orchestrate_started_monotonic=300.0,
+        status="ok",
+    )
+
+    assert payload["duration_ms"] == 400
+    assert payload["started_offset_ms"] == 500

--- a/scripts/service-start.sh
+++ b/scripts/service-start.sh
@@ -16,6 +16,8 @@ export TZ="${TZ:-America/Monterrey}"
 . "$BASE_DIR/scripts/helpers/suite-uptime-lock.sh"
 # shellcheck source=scripts/helpers/debug_toolbar.sh
 . "$BASE_DIR/scripts/helpers/debug_toolbar.sh"
+# shellcheck source=scripts/helpers/timing.sh
+. "$BASE_DIR/scripts/helpers/timing.sh"
 arthexis_resolve_log_dir "$BASE_DIR" LOG_DIR || exit 1
 LOG_FILE="$LOG_DIR/$(basename "$0" .sh).log"
 ERROR_LOG="$LOG_DIR/error.log"
@@ -146,8 +148,97 @@ clear_pid_files() {
 
 clear_pid_files
 
+declare -Ag STARTUP_PHASE_STARTED_MS
+declare -Ag STARTUP_PHASE_FINISHED_MS
+declare -Ag STARTUP_PHASE_STATUS
+declare -ag STARTUP_PHASE_ORDER
+
+startup_phase_begin() {
+  local phase_name="$1"
+  if [ -z "$phase_name" ]; then
+    return 0
+  fi
+  if [ -z "${STARTUP_PHASE_STARTED_MS[$phase_name]:-}" ]; then
+    STARTUP_PHASE_ORDER+=("$phase_name")
+  fi
+  STARTUP_PHASE_STARTED_MS["$phase_name"]="$(arthexis_timing_now_ms)"
+}
+
+startup_phase_finish() {
+  local phase_name="$1"
+  local status="${2:-completed}"
+  local started_ms="${STARTUP_PHASE_STARTED_MS[$phase_name]:-}"
+  if [ -z "$phase_name" ] || [ -z "$started_ms" ]; then
+    return 0
+  fi
+  STARTUP_PHASE_FINISHED_MS["$phase_name"]="$(arthexis_timing_now_ms)"
+  STARTUP_PHASE_STATUS["$phase_name"]="$status"
+}
+
+startup_phase_timings_json() {
+  {
+    local phase_name
+    for phase_name in "${STARTUP_PHASE_ORDER[@]}"; do
+      local started_ms="${STARTUP_PHASE_STARTED_MS[$phase_name]:-}"
+      local finished_ms="${STARTUP_PHASE_FINISHED_MS[$phase_name]:-}"
+      local status="${STARTUP_PHASE_STATUS[$phase_name]:-completed}"
+      if [ -z "$started_ms" ] || [ -z "$finished_ms" ]; then
+        continue
+      fi
+      printf '%s\t%s\t%s\t%s\n' "$phase_name" "$started_ms" "$finished_ms" "$status"
+    done
+  } | python - <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+entries = []
+for raw_line in sys.stdin:
+    line = raw_line.rstrip("\n")
+    if not line:
+        continue
+    try:
+        name, started_ms, finished_ms, status = line.split("\t", 3)
+    except ValueError:
+        continue
+    started_value = int(started_ms)
+    finished_value = int(finished_ms)
+    duration_ms = max(finished_value - started_value, 0)
+    entries.append(
+        {
+            "name": name,
+            "started_at": datetime.fromtimestamp(
+                started_value / 1000, tz=timezone.utc
+            ).isoformat(),
+            "finished_at": datetime.fromtimestamp(
+                finished_value / 1000, tz=timezone.utc
+            ).isoformat(),
+            "duration_ms": duration_ms,
+            "status": status,
+        }
+    )
+
+print(json.dumps(entries, sort_keys=False))
+PY
+}
+
+wait_for_suite_startup_timed() {
+  local port="$1"
+  local server_pid="$2"
+  local timeout_seconds="$3"
+  startup_phase_begin "readiness_wait"
+  if wait_for_suite_startup "$port" "$server_pid" "$timeout_seconds"; then
+    startup_phase_finish "readiness_wait"
+    return 0
+  fi
+  startup_phase_finish "readiness_wait" "error"
+  return 1
+}
+
 # Ensure virtual environment is available
+startup_phase_begin "runtime_bootstrap"
 if [ ! -d .venv ]; then
+  startup_phase_finish "runtime_bootstrap" "error"
   echo "Virtual environment not found. Run ./install.sh first." >&2
   exit 1
 fi
@@ -160,6 +251,7 @@ for env_file in *.env; do
   . "$env_file"
   set +a
 done
+startup_phase_finish "runtime_bootstrap"
 
 SOFT_FD_LIMIT="$(ulimit -Sn 2>/dev/null || echo "unknown")"
 HARD_FD_LIMIT="$(ulimit -Hn 2>/dev/null || echo "unknown")"
@@ -287,6 +379,7 @@ STATIC_HASH=""
 STORED_HASH=""
 [ -f "$STATIC_MD5_FILE" ] && STORED_HASH=$(cat "$STATIC_MD5_FILE")
 
+startup_phase_begin "staticfiles"
 if [ "$FORCE_COLLECTSTATIC" = false ]; then
   set +e
   STATIC_HASH=$(arthexis_staticfiles_snapshot_check "$STATIC_MD5_FILE" "$STATIC_META_FILE")
@@ -324,6 +417,7 @@ else
   arthexis_staticfiles_clear_staged_lock
   echo "Static files unchanged. Skipping collectstatic."
 fi
+startup_phase_finish "staticfiles"
 
 arthexis_suite_reachable() {
   local port="$1"
@@ -406,8 +500,11 @@ record_startup_duration() {
   local end_time
   end_time=$(date +%s)
   local duration=$((end_time - STARTUP_STARTED_AT))
-  python - "$STARTUP_DURATION_LOCK" "$STARTUP_STARTED_AT" "$end_time" "$duration" "$status" "$PORT" <<'PY'
+  local phase_timings_json
+  phase_timings_json="$(startup_phase_timings_json)"
+  STARTUP_PHASE_TIMINGS_JSON="$phase_timings_json" python - "$STARTUP_DURATION_LOCK" "$STARTUP_STARTED_AT" "$end_time" "$duration" "$status" "$PORT" <<'PY'
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -418,6 +515,15 @@ finished_at = int(sys.argv[3])
 duration = int(sys.argv[4])
 status = int(sys.argv[5])
 port = sys.argv[6] if len(sys.argv) > 6 else ""
+phase_timings = []
+raw_phase_timings = os.environ.get("STARTUP_PHASE_TIMINGS_JSON", "")
+if raw_phase_timings:
+    try:
+        parsed_phase_timings = json.loads(raw_phase_timings)
+    except json.JSONDecodeError:
+        parsed_phase_timings = []
+    if isinstance(parsed_phase_timings, list):
+        phase_timings = parsed_phase_timings
 
 payload = {
     "started_at": datetime.fromtimestamp(started_at, tz=timezone.utc).isoformat(),
@@ -425,6 +531,7 @@ payload = {
     "duration_seconds": duration,
     "status": status,
     "port": port,
+    "phase_timings": phase_timings,
 }
 
 lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -434,17 +541,20 @@ PY
 
 STARTUP_STARTED_AT=$(date +%s)
 ORCHESTRATE_OUTPUT_FILE="$(mktemp)"
+startup_phase_begin "startup_orchestrate"
 if ! python manage.py startup_orchestrate \
   --port "$PORT" \
   --lock-dir "$LOCK_DIR" \
   --service-name "$SERVICE_NAME" \
   --service-mode "$SERVICE_MANAGEMENT_MODE" \
   --celery-mode "$CELERY_MANAGEMENT_MODE" > "$ORCHESTRATE_OUTPUT_FILE"; then
+  startup_phase_finish "startup_orchestrate" "error"
   echo "Startup orchestration failed; aborting startup." >&2
   cat "$ORCHESTRATE_OUTPUT_FILE" >&2 || true
   rm -f "$ORCHESTRATE_OUTPUT_FILE"
   exit 1
 fi
+startup_phase_finish "startup_orchestrate"
 
 readarray -t ORCHESTRATE_EXPORTS < <(
   python - "$ORCHESTRATE_OUTPUT_FILE" <<'PY'
@@ -483,11 +593,15 @@ if [ "$STARTUP_STARTED_AT" -le 0 ]; then
 fi
 
 if [ "$LCD_TARGET_MODE" = "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ] || [ "$LCD_EMBEDDED" = true ]; then
+  startup_phase_begin "lcd_coordination"
   arthexis_disable_lcd_modes "$LOCK_DIR" "$SERVICE_NAME"
+  startup_phase_finish "lcd_coordination"
 fi
 
 if [ "$LCD_TARGET_MODE" = "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ] && [ -n "$SERVICE_NAME" ]; then
+  startup_phase_begin "lcd_target_activation"
   arthexis_start_systemd_unit_if_present "lcd-${SERVICE_NAME}.service"
+  startup_phase_finish "lcd_target_activation"
 elif [ "$LCD_EMBEDDED" = true ] && [ "$LCD_SYSTEMD_UNIT" = true ]; then
   echo "Skipping systemd-managed LCD service because embedded mode is enabled. Reinstall with --systemd to manage the LCD via systemd."
 fi
@@ -495,6 +609,7 @@ fi
 RUNSERVER_EXTRA_ARGS=()
 
 # Start Celery components to handle queued email if enabled
+startup_phase_begin "celery_coordination"
 if [ "$CELERY_EMBEDDED" = true ]; then
   CELERY_NODE_SERVICE_NAME="${SERVICE_NAME:-}"
   if [ -z "$CELERY_NODE_SERVICE_NAME" ]; then
@@ -513,14 +628,18 @@ elif [ "$SERVICE_MANAGEMENT_MODE" = "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ] && \
   arthexis_start_systemd_unit_if_present "celery-${SERVICE_NAME}.service"
   arthexis_start_systemd_unit_if_present "celery-beat-${SERVICE_NAME}.service"
 fi
+startup_phase_finish "celery_coordination"
 
 if [ "$LCD_EMBEDDED" = true ]; then
+  startup_phase_begin "lcd_launch"
   python -m apps.screens.lcd_screen.runner &
   LCD_PROCESS_PID=$!
   record_pid_file "$LCD_PROCESS_PID" "$LCD_PID_FILE"
+  startup_phase_finish "lcd_launch"
 fi
 
 if [ "$AWAIT_START" = true ]; then
+  startup_phase_begin "runserver_spawn"
   if [ "$RELOAD" = true ]; then
     python manage.py runserver 0.0.0.0:"$PORT" "${RUNSERVER_EXTRA_ARGS[@]}" &
   else
@@ -528,8 +647,9 @@ if [ "$AWAIT_START" = true ]; then
   fi
   DJANGO_SERVER_PID=$!
   record_pid_file "$DJANGO_SERVER_PID" "$DJANGO_PID_FILE"
+  startup_phase_finish "runserver_spawn"
 
-  if wait_for_suite_startup "$PORT" "$DJANGO_SERVER_PID" "$STARTUP_TIMEOUT"; then
+  if wait_for_suite_startup_timed "$PORT" "$DJANGO_SERVER_PID" "$STARTUP_TIMEOUT"; then
     record_startup_duration 0
     arthexis_log_suite_uptime "$BASE_DIR" || true
     wait "$DJANGO_SERVER_PID"
@@ -538,6 +658,7 @@ if [ "$AWAIT_START" = true ]; then
     exit 1
   fi
 else
+  startup_phase_begin "runserver_spawn"
   if [ "$RELOAD" = true ]; then
     python manage.py runserver 0.0.0.0:"$PORT" "${RUNSERVER_EXTRA_ARGS[@]}" &
   else
@@ -545,8 +666,9 @@ else
   fi
   DJANGO_SERVER_PID=$!
   record_pid_file "$DJANGO_SERVER_PID" "$DJANGO_PID_FILE"
+  startup_phase_finish "runserver_spawn"
   (
-    if wait_for_suite_startup "$PORT" "$DJANGO_SERVER_PID" "$STARTUP_TIMEOUT"; then
+    if wait_for_suite_startup_timed "$PORT" "$DJANGO_SERVER_PID" "$STARTUP_TIMEOUT"; then
       record_startup_duration 0
       arthexis_log_suite_uptime "$BASE_DIR" || true
     else


### PR DESCRIPTION
## Summary
- record per-phase timings in `service-start.sh` and persist them in `startup_duration.lck`
- add timed orchestration substeps for migration preflight, startup maintenance, and startup net-message queueing
- expose the most recent breakdown through `manage.py startup --timings`

## Details
This PR makes the suite's startup path measurable without scraping ad hoc journal output.

It adds shell-side timing for the major runtime phases:
- runtime bootstrap
- static-file gating
- startup orchestration
- LCD/Celery coordination
- runserver spawn
- readiness wait

It also adds orchestration-side timing for the previously opaque `startup_orchestrate` block, including:
- `runserver_preflight`
- `startup_maintenance`
- `startup_message`

The resulting timing breakdown is written into the existing startup lock payloads so the latest startup can be inspected later with:
- `python manage.py startup --timings`

## Verification
- `bash -n scripts/service-start.sh`
- `.venv/bin/python -m pytest apps/core/tests/test_startup_orchestrate_command.py apps/core/tests/test_startup_maintenance_command.py apps/core/tests/test_startup_command.py`

## Notes
- This is instrumentation only. It does not change service ordering or startup policy yet.
- The goal is to make the next round of boot-performance work data-driven.