### PR TITLE
links: set footer reference to "Github Repo" and point to arthexis repo

### DIFF
--- a/apps/links/fixtures/references__reference_8.json
+++ b/apps/links/fixtures/references__reference_8.json
@@ -2,8 +2,8 @@
   {
     "model": "links.reference",
     "fields": {
-      "value": "https://github.com/orgs/arthexis/repositories",
-      "alt_text": "GitHub Repos",
+      "value": "https://github.com/arthexis/arthexis",
+      "alt_text": "Github Repo",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/migrations/0007_fix_github_footer_reference.py
+++ b/apps/links/migrations/0007_fix_github_footer_reference.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+OLD_GITHUB_FOOTER_VARIANTS = [
+    ("GitHub Repos", "https://github.com/orgs/arthexis/repositories"),
+    ("GitHub Repositories", "https://github.com/orgs/arthexis/repositories"),
+    ("GitHub Repo", "https://github.com/arthexis/arthexis"),
+]
+
+NEW_ALT_TEXT = "Github Repo"
+NEW_VALUE = "https://github.com/arthexis/arthexis"
+
+
+def fix_github_footer_reference(apps, schema_editor) -> None:
+    Reference = apps.get_model("links", "Reference")
+
+    candidate_rows = []
+    for alt_text, value in OLD_GITHUB_FOOTER_VARIANTS:
+        candidate_rows.extend(
+            Reference.objects.filter(
+                alt_text=alt_text,
+                value=value,
+                is_seed_data=True,
+            ).order_by("pk")
+        )
+
+    if not candidate_rows:
+        candidate_rows.extend(
+            Reference.objects.filter(
+                alt_text=NEW_ALT_TEXT,
+                value=NEW_VALUE,
+                is_seed_data=True,
+            ).order_by("pk")
+        )
+
+    if not candidate_rows:
+        return
+
+    keep = candidate_rows[0]
+    duplicate_pks = [row.pk for row in candidate_rows[1:]]
+    if duplicate_pks:
+        Reference.all_objects.filter(pk__in=duplicate_pks)._raw_delete(
+            schema_editor.connection.alias
+        )
+
+    if keep.alt_text != NEW_ALT_TEXT or keep.value != NEW_VALUE:
+        keep.alt_text = NEW_ALT_TEXT
+        keep.value = NEW_VALUE
+        keep.save(update_fields=["alt_text", "value"])
+
+
+def noop_reverse(apps, schema_editor) -> None:
+    return None
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("links", "0006_referenceattachment"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_github_footer_reference, noop_reverse),
+    ]

--- a/apps/links/migrations/0007_fix_github_footer_reference.py
+++ b/apps/links/migrations/0007_fix_github_footer_reference.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.db import migrations
+from django.db.models import Q
 
 
 OLD_GITHUB_FOOTER_VARIANTS = [
@@ -15,40 +16,38 @@ NEW_VALUE = "https://github.com/arthexis/arthexis"
 
 def fix_github_footer_reference(apps, schema_editor) -> None:
     Reference = apps.get_model("links", "Reference")
+    manager = getattr(Reference, "all_objects", Reference._base_manager)
 
-    candidate_rows = []
-    for alt_text, value in OLD_GITHUB_FOOTER_VARIANTS:
-        candidate_rows.extend(
-            Reference.objects.filter(
-                alt_text=alt_text,
-                value=value,
-                is_seed_data=True,
-            ).order_by("pk")
-        )
+    variants = [*OLD_GITHUB_FOOTER_VARIANTS, (NEW_ALT_TEXT, NEW_VALUE)]
 
-    if not candidate_rows:
-        candidate_rows.extend(
-            Reference.objects.filter(
-                alt_text=NEW_ALT_TEXT,
-                value=NEW_VALUE,
-                is_seed_data=True,
-            ).order_by("pk")
-        )
+    filters = Q()
+    for alt_text, value in variants:
+        filters |= Q(alt_text=alt_text, value=value)
 
+    candidate_rows = list(manager.filter(filters).order_by("pk"))
     if not candidate_rows:
         return
 
-    keep = candidate_rows[0]
-    duplicate_pks = [row.pk for row in candidate_rows[1:]]
+    keep = next(
+        (
+            row
+            for row in candidate_rows
+            if row.alt_text == NEW_ALT_TEXT and row.value == NEW_VALUE
+        ),
+        candidate_rows[0],
+    )
+
+    duplicate_pks = [row.pk for row in candidate_rows if row.pk != keep.pk]
     if duplicate_pks:
-        Reference.all_objects.filter(pk__in=duplicate_pks)._raw_delete(
-            schema_editor.connection.alias
-        )
+        manager.using(schema_editor.connection.alias).filter(pk__in=duplicate_pks).delete()
 
     if keep.alt_text != NEW_ALT_TEXT or keep.value != NEW_VALUE:
         keep.alt_text = NEW_ALT_TEXT
         keep.value = NEW_VALUE
-        keep.save(update_fields=["alt_text", "value"])
+        keep.save(
+            update_fields=["alt_text", "value"],
+            using=schema_editor.connection.alias,
+        )
 
 
 def noop_reverse(apps, schema_editor) -> None:


### PR DESCRIPTION
### Motivation
- The footer previously referenced a generic or org-level GitHub list and inconsistent labels, causing the footer link to not point directly at the project repository.  
- Normalize historical seeded variants so upgraded installations converge to a single, correct footer entry.  

### Description
- Updated the seed fixture `apps/links/fixtures/references__reference_8.json` to use `"alt_text": "Github Repo"` and `"value": "https://github.com/arthexis/arthexis"`.  
- Added a data migration `apps/links/migrations/0007_fix_github_footer_reference.py` that finds prior footer variants (`"GitHub Repos"`, `"GitHub Repositories"`, `"GitHub Repo"`) and normalizes them to `Github Repo` pointing at `https://github.com/arthexis/arthexis`, removing duplicate seed rows.  
- Committed the fixture and migration so fresh installs and upgrades both get the corrected footer reference.  

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` and `./env-refresh.sh`, and the commands completed successfully.  
- Ran unit tests for the links app with `.venv/bin/python manage.py test run -- apps/links`, resulting in `6 passed`.  
- Executed `.venv/bin/python manage.py migrations check` and migrations applied cleanly during the env refresh (including the new `0007` migration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8345ecee4832696023276fc9a8de2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR fixes the footer reference in the links app to correctly point to the arthexis repository and normalizes inconsistent historical variants.

## Changes

### Fixture Update
Updated `apps/links/fixtures/references__reference_8.json` to standardize the footer reference:
- Changed `alt_text` from "GitHub Repos" to "Github Repo"
- Changed `value` from `https://github.com/orgs/arthexis/repositories` to `https://github.com/arthexis/arthexis`

### Data Migration
Added `apps/links/migrations/0007_fix_github_footer_reference.py` to handle existing installations:
- Identifies and normalizes prior footer variants ("GitHub Repos", "GitHub Repositories", "GitHub Repo")
- Updates all matching legacy references to the canonical values
- Removes duplicate seed data rows, keeping only one and deleting the rest
- Ensures both fresh installs (via fixture) and existing deployments (via migration) have the correct footer reference

## Testing
- Environment bootstrap completed successfully with `./env-refresh.sh` 
- Links app unit tests passed (6/6)
- Migration check passed with clean application of all migrations including the new migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->