### PR TITLE
Fix supported chargers module links, theme integration, and IOJ2Y rating

### DIFF
--- a/apps/ocpp/fixtures/station_models__iocharger__ioj2y__ioc750200a_t08.json
+++ b/apps/ocpp/fixtures/station_models__iocharger__ioj2y__ioc750200a_t08.json
@@ -5,6 +5,7 @@
       "vendor": "IOCHARGER",
       "model_family": "IOJ2Y",
       "model": "IOC750200A-T08",
+      "integration_rating": 5,
       "max_power_kw": "7.50",
       "max_voltage_v": 480,
       "connector_type": "CCS Type 1",

--- a/apps/ocpp/static/ocpp/supported_chargers.css
+++ b/apps/ocpp/static/ocpp/supported_chargers.css
@@ -1,0 +1,47 @@
+:root {
+  --landing-card-radius: var(--bs-border-radius-xl);
+  --landing-card-gap-y: var(--bs-spacer);
+  --landing-card-gap-x: calc(var(--bs-spacer) * 2);
+  --landing-meta-font-size: var(--bs-body-font-size-sm, 0.875rem);
+  --landing-meta-letter-spacing: 0.04em;
+  --landing-section-spacing: calc(var(--bs-spacer) * 1.25);
+  --landing-section-title-size: var(--bs-body-font-size-sm, 0.875rem);
+}
+
+.landing-meta-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--landing-card-gap-y) var(--landing-card-gap-x);
+  margin: 0;
+  padding: 0;
+}
+
+.landing-meta-list div {
+  min-width: 0;
+}
+
+.landing-meta-list dt {
+  margin: 0;
+  font-size: var(--landing-meta-font-size);
+  letter-spacing: var(--landing-meta-letter-spacing);
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+
+.landing-meta-list dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--bs-body-color);
+}
+
+.landing-card-section + .landing-card-section {
+  margin-top: var(--landing-section-spacing);
+}
+
+.landing-card-section-title {
+  font-size: var(--landing-section-title-size);
+  letter-spacing: var(--landing-meta-letter-spacing);
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+  margin: 0 0 calc(var(--bs-spacer) * 0.5);
+}

--- a/apps/ocpp/templates/ocpp/supported_charger_detail.html
+++ b/apps/ocpp/templates/ocpp/supported_charger_detail.html
@@ -1,20 +1,11 @@
 {% extends "pages/base.html" %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block title %}{{ station_model.vendor }} {{ station_model.model_family }} {{ station_model.model }}{% endblock %}
 
 {% block extra_head %}
+<link rel="stylesheet" href="{% static 'ocpp/supported_chargers.css' %}">
 <style>
-  .landing-card-section + .landing-card-section {
-    margin-top: 1.25rem;
-  }
-  .landing-card-section-title {
-    font-size: 0.9rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--bs-secondary-color);
-    margin: 0 0 0.5rem;
-  }
   .spec-chip-grid {
     display: flex;
     flex-wrap: wrap;
@@ -25,8 +16,8 @@
     flex-direction: column;
     gap: 0.12rem;
     border-radius: 0.75rem;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background-color: #fff;
+    border: 1px solid var(--bs-border-color-translucent);
+    background-color: var(--bs-body-bg);
     padding: 0.45rem 0.7rem;
     min-width: 7rem;
   }
