### PR TITLE
Synchronize seeded staff tasks to canonical defaults and update tests

### DIFF
--- a/apps/actions/staff_tasks.py
+++ b/apps/actions/staff_tasks.py
@@ -180,21 +180,21 @@ def user_can_access_staff_task(user, task: StaffTask) -> bool:
 def ensure_default_staff_tasks_exist() -> None:
     """Backfill missing default staff tasks in existing and new environments.
 
-    Existing rows are left intact so operator edits to labels, ordering, and
-    visibility remain persistent after the defaults have been seeded once.
+    Existing rows are synchronized to the suite defaults so each reseed keeps
+    labels, ordering, and visibility aligned across environments.
     """
 
     for task in DEFAULT_STAFF_TASKS:
-        StaffTask.objects.get_or_create(
+        StaffTask.objects.update_or_create(
             slug=task["slug"],
             defaults={
-                "label": task["label"],
-                "description": task["description"],
                 "action_name": task["action_name"],
-                "order": task["order"],
                 "default_enabled": True,
+                "description": task["description"],
+                "is_active": True,
+                "label": task["label"],
+                "order": task["order"],
                 "staff_only": True,
                 "superuser_only": bool(task.get("superuser_only", False)),
-                "is_active": True,
             },
         )

--- a/apps/actions/tests/test_api.py
+++ b/apps/actions/tests/test_api.py
@@ -74,8 +74,8 @@ def test_staff_task_resolves_named_internal_action_for_visible_tasks():
 
 
 @pytest.mark.django_db
-def test_ensure_default_staff_tasks_exist_preserves_existing_seeded_task_edits():
-    """Regression: reseeding should not overwrite operator changes to seeded tasks."""
+def test_ensure_default_staff_tasks_exist_overrides_existing_seeded_task_edits():
+    """Regression: reseeding should enforce canonical defaults for seeded tasks."""
 
     StaffTask.objects.create(
         slug="groups",
@@ -92,10 +92,10 @@ def test_ensure_default_staff_tasks_exist_preserves_existing_seeded_task_edits()
     ensure_default_staff_tasks_exist()
 
     task = StaffTask.objects.get(slug="groups")
-    assert task.label == "Customized Groups"
-    assert task.description == "Customized description."
-    assert task.order == 5
-    assert task.default_enabled is False
-    assert task.staff_only is False
-    assert task.superuser_only is True
-    assert task.is_active is False
+    assert task.label == "Groups"
+    assert task.description == "Browse the current user's security groups."
+    assert task.order == 55
+    assert task.default_enabled is True
+    assert task.staff_only is True
+    assert task.superuser_only is False
+    assert task.is_active is True


### PR DESCRIPTION
### Motivation
- Ensure seeded staff tasks are kept in sync with the canonical defaults on reseed instead of preserving local edits.
- Simplify and standardize the model fields used for defaults by aligning seeding to `is_active` and `default_enabled` semantics.
- Make sure internal named actions resolve correctly after reseeding.

### Description
- Replace `StaffTask.objects.get_or_create` with `StaffTask.objects.update_or_create` in `ensure_default_staff_tasks_exist` so existing rows are synchronized to suite defaults rather than left intact.
- Reorder and update the `defaults` mapping to set `description`, `is_active`, `label`, and `order` consistently and retain `staff_only` and `superuser_only` flags.
- Update the tests to reflect the new reseed behavior by renaming the test to `test_ensure_default_staff_tasks_exist_overrides_existing_seeded_task_edits` and asserting that seeded tasks are overwritten with canonical defaults.

### Testing
- Ran the module tests in `apps/actions/tests/test_api.py` including `test_staff_task_resolves_named_internal_action_for_visible_tasks` and `test_ensure_default_staff_tasks_exist_overrides_existing_seeded_task_edits` with `pytest`, and they passed.
- Confirmed that `visible_staff_tasks_for_user` returns expected URLs for seeded tasks after reseeding by exercising the relevant assertions in the test module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9676fb1948326af997f8f163621a0)