### PR TITLE
repos: require verified webhook signature before issue spam moderation

### DIFF
--- a/apps/repos/tests/test_spam_filter.py
+++ b/apps/repos/tests/test_spam_filter.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from decimal import Decimal
+import hashlib
+import hmac
 import json
 
 import pytest
 from django.urls import reverse
 
+from apps.repos.models.github_apps import GitHubApp
 from apps.repos.models.repositories import GitHubRepository
 from apps.repos.models.spam import RepositoryIssueSpamAssessment
 from apps.repos.services import github as github_service
@@ -38,6 +41,12 @@ def test_github_webhook_creates_spam_assessment(client, settings):
     settings.GITHUB_ISSUE_SPAM_THRESHOLD = "0.20"
 
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    app = GitHubApp.objects.create(
+        display_name="Webhook App",
+        app_id=1001,
+        webhook_secret="topsecret",
+        webhook_slug="webhook-app",
+    )
     url = reverse("repos:github-webhook")
     payload = {
         "action": "opened",
@@ -49,12 +58,22 @@ def test_github_webhook_creates_spam_assessment(client, settings):
             "user": {"login": "spambot"},
         },
     }
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
 
     response = client.post(
         url,
-        data=json.dumps(payload),
+        data=body,
         content_type="application/json",
-        **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_GITHUB_DELIVERY": "delivery-42"},
+        **{
+            "HTTP_X_GITHUB_EVENT": "issues",
+            "HTTP_X_GITHUB_DELIVERY": "delivery-42",
+            "HTTP_X_HUB_SIGNATURE_256": signature,
+        },
     )
 
     assert response.status_code == 200
@@ -74,6 +93,12 @@ def test_github_webhook_auto_moderates_when_enabled(client, monkeypatch, setting
     settings.GITHUB_ISSUE_SPAM_AUTO_LABELS = ["spam-suspected", "triage"]
 
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    app = GitHubApp.objects.create(
+        display_name="Webhook App",
+        app_id=1002,
+        webhook_secret="topsecret",
+        webhook_slug="webhook-app",
+    )
     url = reverse("repos:github-webhook")
 
     calls: list[tuple[str, int]] = []
@@ -101,11 +126,21 @@ def test_github_webhook_auto_moderates_when_enabled(client, monkeypatch, setting
             "user": {"login": "spambot"},
         },
     }
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
     response = client.post(
         url,
-        data=json.dumps(payload),
+        data=body,
         content_type="application/json",
-        **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_GITHUB_DELIVERY": "delivery-77"},
+        **{
+            "HTTP_X_GITHUB_EVENT": "issues",
+            "HTTP_X_GITHUB_DELIVERY": "delivery-77",
+            "HTTP_X_HUB_SIGNATURE_256": signature,
+        },
     )
 
     assert response.status_code == 200
@@ -123,6 +158,12 @@ def test_github_webhook_auto_moderation_closes_issue_when_labeling_fails(
     settings.GITHUB_ISSUE_SPAM_AUTO_LABELS = ["spam-suspected"]
 
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    app = GitHubApp.objects.create(
+        display_name="Webhook App",
+        app_id=1003,
+        webhook_secret="topsecret",
+        webhook_slug="webhook-app",
+    )
     url = reverse("repos:github-webhook")
 
     calls: list[tuple[str, int]] = []
@@ -149,12 +190,67 @@ def test_github_webhook_auto_moderation_closes_issue_when_labeling_fails(
             "user": {"login": "spambot"},
         },
     }
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
     response = client.post(
         url,
-        data=json.dumps(payload),
+        data=body,
         content_type="application/json",
-        **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_GITHUB_DELIVERY": "delivery-88"},
+        **{
+            "HTTP_X_GITHUB_EVENT": "issues",
+            "HTTP_X_GITHUB_DELIVERY": "delivery-88",
+            "HTTP_X_HUB_SIGNATURE_256": signature,
+        },
     )
 
     assert response.status_code == 200
     assert calls == [("close", 88)]
