### PR TITLE
ops: Inline GitHub access configuration for operator journey step

### DIFF
--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -212,6 +212,7 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         label="GitHub username",
     )
     token = forms.CharField(
+        required=False,
         widget=forms.PasswordInput(),
         help_text="Personal access token used for repository, release, and issue tasks.",
         label="GitHub token",
@@ -227,12 +228,24 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         self.user = user
         super().__init__(*args, **kwargs)
 
-        existing = GitHubToken.objects.filter(user=user).order_by("-pk").first()
-        if existing is None or self.is_bound:
+        self._existing_token_record = GitHubToken.objects.filter(user=user).order_by("-pk").first()
+        if self._existing_token_record is None or self.is_bound:
             return
         self.initial.setdefault("github_username", user.username)
-        self.initial.setdefault("token", existing.__dict__.get("token", ""))
-        self.initial.setdefault("token_label", existing.label)
+        self.initial.setdefault("token", self._existing_token_record.__dict__.get("token", ""))
+        self.initial.setdefault("token_label", self._existing_token_record.label)
+
+    def clean_token(self) -> str:
+        submitted_token = (self.cleaned_data.get("token") or "").strip()
+        if submitted_token:
+            return submitted_token
+
+        existing_token = ""
+        if self._existing_token_record is not None:
+            existing_token = (self._existing_token_record.__dict__.get("token") or "").strip()
+        if existing_token:
+            return existing_token
+        raise forms.ValidationError("Enter a GitHub token.")
 
     def save(self) -> GitHubToken:
         """Persist the token for the active user."""

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError
 from apps.groups.models import SecurityGroup
 from apps.repos.models import GitHubToken
 from apps.repos.services import github as github_service
+from apps.sigils.sigil_resolver import resolve_sigils
 
 
 class OperatorJourneyProvisionSuperuserForm(forms.Form):
@@ -253,8 +254,9 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         """Return whether the token authenticates and matches the requested username."""
 
         cleaned_data = self.cleaned_data
+        submitted_token = (cleaned_data.get("token") or "").strip()
         success, message, login = github_service.validate_token(
-            cleaned_data.get("token") or ""
+            resolve_sigils(submitted_token)
         )
         if not success:
             return False, message

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -211,7 +211,7 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         label="GitHub username",
     )
     token = forms.CharField(
-        widget=forms.PasswordInput(render_value=True),
+        widget=forms.PasswordInput(),
         help_text="Personal access token used for repository, release, and issue tasks.",
         label="GitHub token",
     )
@@ -230,7 +230,7 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         if existing is None or self.is_bound:
             return
         self.initial.setdefault("github_username", user.username)
-        self.initial.setdefault("token", existing.token)
+        self.initial.setdefault("token", existing.__dict__.get("token", ""))
         self.initial.setdefault("token_label", existing.label)
 
     def save(self) -> GitHubToken:

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -11,6 +11,8 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
 from apps.groups.models import SecurityGroup
+from apps.repos.models import GitHubToken
+from apps.repos.services import github as github_service
 
 
 class OperatorJourneyProvisionSuperuserForm(forms.Form):
@@ -197,3 +199,70 @@ class OperatorJourneyProvisionSuperuserForm(forms.Form):
     @classmethod
     def _resolve_upgrade_update_fields(cls, user) -> list[str]:
         return [field for field in cls.UPGRADE_UPDATE_FIELDS if hasattr(user, field)]
