### PR TITLE
tests: include async pytest deps in QA refresh path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Install test dependencies, then run tests before opening a PR:
 `manage.py test run` now begins with a QA readiness step before any targeted pytest execution. It reports:
 - virtualenv presence,
 - the Python executable path used for the run,
-- core test dependency availability (`pytest`, `pytest-django`, `pytest-timeout`).
+- core test dependency availability (`pytest`, `pytest-django`, `pytest-timeout`, `pytest-asyncio`).
 
 If any core dependency is missing, the command fails fast before attempting any tests.
 

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -115,7 +115,8 @@ class Command(BaseCommand):
                 (
                     "import importlib.util,json,os,sys;"
                     "deps={'pytest':'pytest','pytest-django':'pytest_django',"
-                    "'pytest-timeout':'pytest_timeout'};"
+                    "'pytest-timeout':'pytest_timeout',"
+                    "'pytest-asyncio':'pytest_asyncio'};"
                     "print(json.dumps({"
                     "'python_executable':sys.executable,"
                     "'virtualenv_active':bool(os.environ.get('VIRTUAL_ENV')) "

--- a/apps/tests/test_test_command.py
+++ b/apps/tests/test_test_command.py
@@ -26,6 +26,7 @@ def test_run_pytest_prints_readiness_before_execution(monkeypatch, tmp_path, cap
             "pytest": True,
             "pytest-django": True,
             "pytest-timeout": True,
+            "pytest-asyncio": True,
         },
     }
 
@@ -46,8 +47,10 @@ def test_run_pytest_prints_readiness_before_execution(monkeypatch, tmp_path, cap
     assert "virtualenv active: yes" in captured
     assert "python executable: /workspace/arthexis/.venv/bin/python" in captured
     assert "core test dependencies: pytest=yes" in captured
+    assert "pytest-asyncio=yes" in captured
 
     assert calls[0][:2] == ["python", "-c"]
+    assert "'pytest-asyncio':'pytest_asyncio'" in calls[0][2]
     assert calls[1] == ["python", "-m", "pytest", "apps/tests/test_test_command.py"]
 
 
@@ -68,6 +71,7 @@ def test_run_pytest_fails_before_pytest_when_dependency_missing(monkeypatch, tmp
             "pytest": True,
             "pytest-django": False,
             "pytest-timeout": True,
+            "pytest-asyncio": True,
         },
     }
 
@@ -88,5 +92,47 @@ def test_run_pytest_fails_before_pytest_when_dependency_missing(monkeypatch, tmp
         "command": "./env-refresh.sh --deps-only",
         "event": "arthexis.qa.remediation",
         "retry": ".venv/bin/python manage.py test run -- apps/tests/test_test_command.py",
+    }
+    assert len(calls) == 1
+
+
+def test_run_pytest_fails_before_pytest_when_async_dependency_missing(monkeypatch, tmp_path):
+    command = test_command.Command()
+    fake_venv_python = test_command.expected_venv_python(tmp_path)
+    fake_venv_python.parent.mkdir(parents=True)
+    fake_venv_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(command, "_base_dir", lambda: tmp_path)
+    monkeypatch.setattr(test_command, "resolve_project_python", lambda _base_dir: "python")
+
+    probe_payload = {
+        "python_executable": "/workspace/arthexis/.venv/bin/python",
+        "virtualenv_active": True,
+        "virtualenv_path": "/workspace/arthexis/.venv",
+        "dependencies": {
+            "pytest": True,
+            "pytest-django": True,
+            "pytest-timeout": True,
+            "pytest-asyncio": False,
+        },
+    }
+
+    calls: list[list[str]] = []
+
+    def fake_run(command_args, **kwargs):
+        calls.append(command_args)
+        return subprocess.CompletedProcess(command_args, 0, stdout=json.dumps(probe_payload))
+
+    monkeypatch.setattr(test_command.subprocess, "run", fake_run)
+
+    with pytest.raises(CommandError) as exc:
+        command._run_pytest(["--", "apps/ocpp/tests/test_ocpp201_actions.py"])
+
+    payload = json.loads(str(exc.value))
+    assert payload == {
+        "code": "missing_dependency",
+        "command": "./env-refresh.sh --deps-only",
+        "event": "arthexis.qa.remediation",
+        "retry": ".venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp201_actions.py",
     }
     assert len(calls) == 1

--- a/apps/tests/tests/test_local_qa_remediation.py
+++ b/apps/tests/tests/test_local_qa_remediation.py
@@ -46,7 +46,8 @@ def test_test_command_emits_dependency_refresh_remediation(
         stdout = (
             '{"python_executable": ".venv/bin/python", "virtualenv_active": true, '
             '"virtualenv_path": ".venv", "dependencies": {"pytest": false, '
-            '"pytest-django": false, "pytest-timeout": false}}\n'
+            '"pytest-django": false, "pytest-timeout": false, '
+            '"pytest-asyncio": false}}\n'
         )
 
     monkeypatch.setattr(

--- a/env-refresh.sh
+++ b/env-refresh.sh
@@ -459,9 +459,14 @@ should_install_hardware_requirements() {
 collect_requirement_files() {
   local -n out_array="$1"
   local hardware_file="$SCRIPT_DIR/requirements-hw.txt"
+  local ci_requirements_file="$SCRIPT_DIR/requirements-ci.txt"
 
   if [ -f "$SCRIPT_DIR/requirements.txt" ]; then
     out_array+=("$SCRIPT_DIR/requirements.txt")
+  fi
+
+  if [ "$DEPS_ONLY" -eq 1 ] && [ -f "$ci_requirements_file" ]; then
+    out_array+=("$ci_requirements_file")
   fi
 
   if [ -f "$hardware_file" ] && should_install_hardware_requirements; then


### PR DESCRIPTION
## Summary
- install `requirements-ci.txt` during `./env-refresh.sh --deps-only` so the documented local QA refresh path includes async pytest support
- add `pytest-asyncio` to the `manage.py test run` readiness probe so missing async support fails fast with remediation instead of surfacing as a confusing async test error
- update focused test coverage and contributor docs for the expanded readiness check

## Why
Fixes #7178.

The supported QA path (`./env-refresh.sh --deps-only` then `.venv/bin/python manage.py test run -- ...`) could still leave `pytest-asyncio` uninstalled, and the readiness probe never checked for it. That let async OCPP tests fail with an opaque plugin/config error instead of either having the dependency installed or emitting a clear remediation message.

## Testing
- `/home/arthe/arthexis/.venv/bin/python -m pytest apps/tests/test_test_command.py apps/tests/tests/test_local_qa_remediation.py -q`
- `bash -lc 'ARTHEXIS_ENV_REFRESH_SOURCE_ONLY=1 . ./env-refresh.sh; DEPS_ONLY=1; REQUIREMENT_FILES=(); collect_requirement_files REQUIREMENT_FILES; printf "%s\n" "${REQUIREMENT_FILES[@]}"'`
