### PR TITLE
Add Supported CP Models link under Charge Points module pill

### DIFF
--- a/apps/ocpp/tests/test_supported_charger_templates.py
+++ b/apps/ocpp/tests/test_supported_charger_templates.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from apps.media.models import MediaBucket, MediaFile
 from apps.ocpp.models import StationModel
+from apps.ocpp.views.public import _landing_requires_station_models
 
 
 @pytest.mark.django_db
@@ -64,6 +65,22 @@ def test_supported_charger_detail_renders_without_storage_blob_for_document(clie
     assert "manual.pdf" in content
     assert "KB" in content
     assert 'alt="ABB Terra 54"' in content
+
+
+@pytest.mark.django_db
+def test_supported_chargers_landing_validator_uses_station_models(rf):
+    request = rf.get(reverse("ocpp:supported-chargers"))
+
+    assert _landing_requires_station_models(request=request, landing=None) is False
+
+    StationModel.objects.create(
+        vendor="ABB",
+        model_family="Terra",
+        model="54",
+        integration_rating=4,
+    )
+
+    assert _landing_requires_station_models(request=request, landing=None) is True
 
 
 def test_supported_chargers_fixture_path_matches_named_route():

--- a/apps/ocpp/tests/test_supported_charger_templates.py
+++ b/apps/ocpp/tests/test_supported_charger_templates.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pytest
 from django.urls import reverse
 
@@ -61,3 +64,17 @@ def test_supported_charger_detail_renders_without_storage_blob_for_document(clie
     assert "manual.pdf" in content
     assert "KB" in content
     assert 'alt="ABB Terra 54"' in content
+
+
+def test_supported_chargers_fixture_path_matches_named_route():
+    fixture_path = Path("apps/sites/fixtures/default__modules_terminal.json")
+    fixture_data = json.loads(fixture_path.read_text())
+
+    supported_landing = next(
+        item
+        for item in fixture_data
+        if item.get("model") == "pages.landing"
+        and item.get("fields", {}).get("label") == "Supported CP Models"
+    )
+
+    assert supported_landing["fields"]["path"] == reverse("ocpp:supported-chargers")

--- a/apps/ocpp/views/public.py
+++ b/apps/ocpp/views/public.py
@@ -733,6 +733,10 @@ def _station_model_documents(bucket, image_ids):
 
 
 @landing("Supported CP Models")
+@module_pill_link_validation(
+    _landing_requires_chargers,
+    parameter_getter=_landing_visibility_params,
+)
 def supported_chargers(request):
     station_models = StationModel.objects.all().order_by(
         "vendor", "model_family", "model"

--- a/apps/ocpp/views/public.py
+++ b/apps/ocpp/views/public.py
@@ -732,6 +732,7 @@ def _station_model_documents(bucket, image_ids):
     return [media_file for media_file in files if media_file.pk not in image_ids]
 
 
+@landing("Supported CP Models")
 def supported_chargers(request):
     station_models = StationModel.objects.all().order_by(
         "vendor", "model_family", "model"

--- a/apps/ocpp/views/public.py
+++ b/apps/ocpp/views/public.py
@@ -732,9 +732,13 @@ def _station_model_documents(bucket, image_ids):
     return [media_file for media_file in files if media_file.pk not in image_ids]
 
 
+def _landing_requires_station_models(*, request, landing, **kwargs) -> bool:
+    return StationModel.objects.exists()
+
+
 @landing("Supported CP Models")
 @module_pill_link_validation(
-    _landing_requires_chargers,
+    _landing_requires_station_models,
     parameter_getter=_landing_visibility_params,
 )
 def supported_chargers(request):

--- a/apps/sites/fixtures/default__modules_terminal.json
+++ b/apps/sites/fixtures/default__modules_terminal.json
@@ -104,6 +104,21 @@
       "module": [
         "/ocpp/"
       ],
+      "path": "/ocpp/charge-point-models/",
+      "label": "Supported CP Models",
+      "enabled": true,
+      "track_leads": false,
+      "description": ""
+    }
+  },
+  {
+    "model": "pages.landing",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "module": [
+        "/ocpp/"
+      ],
       "path": "/ocpp/charging-map/",
       "label": "Charging Station Map",
       "enabled": true,


### PR DESCRIPTION
### Motivation
- Make the existing public gallery of supported charge point models first-class navigation by exposing it from the Charge Points module pill.
- Surface model pages (including images where available) so operators and visitors can quickly browse supported hardware.
- Keep changes minimal: this is a navigation/fixture addition without data model or migration work.

### Description
- Annotated the public supported-chargers view with `@landing("Supported CP Models")` so it becomes a module landing (`apps/ocpp/views/public.py`).
- Seeded a new module landing at path `/ocpp/charge-point-models/` with label "Supported CP Models" in the terminal default fixture (`apps/sites/fixtures/default__modules_terminal.json`).
- No database migrations or schema changes were required; only view metadata and fixture navigation were updated.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and installed CI extras with `.venv/bin/pip install -r requirements-ci.txt` as needed.
- Ran the canonical app test: `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_supported_charger_templates.py`, and the test suite for the affected templates passed (`2 passed`).
- No regression tests were introduced or required beyond the existing template tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a7ee347c83268051908196e84cec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Summary

### View Metadata & Visibility Control (apps/ocpp/views/public.py)

Added a new validation function `_landing_requires_station_models()` that checks whether any `StationModel` records exist in the database. Applied the `@landing("Supported CP Models")` decorator to the existing `supported_chargers` view, along with `@module_pill_link_validation` using the new validator function with `parameter_getter=_landing_visibility_params`. This makes the landing visible in the Charge Points module navigation only when supported CP models are available in the system.

### Navigation Fixture (apps/sites/fixtures/default__modules_terminal.json)

Seeded a new module landing entry with path `/ocpp/charge-point-models/` and label "Supported CP Models" under the OCPP module. The entry is enabled, marked as seed data, and configured with visibility tracking disabled.

### Tests (apps/ocpp/tests/test_supported_charger_templates.py)

Added two new tests:
- `test_supported_chargers_landing_validator_uses_station_models`: Validates that the `_landing_requires_station_models` function returns `False` when no station models exist and `True` after one is created.
- `test_supported_chargers_fixture_path_matches_named_route`: Verifies the fixture entry's path matches the `reverse("ocpp:supported-chargers")` named route.

The implementation follows the existing pattern used by other OCPP landings (e.g., "Charging Station Map", "OCPP Simulator") and reuses the standard `_landing_visibility_params` parameter getter for caching consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->