### PR TITLE
Remove unused variables/imports and simplify uptime/upgrade and form handling

### DIFF
--- a/apps/core/admin/rfid.py
+++ b/apps/core/admin/rfid.py
@@ -1017,7 +1017,6 @@ class RFIDAdmin(EntityModelAdmin, ImportExportModelAdmin):
         from apps.cards.reader import validate_rfid_value
 
         ensure_feature_enabled("rfid-scanner", logger=logger)
-        rfid_feature_enabled = _feature_enabled("rfid-scanner")
         if request.method == "POST":
             try:
                 payload = json.loads(request.body.decode("utf-8") or "{}")

--- a/apps/core/admin/users.py
+++ b/apps/core/admin/users.py
@@ -17,7 +17,6 @@ from apps.locals.user_data import (
     delete_user_fixture,
     dump_user_fixture,
     resolve_fixture_user,
-    user_allows_user_data,
 )
 from apps.core.admin.mixins import OwnedObjectLinksMixin
 from apps.core.impersonation import (
@@ -539,7 +538,6 @@ class UserAdmin(OwnedObjectLinksMixin, UserDatumAdminMixin, DjangoUserAdmin):
         if not getattr(obj, "pk", None):
             return
         target_user = resolve_fixture_user(obj, obj)
-        allow_user_data = user_allows_user_data(target_user)
         if request.POST.get("_user_datum") == "on":
             type(obj).all_objects.filter(pk=obj.pk).update(is_user_data=False)
             obj.is_user_data = False

--- a/apps/core/system/ui/__init__.py
+++ b/apps/core/system/ui/__init__.py
@@ -34,11 +34,9 @@ from .uptime import (
     _load_shutdown_periods,
     _system_boot_time,
     _suite_offline_period,
-    _suite_uptime,
     _suite_uptime_details,
     build_uptime_segments,
     load_shutdown_periods,
-    suite_offline_period,
 )
 
 STARTUP_REPORT_DEFAULT_LIMIT = 50

--- a/apps/core/system/ui/uptime.py
+++ b/apps/core/system/ui/uptime.py
@@ -121,12 +121,6 @@ def _suite_uptime_details() -> SuiteUptimeDetailsPayload:
     }
 
 
-def _suite_uptime() -> str:
-    """Return a human-readable uptime for the running suite when possible."""
-
-    return _suite_uptime_details().get("uptime", "")
-
-
 def _suite_offline_period(now: datetime) -> tuple[datetime, datetime] | None:
     """Return a downtime window when the lock predates the current boot."""
 
@@ -138,12 +132,6 @@ def _suite_offline_period(now: datetime) -> tuple[datetime, datetime] | None:
         return boot_time, now
 
     return None
-
-
-def suite_offline_period(now: datetime) -> tuple[datetime, datetime] | None:
-    """Return a downtime window when the lock predates the current boot."""
-
-    return _suite_offline_period(now)
 
 
 def _parse_last_history_line(line: str) -> dict[str, datetime | str | None] | None:

--- a/apps/core/system/upgrade.py
+++ b/apps/core/system/upgrade.py
@@ -843,20 +843,11 @@ def _build_auto_upgrade_report(
     skip_revisions = _load_auto_upgrade_skip_revisions(base_dir)
     schedule_info = _load_auto_upgrade_schedule()
 
-    used_log_last_run = False
     entries = log_info.get("entries") or []
     last_log_entry = next(iter(entries), None)
-    last_log_timestamp_raw = None
-    if last_log_entry:
-        last_log_timestamp_raw = last_log_entry.get("timestamp_raw")
     if not schedule_info.get("last_run_at") and last_log_entry:
         if last_log_entry.get("timestamp"):
             schedule_info["last_run_at"] = last_log_entry["timestamp"]
-            used_log_last_run = True
-
-    schedule_disabled = schedule_info.get("enabled") is False
-    if schedule_info.get("next_run") == str(_("Disabled")):
-        schedule_disabled = True
 
     revision_details = _prepare_revision_info(revision_info)
 

--- a/apps/logbook/forms.py
+++ b/apps/logbook/forms.py
@@ -82,7 +82,7 @@ class LogbookEntryForm(forms.ModelForm):
         try:
             json.loads(document.read().decode("utf-8"))
         except Exception:
-            raise forms.ValidationError(_("Debug document must contain valid JSON (%(error)s)"))
+            raise forms.ValidationError(_("Debug document must contain valid JSON"))
         finally:
             if document and hasattr(document, "seek"):
                 document.seek(0)

--- a/apps/logbook/forms.py
+++ b/apps/logbook/forms.py
@@ -81,7 +81,7 @@ class LogbookEntryForm(forms.ModelForm):
             return None
         try:
             json.loads(document.read().decode("utf-8"))
-        except Exception as exc:
+        except Exception:
             raise forms.ValidationError(_("Debug document must contain valid JSON (%(error)s)"))
         finally:
             if document and hasattr(document, "seek"):

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             help="Arguments forwarded directly to pytest (use '-- ...').",
         )
 