+
+
+class OperatorJourneyGitHubAccessForm(forms.Form):
+    """Configure and validate the current user's GitHub token."""
+
+    github_username = forms.CharField(
+        max_length=255,
+        required=False,
+        help_text="Optional GitHub username to confirm against the token.",
+        label="GitHub username",
+    )
+    token = forms.CharField(
+        widget=forms.PasswordInput(render_value=True),
+        help_text="Personal access token used for repository, release, and issue tasks.",
+        label="GitHub token",
+    )
+    token_label = forms.CharField(
+        max_length=255,
+        required=False,
+        help_text="Optional label shown in token admin records.",
+        label="Token label",
+    )
+
+    def __init__(self, *args, user, **kwargs):
+        self.user = user
+        super().__init__(*args, **kwargs)
+
+        existing = GitHubToken.objects.filter(user=user).order_by("-pk").first()
+        if existing is None or self.is_bound:
+            return
+        self.initial.setdefault("github_username", user.username)
+        self.initial.setdefault("token", existing.token)
+        self.initial.setdefault("token_label", existing.label)
+
+    def save(self) -> GitHubToken:
+        """Persist the token for the active user."""
+
+        cleaned_data = self.cleaned_data
+        label = (cleaned_data.get("token_label") or "").strip()
+        username = (cleaned_data.get("github_username") or "").strip()
+        defaults = {
+            "label": label or username or "GitHub access token",
+            "token": (cleaned_data.get("token") or "").strip(),
+        }
+        token, _created = GitHubToken.objects.update_or_create(
+            user=self.user,
+            defaults=defaults,
+        )
+        return token
+
+    def validate_connection(self) -> tuple[bool, str]:
+        """Return whether the token authenticates and matches the requested username."""
+
+        cleaned_data = self.cleaned_data
+        success, message, login = github_service.validate_token(
+            cleaned_data.get("token") or ""
+        )
+        if not success:
+            return False, message
+
+        expected_username = (cleaned_data.get("github_username") or "").strip()
+        if expected_username and login and login.lower() != expected_username.lower():
+            return (
+                False,
+                f"Token authenticated as {login}, which does not match {expected_username}.",
+            )
+        return True, message

--- a/apps/ops/forms.py
+++ b/apps/ops/forms.py
@@ -231,7 +231,6 @@ class OperatorJourneyGitHubAccessForm(forms.Form):
         self._existing_token_record = GitHubToken.objects.filter(user=user).order_by("-pk").first()
         if self._existing_token_record is None or self.is_bound:
             return
-        self.initial.setdefault("github_username", user.username)
         self.initial.setdefault("token", self._existing_token_record.__dict__.get("token", ""))
         self.initial.setdefault("token_label", self._existing_token_record.label)
 

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -297,6 +297,46 @@
         </div>
         <button type="submit" class="button default operator-journey-primary-button">{% translate "Create account and complete step" %}</button>
       </form>
+    {% elif github_access_form %}
+      <p>{{ step.instruction }}</p>
+      {% if step.help_text %}
+        <p><strong>{% translate "Manual help:" %}</strong> {{ step.help_text }}</p>
+      {% endif %}
+      <style>
+        .operator-journey-github-panel {
+          border: 1px solid var(--hairline-color);
+          border-radius: var(--admin-ui-radius-md, 0.5rem);
+          margin-top: 1rem;
+          padding: 1rem;
+        }
+        .operator-journey-github-actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--admin-ui-space-2, 0.5rem);
+          margin-top: 1rem;
+        }
+      </style>
+      <form method="post" action="{% url 'ops:operator-journey-step-complete' journey_slug=step.journey.slug step_slug=step.slug %}" class="operator-journey-github-panel">
+        {% csrf_token %}
+        {{ github_access_form.non_field_errors }}
+        <fieldset class="module aligned" style="padding: 0;">
+          {% for field in github_access_form %}
+            <div class="form-row" style="margin-bottom: 0.75rem;">
+              <label for="{{ field.id_for_label }}" style="display: block; font-weight: 600;">{{ field.label }}</label>
+              {{ field }}
+              {% if field.help_text %}
+                <p class="help" style="margin: 0.25rem 0 0;">{{ field.help_text }}</p>
+              {% endif %}
+              {{ field.errors }}
+            </div>
+          {% endfor %}
+        </fieldset>
+        <div class="operator-journey-github-actions">
+          <button type="submit" name="journey_action" value="save" class="button">{% translate "Save GitHub access" %}</button>
+          <button type="submit" name="journey_action" value="test" class="button">{% translate "Test GitHub access" %}</button>
+          <button type="submit" name="journey_action" value="complete" class="button default">{% translate "Validate GitHub access and complete step" %}</button>
+        </div>
+      </form>
     {% else %}
       <p>{{ step.instruction }}</p>
       {% if step.help_text %}
