### PR TITLE
Share CustomerAccountRFIDForm between core and energy admin forms

### DIFF
--- a/apps/core/admin/forms.py
+++ b/apps/core/admin/forms.py
@@ -11,7 +11,7 @@ from import_export.forms import (
 from apps.cards.models import RFID
 from apps.core.widgets import OdooProductWidget
 from apps.emails.models import EmailInbox, EmailOutbox
-from apps.energy.models import CustomerAccount
+from apps.energy.admin.forms_shared import CustomerAccountRFIDForm
 from apps.odoo.models import OdooEmployee, OdooProduct
 from apps.payments.models.openpay import OpenPayProcessor
 from apps.payments.models.paypal import PayPalProcessor
@@ -66,22 +66,6 @@ def _restore_sigil_values(form, field_names):
         else:
             raw = _raw_instance_value(form.instance, name)
         setattr(form.instance, name, raw)
-
-
-class CustomerAccountRFIDForm(forms.ModelForm):
-    """Form for assigning existing RFIDs to a customer account."""
-
-    class Meta:
-        model = CustomerAccount.rfids.through
-        fields = ["rfid"]
-
-    def clean_rfid(self):
-        rfid = self.cleaned_data["rfid"]
-        if rfid.energy_accounts.exclude(pk=self.instance.customeraccount_id).exists():
-            raise forms.ValidationError(
-                "RFID is already assigned to another customer account"
-            )
-        return rfid
 
 
 class UserCreationWithExpirationForm(UserCreationForm):

--- a/apps/energy/admin/forms.py
+++ b/apps/energy/admin/forms.py
@@ -3,23 +3,7 @@ from __future__ import annotations
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from ..models import CustomerAccount
-
-
-class CustomerAccountRFIDForm(forms.ModelForm):
-    """Form for assigning existing RFIDs to a customer account."""
-
-    class Meta:
-        model = CustomerAccount.rfids.through
-        fields = ["rfid"]
-
-    def clean_rfid(self):
-        rfid = self.cleaned_data["rfid"]
-        if rfid.energy_accounts.exclude(pk=self.instance.customeraccount_id).exists():
-            raise forms.ValidationError(
-                "RFID is already assigned to another customer account"
-            )
-        return rfid
+from .forms_shared import CustomerAccountRFIDForm
 
 
 class OdooCustomerSearchForm(forms.Form):

--- a/apps/energy/admin/forms_shared.py
+++ b/apps/energy/admin/forms_shared.py
@@ -1,0 +1,19 @@
+from django import forms
+
+from ..models import CustomerAccount
+
+
+class CustomerAccountRFIDForm(forms.ModelForm):
+    """Form for assigning existing RFIDs to a customer account."""
+
+    class Meta:
+        model = CustomerAccount.rfids.through
+        fields = ["rfid"]
+
+    def clean_rfid(self):
+        rfid = self.cleaned_data["rfid"]
+        if rfid.energy_accounts.exclude(pk=self.instance.customeraccount_id).exists():
+            raise forms.ValidationError(
+                "RFID is already assigned to another customer account"
+            )
+        return rfid


### PR DESCRIPTION
### Motivation
- Reduce duplicate code by providing a single shared implementation of `CustomerAccountRFIDForm` for admin use across apps.
- Keep the existing validation and model wiring intact while centralizing the form for easier maintenance.

### Description
- Added `apps/energy/admin/forms_shared.py` containing the unchanged `CustomerAccountRFIDForm` implementation targeting `CustomerAccount.rfids.through` and preserving the original `clean_rfid` validation.
- Replaced the local class in `apps/energy/admin/forms.py` with an import: `from .forms_shared import CustomerAccountRFIDForm`.
- Replaced the duplicate class in `apps/core/admin/forms.py` with an import: `from apps.energy.admin.forms_shared import CustomerAccountRFIDForm`.
- Removed the duplicated class definitions so there is a single canonical implementation.

### Testing
- Verified there is only one definition remaining with `rg "^class CustomerAccountRFIDForm" -n apps` and it reported only `apps/energy/admin/forms_shared.py`.
- Compiled the affected modules successfully with `.venv/bin/python -m compileall apps/core/admin/forms.py apps/energy/admin/forms.py apps/energy/admin/forms_shared.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c0414b9c8326859efa4475a1245f)