### PR TITLE
Reduce LCD-less startup noise and avoid lcd runner re-import warning

### DIFF
--- a/apps/clocks/tests/test_utils.py
+++ b/apps/clocks/tests/test_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+
+from apps.clocks import utils
+
+
+def test_discover_clock_devices_logs_info_for_missing_i2c_bus(caplog):
+    def missing_bus_scanner(_bus: int) -> str:
+        raise RuntimeError("Error: Could not open file `/dev/i2c-1' or `/dev/i2c/1': No such file or directory")
+
+    with caplog.at_level(logging.INFO):
+        devices = utils.discover_clock_devices(scanner=missing_bus_scanner)
+
+    assert devices == []
+    assert "I2C scan skipped" in caplog.text
+    assert "WARNING" not in caplog.text
+
+
+def test_discover_clock_devices_logs_warning_for_other_runtime_errors(caplog):
+    def failing_scanner(_bus: int) -> str:
+        raise RuntimeError("i2cdetect timed out")
+
+    with caplog.at_level(logging.WARNING):
+        devices = utils.discover_clock_devices(scanner=failing_scanner)
+
+    assert devices == []
+    assert "I2C scan skipped" in caplog.text

--- a/apps/clocks/tests/test_utils.py
+++ b/apps/clocks/tests/test_utils.py
@@ -26,3 +26,14 @@ def test_discover_clock_devices_logs_warning_for_other_runtime_errors(caplog):
 
     assert devices == []
     assert "I2C scan skipped" in caplog.text
+
+
+def test_discover_clock_devices_logs_warning_for_permission_denied_i2c_open(caplog):
+    def permission_denied_scanner(_bus: int) -> str:
+        raise RuntimeError("Error: Could not open file `/dev/i2c-1': Permission denied")
+
+    with caplog.at_level(logging.WARNING):
+        devices = utils.discover_clock_devices(scanner=permission_denied_scanner)
+
+    assert devices == []
+    assert "I2C scan skipped" in caplog.text

--- a/apps/clocks/utils.py
+++ b/apps/clocks/utils.py
@@ -23,6 +23,11 @@ class DetectedClockDevice:
 Scanner = Callable[[int], str]
 
 
+def _is_missing_i2c_bus_error(message: str) -> bool:
+    normalized = message.lower()
+    return "could not open file `/dev/i2c-" in normalized
+
+
 def _run_i2cdetect(bus: int) -> str:
     tool_path = shutil.which(I2C_SCANNER)
     if not tool_path:
