### PR TITLE
rpiconnect: add admin campaign wizard, progress view, and rollback actions

### DIFF
--- a/apps/rpiconnect/admin.py
+++ b/apps/rpiconnect/admin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django import forms
 from django.contrib import admin, messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Count, Q
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -168,13 +168,14 @@ class ConnectDeviceAdmin(admin.ModelAdmin):
     @admin.display(description=_("Eligibility indicator"))
     def eligibility_indicator(self, obj: ConnectDevice) -> str:
         missing: list[str] = []
+        metadata = obj.metadata if isinstance(obj.metadata, dict) else {}
         if not obj.hardware_model:
             missing.append(_("Pi model"))
         if not obj.os_release:
             missing.append(_("OS release"))
-        if self.connectivity_indicator(obj) == _("Unknown"):
+        if not metadata.get("connectivity"):
             missing.append(_("connectivity"))
-        if self.free_space_indicator(obj) == _("Not reported"):
+        if not (metadata.get("free_space") or metadata.get("free_space_bytes")):
             missing.append(_("free space"))
 
         if missing:
@@ -225,6 +226,19 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
     list_filter = ("strategy", "status", "started_at", "completed_at")
     search_fields = ("id", "release__name")
 
+    def get_queryset(self, request: HttpRequest):
+        return super().get_queryset(request).annotate(
+            failed_count=Count(
+                "deployments",
+                filter=Q(deployments__status=ConnectUpdateDeployment.Status.FAILED),
+            ),
+            succeeded_count=Count(
+                "deployments",
+                filter=Q(deployments__status=ConnectUpdateDeployment.Status.SUCCEEDED),
+            ),
+            total_count=Count("deployments"),
+        )
+
     def get_urls(self):
         custom_urls = [
             path("wizard/", self.admin_site.admin_view(self.campaign_wizard_view), name="rpiconnect_campaign_wizard"),
@@ -258,13 +272,19 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
 
     @admin.display(description=_("Progress"))
     def progress_summary(self, obj: ConnectUpdateCampaign) -> str:
-        totals = obj.deployments.values("status").annotate(count=Count("id"))
-        status_counts = {entry["status"]: entry["count"] for entry in totals}
-        total = sum(status_counts.values())
+        total = getattr(obj, "total_count", None)
+        if total is None:
+            totals = obj.deployments.values("status").annotate(count=Count("id"))
+            status_counts = {entry["status"]: entry["count"] for entry in totals}
+            total = sum(status_counts.values())
+            succeeded = status_counts.get(ConnectUpdateDeployment.Status.SUCCEEDED, 0)
+            failed = status_counts.get(ConnectUpdateDeployment.Status.FAILED, 0)
+        else:
+            succeeded = getattr(obj, "succeeded_count", 0)
+            failed = getattr(obj, "failed_count", 0)
+
         if total == 0:
             return _("No deployments queued")
-        succeeded = status_counts.get(ConnectUpdateDeployment.Status.SUCCEEDED, 0)
-        failed = status_counts.get(ConnectUpdateDeployment.Status.FAILED, 0)
         return _("%(succeeded)s/%(total)s succeeded, %(failed)s failed") % {
             "failed": failed,
             "succeeded": succeeded,
@@ -287,9 +307,6 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
                 notes_sections.append(f"Timing notes: {cleaned['timing_notes'].strip()}")
             notes = "\n\n".join(section for section in notes_sections if section)
 
-            resolved_devices = CampaignService().resolve_targets(target_set)
-            canary_size = max(1, round(len(resolved_devices) * (cleaned.get("canary_percent") or 10) / 100))
-
             try:
                 campaign = CampaignService().create_campaign(
                     release=release,
@@ -299,17 +316,19 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
                     notes=notes,
                     override_conflicts=cleaned.get("override_conflicts", False),
                     batch_size=cleaned.get("batch_size") or 0,
-                    canary_size=canary_size,
+                    canary_percent=cleaned.get("canary_percent") or 10,
                 )
                 if cleaned.get("launch_timing") == "start_now":
                     CampaignService().start_campaign(campaign, created_by=request.user)
             except CampaignServiceError as exc:
                 form.add_error(None, exc)
             else:
+                creation_event = campaign.events.filter(event_type=CampaignService.EVENT_CAMPAIGN_CREATED).first()
+                target_count = (creation_event.payload or {}).get("target_count", 0) if creation_event else 0
                 messages.success(
                     request,
                     _("Campaign %(campaign)s created with %(count)s targeted devices.")
-                    % {"campaign": campaign.pk, "count": len(resolved_devices)},
+                    % {"campaign": campaign.pk, "count": target_count},
                 )
                 return HttpResponseRedirect(
                     reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk])
@@ -324,11 +343,15 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
         return TemplateResponse(request, "admin/rpiconnect/connectupdatecampaign/campaign_wizard.html", context)
 
     def campaign_progress_view(self, request: HttpRequest, campaign_id: int) -> HttpResponse:
+        if not self.has_view_or_change_permission(request):
+            raise PermissionDenied
         campaign = (
             ConnectUpdateCampaign.objects.select_related("release", "created_by")
             .prefetch_related("deployments__device")
             .get(pk=campaign_id)
         )
+        if not self.has_view_or_change_permission(request, campaign):
+            raise PermissionDenied
         status_counts = {
             entry["status"]: entry["count"]
             for entry in campaign.deployments.values("status").annotate(count=Count("id")).order_by("status")
@@ -349,6 +372,8 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
 
     def rollback_campaign_view(self, request: HttpRequest, campaign_id: int) -> HttpResponse:
         campaign = ConnectUpdateCampaign.objects.select_related("release").get(pk=campaign_id)
+        if not self.has_change_permission(request, campaign) or not self.has_add_permission(request):
+            raise PermissionDenied
         if request.method != "POST":
             messages.warning(request, _("Use the rollback button from the campaign form to confirm this action."))
             return HttpResponseRedirect(reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk]))
