### PR TITLE
repos: centralize GitHub fetch admin action workflow

### DIFF
--- a/apps/repos/admin.py
+++ b/apps/repos/admin.py
@@ -24,6 +24,38 @@ class FetchFromGitHubMixin(DjangoObjectActions):
     changelist_actions: list[str] = []
     dashboard_actions: list[str] = []
 
+    def _run_fetch_from_github_action(
+        self,
+        request,
+        *,
+        sync_function,
+        error_message_template,
+        success_message_template,
+        empty_state_message_template,
+    ):
+        try:
+            created, updated = sync_function()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.message_user(
+                request,
+                error_message_template % {"error": exc},
+                level=messages.ERROR,
+            )
+            return self._redirect_to_changelist()
+
+        if created or updated:
+            message = success_message_template % {
+                "created": created,
+                "updated": updated,
+            }
+            level = messages.SUCCESS
+        else:
+            message = empty_state_message_template
+            level = messages.INFO
+
+        self.message_user(request, message, level=level)
+        return self._redirect_to_changelist()
+
     def _redirect_to_changelist(self):
         opts = self.model._meta
         return HttpResponseRedirect(
@@ -59,28 +91,15 @@ class RepositoryIssueAdmin(
     raw_id_fields = ("repository",)
 
     def fetch_open_issues(self, request, queryset=None):
-        try:
-            created, updated = RepositoryIssue.fetch_open_issues()
-        except Exception as exc:  # pragma: no cover - defensive
-            self.message_user(
-                request,
-                _("Failed to fetch issues from GitHub: %s") % (exc,),
-                level=messages.ERROR,
-            )
-            return self._redirect_to_changelist()
-
-        if created or updated:
-            message = _("Fetched %(created)s new and %(updated)s updated issues.") % {
-                "created": created,
-                "updated": updated,
-            }
-            level = messages.SUCCESS
-        else:
-            message = _("No open issues found to sync.")
-            level = messages.INFO
-
-        self.message_user(request, message, level=level)
-        return self._redirect_to_changelist()
+        return self._run_fetch_from_github_action(
+            request,
+            sync_function=RepositoryIssue.fetch_open_issues,
+            error_message_template=_("Failed to fetch issues from GitHub: %(error)s"),
+            success_message_template=_(
+                "Fetched %(created)s new and %(updated)s updated issues."
+            ),
+            empty_state_message_template=_("No open issues found to sync."),
+        )
 
     fetch_open_issues.label = _("Fetch Open")
     fetch_open_issues.short_description = _("Fetch Open")
@@ -109,30 +128,17 @@ class RepositoryPullRequestAdmin(FetchFromGitHubMixin, admin.ModelAdmin):
     raw_id_fields = ("repository",)
 
     def fetch_open_pull_requests(self, request, queryset=None):
-        try:
-            created, updated = RepositoryPullRequest.fetch_open_pull_requests()
-        except Exception as exc:  # pragma: no cover - defensive
-            self.message_user(
-                request,
-                _("Failed to fetch pull requests from GitHub: %s") % (exc,),
-                level=messages.ERROR,
-            )
-            return self._redirect_to_changelist()
-
-        if created or updated:
-            message = _(
+        return self._run_fetch_from_github_action(
+            request,
+            sync_function=RepositoryPullRequest.fetch_open_pull_requests,
+            error_message_template=_(
+                "Failed to fetch pull requests from GitHub: %(error)s"
+            ),
+            success_message_template=_(
                 "Fetched %(created)s new and %(updated)s updated pull requests."
-            ) % {
-                "created": created,
-                "updated": updated,
-            }
-            level = messages.SUCCESS
-        else:
-            message = _("No open pull requests found to sync.")
-            level = messages.INFO
-
-        self.message_user(request, message, level=level)
-        return self._redirect_to_changelist()
+            ),
+            empty_state_message_template=_("No open pull requests found to sync."),
+        )
 
     fetch_open_pull_requests.label = _("Fetch Open")
     fetch_open_pull_requests.short_description = _("Fetch Open")

--- a/apps/repos/admin.py
+++ b/apps/repos/admin.py
@@ -35,7 +35,7 @@ class FetchFromGitHubMixin(DjangoObjectActions):
     ):
         try:
             created, updated = sync_function()
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:
             self.message_user(
                 request,
                 error_message_template % {"error": exc},

--- a/apps/repos/tests/test_admin_fetch_actions.py
+++ b/apps/repos/tests/test_admin_fetch_actions.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from django.contrib import admin, messages
+from django.test import RequestFactory
+from django.utils.translation import gettext_lazy as _
+
+from apps.repos.admin import RepositoryIssueAdmin, RepositoryPullRequestAdmin
+from apps.repos.models.issues import RepositoryIssue, RepositoryPullRequest
+
+
+def _make_request():
+    return RequestFactory().post("/admin/repos/")
+
+
+@pytest.mark.django_db
+def test_run_fetch_from_github_action_emits_success_message_and_redirects():
+    model_admin = RepositoryIssueAdmin(RepositoryIssue, admin.site)
+    request = _make_request()
+    model_admin.message_user = Mock()
+
+    response = model_admin._run_fetch_from_github_action(
+        request,
+        sync_function=lambda: (3, 2),
+        error_message_template=_("Failed: %(error)s"),
+        success_message_template=_("Fetched %(created)s/%(updated)s"),
+        empty_state_message_template=_("No data"),
+    )
+
+    assert response.status_code == 302
+    model_admin.message_user.assert_called_once_with(
+        request,
+        "Fetched 3/2",
+        level=messages.SUCCESS,
+    )
+
+
+@pytest.mark.django_db
+def test_run_fetch_from_github_action_emits_empty_state_message_and_redirects():
+    model_admin = RepositoryIssueAdmin(RepositoryIssue, admin.site)
+    request = _make_request()
+    model_admin.message_user = Mock()
+
+    response = model_admin._run_fetch_from_github_action(
+        request,
+        sync_function=lambda: (0, 0),
+        error_message_template=_("Failed: %(error)s"),
+        success_message_template=_("Fetched %(created)s/%(updated)s"),
+        empty_state_message_template=_("No data"),
+    )
+
+    assert response.status_code == 302
+    model_admin.message_user.assert_called_once_with(
+        request,
+        "No data",
+        level=messages.INFO,
+    )
+
+
+@pytest.mark.django_db
+def test_run_fetch_from_github_action_emits_error_message_and_redirects():
+    model_admin = RepositoryIssueAdmin(RepositoryIssue, admin.site)
+    request = _make_request()
+    model_admin.message_user = Mock()
+
+    def failing_sync():
+        raise RuntimeError("boom")
+
+    response = model_admin._run_fetch_from_github_action(
+        request,
+        sync_function=failing_sync,
+        error_message_template=_("Failed: %(error)s"),
+        success_message_template=_("Fetched %(created)s/%(updated)s"),
+        empty_state_message_template=_("No data"),
+    )
+
+    assert response.status_code == 302
+    model_admin.message_user.assert_called_once_with(
+        request,
+        "Failed: boom",
+        level=messages.ERROR,
+    )
+
+
+@pytest.mark.django_db
+def test_fetch_open_actions_delegate_to_shared_helper(monkeypatch):
+    issue_admin = RepositoryIssueAdmin(RepositoryIssue, admin.site)
+    pull_request_admin = RepositoryPullRequestAdmin(RepositoryPullRequest, admin.site)
+    request = _make_request()
+    sentinel = object()
+    issue_call = {}
+    pull_request_call = {}
+
+    def fake_issue_runner(req, **kwargs):
+        issue_call["request"] = req
+        issue_call.update(kwargs)
+        return sentinel
+
+    def fake_pull_request_runner(req, **kwargs):
+        pull_request_call["request"] = req
+        pull_request_call.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(issue_admin, "_run_fetch_from_github_action", fake_issue_runner)
+    monkeypatch.setattr(
+        pull_request_admin,
+        "_run_fetch_from_github_action",
+        fake_pull_request_runner,
+    )
+
+    issue_result = issue_admin.fetch_open_issues(request)
+    pull_request_result = pull_request_admin.fetch_open_pull_requests(request)
+    issue_sync_function = issue_call["sync_function"]
+    pull_request_sync_function = pull_request_call["sync_function"]
+
+    assert issue_result is sentinel
+    assert issue_call["request"] is request
+    assert issue_sync_function.__self__ is RepositoryIssue
+    assert issue_sync_function.__func__ is RepositoryIssue.fetch_open_issues.__func__
+    assert str(issue_call["error_message_template"]) == "Failed to fetch issues from GitHub: %(error)s"
+    assert (
+        str(issue_call["success_message_template"])
+        == "Fetched %(created)s new and %(updated)s updated issues."
+    )
+    assert str(issue_call["empty_state_message_template"]) == "No open issues found to sync."
+
+    assert pull_request_result is sentinel
+    assert pull_request_call["request"] is request
+    assert pull_request_sync_function.__self__ is RepositoryPullRequest
+    assert (
+        pull_request_sync_function.__func__
+        is RepositoryPullRequest.fetch_open_pull_requests.__func__
+    )
+    assert (
+        str(pull_request_call["error_message_template"])
+        == "Failed to fetch pull requests from GitHub: %(error)s"
+    )
+    assert (
+        str(pull_request_call["success_message_template"])
+        == "Fetched %(created)s new and %(updated)s updated pull requests."
+    )
+    assert (
+        str(pull_request_call["empty_state_message_template"])
+        == "No open pull requests found to sync."
+    )


### PR DESCRIPTION
### Motivation

- Remove duplicated try/except, message emission, and changelist redirect logic across GitHub fetch admin actions to improve maintainability and reduce drift. 
- Provide a single reusable helper for future fetch-style admin actions while preserving current action labels and metadata.

### Description

- Add `_run_fetch_from_github_action` to `FetchFromGitHubMixin` in `apps/repos/admin.py` to accept a sync callable and error/success/empty-state message templates and centralize execution, exception handling, `message_user(...)`, and changelist redirect. 
- Refactor `RepositoryIssueAdmin.fetch_open_issues` and `RepositoryPullRequestAdmin.fetch_open_pull_requests` to delegate to the new helper and keep only action-specific callables and templates. 
- Preserve existing action metadata (`label`, `short_description`, `requires_queryset = False`) for both admin actions. 
- Add focused regression tests in `apps/repos/tests/test_admin_fetch_actions.py` that validate success, empty-state, and error flows and assert both actions delegate to the shared helper with the expected callables/templates.

### Testing

- Ran environment preparation commands: `./env-refresh.sh --deps-only` and `./env-refresh.sh` (dependency refresh completed). 
- Installed test dependencies with `.venv/bin/pip install pytest pytest-django pytest-timeout` to satisfy test runner requirements. 
- Executed the targeted tests with `.venv/bin/python manage.py test run -- apps/repos/tests/test_admin_fetch_actions.py` which ultimately passed: `4 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c04dff188326a77a5f11f64b0255)