@@ -322,7 +362,7 @@
         </p>
       </div>
     {% endif %}
-    {% if not provision_superuser_form %}
+    {% if not provision_superuser_form and not github_access_form %}
       <form method="post" action="{% url 'ops:operator-journey-step-complete' journey_slug=step.journey.slug step_slug=step.slug %}" style="margin-top: 1rem;">
         {% csrf_token %}
         <button type="submit" class="button default">{% translate "Mark this step complete" %}</button>

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -282,11 +282,11 @@
             <fieldset class="module aligned" style="padding: 0;">
               {% for field in provision_superuser_form %}
                 {% if field.name != "security_groups" %}
-                  <div class="form-row" style="margin-bottom: 0.75rem;">
+                  <div class="form-row" style="margin-bottom: var(--admin-ui-space-3, 0.75rem);">
                     <label for="{{ field.id_for_label }}" style="display: block; font-weight: 600;">{{ field.label }}</label>
                     {{ field }}
                     {% if field.help_text %}
-                      <p class="help" style="margin: 0.25rem 0 0;">{{ field.help_text }}</p>
+                      <p class="help" style="margin: var(--admin-ui-space-1, 0.25rem) 0 0;">{{ field.help_text }}</p>
                     {% endif %}
                     {{ field.errors }}
                   </div>
@@ -321,11 +321,11 @@
         {{ github_access_form.non_field_errors }}
         <fieldset class="module aligned" style="padding: 0;">
           {% for field in github_access_form %}
-            <div class="form-row" style="margin-bottom: 0.75rem;">
+            <div class="form-row" style="margin-bottom: var(--admin-ui-space-3, 0.75rem);">
               <label for="{{ field.id_for_label }}" style="display: block; font-weight: 600;">{{ field.label }}</label>
               {{ field }}
               {% if field.help_text %}
-                <p class="help" style="margin: 0.25rem 0 0;">{{ field.help_text }}</p>
+                <p class="help" style="margin: var(--admin-ui-space-1, 0.25rem) 0 0;">{{ field.help_text }}</p>
               {% endif %}
               {{ field.errors }}
             </div>

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -460,6 +460,104 @@ class OperatorJourneyViewTests(TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data["token"], token.__dict__.get("token"))
 
