### PR TITLE
manage: clarify env-refresh failures during runserver startup

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -127,7 +127,21 @@ def _run_env_refresh(base_dir: Path) -> None:
     command = [sys.executable, str(base_dir / "env-refresh.py"), "--latest", "database"]
     env = os.environ.copy()
     env.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
-    subprocess.run(command, cwd=base_dir, check=True, env=env)
+    try:
+        subprocess.run(command, cwd=base_dir, check=True, env=env)
+    except subprocess.CalledProcessError as exc:
+        command_str = " ".join(command)
+        print(
+            "Environment refresh failed before runserver startup.",
+            file=sys.stderr,
+        )
+        print(f"Failed command: {command_str}", file=sys.stderr)
+        print(
+            "Re-run manually for full details: "
+            f"{command_str} --reconcile",
+            file=sys.stderr,
+        )
+        raise SystemExit(exc.returncode) from exc
 
 
 def _service_mode_allows_embedded_celery(base_dir: Path) -> bool:

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -130,7 +131,7 @@ def _run_env_refresh(base_dir: Path) -> None:
     try:
         subprocess.run(command, cwd=base_dir, check=True, env=env)
     except subprocess.CalledProcessError as exc:
-        command_str = " ".join(command)
+        command_str = shlex.join(command)
         print(
             "Environment refresh failed before runserver startup.",
             file=sys.stderr,

--- a/tests/test_manage_embedded_celery.py
+++ b/tests/test_manage_embedded_celery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import subprocess
 from pathlib import Path
 
 import manage
@@ -103,3 +104,51 @@ def test_main_does_not_check_service_mode_outside_runserver(
     )
 
     manage.main(["check"])
+
+
+def test_run_env_refresh_runs_latest_database_refresh(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return None
+
+    monkeypatch.setattr(manage.subprocess, "run", fake_run)
+
+    manage._run_env_refresh(tmp_path)
+
+    assert captured["command"] == [
+        manage.sys.executable,
+        str(tmp_path / "env-refresh.py"),
+        "--latest",
+        "database",
+    ]
+    kwargs = captured["kwargs"]
+    assert kwargs["check"] is True
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["env"]["DJANGO_SETTINGS_MODULE"] == "config.settings"
+
+
+def test_run_env_refresh_exits_with_context_when_refresh_fails(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    command = [manage.sys.executable, str(tmp_path / "env-refresh.py"), "--latest"]
+
+    def fake_run(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(manage.subprocess, "run", fake_run)
+
+    try:
+        manage._run_env_refresh(tmp_path)
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected SystemExit")
+
+    captured = capsys.readouterr()
+    assert "Environment refresh failed before runserver startup." in captured.err
+    assert "Re-run manually for full details:" in captured.err

--- a/tests/test_manage_embedded_celery.py
+++ b/tests/test_manage_embedded_celery.py
@@ -135,7 +135,13 @@ def test_run_env_refresh_runs_latest_database_refresh(
 def test_run_env_refresh_exits_with_context_when_refresh_fails(
     monkeypatch, tmp_path: Path, capsys
 ) -> None:
-    command = [manage.sys.executable, str(tmp_path / "env-refresh.py"), "--latest"]
+    command = [
+        manage.sys.executable,
+        str(tmp_path / "env-refresh.py"),
+        "--latest",
+        "database",
+    ]
+    command_str = manage.shlex.join(command)
 
     def fake_run(*_args, **_kwargs):
         raise subprocess.CalledProcessError(1, command)
@@ -151,4 +157,6 @@ def test_run_env_refresh_exits_with_context_when_refresh_fails(
 
     captured = capsys.readouterr()
     assert "Environment refresh failed before runserver startup." in captured.err
+    assert f"Failed command: {command_str}" in captured.err
     assert "Re-run manually for full details:" in captured.err
+    assert f"{command_str} --reconcile" in captured.err


### PR DESCRIPTION
### Motivation

- The `manage.py` startup path invoked `env-refresh.py --latest database` and surfaced a raw Python traceback when the subprocess failed, which is noisy for operators.
- Provide a concise, actionable operator-facing message that includes the failed command and a retry hint to make troubleshooting latest-upgrade failures easier.

### Description

- Catch `subprocess.CalledProcessError` in `manage._run_env_refresh` and print a focused failure summary including the exact failed command and a `--reconcile` retry hint, then exit with the subprocess return code via `SystemExit`.
- Preserve the successful invocation behavior by continuing to call `subprocess.run([... , "--latest", "database"])` when it succeeds.
- Add tests in `tests/test_manage_embedded_celery.py` that assert the `subprocess.run` call arguments for the success path and validate the failure path produces a `SystemExit` and the expected stderr guidance.
- Add an explicit `import subprocess` to the test module to support raising `CalledProcessError` in the failure test.

### Testing

- Ran dependency bootstrap with `./env-refresh.sh --deps-only` which completed successfully and skipped database updates; this was used to prepare the environment for tests.
- Installed CI test dependencies with `.venv/bin/pip install -r requirements-ci.txt` to ensure pytest and pytest-django were available for test execution.
- Executed the modified test suite with `.venv/bin/python manage.py test run -- tests/test_manage_embedded_celery.py` and observed `8 passed` for the file, indicating the new tests and existing coverage succeeded.
- Ran the env-refresh command manually with `.venv/bin/python env-refresh.py --latest database` during verification which completed as part of the reproduction steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4471b2e3483268a56a260e756e0f0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### manage.py
Modified the `_run_env_refresh()` function to handle subprocess failures more gracefully. The function now wraps the `subprocess.run()` call in a try-except block that catches `subprocess.CalledProcessError`. On failure, it prints three contextual messages to stderr:
- A failure notice indicating the environment refresh failed before runserver startup
- The exact failed command that was executed
- An instruction to re-run the command with the `--reconcile` flag for full details

After printing these messages, the function exits via `raise SystemExit(exc.returncode)` with the original subprocess return code, instead of letting the exception propagate uncaught.

### tests/test_manage_embedded_celery.py
Added two test cases for `_run_env_refresh()`:

1. `test_run_env_refresh_runs_latest_database_refresh`: Verifies the success path by mocking `subprocess.run` and asserting that `_run_env_refresh` invokes it with the correct arguments—Python executable, env-refresh.py path, `--latest database` flags—and passes `check=True`, the correct working directory, and the `DJANGO_SETTINGS_MODULE` environment variable.

2. `test_run_env_refresh_exits_with_context_when_refresh_fails`: Simulates a `subprocess.CalledProcessError` and verifies that `_run_env_refresh` catches it, prints the expected failure messages to stderr, and exits cleanly via `SystemExit` with exit code 1.

These tests ensure the failure handling path provides users with clear, actionable guidance when env-refresh fails during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->