### PR TITLE
docs: codify forward-only migration recovery policy

### DIFF
--- a/docs/operations/reinstall-data-import-runbook.md
+++ b/docs/operations/reinstall-data-import-runbook.md
@@ -87,7 +87,7 @@ must rerun with explicit reconciliation (for example `./upgrade.sh --migrate`).
    recovery source).
 3. Restore the repository working tree to the matching pre-upgrade revision
    (for example with your Git tag/commit pinning process for that environment).
-4. Re-run upgrade and inspect migration health before continuing.
+4. Re-run upgrade with the --local flag and inspect migration health before continuing.
 
 Do not perform reverse migrations as an operational recovery path; Arthexis
 upgrade recovery is database + repository restore based.

--- a/docs/operations/reinstall-data-import-runbook.md
+++ b/docs/operations/reinstall-data-import-runbook.md
@@ -79,13 +79,18 @@ When enabled, if `env-refresh.py` detects mismatch failures (for example
 Without this flag, upgrade remains fail-fast for mismatch failures, and operators
 must rerun with explicit reconciliation (for example `./upgrade.sh --migrate`).
 
-#### Rollback steps after fallback
+#### Recovery steps after fallback (forward-only policy)
 
 1. Stop services (`./upgrade.sh --stop`) before restoration.
-2. Restore from your pre-upgrade DB backup/snapshot (or from the generated
-   `.locks/*.pre_major_migrate.*` artifact if that is your approved rollback
-   source).
-3. Re-run upgrade and inspect migration health before continuing.
+2. Restore the database from your pre-upgrade DB backup/snapshot (or from the
+   generated `.locks/*.pre_major_migrate.*` artifact if that is your approved
+   recovery source).
+3. Restore the repository working tree to the matching pre-upgrade revision
+   (for example with your Git tag/commit pinning process for that environment).
+4. Re-run upgrade and inspect migration health before continuing.
+
+Do not perform reverse migrations as an operational recovery path; Arthexis
+upgrade recovery is database + repository restore based.
 
 #### Post-check steps after fallback
 

--- a/docs/upgrade-error-handling.md
+++ b/docs/upgrade-error-handling.md
@@ -14,7 +14,7 @@ Upgrades should remain predictable and as stable as possible. When errors are re
 
 ## 3. Strengthen preflight and validation
 - **Schema and data prechecks**: add light-weight preflight checks (e.g., required feature flags, critical tables/columns existence) that surface blockers before long upgrade runs. Keep these checks within the migration sequence or a dedicated validation command, not the central upgrade script.
-- **Repeatable dry runs**: support dry-run modes for migrations in CI or staging that run against anonymized snapshots. Validate both forward and backward migration paths where possible.
+- **Repeatable dry runs**: support dry-run modes for migrations in CI or staging that run against anonymized snapshots. Validate forward-only migration paths and recovery playbooks that restore from database and repository snapshots.
 - **Safe defaults for invalid data**: when encountering invalid or null values, prefer explicit remediation steps (data cleanup migrations or default-setting migrations) instead of suppressing errors globally.
 
 ## 4. Observability and feedback
@@ -23,18 +23,18 @@ Upgrades should remain predictable and as stable as possible. When errors are re
 - **Link reports to code owners**: tag migrations with ownership metadata so error reports route to the correct team. Include migration file paths and app labels in alerts.
 
 ## 5. Continuous verification
-- **Migration test harnesses**: add targeted tests that exercise migrations against fixtures representing legacy states. Include tests for idempotency and reversibility where applicable.
+- **Migration test harnesses**: add targeted tests that exercise migrations against fixtures representing legacy states. Include tests for idempotency and forward-only safety where applicable.
 - **Backfill coverage**: when adding compensating data migrations, include assertions that the expected rows are updated and that downstream constraints (unique, foreign keys) hold.
 - **Upgrade playbooks**: maintain documented runbooks for common failure classes (missing imports, bad defaults, ordering issues) with known fixes and verification steps.
 
 ## 6. Change management
 - **Limit changes to the upgrade driver**: treat the upgrade script as infrastructure—only change it for platform-level needs (new CLI flags, logging improvements) and not to patch individual migration failures.
 - **Postmortems for severe incidents**: when an upgrade failure causes downtime, record the root cause, the migration(s) involved, data states encountered, and the fix. Feed lessons back into migration authoring guidelines.
-- **Education and templates**: provide scaffolding/templates for new migrations that encourage safe patterns (explicit imports, `apps.get_model`, guards against null/invalid values, backwards-safe data changes).
+- **Education and templates**: provide scaffolding/templates for new migrations that encourage safe patterns (explicit imports, `apps.get_model`, guards against null/invalid values, forward-compatible data changes).
 
 ## 7. Tooling roadmap
-- **Automated migration linting**: add static checks for forbidden current-model imports, missing `RunPython` reverse functions, and unsafe operations on large tables without batching.
+- **Automated migration linting**: add static checks for forbidden current-model imports and unsafe operations on large tables without batching.
 - **Replay tooling**: build scripts to replay failing migrations against sanitized production snapshots to confirm fixes before release.
 - **Visibility in CI**: surface migration test results and dry-run findings as first-class CI signals to prevent regressions from reaching production.
 
-By keeping the upgrade driver stable and focusing remediation on migrations, data correctness, and observability, we can resolve upgrade errors faster and prevent similar issues in future releases.
+By keeping the upgrade driver stable and focusing remediation on migrations, data correctness, and observability, we can resolve upgrade errors faster and prevent similar issues in future releases. Recovery should rely on database + repository-level restore procedures instead of reverse migrations.


### PR DESCRIPTION
### Motivation
- Align upgrade and migration guidance with the project policy to always move forward and to require database + repository-level restores for recovery instead of recommending or depending on reverse migrations.

### Description
- Update `docs/upgrade-error-handling.md` and `docs/operations/reinstall-data-import-runbook.md` to remove language that implied reverse/backward migrations are expected, to change dry-run and test-harness guidance to forward-only safety, and to replace the rollback steps with a forward-only recovery procedure that restores the database and the repository working tree.

### Testing
- Ran basic repository checks: `git diff --check` and `git status --short`, both succeeded (no code tests were modified or required for these documentation changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e967da3adc832696fb1d0cdd31a5d9)