### PR TITLE
Mark OCPP 2.x boot-notification async test with `anyio`

### DIFF
--- a/apps/ocpp/tests/test_ocpp201_actions.py
+++ b/apps/ocpp/tests/test_ocpp201_actions.py
@@ -229,6 +229,7 @@ async def test_authorize_keeps_id_token_info_shape_for_ocpp2x():
 
     assert result == {"idTokenInfo": {"status": "Accepted"}}
 
+@pytest.mark.anyio
 async def test_boot_notification_normalizes_ocpp2x_payload(caplog):
     consumer = CSMSConsumer(scope={}, receive=None, send=None)
     consumer.ocpp_version = "ocpp2.0.1"


### PR DESCRIPTION
### Motivation
- Stabilize a failing OCPP 2.x async test so it does not rely on implicit `pytest-asyncio` auto-mode and unblock the QA canary (`sys-up.sh`) that requires the suite to pass.

### Description
- Added an explicit `@pytest.mark.anyio` marker to `apps/ocpp/tests/test_ocpp201_actions.py::test_boot_notification_normalizes_ocpp2x_payload` so the async test runs with the repository's `anyio`-backed async strategy.

### Testing
- Ran dependency bootstrap via `./env-refresh.sh --deps-only` which completed successfully.
- Installed CI test extras with `.venv/bin/pip install -r requirements-ci.txt` which completed successfully.
- Executed the targeted test suite with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp201_actions.py -vv` and observed `53 passed` for the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62c7b5df48326982cf06f8e823b40)