+
+
+@pytest.mark.django_db
+def test_github_webhook_skips_spam_assessment_without_valid_signature(
+    client, monkeypatch, settings
+):
+    settings.GITHUB_ISSUE_SPAM_FILTER_ENABLED = True
+    settings.GITHUB_ISSUE_SPAM_AUTO_MODERATE = True
+    settings.GITHUB_ISSUE_SPAM_MAX_LINKS = 0
+    settings.GITHUB_ISSUE_SPAM_THRESHOLD = "0.20"
+
+    repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    url = reverse("repos:github-webhook")
+
+    calls: list[str] = []
+    monkeypatch.setattr("apps.repos.spam_filter.github_service.get_github_issue_token", lambda: "token")
+    monkeypatch.setattr(
+        "apps.repos.spam_filter.github_service.add_issue_labels",
+        lambda **kwargs: calls.append("labels"),
+    )
+    monkeypatch.setattr(
+        "apps.repos.spam_filter.github_service.close_issue",
+        lambda **kwargs: calls.append("close"),
+    )
+
+    payload = {
+        "action": "opened",
+        "repository": {"owner": {"login": repo.owner}, "name": repo.name},
+        "issue": {
+            "number": 90,
+            "title": "promo",
+            "body": "https://spam.example",
+            "user": {"login": "spambot"},
+        },
+    }
+    response = client.post(
+        url,
+        data=json.dumps(payload),
+        content_type="application/json",
+        **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_GITHUB_DELIVERY": "delivery-90"},
+    )
+
+    assert response.status_code == 200
+    assert RepositoryIssueSpamAssessment.objects.count() == 0
+    assert calls == []

--- a/apps/repos/tests/test_spam_filter.py
+++ b/apps/repos/tests/test_spam_filter.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from django.urls import reverse
 
-from apps.repos.models.github_apps import GitHubApp
+from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall
 from apps.repos.models.repositories import GitHubRepository
 from apps.repos.models.spam import RepositoryIssueSpamAssessment
 from apps.repos.services import github as github_service
