### PR TITLE
Allow staff to access Evergo order tracking pages across profiles

### DIFF
--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -31,6 +31,40 @@ def test_order_tracking_public_requires_login(client):
     assert response.status_code == 302
     assert "login" in response["Location"]
 
+
+@pytest.mark.django_db
+def test_order_tracking_public_allows_staff_cross_profile_access(client, monkeypatch):
+    """Regression: staff users can access tracking helper pages across profiles."""
+    user_model = get_user_model()
+    owner = user_model.objects.create_user(
+        username="evergo-owner-order-staff",
+        email="owner-order-staff@example.com",
+    )
+    profile = EvergoUser.objects.create(
+        user=owner,
+        evergo_email="owner-order-staff@example.com",
+        evergo_password="secret",  # noqa: S106
+    )
+    from apps.evergo.models import EvergoOrder
+
+    order = EvergoOrder.objects.create(user=profile, remote_id=30939, order_number="GM030939")
+    staff_user = user_model.objects.create_user(
+        username="evergo-order-staff-viewer",
+        email="order-staff-viewer@example.com",
+        password="secret",  # noqa: S106
+        is_staff=True,
+    )
+    client.force_login(staff_user)
+    monkeypatch.setattr("apps.evergo.views._load_remote_phase_one_initial_data", lambda **_: ({}, {}, {}))
+    monkeypatch.setattr(
+        "apps.evergo.models.user.EvergoUser.fetch_charger_brand_options",
+        lambda self: [],
+    )
+
+    response = client.get(reverse("evergo:order-tracking-public", args=[order.remote_id]))
+
+    assert response.status_code == 200
+
 @pytest.mark.django_db
 def test_my_evergo_dashboard_renders_and_generates_table_from_local_orders(client):
     """Regression: dashboard token page should render readonly username and order table rows."""

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -296,11 +296,12 @@ def _to_tsv(rows: list[dict[str, str]]) -> str:
 @login_required
 def order_tracking_public(request, order_id: int) -> HttpResponse:
     """Render and submit the order tracking phase-one helper form for authorized owners only."""
-    order = get_object_or_404(
-        EvergoOrder.objects.select_related("user"),
-        remote_id=order_id,
-        user__user=request.user,
-    )
+    order_lookup = {
+        "remote_id": order_id,
+    }
+    if not request.user.is_staff:
+        order_lookup["user__user"] = request.user
+    order = get_object_or_404(EvergoOrder.objects.select_related("user"), **order_lookup)
     profile = order.user
     brands = profile.fetch_charger_brand_options()
     remote_image_urls: dict[str, str] = {}


### PR DESCRIPTION
### Motivation

- Staff/support users were receiving 404 when opening valid `/evergo/orders/<order_id>/tracking/` links for orders owned by other profiles. 
- Normal owner scoping must be preserved while allowing staff to inspect tracking helper pages across profiles for support/debugging.

### Description

- Update `order_tracking_public` lookup to build `order_lookup` and include `user__user=request.user` only when the requester is not staff, allowing staff to resolve orders by `remote_id` alone. 
- Add regression test `test_order_tracking_public_allows_staff_cross_profile_access` to exercise staff cross-profile access to the tracking page and stub out external dependencies via `monkeypatch` to keep the test focused and deterministic.

### Testing

- Bootstrapped test deps with `./env-refresh.sh --deps-only` which completed successfully. 
- Installed QA extras with `.venv/bin/pip install '.[qa]'` which completed successfully. 
- Ran the targeted test file with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_public_views.py` and all tests in that file passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e699d6440c832688b13c24385cfc5a)