### PR TITLE
tests: suppress pytest class collection warnings

### DIFF
--- a/apps/release/services/test_commands.py
+++ b/apps/release/services/test_commands.py
@@ -9,6 +9,8 @@ from typing import Sequence
 class TestCommandPolicy:
     """Policy definition for an approved release test command wrapper."""
 
+    __test__ = False
+
     value: str
     label: str
     prefix: tuple[str, ...]

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -21,6 +21,8 @@ from utils.qa_remediation import emit_remediation, expected_venv_python, find_re
 class Command(BaseCommand):
     """Run local test workflows from a single command entrypoint."""
 
+    __test__ = False
+
     help = "Run suite tests via the canonical manage.py entrypoint or launch the VS Code test server."
 
     def add_arguments(self, parser) -> None:

--- a/apps/tests/management/commands/test.py
+++ b/apps/tests/management/commands/test.py
@@ -17,11 +17,11 @@ from apps.tests.models import SuiteTest
 from utils.python_env import resolve_project_python
 from utils.qa_remediation import emit_remediation, expected_venv_python, find_repo_root
 
+__test__ = False
+
 
 class Command(BaseCommand):
     """Run local test workflows from a single command entrypoint."""
-
-    __test__ = False
 
     help = "Run suite tests via the canonical manage.py entrypoint or launch the VS Code test server."
 


### PR DESCRIPTION
### Motivation
- Prevent pytest from attempting to collect non-test classes that cause collection warnings during test discovery.

### Description
- Added `__test__ = False` to `TestCommandPolicy` in `apps/release/services/test_commands.py` to stop pytest treating the dataclass as a test class.
- Added `__test__ = False` to the `Command` class in `apps/tests/management/commands/test.py` to prevent pytest collection warnings when importing the management command module.

### Testing
- Prepared the environment with `./env-refresh.sh --deps-only` and `.venv/bin/python -m pip install --only-binary=:all: -r requirements-ci.txt` which completed successfully.
- Ran the full test suite with `.venv/bin/python manage.py test run --` which completed with `1261 passed, 4 skipped` and no failures.
- Ran focused regression checks with `.venv/bin/python manage.py test run -- apps/tests/tests/test_local_qa_remediation.py apps/tests/test_test_command.py apps/release/tests/test_release_command.py` which completed with `21 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68157ff848326aba20b8ad5132715)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `__test__ = False` to two classes to suppress pytest collection warnings for non-test classes:

- `TestCommandPolicy` dataclass in `apps/release/services/test_commands.py`
- `Command` class in `apps/tests/management/commands/test.py`

## Changes

### apps/release/services/test_commands.py
Added class attribute `__test__ = False` to the `TestCommandPolicy` dataclass to prevent pytest from incorrectly identifying it as a test class during collection.

### apps/tests/management/commands/test.py
Added class attribute `__test__ = False` to the `Command` class (Django management command) to prevent pytest from treating the management command module as a test target.

## Testing
- Full test suite: 1261 passed, 4 skipped
- Focused regression tests: 21 passed across `apps/tests/tests/test_local_qa_remediation.py`, `apps/tests/test_test_command.py`, and `apps/release/tests/test_release_command.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->