### PR TITLE
core: refactor Odoo employee password handling to use MaskedPasswordFormMixin

### DIFF
--- a/apps/core/admin/forms.py
+++ b/apps/core/admin/forms.py
@@ -160,19 +160,30 @@ class MaskedPasswordFormMixin:
         field.widget.attrs.setdefault("autocomplete", "new-password")
         field.help_text = field.help_text or "Leave blank to keep the current password."
         if self.instance.pk:
+            field.required = False
             field.initial = ""
             self.initial[self.password_field_name] = ""
         else:
             field.required = True
 
-    def clean_password(self):
+    def _clean_password_field(self, cleaned_data):
         field = self.fields.get(self.password_field_name)
         if field is None:
-            return self.cleaned_data.get(self.password_field_name)
-        pwd = self.cleaned_data.get(self.password_field_name)
+            return cleaned_data
+        pwd = cleaned_data.get(self.password_field_name)
         if not pwd and self.instance.pk:
-            return keep_existing(self.password_field_name)
-        return pwd
+            cleaned_data[self.password_field_name] = keep_existing(
+                self.password_field_name
+            )
+        return cleaned_data
+
+    def clean_password(self):
+        cleaned_data = self._clean_password_field(self.cleaned_data)
+        return cleaned_data.get(self.password_field_name)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        return self._clean_password_field(cleaned_data)
 
     def _post_clean(self):
         super()._post_clean()
@@ -184,7 +195,6 @@ class OdooEmployeeAdminForm(MaskedPasswordFormMixin, forms.ModelForm):
     """Admin form for :class:`core.models.OdooEmployee` with hidden password."""
 
     password = forms.CharField(
-        widget=forms.PasswordInput(render_value=True),
         required=False,
         help_text="Leave blank to keep the current password.",
     )

--- a/apps/core/admin/forms.py
+++ b/apps/core/admin/forms.py
@@ -140,7 +140,47 @@ class UserDiagnosticsProfileInlineForm(forms.ModelForm):
         fields = ("is_enabled", "collect_diagnostics", "allow_manual_feedback")
 
 
-class OdooEmployeeAdminForm(forms.ModelForm):
+class MaskedPasswordFormMixin:
+    """Mixin that hides stored passwords while allowing updates."""
+
+    password_field_name = "password"
+    password_field_render_value: bool | None = None
+    password_sigil_fields: tuple[str, ...] = ()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        field = self.fields.get(self.password_field_name)
+        if field is None:
+            return
+        render_value = self.password_field_render_value
+        if not isinstance(field.widget, forms.PasswordInput):
+            field.widget = forms.PasswordInput(render_value=bool(render_value))
+        elif render_value is not None:
+            field.widget.render_value = render_value
+        field.widget.attrs.setdefault("autocomplete", "new-password")
+        field.help_text = field.help_text or "Leave blank to keep the current password."
+        if self.instance.pk:
+            field.initial = ""
+            self.initial[self.password_field_name] = ""
+        else:
+            field.required = True
+
+    def clean_password(self):
+        field = self.fields.get(self.password_field_name)
+        if field is None:
+            return self.cleaned_data.get(self.password_field_name)
+        pwd = self.cleaned_data.get(self.password_field_name)
+        if not pwd and self.instance.pk:
+            return keep_existing(self.password_field_name)
+        return pwd
+
+    def _post_clean(self):
+        super()._post_clean()
+        if self.password_sigil_fields:
+            _restore_sigil_values(self, self.password_sigil_fields)
+
+
+class OdooEmployeeAdminForm(MaskedPasswordFormMixin, forms.ModelForm):
     """Admin form for :class:`core.models.OdooEmployee` with hidden password."""
 
     password = forms.CharField(
@@ -148,31 +188,12 @@ class OdooEmployeeAdminForm(forms.ModelForm):
         required=False,
         help_text="Leave blank to keep the current password.",
     )
+    password_field_render_value = True
+    password_sigil_fields = ("host", "database", "username", "password")
 
     class Meta:
         model = OdooEmployee
         fields = "__all__"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.instance.pk:
