### PR TITLE
evergo: allow staff users to access customer public pages and artifact downloads

### DIFF
--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -94,3 +94,71 @@ def test_to_tsv_sanitizes_formula_and_line_break_characters():
     assert "' @phone" in tsv
     assert "'-brand" in tsv
     assert "Monterrey NL" in tsv
+
+
+@pytest.mark.django_db
+def test_customer_public_detail_allows_staff_cross_profile_access(client):
+    """Regression: staff users can inspect customer pages without owner scoping."""
+    user_model = get_user_model()
+    owner = user_model.objects.create_user(username="evergo-owner-staff", email="owner-staff@example.com")
+    owner_profile = EvergoUser.objects.create(
+        user=owner,
+        evergo_email="owner-staff@evergo.example.com",
+        evergo_password="secret",  # noqa: S106
+    )
+    customer = EvergoCustomer.objects.create(
+        user=owner_profile,
+        name="Cross Profile Customer",
+        latest_so="SO-777",
+    )
+
+    staff_user = user_model.objects.create_user(
+        username="evergo-staff-viewer",
+        email="staff-viewer@example.com",
+        password="secret",  # noqa: S106
+        is_staff=True,
+    )
+    client.force_login(staff_user)
+
+    response = client.get(reverse("evergo:customer-public-detail", kwargs={"pk": customer.pk}))
+
+    assert response.status_code == 200
+    assert "Cross Profile Customer" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_customer_artifact_download_allows_staff_cross_profile_access(client):
+    """Regression: staff users can download customer PDF artifacts across profiles."""
+    user_model = get_user_model()
+    owner = user_model.objects.create_user(username="evergo-owner-artifacts", email="owner-artifacts@example.com")
+    owner_profile = EvergoUser.objects.create(
+        user=owner,
+        evergo_email="owner-artifacts@evergo.example.com",
+        evergo_password="secret",  # noqa: S106
+    )
+    customer = EvergoCustomer.objects.create(
+        user=owner_profile,
+        name="Artifact Customer",
+    )
+    artifact = EvergoArtifact.objects.create(
+        customer=customer,
+        file=SimpleUploadedFile("summary.pdf", b"%PDF-1.4 fake", content_type="application/pdf"),
+    )
+
+    staff_user = user_model.objects.create_user(
+        username="evergo-staff-artifact",
+        email="staff-artifact@example.com",
+        password="secret",  # noqa: S106
+        is_staff=True,
+    )
+    client.force_login(staff_user)
+
+    response = client.get(
+        reverse(
+            "evergo:customer-artifact-download",
+            kwargs={"pk": customer.pk, "artifact_id": artifact.pk},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -101,10 +101,14 @@ def _normalize_display_text(value: str | None, *, default: str = "-") -> str:
 @login_required
 def customer_public_detail(request, pk: int) -> HttpResponse:
     """Render a public Evergo customer profile and artifacts."""
+    customer_lookup = {
+        "pk": pk,
+    }
+    if not request.user.is_staff:
+        customer_lookup["user__user"] = request.user
     customer = get_object_or_404(
         EvergoCustomer.objects.select_related("latest_order", "user__user").prefetch_related("artifacts"),
-        pk=pk,
-        user__user=request.user,
+        **customer_lookup,
     )
     artifacts = list(customer.artifacts.all())
     address = customer.address.strip()
@@ -127,11 +131,15 @@ def customer_public_detail(request, pk: int) -> HttpResponse:
 @login_required
 def customer_artifact_download(request, pk: int, artifact_id: int) -> HttpResponse:
     """Download a PDF artifact attached to a customer profile."""
+    artifact_lookup = {
+        "pk": artifact_id,
+        "customer_id": pk,
+    }
+    if not request.user.is_staff:
+        artifact_lookup["customer__user__user"] = request.user
     artifact = get_object_or_404(
         EvergoArtifact.objects.select_related("customer__user__user"),
-        pk=artifact_id,
-        customer_id=pk,
-        customer__user__user=request.user,
+        **artifact_lookup,
     )
     if not artifact.is_pdf:
         raise Http404("Only PDF artifacts can be downloaded from this endpoint.")


### PR DESCRIPTION
### Motivation

- Staff and admin users were unable to reach existing Evergo customer public pages or download customer PDF artifacts when they were not the owning profile, resulting in confusing 404s for legitimate admin viewers.

### Description

- Relax the owner scoping for staff users in `customer_public_detail` by building the `get_object_or_404` lookup conditionally so non-staff behavior is unchanged while staff may access any customer by `pk`.
- Apply the same staff override to `customer_artifact_download` so staff can retrieve PDF artifacts across profiles while preserving non-staff restrictions.
- Add regression tests `test_customer_public_detail_allows_staff_cross_profile_access` and `test_customer_artifact_download_allows_staff_cross_profile_access` in `apps/evergo/tests/test_public_views.py` to cover both staff cross-profile access cases and fix the artifact creation in the test to match model properties.

### Testing

- Ran environment refresh and dependency install with `./env-refresh.sh --deps-only` and `./env-refresh.sh` and installed test helpers with `.venv/bin/pip install pytest pytest-django pytest-timeout`.
- Executed the focused test file with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_public_views.py` and all tests passed (`5 passed, 1 warning`).
- Database migrations were applied during the env refresh step as part of test setup and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d4dde30832687fb4c14a463a75c)