### PR TITLE
Expand install-hourly workflow matrix to run in containers with Postgres and OS variants

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -143,7 +143,8 @@ jobs:
       - name: Install base system dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends curl git python3 python3-venv
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git sudo python3 python3-venv
       - uses: actions/checkout@v6
         with:
           clean: false

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -156,9 +156,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('requirements*.txt', 'pyproject.toml') }}
+          key: pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
           restore-keys: |
-            pip-${{ runner.os }}-
+            pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-
+            pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-
+            pip-${{ runner.os }}-${{ matrix.os_flavor }}-
       - name: Cache virtualenv
         uses: actions/cache@v5
         with:
@@ -184,7 +186,7 @@ jobs:
           fi
       - name: Install suite from repository
         run: |
-          ./install.sh ${{ matrix.install_args }} --no-start
+          ./install.sh ${{ matrix.install_args }} --embedded --no-start
       - name: Refresh environment dependencies
         run: |
           ./env-refresh.sh

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -132,6 +132,8 @@ jobs:
     env:
       ARTHEXIS_DB_BACKEND: ${{ matrix.db_backend }}
       OCPP_STATE_REDIS_URL: redis://redis:6379
+      REDIS_HOST: redis
+      REDIS_PORT: '6379'
       POSTGRES_DB: arthexis
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: postgres

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -3,7 +3,6 @@ name: Install Health Check
 env:
   PYTHONDONTWRITEBYTECODE: '1'
   NODE_OPTIONS: '--no-deprecation'
-  ARTHEXIS_DB_BACKEND: sqlite
   PYTEST_WORKERS: 'auto'
 
 concurrency:
@@ -17,19 +16,93 @@ on:
 
 jobs:
   install:
-    name: install (${{ matrix.role }})
+    name: install (${{ matrix.os_flavor }}, ${{ matrix.db_backend }}, ${{ matrix.role }})
     runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container_image }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - role: terminal
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: sqlite
+            role: terminal
             install_args: --terminal
-          - role: control
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: sqlite
+            role: control
             install_args: --control
-          - role: satellite
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: sqlite
+            role: satellite
             install_args: --satellite
-          - role: watchtower
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: sqlite
+            role: watchtower
+            install_args: --watchtower
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: postgres
+            role: terminal
+            install_args: --terminal
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: postgres
+            role: control
+            install_args: --control
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: postgres
+            role: satellite
+            install_args: --satellite
+          - os_flavor: ubuntu
+            container_image: ubuntu:24.04
+            db_backend: postgres
+            role: watchtower
+            install_args: --watchtower
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: sqlite
+            role: terminal
+            install_args: --terminal
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: sqlite
+            role: control
+            install_args: --control
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: sqlite
+            role: satellite
+            install_args: --satellite
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: sqlite
+            role: watchtower
+            install_args: --watchtower
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: postgres
+            role: terminal
+            install_args: --terminal
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: postgres
+            role: control
+            install_args: --control
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: postgres
+            role: satellite
+            install_args: --satellite
+          - os_flavor: debian
+            container_image: debian:12
+            db_backend: postgres
+            role: watchtower
             install_args: --watchtower
     permissions:
       contents: read
@@ -43,9 +116,32 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: arthexis
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d arthexis"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
-      OCPP_STATE_REDIS_URL: redis://localhost:6379
+      ARTHEXIS_DB_BACKEND: ${{ matrix.db_backend }}
+      OCPP_STATE_REDIS_URL: redis://redis:6379
+      POSTGRES_DB: arthexis
+      POSTGRES_HOST: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: postgres
     steps:
+      - name: Install base system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends curl git python3 python3-venv
       - uses: actions/checkout@v6
         with:
           clean: false
@@ -64,9 +160,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
+          key: venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
           restore-keys: |
-            venv-${{ runner.os }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-
+            venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-
       - name: Validate pyproject dependency ordering
         run: |
           python "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check
@@ -76,8 +172,13 @@ jobs:
       - name: Install redis CLI
         if: ${{ matrix.role == 'control' || matrix.role == 'satellite' || matrix.role == 'watchtower' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends redis-tools
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends redis-tools
+          else
+            apt-get update
+            apt-get install -y --no-install-recommends redis-tools
+          fi
       - name: Install suite from repository
         run: |
           ./install.sh ${{ matrix.install_args }} --no-start
@@ -155,7 +256,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: install-hourly-pytest-results-${{ matrix.role }}
+          name: install-hourly-pytest-results-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.role }}
           path: |
             pytest.log
             pytest-junit.xml
@@ -180,7 +281,7 @@ jobs:
             const marker = '<!-- install-health-check-failure -->';
             let runData = null;
             let failedSteps = '';
-            let failedRoles = '';
+            let failedTargets = '';
             let failedJobCount = 0;
 
             try {
@@ -199,14 +300,14 @@ jobs:
               });
 
               const failedJobs = jobsData.jobs.filter((job) => job.conclusion === 'failure');
