### PR TITLE
Respect disabled LCD state during upgrade

### DIFF
--- a/scripts/helpers/service_manager.sh
+++ b/scripts/helpers/service_manager.sh
@@ -327,6 +327,22 @@ arthexis_lcd_feature_enabled() {
   return 0
 }
 
+arthexis_lcd_service_configured() {
+  local lock_dir="$1"
+  local service_name="$2"
+  local service_mode="${3:-$ARTHEXIS_SERVICE_MODE_EMBEDDED}"
+
+  if [ -z "$lock_dir" ] || [ -z "$service_name" ]; then
+    return 1
+  fi
+
+  if [ "$service_mode" != "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ]; then
+    return 1
+  fi
+
+  arthexis_systemd_unit_recorded "$lock_dir" "lcd-${service_name}.service"
+}
+
 arthexis_enable_lcd_feature_flag() {
   local lock_dir="$1"
   if [ -z "$lock_dir" ]; then

--- a/scripts/helpers/systemd_locks.sh
+++ b/scripts/helpers/systemd_locks.sh
@@ -237,7 +237,7 @@ arthexis_systemd_unit_recorded() {
     return 1
   fi
 
-  grep -Fxq "$unit_name" "$lock_file"
+  grep -Fxq -- "$unit_name" "$lock_file"
 }
 
 arthexis_install_service_stack() {

--- a/scripts/helpers/systemd_locks.sh
+++ b/scripts/helpers/systemd_locks.sh
@@ -222,6 +222,24 @@ arthexis_read_systemd_unit_records() {
   cat "$lock_file"
 }
 
+arthexis_systemd_unit_recorded() {
+  local lock_dir="$1"
+  local unit_name="$2"
+
+  if [ -z "$lock_dir" ] || [ -z "$unit_name" ]; then
+    return 1
+  fi
+
+  local lock_file
+  lock_file="$(_arthexis_systemd_lock_file "$lock_dir")"
+
+  if [ ! -f "$lock_file" ]; then
+    return 1
+  fi
+
+  grep -Fxq "$unit_name" "$lock_file"
+}
+
 arthexis_install_service_stack() {
   local base_dir="$1"
   local lock_dir="$2"

--- a/tests/test_service_manager_lcd_unit_selection.py
+++ b/tests/test_service_manager_lcd_unit_selection.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+
+def _run_lcd_configured_check(
+    tmp_path: Path,
+    *,
+    systemd_units: str = "",
+    service_mode: str = "systemd",
+    service_name: str = "suite",
+) -> subprocess.CompletedProcess[str]:
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    if systemd_units:
+        (lock_dir / "systemd_services.lck").write_text(systemd_units, encoding="utf-8")
+
+    helper_path = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "helpers"
+        / "service_manager.sh"
+    )
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(helper_path))}
+if arthexis_lcd_service_configured {shlex.quote(str(lock_dir))} {shlex.quote(service_name)} {shlex.quote(service_mode)}; then
+  echo configured
+else
+  echo disabled
+fi
+"""
+
+    return subprocess.run(
+        ["bash", "-lc", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_lcd_service_configured_requires_recorded_unit(tmp_path: Path) -> None:
+    result = _run_lcd_configured_check(
+        tmp_path,
+        systemd_units="suite.service\ncelery-suite.service\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "disabled"
+
+
+def test_lcd_service_configured_accepts_recorded_unit(tmp_path: Path) -> None:
+    result = _run_lcd_configured_check(
+        tmp_path,
+        systemd_units="suite.service\nlcd-suite.service\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "configured"
+
+
+def test_lcd_service_configured_skips_embedded_mode(tmp_path: Path) -> None:
+    result = _run_lcd_configured_check(
+        tmp_path,
+        systemd_units="suite.service\nlcd-suite.service\n",
+        service_mode="embedded",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "disabled"

--- a/tests/test_service_manager_lcd_unit_selection.py
+++ b/tests/test_service_manager_lcd_unit_selection.py
@@ -34,7 +34,7 @@ fi
 """
 
     return subprocess.run(
-        ["bash", "-lc", script],
+        ["bash", "-c", script],
         text=True,
         capture_output=True,
         check=False,

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -643,6 +643,10 @@ lcd_service_lockfiles_present() {
   return 1
 }
 
+lcd_service_configured() {
+  arthexis_lcd_service_configured "$LOCK_DIR" "$1" "$SERVICE_MANAGEMENT_MODE"
+}
+
 lcd_systemd_unit_present() {
   _prefixed_systemd_unit_present "lcd" "$1"
 }
@@ -2093,13 +2097,15 @@ if [ -n "$SERVICE_NAME" ] && [ "$SERVICE_MANAGEMENT_MODE" = "$ARTHEXIS_SERVICE_M
   fi
 fi
 
-if [ -n "$SERVICE_NAME" ] && lcd_systemd_unit_present "$SERVICE_NAME"; then
-  arthexis_install_lcd_service_unit "$BASE_DIR" "$LOCK_DIR" "$SERVICE_NAME"
-elif [ -n "$SERVICE_NAME" ] && [ "$NODE_ROLE_NAME" = "Control" ] && [ "$SERVICE_MANAGEMENT_MODE" = "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ]; then
-  arthexis_install_lcd_service_unit "$BASE_DIR" "$LOCK_DIR" "$SERVICE_NAME"
+if [ -n "$SERVICE_NAME" ] && [ "$SERVICE_MANAGEMENT_MODE" = "$ARTHEXIS_SERVICE_MODE_SYSTEMD" ]; then
+  if lcd_service_configured "$SERVICE_NAME"; then
+    arthexis_install_lcd_service_unit "$BASE_DIR" "$LOCK_DIR" "$SERVICE_NAME"
+  else
+    arthexis_remove_systemd_unit_if_present "$LOCK_DIR" "lcd-${SERVICE_NAME}.service"
+  fi
 fi
 
-if [ -n "$SERVICE_NAME" ] && [[ $NO_RESTART -eq 0 ]] && lcd_systemd_unit_present "$SERVICE_NAME"; then
+if [ -n "$SERVICE_NAME" ] && [[ $NO_RESTART -eq 0 ]] && lcd_service_configured "$SERVICE_NAME"; then
   clear_lcd_lockfiles
 fi
 


### PR DESCRIPTION
## Summary
- stop `upgrade.sh` from blindly reinstalling LCD sidecars on Control-role systemd installs after lifecycle reconciliation
- treat `.locks/systemd_services.lck` as the post-reconcile source of truth for LCD sidecar installation and remove stale LCD units when the record is gone
- add a shell-level regression test for the LCD systemd-unit selection helper

## Issue
- Refs #7284

## Verification
- `bash -n upgrade.sh scripts/helpers/systemd_locks.sh scripts/helpers/service_manager.sh`
- `pytest -q tests/test_service_manager_lcd_unit_selection.py`

## Notes
- A broader `pytest tests/test_service_manager_lcd_unit_selection.py apps/services/tests/test_lifecycle_reconcile.py` run entered `apps/services/tests/test_lifecycle_reconcile.py` and did not finish in a reasonable interactive window, so only the targeted shell regression test is included here.