### PR TITLE
docs/repos: add PR review and merge controls to GitHub detail view

### DIFF
--- a/apps/docs/templates/docs/github_detail.html
+++ b/apps/docs/templates/docs/github_detail.html
@@ -25,6 +25,23 @@
       <p class="text-muted mb-3">
         {% trans "Overall checks" %}: <strong>{{ checks_state }}</strong>
       </p>
+      <p class="text-muted mb-1">
+        {% trans "Mergeable" %}: <strong>{{ mergeability.mergeable|default:"unknown" }}</strong>
+      </p>
+      <p class="text-muted mb-3">
+        {% trans "Merge status" %}: <strong>{{ mergeability.mergeable_state|default:"unknown" }}</strong>
+      </p>
+      <h2>{% trans "Review Summary" %}</h2>
+      <ul>
+        <li>{% trans "Approved" %}: <strong>{{ review_summary.approved }}</strong></li>
+        <li>{% trans "Changes requested" %}: <strong>{{ review_summary.changes_requested }}</strong></li>
+        <li>{% trans "Pending reviewers" %}: <strong>{{ review_summary.pending }}</strong></li>
+      </ul>
+      <h2>{% trans "Review Threads" %}</h2>
+      <ul>
+        <li>{% trans "Review comments" %}: <strong>{{ review_comment_summary.comments }}</strong></li>
+        <li>{% trans "Threads" %}: <strong>{{ review_comment_summary.threads }}</strong></li>
+      </ul>
     {% endif %}
 
     {% if error_message %}
@@ -36,6 +53,7 @@
     <h2>{% trans "Respond" %}</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
+      <input type="hidden" name="action" value="comment">
       <div class="mb-3">
         <label class="form-label" for="template">{% trans "Template" %}</label>
         <select class="form-select" id="template" name="template">
@@ -51,6 +69,55 @@
       </div>
       <button class="btn btn-primary" type="submit">{% trans "Post response" %}</button>
     </form>
+
+    {% if item.pull_request %}
+      <h2>{% trans "Pull Request Review" %}</h2>
+      <form method="post" class="mb-4">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="pr_review">
+        <div class="mb-3">
+          <label class="form-label" for="decision">{% trans "Review decision" %}</label>
+          <select class="form-select" id="decision" name="decision" required>
+            <option value="approve">{% trans "Approve" %}</option>
+            <option value="request_changes">{% trans "Request changes" %}</option>
+            <option value="comment">{% trans "Comment only" %}</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="review_body">{% trans "Review summary" %}</label>
+          <textarea class="form-control" id="review_body" name="review_body" rows="4" placeholder="{% trans 'Required for request changes and comment-only reviews.' %}"></textarea>
+        </div>
+        <button class="btn btn-outline-primary" type="submit">{% trans "Submit review" %}</button>
+      </form>
+
+      <h2>{% trans "Merge Pull Request" %}</h2>
+      {% if merge_guardrail %}
+        <div class="alert alert-warning" role="alert">{{ merge_guardrail }}</div>
+      {% endif %}
+      <form method="post" class="mb-4">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="pr_merge">
+        <div class="mb-3">
+          <label class="form-label" for="merge_method">{% trans "Merge method" %}</label>
+          <select class="form-select" id="merge_method" name="merge_method">
+            <option value="squash">{% trans "Squash merge" %}</option>
+            <option value="merge">{% trans "Create merge commit" %}</option>
+            <option value="rebase">{% trans "Rebase and merge" %}</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="commit_title">{% trans "Commit title (optional)" %}</label>
+          <input class="form-control" id="commit_title" name="commit_title" type="text">
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="commit_message">{% trans "Commit message (optional)" %}</label>
+          <textarea class="form-control" id="commit_message" name="commit_message" rows="4"></textarea>
+        </div>
+        <button class="btn btn-success" type="submit" {% if not merge_allowed %}disabled aria-disabled="true"{% endif %}>
+          {% trans "Merge pull request" %}
+        </button>
+      </form>
+    {% endif %}
 
     <h2>{% trans "Comments" %}</h2>
     {% for comment in comments %}

--- a/apps/docs/templates/docs/github_detail.html
+++ b/apps/docs/templates/docs/github_detail.html
@@ -26,7 +26,7 @@
         {% trans "Overall checks" %}: <strong>{{ checks_state }}</strong>
       </p>
       <p class="text-muted mb-1">
-        {% trans "Mergeable" %}: <strong>{{ mergeability.mergeable|default:"unknown" }}</strong>
+        {% trans "Mergeability flag" %}: <strong>{{ mergeability.mergeable|default_if_none:"unknown" }}</strong>
       </p>
       <p class="text-muted mb-3">
         {% trans "Merge status" %}: <strong>{{ mergeability.mergeable_state|default:"unknown" }}</strong>

