### PR TITLE
ops: seed Product Developer GitHub supervision follow-up steps

### DIFF
--- a/apps/ops/migrations/0011_seed_product_developer_github_supervision_steps.py
+++ b/apps/ops/migrations/0011_seed_product_developer_github_supervision_steps.py
@@ -1,0 +1,164 @@
+from django.db import migrations
+
+PRODUCT_DEVELOPER_JOURNEY_SLUG = "product-developer-github-access"
+
+STEP_DEFINITIONS = (
+    {
+        "slug": "setup-github-token",
+        "order": 1,
+        "title": "Connect your GitHub access",
+        "instruction": (
+            "Use the GitHub token setup wizard to connect your product developer account "
+            "for repository, release, and issue workflows."
+        ),
+        "help_text": (
+            "This step is for Product Developer members only. "
+            "The wizard opens your token record and keeps setup in one place."
+        ),
+        "iframe_url": "/admin/repos/githubrepository/setup-token/",
+    },
+    {
+        "slug": "review-issue-inbox",
+        "order": 2,
+        "title": "Review GitHub issue inbox",
+        "instruction": (
+            "Open the Arthexis GitHub issue inbox and triage newly synced issues. "
+            "Confirm ownership, labels, and response expectations before moving forward."
+        ),
+        "help_text": (
+            "Use the issue list to identify unreviewed work and keep team triage visible "
+            "inside the suite."
+        ),
+        "iframe_url": "/admin/repos/repositoryissue/?state__exact=open",
+    },
+    {
+        "slug": "review-pr-queue",
+        "order": 3,
+        "title": "Review pull request queue",
+        "instruction": (
+            "Check the pull request supervision queue to confirm incoming changes have "
+            "active review coverage and no stalled approvals."
+        ),
+        "help_text": (
+            "Use this queue to keep review throughput healthy and to spot drafts or "
+            "blocked PRs quickly."
+        ),
+        "iframe_url": "/admin/repos/repositorypullrequest/?state__exact=open",
+    },
+    {
+        "slug": "run-issue-lifecycle-actions",
+        "order": 4,
+        "title": "Execute issue lifecycle actions",
+        "instruction": (
+            "From the issue supervision screen, perform lifecycle actions such as adding "
+            "labels, posting follow-up responses, and closing resolved issues."
+        ),
+        "help_text": (
+            "Finish this step after confirming issue states in Arthexis reflect current "
+            "delivery and support status."
+        ),
+        "iframe_url": "/admin/repos/repositoryissue/",
+    },
+    {
+        "slug": "run-pr-lifecycle-actions",
+        "order": 5,
+        "title": "Execute pull request lifecycle actions",
+        "instruction": (
+            "Use the pull request supervision screen to apply lifecycle actions, including "
+            "updating review status, recording outcomes, and closing completed PRs."
+        ),
+        "help_text": (
+            "Complete this step when PR states in Arthexis accurately match merge, close, "
+            "or follow-up decisions."
+        ),
+        "iframe_url": "/admin/repos/repositorypullrequest/",
+    },
+)
+
+
+def seed_product_developer_github_supervision_steps(apps, schema_editor):
+    """Ensure Product Developer GitHub supervision journey steps are seeded and ordered."""
+
+    OperatorJourney = apps.get_model("ops", "OperatorJourney")
+    OperatorJourneyStep = apps.get_model("ops", "OperatorJourneyStep")
+
+    journey = OperatorJourney.objects.filter(slug=PRODUCT_DEVELOPER_JOURNEY_SLUG).first()
+    if journey is None:
+        return
+
+    seeded_slugs = {definition["slug"] for definition in STEP_DEFINITIONS}
+    steps_by_slug = {
+        step.slug: step
+        for step in OperatorJourneyStep.objects.filter(
+            journey=journey,
+            slug__in=seeded_slugs,
+        )
+    }
+
+    for definition in STEP_DEFINITIONS:
+        step = steps_by_slug.get(definition["slug"])
+        if step is None:
+            step = OperatorJourneyStep.objects.create(
+                journey=journey,
+                slug=definition["slug"],
+                title=definition["title"],
+                instruction=definition["instruction"],
+                help_text=definition["help_text"],
+                iframe_url=definition["iframe_url"],
+                order=definition["order"],
+                is_active=True,
+                is_seed_data=True,
+            )
+            steps_by_slug[definition["slug"]] = step
+            continue
+
+        step.title = definition["title"]
+        step.instruction = definition["instruction"]
+        step.help_text = definition["help_text"]
+        step.iframe_url = definition["iframe_url"]
+        step.is_active = True
+        step.is_seed_data = True
+        step.save(
+            update_fields=[
+                "title",
+                "instruction",
+                "help_text",
+                "iframe_url",
+                "is_active",
+                "is_seed_data",
+            ]
+        )
+
+    ordered_steps = [steps_by_slug[definition["slug"]] for definition in STEP_DEFINITIONS]
+    ordered_step_ids = {step.id for step in ordered_steps}
+    remaining_steps = list(
+        OperatorJourneyStep.objects.filter(journey=journey)
+        .exclude(id__in=ordered_step_ids)
+        .order_by("order", "id")
+    )
+
+    for step in ordered_steps + remaining_steps:
+        step.order += 1000
+        step.save(update_fields=["order"])
+
+    for position, step in enumerate(ordered_steps + remaining_steps, start=1):
+        step.order = position
+        step.save(update_fields=["order"])
+
+
+def noop_reverse(apps, schema_editor):
+    """Keep operator journey changes in place on reverse migration."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ops", "0010_split_github_setup_into_product_developer_journey"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_product_developer_github_supervision_steps,
+            noop_reverse,
+        ),
+    ]

--- a/apps/ops/migrations/0011_seed_product_developer_github_supervision_steps.py
+++ b/apps/ops/migrations/0011_seed_product_developer_github_supervision_steps.py
@@ -1,4 +1,4 @@
-from django.db import migrations
+from django.db import migrations, models
 
 PRODUCT_DEVELOPER_JOURNEY_SLUG = "product-developer-github-access"
 
@@ -86,6 +86,10 @@ def seed_product_developer_github_supervision_steps(apps, schema_editor):
     if journey is None:
         return
 
+    OperatorJourneyStep.objects.filter(journey=journey).update(
+        order=models.F("order") + 1000
+    )
+
     seeded_slugs = {definition["slug"] for definition in STEP_DEFINITIONS}
     steps_by_slug = {
         step.slug: step
@@ -136,10 +140,6 @@ def seed_product_developer_github_supervision_steps(apps, schema_editor):
         .exclude(id__in=ordered_step_ids)
         .order_by("order", "id")
     )
-
-    for step in ordered_steps + remaining_steps:
-        step.order += 1000
-        step.save(update_fields=["order"])
 
     for position, step in enumerate(ordered_steps + remaining_steps, start=1):
         step.order = position

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -98,6 +98,102 @@ class OperatorJourneyFlowTests(TestCase):
 
         self.assertFalse(completed)
 
+    def test_product_developer_follow_up_steps_are_ordered_after_token_setup(self):
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        setup_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+        issue_inbox_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Review GitHub issue inbox",
+            slug="review-issue-inbox",
+            instruction="Triage open repository issues.",
+            iframe_url="/admin/repos/repositoryissue/?state__exact=open",
+            order=2,
+        )
+        pr_queue_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Review pull request queue",
+            slug="review-pr-queue",
+            instruction="Review open pull requests.",
+            iframe_url="/admin/repos/repositorypullrequest/?state__exact=open",
+            order=3,
+        )
+        issue_lifecycle_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Execute issue lifecycle actions",
+            slug="run-issue-lifecycle-actions",
+            instruction="Perform issue follow-up and closure actions.",
+            iframe_url="/admin/repos/repositoryissue/",
+            order=4,
+        )
+        pr_lifecycle_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Execute pull request lifecycle actions",
+            slug="run-pr-lifecycle-actions",
+            instruction="Perform pull request review and completion actions.",
+            iframe_url="/admin/repos/repositorypullrequest/",
+            order=5,
+        )
+
+        step_titles_in_order = list(
+            OperatorJourneyStep.objects.filter(journey=github_journey).values_list(
+                "title", flat=True
+            )
+        )
+
+        self.assertEqual(
+            step_titles_in_order,
+            [
+                setup_step.title,
+                issue_inbox_step.title,
+                pr_queue_step.title,
+                issue_lifecycle_step.title,
+                pr_lifecycle_step.title,
+            ],
+        )
+
+    def test_product_developer_progression_advances_after_token_setup(self):
+        github_journey = OperatorJourney.objects.create(
+            name="Product Developer GitHub Access",
+            slug="product-developer-github-access",
+            security_group=self.group,
+            is_active=True,
+            priority=1,
+        )
+        setup_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Connect your GitHub access",
+            slug="setup-github-token",
+            instruction="Configure GitHub access directly in this step.",
+            iframe_url="/admin/repos/githubrepository/setup-token/",
+            order=1,
+        )
+        issue_inbox_step = OperatorJourneyStep.objects.create(
+            journey=github_journey,
+            title="Review GitHub issue inbox",
+            slug="review-issue-inbox",
+            instruction="Triage open repository issues.",
+            iframe_url="/admin/repos/repositoryissue/?state__exact=open",
+            order=2,
+        )
+
+        self.assertEqual(next_step_for_user(user=self.user), setup_step)
+
+        self.assertTrue(complete_step_for_user(user=self.user, step=setup_step))
+        self.assertEqual(next_step_for_user(user=self.user), issue_inbox_step)
+
     @patch("apps.ops.operator_journey._local_node_role_is_available", return_value=True)
     def test_next_step_skips_provision_for_non_superuser_operational_staff(
         self, _mock_role_check


### PR DESCRIPTION
### Motivation

- Ensure Product Developer GitHub onboarding continues with actionable supervision tasks after `setup-github-token` so product developers can triage issues and PRs from inside Arthexis.

### Description

- Add `apps/ops/migrations/0011_seed_product_developer_github_supervision_steps.py` to seed five journey steps (including `setup-github-token` plus follow-ups for issue inbox review, PR review queue, issue lifecycle actions, and PR lifecycle actions) with meaningful `instruction`, `help_text`, and Arthexis-native `iframe_url` targets.
- Make seeding idempotent by upserting seeded slugs, enforcing seeded content fields, and deterministically reordering seeded and existing steps (bump orders by `+1000` then assign sequential positions) so ordering is stable on repeated runs.
- Update `apps/ops/tests/test_operator_journey.py` to add assertions that the new steps appear in the expected order and that progression advances from `setup-github-token` to the next supervision step when completed.
- Migration depends on the previous GitHub split migration (`0010_split_github_setup_into_product_developer_journey`) and leaves reverse as a no-op to preserve user edits.

### Testing

- Ran dependency/bootstrap commands: `./env-refresh.sh --deps-only` and `.venv/bin/python -m pip install -r requirements-ci.txt`, both completed successfully. 
- Verified migrations: `.venv/bin/python manage.py migrations check` returned no changes. 
- Executed targeted test suite: `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` and all tests passed (`44 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83165204c8326b39a6e84f5e7bb0c)