### PR TITLE
evergo: harden public image upload validation and reject non-image artifact uploads

### DIFF
--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -212,6 +213,55 @@ def test_customer_public_detail_enforces_image_and_storage_limits(client, settin
 
     assert response.status_code == 200
     assert "You can only add up to 1 images." in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_customer_public_detail_handles_artifact_model_validation_error(client, monkeypatch):
+    customer = _create_customer(username="owner-validation-error")
+    detail_url = reverse("evergo:customer-public-detail", kwargs={"public_id": customer.public_id})
+
+    def _raise_validation_error(**_kwargs):
+        raise ValidationError({"file": ["Only image files and PDFs are allowed."]})
+
+    monkeypatch.setattr("apps.evergo.views.EvergoArtifact.objects.create", _raise_validation_error)
+
+    response = client.post(
+        detail_url,
+        data={
+            "action": "upload-image",
+            "image": SimpleUploadedFile(
+                "photo.jpg",
+                b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff\x21\xf9\x04\x01\x00\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b",
+                content_type="image/gif",
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Only image files and PDFs are allowed." in response.content.decode()
+    assert not EvergoArtifact.objects.filter(customer=customer).exists()
+
+
+@pytest.mark.django_db
+def test_customer_public_detail_rejects_upload_that_resolves_to_non_image_artifact_type(client):
+    customer = _create_customer(username="owner-non-image-artifact")
+    detail_url = reverse("evergo:customer-public-detail", kwargs={"public_id": customer.public_id})
+
+    response = client.post(
+        detail_url,
+        data={
+            "action": "upload-image",
+            "image": SimpleUploadedFile(
+                "not-image.pdf",
+                b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff\x21\xf9\x04\x01\x00\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b",
+                content_type="image/gif",
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Only image files are allowed for this upload." in response.content.decode()
+    assert not EvergoArtifact.objects.filter(customer=customer).exists()
 
 
 @pytest.mark.django_db

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.models import Site
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -240,14 +241,27 @@ def customer_public_detail(request, public_id) -> HttpResponse:
                         )
                     else:
                         next_order = max((artifact.display_order for artifact in image_artifacts), default=0) + 1
-                        EvergoArtifact.objects.create(
-                            customer=customer,
-                            file=uploaded_image,
-                            artifact_type=EvergoArtifact.ARTIFACT_TYPE_IMAGE,
-                            display_order=next_order,
-                        )
-                        messages.success(request, "Image added.")
-                        return redirect(customer.get_absolute_url())
+                        try:
+                            artifact = EvergoArtifact.objects.create(
+                                customer=customer,
+                                file=uploaded_image,
+                                artifact_type=EvergoArtifact.ARTIFACT_TYPE_IMAGE,
+                                display_order=next_order,
+                            )
+                        except ValidationError as exc:
+                            field_errors = list(exc.message_dict.get("file", [])) if hasattr(exc, "message_dict") else []
+                            for error in field_errors or list(exc.messages):
+                                upload_form.add_error("image", error)
+                        else:
+                            if not artifact.is_image:
+                                _delete_artifact_and_blob(artifact)
+                                upload_form.add_error(
+                                    "image",
+                                    "Only image files are allowed for this upload.",
+                                )
+                            else:
+                                messages.success(request, "Image added.")
+                                return redirect(customer.get_absolute_url())
         elif action == "delete-image":
             artifact_id = request.POST.get("artifact_id")
             if request.POST.get("confirm_delete") != "yes":


### PR DESCRIPTION
### Motivation

- Prevent anonymous `upload-image` requests from causing a 500 when `EvergoArtifact.save()` raises model-level `ValidationError` for unsupported filenames. 
- Close a bypass where image bytes uploaded under non-image filenames (for example `*.pdf`) were stored as non-image artifacts and evaded image-count/storage limits and deletion controls.

### Description

- Catch `ValidationError` around `EvergoArtifact.objects.create(...)` in `customer_public_detail` and map model file validation messages back onto the `EvergoCustomerImageUploadForm` instead of raising. 
- After a successful create, verify `artifact.is_image`; if it resolves to a non-image type, remove the DB row and backing blob with `_delete_artifact_and_blob(...)` and return a form error. 
- Import `ValidationError` in `apps/evergo/views.py` and reuse the existing `_delete_artifact_and_blob` helper for consistent blob cleanup. 
- Add two regression tests in `apps/evergo/tests/test_public_views.py`: `test_customer_public_detail_handles_artifact_model_validation_error` and `test_customer_public_detail_rejects_upload_that_resolves_to_non_image_artifact_type`.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only`, which completed successfully. 
- Installed test tooling with `.venv/bin/pip install pytest pytest-django pytest-timeout`, which completed successfully. 
- Validated migrations with `.venv/bin/python manage.py migrations check`, which reported no outstanding issues. 
- Ran the focused public-view test suite with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_public_views.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c0aac6d48326a434b3447d1ab29f)