### PR TITLE
Add configurable OCPP simulator presets to the CLI command

### DIFF
--- a/apps/ocpp/management/commands/simulator.py
+++ b/apps/ocpp/management/commands/simulator.py
@@ -266,9 +266,15 @@ class Command(BaseCommand):
         if isinstance(existing, bool):
             return self._parse_bool(raw_value)
         if isinstance(existing, int) and not isinstance(existing, bool):
-            return int(raw_value)
+            try:
+                return int(raw_value)
+            except ValueError:
+                raise CommandError(f"Invalid integer value '{raw_value}' for key '{key}'.")
         if isinstance(existing, float):
-            return float(raw_value)
+            try:
+                return float(raw_value)
+            except ValueError:
+                raise CommandError(f"Invalid float value '{raw_value}' for key '{key}'.")
         return raw_value
 
     def _parse_bool(self, value: str) -> bool:

--- a/apps/ocpp/management/commands/simulator.py
+++ b/apps/ocpp/management/commands/simulator.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 from argparse import BooleanOptionalAction
+from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.simulators.evcs import _start_simulator, _stop_simulator, get_simulator_state
+from apps.simulators.presets import get_simulator_preset, get_simulator_preset_names
 from apps.simulators.simulator_runtime import (
     ARTHEXIS_BACKEND,
     MOBILITY_HOUSE_BACKEND,
@@ -35,43 +37,82 @@ class Command(BaseCommand):
             choices=(1, 2),
             help="Simulator slot number.",
         )
+        parser.add_argument(
+            "--preset",
+            default="default",
+            help="Named simulator preset to seed runtime parameters.",
+        )
+        parser.add_argument(
+            "--preset-override",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            help="Override a preset key before start. Repeat for multiple values.",
+        )
+        parser.add_argument(
+            "--list-presets",
+            action="store_true",
+            default=False,
+            help="List available simulator presets and exit.",
+        )
 
-        parser.add_argument("--host", default="127.0.0.1", help="WebSocket host.")
-        parser.add_argument("--ws-port", type=int, default=8000, help="WebSocket port.")
-        parser.add_argument("--cp-path", default="CP2", help="Charge point path.")
+        parser.add_argument("--host", default=None, help="WebSocket host.")
+        parser.add_argument("--ws-port", type=int, default=None, help="WebSocket port.")
+        parser.add_argument("--cp-path", default=None, help="Charge point path.")
         parser.add_argument(
             "--serial-number",
-            default="CP2",
+            default=None,
             help="Charge point serial number.",
         )
-        parser.add_argument("--connector-id", type=int, default=1, help="Connector ID.")
-        parser.add_argument("--rfid", default="FFFFFFFF", help="RFID idTag.")
-        parser.add_argument("--vin", default="WP0ZZZ00000000000", help="Vehicle VIN.")
-        parser.add_argument("--duration", type=int, default=600, help="Duration in seconds.")
-        parser.add_argument("--interval", type=float, default=5.0, help="Polling interval in seconds.")
+        parser.add_argument(
+            "--connector-id", type=int, default=None, help="Connector ID."
+        )
+        parser.add_argument("--rfid", default=None, help="RFID idTag.")
+        parser.add_argument("--vin", default=None, help="Vehicle VIN.")
+        parser.add_argument(
+            "--duration", type=int, default=None, help="Duration in seconds."
+        )
+        parser.add_argument(
+            "--interval", type=float, default=None, help="Polling interval in seconds."
+        )
         parser.add_argument(
             "--pre-charge-delay",
             type=float,
-            default=0.0,
+            default=None,
             help="Delay before charging starts in seconds.",
         )
-        parser.add_argument("--average-kwh", type=float, default=60.0, help="Average kWh target.")
-        parser.add_argument("--amperage", type=float, default=90.0, help="Charging amperage.")
+        parser.add_argument(
+            "--average-kwh", type=float, default=None, help="Average kWh target."
+        )
+        parser.add_argument(
+            "--amperage", type=float, default=None, help="Charging amperage."
+        )
         parser.add_argument(
             "--repeat",
             action=BooleanOptionalAction,
-            default=False,
+            default=None,
             help="Repeat charging sessions forever.",
         )