@@ -45,9 +36,9 @@
   .hero-media {
     border-radius: 1rem;
     overflow: hidden;
-    border: 1px solid rgba(15, 23, 42, 0.12);
+    border: 1px solid var(--bs-border-color-translucent);
     box-shadow: 0 0.85rem 1.5rem rgba(15, 23, 42, 0.1);
-    background: #fff;
+    background: var(--bs-body-bg);
   }
   .hero-media img {
     width: 100%;
@@ -63,8 +54,8 @@
   .thumb-item {
     border-radius: 0.65rem;
     overflow: hidden;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background: #fff;
+    border: 1px solid var(--bs-border-color-translucent);
+    background: var(--bs-body-bg);
     box-shadow: 0 0.45rem 0.9rem rgba(15, 23, 42, 0.06);
   }
   .thumb-item img {

--- a/apps/ocpp/templates/ocpp/supported_charger_detail.html
+++ b/apps/ocpp/templates/ocpp/supported_charger_detail.html
@@ -1,10 +1,20 @@
-{% extends "ocpp/landing_base.html" %}
+{% extends "pages/base.html" %}
 {% load i18n %}
 
 {% block title %}{{ station_model.vendor }} {{ station_model.model_family }} {{ station_model.model }}{% endblock %}
 
 {% block extra_head %}
 <style>
+  .landing-card-section + .landing-card-section {
+    margin-top: 1.25rem;
+  }
+  .landing-card-section-title {
+    font-size: 0.9rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bs-secondary-color);
+    margin: 0 0 0.5rem;
+  }
   .spec-chip-grid {
     display: flex;
     flex-wrap: wrap;

--- a/apps/ocpp/templates/ocpp/supported_chargers.html
+++ b/apps/ocpp/templates/ocpp/supported_chargers.html
@@ -1,10 +1,35 @@
-{% extends "ocpp/landing_base.html" %}
+{% extends "pages/base.html" %}
 {% load i18n %}
 
 {% block title %}{% trans "Supported Chargers" %}{% endblock %}
 
 {% block extra_head %}
 <style>
+  :root {
+    --landing-card-radius: 1.25rem;
+  }
+  .landing-meta-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .landing-meta-list div {
+    min-width: 0;
+  }
+  .landing-meta-list dt {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bs-secondary-color);
+  }
+  .landing-meta-list dd {
+    margin: 0;
+    font-weight: 600;
+    color: var(--bs-body-color);
+  }
   .supported-toolbar {
     border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: var(--landing-card-radius);
@@ -168,7 +193,7 @@
 </div>
 {% endblock %}
 
-{% block extra_js %}
+{% block extra_scripts %}
 <script>
   (() => {
     const cards = Array.from(document.querySelectorAll('[data-supported-card]'));

--- a/apps/ocpp/templates/ocpp/supported_chargers.html
+++ b/apps/ocpp/templates/ocpp/supported_chargers.html
@@ -1,44 +1,20 @@
 {% extends "pages/base.html" %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block title %}{% trans "Supported Chargers" %}{% endblock %}
 
 {% block extra_head %}
+<link rel="stylesheet" href="{% static 'ocpp/supported_chargers.css' %}">
 <style>
-  :root {
-    --landing-card-radius: 1.25rem;
-  }
-  .landing-meta-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1.5rem;
-    margin: 0;
-    padding: 0;
-  }
-  .landing-meta-list div {
-    min-width: 0;
-  }
-  .landing-meta-list dt {
-    margin: 0;
-    font-size: 0.75rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--bs-secondary-color);
-  }
-  .landing-meta-list dd {
-    margin: 0;
-    font-weight: 600;
-    color: var(--bs-body-color);
-  }
   .supported-toolbar {
-    border: 1px solid rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--bs-border-color-translucent);
     border-radius: var(--landing-card-radius);
-    background: #fff;
-    padding: 1rem;
+    background: var(--bs-body-bg);
+    padding: var(--bs-spacer);
   }
   .supported-toolbar .chip-label {
-    font-size: 0.75rem;
-    letter-spacing: 0.04em;
+    font-size: var(--landing-meta-font-size);
+    letter-spacing: var(--landing-meta-letter-spacing);
     text-transform: uppercase;
     color: var(--bs-secondary-color);
     margin-bottom: 0.5rem;
@@ -52,9 +28,9 @@
     border-radius: 999px;
   }
   .supported-card {
-    border: 1px solid rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--bs-border-color-translucent);
     border-radius: 1rem;
-    background-color: #fff;
+    background-color: var(--bs-body-bg);
     box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.04);
     transition: transform 0.15s ease, box-shadow 0.15s ease;
   }

--- a/apps/ocpp/tests/test_supported_charger_templates.py
+++ b/apps/ocpp/tests/test_supported_charger_templates.py
@@ -102,14 +102,14 @@ def test_ocpp_module_fixture_landings_prioritize_dashboard_simulator_supported()
     fixture_data = json.loads(fixture_path.read_text())
 
     ocpp_landings = [
-        item["fields"]["path"]
+        (item["fields"]["path"], item["fields"]["label"])
         for item in fixture_data
         if item.get("model") == "pages.landing"
         and item.get("fields", {}).get("module") == ["/ocpp/"]
     ]
 
     assert ocpp_landings == [
-        reverse("ocpp:ocpp-dashboard"),
-        reverse("ocpp:cp-simulator"),
-        reverse("ocpp:supported-chargers"),
+        (reverse("ocpp:ocpp-dashboard"), "Charging Station Dashboards"),
+        (reverse("ocpp:cp-simulator"), "EVCS Online Simulator"),
+        (reverse("ocpp:supported-chargers"), "Supported CP Models"),
     ]

--- a/apps/ocpp/tests/test_supported_charger_templates.py
+++ b/apps/ocpp/tests/test_supported_charger_templates.py
@@ -95,3 +95,21 @@ def test_supported_chargers_fixture_path_matches_named_route():
     )
 
     assert supported_landing["fields"]["path"] == reverse("ocpp:supported-chargers")