@@ -249,6 +249,73 @@ def test_github_webhook_skips_spam_assessment_without_valid_signature(
         data=json.dumps(payload),
         content_type="application/json",
         **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_GITHUB_DELIVERY": "delivery-90"},
+    )
+
+    assert response.status_code == 200
+    assert RepositoryIssueSpamAssessment.objects.count() == 0
+    assert calls == []
+
+
+@pytest.mark.django_db
+def test_github_webhook_skips_spam_assessment_for_installation_secret_mismatch(
+    client, monkeypatch, settings
+):
+    settings.GITHUB_ISSUE_SPAM_FILTER_ENABLED = True
+    settings.GITHUB_ISSUE_SPAM_AUTO_MODERATE = True
+    settings.GITHUB_ISSUE_SPAM_MAX_LINKS = 0
+    settings.GITHUB_ISSUE_SPAM_THRESHOLD = "0.20"
+
+    repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    victim_app = GitHubApp.objects.create(
+        display_name="Victim App",
+        app_id=3001,
+        webhook_secret="victimsecret",
+    )
+    GitHubAppInstall.objects.create(app=victim_app, installation_id=4242)
+    attacker_app = GitHubApp.objects.create(
+        display_name="Attacker App",
+        app_id=3002,
+        webhook_secret="attackersecret",
+    )
+    url = reverse("repos:github-webhook")
+
+    calls: list[str] = []
+    monkeypatch.setattr("apps.repos.spam_filter.github_service.get_github_issue_token", lambda: "token")
+    monkeypatch.setattr(
+        "apps.repos.spam_filter.github_service.add_issue_labels",
+        lambda **kwargs: calls.append("labels"),
+    )
+    monkeypatch.setattr(
+        "apps.repos.spam_filter.github_service.close_issue",
+        lambda **kwargs: calls.append("close"),
+    )
+
+    payload = {
+        "action": "opened",
+        "installation": {"id": 4242},
+        "repository": {"owner": {"login": repo.owner}, "name": repo.name},
+        "issue": {
+            "number": 91,
+            "title": "promo",
+            "body": "https://spam.example",
+            "user": {"login": "spambot"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        attacker_app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+    response = client.post(
+        url,
+        data=body,
+        content_type="application/json",
+        **{
+            "HTTP_X_GITHUB_EVENT": "issues",
+            "HTTP_X_GITHUB_DELIVERY": "delivery-91",
+            "HTTP_X_HUB_SIGNATURE_256": signature,
+        },
     )
 
     assert response.status_code == 200

--- a/apps/repos/tests/test_webhooks.py
+++ b/apps/repos/tests/test_webhooks.py
@@ -120,8 +120,20 @@ def test_github_webhook_app_rejects_invalid_signature(client):
 @pytest.mark.django_db
 def test_github_webhook_returns_ok_when_spam_assessment_fails(client, monkeypatch):
     repo = GitHubRepository.objects.create(owner="octocat", name="hello-world")
+    app = GitHubApp.objects.create(
+        display_name="Example App",
+        app_id=9999,
+        webhook_secret="topsecret",
+        webhook_slug="example-app",
+    )
     url = reverse("repos:github-webhook")
     payload = {"repository": {"owner": {"login": repo.owner}, "name": repo.name}}
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
 
     def raise_assessment_error(event):
         del event
@@ -131,9 +143,9 @@ def test_github_webhook_returns_ok_when_spam_assessment_fails(client, monkeypatc
 
     response = client.post(
         url,
-        data=json.dumps(payload),
+        data=body,
         content_type="application/json",
-        **{"HTTP_X_GITHUB_EVENT": "issues"},
+        **{"HTTP_X_GITHUB_EVENT": "issues", "HTTP_X_HUB_SIGNATURE_256": signature},
     )
 
     assert response.status_code == 200

--- a/apps/repos/tests/test_webhooks.py
+++ b/apps/repos/tests/test_webhooks.py
@@ -9,7 +9,7 @@ import pytest
 from django.urls import reverse
 
 from apps.repos.models.events import GitHubEvent
-from apps.repos.models.github_apps import GitHubApp
+from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall
 from apps.repos.models.repositories import GitHubRepository
 
 
@@ -150,3 +150,69 @@ def test_github_webhook_returns_ok_when_spam_assessment_fails(client, monkeypatc
 
     assert response.status_code == 200
     assert GitHubEvent.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_github_webhook_verifies_default_route_with_installation_secret(client):
+    app = GitHubApp.objects.create(
+        display_name="Installation App",
+        app_id=9876,
+        webhook_secret="installsecret",
+    )
+    GitHubAppInstall.objects.create(app=app, installation_id=4242)
+
+    GitHubApp.objects.create(
+        display_name="Other App",
+        app_id=9877,
+        webhook_secret="differentsecret",
+    )
+
+    url = reverse("repos:github-webhook")
+    payload = {"installation": {"id": 4242}, "action": "opened"}
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        app.webhook_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    response = client.post(
+        url,
+        data=body,
+        content_type="application/json",
+        **{"HTTP_X_HUB_SIGNATURE_256": signature},
+    )
+
+    assert response.status_code == 200
+    event = GitHubEvent.objects.get()
+    assert event.payload == payload
+
+
+@pytest.mark.django_db
+def test_github_webhook_verifies_with_sigil_secret(client, monkeypatch):
+    monkeypatch.setenv("REPOS_WEBHOOK_SECRET", "sigilsecret")
+    app = GitHubApp.objects.create(
+        display_name="Sigil App",
+        app_id=2468,
+        webhook_secret="[ENV.REPOS_WEBHOOK_SECRET]",
+    )
+    url = reverse("repos:github-webhook")
+    payload = {"action": "opened"}
+    body = json.dumps(payload).encode("utf-8")
+    signature = "sha256=" + hmac.new(
+        "sigilsecret".encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    response = client.post(
+        url,
+        data=body,
+        content_type="application/json",
+        **{"HTTP_X_HUB_SIGNATURE_256": signature},
+    )
+
+    assert response.status_code == 200
+    event = GitHubEvent.objects.get()
+    assert event.payload == payload
+    assert app.webhook_secret == "sigilsecret"

--- a/apps/repos/views/webhooks.py
+++ b/apps/repos/views/webhooks.py
@@ -6,8 +6,8 @@ import hashlib
 import hmac
 import json
 import logging
-from urllib.parse import parse_qs
 from typing import TypeAlias, TypedDict
+from urllib.parse import parse_qs
 
 from django.db.models import Q
 from django.http import HttpRequest, JsonResponse
@@ -169,6 +169,18 @@ def _verify_signature(request: HttpRequest, secret: str) -> bool:
     return False
 
 
+def _verify_signature_for_any_app(request: HttpRequest) -> bool:
+    signature_256 = request.headers.get("X-Hub-Signature-256", "")
+    signature = request.headers.get("X-Hub-Signature", "")
+    if not signature_256 and not signature:
+        return False
+
+    webhook_secrets = GitHubApp.objects.exclude(webhook_secret="").values_list(
+        "webhook_secret", flat=True
+    )
+    return any(_verify_signature(request, secret) for secret in webhook_secrets)
+
+
 @csrf_exempt
 def github_webhook(
     request: HttpRequest,
@@ -176,12 +188,16 @@ def github_webhook(
     name: str = "",
     app_slug: str = "",
 ) -> JsonResponse:
+    is_verified = False
     if app_slug:
         app = GitHubApp.objects.filter(
             Q(webhook_slug=app_slug) | Q(app_slug=app_slug)
         ).first()
         if not app or not _verify_signature(request, app.webhook_secret):
             return JsonResponse({"status": "unauthorized"}, status=401)
+        is_verified = True
+    else:
+        is_verified = _verify_signature_for_any_app(request)
 
     payload, raw_body = _extract_payload(request)
     owner, name = _resolve_event_route(owner, name, _payload_for_routing(payload))
@@ -209,9 +225,10 @@ def github_webhook(
         payload=payload,
         raw_body=raw_body,
     )
-    try:
-        assess_github_issue_event(event)
-    except Exception:  # pragma: no cover - defensive guard to keep webhook ingestion resilient
-        logger.exception("GitHub issue spam assessment failed for event_id=%s", event.pk)
+    if is_verified:
+        try:
+            assess_github_issue_event(event)
+        except Exception:  # pragma: no cover - defensive guard to keep webhook ingestion resilient
+            logger.exception("GitHub issue spam assessment failed for event_id=%s", event.pk)
 
     return JsonResponse({"status": "ok", "event_id": event.pk})

--- a/apps/repos/views/webhooks.py
+++ b/apps/repos/views/webhooks.py
@@ -202,8 +202,8 @@ def _verify_signature_for_payload(
             .filter(installation_id=installation_id)
             .first()
         )
-        if install and _verify_signature(request, install.app.webhook_secret):
-            return True
+        if install:
+            return _verify_signature(request, install.app.webhook_secret)
     return _verify_signature_for_any_app(request)
 
 

--- a/apps/repos/views/webhooks.py
+++ b/apps/repos/views/webhooks.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from apps.repos.models.events import GitHubEvent
-from apps.repos.models.github_apps import GitHubApp
+from apps.repos.models.github_apps import GitHubApp, GitHubAppInstall
 from apps.repos.models.repositories import GitHubRepository
 from apps.repos.spam_filter import assess_github_issue_event
 
@@ -175,10 +175,36 @@ def _verify_signature_for_any_app(request: HttpRequest) -> bool:
     if not signature_256 and not signature:
         return False
 
-    webhook_secrets = GitHubApp.objects.exclude(webhook_secret="").values_list(
-        "webhook_secret", flat=True
-    )
-    return any(_verify_signature(request, secret) for secret in webhook_secrets)
+    apps = GitHubApp.objects.exclude(webhook_secret="")
+    return any(_verify_signature(request, app.webhook_secret) for app in apps)
+
+
+def _installation_id_from_payload(payload: ParsedWebhookPayload) -> int | None:
+    installation = payload.get("installation")
+    if not isinstance(installation, dict):
+        return None
+    installation_id = installation.get("id")
+    if isinstance(installation_id, int):
+        return installation_id
+    if isinstance(installation_id, str) and installation_id.isdigit():
+        return int(installation_id)
+    return None
+
+
+def _verify_signature_for_payload(
+    request: HttpRequest,
+    payload: ParsedWebhookPayload,
+) -> bool:
+    installation_id = _installation_id_from_payload(payload)
+    if installation_id is not None:
+        install = (
+            GitHubAppInstall.objects.select_related("app")
+            .filter(installation_id=installation_id)
+            .first()
+        )
+        if install and _verify_signature(request, install.app.webhook_secret):
+            return True
+    return _verify_signature_for_any_app(request)
 
 
 @csrf_exempt
@@ -188,6 +214,8 @@ def github_webhook(
     name: str = "",
     app_slug: str = "",
 ) -> JsonResponse:
+    payload, raw_body = _extract_payload(request)
+
     is_verified = False
     if app_slug:
         app = GitHubApp.objects.filter(
@@ -197,9 +225,7 @@ def github_webhook(
             return JsonResponse({"status": "unauthorized"}, status=401)
         is_verified = True
     else:
-        is_verified = _verify_signature_for_any_app(request)
-
-    payload, raw_body = _extract_payload(request)
+        is_verified = _verify_signature_for_payload(request, payload)
     owner, name = _resolve_event_route(owner, name, _payload_for_routing(payload))
 
     repository = None


### PR DESCRIPTION
### Motivation

- Fix a security issue where unsigned/default GitHub webhook routes could trigger issue spam assessment and cause auto-moderation (label/close) using the service GitHub token.
- Preserve webhook ingestion (events are still recorded and 200 responses returned) while preventing unauthenticated callers from invoking moderation actions.

### Description

- Gate the spam assessment call to `assess_github_issue_event` behind a signature check by introducing `is_verified` in `github_webhook` and only invoking the assessment when verified.
- Add `_verify_signature_for_any_app(request)` to validate incoming `X-Hub-Signature(-256)` HMACs against all configured `GitHubApp.webhook_secret` values for non-`app_slug` routes.
- Keep the existing per-app `app_slug` verification behavior intact and mark such requests as verified when their secret matches.
- Update tests in `apps/repos/tests/test_spam_filter.py` and `apps/repos/tests/test_webhooks.py` to sign payloads for cases expecting assessment/moderation and add `test_github_webhook_skips_spam_assessment_without_valid_signature` to cover the regression.

### Testing

- Ran `./env-refresh.sh --deps-only` and then executed the targeted test suite with `.venv/bin/python manage.py test run -- apps/repos/tests/test_webhooks.py apps/repos/tests/test_spam_filter.py`, and the full test run passed (`10 passed`).
- The test set includes the new regression `test_github_webhook_skips_spam_assessment_without_valid_signature` which verifies unsigned issue webhooks do not create spam assessments or invoke moderation calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69a2b4038832698a1eceb9f82691a)