### PR TITLE
gallery: default manager owner group and preserve staged upload on form errors

### DIFF
--- a/apps/gallery/forms.py
+++ b/apps/gallery/forms.py
@@ -3,12 +3,13 @@ from django.contrib.auth import get_user_model
 
 from apps.groups.models import SecurityGroup
 
+from .constants import GALLERY_MANAGER_GROUP_NAME
 from .models import GalleryCategory, GalleryCredit, GalleryImage, GalleryImageTrait, GalleryTrait
 
 
 class GalleryUploadForm(forms.Form):
     image = forms.ImageField(
-        required=True,
+        required=False,
         widget=forms.ClearableFileInput(attrs={"class": "form-control", "accept": "image/*"}),
     )
     title = forms.CharField(max_length=255, widget=forms.TextInput(attrs={"class": "form-control"}))
@@ -37,9 +38,24 @@ class GalleryUploadForm(forms.Form):
         required=False,
         widget=forms.Select(attrs={"class": "form-select"}),
     )
+    staged_upload_key = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        default_owner_group = SecurityGroup.objects.filter(name=GALLERY_MANAGER_GROUP_NAME).first()
+        if default_owner_group and not self.is_bound:
+            self.fields["owner_group"].initial = default_owner_group.pk
 
     def clean(self):
         cleaned = super().clean()
+        image = cleaned.get("image")
+        staged_upload_key = (cleaned.get("staged_upload_key") or "").strip()
+        if image is None and not staged_upload_key:
+            self.add_error("image", "Upload an image.")
+
         owner_user = cleaned.get("owner_user")
         owner_group = cleaned.get("owner_group")
         if bool(owner_user) == bool(owner_group):

--- a/apps/gallery/templates/gallery/upload.html
+++ b/apps/gallery/templates/gallery/upload.html
@@ -8,6 +8,7 @@
   <h1 class="h4 mb-3">{% trans "Upload Image" %}</h1>
   <form method="post" enctype="multipart/form-data" class="card card-body shadow-sm" id="upload-form">
     {% csrf_token %}
+    {{ form.staged_upload_key }}
     {{ form.non_field_errors }}
     <div class="row g-4 align-items-start">
       <div class="col-12 col-lg-6">
@@ -18,6 +19,9 @@
             {{ form.image }}
           </div>
           {{ form.image.errors }}
+          {% if form.staged_upload_key.value %}
+            <div class="form-text">{% trans "Image file is retained from your previous attempt. You can resubmit without re-uploading, or pick a new file to replace it." %}</div>
+          {% endif %}
         </div>
         <div class="border rounded p-3 bg-body-tertiary">
           <img

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from PIL import Image
 
 from apps.content.models import ContentSample
@@ -100,6 +100,11 @@ class GalleryManagementPermissionTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(GalleryImage.objects.filter(title="Managed").exists())
 
+    def test_upload_form_defaults_owner_group_to_gallery_manager(self):
+        self.client.force_login(self.manager)
+        response = self.client.get("/gallery/upload/")
+        self.assertContains(response, f'<option value="{self.group.pk}" selected>')
+
     def test_non_manager_cannot_upload(self):
         non_manager = get_user_model().objects.create_user(username="non-manager", password="pw")
         self.client.force_login(non_manager)
@@ -126,6 +131,35 @@ class GalleryManagementPermissionTests(TestCase):
         self.assertEqual(response.status_code, 302)
         image = GalleryImage.objects.get(title="Managed With Sample")
         self.assertIsNotNone(image.content_sample_id)
+
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+    def test_upload_reuses_staged_file_after_validation_error(self):
+        self.client.force_login(self.manager)
+        initial_response = self.client.post(
+            "/gallery/upload/",
+            {
+                "image": self._upload("retry.jpg"),
+                "title": "",
+                "description": "",
+                "owner_user": self.manager.username,
+            },
+        )
+        self.assertEqual(initial_response.status_code, 200)
+        self.assertContains(initial_response, "Image file is retained from your previous attempt.")
+        staged_upload_key = initial_response.context["form"]["staged_upload_key"].value()
+        self.assertTrue(staged_upload_key)
+
+        retry_response = self.client.post(
+            "/gallery/upload/",
+            {
+                "title": "Retry Works",
+                "description": "",
+                "owner_user": self.manager.username,
+                "staged_upload_key": staged_upload_key,
+            },
+        )
+        self.assertEqual(retry_response.status_code, 302)
+        self.assertTrue(GalleryImage.objects.filter(title="Retry Works").exists())
 
     def test_gallery_manager_can_view_private_image(self):
         image = create_gallery_image(

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -2,6 +2,7 @@ from io import BytesIO
 from unittest import mock
 
 from django.contrib.auth import get_user_model
+from django.core import signing
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from PIL import Image
@@ -160,6 +161,38 @@ class GalleryManagementPermissionTests(TestCase):
         )
         self.assertEqual(retry_response.status_code, 302)
         self.assertTrue(GalleryImage.objects.filter(title="Retry Works").exists())
