### PR TITLE
cards: recover RFID validator ingest when scanner log rotates

### DIFF
--- a/apps/cards/scanner.py
+++ b/apps/cards/scanner.py
@@ -135,6 +135,44 @@ def _scan_ingest_offset_path() -> Path:
     return Path(settings.BASE_DIR) / ".locks" / SCAN_INGEST_OFFSET_FILE
 
 
+def _read_ingest_offset_state(offset_path: Path) -> tuple[int | None, int]:
+    """Return the last ingested inode and byte offset for the scan log."""
+
+    try:
+        raw_value = offset_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return None, 0
+    if not raw_value:
+        return None, 0
+    try:
+        payload = json.loads(raw_value)
+    except (TypeError, ValueError):
+        try:
+            return None, int(raw_value)
+        except Exception:
+            return None, 0
+    if not isinstance(payload, dict):
+        return None, 0
+    inode = payload.get("inode")
+    offset = payload.get("offset")
+    try:
+        normalized_inode = int(inode) if inode is not None else None
+    except Exception:
+        normalized_inode = None
+    try:
+        normalized_offset = int(offset)
+    except Exception:
+        normalized_offset = 0
+    return normalized_inode, normalized_offset
+
+
+def _write_ingest_offset_state(offset_path: Path, inode: int | None, offset: int) -> None:
+    """Persist the inode and byte offset for the next scan-log ingest run."""
+
+    payload = {"inode": inode, "offset": max(0, int(offset))}
+    offset_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def ingest_service_scans() -> int:
     """Ingest scanner service NDJSON entries into RFIDAttempt history."""
 
@@ -143,12 +181,17 @@ def ingest_service_scans() -> int:
         return 0
     offset_path = _scan_ingest_offset_path()
     offset_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        last_offset = int(offset_path.read_text(encoding="utf-8").strip())
-    except Exception:
-        last_offset = 0
+    stat = log_path.stat()
+    current_inode = getattr(stat, "st_ino", None)
+    file_size = stat.st_size
+    last_inode, last_offset = _read_ingest_offset_state(offset_path)
 
     processed = 0
+    if last_inode is not None and current_inode is not None and last_inode != current_inode:
+        last_offset = 0
+    if last_offset < 0 or last_offset > file_size:
+        last_offset = 0
+
     with log_path.open("r", encoding="utf-8") as scan_log:
         scan_log.seek(last_offset)
         while True:
@@ -170,7 +213,7 @@ def ingest_service_scans() -> int:
             )
             if attempt is not None:
                 processed += 1
-        offset_path.write_text(str(scan_log.tell()), encoding="utf-8")
+        _write_ingest_offset_state(offset_path, current_inode, scan_log.tell())
     return processed
 
 

--- a/apps/cards/scanner.py
+++ b/apps/cards/scanner.py
@@ -152,7 +152,10 @@ def _read_ingest_offset_state(offset_path: Path) -> tuple[int | None, int]:
         except Exception:
             return None, 0
     if not isinstance(payload, dict):
-        return None, 0
+        try:
+            return None, int(payload)
+        except (TypeError, ValueError):
+            return None, 0
     inode = payload.get("inode")
     offset = payload.get("offset")
     try:
@@ -181,18 +184,17 @@ def ingest_service_scans() -> int:
         return 0
     offset_path = _scan_ingest_offset_path()
     offset_path.parent.mkdir(parents=True, exist_ok=True)
-    stat = log_path.stat()
-    current_inode = getattr(stat, "st_ino", None)
-    file_size = stat.st_size
     last_inode, last_offset = _read_ingest_offset_state(offset_path)
 
     processed = 0
-    if last_inode is not None and current_inode is not None and last_inode != current_inode:
-        last_offset = 0
-    if last_offset < 0 or last_offset > file_size:
-        last_offset = 0
-
     with log_path.open("r", encoding="utf-8") as scan_log:
+        stat = os.fstat(scan_log.fileno())
+        current_inode = getattr(stat, "st_ino", None)
+        file_size = stat.st_size
+        if last_inode is not None and current_inode is not None and last_inode != current_inode:
+            last_offset = 0
+        if last_offset < 0 or last_offset > file_size:
+            last_offset = 0
         scan_log.seek(last_offset)
         while True:
             line = scan_log.readline()