@@ -387,14 +412,14 @@ class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
         )
 
     def _find_previous_known_good_release(self, campaign: ConnectUpdateCampaign) -> ConnectImageRelease | None:
-        successful_device_pk_set = set(
-            campaign.deployments.filter(status=ConnectUpdateDeployment.Status.SUCCEEDED).values_list("device_id", flat=True)
-        )
-        if not successful_device_pk_set:
+        successful_device_ids = campaign.deployments.filter(
+            status=ConnectUpdateDeployment.Status.SUCCEEDED
+        ).values_list("device_id", flat=True)
+        if not successful_device_ids:
             return None
 
         successful_campaign_ids = ConnectUpdateCampaign.objects.filter(
-            deployments__device_id__in=successful_device_pk_set,
+            deployments__device_id__in=successful_device_ids,
             deployments__status=ConnectUpdateDeployment.Status.SUCCEEDED,
             status=ConnectUpdateCampaign.Status.COMPLETED,
         ).exclude(pk=campaign.pk)

--- a/apps/rpiconnect/admin.py
+++ b/apps/rpiconnect/admin.py
@@ -1,16 +1,26 @@
 """Admin registrations for Raspberry Pi Connect integration models."""
 
-from django import forms
-from django.contrib import admin
+from __future__ import annotations
 
-from .models import (
+from django import forms
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.db.models import Count, Q
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy as _
+
+from apps.rpiconnect.models import (
     ConnectAccount,
+    ConnectCampaignEvent,
     ConnectDevice,
-    ConnectIngestionEvent,
     ConnectImageRelease,
+    ConnectIngestionEvent,
     ConnectUpdateCampaign,
     ConnectUpdateDeployment,
 )
+from apps.rpiconnect.services import CampaignService, CampaignServiceError
 
 
 class ConnectAccountAdminForm(forms.ModelForm):
@@ -18,9 +28,101 @@ class ConnectAccountAdminForm(forms.ModelForm):
         model = ConnectAccount
         fields = "__all__"
         widgets = {
-            "token_reference": forms.PasswordInput(render_value=True),
             "refresh_token_reference": forms.PasswordInput(render_value=True),
+            "token_reference": forms.PasswordInput(render_value=True),
         }
+
+
+class ConnectCampaignWizardForm(forms.Form):
+    """Collect campaign targeting and rollout controls for admin operators."""
+
+    release = forms.ModelChoiceField(
+        queryset=ConnectImageRelease.objects.order_by("-released_at", "name", "version"),
+        help_text=_("Release to deploy. Checksums and compatibility tags are shown in the registry list."),
+        label=_("Release to deploy"),
+    )
+    device_ids = forms.CharField(
+        help_text=_("Comma-separated external device IDs (for explicit targeting)."),
+        label=_("Target specific device IDs"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 3}),
+    )
+    labels = forms.CharField(
+        help_text=_("Comma-separated metadata labels; devices with any listed label are included."),
+        label=_("Target by metadata labels"),
+        required=False,
+    )
+    cohorts = forms.CharField(
+        help_text=_("Comma-separated cohort values from device metadata (for staged populations)."),
+        label=_("Target by metadata cohorts"),
+        required=False,
+    )
+    strategy = forms.ChoiceField(
+        choices=ConnectUpdateCampaign.Strategy.choices,
+        help_text=_("Rollout strategy controls whether all targets, canary sets, or batches queue first."),
+        label=_("Rollout strategy"),
+    )
+    canary_percent = forms.IntegerField(
+        help_text=_("Canary percentage of matched devices to queue first when strategy is Canary."),
+        initial=10,
+        label=_("Canary percentage"),
+        max_value=100,
+        min_value=1,
+        required=False,
+    )
+    batch_size = forms.IntegerField(
+        help_text=_("Number of devices queued per stage when strategy is Batched."),
+        initial=25,
+        label=_("Batch size"),
+        min_value=1,
+        required=False,
+    )
+    launch_timing = forms.ChoiceField(
+        choices=(
+            ("start_now", _("Start now")),
+            ("draft", _("Save as draft")),
+        ),
+        help_text=_("Choose whether to launch immediately or leave the campaign in draft for manual timing."),
+        initial="start_now",
+        label=_("Campaign launch timing"),
+    )
+    timing_notes = forms.CharField(
+        help_text=_("Optional operator timing context, such as maintenance window expectations."),
+        label=_("Timing and scheduling notes"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2}),
+    )
+    notes = forms.CharField(
+        help_text=_("Operator notes shown on the campaign and event timeline."),
+        label=_("Campaign notes"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 3}),
+    )
+    override_conflicts = forms.BooleanField(
+        help_text=_("Allow launch even when devices are part of another active campaign."),
+        label=_("Override campaign conflict protection"),
+        required=False,
+    )
+
+    @staticmethod
+    def _split_tokens(raw_value: str) -> list[str]:
+        return [token.strip() for token in raw_value.replace("\n", ",").split(",") if token.strip()]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        device_ids = self._split_tokens(cleaned_data.get("device_ids", ""))
+        labels = self._split_tokens(cleaned_data.get("labels", ""))
+        cohorts = self._split_tokens(cleaned_data.get("cohorts", ""))
+
+        if not any([device_ids, labels, cohorts]):
+            raise ValidationError(_("Provide at least one targeting selector: device IDs, labels, or cohorts."))
+
+        cleaned_data["target_set"] = {
+            "cohorts": cohorts,
+            "device_ids": device_ids,
+            "labels": labels,
+        }
+        return cleaned_data
 
 
 @admin.register(ConnectAccount)