+
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+    def test_upload_with_invalid_image_does_not_stage_file(self):
+        self.client.force_login(self.manager)
+        response = self.client.post(
+            "/gallery/upload/",
+            {
+                "image": SimpleUploadedFile("not-image.txt", b"not-an-image", content_type="text/plain"),
+                "title": "Invalid Image",
+                "description": "",
+                "owner_user": self.manager.username,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Upload a valid image.")
+        self.assertFalse(response.context["form"]["staged_upload_key"].value())
+        self.assertFalse(GalleryImage.objects.filter(title="Invalid Image").exists())
+
+    def test_expired_or_invalid_staged_key_returns_form_error(self):
+        self.client.force_login(self.manager)
+        response = self.client.post(
+            "/gallery/upload/",
+            {
+                "title": "Retry Fails",
+                "description": "",
+                "owner_user": self.manager.username,
+                "staged_upload_key": signing.TimestampSigner(salt="gallery-upload").sign("gallery/staged/999/missing.jpg"),
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "The previously uploaded image has expired or is invalid. Please upload it again.")
+        self.assertFalse(GalleryImage.objects.filter(title="Retry Fails").exists())
 
     def test_gallery_manager_can_view_private_image(self):
         image = create_gallery_image(

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -1,6 +1,12 @@
+from pathlib import Path
+from uuid import uuid4
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.core.files import File
+from django.core.files.storage import default_storage
+from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 from django.db.models import Q
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -17,6 +23,34 @@ from .forms import (
 from .models import GalleryImage
 from .permissions import can_manage_gallery
 from .services import create_gallery_image
+
+_STAGED_UPLOAD_MAX_AGE_SECONDS = 60 * 60
+_STAGED_UPLOAD_SIGNER = TimestampSigner(salt="gallery-upload")
+
+
+def _stage_uploaded_image(*, uploaded_file, user_id: int) -> str:
+    suffix = Path(uploaded_file.name or "").suffix
+    staged_path = f"gallery/staged/{user_id}/{uuid4().hex}{suffix}"
+    saved_path = default_storage.save(staged_path, uploaded_file)
+    return _STAGED_UPLOAD_SIGNER.sign(saved_path)
+
+
+def _resolve_staged_upload(*, staged_upload_key: str):
+    try:
+        staged_path = _STAGED_UPLOAD_SIGNER.unsign(
+            staged_upload_key,
+            max_age=_STAGED_UPLOAD_MAX_AGE_SECONDS,
+        )
+    except (BadSignature, SignatureExpired):
+        return None
+    if not default_storage.exists(staged_path):
+        return None
+    return staged_path
+
+
+def _clear_staged_upload(*, staged_path: str | None):
+    if staged_path and default_storage.exists(staged_path):
+        default_storage.delete(staged_path)
 
 
 def _visible_images_for_user(user):
@@ -158,17 +192,42 @@ def gallery_upload(request):
                 form.add_error("owner_user", "User not found.")
                 return render(request, "gallery/upload.html", {"form": form})
 
-        image = create_gallery_image(
-            uploaded_file=form.cleaned_data["image"],
-            title=form.cleaned_data["title"],
-            description=form.cleaned_data.get("description", ""),
-            include_in_public_gallery=form.cleaned_data.get("include_in_public_gallery", False),
-            create_content_sample=form.cleaned_data.get("create_content_sample", False),
-            owner_user=owner_user,
-            owner_group=form.cleaned_data.get("owner_group"),
-        )
+        staged_upload_key = form.cleaned_data.get("staged_upload_key") or ""
+        staged_path = _resolve_staged_upload(staged_upload_key=staged_upload_key) if staged_upload_key else None
+        uploaded_file = form.cleaned_data.get("image")
+        staged_handle = None
+        if uploaded_file is None and staged_path:
+            staged_handle = default_storage.open(staged_path, mode="rb")
+            uploaded_file = File(staged_handle, name=Path(staged_path).name)
+
+        try:
+            image = create_gallery_image(
+                uploaded_file=uploaded_file,
+                title=form.cleaned_data["title"],
+                description=form.cleaned_data.get("description", ""),
+                include_in_public_gallery=form.cleaned_data.get("include_in_public_gallery", False),
+                create_content_sample=form.cleaned_data.get("create_content_sample", False),
+                owner_user=owner_user,
+                owner_group=form.cleaned_data.get("owner_group"),
+            )
+        finally:
+            if staged_handle is not None:
+                staged_handle.close()
+        _clear_staged_upload(staged_path=staged_path)
         messages.success(request, "Image uploaded successfully.")
         return redirect("gallery:detail", slug=image.slug)
+
+    if request.method == "POST" and request.FILES.get("image"):
+        previous_staged_upload_key = (request.POST.get("staged_upload_key") or "").strip()
+        previous_staged_path = (
+            _resolve_staged_upload(staged_upload_key=previous_staged_upload_key) if previous_staged_upload_key else None
+        )
+        _clear_staged_upload(staged_path=previous_staged_path)
+        form.data = form.data.copy()
+        form.data["staged_upload_key"] = _stage_uploaded_image(
+            uploaded_file=request.FILES["image"],
+            user_id=request.user.pk,
+        )
 
     return render(request, "gallery/upload.html", {"form": form})
 

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -29,19 +29,21 @@ _STAGED_UPLOAD_SIGNER = TimestampSigner(salt="gallery-upload")
 
 
 def _stage_uploaded_image(*, uploaded_file, user_id: int) -> str:
-    suffix = Path(uploaded_file.name or "").suffix
-    staged_path = f"gallery/staged/{user_id}/{uuid4().hex}{suffix}"
+    original_name = Path(uploaded_file.name or "image").name
+    staged_path = f"gallery/staged/{user_id}/{uuid4().hex}_{original_name}"
     saved_path = default_storage.save(staged_path, uploaded_file)
     return _STAGED_UPLOAD_SIGNER.sign(saved_path)
 
 
-def _resolve_staged_upload(*, staged_upload_key: str):
+def _resolve_staged_upload(*, staged_upload_key: str, user_id: int):
     try:
         staged_path = _STAGED_UPLOAD_SIGNER.unsign(
             staged_upload_key,
             max_age=_STAGED_UPLOAD_MAX_AGE_SECONDS,
         )
     except (BadSignature, SignatureExpired):
+        return None
+    if not str(staged_path).startswith(f"gallery/staged/{user_id}/"):
         return None
     if not default_storage.exists(staged_path):
         return None
@@ -193,7 +195,12 @@ def gallery_upload(request):
                 return render(request, "gallery/upload.html", {"form": form})
 
         staged_upload_key = form.cleaned_data.get("staged_upload_key") or ""
-        staged_path = _resolve_staged_upload(staged_upload_key=staged_upload_key) if staged_upload_key else None
+        staged_path = (
+            _resolve_staged_upload(staged_upload_key=staged_upload_key, user_id=request.user.pk) if staged_upload_key else None
+        )
+        if staged_upload_key and staged_path is None:
+            form.add_error("image", "The previously uploaded image has expired or is invalid. Please upload it again.")
+            return render(request, "gallery/upload.html", {"form": form})
         uploaded_file = form.cleaned_data.get("image")
         staged_handle = None
         if uploaded_file is None and staged_path:
@@ -217,10 +224,12 @@ def gallery_upload(request):
         messages.success(request, "Image uploaded successfully.")
         return redirect("gallery:detail", slug=image.slug)
 
-    if request.method == "POST" and request.FILES.get("image"):
+    if request.method == "POST" and request.FILES.get("image") and "image" not in form.errors:
         previous_staged_upload_key = (request.POST.get("staged_upload_key") or "").strip()
         previous_staged_path = (
-            _resolve_staged_upload(staged_upload_key=previous_staged_upload_key) if previous_staged_upload_key else None
+            _resolve_staged_upload(staged_upload_key=previous_staged_upload_key, user_id=request.user.pk)
+            if previous_staged_upload_key
+            else None
         )
         _clear_staged_upload(staged_path=previous_staged_path)
         form.data = form.data.copy()


### PR DESCRIPTION
### Motivation

- Improve upload usability by defaulting the owner group to the Gallery Manager group to reduce clicks for common workflows.
- Prevent users from having to re-upload images after simple validation failures by retaining a staged copy of the uploaded file between form submissions.

### Description

- Made `image` optional in `GalleryUploadForm`, added a hidden `staged_upload_key` field, and defaulted `owner_group` initial value to the `GALLERY_MANAGER_GROUP_NAME` when the form is first rendered.
- Added staging helpers in `gallery.views`: `_stage_uploaded_image`, `_resolve_staged_upload`, and `_clear_staged_upload` that save uploaded files to `default_storage`, sign the staged path with `TimestampSigner`, resolve signed keys, and delete staged files when superseded or after successful upload.
- Updated `gallery_upload` view to stage incoming files on the initial POST, reuse a resolved staged file when the form is resubmitted without a fresh `image`, and always clean up handles and staged files appropriately.
- Updated `gallery/templates/gallery/upload.html` to include the hidden `staged_upload_key` and show a user-facing message when a previous image is retained for resubmission.
- Added regression tests in `apps/gallery/tests/test_gallery.py` verifying the default owner-group selection and the staged-upload retry flow.

### Testing

- Bootstrapped environment with `./env-refresh.sh --deps-only` and installed test helpers via `.venv/bin/pip install pytest pytest-django pytest-timeout` which completed successfully.
- Ran the gallery test module with `.venv/bin/python manage.py test run -- apps/gallery/tests/test_gallery.py` and all tests passed (`14 passed`, `1 warning`).
- Verified staging/cleanup behavior via the added tests that simulate a validation failure and a subsequent retry using the `staged_upload_key`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bda30d2c8326aef3ded38aa5098f)