### PR TITLE
sites: make log viewer per-file filenames directly selectable

### DIFF
--- a/apps/sites/templates/admin/log_viewer.html
+++ b/apps/sites/templates/admin/log_viewer.html
@@ -222,7 +222,7 @@
           <tbody>
             {% for row in log_dashboard.file_rows %}
               <tr>
-                <th scope="row">{{ row.name }}</th>
+                <th scope="row"><a href="?log={{ row.name|urlencode }}">{{ row.name }}</a></th>
                 <td>{{ row.line_count }}</td>
                 <td>{{ row.recent_warning }}</td>
                 <td>{{ row.recent_error }}</td>

--- a/apps/sites/tests/test_log_viewer.py
+++ b/apps/sites/tests/test_log_viewer.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+from urllib.parse import quote
+from uuid import uuid4
 
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
+from django.urls import reverse
 
 from apps.sites.admin.reports_admin import log_viewer
 
@@ -11,35 +14,38 @@ from apps.sites.admin.reports_admin import log_viewer
 pytestmark = [pytest.mark.django_db]
 
 
-def test_log_viewer_per_file_table_links_to_log_selection():
+def test_log_viewer_per_file_table_links_to_log_selection(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "BASE_DIR", tmp_path)
     logs_dir = Path(settings.BASE_DIR) / "logs"
     logs_dir.mkdir(exist_ok=True)
-    log_name = "test-log-viewer clickable.log"
+    log_name = f"test-log-viewer clickable {uuid4().hex}.log"
     log_path = logs_dir / log_name
-    log_path.write_text("[INFO] boot ok\n", encoding="utf-8")
-
-    user_model = get_user_model()
-    staff_user = user_model.objects.create_user(
-        username="log-viewer-staff",
-        email="log-viewer-staff@example.com",
-        password="secret",
-        is_staff=True,
-        is_superuser=True,
-    )
-
-    rf = RequestFactory()
 
     try:
-        request = rf.get("/admin/logs/viewer/")
+        log_path.write_text("[INFO] boot ok\n", encoding="utf-8")
+
+        user_model = get_user_model()
+        staff_user = user_model.objects.create_user(
+            username=f"log-viewer-staff-{uuid4().hex[:8]}",
+            email="log-viewer-staff@example.com",
+            password="secret",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        rf = RequestFactory()
+        url = reverse("admin:log_viewer")
+
+        request = rf.get(url)
         request.user = staff_user
         response = log_viewer(request)
         response.render()
         body = response.content.decode()
 
         assert response.status_code == 200
-        assert "?log=test-log-viewer%20clickable.log" in body
+        assert f'?log={quote(log_name)}' in body
 
-        selected_request = rf.get("/admin/logs/viewer/", {"log": log_name})
+        selected_request = rf.get(url, {"log": log_name})
         selected_request.user = staff_user
         selected_response = log_viewer(selected_request)
         selected_response.render()

--- a/apps/sites/tests/test_log_viewer.py
+++ b/apps/sites/tests/test_log_viewer.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from apps.sites.admin.reports_admin import log_viewer
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_log_viewer_per_file_table_links_to_log_selection():
+    logs_dir = Path(settings.BASE_DIR) / "logs"
+    logs_dir.mkdir(exist_ok=True)
+    log_name = "test-log-viewer clickable.log"
+    log_path = logs_dir / log_name
+    log_path.write_text("[INFO] boot ok\n", encoding="utf-8")
+
+    user_model = get_user_model()
+    staff_user = user_model.objects.create_user(
+        username="log-viewer-staff",
+        email="log-viewer-staff@example.com",
+        password="secret",
+        is_staff=True,
+        is_superuser=True,
+    )
+
+    rf = RequestFactory()
+
+    try:
+        request = rf.get("/admin/logs/viewer/")
+        request.user = staff_user
+        response = log_viewer(request)
+        response.render()
+        body = response.content.decode()
+
+        assert response.status_code == 200
+        assert "?log=test-log-viewer%20clickable.log" in body
+
+        selected_request = rf.get("/admin/logs/viewer/", {"log": log_name})
+        selected_request.user = staff_user
+        selected_response = log_viewer(selected_request)
+        selected_response.render()
+        selected_body = selected_response.content.decode()
+
+        assert selected_response.status_code == 200
+        assert f"Viewing {log_name}" in selected_body
+    finally:
+        log_path.unlink(missing_ok=True)


### PR DESCRIPTION
### Motivation
- Allow administrators to open a log file by clicking its name in the Log viewer per-file health snapshot so file selection is one-click and more discoverable.

### Description
- Render per-file filenames as links in `apps/sites/templates/admin/log_viewer.html` using `?log={{ row.name|urlencode }}` so names containing spaces are encoded correctly.
- Add a regression test `apps/sites/tests/test_log_viewer.py` that creates a sample log, asserts the generated clickable link appears in the viewer, and verifies selecting the file renders the "Viewing <name>" state.

### Testing
- Bootstrapped the test environment and executed the new test: `.venv/bin/python manage.py test run -- apps/sites/tests/test_log_viewer.py`, which passed (`1 passed`).
- No other test changes were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41260811c8326b518c5d866077fcb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR makes log file selection in the admin log viewer more discoverable by rendering per-file filenames as clickable links.

## Changes

### Template (`apps/sites/templates/admin/log_viewer.html`)
Changed the "Per-file health snapshot" table's "File" column to render each filename as a hyperlink to the same page with a `?log={{ row.name|urlencode }}` query parameter. Previously filenames were displayed as plain text, requiring users to locate and use the dropdown selector. The `urlencode` filter ensures proper handling of filenames containing spaces and special characters.

### Test (`apps/sites/tests/test_log_viewer.py`)
Added `test_log_viewer_per_file_table_links_to_log_selection()` that validates:
1. The per-file health snapshot table generates correctly formatted clickable links with URL-encoded filenames (tested with a filename containing spaces: `test-log-viewer clickable.log`)
2. Clicking the link (via the query parameter) successfully displays the selected log file with the "Viewing {filename}" header

The test creates a sample log file, verifies both HTTP responses return status 200, and performs cleanup of the test log file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->