@@ -38,6 +140,9 @@ class ConnectDeviceAdmin(admin.ModelAdmin):
         "account",
         "hardware_model",
         "os_release",
+        "connectivity_indicator",
+        "free_space_indicator",
+        "eligibility_indicator",
         "is_online",
         "last_seen",
         "enrollment_source",
@@ -45,19 +150,262 @@ class ConnectDeviceAdmin(admin.ModelAdmin):
     list_filter = ("is_online", "enrollment_source", "hardware_model")
     search_fields = ("device_id", "hardware_model", "os_release", "account__name")
 
+    @admin.display(description=_("Connectivity signal"))
+    def connectivity_indicator(self, obj: ConnectDevice) -> str:
+        connectivity = obj.metadata.get("connectivity") if isinstance(obj.metadata, dict) else None
+        if isinstance(connectivity, str) and connectivity.strip():
+            return connectivity.strip()
+        return _("Unknown")
+
+    @admin.display(description=_("Reported free space"))
+    def free_space_indicator(self, obj: ConnectDevice) -> str:
+        metadata = obj.metadata if isinstance(obj.metadata, dict) else {}
+        free_space = metadata.get("free_space") or metadata.get("free_space_bytes")
+        if free_space in {None, ""}:
+            return _("Not reported")
+        return str(free_space)
+
+    @admin.display(description=_("Eligibility indicator"))
+    def eligibility_indicator(self, obj: ConnectDevice) -> str:
+        missing: list[str] = []
+        if not obj.hardware_model:
+            missing.append(_("Pi model"))
+        if not obj.os_release:
+            missing.append(_("OS release"))
+        if self.connectivity_indicator(obj) == _("Unknown"):
+            missing.append(_("connectivity"))
+        if self.free_space_indicator(obj) == _("Not reported"):
+            missing.append(_("free space"))
+
+        if missing:
+            return _("Review required: %(missing)s") % {"missing": ", ".join(missing)}
+        return _("Eligible: inventory signals complete")
+
 
 @admin.register(ConnectImageRelease)
 class ConnectImageReleaseAdmin(admin.ModelAdmin):
-    list_display = ("name", "version", "checksum", "released_at")
+    list_display = (
+        "name",
+        "version",
+        "compatibility_summary",
+        "checksum",
+        "released_at",
+    )
     list_filter = ("released_at",)
     search_fields = ("name", "version", "checksum")
+
+    @admin.display(description=_("Compatibility summary"))
+    def compatibility_summary(self, obj: ConnectImageRelease) -> str:
+        tags = obj.compatibility_tags if isinstance(obj.compatibility_tags, list) else []
+        if not tags:
+            return _("All tracked devices (no compatibility tags provided)")
+        preview = ", ".join(str(tag) for tag in tags[:4])
+        if len(tags) > 4:
+            return _("Targets tagged devices: %(preview)s, +%(extra)s more") % {
+                "extra": len(tags) - 4,
+                "preview": preview,
+            }
+        return _("Targets tagged devices: %(preview)s") % {"preview": preview}
 
 
 @admin.register(ConnectUpdateCampaign)
 class ConnectUpdateCampaignAdmin(admin.ModelAdmin):
