### PR TITLE
docs-reader: improve collapsed table labels with descriptive content hints

### DIFF
--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -136,10 +136,48 @@
       return Math.max(0, table.rows.length - 1);
     };
 
+    const summarizeColumns = (table) => {
+      const headers = Array.from(table.querySelectorAll("thead th"))
+        .map((cell) => cell.textContent.trim())
+        .filter(Boolean);
+
+      if (!headers.length) {
+        return "";
+      }
+
+      const visibleHeaders = headers.slice(0, 3).join(", ");
+      if (headers.length <= 3) {
+        return visibleHeaders;
+      }
+
+      return `${visibleHeaders}, …`;
+    };
+
+    const summarizeFirstRow = (table) => {
+      const firstBodyRow = table.tBodies[0]?.rows[0];
+      if (!firstBodyRow) {
+        return "";
+      }
+
+      const values = Array.from(firstBodyRow.cells)
+        .map((cell) => cell.textContent.trim())
+        .filter(Boolean)
+        .slice(0, 2);
+      return values.join(" • ");
+    };
+
     const buildTableToggleLabel = (table, rowCount) => {
       const captionText = table.caption ? table.caption.textContent.trim() : "";
       const tableName = captionText || tableLabel;
       const rowLabel = rowCount === 1 ? rowLabelSingular : rowLabelPlural;
+      const columnSummary = summarizeColumns(table);
+      const rowSummary = summarizeFirstRow(table);
+      const detailSummary = columnSummary || rowSummary;
+
+      if (detailSummary) {
+        return `${tableName}: ${detailSummary} (${rowCount} ${rowLabel})`;
+      }
+
       return `${tableName} (${rowCount} ${rowLabel})`;
     };
 

--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -154,7 +154,7 @@
     };
 
     const summarizeFirstRow = (table) => {
-      const firstBodyRow = table.tBodies[0]?.rows[0];
+      const firstBodyRow = table.tBodies[0]?.rows[0] || table.rows[1];
       if (!firstBodyRow) {
         return "";
       }
@@ -170,9 +170,7 @@
       const captionText = table.caption ? table.caption.textContent.trim() : "";
       const tableName = captionText || tableLabel;
       const rowLabel = rowCount === 1 ? rowLabelSingular : rowLabelPlural;
-      const columnSummary = summarizeColumns(table);
-      const rowSummary = summarizeFirstRow(table);
-      const detailSummary = columnSummary || rowSummary;
+      const detailSummary = summarizeColumns(table) || summarizeFirstRow(table);
 
       if (detailSummary) {
         return `${tableName}: ${detailSummary} (${rowCount} ${rowLabel})`;
@@ -208,7 +206,16 @@
         headingButton.setAttribute("aria-expanded", "false");
         headingButton.setAttribute("aria-controls", tableId);
         headingButton.setAttribute("title", collapseLabel);
-        headingButton.innerHTML = `<span class="reader-table-toggle-text">${headingText}</span><span class="reader-table-toggle-icon" aria-hidden="true">▸</span>`;
+        const textNode = document.createElement("span");
+        textNode.className = "reader-table-toggle-text";
+        textNode.textContent = headingText;
+
+        const iconNode = document.createElement("span");
+        iconNode.className = "reader-table-toggle-icon";
+        iconNode.setAttribute("aria-hidden", "true");
+        iconNode.textContent = "▸";
+
+        headingButton.append(textNode, iconNode);
 
         headingButton.addEventListener("click", () => {
           const expanded = headingButton.getAttribute("aria-expanded") === "true";


### PR DESCRIPTION
### Motivation
- Collapsed tables in the README/docs reader used a generic `Table (X rows)` label which provided little context about the content users would see when expanded.
- The intent is to give users a quick, humane preview so they can decide whether to expand a table without opening it.
- Improve usability while preserving the existing size/row-count affordance.

### Description
- Add `summarizeColumns` to build a short header summary (first 3 column headers) and `summarizeFirstRow` to derive a fallback preview from the first body row.
- Update `buildTableToggleLabel` to prefer a column summary, fall back to a first-row sample, and still include the row count and caption-derived table name.
- Change applied to `apps/docs/templates/includes/reader_qr_script.html` so collapsed reader tables show `TableName: <summary> (N rows)` when possible.

### Testing
- Ran `./env-refresh.sh --deps-only` to ensure environment dependencies were available, and the command completed successfully.
- Ran `.venv/bin/python manage.py test run -- apps/docs/tests` and the test suite for `apps.docs` passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f40bad5c83269a824b0f9ac3753e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Enhances the collapsed table toggle labels in the docs reader to provide descriptive content previews alongside the existing row count.

## Changes

**apps/docs/templates/includes/reader_qr_script.html**

Added three helper functions to derive compact table summaries:
- `summarizeColumns()`: Extracts up to the first 3 column headers from the table's `<thead>`, joining them with commas and appending "…" if more headers exist
- `summarizeFirstRow()`: Falls back to deriving a preview from the first body row's first two cell values (joined with " • ") when headers are unavailable
- `buildTableToggleLabel()`: Constructs the final label, preferring the column summary and falling back to the first-row sample, while preserving the table name (from caption or generic "Table" label) and row count

Updated the table enhancement logic to use these summaries in toggle button labels, changing the format from `"<TableName> (<N> <row(s)>)"` to `"<TableName>: <summary> (<N> <row(s)>)"` when a summary is available.

Replaced string-based `innerHTML` construction with explicit DOM node creation and `append()` calls to render the label text span and icon span, maintaining existing CSS classes and `aria-hidden` attributes while improving robustness.

## Testing

The apps.docs test suite passed (2 passed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->