### PR TITLE
gallery: improve upload image form layout and field usability

### DIFF
--- a/apps/gallery/forms.py
+++ b/apps/gallery/forms.py
@@ -6,16 +6,36 @@ from .models import GalleryCategory, GalleryCredit, GalleryImage, GalleryImageTr
 
 
 class GalleryUploadForm(forms.Form):
-    image = forms.ImageField(required=True)
-    title = forms.CharField(max_length=255)
-    description = forms.CharField(required=False, widget=forms.Textarea)
-    include_in_public_gallery = forms.BooleanField(required=False)
+    image = forms.ImageField(
+        required=True,
+        widget=forms.ClearableFileInput(attrs={"class": "form-control", "accept": "image/*"}),
+    )
+    title = forms.CharField(max_length=255, widget=forms.TextInput(attrs={"class": "form-control"}))
+    description = forms.CharField(
+        required=False,
+        widget=forms.Textarea(
+            attrs={
+                "class": "form-control",
+                "rows": 3,
+                "data-autogrow": "true",
+            }
+        ),
+    )
+    include_in_public_gallery = forms.BooleanField(
+        required=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+    )
     create_content_sample = forms.BooleanField(
         required=False,
         label="Also create a Content Sample record",
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
     )
-    owner_user = forms.CharField(required=False)
-    owner_group = forms.ModelChoiceField(queryset=SecurityGroup.objects.order_by("name"), required=False)
+    owner_user = forms.CharField(required=False, widget=forms.TextInput(attrs={"class": "form-control"}))
+    owner_group = forms.ModelChoiceField(
+        queryset=SecurityGroup.objects.order_by("name"),
+        required=False,
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
 
     def clean(self):
         cleaned = super().clean()

--- a/apps/gallery/templates/gallery/upload.html
+++ b/apps/gallery/templates/gallery/upload.html
@@ -23,7 +23,7 @@
           <img
             id="image-preview"
             alt="{% trans 'Selected image preview' %}"
-            class="img-fluid rounded d-none"
+            class="img-fluid rounded d-none gallery-upload-preview"
           />
           <p id="image-preview-placeholder" class="text-body-secondary mb-0">{% trans "Selected image preview will appear here." %}</p>
         </div>
@@ -53,13 +53,17 @@
           <div class="col-12">
             <div class="form-check">
               {{ form.include_in_public_gallery }}
-              {{ form.include_in_public_gallery.label_tag }}
+              <label class="form-check-label" for="{{ form.include_in_public_gallery.id_for_label }}">
+                {{ form.include_in_public_gallery.label }}
+              </label>
             </div>
           </div>
           <div class="col-12">
             <div class="form-check">
               {{ form.create_content_sample }}
-              {{ form.create_content_sample.label_tag }}
+              <label class="form-check-label" for="{{ form.create_content_sample.id_for_label }}">
+                {{ form.create_content_sample.label }}
+              </label>
             </div>
           </div>
           <div class="col-12">
@@ -72,32 +76,41 @@
 </div>
 <script>
 (() => {
-  const dropZone = document.getElementById('drop-zone');
-  const fileInput = document.getElementById('{{ form.image.id_for_label }}');
-  const preview = document.getElementById('image-preview');
-  const previewPlaceholder = document.getElementById('image-preview-placeholder');
-  const autoGrowTextareas = document.querySelectorAll('textarea[data-autogrow="true"]');
-  if (!dropZone || !fileInput || !preview || !previewPlaceholder) return;
-
   const syncTextareaHeight = (textarea) => {
     textarea.style.height = 'auto';
     textarea.style.height = `${textarea.scrollHeight}px`;
   };
 
-  autoGrowTextareas.forEach((textarea) => {
+  document.querySelectorAll('textarea[data-autogrow="true"]').forEach((textarea) => {
     syncTextareaHeight(textarea);
     textarea.addEventListener('input', () => syncTextareaHeight(textarea));
   });
 
+  const dropZone = document.getElementById('drop-zone');
+  const fileInput = document.getElementById('{{ form.image.id_for_label }}');
+  const preview = document.getElementById('image-preview');
+  const previewPlaceholder = document.getElementById('image-preview-placeholder');
+  if (!dropZone || !fileInput || !preview || !previewPlaceholder) return;
+
+  let previewObjectUrl = null;
+
   const updatePreview = (file) => {
-    if (!file || !file.type.startsWith('image/')) return;
-    const reader = new FileReader();
-    reader.onload = ({ target }) => {
-      preview.src = target?.result || '';
-      preview.classList.remove('d-none');
-      previewPlaceholder.classList.add('d-none');
-    };
-    reader.readAsDataURL(file);
+    if (previewObjectUrl) {
+      URL.revokeObjectURL(previewObjectUrl);
+      previewObjectUrl = null;
+    }
+
+    if (!file || !file.type.startsWith('image/')) {
+      preview.src = '';
+      preview.classList.add('d-none');
+      previewPlaceholder.classList.remove('d-none');
+      return;
+    }
+
+    previewObjectUrl = URL.createObjectURL(file);
+    preview.src = previewObjectUrl;
+    preview.classList.remove('d-none');
+    previewPlaceholder.classList.add('d-none');
   };
 
   fileInput.addEventListener('change', () => updatePreview(fileInput.files?.[0]));
@@ -119,6 +132,17 @@
     fileInput.files = files;
     updatePreview(files[0]);
   });
+
+  window.addEventListener('beforeunload', () => {
+    if (previewObjectUrl) URL.revokeObjectURL(previewObjectUrl);
+  });
 })();
 </script>
+<style>
+  .gallery-upload-preview {
+    max-height: 50vh;
+    object-fit: contain;
+    width: 100%;
+  }
+</style>
 {% endblock %}

--- a/apps/gallery/templates/gallery/upload.html
+++ b/apps/gallery/templates/gallery/upload.html
@@ -9,28 +9,98 @@
   <form method="post" enctype="multipart/form-data" class="card card-body shadow-sm" id="upload-form">
     {% csrf_token %}
     {{ form.non_field_errors }}
-    <div class="mb-3">
-      <label class="form-label" for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
-      <div id="drop-zone" class="border border-2 rounded p-4 text-center">
-        <p class="mb-2">{% trans "Drag and drop an image here, or choose from your device." %}</p>
-        {{ form.image }}
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-lg-6">
+        <div class="mb-3">
+          <label class="form-label" for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
+          <div id="drop-zone" class="border border-2 rounded p-4 text-center h-100">
+            <p class="mb-2">{% trans "Drag and drop an image here, or choose from your device." %}</p>
+            {{ form.image }}
+          </div>
+          {{ form.image.errors }}
+        </div>
+        <div class="border rounded p-3 bg-body-tertiary">
+          <img
+            id="image-preview"
+            alt="{% trans 'Selected image preview' %}"
+            class="img-fluid rounded d-none"
+          />
+          <p id="image-preview-placeholder" class="text-body-secondary mb-0">{% trans "Selected image preview will appear here." %}</p>
+        </div>
       </div>
-      {{ form.image.errors }}
+      <div class="col-12 col-lg-6">
+        <div class="row g-3">
+          <div class="col-12">
+            <label class="form-label" for="{{ form.title.id_for_label }}">{{ form.title.label }}</label>
+            {{ form.title }}
+            {{ form.title.errors }}
+          </div>
+          <div class="col-12">
+            <label class="form-label" for="{{ form.description.id_for_label }}">{{ form.description.label }}</label>
+            {{ form.description }}
+            {{ form.description.errors }}
+          </div>
+          <div class="col-12">
+            <label class="form-label" for="{{ form.owner_user.id_for_label }}">{{ form.owner_user.label }}</label>
+            {{ form.owner_user }}
+            {{ form.owner_user.errors }}
+          </div>
+          <div class="col-12">
+            <label class="form-label" for="{{ form.owner_group.id_for_label }}">{{ form.owner_group.label }}</label>
+            {{ form.owner_group }}
+            {{ form.owner_group.errors }}
+          </div>
+          <div class="col-12">
+            <div class="form-check">
+              {{ form.include_in_public_gallery }}
+              {{ form.include_in_public_gallery.label_tag }}
+            </div>
+          </div>
+          <div class="col-12">
+            <div class="form-check">
+              {{ form.create_content_sample }}
+              {{ form.create_content_sample.label_tag }}
+            </div>
+          </div>
+          <div class="col-12">
+            <button class="btn btn-primary" type="submit">{% trans "Upload" %}</button>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="mb-3">{{ form.title.label_tag }} {{ form.title }} {{ form.title.errors }}</div>
-    <div class="mb-3">{{ form.description.label_tag }} {{ form.description }} {{ form.description.errors }}</div>
-    <div class="mb-3">{{ form.owner_user.label_tag }} {{ form.owner_user }} {{ form.owner_user.errors }}</div>
-    <div class="mb-3">{{ form.owner_group.label_tag }} {{ form.owner_group }} {{ form.owner_group.errors }}</div>
-    <div class="form-check mb-3">{{ form.include_in_public_gallery }} {{ form.include_in_public_gallery.label_tag }}</div>
-    <div class="form-check mb-3">{{ form.create_content_sample }} {{ form.create_content_sample.label_tag }}</div>
-    <button class="btn btn-primary" type="submit">{% trans "Upload" %}</button>
   </form>
 </div>
 <script>
 (() => {
   const dropZone = document.getElementById('drop-zone');
   const fileInput = document.getElementById('{{ form.image.id_for_label }}');
-  if (!dropZone || !fileInput) return;
+  const preview = document.getElementById('image-preview');
+  const previewPlaceholder = document.getElementById('image-preview-placeholder');
+  const autoGrowTextareas = document.querySelectorAll('textarea[data-autogrow="true"]');
+  if (!dropZone || !fileInput || !preview || !previewPlaceholder) return;
+
+  const syncTextareaHeight = (textarea) => {
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
+
+  autoGrowTextareas.forEach((textarea) => {
+    syncTextareaHeight(textarea);
+    textarea.addEventListener('input', () => syncTextareaHeight(textarea));
+  });
+
+  const updatePreview = (file) => {
+    if (!file || !file.type.startsWith('image/')) return;
+    const reader = new FileReader();
+    reader.onload = ({ target }) => {
+      preview.src = target?.result || '';
+      preview.classList.remove('d-none');
+      previewPlaceholder.classList.add('d-none');
+    };
+    reader.readAsDataURL(file);
+  };
+
+  fileInput.addEventListener('change', () => updatePreview(fileInput.files?.[0]));
   ['dragenter', 'dragover'].forEach((eventName) => {
     dropZone.addEventListener(eventName, (event) => {
       event.preventDefault();
@@ -47,6 +117,7 @@
     const files = event.dataTransfer?.files;
     if (!files || !files.length) return;
     fileInput.files = files;
+    updatePreview(files[0]);
   });
 })();
 </script>


### PR DESCRIPTION
### Motivation

- Improve the Upload Image page UX by placing the image area on the left and form fields on the right on larger screens, making the description more compact and auto-growing, and aligning other fields for clearer, consistent interaction.
- Address feedback about usability and alignment so uploading and annotating images is faster and less error-prone.

### Description

- Updated `GalleryUploadForm` widget configuration to use Bootstrap-friendly classes and sensible attributes for the file, text, select, textarea, and checkbox inputs (`apps/gallery/forms.py`).
- Reworked the upload template into a responsive two-column layout with the upload/drop zone and preview on the left and metadata fields on the right (`apps/gallery/templates/gallery/upload.html`).
- Added client-side improvements: live image preview on file select or drop, auto-grow behavior for the description textarea, and drag/drop UI highlighting in the upload template JavaScript (`apps/gallery/templates/gallery/upload.html`).
- Adjusted checkbox and select widgets to use `form-check-input` and `form-select` classes so controls align with the rest of the form (`apps/gallery/forms.py`).

### Testing

- Ran environment bootstrap with `./env-refresh.sh --deps-only`, which completed successfully.
- Installed test tooling with `.venv/bin/python -m pip install pytest pytest-django pytest-timeout`, which completed successfully.
- Executed the gallery management permission tests with `.venv/bin/python manage.py test run -- apps/gallery/tests/test_gallery.py::GalleryManagementPermissionTests` and received `6 passed` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a251eb1c83269019c598ec3a45a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Improves the gallery upload form's user experience by restructuring the layout to a responsive two-column grid (image area on left, form fields on right) and adding Bootstrap-compatible styling to all form controls. Client-side enhancements include live image preview and auto-expanding textarea for descriptions.

## Changes

### Form Configuration (`apps/gallery/forms.py`)
Updated field widget definitions with Bootstrap classes and enhanced attributes:
- **image**: Now uses `ClearableFileInput` with `class="form-control"` and `accept="image/*"` attributes
- **title**: Updated to `TextInput` with `class="form-control"`
- **description**: Changed to `Textarea` with `class="form-control"`, `rows=3`, and `data-autogrow="true"` for client-side auto-expansion
- **include_in_public_gallery** and **create_content_sample**: Both now explicitly use `CheckboxInput` with `class="form-check-input"`
- **owner_user**: Changed to `TextInput` with `class="form-control"`
- **owner_group**: Updated to `Select` widget with `class="form-select"`, maintaining existing queryset and optional field behavior

The validation logic in the `clean()` method remains unchanged.

### Template Restructuring (`apps/gallery/templates/gallery/upload.html`)
Reorganized from a single-column form layout into a responsive two-column grid:
- **Left column**: Image drop zone with inline error display and a preview area (initially hidden)
- **Right column**: Grouped metadata fields (title, description, owner fields) with per-field error rendering and boolean options

### Client-Side Behavior
- **Live image preview**: Triggered when a file is selected via file input or drag-dropped onto the drop zone; toggles visibility between preview image and placeholder
- **Textarea auto-grow**: Script monitors elements with `data-autogrow="true"` attribute and dynamically adjusts height based on content

## Testing
Gallery management permission tests executed successfully: 6 passed with `pytest` in the isolated test suite (`apps/gallery/tests/test_gallery.py::GalleryManagementPermissionTests`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->