-    list_display = ("id", "release", "strategy", "status", "created_by", "started_at", "completed_at")
+    change_form_template = "admin/rpiconnect/connectupdatecampaign/change_form.html"
+    change_list_template = "admin/rpiconnect/connectupdatecampaign/change_list.html"
+    list_display = (
+        "id",
+        "release",
+        "strategy",
+        "status",
+        "progress_summary",
+        "created_by",
+        "started_at",
+        "completed_at",
+    )
     list_filter = ("strategy", "status", "started_at", "completed_at")
     search_fields = ("id", "release__name")
+
+    def get_urls(self):
+        custom_urls = [
+            path("wizard/", self.admin_site.admin_view(self.campaign_wizard_view), name="rpiconnect_campaign_wizard"),
+            path(
+                "<int:campaign_id>/progress/",
+                self.admin_site.admin_view(self.campaign_progress_view),
+                name="rpiconnect_campaign_progress",
+            ),
+            path(
+                "<int:campaign_id>/rollback/",
+                self.admin_site.admin_view(self.rollback_campaign_view),
+                name="rpiconnect_campaign_rollback",
+            ),
+        ]
+        return custom_urls + super().get_urls()
+
+    def changelist_view(self, request: HttpRequest, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["campaign_wizard_url"] = reverse("admin:rpiconnect_campaign_wizard")
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def change_view(self, request: HttpRequest, object_id: str, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        extra_context.update(
+            {
+                "campaign_progress_url": reverse("admin:rpiconnect_campaign_progress", args=[object_id]),
+                "campaign_rollback_url": reverse("admin:rpiconnect_campaign_rollback", args=[object_id]),
+            }
+        )
+        return super().change_view(request, object_id, form_url=form_url, extra_context=extra_context)
+
+    @admin.display(description=_("Progress"))
+    def progress_summary(self, obj: ConnectUpdateCampaign) -> str:
+        totals = obj.deployments.values("status").annotate(count=Count("id"))
+        status_counts = {entry["status"]: entry["count"] for entry in totals}
+        total = sum(status_counts.values())
+        if total == 0:
+            return _("No deployments queued")
+        succeeded = status_counts.get(ConnectUpdateDeployment.Status.SUCCEEDED, 0)
+        failed = status_counts.get(ConnectUpdateDeployment.Status.FAILED, 0)
+        return _("%(succeeded)s/%(total)s succeeded, %(failed)s failed") % {
+            "failed": failed,
+            "succeeded": succeeded,
+            "total": total,
+        }
+
+    def campaign_wizard_view(self, request: HttpRequest) -> HttpResponse:
+        if not self.has_add_permission(request):
+            messages.error(request, _("You do not have permission to create campaigns."))
+            return HttpResponseRedirect(reverse("admin:rpiconnect_connectupdatecampaign_changelist"))
+
+        form = ConnectCampaignWizardForm(request.POST or None)
+        if request.method == "POST" and form.is_valid():
+            cleaned = form.cleaned_data
+            release = cleaned["release"]
+            strategy = cleaned["strategy"]
+            target_set = cleaned["target_set"]
+            notes_sections = [cleaned.get("notes", "").strip()]
+            if cleaned.get("timing_notes"):
+                notes_sections.append(f"Timing notes: {cleaned['timing_notes'].strip()}")
+            notes = "\n\n".join(section for section in notes_sections if section)
+
+            resolved_devices = CampaignService().resolve_targets(target_set)
+            canary_size = max(1, round(len(resolved_devices) * (cleaned.get("canary_percent") or 10) / 100))
+
+            try:
+                campaign = CampaignService().create_campaign(
+                    release=release,
+                    target_set=target_set,
+                    strategy=strategy,
+                    created_by=request.user,
+                    notes=notes,
+                    override_conflicts=cleaned.get("override_conflicts", False),
+                    batch_size=cleaned.get("batch_size") or 0,
+                    canary_size=canary_size,
+                )
+                if cleaned.get("launch_timing") == "start_now":
+                    CampaignService().start_campaign(campaign, created_by=request.user)
+            except CampaignServiceError as exc:
+                form.add_error(None, exc)
+            else:
+                messages.success(
+                    request,
+                    _("Campaign %(campaign)s created with %(count)s targeted devices.")
+                    % {"campaign": campaign.pk, "count": len(resolved_devices)},
+                )
+                return HttpResponseRedirect(
+                    reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk])
+                )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "form": form,
+            "opts": self.model._meta,
+            "title": _("Campaign wizard"),
+        }
+        return TemplateResponse(request, "admin/rpiconnect/connectupdatecampaign/campaign_wizard.html", context)
+
+    def campaign_progress_view(self, request: HttpRequest, campaign_id: int) -> HttpResponse:
+        campaign = (
+            ConnectUpdateCampaign.objects.select_related("release", "created_by")
+            .prefetch_related("deployments__device")
+            .get(pk=campaign_id)
+        )
+        status_counts = {
+            entry["status"]: entry["count"]
+            for entry in campaign.deployments.values("status").annotate(count=Count("id")).order_by("status")
+        }
+        failed_deployments = campaign.deployments.filter(
+            Q(status=ConnectUpdateDeployment.Status.FAILED)
+            | Q(status=ConnectUpdateDeployment.Status.ROLLED_BACK)
+        ).select_related("device")
+        context = {
+            **self.admin_site.each_context(request),
+            "campaign": campaign,
+            "failed_deployments": failed_deployments,
+            "opts": self.model._meta,
+            "status_counts": status_counts,
+            "title": _("Live campaign progress"),
+        }
+        return TemplateResponse(request, "admin/rpiconnect/connectupdatecampaign/progress.html", context)
+
+    def rollback_campaign_view(self, request: HttpRequest, campaign_id: int) -> HttpResponse:
+        campaign = ConnectUpdateCampaign.objects.select_related("release").get(pk=campaign_id)
+        if request.method != "POST":
+            messages.warning(request, _("Use the rollback button from the campaign form to confirm this action."))
+            return HttpResponseRedirect(reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk]))
+
+        previous_release = self._find_previous_known_good_release(campaign)
+        if previous_release is None:
+            messages.error(request, _("No previous known-good release could be identified for rollback."))
+            return HttpResponseRedirect(reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk]))
+
+        successful_device_ids = list(
+            campaign.deployments.filter(status=ConnectUpdateDeployment.Status.SUCCEEDED).values_list(
+                "device__device_id", flat=True
+            )
+        )
+        if not successful_device_ids:
+            messages.error(request, _("Rollback requires at least one succeeded deployment in the source campaign."))
+            return HttpResponseRedirect(reverse("admin:rpiconnect_connectupdatecampaign_change", args=[campaign.pk]))
+
+        rollback_campaign = CampaignService().create_campaign(
+            release=previous_release,
+            target_set={"cohorts": [], "device_ids": successful_device_ids, "labels": []},
+            strategy=ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+            created_by=request.user,
+            notes=_("Rollback from campaign %(campaign)s to previous known-good release.") % {"campaign": campaign.pk},
+            override_conflicts=True,
+        )
+        CampaignService().start_campaign(rollback_campaign, created_by=request.user)
+
+        messages.success(
+            request,
+            _("Rollback campaign %(rollback)s created using release %(release)s.")
+            % {"release": previous_release, "rollback": rollback_campaign.pk},
+        )
+        return HttpResponseRedirect(
+            reverse("admin:rpiconnect_connectupdatecampaign_change", args=[rollback_campaign.pk])
+        )
+
+    def _find_previous_known_good_release(self, campaign: ConnectUpdateCampaign) -> ConnectImageRelease | None:
+        successful_device_pk_set = set(
+            campaign.deployments.filter(status=ConnectUpdateDeployment.Status.SUCCEEDED).values_list("device_id", flat=True)
+        )
+        if not successful_device_pk_set:
+            return None
+
+        successful_campaign_ids = ConnectUpdateCampaign.objects.filter(
+            deployments__device_id__in=successful_device_pk_set,
+            deployments__status=ConnectUpdateDeployment.Status.SUCCEEDED,
+            status=ConnectUpdateCampaign.Status.COMPLETED,
+        ).exclude(pk=campaign.pk)
+
+        previous_release_qs = (
+            ConnectImageRelease.objects.filter(campaigns__in=successful_campaign_ids)
+            .exclude(pk=campaign.release_id)
+            .order_by("-released_at", "-created_at")
+            .distinct()
+        )
+        return previous_release_qs.first()
 
 
 @admin.register(ConnectUpdateDeployment)
