### PR TITLE
ops: follow-up fixes for Journey dashboard step ordering and actions

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_dashboard.html
+++ b/apps/ops/templates/admin/ops/operator_journey_dashboard.html
@@ -44,23 +44,18 @@
                 {% endif %}
               </td>
               <td>
-                <a class="button" href="{{ row.url }}">
-                  {% if row.is_current %}
+                {% if row.is_current %}
+                  <a class="button" href="{{ row.url }}">
                     {% translate "Open task" %}
-                  {% else %}
-                    {% translate "Review" %}
-                  {% endif %}
-                </a>
+                  </a>
+                {% else %}
+                  &mdash;
+                {% endif %}
               </td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
-    {% elif next_step %}
-      <p>
-        {% translate "Your current required task is ready." %}
-        <a class="button default" href="{% url 'ops:operator-journey-step' journey_slug=next_step.journey.slug step_slug=next_step.slug %}">{% translate "Open task" %}</a>
-      </p>
     {% else %}
       <p>{% translate "All Operator tasks completed to date. Keep coming back for more." %}</p>
     {% endif %}

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -239,6 +239,16 @@ class OperatorJourneyViewTests(TestCase):
         self.assertContains(response, self.step_2.title)
         self.assertContains(response, "Current required task")
         self.assertContains(response, "Completed")
+        self.assertNotContains(
+            response,
+            reverse(
+                "ops:operator-journey-step",
+                kwargs={
+                    "journey_slug": self.step_1.journey.slug,
+                    "step_slug": self.step_1.slug,
+                },
+            ),
+        )
         self.assertNotContains(response, step_3.title)
 
     def test_step_view_redirects_when_opening_future_step(self):

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -281,6 +281,7 @@ def operator_journey_step(
 def operator_journey_dashboard(request: HttpRequest) -> HttpResponse:
     """Render completed and current steps while hiding future journey steps."""
 
+    next_step = next_step_for_user(user=request.user)
     steps = list(
         OperatorJourneyStep.objects.filter(
             is_active=True,
@@ -295,9 +296,8 @@ def operator_journey_dashboard(request: HttpRequest) -> HttpResponse:
         for completion in OperatorJourneyStepCompletion.objects.filter(
             user=request.user,
             step__in=steps,
-        ).select_related("step")
+        )
     }
-    next_step = next_step_for_user(user=request.user)
 
     visible_steps = [
         step
@@ -315,7 +315,7 @@ def operator_journey_dashboard(request: HttpRequest) -> HttpResponse:
                 "is_completed": completion is not None,
                 "is_current": is_current,
                 "completed_at": getattr(completion, "completed_at", None),
-                "url": operator_journey_step_url(step=step),
+                "url": operator_journey_step_url(step=step) if is_current else None,
             }
         )
 


### PR DESCRIPTION
### Motivation
- Ensure `next_step_for_user` side effects (group initialization and auto-completions) are applied before building dashboard data so the view shows up-to-date completed/current steps. 
- Remove an unnecessary DB join and avoid fetching related objects that are not used. 
- Fix a UX bug where completed rows showed a `Review` link that always redirected away, and simplify unreachable template logic.

### Description
- Call `next_step_for_user(user=request.user)` before querying `OperatorJourneyStep` and completions so any auto-completions are visible in the same request. 
- Remove `select_related("step")` from the `OperatorJourneyStepCompletion` query to avoid a redundant join. 
- Only attach a step URL for the current required step (`url` is now `None` for completed rows) and update the template to show an action button only for the current step. 
- Remove the unreachable `elif next_step` branch from `admin/ops/operator_journey_dashboard.html`. 
- Update `apps/ops/tests/test_operator_journey.py` assertions to match the new behavior (completed steps listed without direct links, current step still visible).

### Testing
- Ran environment prep with `./env-refresh.sh --deps-only` which completed successfully. 
- Installed test deps with `.venv/bin/python -m pip install pytest pytest-django pytest-timeout`. 
- Executed view tests with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py::OperatorJourneyViewTests`; an initial run surfaced one failing assertion, the code and test were updated, and the final run passed with `35 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ac286b60832680a73f57e1667c3f)