-        server_parser = subparsers.add_parser(
+        subparsers.add_parser(
             "server",
             help="Start the VS Code test server watcher.",
         )
@@ -91,7 +91,6 @@ class Command(BaseCommand):
             if not available
         ]
         if missing_dependencies:
-            dependency_list = ", ".join(missing_dependencies)
             raise CommandError(
                 emit_remediation(
                     code="missing_dependency",


### PR DESCRIPTION
### Motivation

- Remove dead/unused variables and imports to reduce noise and potential lint warnings.
- Simplify uptime and auto-upgrade reporting by eliminating redundant wrappers and tracking variables.
- Tighten up minor exception handling and clean up unused locals in admin and test command code.

### Description

- Drop an unused `rfid_feature_enabled` assignment in `apps/core/admin/rfid.py` when polling scanner input.
- Remove the unused import and variable `user_allows_user_data` / `allow_user_data` from `apps/core/admin/users.py`.
- Remove unused imports of `_suite_uptime` and `suite_offline_period` from `apps/core/system/ui/__init__.py` and delete the corresponding `_suite_uptime` and `suite_offline_period` wrapper functions from `apps/core/system/ui/uptime.py`.
- Simplify the auto-upgrade report in `apps/core/system/upgrade.py` by removing `used_log_last_run`, `last_log_timestamp_raw`, and `schedule_disabled` bookkeeping variables.
- Change exception handling in `apps/logbook/forms.py` to not capture the exception object in `clean_debug_document`, and adjust the error raise accordingly.
- Tidy the test management command in `apps/tests/management/commands/test.py` by removing an unused `server_parser` local and an unused `dependency_list` construction.

### Testing

- Ran the project test suite with `pytest -q`, and all tests completed successfully.
- No new tests were added for these cleanup changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b497c65883269c21dc070af7d564)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes unused variables and imports across several modules, simplifies auto-upgrade reporting logic, and adjusts exception handling. The changes focus on eliminating dead code without altering control flow or business logic.

## Changes by file

**apps/core/admin/rfid.py**
- Removed the unused local variable `rfid_feature_enabled` from the `RFIDAdmin.scan_next` method, which previously assigned the result of `_feature_enabled("rfid-scanner")` after the feature check.

**apps/core/admin/users.py**
- Removed the unused import and local variable `allow_user_data` from the `save_model` method. The surrounding control flow for handling user data remains unchanged.

**apps/core/system/ui/__init__.py**
- Removed the import and re-export of `_suite_uptime` from the module's exports, while keeping other uptime-related exports (`suite_uptime_details`, etc.).

**apps/core/system/ui/uptime.py**
- Removed the `_suite_uptime()` internal helper function that extracted the uptime string from uptime details.
- Removed the `suite_offline_period(now)` public wrapper function. Callers now rely directly on `_suite_uptime_details()` and internal `_suite_offline_period(current_time)` for downtime calculations.

**apps/core/system/upgrade.py**
- Removed unused variables tracking whether `last_run_at` was backfilled from logs (`used_log_last_run`) and the raw timestamp variable (`last_log_timestamp_raw`).
- Removed the `schedule_disabled` flag calculation, leaving only the existing `schedule_info` fields for downstream usage.

**apps/logbook/forms.py**
- Modified `clean_debug_document` to raise `forms.ValidationError` with a generic message when JSON parsing fails, rather than including exception details in the message. Exception capture is removed while preserving the try/except and file rewind behavior.

**apps/tests/management/commands/test.py**
- Removed the unused `server_parser` local variable assignment in `add_arguments`.
- Removed the unused construction of `dependency_list` string in `_run_pytest`, though the error handling for missing dependencies remains the same.

## Testing
The project test suite was run with `pytest -q` and completed successfully. No new tests were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->