### PR TITLE
screens: bootstrap LCD service before importing runner

### DIFF
--- a/apps/nodes/fixtures/node_services__nodeservice_lcd_updater.json
+++ b/apps/nodes/fixtures/node_services__nodeservice_lcd_updater.json
@@ -12,7 +12,7 @@
       ],
       "is_required": true,
       "template_path": "lcd.service",
-      "template_content": "[Unit]\nDescription=LCD screen updater service for Arthexis\nAfter={service_name}.service network-online.target\nWants={service_name}.service\nPartOf={service_name}.service\nWants=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory={base_dir}\nExecStart={base_dir}/.venv/bin/python -m apps.screens.lcd_screen.runner\nRestart=always\nTimeoutStartSec=500\nStandardOutput=journal\nStandardError=journal\nUser={service_user}\n\n[Install]\nWantedBy=multi-user.target\nWantedBy={service_name}.service\n"
+      "template_content": "[Unit]\nDescription=LCD screen updater service for Arthexis\nAfter={service_name}.service network-online.target\nWants={service_name}.service\nPartOf={service_name}.service\nWants=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory={base_dir}\nExecStart={base_dir}/.venv/bin/python -m apps.screens.lcd_screen\nRestart=always\nTimeoutStartSec=500\nStandardOutput=journal\nStandardError=journal\nUser={service_user}\n\n[Install]\nWantedBy=multi-user.target\nWantedBy={service_name}.service\n"
     }
   }
 ]

--- a/apps/screens/lcd_screen/__main__.py
+++ b/apps/screens/lcd_screen/__main__.py
@@ -1,6 +1,34 @@
 """Package entry point for the LCD screen service."""
 
-from .runner import main
+from __future__ import annotations
+
+import os
+
+
+def _bootstrap_django() -> None:
+    """Ensure Django is configured before importing the LCD runner."""
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+    import django
+
+    django.setup()
+
+
+def _run_lcd_service() -> None:
+    """Import and run the LCD service after Django is ready."""
+
+    from .runner import main as runner_main
+
+    runner_main()
+
+
+def main() -> None:
+    """Bootstrap Django and start the LCD service."""
+
+    _bootstrap_django()
+    _run_lcd_service()
+
 
 if __name__ == "__main__":  # pragma: no cover - script entry point
     main()

--- a/apps/screens/tests/test_lcd_service_entrypoint.py
+++ b/apps/screens/tests/test_lcd_service_entrypoint.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from apps.screens.lcd_screen import __main__ as lcd_service_main
+
+
+def test_main_bootstraps_django_before_running_service(monkeypatch):
+    monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
+
+    with (
+        mock.patch("django.setup") as mock_setup,
+        mock.patch.object(lcd_service_main, "_run_lcd_service") as mock_run,
+    ):
+        lcd_service_main.main()
+
+    assert os.environ["DJANGO_SETTINGS_MODULE"] == "config.settings"
+    mock_setup.assert_called_once_with()
+    mock_run.assert_called_once_with()
+
+
+def test_main_preserves_existing_django_settings_module(monkeypatch):
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "custom.settings")
+
+    with (
+        mock.patch("django.setup") as mock_setup,
+        mock.patch.object(lcd_service_main, "_run_lcd_service") as mock_run,
+    ):
+        lcd_service_main.main()
+
+    assert os.environ["DJANGO_SETTINGS_MODULE"] == "custom.settings"
+    mock_setup.assert_called_once_with()
+    mock_run.assert_called_once_with()

--- a/scripts/helpers/lcd-upgrade-helper.py
+++ b/scripts/helpers/lcd-upgrade-helper.py
@@ -114,7 +114,10 @@ def _lcd_service_active(base_dir: Path) -> bool:
     if not pgrep:
         return False
 
-    for pattern in ("python -m apps.screens.lcd_screen.runner",):
+    for pattern in (
+        "python -m apps.screens.lcd_screen",
+        "python -m apps.screens.lcd_screen.runner",
+    ):
         result = subprocess.run(
             [pgrep, "-f", pattern],
             stdout=subprocess.DEVNULL,

--- a/scripts/helpers/systemd_locks.sh
+++ b/scripts/helpers/systemd_locks.sh
@@ -69,7 +69,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=$base_dir
-ExecStart=$base_dir/.venv/bin/python -m apps.screens.lcd_screen.runner
+ExecStart=$base_dir/.venv/bin/python -m apps.screens.lcd_screen
 Restart=always
 TimeoutStartSec=500
 StandardOutput=journal

--- a/scripts/service-start.sh
+++ b/scripts/service-start.sh
@@ -216,7 +216,7 @@ start_embedded_lcd_if_needed() {
     return 0
   fi
 
-  python -m apps.screens.lcd_screen.runner &
+  python -m apps.screens.lcd_screen &
   LCD_PROCESS_PID=$!
   LCD_STARTED=true
   record_pid_file "$LCD_PROCESS_PID" "$LCD_PID_FILE"


### PR DESCRIPTION
## Summary
- switch LCD service entrypoints from `python -m apps.screens.lcd_screen.runner` to the package entrypoint so Django is configured before the runner is imported
- bootstrap Django inside `apps.screens.lcd_screen.__main__` and update generated/system helper service invocations to use it
- keep LCD upgrade-helper detection compatible with both the new package entrypoint and the legacy runner form

## Why
Fixes #7177.

The generated `lcd-<service>.service` units were starting the LCD runner without Django bootstrap, which can fail with `ImproperlyConfigured` before the service loop starts.

## Testing
- `/home/arthe/arthexis/.venv/bin/python -m pytest apps/screens/tests/test_lcd_service_entrypoint.py -q`
- `/home/arthe/arthexis/.venv/bin/python -m pytest apps/screens/tests/test_lcd_runner.py -q`
