### PR TITLE
core/evergo: make ownable admin validation configurable

### DIFF
--- a/apps/core/admin/mixins.py
+++ b/apps/core/admin/mixins.py
@@ -57,13 +57,18 @@ class OwnableAdminForm(forms.ModelForm):
         return getattr(self._meta.model, "owner_required", self.owner_required)
 
     def _owner_validation_message(self, message, owner_field_names):
+        if not owner_field_names:
+            return message
         return {field_name: message for field_name in owner_field_names}
 
     def normalize_owner_data(self, cleaned):
         return cleaned
 
     def clean(self):
-        cleaned = self.normalize_owner_data(super().clean())
+        cleaned = super().clean()
+        if cleaned is None:
+            return None
+        cleaned = self.normalize_owner_data(cleaned)
         owner_field_names = self._configured_owner_field_names()
         owners = [cleaned.get(field_name) for field_name in owner_field_names]
         owner_count = sum(owner is not None for owner in owners)

--- a/apps/core/admin/mixins.py
+++ b/apps/core/admin/mixins.py
@@ -35,24 +35,60 @@ def _build_credentials_actions(action_name, handler_name, description=TEST_CREDE
 
 
 class OwnableAdminForm(forms.ModelForm):
-    """Enforce mutual exclusivity between user and security group owners."""
+    """Enforce configurable ownership requirements for admin model forms."""
 
+    owner_exactly_one: bool = False
+    owner_field_names: tuple[str, ...] = ("user", "group")
     owner_required: bool = True
 
+    owner_conflict_message = _("Select either a user or a security group, not both.")
+    owner_required_message = _("Ownable objects must be assigned to a user or a security group.")
+    owner_exactly_one_message = _("Select exactly one owner.")
+
+    def _configured_owner_field_names(self) -> tuple[str, ...]:
+        configured_names = getattr(self, "owner_field_names", ())
+        owner_names: list[str] = []
+        for field_name in configured_names:
+            if field_name in self.fields:
+                owner_names.append(field_name)
+        return tuple(owner_names)
+
+    def _resolved_owner_required(self) -> bool:
+        return getattr(self._meta.model, "owner_required", self.owner_required)
+
+    def _owner_validation_message(self, message, owner_field_names):
+        return {field_name: message for field_name in owner_field_names}
+
+    def normalize_owner_data(self, cleaned):
+        return cleaned
+
     def clean(self):
-        cleaned = super().clean()
-        user = cleaned.get("user")
-        group = cleaned.get("group")
-        if user and group:
+        cleaned = self.normalize_owner_data(super().clean())
+        owner_field_names = self._configured_owner_field_names()
+        owners = [cleaned.get(field_name) for field_name in owner_field_names]
+        owner_count = sum(owner is not None for owner in owners)
+
+        if self.owner_exactly_one and owner_count != 1:
             raise ValidationError(
-                {
-                    "group": _("Select either a user or a security group, not both."),
-                    "user": _("Select either a user or a security group, not both."),
-                }
+                self._owner_validation_message(
+                    self.owner_exactly_one_message,
+                    owner_field_names,
+                )
             )
-        required = getattr(self._meta.model, "owner_required", self.owner_required)
-        if required and not user and not group:
-            raise ValidationError(_("Ownable objects must be assigned to a user or a security group."))
+        if not self.owner_exactly_one and owner_count > 1:
+            raise ValidationError(
+                self._owner_validation_message(
+                    self.owner_conflict_message,
+                    owner_field_names,
+                )
+            )
+        if self._resolved_owner_required() and owner_count == 0:
+            raise ValidationError(
+                self._owner_validation_message(
+                    self.owner_required_message,
+                    owner_field_names,
+                )
+            )
         return cleaned
 
 

--- a/apps/core/tests/test_ownable.py
+++ b/apps/core/tests/test_ownable.py
@@ -7,6 +7,7 @@ import pytest
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.forms import ModelForm
 
 from apps.chats.models import ChatAvatar
 from apps.core.admin.mixins import OwnableAdminForm, OwnableAdminMixin
@@ -111,3 +112,47 @@ def test_ownable_admin_form_supports_exactly_one_owner_configuration():
     )
     assert not multiple_owner_form.is_valid()
     assert "Select exactly one owner." in multiple_owner_form.errors["user"][0]
