### PR TITLE
docs: use GitHub links for versioning & maturity policy references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Arthexis Constellation is a Django-based software suite that centralizes tools f
 
 Visit our [Changelog Report](https://arthexis.com/changelog/) to browse release history and operational updates.
 
-For release confidence and version lifecycle expectations, see the [Versioning and Maturity Policy](docs/development/versioning-maturity-policy.md).
+For release confidence and version lifecycle expectations, see the [Versioning and Maturity Policy](https://github.com/arthexis/arthexis/blob/main/docs/development/versioning-maturity-policy.md).
 
 ## Suite Features
 

--- a/apps/nodes/admin/README.md
+++ b/apps/nodes/admin/README.md
@@ -8,7 +8,7 @@ The Django admin setup for the nodes app is split across focused modules to keep
 
 > Note: this link targets the in-repo docs index for repository readers, not a runtime web route.
 
-For release confidence criteria and maturity semantics, see the [Versioning and Maturity Policy](../../../docs/development/versioning-maturity-policy.md).
+For release confidence criteria and maturity semantics, see the [Versioning and Maturity Policy](https://github.com/arthexis/arthexis/blob/main/docs/development/versioning-maturity-policy.md).
 
 For a module-by-module map, see the dedicated reference:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ This README provides a lightweight entrypoint for repository test guidance.
 
 > Note: this link targets the in-repo docs index for repository readers, not a runtime web route.
 
-For release confidence criteria and maturity semantics, see the [Versioning and Maturity Policy](../docs/development/versioning-maturity-policy.md).
+For release confidence criteria and maturity semantics, see the [Versioning and Maturity Policy](https://github.com/arthexis/arthexis/blob/main/docs/development/versioning-maturity-policy.md).
 
 For targeted notes about notable test-suite decisions and historical changes, see the dedicated testing notes document:
 


### PR DESCRIPTION
### Motivation
- Ensure readers who are not browsing the site (or not logged in) are directed to the canonical Versioning and Maturity Policy on GitHub rather than a repository-relative path.

### Description
- Replaced repository-relative references with the GitHub blob URL `https://github.com/arthexis/arthexis/blob/main/docs/development/versioning-maturity-policy.md` in `README.md`, `tests/README.md`, and `apps/nodes/admin/README.md`.

### Testing
- Ran a focused grep check (`rg -n "Versioning and Maturity Policy|versioning-maturity-policy.md"`) to verify the three files now reference the GitHub blob URL, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97a4b241c832692bc6265e1bd2fca)