### PR TITLE
Add MediaUploadAdminFormMixin and refactor CardFace/SSH forms

### DIFF
--- a/apps/cards/forms.py
+++ b/apps/cards/forms.py
@@ -7,8 +7,8 @@ from django.utils.translation import gettext_lazy as _
 from apps.cards import mse
 from apps.cards.models import CardFace, CardSet, OfferingSoul, get_cardface_bucket
 from apps.cards.soul import MAX_UPLOAD_BYTES, SoulDerivationError
+from apps.media.forms_mixins import MediaUploadAdminFormMixin
 from apps.media.models import MediaFile
-from apps.media.utils import create_media_file
 
 
 class CardFacePreviewForm(forms.Form):
@@ -52,12 +52,19 @@ class CardFacePreviewForm(forms.Form):
         return overrides
 
 
-class CardFaceAdminForm(forms.ModelForm):
+class CardFaceAdminForm(MediaUploadAdminFormMixin, forms.ModelForm):
     background_upload = forms.ImageField(
         required=False,
         label=_("Background upload"),
         help_text=_("Upload a printable background image for this card face."),
     )
+    media_upload_bindings = {
+        "background_upload": {
+            "media_field": "background_media",
+            "bucket_provider": get_cardface_bucket,
+            "extra_validator": CardFace.validate_background_file,
+        },
+    }
 
     class Meta:
         model = CardFace
@@ -65,8 +72,7 @@ class CardFaceAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        bucket = get_cardface_bucket()
-        self.fields["background_media"].queryset = MediaFile.objects.filter(bucket=bucket)
+        self.setup_bucket_aware_querysets()
 
     def clean(self):
         cleaned = super().clean()
@@ -74,26 +80,27 @@ class CardFaceAdminForm(forms.ModelForm):
         background_upload = cleaned.get("background_upload")
         if not background_media and not background_upload:
             raise ValidationError({"background_media": _("A background image is required.")})
-        if background_upload:
-            bucket = get_cardface_bucket()
-            if not bucket.allows_filename(background_upload.name):
-                raise ValidationError({"background_upload": _("File type is not allowed.")})
-            if not bucket.allows_size(background_upload.size):
-                raise ValidationError({"background_upload": _("File exceeds the allowed size.")})
-            CardFace.validate_background_file(background_upload)
+        if background_upload and not background_media:
+            bucket = self.get_media_bucket(get_cardface_bucket)
+            cleaned["background_media"] = MediaFile(
+                bucket=bucket,
+                file=background_upload,
+                original_name=background_upload.name,
+                content_type=getattr(background_upload, "content_type", "") or "",
+                size=getattr(background_upload, "size", 0) or 0,
+            )
         return cleaned
 
     def save(self, commit=True):
         instance = super().save(commit=False)
-        upload = self.cleaned_data.get("background_upload")
-        if upload:
-            bucket = get_cardface_bucket()
-            media_file = create_media_file(bucket=bucket, uploaded_file=upload)
-            instance.background_media = media_file
+        self.store_uploads_on_instance(instance)
         if commit:
             instance.save()
             self.save_m2m()
         return instance
+
+    def clean_background_upload(self):
+        return self.clean_upload_field("background_upload")
 
 
 class CardSetUploadForm(forms.Form):

--- a/apps/cards/tests/test_forms.py
+++ b/apps/cards/tests/test_forms.py
@@ -5,6 +5,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 
 from apps.cards.forms import CardFaceAdminForm
 from apps.cards.models import CardFace, get_cardface_bucket
+from apps.media import forms_mixins
 from apps.media.models import MediaFile
 
 
@@ -58,3 +59,24 @@ def test_cardface_form_upload_creates_media_file():
     instance = form.save(commit=False)
     assert instance.background_media is not None
     assert instance.background_media.original_name == "fresh.png"
+
+
+@pytest.mark.django_db
+def test_cardface_form_upload_rewinds_stream_before_media_persist(monkeypatch):
+    observed_positions = []
+    original_create = forms_mixins.create_media_file
+
+    def observing_create_media_file(*, bucket, uploaded_file):
+        observed_positions.append(uploaded_file.tell())
+        return original_create(bucket=bucket, uploaded_file=uploaded_file)
+
+    monkeypatch.setattr(forms_mixins, "create_media_file", observing_create_media_file)
+
+    form = CardFaceAdminForm(
+        data=_cardface_data(name="Uploaded media rewind"),
+        files={"background_upload": _image_file(name="rewind.png")},
+    )
+
+    assert form.is_valid()
+    form.save(commit=False)
+    assert observed_positions == [0]

