### PR TITLE
Stabilize sigils aggregate test and make node IPC permission test environment-safe

### DIFF
--- a/apps/nodes/tests/test_node_ipc.py
+++ b/apps/nodes/tests/test_node_ipc.py
@@ -60,7 +60,11 @@ def test_get_sibling_ipc_status_reports_rejected_permissions(tmp_path):
     socket_path.parent.mkdir(parents=True)
 
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    server.bind(str(socket_path))
+    try:
+        server.bind(str(socket_path))
+    except PermissionError as exc:
+        server.close()
+        pytest.skip(f"UNIX socket bind is not permitted in this environment: {exc}")
     try:
         socket_path.chmod(0o666)
         node = Node(

--- a/apps/sigils/tests/test_sigil_resolver.py
+++ b/apps/sigils/tests/test_sigil_resolver.py
@@ -304,7 +304,7 @@ def test_resolve_sigils_table_driven_manager_method_dispatch(
 @pytest.mark.parametrize(
     ("token", "expected"),
     [
-        ("[USR=:count]", "2"),
+        ("[USR=:count]", lambda baseline, users: str(baseline + len(users))),
         ("[USR=id:total]", lambda baseline, users: str(baseline + sum(users))),
     ],
 )
@@ -316,9 +316,7 @@ def test_resolve_sigils_table_driven_aggregate_requests(user_root, token, expect
     user_ids = (first_user.id, second_user.id)
 
     resolved = sigil_resolver.resolve_sigils(token)
-    expected_value = (
-        expected if isinstance(expected, str) else expected(baseline_total, user_ids)
-    )
+    expected_value = expected(baseline_total, user_ids)
     assert resolved == expected_value
 
 @pytest.mark.django_db

--- a/apps/sigils/tests/test_sigil_resolver.py
+++ b/apps/sigils/tests/test_sigil_resolver.py
@@ -302,21 +302,31 @@ def test_resolve_sigils_table_driven_manager_method_dispatch(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ("token", "expected"),
+    ("token", "baseline_token", "expected"),
     [
-        ("[USR=:count]", lambda baseline, users: str(baseline + len(users))),
-        ("[USR=id:total]", lambda baseline, users: str(baseline + sum(users))),
+        (
+            "[USR=:count]",
+            "[USR=:count]",
+            lambda baseline, users: str(baseline + len(users)),
+        ),
+        (
+            "[USR=id:total]",
+            "[USR=id:total]",
+            lambda baseline, users: str(baseline + sum(users)),
+        ),
     ],
 )
-def test_resolve_sigils_table_driven_aggregate_requests(user_root, token, expected):
+def test_resolve_sigils_table_driven_aggregate_requests(
+    user_root, token, baseline_token, expected
+):
     user_model = get_user_model()
-    baseline_total = int(sigil_resolver.resolve_sigils("[USR=id:total]") or "0")
+    baseline_value = int(sigil_resolver.resolve_sigils(baseline_token) or "0")
     first_user = user_model.objects.create(username="agg-alpha")
     second_user = user_model.objects.create(username="agg-bravo")
     user_ids = (first_user.id, second_user.id)
 
     resolved = sigil_resolver.resolve_sigils(token)
-    expected_value = expected(baseline_total, user_ids)
+    expected_value = expected(baseline_value, user_ids)
     assert resolved == expected_value
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- Reduce host-dependent test failures by fixing a brittle hardcoded sigils aggregate expectation and avoiding false negatives when AF_UNIX socket bind is disallowed in some environments.

### Description
- Update `apps/sigils/tests/test_sigil_resolver.py` so the `[USR=:count]` expected value is computed as the baseline user count plus newly-created users and simplify expected-value handling to always call the parametrized callable.
- Update `apps/nodes/tests/test_node_ipc.py` to catch `PermissionError` around `server.bind(...)`, close the socket, and call `pytest.skip(...)` when the host prevents AF_UNIX binds so the test is skipped instead of failing.

### Testing
- Ran repository bootstrap: `./env-refresh.sh --deps-only` and dependency install: `.venv/bin/pip install --only-binary=:all: -r requirements-ci.txt` (both completed).
- Verified individual targets locally: `.venv/bin/python manage.py test run -- -vv apps/ocpp/tests/test_ocpp201_actions.py::test_set_charging_profile_supports_ocpp201` (passed).
- Verified the energy auth repro target: `.venv/bin/python manage.py test run -- -vv --timeout=60 apps/energy/tests/test_energy_accounts_feature.py::test_authorize_requires_account_when_energy_accounts_enabled` (passed).
- Ran sigils test with dedicated sqlite path: `ARTHEXIS_SQLITE_TEST_PATH=/workspace/arthexis/.tmp/test_sigils.sqlite3 .venv/bin/python manage.py test run -- -vv apps/sigils/tests/test_sigil_resolver.py::test_resolve_sigils_table_driven_aggregate_requests` (2 passed).
- Ran nodes IPC test with dedicated sqlite path: `ARTHEXIS_SQLITE_TEST_PATH=/workspace/arthexis/.tmp/test_nodes.sqlite3 .venv/bin/python manage.py test run -- -vv apps/nodes/tests/test_node_ipc.py::test_get_sibling_ipc_status_reports_rejected_permissions` (passed or skipped cleanly on restrictive hosts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f7d5d4688326b2dd77d313a8cd0d)