-            self.fields["password"].initial = ""
-            self.initial["password"] = ""
-        else:
-            self.fields["password"].required = True
-
-    def clean_password(self):
-        pwd = self.cleaned_data.get("password")
-        if not pwd and self.instance.pk:
-            return keep_existing("password")
-        return pwd
-
-    def _post_clean(self):
-        super()._post_clean()
-        _restore_sigil_values(
-            self,
-            ["host", "database", "username", "password"],
-        )
 
 
 class PaymentProcessorAdminForm(forms.ModelForm):
@@ -324,41 +345,6 @@ class StripeProcessorAdminForm(PaymentProcessorAdminForm):
                 _("Provide Stripe secret and publishable keys to configure Stripe.")
             )
         return cleaned
-
-
-class MaskedPasswordFormMixin:
-    """Mixin that hides stored passwords while allowing updates."""
-
-    password_sigil_fields: tuple[str, ...] = ()
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        field = self.fields.get("password")
-        if field is None:
-            return
-        if not isinstance(field.widget, forms.PasswordInput):
-            field.widget = forms.PasswordInput()
-        field.widget.attrs.setdefault("autocomplete", "new-password")
-        field.help_text = field.help_text or "Leave blank to keep the current password."
-        if self.instance.pk:
-            field.initial = ""
-            self.initial["password"] = ""
-        else:
-            field.required = True
-
-    def clean_password(self):
-        field = self.fields.get("password")
-        if field is None:
-            return self.cleaned_data.get("password")
-        pwd = self.cleaned_data.get("password")
-        if not pwd and self.instance.pk:
-            return keep_existing("password")
-        return pwd
-
-    def _post_clean(self):
-        super()._post_clean()
-        if self.password_sigil_fields:
-            _restore_sigil_values(self, self.password_sigil_fields)
 
 
 class EmailInboxAdminForm(MaskedPasswordFormMixin, forms.ModelForm):

--- a/apps/core/tests/test_admin_forms.py
+++ b/apps/core/tests/test_admin_forms.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from django import forms
 
 import pytest
 
-from apps.core.admin.forms import KeepExistingValue, OdooEmployeeAdminForm
+from apps.core.admin.forms import (
+    KeepExistingValue,
+    MaskedPasswordFormMixin,
+    OdooEmployeeAdminForm,
+)
 from apps.odoo.models import OdooEmployee
 
 
@@ -60,3 +66,17 @@ class TestMaskedPasswordFormMixinSupport:
 
         assert isinstance(form.fields["password"].widget, forms.PasswordInput)
         assert form.fields["password"].widget.render_value is True
+
+    def test_configurable_password_field_name_uses_keep_existing_on_update(self):
+        class DummyForm(MaskedPasswordFormMixin, forms.Form):
+            password_field_name = "secret"
+            secret = forms.CharField(required=False)
+
+            def __init__(self, *args, instance=None, **kwargs):
+                self.instance = instance or SimpleNamespace(pk=None)
+                super().__init__(*args, **kwargs)
+
+        form = DummyForm(data={"secret": ""}, instance=SimpleNamespace(pk=1))
+
+        assert form.is_valid(), form.errors
+        assert isinstance(form.cleaned_data["secret"], KeepExistingValue)