--- a/apps/cards/tests/test_forms.py
+++ b/apps/cards/tests/test_forms.py
@@ -1,0 +1,60 @@
+import io
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from apps.cards.forms import CardFaceAdminForm
+from apps.cards.models import CardFace, get_cardface_bucket
+from apps.media.models import MediaFile
+
+
+def _cardface_data(**overrides):
+    payload = {
+        "name": "Card face",
+        "overlay_one_font_size": 28,
+        "overlay_one_x": 0,
+        "overlay_one_y": 0,
+        "overlay_two_font_size": 24,
+        "overlay_two_x": 0,
+        "overlay_two_y": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _image_file(mode="1", size=(64, 64), name="bg.png"):
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new(mode, size=size, color=1).save(buffer, format="PNG")
+    return SimpleUploadedFile(name, buffer.getvalue(), content_type="image/png")
+
+
+@pytest.mark.django_db
+def test_cardface_form_accepts_existing_background_media_without_upload():
+    bucket = get_cardface_bucket()
+    media = MediaFile.objects.create(
+        bucket=bucket,
+        file=_image_file(name="existing.png"),
+        original_name="existing.png",
+        content_type="image/png",
+        size=32,
+    )
+    form = CardFaceAdminForm(data=_cardface_data(name="Existing media", background_media=media.pk))
+
+    assert form.is_valid()
+    instance = form.save(commit=False)
+    assert instance.background_media_id == media.pk
+
+
+@pytest.mark.django_db
+def test_cardface_form_upload_creates_media_file():
+    form = CardFaceAdminForm(
+        data=_cardface_data(name="Uploaded media"),
+        files={"background_upload": _image_file(name="fresh.png")},
+    )
+
+    assert form.is_valid()
+    instance = form.save(commit=False)
+    assert instance.background_media is not None
+    assert instance.background_media.original_name == "fresh.png"

--- a/apps/credentials/forms.py
+++ b/apps/credentials/forms.py
@@ -1,15 +1,24 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from apps.media.models import MediaFile
-from apps.media.utils import create_media_file
+from apps.media.forms_mixins import MediaUploadAdminFormMixin
 
 from .models import SSHAccount, get_ssh_key_bucket
 
 
-class SSHAccountAdminForm(forms.ModelForm):
+class SSHAccountAdminForm(MediaUploadAdminFormMixin, forms.ModelForm):
     private_key_upload = forms.FileField(required=False, label=_("Private key upload"))
     public_key_upload = forms.FileField(required=False, label=_("Public key upload"))
+    media_upload_bindings = {
+        "private_key_upload": {
+            "media_field": "private_key_media",
+            "bucket_provider": get_ssh_key_bucket,
+        },
+        "public_key_upload": {
+            "media_field": "public_key_media",
+            "bucket_provider": get_ssh_key_bucket,
+        },
+    }
 
     class Meta:
         model = SSHAccount
@@ -17,42 +26,18 @@ class SSHAccountAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        bucket = self._get_ssh_key_bucket()
-        self.fields["private_key_media"].queryset = MediaFile.objects.filter(bucket=bucket)
-        self.fields["public_key_media"].queryset = MediaFile.objects.filter(bucket=bucket)
-
-    def _get_ssh_key_bucket(self):
-        if not hasattr(self, "_ssh_key_bucket"):
-            self._ssh_key_bucket = get_ssh_key_bucket()
-        return self._ssh_key_bucket
-
-    def _clean_key_upload(self, upload):
-        if upload:
-            bucket = self._get_ssh_key_bucket()
-            if not bucket.allows_filename(upload.name):
-                raise forms.ValidationError(_("File type is not allowed."))
-            if not bucket.allows_size(upload.size):
-                raise forms.ValidationError(_("File exceeds the allowed size."))
-        return upload
+        self.setup_bucket_aware_querysets()
 
     def save(self, commit=True):
         instance = super().save(commit=False)
-        bucket = self._get_ssh_key_bucket()
-        private_upload = self.cleaned_data.get("private_key_upload")
-        if private_upload:
-            instance.private_key_media = create_media_file(bucket=bucket, uploaded_file=private_upload)
-        public_upload = self.cleaned_data.get("public_key_upload")
-        if public_upload:
-            instance.public_key_media = create_media_file(bucket=bucket, uploaded_file=public_upload)
+        self.store_uploads_on_instance(instance)
         if commit:
             instance.save()
             self.save_m2m()
         return instance
 
     def clean_private_key_upload(self):
-        upload = self.cleaned_data.get("private_key_upload")
-        return self._clean_key_upload(upload)
+        return self.clean_upload_field("private_key_upload")
 
     def clean_public_key_upload(self):
-        upload = self.cleaned_data.get("public_key_upload")
-        return self._clean_key_upload(upload)
+        return self.clean_upload_field("public_key_upload")

--- a/apps/credentials/tests/test_forms.py
+++ b/apps/credentials/tests/test_forms.py
@@ -1,0 +1,47 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from apps.credentials.forms import SSHAccountAdminForm
+from apps.credentials.models import get_ssh_key_bucket
+from apps.media.models import MediaFile
+from apps.nodes.models import Node
+
+
+@pytest.mark.django_db
+def test_ssh_account_form_accepts_existing_media_without_upload():
+    node = Node.objects.create(hostname="ssh-form-existing")
+    bucket = get_ssh_key_bucket()
+    media = MediaFile.objects.create(
+        bucket=bucket,
+        file=SimpleUploadedFile("id_existing", b"private-key"),
+        original_name="id_existing",
+        content_type="application/octet-stream",
+        size=11,
+    )
+    form = SSHAccountAdminForm(
+        data={
+            "node": node.pk,
+            "username": "root",
+            "password": "",
+            "private_key_media": media.pk,
+        }
+    )
+
+    assert form.is_valid()
+    instance = form.save(commit=False)
+    assert instance.private_key_media_id == media.pk
+
+
+@pytest.mark.django_db
+def test_ssh_account_form_upload_creates_media_file():
+    node = Node.objects.create(hostname="ssh-form-upload")
+    form = SSHAccountAdminForm(
+        data={"node": node.pk, "username": "root", "password": "secret"},
+        files={"private_key_upload": SimpleUploadedFile("id_upload", b"private-key")},
+    )
+
+    assert form.is_valid()
+    instance = form.save(commit=False)
+    assert instance.private_key_media is not None
+    assert instance.private_key_media.original_name == "id_upload"
+

--- a/apps/credentials/tests/test_forms.py
+++ b/apps/credentials/tests/test_forms.py
@@ -2,7 +2,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from apps.credentials.forms import SSHAccountAdminForm
-from apps.credentials.models import get_ssh_key_bucket
+from apps.credentials.models import SSHAccount, get_ssh_key_bucket
 from apps.media.models import MediaFile
 from apps.nodes.models import Node
 
@@ -45,3 +45,18 @@ def test_ssh_account_form_upload_creates_media_file():
     assert instance.private_key_media is not None
     assert instance.private_key_media.original_name == "id_upload"
 
+
+@pytest.mark.django_db
+def test_ssh_account_form_setup_bucket_querysets_allows_excluded_media_fields():
+    class SSHAccountWithoutMediaFieldsForm(SSHAccountAdminForm):
+        class Meta(SSHAccountAdminForm.Meta):
+            model = SSHAccount
+            exclude = ("private_key_media", "public_key_media")
+
+    node = Node.objects.create(hostname="ssh-form-excluded-fields")
+    form = SSHAccountWithoutMediaFieldsForm(
+        data={"node": node.pk, "username": "root", "password": "secret"}
+    )
+
+    assert "private_key_media" not in form.fields
+    assert "public_key_media" not in form.fields

--- a/apps/media/forms_mixins.py
+++ b/apps/media/forms_mixins.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from apps.media.models import MediaFile
+from apps.media.utils import create_media_file
+
+
+class MediaUploadAdminFormMixin:
+    """Reusable helpers for admin forms that support existing media or uploads."""
+
+    media_upload_bindings: dict[str, dict[str, Any]] = {}
+
+    def setup_bucket_aware_querysets(self) -> None:
+        for binding in self.media_upload_bindings.values():
+            media_field_name = binding["media_field"]
+            bucket = self.get_media_bucket(binding["bucket_provider"])
+            self.fields[media_field_name].queryset = MediaFile.objects.filter(bucket=bucket)
+
+    def get_media_bucket(self, bucket_provider: Callable[[], Any]) -> Any:
+        cache = getattr(self, "_media_bucket_cache", None)
+        if cache is None:
+            cache = {}
+            self._media_bucket_cache = cache
+        if bucket_provider not in cache:
+            cache[bucket_provider] = bucket_provider()
+        return cache[bucket_provider]
+
+    def validate_bucket_upload(self, upload: Any, *, bucket_provider: Callable[[], Any]) -> Any:
+        if upload:
+            bucket = self.get_media_bucket(bucket_provider)
+            if not bucket.allows_filename(upload.name):
+                raise forms.ValidationError(_("File type is not allowed."))
+            if not bucket.allows_size(upload.size):
+                raise forms.ValidationError(_("File exceeds the allowed size."))
+        return upload
+
+    def clean_upload_field(self, upload_field_name: str) -> Any:
+        upload = self.cleaned_data.get(upload_field_name)
+        binding = self.media_upload_bindings[upload_field_name]
+        upload = self.validate_bucket_upload(upload, bucket_provider=binding["bucket_provider"])
+        validator = binding.get("extra_validator")
+        if upload and validator:
+            validator(upload)
+        return upload
+
+    def store_uploads_on_instance(self, instance: Any) -> Any:
+        for upload_field_name, binding in self.media_upload_bindings.items():
+            upload = self.cleaned_data.get(upload_field_name)
+            if not upload:
+                continue
+            bucket = self.get_media_bucket(binding["bucket_provider"])
+            media_file = create_media_file(bucket=bucket, uploaded_file=upload)
+            setattr(instance, binding["media_field"], media_file)
+        return instance

--- a/apps/media/forms_mixins.py
+++ b/apps/media/forms_mixins.py
@@ -18,6 +18,8 @@ class MediaUploadAdminFormMixin:
     def setup_bucket_aware_querysets(self) -> None:
         for binding in self.media_upload_bindings.values():
             media_field_name = binding["media_field"]
+            if media_field_name not in self.fields:
+                continue
             bucket = self.get_media_bucket(binding["bucket_provider"])
             self.fields[media_field_name].queryset = MediaFile.objects.filter(bucket=bucket)
 
@@ -53,6 +55,8 @@ class MediaUploadAdminFormMixin:
             upload = self.cleaned_data.get(upload_field_name)
             if not upload:
                 continue
+            if hasattr(upload, "seek"):
+                upload.seek(0)
             bucket = self.get_media_bucket(binding["bucket_provider"])
             media_file = create_media_file(bucket=bucket, uploaded_file=upload)
             setattr(instance, binding["media_field"], media_file)


### PR DESCRIPTION
### Motivation

- Reduce duplicated bucket-aware upload logic across admin forms by centralizing common behavior.  
- Preserve existing "existing media or upload" UX while providing a reusable hook for domain validators.  
- Make upload handling clearer and easier to add to future forms with minimal boilerplate.  

### Description

- Add `MediaUploadAdminFormMixin` in `apps/media/forms_mixins.py` with declarative `media_upload_bindings` and helpers `setup_bucket_aware_querysets`, `get_media_bucket`, `validate_bucket_upload`, `clean_upload_field`, and `store_uploads_on_instance`.  
- Refactor `SSHAccountAdminForm` (`apps/credentials/forms.py`) to inherit the mixin and declare bindings for `private_key_upload` and `public_key_upload`, preserving field labels/help text and behavior.  
- Refactor `CardFaceAdminForm` (`apps/cards/forms.py`) to inherit the mixin, declare a binding that uses `CardFace.validate_background_file` as an `extra_validator`, and populate a temporary `MediaFile` during `clean()` so the model-level validation still accepts upload-only flows.  
- Add focused tests `apps/cards/tests/test_forms.py` and `apps/credentials/tests/test_forms.py` that assert both existing-media and upload paths work and that uploads produce `MediaFile` instances.  

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and installed test helpers with `.venv/bin/python -m pip install pytest pytest-django pytest-timeout`.  
- Ran the focused tests with `.venv/bin/python manage.py test run -- apps/cards/tests/test_forms.py apps/credentials/tests/test_forms.py`.  
- All tested specs passed: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c0544e2083269b3331c594467077)