### PR TITLE
ci: include image gallery screenshot in PR preview artifacts

### DIFF
--- a/.github/screenshot-paths.authenticated.txt
+++ b/.github/screenshot-paths.authenticated.txt
@@ -4,3 +4,4 @@
 # /admin/links/reference/
 
 /ocpp/c/SIM-CP-1/
+/gallery/

--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -348,6 +348,14 @@ jobs:
           name: developer-library
           path: artifacts/docs-library-desktop.png
 
+      - name: Upload gallery screenshot for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        id: upload-gallery
+        uses: actions/upload-artifact@v7
+        with:
+          name: image-gallery
+          path: artifacts/gallery-desktop.png
+
       - name: Verify screenshot artifacts checklist (pull requests)
         if: ${{ github.event_name == 'pull_request' }}
         id: verify-pr-screenshot-artifacts
@@ -422,6 +430,7 @@ jobs:
           ADMIN_DASHBOARD_URL: ${{ steps.upload-admin-dashboard.outputs.artifact-url || '' }}
           OCPP_DASHBOARD_URL: ${{ steps.upload-ocpp-dashboard.outputs.artifact-url || '' }}
           DEVELOPER_LIBRARY_URL: ${{ steps.upload-developer-library.outputs.artifact-url || '' }}
+          GALLERY_URL: ${{ steps.upload-gallery.outputs.artifact-url || '' }}
           METADATA_URL: ${{ steps.upload-pr-screenshot-metadata.outputs.artifact-url || '' }}
         run: |
           source .venv/bin/activate
@@ -437,6 +446,7 @@ jobs:
               "admin-desktop.png": os.environ.get("ADMIN_DASHBOARD_URL", "").strip(),
               "ocpp-cpms-dashboard-desktop.png": os.environ.get("OCPP_DASHBOARD_URL", "").strip(),
               "docs-library-desktop.png": os.environ.get("DEVELOPER_LIBRARY_URL", "").strip(),
+              "gallery-desktop.png": os.environ.get("GALLERY_URL", "").strip(),
           }
 
           expected_images: list[tuple[str, str]] = []

--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -356,6 +356,14 @@ jobs:
           name: image-gallery
           path: artifacts/gallery-desktop.png
 
+      - name: Upload OCPP charger detail screenshot for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        id: upload-ocpp-charger-detail
+        uses: actions/upload-artifact@v7
+        with:
+          name: ocpp-charger-detail
+          path: artifacts/ocpp-c-SIM-CP-1-desktop.png
+
       - name: Verify screenshot artifacts checklist (pull requests)
         if: ${{ github.event_name == 'pull_request' }}
         id: verify-pr-screenshot-artifacts
@@ -429,6 +437,7 @@ jobs:
         env:
           ADMIN_DASHBOARD_URL: ${{ steps.upload-admin-dashboard.outputs.artifact-url || '' }}
           OCPP_DASHBOARD_URL: ${{ steps.upload-ocpp-dashboard.outputs.artifact-url || '' }}
+          OCPP_CHARGER_DETAIL_URL: ${{ steps.upload-ocpp-charger-detail.outputs.artifact-url || '' }}
           DEVELOPER_LIBRARY_URL: ${{ steps.upload-developer-library.outputs.artifact-url || '' }}
           GALLERY_URL: ${{ steps.upload-gallery.outputs.artifact-url || '' }}
           METADATA_URL: ${{ steps.upload-pr-screenshot-metadata.outputs.artifact-url || '' }}
@@ -445,6 +454,7 @@ jobs:
           artifact_links = {
               "admin-desktop.png": os.environ.get("ADMIN_DASHBOARD_URL", "").strip(),
               "ocpp-cpms-dashboard-desktop.png": os.environ.get("OCPP_DASHBOARD_URL", "").strip(),
+              "ocpp-c-SIM-CP-1-desktop.png": os.environ.get("OCPP_CHARGER_DETAIL_URL", "").strip(),
               "docs-library-desktop.png": os.environ.get("DEVELOPER_LIBRARY_URL", "").strip(),
               "gallery-desktop.png": os.environ.get("GALLERY_URL", "").strip(),
           }


### PR DESCRIPTION
### Motivation

- Ensure the image gallery feature is included in the automated PR screenshot preview so reviewers see gallery UI changes immediately.
- Provide a dedicated artifact and a direct link in the generated PR comment for easier inspection of gallery screenshots.

### Description

- Add `/gallery/` to `.github/screenshot-paths.authenticated.txt` so the gallery is captured by default in authenticated preview runs.
- Upload `artifacts/gallery-desktop.png` as a dedicated artifact (`image-gallery`) in `.github/workflows/dashboard-screenshot.yml` for pull-request runs.
- Wire the new gallery artifact URL into the PR screenshot comment flow by exposing `GALLERY_URL` and adding `gallery-desktop.png` to the `artifact_links` table generation.

### Testing

- Ran `./env-refresh.sh --deps-only` which completed successfully.
- Installed CI test deps via `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed `.venv/bin/python manage.py test run -- tests/test_verify_screenshot_artifacts.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4dc253eb883269024c0793a180b93)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Objective
Include the image gallery feature in automated PR screenshot previews by capturing its screenshot and providing a dedicated artifact with a direct link in the PR screenshot comment.

## Changes Made

**GitHub Workflow Configuration** (`.github/screenshot-paths.authenticated.txt`)
- Added `/gallery/` path to the authenticated screenshot paths list to ensure gallery pages are captured during preview runs

**Dashboard Screenshot Workflow** (`.github/workflows/dashboard-screenshot.yml`)
- Added two artifact upload steps for pull request runs:
  - `artifacts/gallery-desktop.png` as `image-gallery` artifact
  - `artifacts/ocpp-c-SIM-CP-1-desktop.png` as `ocpp-charger-detail` artifact
- Extended PR comment environment with `GALLERY_URL` and `OCPP_CHARGER_DETAIL_URL` variables
- Expanded `artifact_links` mapping to associate the gallery and OCPP charger screenshots with their respective artifact URLs, enabling direct links in PR screenshot comments

## Testing
- Environment setup completed successfully (`./env-refresh.sh --deps-only`)
- CI test dependencies installed (`pip install -r requirements-ci.txt`)
- Verification tests passed (3/3): `python manage.py test run -- tests/test_verify_screenshot_artifacts.py`

## Notes
The OCPP charger screenshot (`/ocpp/c/SIM-CP-1/`) is also included in this PR with dedicated artifact handling, though the artifact itself is not yet available through the dedicated upload path; reviewers can reference the metadata artifact as an alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->