### PR TITLE
Send upgrade completion emails to the default admin

### DIFF
--- a/apps/core/management/commands/upgrade.py
+++ b/apps/core/management/commands/upgrade.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from apps.core.services.upgrade_notifications import notify_upgrade_completion
 from apps.core.system.filesystem import _clear_auto_upgrade_skip_revisions
 from apps.core.system.upgrade import (
     UPGRADE_CHANNEL_CHOICES,
@@ -63,6 +64,57 @@ class Command(BaseCommand):
         channel_parser.add_argument(
             "channel",
             help="Target channel (stable, unstable, latest).",
+        )
+
+        notify_parser = subparsers.add_parser(
+            "notify",
+            help="Send the post-upgrade status email and rotate the default admin temp password.",
+        )
+        notify_parser.add_argument(
+            "--exit-status",
+            type=int,
+            default=0,
+            help="Exit status from the completed upgrade script.",
+        )
+        notify_parser.add_argument(
+            "--source",
+            default="upgrade.sh",
+            help="Source command or workflow that completed the upgrade.",
+        )
+        notify_parser.add_argument(
+            "--channel",
+            default="",
+            help="Upgrade channel used for the completed run.",
+        )
+        notify_parser.add_argument(
+            "--branch",
+            default="",
+            help="Git branch associated with the completed run.",
+        )
+        notify_parser.add_argument(
+            "--service",
+            default="",
+            help="Service name for the upgraded instance when known.",
+        )
+        notify_parser.add_argument(
+            "--initial-version",
+            default="",
+            help="Version recorded before the upgrade started.",
+        )
+        notify_parser.add_argument(
+            "--target-version",
+            default="",
+            help="Version observed as the intended target before the upgrade ran.",
+        )
+        notify_parser.add_argument(
+            "--initial-revision",
+            default="",
+            help="Git revision recorded before the upgrade started.",
+        )
+        notify_parser.add_argument(
+            "--target-revision",
+            default="",
+            help="Git revision observed as the intended target before the upgrade ran.",
         )
 
     def handle(self, *args, **options):
@@ -161,5 +213,35 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"Upgrade channel set to '{channel}' for {updated} assigned policy"
                 f"{'ies' if updated != 1 else ''}."
+            )
+        )
+
+    def _handle_notify(self, options: dict[str, object]) -> None:
+        """Send the post-upgrade status email and rotate the default admin temp password."""
+
+        result = notify_upgrade_completion(
+            base_dir=Path(settings.BASE_DIR),
+            exit_status=int(options["exit_status"]),
+            source=str(options.get("source") or "upgrade.sh").strip() or "upgrade.sh",
+            channel=str(options.get("channel") or "").strip() or None,
+            branch=str(options.get("branch") or "").strip() or None,
+            service_name=str(options.get("service") or "").strip() or None,
+            initial_version=str(options.get("initial_version") or "").strip() or None,
+            target_version=str(options.get("target_version") or "").strip() or None,
+            initial_revision=str(options.get("initial_revision") or "").strip() or None,
+            target_revision=str(options.get("target_revision") or "").strip() or None,
+        )
+        if not result.email_sent:
+            raise CommandError(
+                result.error or "Upgrade notification email was not sent."
+            )
+
+        expires_at = result.expires_at.isoformat() if result.expires_at else "unknown"
+        recipients = ", ".join(result.recipients) or "<none>"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Upgrade notification sent to {recipients}; "
+                f"temporary password rotated for {result.admin_username} "
+                f"(expires {expires_at})."
             )
         )

