### PR TITLE
[codex] Reduce optional hardware warning noise

### DIFF
--- a/apps/cards/background_reader.py
+++ b/apps/cards/background_reader.py
@@ -133,16 +133,18 @@ def _log_fd_snapshot(label: str) -> None:
         logger.debug(message)
 
 
-def _record_setup_failure(reason: str) -> None:
+def _record_setup_failure(reason: str, detail: str | None = None) -> None:
     """Track setup failures to avoid thrashing hardware when unavailable."""
 
     global _last_setup_failure
     _last_setup_failure = time.monotonic()
-    log = logger.warning
-    if _hardware_disabled_reason and is_expected_optional_hardware_absence(
-        _hardware_disabled_reason
-    ):
-        log = logger.info
+    if detail is None:
+        detail = _hardware_disabled_reason
+    log = (
+        logger.info
+        if detail and is_expected_optional_hardware_absence(detail)
+        else logger.warning
+    )
     log(
         "RFID hardware setup failed (%s); skipping retries for %.1fs",
         reason,
@@ -406,7 +408,7 @@ def _worker():  # pragma: no cover - background thread
 
     _log_fd_snapshot("worker-start")
     if not _setup_hardware():
-        _record_setup_failure("initialization")
+        _record_setup_failure("initialization", _hardware_disabled_reason)
         _log_fd_snapshot("worker-setup-failed")
         lock = lock_file_path()
         if lock.exists():

--- a/apps/cards/background_reader.py
+++ b/apps/cards/background_reader.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from django.conf import settings
 
+from apps.core.optional_hardware import is_expected_optional_hardware_absence
 from .constants import DEFAULT_IRQ_PIN, DEFAULT_RST_PIN, GPIO_PIN_MODE_BCM
 from .reader import resolve_spi_bus_device, resolve_spi_device_path
 
@@ -137,7 +138,12 @@ def _record_setup_failure(reason: str) -> None:
 
     global _last_setup_failure
     _last_setup_failure = time.monotonic()
-    logger.warning(
+    log = logger.warning
+    if _hardware_disabled_reason and is_expected_optional_hardware_absence(
+        _hardware_disabled_reason
+    ):
+        log = logger.info
+    log(
         "RFID hardware setup failed (%s); skipping retries for %.1fs",
         reason,
         _SETUP_BACKOFF_SECONDS,
@@ -152,7 +158,12 @@ def _disable_hardware(reason: str) -> None:
     if _hardware_disabled_reason:
         return
     _hardware_disabled_reason = reason
-    logger.warning(
+    log = (
+        logger.info
+        if is_expected_optional_hardware_absence(reason)
+        else logger.warning
+    )
+    log(
         "RFID hardware disabled for this process after setup failure: %s",
         reason,
     )

--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from apps.cards import background_reader
 
 
@@ -7,7 +9,7 @@ def test_setup_hardware_gpio_missing_disables_reader(caplog, monkeypatch):
     monkeypatch.setattr(background_reader, "GPIO", None)
     monkeypatch.setattr(background_reader, "_hardware_disabled_reason", None)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level(logging.INFO):
         first = background_reader._setup_hardware()
         second = background_reader._setup_hardware()
 
@@ -21,6 +23,28 @@ def test_setup_hardware_gpio_missing_disables_reader(caplog, monkeypatch):
     ]
     assert len(matches) == 1
     assert "GPIO library not available" in matches[0]
+    assert "WARNING" not in caplog.text
+
+
+def test_record_setup_failure_logs_info_for_expected_missing_hardware(caplog, monkeypatch):
+    monkeypatch.setattr(background_reader, "_hardware_disabled_reason", "GPIO library not available")
+    monkeypatch.setattr(background_reader, "_last_setup_failure", None)
+
+    with caplog.at_level(logging.INFO):
+        background_reader._record_setup_failure("initialization")
+
+    assert "RFID hardware setup failed" in caplog.text
+    assert "WARNING" not in caplog.text
+
+
+def test_record_setup_failure_logs_warning_for_unexpected_failures(caplog, monkeypatch):
+    monkeypatch.setattr(background_reader, "_hardware_disabled_reason", None)
+    monkeypatch.setattr(background_reader, "_last_setup_failure", None)
+
+    with caplog.at_level(logging.WARNING):
+        background_reader._record_setup_failure("initialization")
+
+    assert "RFID hardware setup failed" in caplog.text
 
 
 def test_start_skips_when_hardware_is_disabled(monkeypatch):

--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -27,11 +27,32 @@ def test_setup_hardware_gpio_missing_disables_reader(caplog, monkeypatch):
 
 
 def test_record_setup_failure_logs_info_for_expected_missing_hardware(caplog, monkeypatch):
-    monkeypatch.setattr(background_reader, "_hardware_disabled_reason", "GPIO library not available")
+    monkeypatch.setattr(
+        background_reader,
+        "_hardware_disabled_reason",
+        "GPIO library not available",
+    )
     monkeypatch.setattr(background_reader, "_last_setup_failure", None)
 
     with caplog.at_level(logging.INFO):
         background_reader._record_setup_failure("initialization")
+
+    assert "RFID hardware setup failed" in caplog.text
+    assert "WARNING" not in caplog.text
+
+
+def test_record_setup_failure_uses_explicit_detail_without_global_reason(
+    caplog,
+    monkeypatch,
+):
+    monkeypatch.setattr(background_reader, "_hardware_disabled_reason", None)
+    monkeypatch.setattr(background_reader, "_last_setup_failure", None)
+
+    with caplog.at_level(logging.INFO):
+        background_reader._record_setup_failure(
+            "initialization",
+            "GPIO library not available",
+        )
 
     assert "RFID hardware setup failed" in caplog.text
     assert "WARNING" not in caplog.text

--- a/apps/clocks/tests/test_utils.py
+++ b/apps/clocks/tests/test_utils.py
@@ -5,6 +5,18 @@ import logging
 from apps.clocks import utils
 
 
+def test_discover_clock_devices_logs_info_when_i2cdetect_is_missing(caplog):
+    def missing_tool_scanner(_bus: int) -> str:
+        raise RuntimeError("i2cdetect is not available")
+
+    with caplog.at_level(logging.INFO):
+        devices = utils.discover_clock_devices(scanner=missing_tool_scanner)
+
+    assert devices == []
+    assert "I2C scan skipped" in caplog.text
+    assert "WARNING" not in caplog.text
+
+
 def test_discover_clock_devices_logs_info_for_missing_i2c_bus(caplog):
     def missing_bus_scanner(_bus: int) -> str:
         raise RuntimeError("Error: Could not open file `/dev/i2c-1' or `/dev/i2c/1': No such file or directory")

--- a/apps/clocks/utils.py
+++ b/apps/clocks/utils.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 from typing import Callable, Iterable
 
+from apps.core.optional_hardware import is_expected_i2c_absence
+
 logger = logging.getLogger(__name__)
 
 I2C_SCANNER = "i2cdetect"
@@ -21,14 +23,6 @@ class DetectedClockDevice:
 
 
 Scanner = Callable[[int], str]
-
-
-def _is_missing_i2c_bus_error(message: str) -> bool:
-    normalized = message.lower()
-    return (
-        "could not open file `/dev/i2c-" in normalized
-        and "no such file or directory" in normalized
-    )
 
 
 def _run_i2cdetect(bus: int) -> str:
@@ -81,7 +75,7 @@ def discover_clock_devices(
             output = scan_bus(bus)
         except RuntimeError as exc:  # pragma: no cover - hardware dependent
             log_message = "I2C scan skipped for bus %s: %s"
-            if _is_missing_i2c_bus_error(str(exc)):
+            if is_expected_i2c_absence(exc):
                 logger.info(log_message, bus, exc)
             else:
                 logger.warning(log_message, bus, exc)

--- a/apps/core/optional_hardware.py
+++ b/apps/core/optional_hardware.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+
+def _normalize_detail(detail: object | None) -> str:
+    """Return normalized text for optional-hardware log classification."""
+
+    return str(detail or "").strip().lower()
+
+
+def is_expected_i2c_absence(detail: object | None) -> bool:
+    """Return whether ``detail`` describes an expected missing I2C runtime."""
+
+    normalized = _normalize_detail(detail)
+    if not normalized:
+        return False
+
+    if "i2cdetect is not available" in normalized:
+        return True
+
+    if "smbus module not found" in normalized:
+        return True
+
+    if (
+        "could not open file `/dev/i2c-" in normalized
+        and "no such file or directory" in normalized
+    ):
+        return True
+
+    if (
+        "i2c bus device for channel" in normalized
+        and "no such file or directory" in normalized
+    ):
+        return True
+
+    return False
+
+
+def is_expected_gpio_absence(detail: object | None) -> bool:
+    """Return whether ``detail`` describes an expected missing GPIO/RFID runtime."""
+
+    normalized = _normalize_detail(detail)
+    return any(
+        marker in normalized
+        for marker in (
+            "gpio library not available",
+            "mfrc522 library not available",
+        )
+    )
+
+
+def is_expected_optional_hardware_absence(detail: object | None) -> bool:
+    """Return whether ``detail`` matches optional-hardware absence we should not warn on."""
+
+    return is_expected_gpio_absence(detail) or is_expected_i2c_absence(detail)
+
+
+__all__ = [
+    "is_expected_gpio_absence",
+    "is_expected_i2c_absence",
+    "is_expected_optional_hardware_absence",
+]

--- a/apps/core/optional_hardware.py
+++ b/apps/core/optional_hardware.py
@@ -14,25 +14,25 @@ def is_expected_i2c_absence(detail: object | None) -> bool:
     if not normalized:
         return False
 
-    if "i2cdetect is not available" in normalized:
-        return True
-
-    if "smbus module not found" in normalized:
-        return True
-
-    if (
-        "could not open file `/dev/i2c-" in normalized
-        and "no such file or directory" in normalized
+    if any(
+        marker in normalized
+        for marker in (
+            "i2cdetect is not available",
+            "smbus module not found",
+        )
     ):
         return True
 
-    if (
-        "i2c bus device for channel" in normalized
-        and "no such file or directory" in normalized
-    ):
-        return True
+    if "no such file or directory" not in normalized:
+        return False
 
-    return False
+    return any(
+        marker in normalized
+        for marker in (
+            "could not open file `/dev/i2c-",
+            "i2c bus device for channel",
+        )
+    )
 
 
 def is_expected_gpio_absence(detail: object | None) -> bool:

--- a/apps/core/tests/test_optional_hardware.py
+++ b/apps/core/tests/test_optional_hardware.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from apps.core.optional_hardware import is_expected_i2c_absence
+
+
+def test_is_expected_i2c_absence_matches_simple_markers() -> None:
+    assert is_expected_i2c_absence("i2cdetect is not available") is True
+    assert is_expected_i2c_absence("smbus module not found") is True
+
+
+def test_is_expected_i2c_absence_matches_missing_device_patterns() -> None:
+    assert is_expected_i2c_absence(
+        "Could not open file `/dev/i2c-1`: No such file or directory"
+    )
+    assert is_expected_i2c_absence(
+        "I2C bus device for channel 1: No such file or directory"
+    )
+
+
+def test_is_expected_i2c_absence_rejects_unrelated_messages() -> None:
+    assert is_expected_i2c_absence(
+        "I2C bus device for channel 1: permission denied"
+    ) is False
+    assert is_expected_i2c_absence("other runtime error") is False

--- a/apps/screens/lcd.py
+++ b/apps/screens/lcd.py
@@ -47,7 +47,7 @@ class _BusWrapper:
             return smbus.SMBus(self.channel)
         except OSError as exc:
             raise LCDUnavailableError(
-                f"I2C bus device for channel {self.channel} is unavailable"
+                f"I2C bus device for channel {self.channel} is unavailable ({exc})"
             ) from exc
 
     def write_byte(

--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone as datetime_timezone
 from pathlib import Path
 
+from apps.core.optional_hardware import is_expected_optional_hardware_absence
 from apps.screens.history import LCDHistoryRecorder
 from apps.screens.lcd import LCDUnavailableError
 
@@ -806,6 +807,8 @@ def _disable_lcd(
     runner.lcd_disabled = True
     if exc is None:
         logger.warning("Disabling LCD feature: %s", reason)
+    elif is_expected_optional_hardware_absence(exc):
+        logger.info("Disabling LCD feature: %s: %s", reason, exc)
     else:
         logger.warning("Disabling LCD feature: %s: %s", reason, exc, exc_info=exc_info)
     _blank_display(runner.lcd)

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -124,6 +125,30 @@ def test_disable_lcd_resets_mutable_runner_state(monkeypatch):
     assert coordinator.event.line_deadline == 0.0
     assert coordinator.frame_writer.lcd is None
     assert coordinator.frame_writer.history_recorder is previous_history
+
+
+def test_disable_lcd_logs_info_for_expected_missing_hardware(caplog):
+    coordinator = runner.LCDRunner()
+
+    with caplog.at_level(logging.INFO):
+        coordinator.disable_lcd(
+            "LCD unavailable during startup",
+            runner.LCDUnavailableError(
+                "I2C bus device for channel 1 is unavailable ([Errno 2] No such file or directory)"
+            ),
+        )
+
+    assert "Disabling LCD feature" in caplog.text
+    assert "WARNING" not in caplog.text
+
+
+def test_disable_lcd_logs_warning_for_unexpected_failures(caplog):
+    coordinator = runner.LCDRunner()
+
+    with caplog.at_level(logging.WARNING):
+        coordinator.disable_lcd("LCD startup failed", RuntimeError("permission denied"))
+
+    assert "Disabling LCD feature" in caplog.text
 
 
 def test_handle_external_event_interrupt_loads_and_renders(monkeypatch):


### PR DESCRIPTION
## Summary
Reduce operator-facing warning noise on nodes that do not have optional GPIO, LCD, or I2C hardware.

## What changed
- added a shared optional-hardware classifier for expected missing GPIO/I2C/LCD conditions
- downgraded expected missing-hardware startup messages from warning to info in the clock discovery, LCD runner, and RFID background reader paths
- preserved warning-level logging for unexpected initialization failures
- expanded targeted tests for each affected path

## Why
Nodes without those peripherals currently emit startup warnings for conditions that are expected in that environment. That creates avoidable operator noise and makes real hardware faults harder to spot.

## Root cause
The hardware setup paths treated missing optional dependencies and missing bus devices as generic failures, so they logged at warning level even when the node was intentionally running without that hardware.

## Validation
- `python -m compileall apps/core/optional_hardware.py apps/clocks/utils.py apps/screens/lcd.py apps/screens/lcd_screen/runner.py apps/cards/background_reader.py`
- `.venv/bin/python manage.py test run -- apps/clocks/tests/test_utils.py apps/cards/tests/test_background_reader.py apps/screens/tests/test_lcd_runner.py`
  - `20 passed, 1 warning in 0.62s`
  - residual warning: `PytestConfigWarning: Unknown config option: asyncio_mode`