--- a/apps/cards/tests/test_scanner_service_ingest.py
+++ b/apps/cards/tests/test_scanner_service_ingest.py
@@ -57,3 +57,31 @@ def test_ingest_service_scans_recovers_when_log_rotates(monkeypatch, settings, t
     assert second_processed == 1
     assert RFIDAttempt.objects.filter(rfid="FEDC4321").count() == 1
     assert RFIDAttempt.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_ingest_service_scans_honors_legacy_integer_offset(
+    monkeypatch, settings, tmp_path
+):
+    settings.BASE_DIR = str(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "LOG_DIR", str(log_dir), raising=False)
+
+    log_file = log_dir / "rfid-scans.ndjson"
+    first_payload = {"rfid": "ABCD1234", "service_mode": "service"}
+    second_payload = {"rfid": "FEDC4321", "service_mode": "service"}
+    first_line = json.dumps(first_payload) + "\n"
+    second_line = json.dumps(second_payload) + "\n"
+    log_file.write_text(first_line + second_line, encoding="utf-8")
+
+    offset_path = tmp_path / ".locks" / "rfid-scan.offset"
+    offset_path.parent.mkdir(parents=True, exist_ok=True)
+    offset_path.write_text(str(len(first_line)), encoding="utf-8")
+
+    processed = ingest_service_scans()
+
+    assert processed == 1
+    assert RFIDAttempt.objects.count() == 1
+    assert RFIDAttempt.objects.filter(rfid="ABCD1234").count() == 0
+    assert RFIDAttempt.objects.filter(rfid="FEDC4321").count() == 1

--- a/apps/cards/tests/test_scanner_service_ingest.py
+++ b/apps/cards/tests/test_scanner_service_ingest.py
@@ -30,3 +30,30 @@ def test_ingest_service_scans_reads_ndjson_log(monkeypatch, settings, tmp_path):
 
     assert processed_again == 0
     assert RFIDAttempt.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_ingest_service_scans_recovers_when_log_rotates(monkeypatch, settings, tmp_path):
+    settings.BASE_DIR = str(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "LOG_DIR", str(log_dir), raising=False)
+
+    log_file = log_dir / "rfid-scans.ndjson"
+    first_payload = {"rfid": "ABCD1234", "service_mode": "service"}
+    second_payload = {"rfid": "FEDC4321", "service_mode": "service"}
+
+    log_file.write_text(json.dumps(first_payload) + "\n", encoding="utf-8")
+    first_processed = ingest_service_scans()
+
+    assert first_processed == 1
+    assert RFIDAttempt.objects.filter(rfid="ABCD1234").count() == 1
+
+    rotated_log_file = log_dir / "rfid-scans.rotated.ndjson"
+    rotated_log_file.write_text(json.dumps(second_payload) + "\n", encoding="utf-8")
+    rotated_log_file.replace(log_file)
+    second_processed = ingest_service_scans()
+
+    assert second_processed == 1
+    assert RFIDAttempt.objects.filter(rfid="FEDC4321").count() == 1
+    assert RFIDAttempt.objects.count() == 2


### PR DESCRIPTION
### Motivation

- The scanner ingest could become stuck after the scanner service replaces or rotates its NDJSON log so the validator remained "ready" but new card scans were never processed.
- The change ensures the ingest process correctly detects log rotation/replacement and resumes consuming new entries.

### Description

- Persist the ingest checkpoint as a JSON object containing `inode` and `offset` instead of a plain integer offset and fall back to the legacy integer-only format for compatibility (`_read_ingest_offset_state` / `_write_ingest_offset_state`).
- Reset the ingest position when the log file identity changes by comparing the current file `st_ino` to the stored `inode` and handling invalid offsets by clamping to zero (`ingest_service_scans`).
- Update the on-disk checkpoint write to store `{inode, offset}` after successful ingest progress (`_write_ingest_offset_state`).
- Add a regression test that simulates log rotation by replacing the log file and verifies the new entry is ingested (`apps/cards/tests/test_scanner_service_ingest.py`).

### Testing

- Ran environment setup with `./env-refresh.sh --deps-only` to ensure dependencies were available, which completed successfully.
- Executed the scanner ingest tests with `.venv/bin/python manage.py test run -- apps/cards/tests/test_scanner_service_ingest.py` and initially installed missing test tooling (`.venv/bin/pip install pytest pytest-django pytest-timeout`) as reported by automated output.
- After installing test tooling, re-ran `manage.py test run -- apps/cards/tests/test_scanner_service_ingest.py` and the test suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5affc6a3c832683b91d970be576a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix RFID scanner ingest stalling on log rotation

## Problem
The RFID scanner ingest process could become stuck when the scanner service rotated its NDJSON log file. The validator remained "ready" but new card scans after rotation were not processed.

## Solution
Enhanced the ingest checkpoint mechanism to detect and recover from log file rotation:

### Changes to `apps/cards/scanner.py`
- Added `_read_ingest_offset_state()` helper to deserialize checkpoint state from disk. The function loads a JSON object containing both inode and byte offset, with fallback support for legacy integer-only format (for backward compatibility).
- Added `_write_ingest_offset_state()` helper to persist checkpoint state as a JSON object `{"inode": <st_ino>, "offset": <byte_position>}`.
- Modified `ingest_service_scans()` to:
  - Load the stored file inode alongside the byte offset
  - Detect log rotation by comparing the stored inode against the current file's `st_ino`
  - Reset ingest position to byte offset 0 when inode changes
  - Validate that the stored offset is within the current log file size; clamp invalid offsets to 0
  - Write the new state with both inode and offset after successfully processing entries

### Changes to `apps/cards/tests/test_scanner_service_ingest.py`
- Added `test_ingest_service_scans_recovers_when_log_rotates()`: Verifies the ingest resumes after log rotation by creating an initial scan, simulating log rotation (via file replacement), and confirming a new scan entry is ingested and the total count reaches 2.
- Added `test_ingest_service_scans_honors_legacy_integer_offset()`: Ensures backward compatibility with legacy offset checkpoints by pre-creating an offset lock file containing only an integer value and verifying that ingestion correctly skips to the second record.

## Testing
Both new tests pass and directly validate the core recovery functionality:
- Log rotation detection and recovery
- Backward compatibility with legacy checkpoint format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->