@@ -71,6 +76,13 @@ def discover_clock_devices(
     for bus in buses:
         try:
             output = scan_bus(bus)
+        except RuntimeError as exc:  # pragma: no cover - hardware dependent
+            log_message = "I2C scan skipped for bus %s: %s"
+            if _is_missing_i2c_bus_error(str(exc)):
+                logger.info(log_message, bus, exc)
+            else:
+                logger.warning(log_message, bus, exc)
+            continue
         except Exception as exc:  # pragma: no cover - defensive; hardware dependent
             logger.warning("I2C scan failed for bus %s: %s", bus, exc)
             continue

--- a/apps/clocks/utils.py
+++ b/apps/clocks/utils.py
@@ -25,7 +25,10 @@ Scanner = Callable[[int], str]
 
 def _is_missing_i2c_bus_error(message: str) -> bool:
     normalized = message.lower()
-    return "could not open file `/dev/i2c-" in normalized
+    return (
+        "could not open file `/dev/i2c-" in normalized
+        and "no such file or directory" in normalized
+    )
 
 
 def _run_i2cdetect(bus: int) -> str:

--- a/apps/screens/lcd_screen/__init__.py
+++ b/apps/screens/lcd_screen/__init__.py
@@ -162,5 +162,7 @@ _RUNNER_EXPORTS = {
 
 def __getattr__(name: str) -> Any:
     if name in _RUNNER_EXPORTS:
-        return getattr(import_module(".runner", __name__), name)
+        value = getattr(import_module(".runner", __name__), name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/screens/lcd_screen/__init__.py
+++ b/apps/screens/lcd_screen/__init__.py
@@ -1,5 +1,10 @@
 """LCD screen service package."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
 from .logging import (
     BASE_DIR,
     HISTORY_DIR,
@@ -112,19 +117,6 @@ from .rendering import (
     _use_fate_vector,
     _warn_on_non_ascii_payload,
 )
-from .runner import (
-    EVENT_LINE_SCROLL_SECONDS,
-    ROTATION_SECONDS,
-    _event_interrupt_requested,
-    _handle_shutdown_request,
-    _request_event_interrupt,
-    _request_shutdown,
-    _reset_event_interrupt_flag,
-    _reset_shutdown_flag,
-    _shutdown_requested,
-    main,
-)
-
 __all__ = [
     "BASE_DIR",
     "HISTORY_DIR",
@@ -153,3 +145,22 @@ __all__ = [
     "main",
     "read_lcd_lock_file",
 ]
+
+_RUNNER_EXPORTS = {
+    "EVENT_LINE_SCROLL_SECONDS",
+    "ROTATION_SECONDS",
+    "_event_interrupt_requested",
+    "_handle_shutdown_request",
+    "_request_event_interrupt",
+    "_request_shutdown",
+    "_reset_event_interrupt_flag",
+    "_reset_shutdown_flag",
+    "_shutdown_requested",
+    "main",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _RUNNER_EXPORTS:
+        return getattr(import_module(".runner", __name__), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/screens/tests/test_lcd_package.py
+++ b/apps/screens/tests/test_lcd_package.py
@@ -1,0 +1,16 @@
+"""Tests for lcd_screen package import behavior."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_lcd_screen_package_does_not_eager_import_runner():
+    sys.modules.pop("apps.screens.lcd_screen", None)
+    sys.modules.pop("apps.screens.lcd_screen.runner", None)
+
+    package = importlib.import_module("apps.screens.lcd_screen")
+
+    assert "apps.screens.lcd_screen.runner" not in sys.modules
+    assert callable(package.main)

--- a/apps/screens/tests/test_lcd_package.py
+++ b/apps/screens/tests/test_lcd_package.py
@@ -14,3 +14,4 @@ def test_lcd_screen_package_does_not_eager_import_runner():
 
     assert "apps.screens.lcd_screen.runner" not in sys.modules
     assert callable(package.main)
+    assert package.__dict__["main"] is package.main


### PR DESCRIPTION
### Motivation

- Reduce noisy startup logs on systems without an I2C/LCD by treating the specific missing `/dev/i2c-*` condition as informational instead of a warning.
- Prevent `python -m apps.screens.lcd_screen.runner` (or other package imports) from eagerly importing `runner` and emitting a `runpy`/`sys.modules` re-import warning.

### Description

- Add `_is_missing_i2c_bus_error` and update `discover_clock_devices` to log missing I2C bus failures at `INFO` while keeping other runtime scan failures at `WARNING` (`apps/clocks/utils.py`).
- Replace eager `from .runner import ...` in the `apps.screens.lcd_screen` package with a lazy `__getattr__` that `import_module(".runner", __name__)` on-demand so runner symbols are resolved only when accessed (`apps/screens/lcd_screen/__init__.py`).
- Add focused tests for both behaviors: `apps/clocks/tests/test_utils.py` to verify logging levels for missing I2C vs other errors, and `apps/screens/tests/test_lcd_package.py` to verify the package no longer eagerly imports `runner`.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed test tooling via `.venv/bin/pip install pytest pytest-django pytest-timeout` when the first test run reported missing test deps.
- Ran the targeted test set with `.venv/bin/python manage.py test run -- apps/clocks/tests/test_utils.py apps/screens/tests/test_lcd_package.py apps/screens/tests/test_lcd_runner.py` and observed all tests in that set pass.
- Test summary: `12 passed, 1 warning` for the executed test set, and dependency refresh completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e574dd3b408326bc6adb1eaf17d39b)