### PR TITLE
Add observability integration status, logging_profile command, configs, docs, and tests

### DIFF
--- a/apps/core/management/commands/logging_profile.py
+++ b/apps/core/management/commands/logging_profile.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from utils.loggers.config import resolve_log_formatter
+from utils.loggers.paths import select_log_dir
+
+
+class Command(BaseCommand):
+    help = "Show the active Arthexis logging profile and observability integration wiring."
+
+    def handle(self, *args, **options):
+        formatter_mode = resolve_log_formatter()
+        configured_log_dir = Path(getattr(settings, "LOG_DIR", select_log_dir(Path(settings.BASE_DIR))))
+        grafana_url = os.environ.get("ARTHEXIS_GRAFANA_URL", "").strip() or "(unset)"
+        loki_url = os.environ.get("ARTHEXIS_LOKI_URL", "").strip() or "(unset)"
+        promtail_config = os.environ.get("ARTHEXIS_PROMTAIL_CONFIG", "").strip() or "(unset)"
+
+        self.stdout.write("Logging profile")
+        self.stdout.write(f"- formatter: {formatter_mode}")
+        self.stdout.write(f"- log_dir: {configured_log_dir}")
+        self.stdout.write("Observability wiring")
+        self.stdout.write(f"- ARTHEXIS_GRAFANA_URL: {grafana_url}")
+        self.stdout.write(f"- ARTHEXIS_LOKI_URL: {loki_url}")
+        self.stdout.write(f"- ARTHEXIS_PROMTAIL_CONFIG: {promtail_config}")

--- a/apps/core/management/commands/logging_profile.py
+++ b/apps/core/management/commands/logging_profile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from django.conf import settings
@@ -9,16 +8,21 @@ from django.core.management.base import BaseCommand
 from utils.loggers.config import resolve_log_formatter
 from utils.loggers.paths import select_log_dir
 
+UNSET_VALUE = "(unset)"
+
 
 class Command(BaseCommand):
     help = "Show the active Arthexis logging profile and observability integration wiring."
 
     def handle(self, *args, **options):
+        """Print active logging formatter, log directory, and observability wiring."""
+
         formatter_mode = resolve_log_formatter()
-        configured_log_dir = Path(getattr(settings, "LOG_DIR", select_log_dir(Path(settings.BASE_DIR))))
-        grafana_url = os.environ.get("ARTHEXIS_GRAFANA_URL", "").strip() or "(unset)"
-        loki_url = os.environ.get("ARTHEXIS_LOKI_URL", "").strip() or "(unset)"
-        promtail_config = os.environ.get("ARTHEXIS_PROMTAIL_CONFIG", "").strip() or "(unset)"
+        log_dir = getattr(settings, "LOG_DIR", None)
+        configured_log_dir = Path(log_dir) if log_dir else select_log_dir(Path(settings.BASE_DIR))
+        grafana_url = (getattr(settings, "ARTHEXIS_GRAFANA_URL", "") or "").strip() or UNSET_VALUE
+        loki_url = (getattr(settings, "ARTHEXIS_LOKI_URL", "") or "").strip() or UNSET_VALUE
+        promtail_config = (getattr(settings, "ARTHEXIS_PROMTAIL_CONFIG", "") or "").strip() or UNSET_VALUE
 
         self.stdout.write("Logging profile")
         self.stdout.write(f"- formatter: {formatter_mode}")

--- a/apps/core/tests/test_logging_profile_command.py
+++ b/apps/core/tests/test_logging_profile_command.py
@@ -3,10 +3,12 @@ from io import StringIO
 from django.core.management import call_command
 
 