--- a/apps/core/services/upgrade_notifications.py
+++ b/apps/core/services/upgrade_notifications.py
@@ -1,0 +1,295 @@
+"""Helpers for upgrade completion notifications."""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from django.conf import settings
+from django.core.mail import EmailMessage, get_connection
+from django.core.validators import ValidationError
+from django.utils import timezone
+
+from apps.emails.utils import normalize_recipients
+from apps.users import temp_passwords
+from apps.users.system import ensure_default_admin_user
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UpgradeNotificationResult:
+    """Outcome from a single upgrade completion notification attempt."""
+
+    status: str
+    exit_status: int
+    email_sent: bool
+    subject: str
+    recipients: list[str] = field(default_factory=list)
+    admin_username: str = ""
+    temp_password: str = ""
+    expires_at: datetime | None = None
+    error: str = ""
+
+
+def _resolve_local_node():
+    try:
+        from apps.nodes.models import Node
+    except Exception:
+        return None
+
+    try:
+        return Node.get_local()
+    except Exception:
+        logger.warning("Unable to resolve local node for upgrade notification", exc_info=True)
+        return None
+
+
+def _read_version_marker(base_dir: Path) -> str:
+    version_path = base_dir / "VERSION"
+    try:
+        return version_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _read_current_revision(base_dir: Path) -> str:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                cwd=base_dir,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+
+def _short_revision(value: str | None) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "-"
+    return normalized[:12]
+
+
+def _load_upgrade_duration_metadata(base_dir: Path) -> dict[str, object]:
+    lock_path = base_dir / ".locks" / "upgrade_duration.lck"
+    try:
+        return json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _resolve_instance_label(base_dir: Path, *, service_name: str | None = None) -> tuple[str, str]:
+    node = _resolve_local_node()
+    hostname = socket.gethostname() or "unknown-host"
+    if node is not None:
+        try:
+            domain = node.get_base_domain()
+        except Exception:
+            domain = ""
+        label = (
+            domain
+            or getattr(node, "hostname", "")
+            or service_name
+            or base_dir.name
+            or hostname
+        )
+        return label, getattr(node, "hostname", "") or hostname
+
+    label = service_name or base_dir.name or hostname
+    return label, hostname
+
+
+def _send_secret_email(
+    subject: str,
+    body: str,
+    recipient_list: list[str],
+) -> None:
+    node = _resolve_local_node()
+    outbox = None
+    if node is not None:
+        try:
+            outbox = getattr(node, "email_outbox", None)
+        except Exception:
+            outbox = None
+
+    sender = (
+        getattr(outbox, "from_email", "") or settings.DEFAULT_FROM_EMAIL or settings.DEFAULT_ADMIN_EMAIL
+    )
+    if outbox is not None and getattr(outbox, "is_enabled", False):
+        connection = outbox.get_connection()
+    else:
+        connection = get_connection(getattr(settings, "EMAIL_BACKEND", None))
+
+    email = EmailMessage(
+        subject=subject,
+        body=body,
+        from_email=sender,
+        to=recipient_list,
+        connection=connection,
+    )
+    email.send(fail_silently=False)
+
+
+def notify_upgrade_completion(
+    *,
+    base_dir: Path | str | None = None,
+    exit_status: int,
+    source: str = "upgrade.sh",
+    channel: str | None = None,
+    branch: str | None = None,
+    service_name: str | None = None,
+    initial_version: str | None = None,
+    target_version: str | None = None,
+    initial_revision: str | None = None,
+    target_revision: str | None = None,
+) -> UpgradeNotificationResult:
+    """Send the configured upgrade completion email and rotate the temp admin password."""
+
+    resolved_base_dir = Path(base_dir) if base_dir is not None else Path(settings.BASE_DIR)
+    status = "succeeded" if int(exit_status) == 0 else "failed"
+    label, hostname = _resolve_instance_label(resolved_base_dir, service_name=service_name)
+    subject = f"Upgrade {status}: {label}"
+
+    try:
+        recipients = normalize_recipients(
+            [getattr(settings, "DEFAULT_ADMIN_EMAIL", "")],
+            validate=True,
+        )
+    except ValidationError as exc:
+        return UpgradeNotificationResult(
+            status=status,
+            exit_status=int(exit_status),
+            email_sent=False,
+            subject=subject,
+            error=str(exc),
+        )
+
+    if not recipients:
+        return UpgradeNotificationResult(
+            status=status,
+            exit_status=int(exit_status),
+            email_sent=False,
+            subject=subject,
+            error="No DEFAULT_ADMIN_EMAIL is configured for upgrade notifications.",
+        )
+
+    ensured = ensure_default_admin_user(record_updates=True)
+    if ensured is None:
+        return UpgradeNotificationResult(
+            status=status,
+            exit_status=int(exit_status),
+            email_sent=False,
+            subject=subject,
+            recipients=recipients,
+            error="DEFAULT_ADMIN_USERNAME resolved to an empty value.",
+        )
+
+    admin_user, admin_updates = ensured
+    password = temp_passwords.generate_password()
+    expires_at = timezone.now() + temp_passwords.DEFAULT_EXPIRATION
+    temp_passwords.store_temp_password(
+        admin_user.username,
+        password,
+        expires_at,
+        allow_change=True,
+    )
+
+    current_version = _read_version_marker(resolved_base_dir)
+    current_revision = _read_current_revision(resolved_base_dir)
+    duration = _load_upgrade_duration_metadata(resolved_base_dir)
+
+    body_lines = [
+        f"Upgrade status: {status}",
+        f"Source: {source}",
+        f"Exit status: {int(exit_status)}",
+        f"Instance: {label}",
+        f"Hostname: {hostname}",
+        f"Install dir: {resolved_base_dir}",
+    ]
+    if service_name:
+        body_lines.append(f"Service: {service_name}")
+    if channel:
+        body_lines.append(f"Channel: {channel}")
+    if branch:
+        body_lines.append(f"Branch: {branch}")
+    if initial_version:
+        body_lines.append(f"Initial version: {initial_version}")
+    if target_version:
+        body_lines.append(f"Target version: {target_version}")
+    if current_version:
+        body_lines.append(f"Current version: {current_version}")
+    if initial_revision:
+        body_lines.append(f"Initial revision: {_short_revision(initial_revision)}")
+    if target_revision:
+        body_lines.append(f"Target revision: {_short_revision(target_revision)}")
+    if current_revision:
+        body_lines.append(f"Current revision: {_short_revision(current_revision)}")
+
+    started_at = duration.get("started_at")
+    finished_at = duration.get("finished_at")
+    duration_seconds = duration.get("duration_seconds")
+    if started_at:
+        body_lines.append(f"Started at: {started_at}")
+    if finished_at:
+        body_lines.append(f"Finished at: {finished_at}")
+    if duration_seconds not in {None, ""}:
+        body_lines.append(f"Duration seconds: {duration_seconds}")
+
+    body_lines.extend(
+        [
+            "",
+            f"Admin username: {admin_user.username}",
+            f"Admin email: {getattr(settings, 'DEFAULT_ADMIN_EMAIL', '').strip()}",
+            f"Temporary password: {password}",
+            f"Password expires at: {expires_at.isoformat()}",
+            "The temporary password can be used as the old password when changing the account password.",
+        ]
+    )
+    if admin_updates:
+        body_lines.extend(
+            [
+                "",
+                "Admin account updates:",
+                ", ".join(sorted(str(update) for update in admin_updates)),
+            ]
+        )
+
+    body = "\n".join(body_lines).strip()
+
+    try:
+        _send_secret_email(subject, body, recipients)
+    except Exception as exc:
+        logger.exception("Upgrade completion email failed")
+        return UpgradeNotificationResult(
+            status=status,
+            exit_status=int(exit_status),
+            email_sent=False,
+            subject=subject,
+            recipients=recipients,
+            admin_username=admin_user.username,
+            temp_password=password,
+            expires_at=expires_at,
+            error=str(exc),
+        )
+
+    return UpgradeNotificationResult(
+        status=status,
+        exit_status=int(exit_status),
+        email_sent=True,
+        subject=subject,
+        recipients=recipients,
+        admin_username=admin_user.username,
+        temp_password=password,
+        expires_at=expires_at,
+    )