@@ -74,6 +422,21 @@ class ConnectUpdateDeploymentAdmin(admin.ModelAdmin):
     )
     list_filter = ("status", "failure_classification", "started_at", "completed_at")
     search_fields = ("device__device_id", "campaign__id", "campaign__release__name")
+
+
+@admin.register(ConnectCampaignEvent)
+class ConnectCampaignEventAdmin(admin.ModelAdmin):
+    list_display = (
+        "campaign",
+        "deployment",
+        "event_type",
+        "from_status",
+        "to_status",
+        "created_by",
+        "created_at",
+    )
+    list_filter = ("event_type", "from_status", "to_status")
+    search_fields = ("campaign__id", "deployment__id", "event_type")
 
 
 @admin.register(ConnectIngestionEvent)

--- a/apps/rpiconnect/services/campaign_service.py
+++ b/apps/rpiconnect/services/campaign_service.py
@@ -82,6 +82,7 @@ class CampaignService:
         notes: str = "",
         override_conflicts: bool = False,
         batch_size: int = 0,
+        canary_percent: int | None = None,
         canary_size: int = 1,
     ) -> ConnectUpdateCampaign:
         """Create campaign, resolve targets, and schedule deployments."""
@@ -90,6 +91,8 @@ class CampaignService:
         devices = self.resolve_targets(target_set)
         if not devices:
             raise CampaignServiceError("No devices matched the provided target set.")