-def test_logging_profile_command_prints_runtime_settings(monkeypatch):
-    monkeypatch.setenv("ARTHEXIS_GRAFANA_URL", "https://grafana.example.test")
-    monkeypatch.setenv("ARTHEXIS_LOKI_URL", "https://loki.example.test")
-    monkeypatch.setenv("ARTHEXIS_PROMTAIL_CONFIG", "/etc/promtail/promtail.yml")
+def test_logging_profile_command_prints_runtime_settings(settings):
+    """The command should display resolved formatter and all observability wiring values."""
+
+    settings.ARTHEXIS_GRAFANA_URL = "https://grafana.example.test"
+    settings.ARTHEXIS_LOKI_URL = "https://loki.example.test"
+    settings.ARTHEXIS_PROMTAIL_CONFIG = "/etc/promtail/promtail.yml"
 
     stdout = StringIO()
     call_command("logging_profile", stdout=stdout)
@@ -15,3 +17,5 @@ def test_logging_profile_command_prints_runtime_settings(monkeypatch):
     assert "Logging profile" in output
     assert "formatter:" in output
     assert "ARTHEXIS_GRAFANA_URL: https://grafana.example.test" in output
+    assert "ARTHEXIS_LOKI_URL: https://loki.example.test" in output
+    assert "ARTHEXIS_PROMTAIL_CONFIG: /etc/promtail/promtail.yml" in output

--- a/apps/core/tests/test_logging_profile_command.py
+++ b/apps/core/tests/test_logging_profile_command.py
@@ -1,0 +1,17 @@
+from io import StringIO
+
+from django.core.management import call_command
+
+
+def test_logging_profile_command_prints_runtime_settings(monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_GRAFANA_URL", "https://grafana.example.test")
+    monkeypatch.setenv("ARTHEXIS_LOKI_URL", "https://loki.example.test")
+    monkeypatch.setenv("ARTHEXIS_PROMTAIL_CONFIG", "/etc/promtail/promtail.yml")
+
+    stdout = StringIO()
+    call_command("logging_profile", stdout=stdout)
+    output = stdout.getvalue()
+
+    assert "Logging profile" in output
+    assert "formatter:" in output
+    assert "ARTHEXIS_GRAFANA_URL: https://grafana.example.test" in output

--- a/apps/sites/admin/reports_admin.py
+++ b/apps/sites/admin/reports_admin.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from collections import deque
 from datetime import datetime, time, timedelta
@@ -43,6 +44,37 @@ def _recommended_log_stack() -> dict[str, str]:
         "name": "Grafana Loki + Promtail",
         "summary": "Low-overhead log aggregation with dashboarding and alerting via Grafana.",
         "url": "https://grafana.com/oss/loki/",
+    }
+
+
+
+
+def _observability_integration_status() -> dict[str, str | bool]:
+    """Return deployment-facing status for external log aggregation wiring."""
+
+    grafana_url = os.environ.get("ARTHEXIS_GRAFANA_URL", "").strip()
+    loki_url = os.environ.get("ARTHEXIS_LOKI_URL", "").strip()
+    promtail_config = os.environ.get("ARTHEXIS_PROMTAIL_CONFIG", "").strip()
+
+    configured = bool(grafana_url and loki_url and promtail_config)
+    if configured:
+        status_label = _("Connected")
+        status_help = _(
+            "Grafana, Loki, and Promtail settings are configured for this process."
+        )
+    else:
+        status_label = _("Not configured")
+        status_help = _(
+            "Set ARTHEXIS_GRAFANA_URL, ARTHEXIS_LOKI_URL, and ARTHEXIS_PROMTAIL_CONFIG to activate external aggregation links."
+        )
+
+    return {
+        "configured": configured,
+        "status_label": str(status_label),
+        "status_help": str(status_help),
+        "grafana_url": grafana_url,
+        "loki_url": loki_url,
+        "promtail_config": promtail_config,
     }
 
 
@@ -366,6 +398,7 @@ def log_viewer(request):
             "hide_limit_slider": True,
             "log_dashboard": dashboard,
             "recommended_stack": _recommended_log_stack(),
+            "observability_status": _observability_integration_status(),
         }
     )
     return TemplateResponse(request, "admin/log_viewer.html", context)

--- a/apps/sites/admin/reports_admin.py
+++ b/apps/sites/admin/reports_admin.py
@@ -1,17 +1,17 @@
 import logging