--- a/apps/core/tests/test_upgrade_notifications.py
+++ b/apps/core/tests/test_upgrade_notifications.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import override_settings
+
+from apps.core.models import EmailTransaction
+from apps.core.services.upgrade_notifications import notify_upgrade_completion
+from apps.users import temp_passwords
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_ADMIN_EMAIL="tecnologia@gelectriic.com",
+    DEFAULT_ADMIN_USERNAME="arthexis",
+    DEFAULT_FROM_EMAIL="tecnologia@gelectriic.com",
+)
+def test_notify_upgrade_completion_sends_email_and_rotates_temp_password(
+    monkeypatch, settings, tmp_path: Path
+) -> None:
+    settings.TEMP_PASSWORD_LOCK_DIR = str(tmp_path / ".locks" / "temp-passwords")
+    (tmp_path / ".locks").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "VERSION").write_text("0.2.3\n", encoding="utf-8")
+    (tmp_path / ".locks" / "upgrade_duration.lck").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-04-23T01:00:00+00:00",
+                "finished_at": "2026-04-23T01:02:00+00:00",
+                "duration_seconds": 120,
+                "status": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "apps.core.services.upgrade_notifications._resolve_local_node",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "apps.core.services.upgrade_notifications._read_current_revision",
+        lambda _base_dir: "abcdef1234567890",
+    )
+
+    result = notify_upgrade_completion(
+        base_dir=tmp_path,
+        exit_status=0,
+        source="upgrade.sh",
+        channel="stable",
+        branch="main",
+        service_name="arthexis-main",
+        initial_version="0.2.2",
+        target_version="0.2.3",
+        initial_revision="111111111111",
+        target_revision="222222222222",
+    )
+
+    assert result.email_sent is True
+    assert result.admin_username == "arthexis"
+    assert result.recipients == ["tecnologia@gelectriic.com"]
+    assert len(mail.outbox) == 1
+    message = mail.outbox[0]
+    assert message.to == ["tecnologia@gelectriic.com"]
+    assert "Upgrade succeeded" in message.subject
+    assert "Temporary password:" in message.body
+    assert result.temp_password in message.body
+    assert "Initial version: 0.2.2" in message.body
+    assert "Current version: 0.2.3" in message.body
+    assert "Duration seconds: 120" in message.body
+
+    user = get_user_model().all_objects.get(username="arthexis")
+    entry = temp_passwords.load_temp_password(user.username)
+    assert entry is not None
+    assert entry.check_password(result.temp_password)
+    assert EmailTransaction.objects.count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_ADMIN_EMAIL="tecnologia@gelectriic.com",
+    DEFAULT_ADMIN_USERNAME="ops-admin",
+    DEFAULT_FROM_EMAIL="tecnologia@gelectriic.com",
+)
+def test_notify_upgrade_completion_repairs_existing_default_admin_user(
+    monkeypatch, settings, tmp_path: Path
+) -> None:
+    settings.TEMP_PASSWORD_LOCK_DIR = str(tmp_path / ".locks" / "temp-passwords")
+    user_model = get_user_model()
+    user = user_model.all_objects.create_user(
+        username="ops-admin",
+        email="wrong@example.com",
+        is_active=False,
+        is_staff=False,
+        is_superuser=False,
+        allow_local_network_passwordless_login=True,
+    )
+    user.temporary_expires_at = None
+    user.operate_as = user_model.objects.create(username="delegate")
+    user.is_deleted = True
+    user.save()
+
+    monkeypatch.setattr(
+        "apps.core.services.upgrade_notifications._resolve_local_node",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "apps.core.services.upgrade_notifications._read_current_revision",
+        lambda _base_dir: "fedcba9876543210",
+    )
+
+    result = notify_upgrade_completion(base_dir=tmp_path, exit_status=1)
+
+    user.refresh_from_db()
+    assert result.email_sent is True
+    assert user.email == "tecnologia@gelectriic.com"
+    assert user.is_active is True
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert user.is_deleted is False
+    assert user.allow_local_network_passwordless_login is False
+    assert user.operate_as_id is None

