### PR TITLE
gitignore: ignore .codex directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ arthexis.env
 .env.*
 .envrc
 .venv
+.codex/
 env/
 venv/
 ENV/


### PR DESCRIPTION
### Motivation
- Prevent local Codex workspace files from being accidentally committed by adding the `.codex/` directory to the repository ignore list.

### Description
- Add `.codex/` to the repository root ` .gitignore` so local Codex state is not tracked by version control.

### Testing
- No automated tests were required for this `gitignore`-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ae2000548326a1c4efc87ac20609)