### PR TITLE
Harden release-simulator workflow failure reporting

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Validate release tag version gate (simulated)
+        id: validate_version_gate
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           python - <<'PY'
@@ -198,6 +199,7 @@ jobs:
           print(f'Simulated tag/version gate passed for VERSION={expected_version!r}.')
           PY
       - name: Preflight PyPI version availability (simulated)
+        id: preflight_pypi
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           python - <<'PY'
@@ -236,36 +238,68 @@ jobs:
           print(f'Simulated PyPI preflight passed for {package_name} {package_version}.')
           PY
       - name: Install build backend
+        id: install_build_backend
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install build twine
       - name: Build sdist and wheel (simulated)
+        id: build_package
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           python -m build
       - name: Validate package metadata (simulated)
+        id: validate_metadata
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           python -m twine check dist/*
       - name: Stop before authorization-required publish step
+        id: authorization_boundary
         if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         run: |
           echo "Release simulator intentionally stopped before PyPI trusted-publisher authorization/publish."
       - name: Generate release simulation summary
         id: finalize
+        if: ${{ always() }}
         run: |
           if [ "${{ needs.evaluate.outputs.can_simulate }}" = "true" ]; then
-            {
-              echo 'summary_markdown<<EOF'
-              echo '### Simulation result'
-              echo ''
-              echo '- ✅ Release simulation reached the authorization boundary successfully.'
-              echo '- ℹ️ Publish to PyPI was intentionally skipped because authorization is required.'
-              echo '- ✅ Recommendation: release is ready if maintainers approve and trigger a real publish.'
-              echo 'EOF'
-              echo 'simulated_ok=true'
-            } >> "$GITHUB_OUTPUT"
+            if [ "${{ job.status }}" = "success" ]; then
+              {
+                echo 'summary_markdown<<EOF'
+                echo '### Simulation result'
+                echo ''
+                echo '- ✅ Release simulation reached the authorization boundary successfully.'
+                echo '- ℹ️ Publish to PyPI was intentionally skipped because authorization is required.'
+                echo '- ✅ Recommendation: release is ready if maintainers approve and trigger a real publish.'
+                echo 'EOF'
+                echo 'simulated_ok=true'
+              } >> "$GITHUB_OUTPUT"
+            else
+              FAILED_STEP='the simulation pipeline'
+              if [ "${{ steps.validate_version_gate.outcome }}" = "failure" ]; then
+                FAILED_STEP='validate_version_gate'
+              elif [ "${{ steps.preflight_pypi.outcome }}" = "failure" ]; then
+                FAILED_STEP='preflight_pypi'
+              elif [ "${{ steps.install_build_backend.outcome }}" = "failure" ]; then
+                FAILED_STEP='install_build_backend'
+              elif [ "${{ steps.build_package.outcome }}" = "failure" ]; then
+                FAILED_STEP='build_package'
+              elif [ "${{ steps.validate_metadata.outcome }}" = "failure" ]; then
+                FAILED_STEP='validate_metadata'
+              elif [ "${{ steps.authorization_boundary.outcome }}" = "failure" ]; then
+                FAILED_STEP='authorization_boundary'
+              fi
+              {
+                echo 'summary_markdown<<EOF'
+                echo '### Simulation result'
+                echo ''
+                echo '- ❌ Release simulation failed before reaching the authorization boundary.'
+                echo "- ❌ First failing step: \`$FAILED_STEP\`."
+                echo "- 🔎 Inspect this workflow run for detailed logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                echo 'EOF'
+                echo 'simulated_ok=false'
+              } >> "$GITHUB_OUTPUT"
+            fi
           else
             {
               echo 'summary_markdown<<EOF'


### PR DESCRIPTION
### Motivation

- The hourly release readiness report could show the generic message "Release simulation failed before producing a summary" because the summary step did not run when earlier simulation steps failed, losing actionable failure details.  
- The change aims to produce deterministic, actionable summaries so maintainers can quickly see which simulation stage failed and where to inspect logs.

### Description

- Added explicit `id` values to key simulation steps (`validate_version_gate`, `preflight_pypi`, `install_build_backend`, `build_package`, `validate_metadata`, `authorization_boundary`) so outcomes can be inspected.  
- Changed the `Generate release simulation summary` step to run with `if: ${{ always() }}` so a summary is produced even if upstream steps fail.  
- Implemented failure-aware summary generation that emits `simulated_ok=false`, identifies the first failing step by checking `steps.<id>.outcome`, and includes a direct workflow run URL for logs.  
- Preserved the existing success summary and the blocker-skip summary behavior when simulation is not allowed to run.

### Testing

- Validated the updated workflow YAML by loading `.github/workflows/release-simulator.yml` with `yaml.safe_load` in Python, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d04282e08326ac399b95bc780d0a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR hardens the release-simulator GitHub Actions workflow to produce deterministic, actionable summaries when release simulations fail. Previously, when simulation steps failed before the summary step executed, the hourly release readiness report showed a generic error message without failure details.

## Changes

The workflow's `simulate_release` job now includes:

**Step IDs**: Added explicit `id` attributes to six key simulation steps—`validate_version_gate`, `preflight_pypi`, `install_build_backend`, `build_package`, `validate_metadata`, and `authorization_boundary`—to enable outcome inspection.

**Unconditional Summary Step**: The "Generate release simulation summary" step now runs with `if: ${{ always() }}` to ensure a summary is produced even when upstream steps fail.

**Failure-Aware Summary Generation**: When simulation is allowed (no blockers), the finalize step now:
- Checks the `outcome` attribute of each identified step to determine which step failed first
- Emits `simulated_ok=false` and generates a failure summary that names the failing step
- Includes a direct workflow run URL in the summary for easy troubleshooting
- Preserves the existing success summary behavior when all steps pass
- Maintains the existing blocker-skip summary when simulation is prevented by install/upgrade blockers

## Scope

Workflow changes only; no exported or public code entities altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->