+        if canary_percent is not None:
+            canary_size = max(1, round(len(devices) * canary_percent / 100))
 
         self._validate_device_compatibility(release, devices)
         rollout_stages = self._build_rollout_stages(

--- a/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/campaign_wizard.html
+++ b/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/campaign_wizard.html
@@ -1,0 +1,36 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{% url 'admin:rpiconnect_connectupdatecampaign_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {% trans "Campaign wizard" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{% trans "Campaign wizard" %}</h1>
+  <p>{% trans "Create an update campaign with explicit targeting, rollout pacing, and launch timing controls." %}</p>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <fieldset class="module aligned">
+      {% for field in form %}
+      <div class="form-row">
+        {{ field.errors }}
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}<div class="help">{{ field.help_text }}</div>{% endif %}
+      </div>
+      {% endfor %}
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" value="{% trans 'Create campaign' %}" class="default">
+      <a href="{% url 'admin:rpiconnect_connectupdatecampaign_changelist' %}" class="button cancel-link">{% trans "Cancel" %}</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/change_form.html
+++ b/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if campaign_progress_url %}
+    <li><a href="{{ campaign_progress_url }}">{% trans "View live campaign progress" %}</a></li>
+  {% endif %}
+  {% if campaign_rollback_url and original %}
+    <li>
+      <form action="{{ campaign_rollback_url }}" method="post">
+        {% csrf_token %}
+        <button type="submit" class="button">{% trans "Rollback to previous known-good release" %}</button>
+      </form>
+    </li>
+  {% endif %}
+{% endblock %}

--- a/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/change_list.html
+++ b/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/change_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if campaign_wizard_url %}
+    <li><a href="{{ campaign_wizard_url }}">{% trans "Open campaign wizard" %}</a></li>
+  {% endif %}
+{% endblock %}

