### PR TITLE
evergo: handle artifact validation errors on public image upload

### DIFF
--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -198,6 +199,32 @@ def test_customer_public_detail_enforces_image_and_storage_limits(client, settin
 
     assert response.status_code == 200
     assert "You can only add up to 1 images." in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_customer_public_detail_upload_shows_form_error_for_model_validation(client, monkeypatch):
+    customer = _create_customer(username="owner-unsupported-suffix")
+    detail_url = reverse("evergo:customer-public-detail", kwargs={"public_id": customer.public_id})
+    monkeypatch.setattr(
+        "apps.evergo.views.EvergoArtifact.objects.create",
+        lambda **_kwargs: (_ for _ in ()).throw(ValidationError({"file": ["Only image files and PDFs are allowed."]})),
+    )
+
+    response = client.post(
+        detail_url,
+        data={
+            "action": "upload-image",
+            "image": SimpleUploadedFile(
+                "photo.gif",
+                b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff\x21\xf9\x04\x01\x00\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b",
+                content_type="image/gif",
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Only image files and PDFs are allowed." in response.content.decode()
+    assert not EvergoArtifact.objects.filter(customer=customer).exists()
 
 
 @pytest.mark.django_db

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.models import Site
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -233,14 +234,19 @@ def customer_public_detail(request, public_id) -> HttpResponse:
                         )
                     else:
                         next_order = max((artifact.display_order for artifact in image_artifacts), default=0) + 1
-                        EvergoArtifact.objects.create(
-                            customer=customer,
-                            file=uploaded_image,
-                            artifact_type=EvergoArtifact.ARTIFACT_TYPE_IMAGE,
-                            display_order=next_order,
-                        )
-                        messages.success(request, "Image added.")
-                        return redirect(customer.get_absolute_url())
+                        try:
+                            EvergoArtifact.objects.create(
+                                customer=customer,
+                                file=uploaded_image,
+                                artifact_type=EvergoArtifact.ARTIFACT_TYPE_IMAGE,
+                                display_order=next_order,
+                            )
+                        except ValidationError as exc:
+                            for message in exc.message_dict.get("file", []):
+                                upload_form.add_error("image", message)
+                        else:
+                            messages.success(request, "Image added.")
+                            return redirect(customer.get_absolute_url())
         elif action == "delete-image":
             artifact_id = request.POST.get("artifact_id")
             if request.POST.get("confirm_delete") != "yes":

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -242,8 +242,9 @@ def customer_public_detail(request, public_id) -> HttpResponse:
                                 display_order=next_order,
                             )
                         except ValidationError as exc:
-                            for message in exc.message_dict.get("file", []):
-                                upload_form.add_error("image", message)
+                            # Map model 'file' errors to form 'image' field; others to non-field errors.
+                            for field, errors in getattr(exc, "error_dict", {None: exc}).items():
+                                upload_form.add_error("image" if field == "file" else None, errors)
                         else:
                             messages.success(request, "Image added.")
                             return redirect(customer.get_absolute_url())


### PR DESCRIPTION
### Motivation

- Prevent anonymous public uploads from raising a server error when model-level validation fails during artifact creation.

### Description

- Catch `ValidationError` around `EvergoArtifact.objects.create(...)` in `customer_public_detail` and map `file`-level messages back to the upload form instead of allowing a 500. 
- Add a regression test that forces `EvergoArtifact.objects.create` to raise `ValidationError` and asserts the response is `200`, the error message is shown, and no artifact row is persisted. 
- Small import addition: `from django.core.exceptions import ValidationError` to support the new handling. 

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` (initial run reported missing pytest deps), installed test deps with `.venv/bin/pip install pytest pytest-django pytest-timeout`, and validated migrations with `.venv/bin/python manage.py migrations check`. 
- Ran the focused public-view test suite with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_public_views.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ac1460e88326bfdd05810d0d3ead)