--- a/apps/docs/tests/test_github_detail_view.py
+++ b/apps/docs/tests/test_github_detail_view.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from apps.docs import views
+
+
+@pytest.fixture
+def staff_client(client):
+    user = get_user_model().objects.create_user(
+        username="docs-admin",
+        password="pass",
+        email="docs@example.com",
+        is_staff=True,
+        is_superuser=True,
+    )
+    client.force_login(user)
+    return client
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _mock_connection(monkeypatch):
+    monkeypatch.setattr(
+        views,
+        "_resolve_github_docs_connection",
+        lambda: SimpleNamespace(
+            connected=True,
+            owner="octo",
+            repo="demo",
+            token="tok",
+            slug="octo/demo",
+        ),
+    )
+
+
+def test_github_detail_pr_open_mergeable_renders_review_and_merge_actions(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 12,
+            "title": "Feature PR",
+            "state": "open",
+            "body": "PR body",
+            "pull_request": {"url": "https://api.github.test/pulls/12"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "requested_reviewers": [{"login": "alice"}],
+            "head": {"sha": "abc123"},
+        },
+    )
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request_reviews",
+        lambda **kwargs: [{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}],
+    )
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request_review_comments",
+        lambda **kwargs: [{"id": 1}, {"id": 2, "in_reply_to_id": 1}],
+    )
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_commit_status_summary",
+        lambda **kwargs: {"state": "success"},
+    )
+
+    response = staff_client.get(reverse("docs:docs-github-item", kwargs={"number": 12}))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Review Summary" in content
+    assert "Approved" in content
+    assert "Changes requested" in content
+    assert "Merge pull request" in content
+    assert "disabled" not in content.split("Merge pull request")[0][-120:]
+
+
+def test_github_detail_pr_closed_disables_merge_and_shows_guardrail(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 14,
+            "title": "Closed PR",
+            "state": "closed",
+            "body": "Closed",
+            "pull_request": {"url": "https://api.github.test/pulls/14"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "closed",
+            "mergeable": False,
+            "mergeable_state": "dirty",
+            "requested_reviewers": [],
+            "head": {"sha": "abc123"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_commit_status_summary", lambda **kwargs: {"state": "failure"})
+
+    response = staff_client.get(reverse("docs:docs-github-item", kwargs={"number": 14}))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Pull request is closed." in content
+    assert 'disabled aria-disabled="true"' in content
+
+
+def test_github_detail_pr_merge_post_surfaces_merge_error(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 15,
+            "title": "Blocked PR",
+            "state": "open",
+            "body": "Blocked",
+            "pull_request": {"url": "https://api.github.test/pulls/15"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": None,
+            "mergeable_state": "unknown",
+            "requested_reviewers": [],
+            "head": {"sha": ""},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
+
+    def fail_merge(**kwargs):
+        raise views.GitHubRepositoryError("Mergeability is unknown")
+
+    monkeypatch.setattr(views.github_service, "merge_pull_request", fail_merge)
+
+    response = staff_client.post(
+        reverse("docs:docs-github-item", kwargs={"number": 15}),
+        data={"action": "pr_merge", "merge_method": "squash"},
+    )
+
+    assert response.status_code == 200
+    assert "Mergeability is unknown" in response.content.decode()

--- a/apps/docs/tests/test_github_detail_view.py
+++ b/apps/docs/tests/test_github_detail_view.py
@@ -67,7 +67,10 @@ def test_github_detail_pr_open_mergeable_renders_review_and_merge_actions(staff_
     monkeypatch.setattr(
         views.github_service,
         "fetch_pull_request_reviews",
-        lambda **kwargs: [{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}],
+        lambda **kwargs: [
+            {"state": "CHANGES_REQUESTED", "user": {"login": "alice"}},
+            {"state": "APPROVED", "user": {"login": "alice"}},
+        ],
     )
     monkeypatch.setattr(
         views.github_service,
@@ -87,6 +90,7 @@ def test_github_detail_pr_open_mergeable_renders_review_and_merge_actions(staff_
     assert "Review Summary" in content
     assert "Approved" in content
     assert "Changes requested" in content
+    assert "<strong>1</strong>" in content
     assert "Merge pull request" in content
     assert "disabled" not in content.split("Merge pull request")[0][-120:]
 
@@ -156,7 +160,10 @@ def test_github_detail_pr_merge_post_surfaces_merge_error(staff_client, monkeypa
     monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
     monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
 
+    merge_calls: list[dict[str, str]] = []
+
     def fail_merge(**kwargs):
+        merge_calls.append(kwargs)
         raise views.GitHubRepositoryError("Mergeability is unknown")
 
     monkeypatch.setattr(views.github_service, "merge_pull_request", fail_merge)
@@ -167,4 +174,94 @@ def test_github_detail_pr_merge_post_surfaces_merge_error(staff_client, monkeypa
     )
 
     assert response.status_code == 200
-    assert "Mergeability is unknown" in response.content.decode()
+    assert "Mergeability is still being calculated by GitHub." in response.content.decode()
+    assert len(merge_calls) == 0
+
+
+def test_github_detail_pr_merge_post_blocks_crafted_request_when_checks_fail(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 18,
+            "title": "Guarded PR",
+            "state": "open",
+            "body": "Guarded",
+            "pull_request": {"url": "https://api.github.test/pulls/18"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "requested_reviewers": [],
+            "head": {"sha": "abc123"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service, "fetch_commit_status_summary", lambda **kwargs: {"state": "failure"}
+    )
+    merge_attempted = {"called": False}
+
+    def fail_if_called(**kwargs):
+        merge_attempted["called"] = True
+        raise AssertionError("merge_pull_request should not run when guardrails fail")
+
+    monkeypatch.setattr(views.github_service, "merge_pull_request", fail_if_called)
+
+    response = staff_client.post(
+        reverse("docs:docs-github-item", kwargs={"number": 18}),
+        data={"action": "pr_merge", "merge_method": "squash"},
+    )
+
+    assert response.status_code == 200
+    assert "Checks are not passing" in response.content.decode()
+    assert merge_attempted["called"] is False
+
+
+def test_github_detail_pr_status_fetch_error_keeps_merge_disabled(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 19,
+            "title": "Status Error PR",
+            "state": "open",
+            "body": "Status Error",
+            "pull_request": {"url": "https://api.github.test/pulls/19"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "requested_reviewers": [],
+            "head": {"sha": "abc123"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
+
+    def raise_status_error(**kwargs):
+        raise views.GitHubRepositoryError("Status lookup failed")
+
+    monkeypatch.setattr(views.github_service, "fetch_commit_status_summary", raise_status_error)
+
+    response = staff_client.get(reverse("docs:docs-github-item", kwargs={"number": 19}))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Status lookup failed" in content
+    assert 'disabled aria-disabled="true"' in content

--- a/apps/docs/tests/test_github_detail_view.py
+++ b/apps/docs/tests/test_github_detail_view.py
@@ -265,3 +265,54 @@ def test_github_detail_pr_status_fetch_error_keeps_merge_disabled(staff_client, 
     content = response.content.decode()
     assert "Status lookup failed" in content
     assert 'disabled aria-disabled="true"' in content
+
+
+def test_github_detail_pr_pending_without_statuses_allows_merge(staff_client, monkeypatch):
+    _mock_connection(monkeypatch)
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_issue_or_pull_request",
+        lambda **kwargs: {
+            "number": 20,
+            "title": "No status checks PR",
+            "state": "open",
+            "body": "No statuses yet",
+            "pull_request": {"url": "https://api.github.test/pulls/20"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_issue_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "requested_reviewers": [],
+            "head": {"sha": "abc123"},
+        },
+    )
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_reviews", lambda **kwargs: [])
+    monkeypatch.setattr(views.github_service, "fetch_pull_request_review_comments", lambda **kwargs: [])
+    monkeypatch.setattr(
+        views.github_service,
+        "fetch_commit_status_summary",
+        lambda **kwargs: {"state": "pending", "total_count": 0},
+    )
+
+    merge_calls: list[dict[str, object]] = []
+
+    def fake_merge(**kwargs):
+        merge_calls.append(kwargs)
+        return {"merged": True}
+
+    monkeypatch.setattr(views.github_service, "merge_pull_request", fake_merge)
+
+    response = staff_client.post(
+        reverse("docs:docs-github-item", kwargs={"number": 20}),
+        data={"action": "pr_merge", "merge_method": "squash"},
+    )
+
+    assert response.status_code == 302
+    assert len(merge_calls) == 1
+    assert merge_calls[0]["expected_head_sha"] == "abc123"

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -957,13 +957,14 @@ def _summarize_pull_request_reviews(
     reviews: list[Mapping[str, object]],
     pull_request: Mapping[str, object],
 ) -> dict[str, int]:
-    counts = Counter()
+    latest_review_state_by_user: dict[str, str] = {}
     for review in reviews:
+        user_login = str((review.get("user") or {}).get("login") or "").strip()
         state = str(review.get("state") or "").strip().upper()
-        if state == "APPROVED":
-            counts["approved"] += 1
-        elif state == "CHANGES_REQUESTED":
-            counts["changes_requested"] += 1
+        if user_login and state in {"APPROVED", "CHANGES_REQUESTED"}:
+            latest_review_state_by_user[user_login] = state
+
+    counts = Counter(latest_review_state_by_user.values())
 
     requested_reviewers = pull_request.get("requested_reviewers")
     if isinstance(requested_reviewers, list):
@@ -972,10 +973,33 @@ def _summarize_pull_request_reviews(
         counts["pending"] = 0
 
     return {
-        "approved": counts["approved"],
-        "changes_requested": counts["changes_requested"],
+        "approved": counts["APPROVED"],
+        "changes_requested": counts["CHANGES_REQUESTED"],
         "pending": counts["pending"],
     }
+
+
+def _build_pull_request_merge_guardrails(
+    *,
+    pull_request: Mapping[str, object],
+    checks_state: str,
+) -> tuple[bool, str]:
+    if str(pull_request.get("state") or "").lower() != "open":
+        return False, "Pull request is closed."
+
+    mergeable = pull_request.get("mergeable")
+    mergeable_state = str(pull_request.get("mergeable_state") or "unknown")
+    if mergeable is None:
+        return False, "Mergeability is still being calculated by GitHub."
+    if mergeable is not True:
+        return (
+            False,
+            "GitHub reports this pull request is currently not mergeable "
+            f"({mergeable_state}).",
+        )
+    if checks_state not in {"success", "not_applicable", "unknown"}:
+        return False, f"Checks are not passing (state: {checks_state})."
+    return True, ""
 
 
 def _summarize_pull_request_review_comments(
@@ -1078,6 +1102,36 @@ def github_issue_detail(request, number: int):
                 return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
 
             if action == "pr_merge":
+                merge_pull_request = dict(
+                    github_service.fetch_pull_request(
+                        token=connection.token,
+                        owner=connection.owner,
+                        name=connection.repo,
+                        number=number,
+                    )
+                )
+                merge_head_sha = str(
+                    (merge_pull_request.get("head") or {}).get("sha") or ""
+                ).strip()
+                merge_checks_state = "unknown"
+                if merge_head_sha:
+                    merge_status_payload = github_service.fetch_commit_status_summary(
+                        token=connection.token,
+                        owner=connection.owner,
+                        name=connection.repo,
+                        sha=merge_head_sha,
+                    )
+                    merge_checks_state = str(
+                        merge_status_payload.get("state") or "unknown"
+                    )
+                merge_allowed, merge_guardrail = _build_pull_request_merge_guardrails(
+                    pull_request=merge_pull_request,
+                    checks_state=merge_checks_state,
+                )
+                if not merge_allowed:
+                    raise GitHubRepositoryError(
+                        merge_guardrail or "Merge guardrails prevented this action."
+                    )
                 merge_method = (request.POST.get("merge_method") or "squash").strip()
                 github_service.merge_pull_request(
                     owner=connection.owner,
@@ -1161,19 +1215,6 @@ def github_issue_detail(request, number: int):
                 "mergeable": pull_request.get("mergeable"),
                 "mergeable_state": str(pull_request.get("mergeable_state") or "unknown"),
             }
-            if str(pull_request.get("state") or "").lower() != "open":
-                merge_guardrail = "Pull request is closed."
-            elif mergeability["mergeable"] is None:
-                merge_guardrail = "Mergeability is still being calculated by GitHub."
-            elif mergeability["mergeable"] is not True:
-                merge_guardrail = (
-                    "GitHub reports this pull request is currently not mergeable "
-                    f"({mergeability['mergeable_state']})."
-                )
-            elif checks_state not in {"success", "not_applicable", "unknown"}:
-                merge_guardrail = f"Checks are not passing (state: {checks_state})."
-            else:
-                merge_allowed = True
 
             if head_sha:
                 status_payload = github_service.fetch_commit_status_summary(
@@ -1183,11 +1224,12 @@ def github_issue_detail(request, number: int):
                     sha=head_sha,
                 )
                 checks_state = str(status_payload.get("state") or "unknown")
-                if merge_allowed and checks_state not in {"success", "not_applicable", "unknown"}:
-                    merge_allowed = False
-                    merge_guardrail = f"Checks are not passing (state: {checks_state})."
             else:
                 checks_state = "unknown"
+            merge_allowed, merge_guardrail = _build_pull_request_merge_guardrails(
+                pull_request=pull_request,
+                checks_state=checks_state,
+            )
     except GitHubRepositoryError as exc:
         post_error = post_error or str(exc)
 

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -1002,6 +1002,14 @@ def _build_pull_request_merge_guardrails(
     return True, ""
 
 
+def _derive_checks_state(status_payload: Mapping[str, object]) -> str:
+    state = str(status_payload.get("state") or "unknown").strip().lower()
+    total_count = status_payload.get("total_count")
+    if state == "pending" and isinstance(total_count, int) and total_count == 0:
+        return "not_applicable"
+    return state or "unknown"
+
+
 def _summarize_pull_request_review_comments(
     review_comments: list[Mapping[str, object]],
 ) -> dict[str, int]:
@@ -1121,9 +1129,7 @@ def github_issue_detail(request, number: int):
                         name=connection.repo,
                         sha=merge_head_sha,
                     )
-                    merge_checks_state = str(
-                        merge_status_payload.get("state") or "unknown"
-                    )
+                    merge_checks_state = _derive_checks_state(merge_status_payload)
                 merge_allowed, merge_guardrail = _build_pull_request_merge_guardrails(
                     pull_request=merge_pull_request,
                     checks_state=merge_checks_state,
@@ -1141,6 +1147,7 @@ def github_issue_detail(request, number: int):
                     merge_method=merge_method,
                     commit_title=(request.POST.get("commit_title") or "").strip(),
                     commit_message=(request.POST.get("commit_message") or "").strip(),
+                    expected_head_sha=merge_head_sha,
                 )
                 return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
 
@@ -1223,7 +1230,7 @@ def github_issue_detail(request, number: int):
                     name=connection.repo,
                     sha=head_sha,
                 )
-                checks_state = str(status_payload.get("state") or "unknown")
+                checks_state = _derive_checks_state(status_payload)
             else:
                 checks_state = "unknown"
             merge_allowed, merge_guardrail = _build_pull_request_merge_guardrails(

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -1,5 +1,7 @@
 import logging
 import mimetypes
+from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import urlencode, urlunsplit
@@ -951,6 +953,43 @@ def _parse_github_comment_payload(
     return True, body, None
 
 
+def _summarize_pull_request_reviews(
+    reviews: list[Mapping[str, object]],
+    pull_request: Mapping[str, object],
+) -> dict[str, int]:
+    counts = Counter()
+    for review in reviews:
+        state = str(review.get("state") or "").strip().upper()
+        if state == "APPROVED":
+            counts["approved"] += 1
+        elif state == "CHANGES_REQUESTED":
+            counts["changes_requested"] += 1
+
+    requested_reviewers = pull_request.get("requested_reviewers")
+    if isinstance(requested_reviewers, list):
+        counts["pending"] = sum(1 for reviewer in requested_reviewers if isinstance(reviewer, Mapping))
+    else:
+        counts["pending"] = 0
+
+    return {
+        "approved": counts["approved"],
+        "changes_requested": counts["changes_requested"],
+        "pending": counts["pending"],
+    }
+
+
+def _summarize_pull_request_review_comments(
+    review_comments: list[Mapping[str, object]],
+) -> dict[str, int]:
+    total = len(review_comments)
+    reply_count = sum(1 for comment in review_comments if comment.get("in_reply_to_id"))
+    thread_count = total - reply_count
+    return {
+        "comments": total,
+        "threads": max(thread_count, 0),
+    }
+
+
 @module_pill_link_validation(_show_docs_navigation_link)
 @security_group_required(*DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES)
 def github_issue_viewer(request):
@@ -1015,24 +1054,65 @@ def github_issue_detail(request, number: int):
         )
 
     post_error = ""
-    is_post, comment_body, payload_error = _parse_github_comment_payload(request)
-    if is_post and payload_error:
-        post_error = payload_error
-    elif is_post:
+    if request.method == "POST":
+        action = (request.POST.get("action") or "comment").strip()
         try:
-            github_service.create_issue_comment(
-                connection.owner,
-                connection.repo,
-                issue_number=number,
-                token=connection.token,
-                body=comment_body,
-            )
-            return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
-        except GitHubRepositoryError as exc:
+            if action == "pr_review":
+                decision_map = {
+                    "approve": "APPROVE",
+                    "request_changes": "REQUEST_CHANGES",
+                    "comment": "COMMENT",
+                }
+                decision = decision_map.get((request.POST.get("decision") or "").strip())
+                if not decision:
+                    raise ValueError("Review decision is required.")
+                review_body = (request.POST.get("review_body") or "").strip()
+                github_service.submit_pull_request_review_decision(
+                    owner=connection.owner,
+                    repository=connection.repo,
+                    pull_number=number,
+                    token=connection.token,
+                    decision=decision,
+                    body=review_body,
+                )
+                return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
+
+            if action == "pr_merge":
+                merge_method = (request.POST.get("merge_method") or "squash").strip()
+                github_service.merge_pull_request(
+                    owner=connection.owner,
+                    repository=connection.repo,
+                    pull_number=number,
+                    token=connection.token,
+                    merge_method=merge_method,
+                    commit_title=(request.POST.get("commit_title") or "").strip(),
+                    commit_message=(request.POST.get("commit_message") or "").strip(),
+                )
+                return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
+
+            is_post, comment_body, payload_error = _parse_github_comment_payload(request)
+            if is_post and payload_error:
+                post_error = payload_error
+            elif is_post:
+                github_service.create_issue_comment(
+                    connection.owner,
+                    connection.repo,
+                    issue_number=number,
+                    token=connection.token,
+                    body=comment_body,
+                )
+                return redirect(reverse("docs:docs-github-item", kwargs={"number": number}))
+        except (GitHubRepositoryError, ValueError) as exc:
             post_error = str(exc)
     item = None
     comments = []
     checks_state = "not_applicable"
+    pull_request = {}
+    review_summary = {"approved": 0, "changes_requested": 0, "pending": 0}
+    review_comment_summary = {"comments": 0, "threads": 0}
+    mergeability = {"mergeable": None, "mergeable_state": "not_applicable"}
+    merge_allowed = False
+    merge_guardrail = ""
     try:
         item = github_service.fetch_issue_or_pull_request(
             token=connection.token,
@@ -1050,13 +1130,51 @@ def github_issue_detail(request, number: int):
             )
         )
         if is_pull_request:
-            pull = github_service.fetch_pull_request(
-                token=connection.token,
-                owner=connection.owner,
-                name=connection.repo,
-                number=number,
+            pull_request = dict(
+                github_service.fetch_pull_request(
+                    token=connection.token,
+                    owner=connection.owner,
+                    name=connection.repo,
+                    number=number,
+                )
             )
-            head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
+            head_sha = str((pull_request.get("head") or {}).get("sha") or "").strip()
+            reviews = list(
+                github_service.fetch_pull_request_reviews(
+                    token=connection.token,
+                    owner=connection.owner,
+                    name=connection.repo,
+                    number=number,
+                )
+            )
+            review_comments = list(
+                github_service.fetch_pull_request_review_comments(
+                    token=connection.token,
+                    owner=connection.owner,
+                    name=connection.repo,
+                    number=number,
+                )
+            )
+            review_summary = _summarize_pull_request_reviews(reviews, pull_request)
+            review_comment_summary = _summarize_pull_request_review_comments(review_comments)
+            mergeability = {
+                "mergeable": pull_request.get("mergeable"),
+                "mergeable_state": str(pull_request.get("mergeable_state") or "unknown"),
+            }
+            if str(pull_request.get("state") or "").lower() != "open":
+                merge_guardrail = "Pull request is closed."
+            elif mergeability["mergeable"] is None:
+                merge_guardrail = "Mergeability is still being calculated by GitHub."
+            elif mergeability["mergeable"] is not True:
+                merge_guardrail = (
+                    "GitHub reports this pull request is currently not mergeable "
+                    f"({mergeability['mergeable_state']})."
+                )
+            elif checks_state not in {"success", "not_applicable", "unknown"}:
+                merge_guardrail = f"Checks are not passing (state: {checks_state})."
+            else:
+                merge_allowed = True
+
             if head_sha:
                 status_payload = github_service.fetch_commit_status_summary(
                     token=connection.token,
@@ -1065,6 +1183,9 @@ def github_issue_detail(request, number: int):
                     sha=head_sha,
                 )
                 checks_state = str(status_payload.get("state") or "unknown")
+                if merge_allowed and checks_state not in {"success", "not_applicable", "unknown"}:
+                    merge_allowed = False
+                    merge_guardrail = f"Checks are not passing (state: {checks_state})."
             else:
                 checks_state = "unknown"
     except GitHubRepositoryError as exc:
@@ -1080,6 +1201,12 @@ def github_issue_detail(request, number: int):
         "error_message": post_error,
         "github_connected": True,
         "item": item,
+        "merge_allowed": merge_allowed,
+        "merge_guardrail": merge_guardrail,
+        "mergeability": mergeability,
+        "pull_request": pull_request,
+        "review_comment_summary": review_comment_summary,
+        "review_summary": review_summary,
         "repository_slug": connection.slug,
         "response_templates": response_templates,
         "title": f"GitHub #{number}",

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -689,17 +689,6 @@ def submit_pull_request_review_decision(
         )
 
     headers = build_headers(token, user_agent="arthexis-runtime-reporter")
-    if not _pull_request_is_open(
-        owner,
-        repository,
-        pull_number=pull_number,
-        headers=headers,
-        timeout=timeout,
-    ):
-        raise GitHubRepositoryError(
-            f"Cannot review PR #{pull_number} because it is not open"
-        )
-
     payload: dict[str, str] = {"event": normalized_decision}
     if cleaned_body:
         payload["body"] = cleaned_body

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -732,6 +732,7 @@ def merge_pull_request(
     merge_method: str = "squash",
     commit_title: str = "",
     commit_message: str = "",
+    expected_head_sha: str = "",
     timeout: int = REQUEST_TIMEOUT,
 ) -> Mapping[str, object]:
     """Merge a pull request when GitHub reports it is mergeable."""
@@ -760,8 +761,16 @@ def merge_pull_request(
         raise GitHubRepositoryError(
             f"Cannot merge PR #{pull_number} while mergeable state is '{mergeable_state}'"
         )
+    current_head_sha = str((pull.get("head") or {}).get("sha") or "").strip()
+    requested_head_sha = expected_head_sha.strip()
+    if requested_head_sha and current_head_sha != requested_head_sha:
+        raise GitHubRepositoryError(
+            "Pull request head changed while preparing merge; refresh and try again"
+        )
 
     payload: dict[str, str] = {"merge_method": method}
+    if current_head_sha:
+        payload["sha"] = requested_head_sha or current_head_sha
     cleaned_title = commit_title.strip()
     cleaned_message = commit_message.strip()
     if cleaned_title:

--- a/apps/repos/services/github.py
+++ b/apps/repos/services/github.py
@@ -428,6 +428,30 @@ def fetch_pull_request(
     )
 
 
+def fetch_pull_request_reviews(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    number: int,
+) -> Iterator[Mapping[str, object]]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/pulls/{number}/reviews"
+    params: dict[str, RequestParamValue] = {"per_page": 100}
+    yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
+
+
+def fetch_pull_request_review_comments(
+    *,
+    token: str,
+    owner: str,
+    name: str,
+    number: int,
+) -> Iterator[Mapping[str, object]]:
+    endpoint = f"{API_ROOT}/repos/{owner}/{name}/pulls/{number}/comments"
+    params: dict[str, RequestParamValue] = {"per_page": 100}
+    yield from fetch_paginated_items(token=token, endpoint=endpoint, params=params)
+
+
 def _ensure_issue_lock_dir() -> None:
     ISSUE_LOCK_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -639,6 +663,143 @@ def create_pull_request_comment(
         response.status_code,
     )
     return response
+
+
+def submit_pull_request_review_decision(
+    *,
+    owner: str,
+    repository: str,
+    pull_number: int,
+    token: str,
+    decision: str,
+    body: str = "",
+    timeout: int = REQUEST_TIMEOUT,
+) -> requests.Response:
+    """Submit a pull request review decision for an open PR."""
+
+    normalized_decision = str(decision or "").strip().upper()
+    allowed_decisions = {"APPROVE", "REQUEST_CHANGES", "COMMENT"}
+    if normalized_decision not in allowed_decisions:
+        raise ValueError("Review decision must be APPROVE, REQUEST_CHANGES, or COMMENT")
+
+    cleaned_body = body.strip()
+    if normalized_decision in {"REQUEST_CHANGES", "COMMENT"} and not cleaned_body:
+        raise ValueError(
+            "Review body is required for request changes and comment decisions"
+        )
+
+    headers = build_headers(token, user_agent="arthexis-runtime-reporter")
+    if not _pull_request_is_open(
+        owner,
+        repository,
+        pull_number=pull_number,
+        headers=headers,
+        timeout=timeout,
+    ):
+        raise GitHubRepositoryError(
+            f"Cannot review PR #{pull_number} because it is not open"
+        )
+
+    payload: dict[str, str] = {"event": normalized_decision}
+    if cleaned_body:
+        payload["body"] = cleaned_body
+
+    url = f"{API_ROOT}/repos/{owner}/{repository}/pulls/{pull_number}/reviews"
+    response = None
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    if not (200 <= response.status_code < 300):
+        try:
+            message = _extract_error_message(response)
+        finally:
+            with contextlib.suppress(Exception):
+                response.close()
+        raise GitHubRepositoryError(message)
+
+    logger.info(
+        "GitHub pull request review submitted for %s/%s#%s with decision %s",
+        owner,
+        repository,
+        pull_number,
+        normalized_decision,
+    )
+    return response
+
+
+def merge_pull_request(
+    *,
+    owner: str,
+    repository: str,
+    pull_number: int,
+    token: str,
+    merge_method: str = "squash",
+    commit_title: str = "",
+    commit_message: str = "",
+    timeout: int = REQUEST_TIMEOUT,
+) -> Mapping[str, object]:
+    """Merge a pull request when GitHub reports it is mergeable."""
+
+    method = str(merge_method or "").strip().lower()
+    if method not in {"merge", "squash", "rebase"}:
+        raise ValueError("Merge method must be merge, squash, or rebase")
+
+    pull = fetch_pull_request(
+        token=token,
+        owner=owner,
+        name=repository,
+        number=pull_number,
+        timeout=timeout,
+    )
+    if str(pull.get("state") or "").lower() != "open":
+        raise GitHubRepositoryError(f"Cannot merge PR #{pull_number} because it is not open")
+
+    mergeable = pull.get("mergeable")
+    if mergeable is None:
+        raise GitHubRepositoryError(
+            f"Cannot merge PR #{pull_number} because mergeability is still being calculated"
+        )
+    if mergeable is not True:
+        mergeable_state = str(pull.get("mergeable_state") or "unknown")
+        raise GitHubRepositoryError(
+            f"Cannot merge PR #{pull_number} while mergeable state is '{mergeable_state}'"
+        )
+
+    payload: dict[str, str] = {"merge_method": method}
+    cleaned_title = commit_title.strip()
+    cleaned_message = commit_message.strip()
+    if cleaned_title:
+        payload["commit_title"] = cleaned_title
+    if cleaned_message:
+        payload["commit_message"] = cleaned_message
+
+    headers = build_headers(token, user_agent="arthexis-runtime-reporter")
+    url = f"{API_ROOT}/repos/{owner}/{repository}/pulls/{pull_number}/merge"
+    response = None
+    try:
+        response = requests.put(url, json=payload, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        raise GitHubRepositoryError(str(exc)) from exc
+
+    try:
+        if not (200 <= response.status_code < 300):
+            raise GitHubRepositoryError(_extract_error_message(response))
+        body = _safe_json(response)
+        if isinstance(body, Mapping):
+            return body
+        raise GitHubRepositoryError("Unable to decode merge response from GitHub")
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
 
 
 def create_issue_comment(

--- a/apps/repos/tests/test_github_service.py
+++ b/apps/repos/tests/test_github_service.py
@@ -175,14 +175,10 @@ def test_close_issue_patches_closed_state(monkeypatch):
 def test_submit_pull_request_review_decision_posts_review_event(monkeypatch):
     calls: dict[str, Any] = {}
 
-    def fake_get(url, headers=None, timeout=None):
-        return DummyResponse({"state": "open"})
-
     def fake_post(url, json=None, headers=None, timeout=None):
         calls["request"] = {"url": url, "json": json, "headers": headers, "timeout": timeout}
         return DummyResponse({"id": 99}, status_code=200)
 
-    monkeypatch.setattr(github.requests, "get", fake_get)
     monkeypatch.setattr(github.requests, "post", fake_post)
 
     response = github.submit_pull_request_review_decision(
@@ -199,13 +195,17 @@ def test_submit_pull_request_review_decision_posts_review_event(monkeypatch):
     assert calls["request"]["json"] == {"event": "APPROVE", "body": "Ship it"}
 
 
-def test_submit_pull_request_review_decision_rejects_closed_pr(monkeypatch):
-    def fake_get(url, headers=None, timeout=None):
-        return DummyResponse({"state": "closed"})
+def test_submit_pull_request_review_decision_surfaces_api_validation_error(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return DummyResponse(
+            {"message": "Review cannot be submitted on a closed pull request"},
+            status_code=422,
+            text="unprocessable",
+        )
 
-    monkeypatch.setattr(github.requests, "get", fake_get)
+    monkeypatch.setattr(github.requests, "post", fake_post)
 
-    with pytest.raises(github.GitHubRepositoryError, match="not open"):
+    with pytest.raises(github.GitHubRepositoryError, match="closed pull request"):
         github.submit_pull_request_review_decision(
             owner="octo",
             repository="demo",

--- a/apps/repos/tests/test_github_service.py
+++ b/apps/repos/tests/test_github_service.py
@@ -170,3 +170,97 @@ def test_close_issue_patches_closed_state(monkeypatch):
     assert response.status_code == 200
     assert calls["request"]["url"].endswith("/repos/octo/demo/issues/44")
     assert calls["request"]["json"] == {"state": "closed"}
+
+
+def test_submit_pull_request_review_decision_posts_review_event(monkeypatch):
+    calls: dict[str, Any] = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        return DummyResponse({"state": "open"})
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls["request"] = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+        return DummyResponse({"id": 99}, status_code=200)
+
+    monkeypatch.setattr(github.requests, "get", fake_get)
+    monkeypatch.setattr(github.requests, "post", fake_post)
+
+    response = github.submit_pull_request_review_decision(
+        owner="octo",
+        repository="demo",
+        pull_number=7,
+        token="tok",
+        decision="APPROVE",
+        body="Ship it",
+    )
+
+    assert response.status_code == 200
+    assert calls["request"]["url"].endswith("/repos/octo/demo/pulls/7/reviews")
+    assert calls["request"]["json"] == {"event": "APPROVE", "body": "Ship it"}
+
+
+def test_submit_pull_request_review_decision_rejects_closed_pr(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        return DummyResponse({"state": "closed"})
+
+    monkeypatch.setattr(github.requests, "get", fake_get)
+
+    with pytest.raises(github.GitHubRepositoryError, match="not open"):
+        github.submit_pull_request_review_decision(
+            owner="octo",
+            repository="demo",
+            pull_number=7,
+            token="tok",
+            decision="COMMENT",
+            body="Needs follow-up",
+        )
+
+
+def test_merge_pull_request_rejects_unknown_mergeability(monkeypatch):
+    monkeypatch.setattr(
+        github,
+        "fetch_pull_request",
+        lambda **kwargs: {"state": "open", "mergeable": None, "mergeable_state": "unknown"},
+    )
+
+    with pytest.raises(github.GitHubRepositoryError, match="being calculated"):
+        github.merge_pull_request(
+            owner="octo",
+            repository="demo",
+            pull_number=22,
+            token="tok",
+        )
+
+
+def test_merge_pull_request_calls_merge_endpoint(monkeypatch):
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        github,
+        "fetch_pull_request",
+        lambda **kwargs: {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+    )
+
+    def fake_put(url, json=None, headers=None, timeout=None):
+        calls["request"] = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+        return DummyResponse({"merged": True, "message": "Pull Request successfully merged"}, status_code=200)
+
+    monkeypatch.setattr(github.requests, "put", fake_put)
+
+    payload = github.merge_pull_request(
+        owner="octo",
+        repository="demo",
+        pull_number=22,
+        token="tok",
+        merge_method="squash",
+        commit_title="Merge feature",
+        commit_message="Includes tests",
+    )
+
+    assert payload["merged"] is True
+    assert calls["request"]["url"].endswith("/repos/octo/demo/pulls/22/merge")
+    assert calls["request"]["json"] == {
+        "merge_method": "squash",
+        "commit_title": "Merge feature",
+        "commit_message": "Includes tests",
+    }

--- a/apps/repos/tests/test_github_service.py
+++ b/apps/repos/tests/test_github_service.py
@@ -238,7 +238,12 @@ def test_merge_pull_request_calls_merge_endpoint(monkeypatch):
     monkeypatch.setattr(
         github,
         "fetch_pull_request",
-        lambda **kwargs: {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "head": {"sha": "head123"},
+        },
     )
 
     def fake_put(url, json=None, headers=None, timeout=None):
@@ -261,6 +266,29 @@ def test_merge_pull_request_calls_merge_endpoint(monkeypatch):
     assert calls["request"]["url"].endswith("/repos/octo/demo/pulls/22/merge")
     assert calls["request"]["json"] == {
         "merge_method": "squash",
+        "sha": "head123",
         "commit_title": "Merge feature",
         "commit_message": "Includes tests",
     }
+
+
+def test_merge_pull_request_rejects_when_expected_head_sha_is_stale(monkeypatch):
+    monkeypatch.setattr(
+        github,
+        "fetch_pull_request",
+        lambda **kwargs: {
+            "state": "open",
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "head": {"sha": "head123"},
+        },
+    )
+
+    with pytest.raises(github.GitHubRepositoryError, match="head changed"):
+        github.merge_pull_request(
+            owner="octo",
+            repository="demo",
+            pull_number=22,
+            token="tok",
+            expected_head_sha="different",
+        )


### PR DESCRIPTION
### Motivation

- Provide richer PR details in the docs GitHub item view so admins can see review summaries, review-thread counts, and mergeability/merge-status indicators. 
- Expose backend service operations for submitting PR review decisions and performing guarded merges to allow UI-driven review and merge workflows.
- Surface guardrails in the UI to prevent merges when GitHub reports non-mergeable or failing-check states.

### Description

- Added paginated fetch helpers for PR review feeds and review comments in `apps/repos/services/github.py` and implemented `submit_pull_request_review_decision(...)` and `merge_pull_request(...)` to submit review events and perform merge calls with validation and clear error handling.
- Extended `apps/docs/views.py` `github_issue_detail` flow to load PR-specific metadata (pull request payload, reviews, review comments, commit status), compute review and thread summaries, and derive merge guardrails and `merge_allowed` state.
- Updated `apps/docs/templates/docs/github_detail.html` to display checks/mergeability/merge-status, review summary and threads, a PR review submission form, and a guarded merge form which is disabled when merge guardrails apply.
- Added unit tests in `apps/repos/tests/test_github_service.py` to cover review submission and merge API boundary behavior and new view tests in `apps/docs/tests/test_github_detail_view.py` for open/closed/non-mergeable PR rendering and merge error surfacing.

### Testing

- Verified the new service and view behavior by running the targeted tests with `./env-refresh.sh --deps-only` (bootstrap) and then the canonical test runner: `.venv/bin/python manage.py test run -- apps/repos/tests/test_github_service.py apps/docs/tests/test_github_detail_view.py`.
- The test run completed successfully with the new tests included: `15 passed, 1 warning` for the targeted files.
- All added automated tests passed and exercise the PR review/merge API boundaries and the view behavior for open, closed, and non-mergeable PR scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83cb40c9483268b7a7203af164a05)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enhances the GitHub detail view in the docs app to surface PR review and merge controls alongside existing PR metadata, enabling users to review pull requests and perform guarded merges directly from the interface.

## Changes

### Backend Services (`apps/repos/services/github.py`)

Added four new GitHub API helpers to support PR operations:
- `fetch_pull_request_reviews()` and `fetch_pull_request_review_comments()` - paginated fetchers for PR review data
- `submit_pull_request_review_decision()` - POSTs a review decision (approve/request_changes/comment) with validation that `body` is required for `REQUEST_CHANGES` and `COMMENT` decisions; raises `GitHubRepositoryError` on API validation failures
- `merge_pull_request()` - validates `merge_method`, verifies the PR is open and mergeable (`mergeable is True`), then PUTs to the merge endpoint with commit metadata; raises `GitHubRepositoryError` if mergeability is unknown

### View Logic (`apps/docs/views.py`)

Extended `github_issue_detail` to compute PR-specific metadata and handle new actions:
- Added helpers to extract review summaries (approved/changes_requested/pending counts), compute mergeability guardrails based on PR state and check status, and thread review comments
- Extended POST handling to support two new actions:
  - `"pr_review"` - submits review decisions via `submit_pull_request_review_decision()`
  - `"pr_merge"` - applies merge guardrails (failing checks, non-mergeable state, or unknown mergeability block the merge) and calls `merge_pull_request()` with the specified merge method
- Expanded context passed to template with pull request details, review summaries, review comment threads, and merge guardrail state

### Templates (`apps/docs/templates/docs/github_detail.html`)

Added PR-specific UI sections conditionally displayed for pull requests:
- Mergeability status and merge state indicator
- "Review Summary" list showing approved/changes_requested/pending review counts
- "Review Threads" section with comment and thread counts
- Two new forms: a pull request review submission form (with decision and body fields) and a guarded merge form (with merge method and optional commit metadata) that disables the merge button when guardrails apply, with explanatory warnings for common failure cases (checks failing, mergeability unknown, PR closed)
- Marked the existing comment form with `action="comment"` for distinction

### Tests

**`apps/docs/tests/test_github_detail_view.py`** - New test module covering the GitHub detail view endpoint for multiple PR scenarios:
- Open/mergeable PR renders review summaries and an enabled merge control
- Closed PR disables the merge UI and shows closure message
- Handles missing commit status data gracefully while keeping merge disabled
- POST requests validate guardrail enforcement: mergeability unknown and failing checks prevent merge execution and display appropriate warnings
- Verifies `merge_pull_request` is not called when guardrails are active

**`apps/repos/tests/test_github_service.py`** - New tests for the service layer:
- `submit_pull_request_review_decision` issues correct POST payload and converts API validation errors (HTTP 422) into `GitHubRepositoryError`
- `merge_pull_request` rejects indeterminate mergeability scenarios and calls the merge endpoint only when conditions are met, returning merged state in response

## Testing

Targeted tests: 15 passed, 1 warning. Test coverage focuses on PR review/merge API boundaries and view behavior across multiple PR states (open/mergeable, closed, status failures).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->