+    def test_setup_github_token_save_requires_githubtoken_permissions(self):
+        limited_user = get_user_model().objects.create_user(
+            username="ops-journey-limited",
+            password="x",
+            is_staff=True,
+        )
+        limited_user.groups.add(self.group)
+        self.client.force_login(limited_user)
+        complete_step_for_user(user=limited_user, step=self.step_1)
+        complete_step_for_user(user=limited_user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "save",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You do not have permission to save a GitHub token.")
+        self.assertFalse(GitHubToken.objects.filter(user=limited_user).exists())
+
+    @patch("apps.ops.forms.github_service.validate_token")
+    def test_setup_github_token_complete_requires_githubtoken_permissions(
+        self,
+        mock_validate_token,
+    ):
+        mock_validate_token.return_value = (True, "Connected to GitHub as arthexis.", "arthexis")
+        limited_user = get_user_model().objects.create_user(
+            username="ops-journey-complete-limited",
+            password="x",
+            is_staff=True,
+        )
+        limited_user.groups.add(self.group)
+        self.client.force_login(limited_user)
+        complete_step_for_user(user=limited_user, step=self.step_1)
+        complete_step_for_user(user=limited_user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "complete",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You do not have permission to save a GitHub token.")
+        self.assertFalse(GitHubToken.objects.filter(user=limited_user).exists())
+        self.assertFalse(github_step.completions.filter(user=limited_user).exists())
+
     @patch("apps.ops.forms.github_service.validate_token")
     @patch("apps.ops.forms.resolve_sigils")
     def test_setup_github_token_validation_resolves_sigil_tokens(

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -10,7 +10,10 @@ from django.urls import reverse
 from apps.groups.constants import SITE_OPERATOR_GROUP_NAME
 from apps.groups.models import SecurityGroup
 from apps.nodes.models import NodeRole
-from apps.ops.forms import OperatorJourneyProvisionSuperuserForm
+from apps.ops.forms import (
+    OperatorJourneyGitHubAccessForm,
+    OperatorJourneyProvisionSuperuserForm,
+)
 from apps.ops.models import OperatorJourney, OperatorJourneyStep
 from apps.ops.operator_journey import (
     PROVISION_SUPERUSER_STEP_SLUG,
@@ -300,7 +303,7 @@ class OperatorJourneyViewTests(TestCase):
         self.assertNotContains(response, "Open task page")
 
     @patch("apps.ops.forms.github_service.validate_token")
-    def test_setup_github_token_test_action_saves_and_validates(self, mock_validate_token):
+    def test_setup_github_token_test_action_validates_without_saving(self, mock_validate_token):
         mock_validate_token.return_value = (True, "Connected to GitHub as arthexis.", "arthexis")
         complete_step_for_user(user=self.user, step=self.step_1)
         complete_step_for_user(user=self.user, step=self.step_2)
@@ -337,11 +340,52 @@ class OperatorJourneyViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertFalse(GitHubToken.objects.filter(user=self.user).exists())
+        mock_validate_token.assert_called_once_with("ghp_demo_token")
+        self.assertFalse(github_step.completions.filter(user=self.user).exists())
+
+    @patch("apps.ops.forms.github_service.validate_token")
+    def test_setup_github_token_complete_saves_after_successful_validation(self, mock_validate_token):
+        mock_validate_token.return_value = (True, "Connected to GitHub as arthexis.", "arthexis")
+        complete_step_for_user(user=self.user, step=self.step_1)
+        complete_step_for_user(user=self.user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "complete",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
         saved_token = GitHubToken.objects.get(user=self.user)
         self.assertEqual(saved_token.label, "Dev token")
         self.assertEqual(saved_token.token, "ghp_demo_token")
-        mock_validate_token.assert_called_once_with("ghp_demo_token")
-        self.assertFalse(github_step.completions.filter(user=self.user).exists())
+        self.assertTrue(github_step.completions.filter(user=self.user).exists())
 
     @patch("apps.ops.forms.github_service.validate_token")
     def test_setup_github_token_complete_requires_successful_validation(self, mock_validate_token):
@@ -383,6 +427,20 @@ class OperatorJourneyViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Bad credentials")
         self.assertFalse(github_step.completions.filter(user=self.user).exists())
+
+    def test_setup_github_token_form_prefills_raw_stored_token(self):
+        token = GitHubToken.objects.create(
+            user=self.user,
+            label="Sigil token",
+            token="[ENV.GITHUB_TOKEN]",
+        )
+
+        form = OperatorJourneyGitHubAccessForm(user=self.user)
+
+        self.assertEqual(
+            form.initial.get("token"),
+            token.__dict__.get("token"),
+        )
 
     def test_slug_step_url_that_matches_legacy_complete_shape_stays_canonical(self):
         numeric_journey = OperatorJourney.objects.create(

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -437,6 +437,7 @@ class OperatorJourneyViewTests(TestCase):
 
         form = OperatorJourneyGitHubAccessForm(user=self.user)
 
+        self.assertEqual(form.initial.get("github_username"), None)
         self.assertEqual(
             form.initial.get("token"),
             token.__dict__.get("token"),

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -442,6 +442,24 @@ class OperatorJourneyViewTests(TestCase):
             token.__dict__.get("token"),
         )
 
+    def test_setup_github_token_form_reuses_stored_token_when_submission_is_blank(self):
+        token = GitHubToken.objects.create(
+            user=self.user,
+            label="Sigil token",
+            token="[ENV.GITHUB_TOKEN]",
+        )
+        form = OperatorJourneyGitHubAccessForm(
+            data={
+                "github_username": "arthexis",
+                "token": "",
+                "token_label": "Existing token",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["token"], token.__dict__.get("token"))
+
     @patch("apps.ops.forms.github_service.validate_token")
     @patch("apps.ops.forms.resolve_sigils")
     def test_setup_github_token_validation_resolves_sigil_tokens(

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -507,6 +507,62 @@ class OperatorJourneyViewTests(TestCase):
         self.assertFalse(GitHubToken.objects.filter(user=limited_user).exists())
 
     @patch("apps.ops.forms.github_service.validate_token")
+    def test_setup_github_token_test_requires_githubtoken_permissions(
+        self,
+        mock_validate_token,
+    ):
+        mock_validate_token.return_value = (
+            True,
+            "Connected to GitHub as arthexis.",
+            "arthexis",
+        )
+        limited_user = get_user_model().objects.create_user(
+            username="ops-journey-test-limited",
+            password="x",
+            is_staff=True,
+        )
+        limited_user.groups.add(self.group)
+        self.client.force_login(limited_user)
+        complete_step_for_user(user=limited_user, step=self.step_1)
+        complete_step_for_user(user=limited_user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "test",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You do not have permission to save a GitHub token.")
+        mock_validate_token.assert_not_called()
+        self.assertFalse(GitHubToken.objects.filter(user=limited_user).exists())
+
+    @patch("apps.ops.forms.github_service.validate_token")
     def test_setup_github_token_complete_requires_githubtoken_permissions(
         self,
         mock_validate_token,

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -23,6 +23,7 @@ from apps.ops.views import (
     _build_node_role_validation_summary,
     _build_security_group_rows,
 )
+from apps.repos.models import GitHubToken
 
 
 class OperatorJourneyFlowTests(TestCase):
@@ -263,6 +264,125 @@ class OperatorJourneyViewTests(TestCase):
                 },
             ),
         )
+
+    def test_setup_github_token_step_renders_inline_configuration_form(self):
+        complete_step_for_user(user=self.user, step=self.step_1)
+        complete_step_for_user(user=self.user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.get(
+            reverse(
+                "ops:operator-journey-step",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            )
+        )
+
+        self.assertContains(response, "GitHub token")
+        self.assertContains(response, "Test GitHub access")
+        self.assertNotContains(response, "Guided action")
+        self.assertNotContains(response, "Open task page")
+
+    @patch("apps.ops.forms.github_service.validate_token")
+    def test_setup_github_token_test_action_saves_and_validates(self, mock_validate_token):
+        mock_validate_token.return_value = (True, "Connected to GitHub as arthexis.", "arthexis")
+        complete_step_for_user(user=self.user, step=self.step_1)
+        complete_step_for_user(user=self.user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "test",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        saved_token = GitHubToken.objects.get(user=self.user)
+        self.assertEqual(saved_token.label, "Dev token")
+        self.assertEqual(saved_token.token, "ghp_demo_token")
+        mock_validate_token.assert_called_once_with("ghp_demo_token")
+        self.assertFalse(github_step.completions.filter(user=self.user).exists())
+
+    @patch("apps.ops.forms.github_service.validate_token")
+    def test_setup_github_token_complete_requires_successful_validation(self, mock_validate_token):
+        mock_validate_token.return_value = (False, "Bad credentials", "")
+        complete_step_for_user(user=self.user, step=self.step_1)
+        complete_step_for_user(user=self.user, step=self.step_2)
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        github_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": github_journey.slug,
+                    "step_slug": github_step.slug,
+                },
+            ),
+            {
+                "journey_action": "complete",
+                "github_username": "arthexis",
+                "token": "ghp_demo_token",
+                "token_label": "Dev token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Bad credentials")
+        self.assertFalse(github_step.completions.filter(user=self.user).exists())
 
     def test_slug_step_url_that_matches_legacy_complete_shape_stays_canonical(self):
         numeric_journey = OperatorJourney.objects.create(

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -442,6 +442,32 @@ class OperatorJourneyViewTests(TestCase):
             token.__dict__.get("token"),
         )
 
+    @patch("apps.ops.forms.github_service.validate_token")
+    @patch("apps.ops.forms.resolve_sigils")
+    def test_setup_github_token_validation_resolves_sigil_tokens(
+        self,
+        mock_resolve_sigils,
+        mock_validate_token,
+    ):
+        mock_resolve_sigils.return_value = "resolved-token"
+        mock_validate_token.return_value = (True, "Connected to GitHub as arthexis.", "arthexis")
+        form = OperatorJourneyGitHubAccessForm(
+            data={
+                "github_username": "arthexis",
+                "token": "[ENV.GITHUB_TOKEN]",
+                "token_label": "",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid())
+        is_valid, message = form.validate_connection()
+
+        self.assertTrue(is_valid)
+        self.assertEqual(message, "Connected to GitHub as arthexis.")
+        mock_resolve_sigils.assert_called_once_with("[ENV.GITHUB_TOKEN]")
+        mock_validate_token.assert_called_once_with("resolved-token")
+
     def test_slug_step_url_that_matches_legacy_complete_shape_stays_canonical(self):
         numeric_journey = OperatorJourney.objects.create(
             name="AAA Numeric Journey",

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -353,56 +353,25 @@ def complete_operator_journey_step(
             user=request.user,
         )
         action = (request.POST.get("journey_action") or "").strip().lower()
-        if not github_access_form.is_valid():
-            context = {
-                **_build_admin_context(request),
-                "step": step,
-                "github_access_form": github_access_form,
-            }
-            return render(
-                request,
-                "admin/ops/operator_journey_step.html",
-                context,
-            )
 
-        github_access_form.save()
-        if action == "save":
-            messages.add_message(
-                request,
-                messages.SUCCESS,
-                "GitHub token saved.",
-            )
-            context = {
-                **_build_admin_context(request),
-                "step": step,
-                "github_access_form": github_access_form,
-            }
-            return render(
-                request,
-                "admin/ops/operator_journey_step.html",
-                context,
-            )
+        if github_access_form.is_valid():
+            if action == "save":
+                github_access_form.save()
+                messages.success(request, "GitHub token saved.")
+            elif action in ("test", "complete"):
+                is_valid_connection, validation_message = github_access_form.validate_connection()
+                if action == "test":
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS if is_valid_connection else messages.ERROR,
+                        validation_message,
+                    )
+                elif not is_valid_connection:
+                    github_access_form.add_error("token", validation_message)
+                else:
+                    github_access_form.save()
 
-        is_valid_connection, validation_message = github_access_form.validate_connection()
-        if action == "test":
-            messages.add_message(
-                request,
-                messages.SUCCESS if is_valid_connection else messages.ERROR,
-                validation_message,
-            )
-            context = {
-                **_build_admin_context(request),
-                "step": step,
-                "github_access_form": github_access_form,
-            }
-            return render(
-                request,
-                "admin/ops/operator_journey_step.html",
-                context,
-            )
-
-        if not is_valid_connection:
-            github_access_form.add_error("token", validation_message)
+        if action != "complete" or not github_access_form.is_valid():
             context = {
                 **_build_admin_context(request),
                 "step": step,

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -50,6 +50,25 @@ def _build_admin_context(request: HttpRequest) -> dict[str, object]:
     return admin.site.each_context(request)
 
 
+def _can_manage_github_token(request: HttpRequest, token=None) -> bool:
+    """Return whether the current user can create/update GitHubToken records."""
+
+    try:
+        from apps.repos.models import GitHubToken
+    except (ImportError, LookupError):
+        return False
+
+    token_admin = admin.site._registry.get(GitHubToken)
+    if token_admin is not None:
+        if token is None:
+            return bool(token_admin.has_add_permission(request))
+        return bool(token_admin.has_change_permission(request, obj=token))
+
+    if token is None:
+        return request.user.has_perm("repos.add_githubtoken")
+    return request.user.has_perm("repos.change_githubtoken")
+
+
 def _build_security_group_rows(
     provision_superuser_form: OperatorJourneyProvisionSuperuserForm,
 ) -> list[dict[str, object]]:
@@ -353,13 +372,23 @@ def complete_operator_journey_step(
             user=request.user,
         )
         action = (request.POST.get("journey_action") or "").strip().lower()
+        token_record = github_access_form._existing_token_record
+        can_write_token = _can_manage_github_token(request, token=token_record)
 
         if github_access_form.is_valid():
             if action == "save":
-                github_access_form.save()
-                messages.success(request, "GitHub token saved.")
+                if not can_write_token:
+                    messages.warning(
+                        request,
+                        "You do not have permission to save a GitHub token.",
+                    )
+                else:
+                    github_access_form.save()
+                    messages.success(request, "GitHub token saved.")
             elif action in ("test", "complete"):
-                is_valid_connection, validation_message = github_access_form.validate_connection()
+                is_valid_connection, validation_message = (
+                    github_access_form.validate_connection()
+                )
                 if action == "test":
                     messages.add_message(
                         request,
@@ -368,6 +397,11 @@ def complete_operator_journey_step(
                     )
                 elif not is_valid_connection:
                     github_access_form.add_error("token", validation_message)
+                elif not can_write_token:
+                    github_access_form.add_error(
+                        "token",
+                        "You do not have permission to save a GitHub token.",
+                    )
                 else:
                     github_access_form.save()
 

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -386,24 +386,26 @@ def complete_operator_journey_step(
                     github_access_form.save()
                     messages.success(request, "GitHub token saved.")
             elif action in ("test", "complete"):
-                is_valid_connection, validation_message = (
-                    github_access_form.validate_connection()
-                )
-                if action == "test":
-                    messages.add_message(
-                        request,
-                        messages.SUCCESS if is_valid_connection else messages.ERROR,
-                        validation_message,
-                    )
-                elif not is_valid_connection:
-                    github_access_form.add_error("token", validation_message)
-                elif not can_write_token:
-                    github_access_form.add_error(
-                        "token",
-                        "You do not have permission to save a GitHub token.",
-                    )
+                if not can_write_token:
+                    permission_message = "You do not have permission to save a GitHub token."
+                    if action == "test":
+                        messages.warning(request, permission_message)
+                    else:
+                        github_access_form.add_error("token", permission_message)
                 else:
-                    github_access_form.save()
+                    is_valid_connection, validation_message = (
+                        github_access_form.validate_connection()
+                    )
+                    if action == "test":
+                        messages.add_message(
+                            request,
+                            messages.SUCCESS if is_valid_connection else messages.ERROR,
+                            validation_message,
+                        )
+                    elif not is_valid_connection:
+                        github_access_form.add_error("token", validation_message)
+                    else:
+                        github_access_form.save()
 
         if action != "complete" or not github_access_form.is_valid():
             context = {

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 
 OPERATOR_JOURNEY_STEP_URL_NAME = "ops:operator-journey-step"
 
-from .forms import OperatorJourneyProvisionSuperuserForm
+from .forms import OperatorJourneyGitHubAccessForm, OperatorJourneyProvisionSuperuserForm
 from .models import OperatorJourneyStep
 from .operator_journey import (
     complete_step_for_user,
@@ -28,6 +28,7 @@ from .status_surface import build_status_surface, scoped_log_excerpts
 
 ROLE_VALIDATION_STEP_SLUG = "validate-local-node-role"
 PROVISION_SUPERUSER_STEP_SLUG = "provision-ops-superuser"
+SETUP_GITHUB_TOKEN_STEP_SLUG = "setup-github-token"
 KNOWN_NODE_ROLES = ("Terminal", "Satellite", "Control", "Watchtower")
 ROLE_ALIASES = {"constellation": "Watchtower"}
 
@@ -251,6 +252,8 @@ def operator_journey_step(
         provision_form = OperatorJourneyProvisionSuperuserForm()
         context["provision_superuser_form"] = provision_form
         context["security_group_rows"] = _build_security_group_rows(provision_form)
+    if step.slug == SETUP_GITHUB_TOKEN_STEP_SLUG:
+        context["github_access_form"] = OperatorJourneyGitHubAccessForm(user=request.user)
 
     return render(request, "admin/ops/operator_journey_step.html", context)
 
@@ -343,6 +346,73 @@ def complete_operator_journey_step(
                 "next_step": next_step,
             },
         )
+
+    if step.slug == SETUP_GITHUB_TOKEN_STEP_SLUG:
+        github_access_form = OperatorJourneyGitHubAccessForm(
+            request.POST,
+            user=request.user,
+        )
+        action = (request.POST.get("journey_action") or "").strip().lower()
+        if not github_access_form.is_valid():
+            context = {
+                **_build_admin_context(request),
+                "step": step,
+                "github_access_form": github_access_form,
+            }
+            return render(
+                request,
+                "admin/ops/operator_journey_step.html",
+                context,
+            )
+
+        github_access_form.save()
+        if action == "save":
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                "GitHub token saved.",
+            )
+            context = {
+                **_build_admin_context(request),
+                "step": step,
+                "github_access_form": github_access_form,
+            }
+            return render(
+                request,
+                "admin/ops/operator_journey_step.html",
+                context,
+            )
+
+        is_valid_connection, validation_message = github_access_form.validate_connection()
+        if action == "test":
+            messages.add_message(
+                request,
+                messages.SUCCESS if is_valid_connection else messages.ERROR,
+                validation_message,
+            )
+            context = {
+                **_build_admin_context(request),
+                "step": step,
+                "github_access_form": github_access_form,
+            }
+            return render(
+                request,
+                "admin/ops/operator_journey_step.html",
+                context,
+            )
+
+        if not is_valid_connection:
+            github_access_form.add_error("token", validation_message)
+            context = {
+                **_build_admin_context(request),
+                "step": step,
+                "github_access_form": github_access_form,
+            }
+            return render(
+                request,
+                "admin/ops/operator_journey_step.html",
+                context,
+            )
 
     if not complete_step_for_user(user=request.user, step=step):
         next_step = next_step_for_user(user=request.user)

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -68,6 +68,38 @@ def build_headers(token: str, *, user_agent: str = "arthexis-admin") -> Mapping[
     }
 
 
+def validate_token(
+    token: str,
+    *,
+    api_root: str = API_ROOT,
+    timeout: int = REQUEST_TIMEOUT,
+) -> tuple[bool, str, str]:
+    """Validate a GitHub token against the current user endpoint."""
+
+    cleaned_token = str(token or "").strip()
+    if not cleaned_token:
+        return False, "Enter a GitHub token before testing.", ""
+
+    try:
+        response = requests.get(
+            f"{api_root}/user",
+            headers=build_headers(cleaned_token),
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        return False, str(exc), ""
+
+    if not 200 <= response.status_code < 300:
+        return False, _extract_error_message(response), ""
+
+    payload = _safe_json(response)
+    payload_data = payload if isinstance(payload, Mapping) else {}
+    login = str(payload_data.get("login") or "").strip()
+    if login:
+        return True, f"Connected to GitHub as {login}.", login
+    return True, "Connected to GitHub.", ""
+
+
 def _get_latest_release_token() -> str | None:
     """Return the GitHub token from the latest package release, if available."""
 


### PR DESCRIPTION
### Motivation

- Convert the `setup-github-token` operator-journey step from a redirect-only "Guided action" to an inline, actionable form so product developers can enter, test, and save a GitHub token without leaving the step.  
- Provide immediate validation feedback (including resolved GitHub login) before allowing the step to be completed.  
- Keep onboarding flows consistent with other journey tasks that expose forms and actions in-place.

### Description

- Added `OperatorJourneyGitHubAccessForm` to let the signed-in user enter `github_username`, `token`, and `token_label`, pre-fill from any existing `GitHubToken`, persist a token, and validate the token/username match (`apps/ops/forms.py`).  
- Introduced `validate_token` helper that calls the GitHub `/user` endpoint and returns structured success/message/login results for UI-driven validation (`apps/repos/services/github.py`).  
- Updated operator-journey rendering and completion logic so the `setup-github-token` step displays the inline form and supports `save`, `test`, and `complete` actions, with completion blocked unless validation succeeds (`apps/ops/views.py` and `apps/ops/templates/admin/ops/operator_journey_step.html`).  
- Added regression tests for inline rendering, save+test behavior, and completion gating on successful validation (`apps/ops/tests/test_operator_journey.py`).

### Testing

- Bootstrapped environment dependencies with `./env-refresh.sh --deps-only` and installed test helpers with `.venv/bin/pip install pytest pytest-django pytest-timeout`.  
- Ran the operator journey test module with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` and observed the suite pass: `32 passed, 1 warning`.  
- All newly added tests in `apps/ops/tests/test_operator_journey.py` passed and exercise form rendering, save/test flow, and completion validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d5dd66e483269ccc9604bbd34474)