### PR TITLE
Code cleanup: remove unused imports and minor fixes across multiple modules

### DIFF
--- a/apps/core/management/commands/benchmark.py
+++ b/apps/core/management/commands/benchmark.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 try:
     import psutil
-except ImportError as exc:  # pragma: no cover - handled via CommandError in handle
+except ImportError:  # pragma: no cover - handled via CommandError in handle
     psutil = None  # type: ignore[assignment]
 
 

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -2135,7 +2135,7 @@ def _step_wait_for_github_actions_publish(
         ),
         user=user,
     )
-    run = _wait_for_publish_workflow_completion(
+    _wait_for_publish_workflow_completion(
         release,
         ctx,
         log_path,

--- a/apps/sites/utils.py
+++ b/apps/sites/utils.py
@@ -11,7 +11,6 @@ from django.db import DatabaseError
 from django.db.utils import OperationalError, ProgrammingError
 from django.http.request import split_domain_port
 from django.shortcuts import resolve_url
-from django.urls import path as django_path
 from django.utils.translation import get_language
 
 from apps.celery.utils import celery_feature_enabled

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -23,11 +23,6 @@ from apps.links.templatetags.ref_tags import build_footer_context
 from apps.modules.models import Module
 from apps.nodes.models import Node
 from apps.nodes.utils import FeatureChecker
-from apps.ocpp.consumers.constants import (
-    OCPP_VERSION_16,
-    OCPP_VERSION_201,
-    OCPP_VERSION_21,
-)
 from apps.ocpp.utils.websocket import resolve_ws_scheme
 from utils.decorators import security_group_required, staff_required
 from utils.sites import get_site
@@ -221,7 +216,6 @@ def index(request):
 
 
 def sitemap(request):
-    site = get_site(request)
     node = Node.get_local()
     role = node.role if node else None
     role_id = getattr(role, "id", "none")

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -9,7 +8,6 @@ from typing import Any
 import requests
 from celery import shared_task
 from django.apps import apps as django_apps
-from django.conf import settings
 from django.db import models
 from django.utils import timezone
 

--- a/apps/users/models/user.py
+++ b/apps/users/models/user.py
@@ -1,7 +1,6 @@
 from typing import Type
 
 from django.apps import apps
-from django.conf import settings
 from django.contrib.auth.models import AbstractUser, UserManager as DjangoUserManager
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator, validate_ipv46_address
@@ -195,7 +194,6 @@ class User(Entity, AbstractUser):
             self.temporary_expires_at = timezone.now()
         self.is_active = False
         temp_passwords.discard_temp_password(self.username)
-        updates = ["temporary_expires_at", "is_active"]
         if self.pk:
             type(self).all_objects.filter(pk=self.pk).update(
                 temporary_expires_at=self.temporary_expires_at, is_active=self.is_active

--- a/apps/vehicle/admin.py
+++ b/apps/vehicle/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.utils.translation import gettext_lazy as _
 
 from apps.locals.user_data import EntityModelAdmin
 

--- a/env-refresh.py
+++ b/env-refresh.py
@@ -16,7 +16,6 @@ import hashlib
 import time
 from weakref import WeakKeyDictionary
 from typing import TYPE_CHECKING, Iterable, Any
-from datetime import datetime
 
 import django
 import importlib.util
@@ -46,7 +45,6 @@ os.environ.setdefault("NET_MESSAGE_DISABLE_PROPAGATION", "1")
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 django.setup()
 from apps.nodes.models import Node
-from django.contrib.sites.models import Site
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.management import create_contenttypes
 from django.contrib.contenttypes.models import ContentType
@@ -61,8 +59,6 @@ from apps.locals.user_data import (
 )
 from utils.env_refresh import unlink_sqlite_db as _unlink_sqlite_db
 from scripts.fixtures_changed import fixtures_changed
-from django.utils import timezone
-from django.utils.dateparse import parse_datetime
 from scripts.helpers.migration_reconcile import (
     backup_sqlite_database,
     reconcile_sqlite_tables,
@@ -742,7 +738,7 @@ def run_database_tasks(
 
     try:
         call_command("makemigrations", *local_apps, interactive=False)
-    except CommandError as exc:
+    except CommandError:
         call_command("makemigrations", *local_apps, merge=True, interactive=False)
     except InconsistentMigrationHistory:
         if using_sqlite:

--- a/utils/devtools/test_server.py
+++ b/utils/devtools/test_server.py
@@ -8,7 +8,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Protocol, TypedDict
 


### PR DESCRIPTION
### Motivation

- Reduce lint warnings and eliminate unused variables and imports to improve compatibility and readability.
- Remove unnecessary assignments and imports that caused false positives and minor runtime concerns.
- Ensure compatibility across environments by avoiding unused references to Django components and other modules.

### Description

- Simplified exception handling in `apps/core/management/commands/benchmark.py` by removing the unused `exc` variable in the `ImportError` clause.
- Removed unused assignments and imports across multiple modules including `apps/core/views/reports/release_publish/pipeline.py` (no longer assigns unused `run`), `apps/sites/utils.py`, `apps/sites/views/landing.py`, `apps/tasks/tasks.py`, `apps/users/models/user.py` (removed unused `settings` import and redundant `updates` list), `apps/vehicle/admin.py`, `env-refresh.py`, and `utils/devtools/test_server.py`.
- Cleaned `env-refresh.py` error handling by changing `except CommandError as exc` to `except CommandError` and removed several unused imports to streamline startup.
- Performed minor formatting and dead-code removals to reduce warnings and simplify code paths.

### Testing

- Ran the project's unit test suite with `pytest` focusing on the modified modules and the full test run, and all tests passed.
- No regressions were detected by the automated tests after these cleanup changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7faf7808483268710274d918875ed)