-import os
 import re
 from collections import deque
 from datetime import datetime, time, timedelta
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.contrib import admin
 from django.db.models import Count
 from django.db.models.functions import TruncDate
 from django.http import FileResponse, JsonResponse
-from django.template.response import TemplateResponse
 from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -47,31 +47,44 @@ def _recommended_log_stack() -> dict[str, str]:
     }
 
 
+def _is_http_url(value: str) -> bool:
+    """Return whether ``value`` is an HTTP(S) URL."""
+
+    return urlsplit(value).scheme in {"http", "https"}
 
 
 def _observability_integration_status() -> dict[str, str | bool]:
     """Return deployment-facing status for external log aggregation wiring."""
 
-    grafana_url = os.environ.get("ARTHEXIS_GRAFANA_URL", "").strip()
-    loki_url = os.environ.get("ARTHEXIS_LOKI_URL", "").strip()
-    promtail_config = os.environ.get("ARTHEXIS_PROMTAIL_CONFIG", "").strip()
+    raw_grafana_url = getattr(settings, "ARTHEXIS_GRAFANA_URL", "")
+    raw_loki_url = getattr(settings, "ARTHEXIS_LOKI_URL", "")
+    promtail_config = getattr(settings, "ARTHEXIS_PROMTAIL_CONFIG", "")
+
+    grafana_url = raw_grafana_url if _is_http_url(raw_grafana_url) else ""
+    loki_url = raw_loki_url if _is_http_url(raw_loki_url) else ""
+    promtail_config = promtail_config.strip()
 
     configured = bool(grafana_url and loki_url and promtail_config)
     if configured:
-        status_label = _("Connected")
+        status_label = _("External aggregation fully configured")
         status_help = _(
             "Grafana, Loki, and Promtail settings are configured for this process."
         )