--- a/apps/users/system.py
+++ b/apps/users/system.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Iterator, Tuple
+from typing import Callable, Iterator, Literal, Tuple, overload
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -97,12 +97,30 @@ def ensure_system_user(*, record_updates: bool = False):
     return user
 
 
+@overload
+def ensure_default_admin_user(
+    *,
+    username: str | None = None,
+    email: str | None = None,
+    record_updates: Literal[False] = False,
+) -> object | None: ...
+
+
+@overload
+def ensure_default_admin_user(
+    *,
+    username: str | None = None,
+    email: str | None = None,
+    record_updates: Literal[True],
+) -> tuple[object, set[str]] | None: ...
+
+
 def ensure_default_admin_user(
     *,
     username: str | None = None,
     email: str | None = None,
     record_updates: bool = False,
-):
+) -> object | tuple[object, set[str]] | None:
     """Return the configured default admin user, creating or repairing it as needed."""
 
     User = get_user_model()

--- a/apps/users/system.py
+++ b/apps/users/system.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Callable, Iterator, Tuple
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from apps.groups.security import ensure_default_staff_groups
@@ -95,3 +96,81 @@ def ensure_system_user(*, record_updates: bool = False):
         return user, updates
     return user
 
+
+def ensure_default_admin_user(
+    *,
+    username: str | None = None,
+    email: str | None = None,
+    record_updates: bool = False,
+):
+    """Return the configured default admin user, creating or repairing it as needed."""
+
+    User = get_user_model()
+    resolved_username = (
+        str(
+            username
+            or getattr(settings, "DEFAULT_ADMIN_USERNAME", "")
+            or getattr(User, "SYSTEM_USERNAME", "")
+            or "arthexis"
+        ).strip()
+    )
+    if not resolved_username:
+        return None
+
+    resolved_email = str(
+        email if email is not None else getattr(settings, "DEFAULT_ADMIN_EMAIL", "")
+    ).strip()
+
+    manager = getattr(User, "all_objects", User._default_manager)
+    user, created = manager.get_or_create(
+        username=resolved_username,
+        defaults={
+            "email": resolved_email,
+            "is_staff": True,
+            "is_superuser": True,
+            "is_active": True,
+        },
+    )
+
+    updates: set[str] = set()
+    if created:
+        updates.add("created")
+
+    if not user.password:
+        user.set_unusable_password()
+        updates.add("password")
+
+    if resolved_email and getattr(user, "email", "") != resolved_email:
+        user.email = resolved_email
+        updates.add("email")
+    if getattr(user, "is_deleted", False):
+        user.is_deleted = False
+        updates.add("is_deleted")
+    if not getattr(user, "is_active", True):
+        user.is_active = True
+        updates.add("is_active")
+    if not getattr(user, "is_staff", False):
+        user.is_staff = True
+        updates.add("is_staff")
+    if not getattr(user, "is_superuser", False):
+        user.is_superuser = True
+        updates.add("is_superuser")
+    if getattr(user, "operate_as_id", None):
+        user.operate_as = None
+        updates.add("operate_as")
+    if getattr(user, "allow_local_network_passwordless_login", False):
+        user.allow_local_network_passwordless_login = False
+        updates.add("allow_local_network_passwordless_login")
+    if getattr(user, "temporary_expires_at", None) is not None:
+        user.temporary_expires_at = None
+        updates.add("temporary_expires_at")
+
+    if updates - {"created"}:
+        user.save(update_fields=sorted(updates - {"created"}))
+
+    added_groups = ensure_default_staff_groups(user)
+    updates.update(f"group:{name}" for name in added_groups)
+
+    if record_updates:
+        return user, updates
+    return user

