### PR TITLE
core/sigils: harden SQLite upgrade recovery

### DIFF
--- a/apps/app/signals.py
+++ b/apps/app/signals.py
@@ -2,10 +2,13 @@ from django.db.models.signals import post_delete, post_migrate, post_save
 from django.dispatch import receiver
 
 from apps.app.models import Application, refresh_application_models, refresh_enabled_apps_lock
+from utils.post_migrate import is_final_post_migrate_app
 
 
 @receiver(post_migrate)
 def sync_application_models(sender, app_config, using, **kwargs):
+    if not is_final_post_migrate_app(app_config):
+        return
     refresh_application_models(using=using)
 
 

--- a/apps/app/tests/test_signals.py
+++ b/apps/app/tests/test_signals.py
@@ -1,0 +1,38 @@
+"""Tests for application model signal behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from apps.app import signals
+
+
+def test_sync_application_models_runs_only_for_final_post_migrate_app(
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        signals,
+        "refresh_application_models",
+        lambda *, using: calls.append(using),
+    )
+    monkeypatch.setattr(signals, "is_final_post_migrate_app", lambda app_config: False)
+
+    signals.sync_application_models(
+        sender=SimpleNamespace(label="gallery"),
+        app_config=SimpleNamespace(label="gallery"),
+        using="default",
+    )
+
+    assert calls == []
+
+    monkeypatch.setattr(signals, "is_final_post_migrate_app", lambda app_config: True)
+
+    signals.sync_application_models(
+        sender=SimpleNamespace(label="widgets"),
+        app_config=SimpleNamespace(label="widgets"),
+        using="default",
+    )
+
+    assert calls == ["default"]

--- a/apps/sigils/loader.py
+++ b/apps/sigils/loader.py
@@ -11,6 +11,8 @@ from typing import Iterable
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, OperationalError, connections
 
+from utils.post_migrate import is_final_post_migrate_app
+
 from .models import SigilRoot
 
 
@@ -42,6 +44,10 @@ def load_fixture_sigil_roots(sender=None, **kwargs) -> None:
     """Hydrate bundled SigilRoot fixtures while tolerating missing models."""
 
     del sender
+
+    app_config = kwargs.get("app_config")
+    if app_config is not None and not is_final_post_migrate_app(app_config):
+        return
 
     global _missing_content_types_logged
 

--- a/apps/sigils/tests/test_loader.py
+++ b/apps/sigils/tests/test_loader.py
@@ -5,6 +5,64 @@ from apps.sigils import loader
 from apps.sigils.models import SigilRoot
 
 
+def test_load_fixture_sigil_roots_skips_non_final_post_migrate_signal(
+    monkeypatch,
+) -> None:
+    saved_prefixes: list[str] = []
+
+    monkeypatch.setattr(loader, "is_final_post_migrate_app", lambda app_config: False)
+    monkeypatch.setattr(
+        loader,
+        "_iter_fixture_entries",
+        lambda _path: [
+            {
+                "prefix": "late",
+                "context_type": SigilRoot.Context.CONFIG,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        loader,
+        "_save_sigil_root",
+        lambda **kwargs: saved_prefixes.append(kwargs["prefix"]),
+    )
+
+    loader.load_fixture_sigil_roots(
+        sender=object(),
+        app_config=object(),
+        using="default",
+    )
+
+    assert saved_prefixes == []
+
+
+def test_load_fixture_sigil_roots_manual_call_bypasses_post_migrate_guard(
+    monkeypatch,
+) -> None:
+    saved_prefixes: list[str] = []
+
+    monkeypatch.setattr(loader, "is_final_post_migrate_app", lambda app_config: False)
+    monkeypatch.setattr(
+        loader,
+        "_iter_fixture_entries",
+        lambda _path: [
+            {
+                "prefix": "manual",
+                "context_type": SigilRoot.Context.CONFIG,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        loader,
+        "_save_sigil_root",
+        lambda **kwargs: saved_prefixes.append(kwargs["prefix"]),
+    )
+
+    loader.load_fixture_sigil_roots(using="default")
+
+    assert saved_prefixes == ["manual"]
+
+
 
 @pytest.mark.django_db
 def test_load_fixture_sigil_roots_retries_on_locked(monkeypatch, caplog):

--- a/env-refresh.py
+++ b/env-refresh.py
@@ -200,6 +200,26 @@ def _upsert_site_configuration(fields: dict[str, Any]) -> bool:
     return True
 
 
+def _resolve_content_type_natural_key(content_type: Any) -> ContentType | None:
+    """Return a content type for fixture data, or ``None`` when it is unavailable."""
+
+    if isinstance(content_type, (list, tuple)) and len(content_type) >= 2:
+        app_label, model_name = content_type[0], content_type[1]
+    elif isinstance(content_type, dict):
+        app_label = content_type.get("app_label")
+        model_name = content_type.get("model") or content_type.get("model_name")
+    else:
+        return None
+
+    if not app_label or not model_name:
+        return None
+
+    try:
+        return ContentType.objects.get_by_natural_key(app_label, model_name)
+    except ContentType.DoesNotExist:
+        return None
+
+
 def _schema_needs_migration() -> bool:
     """Return ``True`` when unapplied migrations exist."""
 
@@ -1066,27 +1086,18 @@ def run_database_tasks(
                         if prefix:
                             defaults = dict(fields)
                             content_type = defaults.get("content_type")
-                            if isinstance(content_type, (list, tuple)) and len(
+                            resolved_content_type = _resolve_content_type_natural_key(
                                 content_type
-                            ) >= 2:
-                                defaults["content_type"] = (
-                                    ContentType.objects.get_by_natural_key(
-                                        content_type[0],
-                                        content_type[1],
-                                    )
+                            )
+                            if content_type and resolved_content_type is None:
+                                print(
+                                    "Skipping SigilRoot "
+                                    f"'{prefix}' (content type not available yet)",
+                                    flush=True,
                                 )
-                            elif isinstance(content_type, dict):
-                                app_label = content_type.get("app_label")
-                                model_name = content_type.get("model")
-                                if not model_name:
-                                    model_name = content_type.get("model_name")
-                                if app_label and model_name:
-                                    defaults["content_type"] = (
-                                        ContentType.objects.get_by_natural_key(
-                                            app_label,
-                                            model_name,
-                                        )
-                                    )
+                                modified = True
+                                continue
+                            defaults["content_type"] = resolved_content_type
                             SigilRoot = model
                             SigilRoot.objects.update_or_create(
                                 prefix=prefix,

--- a/tests/test_env_refresh_migration_mismatch.py
+++ b/tests/test_env_refresh_migration_mismatch.py
@@ -116,3 +116,40 @@ def test_branch_tag_conflict_without_reconcile_fails_fast(
     assert "branch tag conflict" in output
     assert "Auto-reconcile fallback engaged" not in output
     assert migrate_calls == 1
+
+
+def test_resolve_content_type_natural_key_returns_none_when_missing(
+    env_refresh_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MissingManager:
+        def get_by_natural_key(self, app_label: str, model_name: str):
+            raise env_refresh_module.ContentType.DoesNotExist
+
+    monkeypatch.setattr(env_refresh_module.ContentType, "objects", MissingManager())
+
+    assert (
+        env_refresh_module._resolve_content_type_natural_key(["gallery", "galleryimage"])
+        is None
+    )
+
+
+def test_resolve_content_type_natural_key_returns_content_type_when_present(
+    env_refresh_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = object()
+
+    class PresentManager:
+        def get_by_natural_key(self, app_label: str, model_name: str):
+            assert (app_label, model_name) == ("gallery", "galleryimage")
+            return sentinel
+
+    monkeypatch.setattr(env_refresh_module.ContentType, "objects", PresentManager())
+
+    assert (
+        env_refresh_module._resolve_content_type_natural_key(
+            {"app_label": "gallery", "model": "galleryimage"}
+        )
+        is sentinel
+    )

--- a/utils/post_migrate.py
+++ b/utils/post_migrate.py
@@ -1,0 +1,22 @@
+"""Helpers for coordinating expensive post-migrate work."""
+
+from __future__ import annotations
+
+from django.apps import apps as django_apps
+
+
+def is_final_post_migrate_app(app_config) -> bool:
+    """Return whether ``app_config`` is the final app for Django post-migrate."""
+
+    if app_config is None:
+        return False
+
+    app_configs = tuple(django_apps.get_app_configs())
+    if not app_configs:
+        return False
+
+    final_app_config = app_configs[-1]
+    return (
+        app_config.label == final_app_config.label
+        and app_config.name == final_app_config.name
+    )


### PR DESCRIPTION
## Summary
- run expensive application-model sync only once on the final `post_migrate` emission
- defer `SigilRoot` fixture hydration until the final `post_migrate` emission instead of writing during every app migration
- make `env-refresh.py` skip unresolved `sigils.sigilroot` content-type references instead of crashing startup after a partial SQLite rebuild

## Why
SQLite upgrades on `main` can currently leave the suite down after migration recovery, with repeated `ContentType.DoesNotExist` failures in `env-refresh.py` and repeated post-migrate writes contending on the database.

Fixes #7159.

## Validation
- `.venv/bin/python -m pytest apps/app/tests/test_signals.py apps/app/tests/test_enabled_apps_lock.py apps/sigils/tests/test_loader.py tests/test_env_refresh_migration_mismatch.py`
- `13 passed`

## Notes
- This is intentionally scoped to the repeated post-migrate writers and the fixture fallback path.
- I have not replayed a full live SQLite upgrade inside `experiment`; the live failure mode was diagnosed from `/home/arthe/arthexis` and the targeted regression coverage was added here.