+
+
+def test_ocpp_module_fixture_landings_prioritize_dashboard_simulator_supported():
+    fixture_path = Path("apps/sites/fixtures/default__modules_terminal.json")
+    fixture_data = json.loads(fixture_path.read_text())
+
+    ocpp_landings = [
+        item["fields"]["path"]
+        for item in fixture_data
+        if item.get("model") == "pages.landing"
+        and item.get("fields", {}).get("module") == ["/ocpp/"]
+    ]
+
+    assert ocpp_landings == [
+        reverse("ocpp:ocpp-dashboard"),
+        reverse("ocpp:cp-simulator"),
+        reverse("ocpp:supported-chargers"),
+    ]

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -281,6 +281,28 @@ def _select_primary_landings(module_path: str, landings: list):
     return landings
 
 
+def _sort_module_landings(module_path: str, landings: list):
+    """Return landings sorted by module-specific navigation priorities."""
+
+    normalized_module_path = module_path.rstrip("/") or "/"
+    if normalized_module_path != "/ocpp":
+        return landings
+
+    path_priority = {
+        "/ocpp/cpms/dashboard": 0,
+        "/ocpp/evcs/simulator": 1,
+        "/ocpp/charge-point-models": 2,
+    }
+
+    return sorted(
+        landings,
+        key=lambda landing: (
+            path_priority.get(landing.path.rstrip("/") or "/", len(path_priority)),
+            landing.path,
+        ),
+    )
+
+
 def _assign_module_menu(module):
     """Normalize special module menu labels in place.
 
@@ -355,7 +377,10 @@ def _annotate_module_landings(
             setattr(landing, key, value)
         landings.append(landing)
 
-    landings = _select_primary_landings(module.path, landings)
+    landings = _sort_module_landings(
+        module.path,
+        _select_primary_landings(module.path, landings),
+    )
 
     if not landings:
         return None

--- a/apps/sites/fixtures/default__modules_terminal.json
+++ b/apps/sites/fixtures/default__modules_terminal.json
@@ -69,53 +69,23 @@
       "module": [
         "/ocpp/"
       ],
-      "path": "/ocpp/charge-point-models/",
-      "label": "Supported CP Models",
-      "enabled": true,
-      "track_leads": false,
-      "description": ""
-    }
-  },
-  {
-    "model": "pages.landing",
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": [
-        "/ocpp/"
-      ],
-      "path": "/ocpp/charging-map/",
-      "label": "Charging Station Map",
-      "enabled": true,
-      "track_leads": false,
-      "description": ""
-    }
-  },
-  {
-    "model": "pages.landing",
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": [
-        "/ocpp/"
-      ],
-      "path": "/ocpp/rfid/validator/",
-      "label": "RFID Card Validator",
-      "enabled": true,
-      "track_leads": false,
-      "description": ""
-    }
-  },
-  {
-    "model": "pages.landing",
-    "fields": {
-      "is_seed_data": true,
-      "is_deleted": false,
-      "module": [
-        "/ocpp/"
-      ],
       "path": "/ocpp/evcs/simulator/",
       "label": "EVCS Online Simulator",
+      "enabled": true,
+      "track_leads": false,
+      "description": ""
+    }
+  },
+  {
+    "model": "pages.landing",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "module": [
+        "/ocpp/"
+      ],
+      "path": "/ocpp/charge-point-models/",
+      "label": "Supported CP Models",
       "enabled": true,
       "track_leads": false,
       "description": ""

--- a/apps/sites/migrations/0008_sync_ocpp_terminal_landings.py
+++ b/apps/sites/migrations/0008_sync_ocpp_terminal_landings.py
@@ -1,0 +1,58 @@
+from django.db import migrations
+
+
+OCPP_MODULE_PATH = "/ocpp/"
+OBSOLETE_LANDING_PATHS = (
+    "/ocpp/charging-map/",
+    "/ocpp/rfid/validator/",
+)
+REQUIRED_LANDINGS = (
+    ("/ocpp/cpms/dashboard/", "Charging Station Dashboards"),
+    ("/ocpp/evcs/simulator/", "EVCS Online Simulator"),
+    ("/ocpp/charge-point-models/", "Supported CP Models"),
+)
+
+
+def sync_ocpp_terminal_landings(apps, schema_editor):
+    del schema_editor
+    Landing = apps.get_model("pages", "Landing")
+    Module = apps.get_model("modules", "Module")
+
+    module = Module.objects.filter(path=OCPP_MODULE_PATH).first()
+    if module is None:
+        return
+
+    Landing.objects.filter(module=module, path__in=OBSOLETE_LANDING_PATHS).delete()
+
+    for path, label in REQUIRED_LANDINGS:
+        landing, created = Landing.objects.get_or_create(
+            module=module,
+            path=path,
+            defaults={
+                "enabled": True,
+                "label": label,
+            },
+        )
+        if created:
+            continue
+        changed_fields = []
+        if landing.label != label:
+            landing.label = label
+            changed_fields.append("label")
+        if not landing.enabled:
+            landing.enabled = True
+            changed_fields.append("enabled")
+        if changed_fields:
+            landing.save(update_fields=changed_fields)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("modules", "0003_rename_docs_module_pill"),
+        ("pages", "0007_seed_visitors_module"),
+    ]
+
+    operations = [
+        migrations.RunPython(sync_ocpp_terminal_landings, migrations.RunPython.noop),
+    ]

--- a/apps/sites/tests/test_context_processor_module_landings.py
+++ b/apps/sites/tests/test_context_processor_module_landings.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from apps.sites.context_processors import _sort_module_landings
+
+
+def test_sort_module_landings_prioritizes_ocpp_navigation_paths():
+    landings = [
+        SimpleNamespace(path="/ocpp/charge-point-models/"),
+        SimpleNamespace(path="/ocpp/cpms/dashboard/"),
+        SimpleNamespace(path="/ocpp/evcs/simulator/"),
+    ]
+
+    ordered_paths = [landing.path for landing in _sort_module_landings("/ocpp/", landings)]
+
+    assert ordered_paths == [
+        "/ocpp/cpms/dashboard/",
+        "/ocpp/evcs/simulator/",
+        "/ocpp/charge-point-models/",
+    ]
+
+
+def test_sort_module_landings_keeps_non_ocpp_order():
+    landings = [
+        SimpleNamespace(path="/docs/library/"),
+        SimpleNamespace(path="/docs/help/"),
+    ]
+
+    ordered_paths = [landing.path for landing in _sort_module_landings("/docs/", landings)]
+
+    assert ordered_paths == [
+        "/docs/library/",
+        "/docs/help/",
+    ]


### PR DESCRIPTION
### Motivation
- Ensure the Supported Chargers pages behave like other site landings by preserving global theme and navigation instead of using the isolated landing base. 
- Surface the Supported Chargers view as a module navigation link rather than the primary module action so the module shows exactly three links in the requested order. 
- Reflect the internal preference for IOCHARGER IOJ2Y by making its fixture integration rating 5/5. 

### Description
- Changed `apps/ocpp/templates/ocpp/supported_chargers.html` to extend `pages/base.html`, moved landing-specific CSS into the template, and switched the JS block to `extra_scripts` so it inherits the site theme and navigation. 
- Changed `apps/ocpp/templates/ocpp/supported_charger_detail.html` to extend `pages/base.html` and added small landing-style rules into the template to preserve layout. 
- Reordered and adjusted `apps/sites/fixtures/default__modules_terminal.json` entries so the OCPP module exposes exactly three links in order: dashboard, simulator, supported chargers. 
- Updated `apps/ocpp/fixtures/station_models__iocharger__ioj2y__ioc750200a_t08.json` to set `integration_rating` to `5`. 
- Added `test_ocpp_module_fixture_landings_prioritize_dashboard_simulator_supported` to `apps/ocpp/tests/test_supported_charger_templates.py` to assert the module landing ordering. 

### Testing
- Ran environment bootstrap via `./env-refresh.sh --deps-only` to ensure dependencies and migrations were current, which completed successfully. 
- Installed test helpers when needed via `.venv/bin/pip install pytest pytest-django pytest-timeout` to satisfy test runner requirements. 
- Executed the modified test file with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_supported_charger_templates.py`, and all tests in that file passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d36b678483268fb83acc17294a4c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the theme integration and navigation structure of the Supported Chargers feature within the OCPP module by:

1. **Theme Integration**: Updated the supported chargers templates (`supported_chargers.html` and `supported_charger_detail.html`) to extend `pages/base.html` instead of the isolated `ocpp/landing_base.html`, allowing these pages to inherit the global site theme and navigation structure. Landing-specific styling has been preserved by adding custom CSS rules directly in the templates.

2. **Module Navigation Reordering**: Modified the OCPP module fixture (`default__modules_terminal.json`) to expose exactly three navigation links in the specified order: dashboard, simulator, and supported chargers. This involved removing other landing page entries and repositioning the remaining entries.

3. **Template Block Adjustment**: Renamed the `extra_js` block to `extra_scripts` in `supported_chargers.html` to maintain consistency with the site's base template structure.

4. **Integration Rating Update**: Updated the IOCHARGER IOJ2Y fixture (`station_models__iocharger__ioj2y__ioc750200a_t08.json`) to set the `integration_rating` field to 5.

5. **Test Coverage**: Added a new test (`test_ocpp_module_fixture_landings_prioritize_dashboard_simulator_supported`) to verify that the OCPP module's landing page ordering matches the expected sequence.

All changes maintain the existing visual appearance and functionality while improving the integration with the site's global theme and navigation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->