--- a/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/progress.html
+++ b/apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/progress.html
@@ -1,0 +1,58 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{% url 'admin:rpiconnect_connectupdatecampaign_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; <a href="{% url 'admin:rpiconnect_connectupdatecampaign_change' campaign.pk %}">{% trans "Campaign" %} {{ campaign.pk }}</a>
+  &rsaquo; {% trans "Live campaign progress" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{% trans "Live campaign progress" %}</h1>
+  <p>
+    {% trans "Campaign" %} {{ campaign.pk }}
+    &mdash; {% trans "Release" %}: {{ campaign.release.name }} ({{ campaign.release.version }})
+    &mdash; {% trans "Status" %}: {{ campaign.get_status_display }}
+  </p>
+
+  <h2>{% trans "Status totals" %}</h2>
+  <ul>
+    {% for status, count in status_counts.items %}
+      <li><strong>{{ status }}</strong>: {{ count }}</li>
+    {% empty %}
+      <li>{% trans "No deployments have been queued." %}</li>
+    {% endfor %}
+  </ul>
+
+  <h2>{% trans "Device-level failures and rollbacks" %}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>{% trans "Device ID" %}</th>
+        <th>{% trans "Deployment status" %}</th>
+        <th>{% trans "Failure classification" %}</th>
+        <th>{% trans "Error payload" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for deployment in failed_deployments %}
+      <tr>
+        <td>{{ deployment.device.device_id }}</td>
+        <td>{{ deployment.get_status_display }}</td>
+        <td>{{ deployment.get_failure_classification_display|default:"Unknown" }}</td>
+        <td><pre>{{ deployment.error_payload }}</pre></td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="4">{% trans "No device-level failures or rollbacks recorded." %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/apps/rpiconnect/tests/test_admin.py
+++ b/apps/rpiconnect/tests/test_admin.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.contrib import admin
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 
 from apps.rpiconnect.models import (
@@ -159,3 +160,79 @@ def test_campaign_admin_rollback_creates_previous_release_campaign(admin_client)
     ).get()
     assert rollback_campaign.release == previous_release
     assert rollback_campaign.status == ConnectUpdateCampaign.Status.RUNNING
+
+
+@pytest.mark.django_db
+def test_campaign_progress_requires_model_view_permission(client, django_user_model):
+    """Progress endpoint should deny staff users without campaign model permissions."""
+
+    user = django_user_model.objects.create_user(
+        username="ops-no-view",
+        password="password",
+        is_staff=True,
+    )
+    client.force_login(user)
+
+    release = ConnectImageRelease.objects.create(
+        name="stable",
+        version="2.0.0",
+        artifact_url="https://cdn.example.com/stable-2.0.0.img",
+        checksum="chk-perm-progress",
+    )
+    campaign = ConnectUpdateCampaign.objects.create(
+        release=release,
+        target_set={"device_ids": [], "labels": [], "cohorts": []},
+        strategy=ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+        status=ConnectUpdateCampaign.Status.DRAFT,
+    )
+
+    response = client.get(reverse("admin:rpiconnect_campaign_progress", args=[campaign.pk]))
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_campaign_rollback_requires_change_and_add_permission(client, django_user_model):
+    """Rollback endpoint should deny staff users that lack add/change campaign permissions."""
+
+    user = django_user_model.objects.create_user(
+        username="ops-no-rollback",
+        password="password",
+        is_staff=True,
+    )
+    user.user_permissions.add(
+        Permission.objects.get(codename="view_connectupdatecampaign"),
+    )
+    client.force_login(user)
+
+    account = ConnectAccount.objects.create(
+        name="Ops",
+        account_type=ConnectAccount.AccountType.ORG,
+        organization_name="Arthexis",
+        token_reference="token",
+    )
+    device = ConnectDevice.objects.create(
+        account=account,
+        device_id="pi-rollback-perm",
+    )
+    current_release = ConnectImageRelease.objects.create(
+        name="stable",
+        version="2.1.0",
+        artifact_url="https://cdn.example.com/stable-2.1.0.img",
+        checksum="chk-perm-rollback",
+    )
+    campaign = ConnectUpdateCampaign.objects.create(
+        release=current_release,
+        target_set={"device_ids": [device.device_id], "labels": [], "cohorts": []},
+        strategy=ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+        status=ConnectUpdateCampaign.Status.RUNNING,
+    )
+    ConnectUpdateDeployment.objects.create(
+        campaign=campaign,
+        device=device,
+        status=ConnectUpdateDeployment.Status.SUCCEEDED,
+    )
+
+    response = client.post(reverse("admin:rpiconnect_campaign_rollback", args=[campaign.pk]))
+
+    assert response.status_code == 403

--- a/apps/rpiconnect/tests/test_admin.py
+++ b/apps/rpiconnect/tests/test_admin.py
@@ -1,0 +1,161 @@
+"""Admin UI regression tests for Raspberry Pi Connect operations."""
+
+import pytest
+from django.contrib import admin
+from django.urls import reverse
+
+from apps.rpiconnect.models import (
+    ConnectAccount,
+    ConnectDevice,
+    ConnectImageRelease,
+    ConnectUpdateCampaign,
+    ConnectUpdateDeployment,
+)
+
+
+@pytest.mark.django_db
+def test_connect_device_admin_shows_inventory_eligibility_indicators():
+    """Device admin should render inventory signal columns used for eligibility checks."""
+
+    model_admin = admin.site._registry[ConnectDevice]
+    account = ConnectAccount.objects.create(
+        name="Ops",
+        account_type=ConnectAccount.AccountType.ORG,
+        organization_name="Arthexis",
+        token_reference="token",
+    )
+    device = ConnectDevice.objects.create(
+        account=account,
+        device_id="pi-01",
+        hardware_model="rpi-4b",
+        metadata={"connectivity": "ethernet", "free_space": "12 GB"},
+        os_release="bookworm",
+    )
+
+    assert model_admin.connectivity_indicator(device) == "ethernet"
+    assert model_admin.free_space_indicator(device) == "12 GB"
+    assert "Eligible" in model_admin.eligibility_indicator(device)
+
+
+@pytest.mark.django_db
+def test_campaign_wizard_creates_campaign_and_progress_page_renders(admin_client):
+    """Campaign wizard should create admin-configured campaign and expose progress drill-down."""
+
+    account = ConnectAccount.objects.create(
+        name="Ops",
+        account_type=ConnectAccount.AccountType.ORG,
+        organization_name="Arthexis",
+        token_reference="token",
+    )
+    device = ConnectDevice.objects.create(
+        account=account,
+        device_id="pi-02",
+        hardware_model="rpi-4b",
+        os_release="bookworm",
+    )
+    release = ConnectImageRelease.objects.create(
+        name="stable",
+        version="1.2.3",
+        artifact_url="https://cdn.example.com/stable.img",
+        checksum="abc123",
+        compatibility_tags=["rpi-4b", "bookworm"],
+    )
+
+    response = admin_client.post(
+        reverse("admin:rpiconnect_campaign_wizard"),
+        data={
+            "release": release.pk,
+            "device_ids": device.device_id,
+            "labels": "",
+            "cohorts": "",
+            "strategy": ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+            "canary_percent": 10,
+            "batch_size": 10,
+            "launch_timing": "start_now",
+            "timing_notes": "02:00 UTC",
+            "notes": "Rollout",
+            "override_conflicts": False,
+        },
+    )
+
+    assert response.status_code == 302
+
+    campaign = ConnectUpdateCampaign.objects.get()
+    assert campaign.status == ConnectUpdateCampaign.Status.RUNNING
+    assert "Timing notes: 02:00 UTC" in campaign.notes
+
+    deployment = ConnectUpdateDeployment.objects.get(campaign=campaign)
+    deployment.status = ConnectUpdateDeployment.Status.FAILED
+    deployment.error_payload = {"reason": "checksum mismatch"}
+    deployment.save()
+
+    progress_response = admin_client.get(reverse("admin:rpiconnect_campaign_progress", args=[campaign.pk]))
+    assert progress_response.status_code == 200
+    page = progress_response.content.decode("utf-8")
+    assert "Device-level failures and rollbacks" in page
+    assert "checksum mismatch" in page
+
+
+@pytest.mark.django_db
+def test_campaign_admin_rollback_creates_previous_release_campaign(admin_client):
+    """Rollback action should create a new campaign targeting succeeded devices on previous release."""
+
+    account = ConnectAccount.objects.create(
+        name="Ops",
+        account_type=ConnectAccount.AccountType.ORG,
+        organization_name="Arthexis",
+        token_reference="token",
+    )
+    device = ConnectDevice.objects.create(
+        account=account,
+        device_id="pi-03",
+        hardware_model="rpi-4b",
+        os_release="bookworm",
+    )
+    previous_release = ConnectImageRelease.objects.create(
+        name="stable",
+        version="1.2.2",
+        artifact_url="https://cdn.example.com/stable-1.2.2.img",
+        checksum="chk-prev",
+        compatibility_tags=["rpi-4b", "bookworm"],
+    )
+    current_release = ConnectImageRelease.objects.create(
+        name="stable",
+        version="1.2.3",
+        artifact_url="https://cdn.example.com/stable-1.2.3.img",
+        checksum="chk-cur",
+        compatibility_tags=["rpi-4b", "bookworm"],
+    )
+
+    previous_campaign = ConnectUpdateCampaign.objects.create(
+        release=previous_release,
+        target_set={"device_ids": [device.device_id], "labels": [], "cohorts": []},
+        strategy=ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+        status=ConnectUpdateCampaign.Status.COMPLETED,
+    )
+    ConnectUpdateDeployment.objects.create(
+        campaign=previous_campaign,
+        device=device,
+        status=ConnectUpdateDeployment.Status.SUCCEEDED,
+    )
+
+    current_campaign = ConnectUpdateCampaign.objects.create(
+        release=current_release,
+        target_set={"device_ids": [device.device_id], "labels": [], "cohorts": []},
+        strategy=ConnectUpdateCampaign.Strategy.ALL_AT_ONCE,
+        status=ConnectUpdateCampaign.Status.RUNNING,
+    )
+    ConnectUpdateDeployment.objects.create(
+        campaign=current_campaign,
+        device=device,
+        status=ConnectUpdateDeployment.Status.SUCCEEDED,
+    )
+
+    response = admin_client.post(reverse("admin:rpiconnect_campaign_rollback", args=[current_campaign.pk]))
+
+    assert response.status_code == 302
+    rollback_campaign = ConnectUpdateCampaign.objects.exclude(
+        pk__in=[previous_campaign.pk, current_campaign.pk]
+    ).get()
+    assert rollback_campaign.release == previous_release
+    assert rollback_campaign.status == ConnectUpdateCampaign.Status.RUNNING


### PR DESCRIPTION
### Motivation
- Provide a powerful, descriptive admin surface for managing device rollouts, including inventory eligibility signals (Pi model, OS, connectivity, reported free space) to help operators assess target suitability.
- Expose release metadata (compatibility summary and checksum) and a guided campaign creation flow (target selectors, canary %, batch size, timing) so admins can schedule and pace rollouts from the Django admin.
- Offer live campaign monitoring with device-level failure drill-down and a straightforward rollback action to a previous known-good release to speed incident response.

### Description
- Extended `apps/rpiconnect/admin.py` to add `ConnectCampaignWizardForm`, admin display helpers (`connectivity_indicator`, `free_space_indicator`, `eligibility_indicator`, `compatibility_summary`, `progress_summary`), and admin views for the campaign wizard, progress dashboard, and rollback action that leverages `CampaignService` and `_find_previous_known_good_release`.
- Registered view endpoints and wired them into the change list/change form using `change_list_template` / `change_form_template` and custom `get_urls` shortcuts for `wizard/`, `<id>/progress/`, and `<id>/rollback/`.
- Added templates under `apps/rpiconnect/templates/admin/rpiconnect/connectupdatecampaign/` for `campaign_wizard.html`, `progress.html`, `change_form.html`, and `change_list.html` to keep UI consistent with the suite admin patterns and avoid hardcoded styling.
- Added regression tests at `apps/rpiconnect/tests/test_admin.py` covering inventory indicators, the campaign wizard flow, progress rendering with device-level failure contents, and the rollback creation flow.

### Testing
- Prepared the environment by running `./env-refresh.sh --deps-only` to ensure dependencies and test tooling were available.
- Executed the admin test suites with `.venv/bin/python manage.py test run -- apps/rpiconnect/tests/test_admin.py apps/imager/tests/test_admin.py` and observed successful results: `13 passed`.
- Confirmed the new admin flows through the test assertions which exercise wizard creation, progress page rendering, and rollback campaign creation (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e830b239408326998c17b5dde5112d)