-        parser.add_argument("--username", default="", help="Optional HTTP Basic auth username.")
-        parser.add_argument("--password", default="", help="Optional HTTP Basic auth password.")
+        parser.add_argument(
+            "--username", default=None, help="Optional HTTP Basic auth username."
+        )
+        parser.add_argument(
+            "--password", default=None, help="Optional HTTP Basic auth password."
+        )
         parser.add_argument(
             "--backend",
             default=None,
             help="Simulator backend override (arthexis or mobilityhouse when enabled).",
         )
-        parser.add_argument("--simulator-name", default="Simulator", help="Friendly simulator name.")
-        parser.add_argument("--start-delay", type=float, default=0.0, help="Delay before connection starts.")
+        parser.add_argument(
+            "--simulator-name", default=None, help="Friendly simulator name."
+        )
+        parser.add_argument(
+            "--start-delay",
+            type=float,
+            default=None,
+            help="Delay before connection starts.",
+        )
         parser.add_argument(
             "--reconnect-slots",
             default=None,
@@ -80,19 +121,19 @@ class Command(BaseCommand):
         parser.add_argument(
             "--demo-mode",
             action=BooleanOptionalAction,
-            default=False,
+            default=None,
             help="Enable demo-mode behavior.",
         )
         parser.add_argument(
             "--meter-interval",
             type=float,
-            default=5.0,
+            default=None,
             help="MeterValues reporting interval in seconds.",
         )
         parser.add_argument(
             "--allow-private-network",
             action=BooleanOptionalAction,
-            default=True,
+            default=None,
             help="Allow simulator to target private network hosts.",
         )
         parser.add_argument(
@@ -113,6 +154,9 @@ class Command(BaseCommand):
 
         action = options["action"]
         slot = options["slot"]
+        if options["list_presets"]:
+            self.stdout.write("\n".join(get_simulator_preset_names()))
+            return
 
         if action == "status":
             status = get_simulator_state(cp=slot, refresh_file=True)
@@ -121,43 +165,121 @@ class Command(BaseCommand):
 
         if action == "stop":
             _stop_simulator(slot)
-            self.stdout.write(self.style.SUCCESS(f"Simulator slot {slot} stop requested."))
+            self.stdout.write(
+                self.style.SUCCESS(f"Simulator slot {slot} stop requested.")
+            )
             return
 
         backend = self._resolve_backend(options.get("backend"))
-        params = {
-            "host": options["host"],
-            "ws_port": options["ws_port"],
-            "cp_path": options["cp_path"],
-            "serial_number": options["serial_number"] or options["cp_path"],
-            "connector_id": options["connector_id"],
-            "rfid": options["rfid"],
-            "vin": options["vin"],
-            "duration": options["duration"],
-            "interval": options["interval"],
-            "pre_charge_delay": options["pre_charge_delay"],
-            "average_kwh": options["average_kwh"],
-            "amperage": options["amperage"],
-            "repeat": options["repeat"],
-            "username": options["username"],
-            "password": options["password"],
-            "allow_private_network": options["allow_private_network"],
-            "simulator_backend": backend,
-            "name": options["simulator_name"],
-            "delay": options["start_delay"],
-            "start_delay": options["start_delay"],
-            "reconnect_slots": options["reconnect_slots"],
-            "demo_mode": options["demo_mode"],
-            "meter_interval": options["meter_interval"],
-            "ws_scheme": options["ws_scheme"],
-            "use_tls": options["use_tls"],
-        }
+        params = self._build_start_params(options)
+        params.update(
+            {
+                "simulator_backend": backend,
+                "name": options["simulator_name"] or "Simulator",
+                "delay": params["start_delay"],
+            }
+        )
         started, status, log_file = _start_simulator(params, cp=slot)
         if started:
             self.stdout.write(self.style.SUCCESS(status))
         else:
             raise CommandError(status)
         self.stdout.write(f"log_file={log_file}")
+
+    def _build_start_params(self, options: dict[str, Any]) -> dict[str, Any]:
+        """Build simulator params from preset defaults and CLI overrides."""
+
+        preset_name = str(options.get("preset") or "default")
+        try:
+            params = get_simulator_preset(preset_name)
+        except ValueError as exc:
+            available = ", ".join(get_simulator_preset_names())
+            raise CommandError(f"{exc} Available presets: {available}") from exc
+
+        for override in options.get("preset_override") or []:
+            key, value = self._parse_preset_override(override, params)
+            params[key] = value
+
+        option_key_map = {
+            "host": "host",
+            "ws_port": "ws_port",
+            "cp_path": "cp_path",
+            "serial_number": "serial_number",
+            "connector_id": "connector_id",
+            "rfid": "rfid",
+            "vin": "vin",
+            "duration": "duration",
+            "interval": "interval",
+            "pre_charge_delay": "pre_charge_delay",
+            "average_kwh": "average_kwh",
+            "amperage": "amperage",
+            "repeat": "repeat",
+            "username": "username",
+            "password": "password",
+            "start_delay": "start_delay",
+            "reconnect_slots": "reconnect_slots",
+            "demo_mode": "demo_mode",
+            "meter_interval": "meter_interval",
+            "allow_private_network": "allow_private_network",
+            "ws_scheme": "ws_scheme",
+            "use_tls": "use_tls",
+        }
+        for option_name, param_name in option_key_map.items():
+            value = options.get(option_name)
+            if value is not None:
+                params[param_name] = value
+
+        params["serial_number"] = params.get("serial_number") or params.get("cp_path")
+        return params
+
+    def _parse_preset_override(
+        self,
+        raw_override: str,
+        params: dict[str, Any],
+    ) -> tuple[str, Any]:
+        """Parse ``KEY=VALUE`` preset override and cast using preset types."""
+
+        if "=" not in raw_override:
+            raise CommandError(
+                f"Invalid --preset-override value '{raw_override}'. Use KEY=VALUE."
+            )
+        key, value = [part.strip() for part in raw_override.split("=", 1)]
+        if not key:
+            raise CommandError(
+                f"Invalid --preset-override value '{raw_override}'. Missing key."
+            )
+        if key not in params:
+            raise CommandError(f"Unsupported preset override key '{key}'.")
+        return key, self._coerce_override_value(key, value, params[key])
+
+    def _coerce_override_value(self, key: str, raw_value: str, existing: Any) -> Any:
+        """Cast preset override values using existing preset value types."""
+
+        if existing is None:
+            if raw_value.lower() in {"none", "null"}:
+                return None
+            if key in {"ws_scheme"}:
+                return raw_value
+            if key in {"use_tls"}:
+                return self._parse_bool(raw_value)
+            return raw_value
+        if isinstance(existing, bool):
+            return self._parse_bool(raw_value)
+        if isinstance(existing, int) and not isinstance(existing, bool):
+            return int(raw_value)
+        if isinstance(existing, float):
+            return float(raw_value)
+        return raw_value
+
+    def _parse_bool(self, value: str) -> bool:
+        """Return bool from common truthy/falsy string values."""
+
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise CommandError(f"Invalid boolean value '{value}'.")
 
     def _resolve_backend(self, requested: str | None) -> str:
         """Validate backend choice against enabled simulator backends."""

--- a/apps/ocpp/tests/test_simulator_command.py
+++ b/apps/ocpp/tests/test_simulator_command.py
@@ -18,7 +18,10 @@ class SimulatorCommandTests(SimpleTestCase):
     def test_start_forwards_all_ui_options(self, choices_mock, start_mock) -> None:
         """Start action should forward every UI-exposed runtime option."""
 
-        choices_mock.return_value = (("arthexis", "arthexis"), ("mobilityhouse", "mobilityhouse"))
+        choices_mock.return_value = (
+            ("arthexis", "arthexis"),
+            ("mobilityhouse", "mobilityhouse"),
+        )
         start_mock.return_value = (True, "Connection accepted", "sim.log")
 
         out = io.StringIO()
@@ -105,7 +108,9 @@ class SimulatorCommandTests(SimpleTestCase):
 
     @patch("apps.ocpp.management.commands.simulator._start_simulator")
     @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
-    def test_start_defaults_allow_private_network(self, choices_mock, start_mock) -> None:
+    def test_start_defaults_allow_private_network(
+        self, choices_mock, start_mock
+    ) -> None:
         """Start action should permit localhost defaults without extra flags."""
 
         choices_mock.return_value = (("arthexis", "arthexis"),)
@@ -118,7 +123,9 @@ class SimulatorCommandTests(SimpleTestCase):
 
     @patch("apps.ocpp.management.commands.simulator._start_simulator")
     @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
-    def test_start_raises_error_when_runtime_rejects_request(self, choices_mock, start_mock) -> None:
+    def test_start_raises_error_when_runtime_rejects_request(
+        self, choices_mock, start_mock
+    ) -> None:
         """Start action should return non-zero via CommandError when not started."""
 
         choices_mock.return_value = (("arthexis", "arthexis"),)
@@ -149,3 +156,87 @@ class SimulatorCommandTests(SimpleTestCase):
         rendered = out.getvalue()
         self.assertIn('"running": false', rendered)
         self.assertIn('"last_status": "idle"', rendered)
+
+    @patch("apps.ocpp.management.commands.simulator._start_simulator")
+    @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
+    def test_start_uses_named_preset_values(self, choices_mock, start_mock) -> None:
+        """Named preset values should seed start params when CLI options are omitted."""
+
+        choices_mock.return_value = (("arthexis", "arthexis"),)
+        start_mock.return_value = (True, "Connection accepted", "sim.log")
+
+        call_command("simulator", "start", "--preset", "demo")
+
+        params = start_mock.call_args.args[0]
+        self.assertEqual(params["duration"], 180)
+        self.assertEqual(params["interval"], 2.0)
+        self.assertEqual(params["average_kwh"], 20.0)
+        self.assertEqual(params["amperage"], 40.0)
+        self.assertTrue(params["demo_mode"])
+
+    @patch("apps.ocpp.management.commands.simulator._start_simulator")
+    @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
+    def test_start_applies_preset_overrides(self, choices_mock, start_mock) -> None:
+        """Preset overrides should cast values using the preset schema."""
+
+        choices_mock.return_value = (("arthexis", "arthexis"),)
+        start_mock.return_value = (True, "Connection accepted", "sim.log")
+
+        call_command(
+            "simulator",
+            "start",
+            "--preset",
+            "default",
+            "--preset-override",
+            "duration=77",
+            "--preset-override",
+            "repeat=true",
+            "--preset-override",
+            "meter_interval=1.25",
+        )
+
+        params = start_mock.call_args.args[0]
+        self.assertEqual(params["duration"], 77)
+        self.assertTrue(params["repeat"])
+        self.assertEqual(params["meter_interval"], 1.25)
+
+    @patch("apps.ocpp.management.commands.simulator._start_simulator")
+    @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
+    def test_start_rejects_invalid_preset_override_key(
+        self, choices_mock, start_mock
+    ) -> None:
+        """Unknown preset keys should fail before runtime start is attempted."""
+
+        choices_mock.return_value = (("arthexis", "arthexis"),)
+        start_mock.return_value = (True, "Connection accepted", "sim.log")
+
+        with self.assertRaisesMessage(CommandError, "Unsupported preset override key"):
+            call_command(
+                "simulator",
+                "start",
+                "--preset-override",
+                "unknown_key=1",
+            )
+        start_mock.assert_not_called()
+
+    @patch("apps.ocpp.management.commands.simulator._start_simulator")
+    @patch("apps.ocpp.management.commands.simulator.get_simulator_backend_choices")
+    def test_start_rejects_unknown_preset_name(self, choices_mock, start_mock) -> None:
+        """Unknown preset names should fail with available preset hints."""
+
+        choices_mock.return_value = (("arthexis", "arthexis"),)
+        start_mock.return_value = (True, "Connection accepted", "sim.log")
+
+        with self.assertRaisesMessage(CommandError, "Unknown simulator preset"):
+            call_command("simulator", "start", "--preset", "missing")
+        start_mock.assert_not_called()
+
+    def test_list_presets_prints_available_presets(self) -> None:
+        """Preset list mode should print all available names."""
+
+        out = io.StringIO()
+        call_command("simulator", "status", "--list-presets", stdout=out)
+        rendered = out.getvalue()
+        self.assertIn("default", rendered)
+        self.assertIn("demo", rendered)
+        self.assertIn("longhaul", rendered)

--- a/apps/simulators/presets.py
+++ b/apps/simulators/presets.py
@@ -1,0 +1,77 @@
+"""Preset definitions for OCPP simulator runtime parameters."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+BASE_PRESET_KEY = "default"
+
+SIMULATOR_PRESETS: dict[str, dict[str, Any]] = {
+    BASE_PRESET_KEY: {
+        "host": "127.0.0.1",
+        "ws_port": 8000,
+        "cp_path": "CP2",
+        "serial_number": "CP2",
+        "connector_id": 1,
+        "rfid": "FFFFFFFF",
+        "vin": "WP0ZZZ00000000000",
+        "duration": 600,
+        "interval": 5.0,
+        "pre_charge_delay": 0.0,
+        "average_kwh": 60.0,
+        "amperage": 90.0,
+        "repeat": False,
+        "username": "",
+        "password": "",
+        "start_delay": 0.0,
+        "reconnect_slots": None,
+        "demo_mode": False,
+        "meter_interval": 5.0,
+        "allow_private_network": True,
+        "ws_scheme": None,
+        "use_tls": None,
+    },
+    "demo": {
+        "duration": 180,
+        "interval": 2.0,
+        "average_kwh": 20.0,
+        "amperage": 40.0,
+        "demo_mode": True,
+        "meter_interval": 2.0,
+    },
+    "longhaul": {
+        "duration": 3600,
+        "interval": 15.0,
+        "average_kwh": 90.0,
+        "amperage": 120.0,
+        "meter_interval": 15.0,
+    },
+}
+
+
+def get_simulator_preset_names() -> tuple[str, ...]:
+    """Return available simulator preset names sorted alphabetically."""
+
+    return tuple(sorted(SIMULATOR_PRESETS.keys()))
+
+
+def get_simulator_preset(name: str) -> dict[str, Any]:
+    """Return a merged preset payload for the given preset name."""
+
+    normalized_name = name.strip().lower()
+    if normalized_name not in SIMULATOR_PRESETS:
+        raise ValueError(f"Unknown simulator preset '{name}'.")
+
+    merged = deepcopy(SIMULATOR_PRESETS[BASE_PRESET_KEY])
+    if normalized_name != BASE_PRESET_KEY:
+        merged.update(SIMULATOR_PRESETS[normalized_name])
+    return merged
+
+
+__all__ = [
+    "BASE_PRESET_KEY",
+    "SIMULATOR_PRESETS",
+    "get_simulator_preset",
+    "get_simulator_preset_names",
+]


### PR DESCRIPTION
### Motivation

- Provide reusable, named configuration presets for the OCPP simulator so CLI-driven simulator runs can be seeded with sensible profiles. 
- Allow operators to quickly select or tweak simulator profiles from the command line without duplicating flags each time.

### Description

- Add `apps/simulators/presets.py` with a `default` base preset plus `demo` and `longhaul` variants and helpers `get_simulator_preset` and `get_simulator_preset_names` to return merged preset payloads. 
- Extend the `simulator` management command to accept `--preset`, repeatable `--preset-override KEY=VALUE`, and `--list-presets`, build start parameters from the selected preset, and apply CLI overrides; CLI flags now override preset values. 
- Implement override parsing and typed coercion in `_parse_preset_override` and `_coerce_override_value`, and preserve existing backend resolution and `start`/`stop`/`status` behaviors. 
- Add/modify unit tests in `apps/ocpp/tests/test_simulator_command.py` to cover preset selection, overrides, invalid override keys, unknown presets, and preset listing.

### Testing

- Ran environment refresh and dependency install: `./env-refresh.sh --deps-only` and `.venv/bin/pip install -r requirements-ci.txt`, both completed successfully. 
- Ran formatter and fixed formatting with `black` using `--target-version py312` which reformatted the changed files. 
- Executed the simulator command tests with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_simulator_command.py`, and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8412b7fb883268a4aad8629ee21bc)