### PR TITLE
Move docs module and landing fixtures to end of default__modules_terminal.json

### DIFF
--- a/apps/sites/fixtures/default__modules_terminal.json
+++ b/apps/sites/fixtures/default__modules_terminal.json
@@ -4,41 +4,6 @@
     "fields": {
       "is_seed_data": true,
       "is_deleted": false,
-      "roles": [
-        [
-          "Terminal"
-        ]
-      ],
-      "application": [
-        "docs"
-      ],
-      "path": "/docs/",
-      "menu": "Developers",
-      "priority": 0,
-      "is_default": false,
-      "security_mode": "inclusive"
-    }
-  },
-  {
-    "model": "pages.landing",
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": [
-        "/docs/"
-      ],
-      "path": "/docs/library/",
-      "label": "Developer Documents",
-      "enabled": true,
-      "track_leads": false,
-      "description": ""
-    }
-  },
-  {
-    "model": "modules.module",
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
       "roles": [],
       "application": [
         "awg"
@@ -171,6 +136,41 @@
       ],
       "path": "/shop/",
       "label": "RFID Card Shop",
+      "enabled": true,
+      "track_leads": false,
+      "description": ""
+    }
+  },
+  {
+    "model": "modules.module",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "roles": [
+        [
+          "Terminal"
+        ]
+      ],
+      "application": [
+        "docs"
+      ],
+      "path": "/docs/",
+      "menu": "Developers",
+      "priority": 0,
+      "is_default": false,
+      "security_mode": "inclusive"
+    }
+  },
+  {
+    "model": "pages.landing",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "module": [
+        "/docs/"
+      ],
+      "path": "/docs/library/",
+      "label": "Developer Documents",
       "enabled": true,
       "track_leads": false,
       "description": ""


### PR DESCRIPTION
### Motivation
- Normalize fixture ordering by placing the `docs` module and its `pages.landing` entry after other modules to avoid ordering-related surprises when loading seed data.

### Description
- Removed the `modules.module` and `pages.landing` entries for the `docs` path from the top of `apps/sites/fixtures/default__modules_terminal.json` and appended identical entries to the end of the file.
- Did not alter field values; the change is purely a reordering of the `modules.module` and `pages.landing` fixtures for path `/docs/` and `/docs/library/` respectively.

### Testing
- Loaded the fixture locally with `python manage.py loaddata apps/sites/fixtures/default__modules_terminal.json` to validate JSON and fixture application, which succeeded.
- Ran the test suite with `pytest`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e699f406a08326ab20daf2515f2d39)