+
+
+@pytest.mark.django_db
+def test_ownable_admin_form_uses_non_field_error_when_owner_fields_absent():
+    class NoOwnerFieldsForm(OwnableAdminForm):
+        owner_field_names = ("missing_owner",)
+
+        class Meta:
+            model = EvergoUser
+            fields = ("evergo_email", "evergo_password")
+
+    form = NoOwnerFieldsForm(
+        data={
+            "evergo_email": "contractor@example.com",
+            "evergo_password": "top-secret",  # noqa: S106
+        },
+        instance=EvergoUser(),
+    )
+
+    assert not form.is_valid()
+    assert "__all__" in form.errors
+    assert form.errors["__all__"][0]
+    assert "user" not in form.errors
+    assert "group" not in form.errors
+
+
+@pytest.mark.django_db
+def test_ownable_admin_form_handles_parent_clean_returning_none(monkeypatch):
+    class DefensiveForm(OwnableAdminForm):
+        class Meta:
+            model = EvergoUser
+            fields = "__all__"
+
+    monkeypatch.setattr(ModelForm, "clean", lambda _self: None)
+
+    form = DefensiveForm(
+        data={
+            "evergo_email": "contractor@example.com",
+            "evergo_password": "top-secret",  # noqa: S106
+        },
+        instance=EvergoUser(),
+    )
+
+    assert form.clean() is None

--- a/apps/core/tests/test_ownable.py
+++ b/apps/core/tests/test_ownable.py
@@ -9,12 +9,13 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 
 from apps.chats.models import ChatAvatar
-from apps.core.admin.mixins import OwnableAdminMixin
+from apps.core.admin.mixins import OwnableAdminForm, OwnableAdminMixin
 from apps.core.models import (
     get_owned_objects_for_group,
     get_owned_objects_for_user,
     get_ownable_models,
 )
+from apps.evergo.models import EvergoUser
 from apps.groups.models import SecurityGroup
 from apps.sigils.sigil_resolver import resolve_sigils
 
@@ -73,3 +74,40 @@ def test_ownable_admins_use_mixin():
         assert isinstance(
             admin_instance, OwnableAdminMixin
         ), f"{model.__name__} admin must include OwnableAdminMixin"
+
+
+@pytest.mark.django_db
+def test_ownable_admin_form_supports_exactly_one_owner_configuration():
+    class ExactlyOneEvergoOwnerForm(OwnableAdminForm):
+        owner_exactly_one = True
+        owner_field_names = ("user", "group", "avatar")
+
+        class Meta:
+            model = EvergoUser
+            fields = "__all__"
+
+    User = get_user_model()
+    user = User.objects.create_user(username="exact-owner", email="exact-owner@example.com")
+    group = SecurityGroup.objects.create(name="Exact Owner Group")
+
+    no_owner_form = ExactlyOneEvergoOwnerForm(
+        data={
+            "evergo_email": "contractor@example.com",
+            "evergo_password": "top-secret",  # noqa: S106
+        },
+        instance=EvergoUser(),
+    )
+    assert not no_owner_form.is_valid()
+    assert "Select exactly one owner." in no_owner_form.errors["user"][0]
+
+    multiple_owner_form = ExactlyOneEvergoOwnerForm(
+        data={
+            "user": user.pk,
+            "group": group.pk,
+            "evergo_email": "contractor@example.com",
+            "evergo_password": "top-secret",  # noqa: S106
+        },
+        instance=EvergoUser(),
+    )
+    assert not multiple_owner_form.is_valid()
+    assert "Select exactly one owner." in multiple_owner_form.errors["user"][0]

--- a/apps/evergo/forms.py
+++ b/apps/evergo/forms.py
@@ -4,7 +4,6 @@ import re
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.forms import ModelForm
 from django.utils import timezone
 
 from apps.core.admin import OwnableAdminForm
@@ -170,6 +169,10 @@ class EvergoContractorLoginWizardForm(forms.ModelForm):
 class EvergoUserAdminForm(OwnableAdminForm):
     """Allow user/group/avatar ownership while defaulting new records to the acting user."""
 
+    owner_field_names = ("user", "group", "avatar")
+    owner_conflict_message = "Choose exactly one owner: user, security group, or avatar."
+    owner_required_message = "Choose a user, security group, or avatar owner for this contractor."
+
     class Meta:
         model = EvergoUser
         fields = "__all__"
@@ -178,25 +181,16 @@ class EvergoUserAdminForm(OwnableAdminForm):
         super().__init__(*args, **kwargs)
         self.request_user = request_user
 
-    def clean(self):
-        cleaned_data = ModelForm.clean(self)
-        owners = [cleaned_data.get(field_name) for field_name in ("user", "group", "avatar")]
+    def normalize_owner_data(self, cleaned):
+        owners = [cleaned.get(field_name) for field_name in self.owner_field_names]
         owner_count = sum(owner is not None for owner in owners)