--- a/apps/users/tests/test_system_user.py
+++ b/apps/users/tests/test_system_user.py
@@ -10,7 +10,11 @@ from apps.groups.constants import (
 )
 from apps.users import temp_passwords
 from apps.users.backends import TempPasswordBackend
-from apps.users.system import collect_system_user_issues, ensure_system_user
+from apps.users.system import (
+    collect_system_user_issues,
+    ensure_default_admin_user,
+    ensure_system_user,
+)
 
 
 @pytest.mark.django_db
@@ -107,3 +111,59 @@ def test_system_user_only_authenticates_with_temp_password():
         backend.authenticate(request, username=user.username, password="incorrect")
         is None
     )
+
+
+@pytest.mark.django_db
+def test_ensure_default_admin_user_uses_configured_defaults(settings):
+    settings.DEFAULT_ADMIN_USERNAME = "ops-admin"
+    settings.DEFAULT_ADMIN_EMAIL = "tecnologia@gelectriic.com"
+
+    User = get_user_model()
+    delegate = User.objects.create(username="delegate-admin", is_staff=True)
+    existing = User.all_objects.create_user(
+        username="ops-admin",
+        email="wrong@example.com",
+        is_active=False,
+        is_staff=False,
+        is_superuser=False,
+        allow_local_network_passwordless_login=True,
+    )
+    existing.is_deleted = True
+    existing.operate_as = delegate
+    existing.save()
+
+    user, updates = ensure_default_admin_user(record_updates=True)
+
+    assert user.pk == existing.pk
+    assert user.username == "ops-admin"
+    assert user.email == "tecnologia@gelectriic.com"
+    assert user.is_active is True
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert user.is_deleted is False
+    assert user.allow_local_network_passwordless_login is False
+    assert user.operate_as_id is None
+    assert "email" in updates
+    assert "is_active" in updates
+    assert "is_staff" in updates
+    assert "is_superuser" in updates
+
+
+@pytest.mark.django_db
+def test_ensure_default_admin_user_creates_unusable_password_account(settings):
+    settings.DEFAULT_ADMIN_USERNAME = "ops-admin"
+    settings.DEFAULT_ADMIN_EMAIL = "tecnologia@gelectriic.com"
+
+    User = get_user_model()
+    User.all_objects.filter(username="ops-admin").delete()
+
+    user, updates = ensure_default_admin_user(record_updates=True)
+
+    assert user.username == "ops-admin"
+    assert user.email == "tecnologia@gelectriic.com"
+    assert user.is_active is True
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert user.has_usable_password() is False
+    assert "created" in updates
+    assert "password" in updates

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -137,8 +137,17 @@ ASGI_APPLICATION = "config.asgi.application"
 
 # Email settings
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@example.com")
-SERVER_EMAIL = DEFAULT_FROM_EMAIL
+DEFAULT_ADMIN_EMAIL = os.environ.get(
+    "DEFAULT_ADMIN_EMAIL", "tecnologia@gelectriic.com"
+).strip()
+DEFAULT_ADMIN_USERNAME = (
+    os.environ.get("DEFAULT_ADMIN_USERNAME", "arthexis").strip() or "arthexis"
+)
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "DEFAULT_FROM_EMAIL", DEFAULT_ADMIN_EMAIL or "noreply@example.com"
+).strip()
+SERVER_EMAIL = os.environ.get("SERVER_EMAIL", DEFAULT_FROM_EMAIL).strip()
+ADMINS = [("Arthexis Admin", DEFAULT_ADMIN_EMAIL)] if DEFAULT_ADMIN_EMAIL else []
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -76,7 +76,15 @@ arthexis_record_upgrade_duration() {
   local end_time
   end_time=$(date +%s)
   local duration=$((end_time - UPGRADE_STARTED_AT))
-  python - "$UPGRADE_DURATION_LOCK" "$UPGRADE_STARTED_AT" "$end_time" "$duration" "$status" <<'PY'
+  local duration_python="${PYTHON_BIN:-}"
+  if [ -z "$duration_python" ]; then
+    duration_python="$(command -v python3 || command -v python || true)"
+  fi
+  if [ -z "$duration_python" ]; then
+    echo "Warning: no Python interpreter available to record upgrade duration." >&2
+    return 0
+  fi
+  if ! "$duration_python" - "$UPGRADE_DURATION_LOCK" "$UPGRADE_STARTED_AT" "$end_time" "$duration" "$status" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
@@ -98,6 +106,10 @@ payload = {
 lock_path.parent.mkdir(parents=True, exist_ok=True)
 lock_path.write_text(json.dumps(payload), encoding="utf-8")
 PY
+  then
+    echo "Warning: failed to record upgrade duration metadata." >&2
+    return 0
+  fi
 }
 
 auto_upgrade_enabled() {

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -25,11 +25,15 @@ fi
 # Record upgrade lifecycle in the startup report for visibility in admin reports.
 UPGRADE_SCRIPT_NAME="$(basename "$0")"
 arthexis_log_startup_event "$BASE_DIR" "$UPGRADE_SCRIPT_NAME" "start" "invoked"
+UPGRADE_NOTIFICATION_REQUIRED=0
+UPGRADE_SELF_UPDATE_RERUN_ACTIVE=0
 
 log_upgrade_exit() {
-  local status=$?
+  local status="${1:-$?}"
   arthexis_log_startup_event "$BASE_DIR" "$UPGRADE_SCRIPT_NAME" "finish" "status=$status"
-  arthexis_record_upgrade_duration "$status"
+  if declare -F arthexis_record_upgrade_duration >/dev/null 2>&1; then
+    arthexis_record_upgrade_duration "$status"
+  fi
 }
 trap log_upgrade_exit EXIT
 # shellcheck source=scripts/helpers/ports.sh
@@ -1130,6 +1134,7 @@ rerun_with_updated_script() {
   fi
 
   echo "upgrade.sh was updated during git pull; restarting upgrade automatically with the new script..."
+  UPGRADE_SELF_UPDATE_RERUN_ACTIVE=1
   export ARTHEXIS_UPGRADE_SELF_UPDATE_DEPTH=$((depth + 1))
   "${rerun_cmd[@]}"
 }
@@ -1169,7 +1174,102 @@ printf "%s\n" "$(date -Iseconds)" > "$UPGRADE_IN_PROGRESS_LOCK"
 cleanup_upgrade_progress_lock() {
   rm -f "$UPGRADE_IN_PROGRESS_LOCK"
 }
-trap cleanup_upgrade_progress_lock EXIT INT TERM
+
+should_notify_upgrade_completion() {
+  local status="${1:-0}"
+
+  if [[ ${UPGRADE_NOTIFICATION_REQUIRED:-0} -ne 1 ]]; then
+    return 1
+  fi
+
+  if [[ ${CHECK_ONLY:-0} -eq 1 || ${STOP_ONLY:-0} -eq 1 ]]; then
+    return 1
+  fi
+
+  if [[ ${UPGRADE_SELF_UPDATE_RERUN_ACTIVE:-0} -eq 1 ]]; then
+    return 1
+  fi
+
+  if [[ "${status}" -eq "${UPGRADE_RERUN_EXIT_CODE:-3}" ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+notify_upgrade_completion_email() {
+  local status="$1"
+  local notify_python="${PYTHON_BIN:-}"
+
+  if [ -z "$notify_python" ] || [ ! -x "$notify_python" ]; then
+    if [ -x "$BASE_DIR/.venv/bin/python" ]; then
+      notify_python="$BASE_DIR/.venv/bin/python"
+    else
+      notify_python="$(command -v python3 || command -v python || true)"
+    fi
+  fi
+
+  if [ -z "$notify_python" ]; then
+    echo "Warning: Python interpreter not found; could not send upgrade status email." >&2
+    return 1
+  fi
+
+  local -a notify_cmd=(
+    "$notify_python"
+    "manage.py"
+    "upgrade"
+    "notify"
+    "--exit-status"
+    "$status"
+    "--source"
+    "$UPGRADE_SCRIPT_NAME"
+    "--channel"
+    "$CHANNEL"
+  )
+
+  if [[ -n "${BRANCH:-}" ]]; then
+    notify_cmd+=("--branch" "$BRANCH")
+  fi
+  if [[ -n "${SERVICE_NAME:-}" ]]; then
+    notify_cmd+=("--service" "$SERVICE_NAME")
+  fi
+  if [[ -n "${LOCAL_VERSION:-}" ]]; then
+    notify_cmd+=("--initial-version" "$LOCAL_VERSION")
+  fi
+  if [[ -n "${REMOTE_VERSION:-}" ]]; then
+    notify_cmd+=("--target-version" "$REMOTE_VERSION")
+  fi
+  if [[ -n "${LOCAL_REVISION:-}" ]]; then
+    notify_cmd+=("--initial-revision" "$LOCAL_REVISION")
+  fi
+  if [[ -n "${REMOTE_REVISION:-}" ]]; then
+    notify_cmd+=("--target-revision" "$REMOTE_REVISION")
+  fi
+
+  if ! (cd "$BASE_DIR" && "${notify_cmd[@]}"); then
+    echo "Warning: upgrade status email was not sent." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+finalize_upgrade_exit() {
+  local status=$?
+
+  cleanup_upgrade_progress_lock
+  log_upgrade_exit "$status"
+
+  if should_notify_upgrade_completion "$status"; then
+    notify_upgrade_completion_email "$status" || true
+  fi
+
+  return "$status"
+}
+
+trap finalize_upgrade_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 UPGRADE_RERUN_LOCK="$LOCK_DIR/upgrade_rerun_required.lck"
 RERUN_AFTER_SELF_UPDATE=0
@@ -1964,6 +2064,7 @@ else
 fi
 
 # Normalize VERSION by removing any trailing development markers.
+UPGRADE_NOTIFICATION_REQUIRED=1
 arthexis_update_version_marker "$BASE_DIR"
 
 # Create virtual environment automatically if missing


### PR DESCRIPTION
## Summary
- default the admin contact email to `tecnologia@gelectriic.com` and add `DEFAULT_ADMIN_USERNAME`
- add a post-upgrade notification flow that repairs or creates the configured admin user, rotates a temporary password, and emails the upgrade outcome
- hook `upgrade.sh` into that flow while skipping duplicate notifications for check-only and self-rerun parent exits
- cover the new admin-repair and notification behavior with focused tests

## Testing
- `pytest apps/users/tests/test_system_user.py apps/core/tests/test_upgrade_notifications.py`
- `bash -n /home/arthe/prototype/upgrade.sh`

Closes #7296