-    else:
-        status_label = _("Not configured")
+    elif grafana_url or loki_url or promtail_config:
+        status_label = _("External aggregation partially configured")
         status_help = _(
-            "Set ARTHEXIS_GRAFANA_URL, ARTHEXIS_LOKI_URL, and ARTHEXIS_PROMTAIL_CONFIG to activate external aggregation links."
+            "Set ARTHEXIS_GRAFANA_URL, ARTHEXIS_LOKI_URL, and ARTHEXIS_PROMTAIL_CONFIG to fully activate external aggregation features."
+        )
+    else:
+        status_label = _("External aggregation not configured")
+        status_help = _(
+            "Set ARTHEXIS_GRAFANA_URL, ARTHEXIS_LOKI_URL, and ARTHEXIS_PROMTAIL_CONFIG to fully activate external aggregation features."
         )
 
     return {
         "configured": configured,
-        "status_label": str(status_label),
-        "status_help": str(status_help),
+        "status_label": status_label,
+        "status_help": status_help,
         "grafana_url": grafana_url,
         "loki_url": loki_url,
         "promtail_config": promtail_config,

--- a/apps/sites/templates/admin/log_viewer.html
+++ b/apps/sites/templates/admin/log_viewer.html
@@ -186,6 +186,18 @@
           <a class="button button-secondary" href="{{ recommended_stack.url }}" target="_blank" rel="noopener noreferrer">{% translate "Evaluate integration" %}</a>
         </p>
       </div>
+      <div class="log-viewer-recommendation">
+        <p>
+          <strong>{% translate "Aggregator integration status" %}:</strong>
+          {{ observability_status.status_label }}
+        </p>
+        <p>{{ observability_status.status_help }}</p>
+        {% if observability_status.grafana_url %}
+          <p>
+            <a class="button button-secondary" href="{{ observability_status.grafana_url }}" target="_blank" rel="noopener noreferrer">{% translate "Open Grafana" %}</a>
+          </p>
+        {% endif %}
+      </div>
 
       {% if log_dashboard.level_rows %}
         <table class="log-viewer-table">

--- a/apps/sites/tests/test_log_viewer_observability.py
+++ b/apps/sites/tests/test_log_viewer_observability.py
@@ -1,0 +1,23 @@
+from apps.sites.admin.reports_admin import _observability_integration_status
+
+
+def test_observability_status_reports_not_configured(monkeypatch):
+    monkeypatch.delenv("ARTHEXIS_GRAFANA_URL", raising=False)
+    monkeypatch.delenv("ARTHEXIS_LOKI_URL", raising=False)
+    monkeypatch.delenv("ARTHEXIS_PROMTAIL_CONFIG", raising=False)
+
+    status = _observability_integration_status()
+
+    assert status["configured"] is False
+    assert status["grafana_url"] == ""
+
+
+def test_observability_status_reports_configured(monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_GRAFANA_URL", "https://grafana.example.test")
+    monkeypatch.setenv("ARTHEXIS_LOKI_URL", "https://loki.example.test")
+    monkeypatch.setenv("ARTHEXIS_PROMTAIL_CONFIG", "/etc/promtail/promtail.yml")
+
+    status = _observability_integration_status()
+
+    assert status["configured"] is True
+    assert status["grafana_url"] == "https://grafana.example.test"

--- a/apps/sites/tests/test_log_viewer_observability.py
+++ b/apps/sites/tests/test_log_viewer_observability.py
@@ -1,10 +1,10 @@
 from apps.sites.admin.reports_admin import _observability_integration_status
 
 
-def test_observability_status_reports_not_configured(monkeypatch):
-    monkeypatch.delenv("ARTHEXIS_GRAFANA_URL", raising=False)
-    monkeypatch.delenv("ARTHEXIS_LOKI_URL", raising=False)
-    monkeypatch.delenv("ARTHEXIS_PROMTAIL_CONFIG", raising=False)
+def test_observability_status_reports_not_configured(settings):
+    settings.ARTHEXIS_GRAFANA_URL = ""
+    settings.ARTHEXIS_LOKI_URL = ""
+    settings.ARTHEXIS_PROMTAIL_CONFIG = ""
 
     status = _observability_integration_status()
 
@@ -12,12 +12,24 @@ def test_observability_status_reports_not_configured(monkeypatch):
     assert status["grafana_url"] == ""
 
 
-def test_observability_status_reports_configured(monkeypatch):
-    monkeypatch.setenv("ARTHEXIS_GRAFANA_URL", "https://grafana.example.test")
-    monkeypatch.setenv("ARTHEXIS_LOKI_URL", "https://loki.example.test")
-    monkeypatch.setenv("ARTHEXIS_PROMTAIL_CONFIG", "/etc/promtail/promtail.yml")
+def test_observability_status_reports_configured(settings):
+    settings.ARTHEXIS_GRAFANA_URL = "https://grafana.example.test"
+    settings.ARTHEXIS_LOKI_URL = "https://loki.example.test"
+    settings.ARTHEXIS_PROMTAIL_CONFIG = "/etc/promtail/promtail.yml"
 
     status = _observability_integration_status()
 
     assert status["configured"] is True
     assert status["grafana_url"] == "https://grafana.example.test"
+
+
+def test_observability_status_hides_unsafe_urls(settings):
+    settings.ARTHEXIS_GRAFANA_URL = "javascript:alert(1)"
+    settings.ARTHEXIS_LOKI_URL = "ftp://loki.example.test"
+    settings.ARTHEXIS_PROMTAIL_CONFIG = "/etc/promtail/promtail.yml"
+
+    status = _observability_integration_status()
+
+    assert status["configured"] is False
+    assert status["grafana_url"] == ""
+    assert status["loki_url"] == ""

--- a/config/settings/logging.py
+++ b/config/settings/logging.py
@@ -1,7 +1,12 @@
 """Logging settings."""
 
+import os
+
 from utils.loggers import build_logging_settings
 
 from .base import BASE_DIR, DEBUG
 
 LOG_DIR, LOG_FILE_NAME, LOGGING = build_logging_settings(BASE_DIR, DEBUG)
+ARTHEXIS_GRAFANA_URL = os.environ.get("ARTHEXIS_GRAFANA_URL", "").strip()
+ARTHEXIS_LOKI_URL = os.environ.get("ARTHEXIS_LOKI_URL", "").strip()
+ARTHEXIS_PROMTAIL_CONFIG = os.environ.get("ARTHEXIS_PROMTAIL_CONFIG", "").strip()

--- a/deploy/observability/grafana/arthexis-logs-overview.json
+++ b/deploy/observability/grafana/arthexis-logs-overview.json
@@ -1,0 +1,38 @@
+{
+  "title": "Arthexis Logs Overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Error + Critical logs",
+      "targets": [
+        {
+          "expr": "sum by (level) (count_over_time({app=\"arthexis\", level=~\"ERROR|CRITICAL\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Warning logs",
+      "targets": [
+        {
+          "expr": "sum(count_over_time({app=\"arthexis\", level=\"WARNING\"}[5m]))",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Live logs",
+      "targets": [
+        {
+          "expr": "{app=\"arthexis\"} | json",
+          "refId": "C"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/loki/loki-config.yml
+++ b/deploy/observability/loki/loki-config.yml
@@ -34,5 +34,6 @@ limits_config:
 
 compactor:
   working_directory: /var/lib/loki/compactor
+  delete_request_store: filesystem
   compaction_interval: 10m
   retention_enabled: true

--- a/deploy/observability/loki/loki-config.yml
+++ b/deploy/observability/loki/loki-config.yml
@@ -1,0 +1,38 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /var/lib/loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: loki_index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /var/lib/loki/chunks
+
+ingester:
+  wal:
+    enabled: true
+    dir: /var/lib/loki/wal
+
+limits_config:
+  retention_period: 730d
+
+compactor:
+  working_directory: /var/lib/loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true

--- a/deploy/observability/loki/promtail.yml
+++ b/deploy/observability/loki/promtail.yml
@@ -6,7 +6,7 @@ positions:
   filename: /var/lib/promtail/positions.yaml
 
 clients:
-  - url: ${ARTHEXIS_LOKI_PUSH_URL:-http://localhost:3100/loki/api/v1/push}
+  - url: ${ARTHEXIS_LOKI_URL:-http://localhost:3100}/loki/api/v1/push
 
 scrape_configs:
   - job_name: arthexis-logs
@@ -18,9 +18,6 @@ scrape_configs:
           app: arthexis
           __path__: ${ARTHEXIS_LOG_DIR:-/var/log/arthexis}/*.log
     pipeline_stages:
-      - multiline:
-          firstline: '^\\d{4}-\\d{2}-\\d{2}'
-          max_wait_time: 3s
       - json:
           expressions:
             timestamp: timestamp

--- a/deploy/observability/loki/promtail.yml
+++ b/deploy/observability/loki/promtail.yml
@@ -29,6 +29,9 @@ scrape_configs:
             node_id: node_id
             charger_id: charger_id
             session_id: session_id
+      - timestamp:
+          source: timestamp
+          format: RFC3339
       - labels:
           app:
           hostname:

--- a/deploy/observability/loki/promtail.yml
+++ b/deploy/observability/loki/promtail.yml
@@ -1,0 +1,39 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: ${ARTHEXIS_LOKI_PUSH_URL:-http://localhost:3100/loki/api/v1/push}
+
+scrape_configs:
+  - job_name: arthexis-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: arthexis
+          app: arthexis
+          __path__: ${ARTHEXIS_LOG_DIR:-/var/log/arthexis}/*.log
+    pipeline_stages:
+      - multiline:
+          firstline: '^\\d{4}-\\d{2}-\\d{2}'
+          max_wait_time: 3s
+      - json:
+          expressions:
+            timestamp: timestamp
+            level: level
+            logger: logger
+            message: message
+            hostname: hostname
+            request_id: request_id
+            node_id: node_id
+            charger_id: charger_id
+            session_id: session_id
+      - labels:
+          app:
+          hostname:
+          level:
+          logger:

--- a/docs/operations/logging-loki-promtail.md
+++ b/docs/operations/logging-loki-promtail.md
@@ -22,6 +22,14 @@ Reference configs are provided in:
 
 Promtail should read from the same `ARTHEXIS_LOG_DIR` used by Arthexis processes.
 
+When starting Promtail with the provided config, export the expected environment and enable env expansion:
+
+```bash
+export ARTHEXIS_LOG_DIR=/var/log/arthexis
+export ARTHEXIS_LOKI_URL=http://localhost:3100
+promtail -config.file="$ARTHEXIS_PROMTAIL_CONFIG" -config.expand-env=true
+```
+
 ## 3) Configure Arthexis integration URLs
 
 Set these for admin hand-off links and integration status in Log Viewer:

--- a/docs/operations/logging-loki-promtail.md
+++ b/docs/operations/logging-loki-promtail.md
@@ -27,6 +27,7 @@ When starting Promtail with the provided config, export the expected environment
 ```bash
 export ARTHEXIS_LOG_DIR=/var/log/arthexis
 export ARTHEXIS_LOKI_URL=http://localhost:3100
+export ARTHEXIS_PROMTAIL_CONFIG=/etc/promtail/promtail.yml
 promtail -config.file="$ARTHEXIS_PROMTAIL_CONFIG" -config.expand-env=true
 ```
 

--- a/docs/operations/logging-loki-promtail.md
+++ b/docs/operations/logging-loki-promtail.md
@@ -1,0 +1,57 @@
+# Loki + Promtail integration for Arthexis
+
+Use this guide to connect Arthexis operational logs to Grafana Loki with Promtail shipping and Grafana dashboards.
+
+## 1) Enable JSON logs and shared log directory
+
+Set these environment variables in your runtime units:
+
+```bash
+ARTHEXIS_LOG_FORMAT=json
+ARTHEXIS_LOG_DIR=/var/log/arthexis
+```
+
+Arthexis already supports this mode and emits stable JSON keys appropriate for LogQL pipelines.
+
+## 2) Deploy Loki and Promtail
+
+Reference configs are provided in:
+
+- `deploy/observability/loki/loki-config.yml`
+- `deploy/observability/loki/promtail.yml`
+
+Promtail should read from the same `ARTHEXIS_LOG_DIR` used by Arthexis processes.
+
+## 3) Configure Arthexis integration URLs
+
+Set these for admin hand-off links and integration status in Log Viewer:
+
+```bash
+ARTHEXIS_GRAFANA_URL=https://grafana.example.com
+ARTHEXIS_LOKI_URL=https://loki.example.com
+ARTHEXIS_PROMTAIL_CONFIG=/etc/promtail/promtail.yml
+```
+
+When all three are set, Log Viewer reports the external stack as connected.
+
+## 4) Import starter dashboard
+
+Import:
+
+- `deploy/observability/grafana/arthexis-logs-overview.json`
+
+This dashboard includes:
+
+- Error/critical trend panel
+- Warning trend panel
+- Live logs panel with JSON parsing
+
+## 5) Validate from Arthexis
+
+Run:
+
+```bash
+.venv/bin/python manage.py logging_profile
+```
+
+Then open Admin → Log viewer and confirm integration status and Grafana link.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
       - Install & Lifecycle Scripts Manual: development/install-lifecycle-scripts-manual.md
       - Good Command: operations/good-command.md
       - Operational Commands: operations/operational-commands.md
+      - Loki + Promtail Integration: operations/logging-loki-promtail.md
       - Reinstall + Data Import Runbook: operations/reinstall-data-import-runbook.md
   - Integrations:
       - Integration Onboarding Tracks: integrations/onboarding-tracks.md


### PR DESCRIPTION
### Motivation
- Provide an easy way to inspect the active logging profile and whether external log aggregation (Grafana/Loki/Promtail) is wired for a running process. 
- Surface observability wiring in the admin Log Viewer so operators can see integration status and open Grafana directly. 
- Ship example Loki/Promtail/Grafana starter configs and operator docs to help deploy the stack and wire Arthexis logs. 

### Description
- Add a management command `logging_profile` that prints the resolved formatter, `LOG_DIR`, and `ARTHEXIS_GRAFANA_URL` / `ARTHEXIS_LOKI_URL` / `ARTHEXIS_PROMTAIL_CONFIG` environment values. 
- Introduce `_observability_integration_status()` in `apps/sites/admin/reports_admin.py` to report whether the three integration env vars are set and return status text and URLs, and include it in the Log Viewer context as `observability_status`. 
- Update the Log Viewer template `admin/log_viewer.html` to display the integration status and an `Open Grafana` button when a URL is configured. 
- Add reference deployment configs: `deploy/observability/loki/loki-config.yml`, `deploy/observability/loki/promtail.yml`, and a starter Grafana dashboard `deploy/observability/grafana/arthexis-logs-overview.json`. 
- Add operator documentation `docs/operations/logging-loki-promtail.md` and expose it in `mkdocs.yml`. 
- Add unit tests `apps/core/tests/test_logging_profile_command.py` and `apps/sites/tests/test_log_viewer_observability.py` to validate command output and observability status logic. 

### Testing
- Ran `apps/core/tests/test_logging_profile_command.py` which invokes `call_command('logging_profile')`, and the test passed. 
- Ran `apps/sites/tests/test_log_viewer_observability.py` which exercises `_observability_integration_status()` for both configured and not-configured env cases, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4078ad5b88326b3e82c0aff0a2bc2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds observability integration tooling and documentation to surface Grafana/Loki/Promtail log aggregation support in Arthexis. It includes a management command, a helper function for integration status reporting, template updates to display that status in the Log Viewer, deployment/config file references, operator documentation, and corresponding tests.

## Core Changes

### Management Command
- Added `logging_profile` Django management command that outputs the resolved log formatter, configured log directory, and three observability environment variables (`ARTHEXIS_GRAFANA_URL`, `ARTHEXIS_LOKI_URL`, `ARTHEXIS_PROMTAIL_CONFIG`), replacing empty values with `"(unset)"`.

### Integration Status Helper
- Added `_observability_integration_status()` helper in `apps/sites/admin/reports_admin.py` that reads the three observability environment variables, determines configuration state (all three must be non-empty), and returns a dict with `configured` boolean, translated status labels, and the raw environment values.
- Updated `log_viewer` response context to include `observability_status` for template consumption.

### Template Updates
- Enhanced `admin/log_viewer.html` to display an "Aggregator integration status" section showing the integration status label and help text, with a conditional "Open Grafana" button when a Grafana URL is configured.

### Configuration References
- Added Loki configuration file `deploy/observability/loki/loki-config.yml` with server, storage, ingester, and compactor settings for a filesystem-backed Loki instance on port 3100.
- Added Promtail configuration file `deploy/observability/loki/promtail.yml` that tails JSON-formatted Arthexis logs from a configured directory, applies multiline grouping and JSON parsing, and pushes to Loki with job and app labels.
- Added Grafana dashboard template `deploy/observability/grafana/arthexis-logs-overview.json` with three panels: error/critical log trends, warning log trends, and live logs with JSON parsing.

### Documentation
- Added `docs/operations/logging-loki-promtail.md` describing the end-to-end Loki + Promtail integration setup, including required Arthexis settings, deployment instructions for Loki and Promtail, environment variable configuration for external links, Grafana dashboard import, and validation via the `logging_profile` command.
- Updated `mkdocs.yml` to include the new documentation page under Operations navigation.

## Test Coverage
- Added `test_logging_profile_command_prints_runtime_settings` that invokes `logging_profile` with environment variables set and verifies the output includes expected sections and values.
- Added `test_observability_status_reports_not_configured` and `test_observability_status_reports_configured` that exercise the integration status helper with cleared and populated environment variables respectively, validating both configuration states.

All tests have been executed and passed locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->