-        if owner_count > 1:
-            raise ValidationError("Choose exactly one owner: user, security group, or avatar.")
-
         if (
             owner_count == 0
             and not self.instance.pk
             and getattr(self.request_user, "is_authenticated", False)
         ):
-            cleaned_data["user"] = self.request_user
-            owner_count = 1
-
-        owner_required = getattr(self._meta.model, "owner_required", self.owner_required)
-        if owner_required and owner_count == 0:
-            raise ValidationError("Choose a user, security group, or avatar owner for this contractor.")
-        return cleaned_data
+            cleaned["user"] = self.request_user
+        return cleaned
 
 
 class EvergoOrderTrackingForm(forms.Form):

--- a/apps/evergo/forms.py
+++ b/apps/evergo/forms.py
@@ -5,6 +5,7 @@ import re
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from apps.core.admin import OwnableAdminForm
 
@@ -170,8 +171,8 @@ class EvergoUserAdminForm(OwnableAdminForm):
     """Allow user/group/avatar ownership while defaulting new records to the acting user."""
 
     owner_field_names = ("user", "group", "avatar")
-    owner_conflict_message = "Choose exactly one owner: user, security group, or avatar."
-    owner_required_message = "Choose a user, security group, or avatar owner for this contractor."
+    owner_conflict_message = _("Choose exactly one owner: user, security group, or avatar.")
+    owner_required_message = _("Choose a user, security group, or avatar owner for this contractor.")
 
     class Meta:
         model = EvergoUser

--- a/apps/evergo/tests/test_admin_wizard.py
+++ b/apps/evergo/tests/test_admin_wizard.py
@@ -14,7 +14,7 @@ from apps.evergo.admin import (
     _build_loaded_entities_links,
     _run_contract_login_validation,
 )
-from apps.evergo.forms import EvergoContractorLoginWizardForm
+from apps.evergo.forms import EvergoContractorLoginWizardForm, EvergoUserAdminForm
 from apps.evergo.models import EvergoUser
 from apps.groups.models import SecurityGroup
 
@@ -94,6 +94,33 @@ def test_contractor_login_wizard_form_requires_validation_for_order_numbers():
 
     assert not form.is_valid()
     assert "order_numbers" in form.errors
+
+
+@pytest.mark.django_db
+def test_evergo_user_admin_form_defaults_owner_to_request_user_on_create():
+    """Create form should assign the acting admin when no owner fields are provided."""
+    User = get_user_model()
+    acting_user = User.objects.create_user(username="acting-owner", email="acting-owner@example.com")
+    form = EvergoUserAdminForm(
+        data={
+            "evergo_email": "contractor@example.com",
+            "evergo_password": "top-secret",  # noqa: S106
+        },
+        instance=EvergoUser(),
+        request_user=acting_user,
+    )
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["user"] == acting_user
+
+
+def test_evergo_user_admin_form_reads_owner_required_from_model_metadata(monkeypatch):
+    """Owner-required logic should resolve from model metadata before validation executes."""
+    form = EvergoUserAdminForm(instance=EvergoUser(), request_user=None)
+    assert form._resolved_owner_required() is False
+
+    monkeypatch.setattr(EvergoUser, "owner_required", True)
+    assert form._resolved_owner_required() is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- Make owner validation reusable and configurable so different apps can declare alternative owner fields without duplicating logic. 
- Support “exactly one owner” and model-driven owner-required behavior so forms can express stricter ownership rules when needed. 
- Reduce Evergo-specific duplication by letting `EvergoUserAdminForm` configure a shared admin form hook rather than reimplement `clean()`.

### Description
- Introduced configurable ownership hooks on `OwnableAdminForm` (`owner_field_names`, `owner_exactly_one`) and message attributes, plus helpers `_configured_owner_field_names()`, `_resolved_owner_required()`, and `_owner_validation_message()` to centralize validation. 
- Added `normalize_owner_data()` hook to `OwnableAdminForm` so subclasses can set defaults before validation runs and updated `clean()` to validate against the configured owner fields and modes. 
- Updated `EvergoUserAdminForm` to set `owner_field_names = ("user", "group", "avatar")` and implemented `normalize_owner_data()` to preserve previously‑expected behavior of defaulting new records to the acting `request_user`. 
- Added/updated tests to cover the new behavior (`apps/evergo/tests/test_admin_wizard.py`, `apps/core/tests/test_ownable.py`) and adjusted imports where necessary.

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed pytest extras via `.venv/bin/pip install pytest pytest-django pytest-timeout`. 
- Ran the focused test-suite with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_admin_wizard.py apps/core/tests/test_ownable.py`. 
- Test result: all tests in those targets passed (`14 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c08442048326a01ffd0ff6fea621)