-              const failedRoleSet = new Set();
+              const failedTargetSet = new Set();
               failedJobs.forEach((job) => {
                 const match = /^install \((.+)\)$/.exec(job.name || '');
                 if (match?.[1]) {
-                  failedRoleSet.add(match[1]);
+                  failedTargetSet.add(match[1]);
                 }
               });
-              failedRoles = Array.from(failedRoleSet).sort().join(', ');
+              failedTargets = Array.from(failedTargetSet).sort().join(', ');
               failedJobCount = failedJobs.length;
               failedSteps = failedJobs
                 .map((job) => {
@@ -240,7 +341,7 @@ jobs:
               '',
               '## Failure details',
               '',
-              failedRoles ? `- Failed roles: ${failedRoles}` : '- Failed roles: Unable to determine failed roles from workflow metadata.',
+              failedTargets ? `- Failed matrix targets: ${failedTargets}` : '- Failed matrix targets: Unable to determine failed matrix targets from workflow metadata.',
               failedJobCount ? `- Failed jobs: ${failedJobCount}` : '- Failed jobs: Unable to determine failed jobs from workflow metadata.',
               '',
               failedSteps ? failedSteps : '- Unable to identify failed steps from workflow metadata.',
@@ -266,7 +367,7 @@ jobs:
                   `- Commit: ${context.sha}`,
                   `- Run attempt: ${runData?.run_attempt ?? 1}`,
                   '',
-                  failedRoles ? `### Failed roles\n- ${failedRoles}` : '### Failed roles\n- Unable to determine failed roles from workflow metadata.',
+                  failedTargets ? `### Failed matrix targets\n- ${failedTargets}` : '### Failed matrix targets\n- Unable to determine failed matrix targets from workflow metadata.',
                   failedJobCount ? `### Failed jobs\n- ${failedJobCount}` : '### Failed jobs\n- Unable to determine failed jobs from workflow metadata.',
                   '',
                   failedSteps ? '### Failed steps\n' + failedSteps : '### Failed steps\n- Unable to identify failed steps from workflow metadata.'

--- a/install.sh
+++ b/install.sh
@@ -218,14 +218,18 @@ EOF
 }
 
 require_redis() {
+    local redis_host="${REDIS_HOST:-localhost}"
+    local redis_port="${REDIS_PORT:-6379}"
+
     if ! command -v redis-cli >/dev/null 2>&1; then
         echo "Redis is required for the $1 role but is not installed."
         echo "Install redis-server and re-run this script. For Debian/Ubuntu:"
         echo "  sudo apt update && sudo apt install redis-server"
         exit 1
     fi
-    if ! redis-cli ping >/dev/null 2>&1; then
+    if ! redis-cli -h "$redis_host" -p "$redis_port" ping >/dev/null 2>&1; then
         echo "Redis is required for the $1 role but does not appear to be running."
+        echo "Checked Redis at ${redis_host}:${redis_port}."
         echo "Start redis and re-run this script. For Debian/Ubuntu:"
         echo "  sudo systemctl start redis-server"
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -197,21 +197,24 @@ reset_service_units_for_repair() {
 
 write_redis_env() {
     local role="$1"
+    local redis_host="${REDIS_HOST:-localhost}"
+    local redis_port="${REDIS_PORT:-6379}"
+    local redis_base="redis://${redis_host}:${redis_port}"
 
-    cat > "$BASE_DIR/redis.env" <<'EOF'
-CELERY_BROKER_URL=redis://localhost:6379/0
-CELERY_RESULT_BACKEND=redis://localhost:6379/0
+    cat > "$BASE_DIR/redis.env" <<EOF
+CELERY_BROKER_URL=${redis_base}/0
+CELERY_RESULT_BACKEND=${redis_base}/0
 EOF
 
     case "${role,,}" in
         satellite)
-            cat >> "$BASE_DIR/redis.env" <<'EOF'
-OCPP_STATE_REDIS_URL=redis://localhost:6379/0
+            cat >> "$BASE_DIR/redis.env" <<EOF
+OCPP_STATE_REDIS_URL=${redis_base}/0
 EOF
             ;;
         watchtower)
-            cat >> "$BASE_DIR/redis.env" <<'EOF'
-CHANNEL_REDIS_URL=redis://localhost:6379/0
+            cat >> "$BASE_DIR/redis.env" <<EOF
+CHANNEL_REDIS_URL=${redis_base}/0
 EOF
             ;;
     esac


### PR DESCRIPTION
### Motivation
- Broaden the hourly install health checks to validate multiple OS flavors and database backends and to run tests inside matching container images.
- Support Postgres-backed runs and ensure environment variables and service healthchecks are configured for containerized test targets.
- Improve artifact naming and cache keys to avoid collisions across the expanded matrix.

### Description
- Expanded the job matrix to include `os_flavor`, `container_image`, and `db_backend` and updated the job `name` to include these matrix axes.
- Enabled `container` usage with `image: ${{ matrix.container_image }}` and added matrix entries for Ubuntu (24.04) and Debian (12) with both `sqlite` and `postgres` backends across roles (`terminal`, `control`, `satellite`, `watchtower`).
- Added a `postgres` service with environment, ports and a health check, set `ARTHEXIS_DB_BACKEND` from the matrix, and wired `POSTGRES_*` environment variables and `OCPP_STATE_REDIS_URL` to service hosts.
- Adjusted caching keys to include `os_flavor` and `db_backend`, changed artifact names to incorporate those axes, added an initial base dependency installation step for container environments, and made apt usage resilient to absence of `sudo` when installing `redis-tools`.
- Updated the failure notification script to aggregate and report failed matrix targets (renamed `failedRoles` -> `failedTargets`) and to present failure messages referencing matrix targets.

### Testing
- No CI workflow runs were executed as part of this change; the patch updates the GitHub Actions workflow file only.
- When the workflow runs, it will execute the existing validation and smoke tests such as `python "-m" pytest ... -m "not slow and not integration"`, `scripts/sort_pyproject_deps.py --check`, and `scripts/generate_requirements.py --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f877d4708326a33cfdef22b8f103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Expands the hourly install health-check workflow to validate multiple OS flavors and database backends running in containers, with corresponding updates to support containerized test environments.

## Changes

### `.github/workflows/install-hourly.yml`
- Job matrix expansion: runs install across os_flavor (ubuntu:24.04, debian:12), container_image (matching images), db_backend (sqlite, postgres) and role (terminal, control, satellite, watchtower). Job display names include these matrix axes.
- Container execution: jobs run inside the matrix-selected container via container.image: ${{ matrix.container_image }}.
- Postgres service: added services.postgres with env, ports and a health check; POSTGRES_* env vars set in job env.
- Redis service/addressing: services.redis present; Redis-related envs set to use the service host (REDIS_HOST=redis, REDIS_PORT=6379) and OCPP_STATE_REDIS_URL uses redis://redis:6379.
- Database configuration: ARTHEXIS_DB_BACKEND driven from matrix (ARTHEXIS_DB_BACKEND: ${{ matrix.db_backend }}).
- Container preparation: initial "Install base system dependencies" step added (apt-get update; install ca-certificates, curl, git, sudo, python3, python3-venv).
- Sudo resilience: redis-tools installation step works with or without sudo.
- Caching & artifacts: virtualenv cache key and pytest artifact names include matrix axes (os_flavor, db_backend, role) to avoid collisions.
- Failure reporting: notify_failure script aggregates failed "matrix targets" from failed install job names (renamed failedRoles → failedTargets) and reports failedTargets, failed job count and failed steps in issue/comment bodies.
- Workflow behavior unchanged otherwise: when executed it runs the same validations and smoke tests across the matrix (pytest excluding slow/integration, dependency/requirements checks, linters, migration checks, etc.).

### `install.sh`
- Redis/connectivity parameterization: write_redis_env and require_redis now use REDIS_HOST and REDIS_PORT (defaults preserved) and describe the host:port checked in error messages.
- require_redis uses redis-cli -h/-p for explicit host/port checks and writes redis.env using the resolved host/port.

## Other notes
- No exported/public code entities were modified; changes are limited to CI workflow YAML and installation script logic used by the workflow.
- Lines changed in the PR: +122/-18 (workflow and install script updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->