--- a/apps/core/tests/test_admin_forms.py
+++ b/apps/core/tests/test_admin_forms.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from django import forms
+
+import pytest
+
+from apps.core.admin.forms import KeepExistingValue, OdooEmployeeAdminForm
+from apps.odoo.models import OdooEmployee
+
+
+@pytest.mark.django_db
+def test_odoo_employee_admin_form_requires_password_on_create(admin_user):
+    """Creating an Odoo employee requires a password."""
+
+    form = OdooEmployeeAdminForm(
+        data={
+            "user": str(admin_user.pk),
+            "host": "https://odoo.example.com",
+            "database": "odoodb",
+            "username": "admin",
+            "password": "",
+        }
+    )
+
+    assert not form.is_valid()
+    assert "password" in form.errors
+
+
+@pytest.mark.django_db
+def test_odoo_employee_admin_form_keeps_existing_password_for_updates(admin_user):
+    """Blank password edits keep the stored credential value."""
+
+    employee = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoodb",
+        username="admin",
+        password="stored-secret",
+    )
+    form = OdooEmployeeAdminForm(
+        instance=employee,
+        data={
+            "user": str(admin_user.pk),
+            "host": "https://odoo.example.com",
+            "database": "odoodb",
+            "username": "admin",
+            "password": "",
+        },
+    )
+
+    assert form.is_valid(), form.errors
+    assert isinstance(form.cleaned_data["password"], KeepExistingValue)
+    assert form.instance.password == "stored-secret"
+
+
+@pytest.mark.django_db
+class TestMaskedPasswordFormMixinSupport:
+    def test_odoo_employee_password_widget_keeps_render_value_true(self):
+        form = OdooEmployeeAdminForm()
+
+        assert isinstance(form.fields["password"].widget, forms.PasswordInput)
+        assert form.fields["password"].widget.render_value is True


### PR DESCRIPTION
### Motivation
- Remove duplicated per-form password masking logic and centralize behavior in a reusable mixin. 
- Allow forms to opt into `render_value=True` and specify which sigil fields to restore without special-casing each form. 
- Preserve current create/update semantics for Odoo employee credentials (password required on create; blank on update keeps stored value).

### Description
- Extended `MaskedPasswordFormMixin` to expose `password_field_name`, `password_field_render_value`, and `password_sigil_fields` and to centralize widget initialization, `render_value` handling, `autocomplete` attribute, help text, required-on-create logic, keep-existing semantics, and post-clean sigil restoration (file: `apps/core/admin/forms.py`).
- Refactored `OdooEmployeeAdminForm` to inherit from the mixin, set `password_field_render_value = True` and `password_sigil_fields = ("host", "database", "username", "password")`, and removed its local `__init__`, `clean_password`, and `_post_clean` implementations (file: `apps/core/admin/forms.py`).
- Added focused admin-form tests covering required-on-create behavior, keep-existing update behavior and sigil restoration, and `render_value=True` handling (file: `apps/core/tests/test_admin_forms.py`).

### Testing
- Ran environment prep with `./env-refresh.sh --deps-only` which completed successfully. 
- Installed CI test deps with `.venv/bin/python -m pip install -r requirements-ci.txt` which completed successfully. 
- Executed the new tests with `.venv/bin/python manage.py test run -- apps/core/tests/test_admin_forms.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c06b04bc83268e7d441eeea0bdd0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors password-handling logic for Odoo employee forms by extending `MaskedPasswordFormMixin` to be more configurable and reusable across different forms.

## Changes

**apps/core/admin/forms.py**
- Extended `MaskedPasswordFormMixin` with three configurable class attributes:
  - `password_field_name`: Allows targeting different password field names (defaults to `"password"`)
  - `password_field_render_value`: Controls whether the password widget renders existing values (defaults to `None`)
  - `password_sigil_fields`: Specifies which fields to restore as sigil values after password updates (defaults to empty tuple)
- Updated mixin methods (`__init__`, `clean_password`, `_post_clean`) to use these attributes, eliminating hard-coded assumptions
- Refactored `OdooEmployeeAdminForm` to inherit from the mixin and set:
  - `password_field_render_value = True` to display masked existing passwords
  - `password_sigil_fields = ("host", "database", "username", "password")` to restore credential context after updates
- Removed duplicate password-handling logic that was previously local to `OdooEmployeeAdminForm`

**apps/core/tests/test_admin_forms.py** (new file)
- Added tests covering:
  - Required password validation on form creation
  - Keep-existing behavior: blank password submissions on updates retain the stored value
  - Sigil field restoration after password updates
  - Password widget configuration with `render_value=True`

## Impact
- Centralizes password masking and credential handling logic, reducing code duplication
- Makes the mixin reusable for other forms requiring similar password behavior
- Preserves existing semantics: passwords required on create; blank submissions on updates keep stored values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->