### PR TITLE
ci: auto-close stale issues without linked PRs

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,81 @@
+name: Close stale issues without linked PRs
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  close-stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const DAY_MS = 24 * 60 * 60 * 1000;
+            const CLOSE_AFTER_DAYS = 7;
+            const now = Date.now();
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const issuesOnly = openIssues.filter((issue) => !issue.pull_request);
+
+            for (const issue of issuesOnly) {
+              const inactivityDays = (now - Date.parse(issue.updated_at)) / DAY_MS;
+
+              if (Number.isNaN(inactivityDays) || inactivityDays < CLOSE_AFTER_DAYS) {
+                core.info(`#${issue.number}: skipped (inactive ${inactivityDays.toFixed(1)} days)`);
+                continue;
+              }
+
+              const timelineEvents = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              const hasAssociatedPr = timelineEvents.some((event) => {
+                if (event.event !== 'cross-referenced') {
+                  return false;
+                }
+
+                const sourceIssue = event.source?.issue;
+                return Boolean(sourceIssue?.pull_request);
+              });
+
+              if (hasAssociatedPr) {
+                core.info(`#${issue.number}: skipped (associated PR found)`);
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  'Closing this issue after 7+ days without updates and without an associated PR.',
+                  '',
+                  'If you still want this to land as functionality in the repo, please submit a PR and comment here to reopen momentum, or tag a sponsored developer for help driving implementation.',
+                ].join('\n'),
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+
+              core.info(`#${issue.number}: closed`);
+            }

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -45,14 +45,46 @@ jobs:
                 per_page: 100,
               });
 
-              const hasAssociatedPr = timelineEvents.some((event) => {
-                if (event.event !== 'cross-referenced') {
-                  return false;
+              const associatedPrKeys = new Set();
+              const timelineEventsByTime = [...timelineEvents].sort((left, right) => {
+                const leftTime = Date.parse(left.created_at ?? '');
+                const rightTime = Date.parse(right.created_at ?? '');
+
+                if (Number.isNaN(leftTime) || Number.isNaN(rightTime) || leftTime === rightTime) {
+                  return (left.id ?? 0) - (right.id ?? 0);
+                }
+
+                return leftTime - rightTime;
+              });
+
+              for (const event of timelineEventsByTime) {
+                if (event.event !== 'cross-referenced' && event.event !== 'disconnected') {
+                  continue;
                 }
 
                 const sourceIssue = event.source?.issue;
-                return Boolean(sourceIssue?.pull_request);
-              });
+                if (!sourceIssue?.pull_request) {
+                  continue;
+                }
+
+                const sourcePrKey =
+                  sourceIssue.pull_request?.url ??
+                  sourceIssue.node_id ??
+                  (sourceIssue.id ? String(sourceIssue.id) : null);
+
+                if (!sourcePrKey) {
+                  continue;
+                }
+
+                if (event.event === 'cross-referenced') {
+                  associatedPrKeys.add(sourcePrKey);
+                  continue;
+                }
+
+                associatedPrKeys.delete(sourcePrKey);
+              }
+
+              const hasAssociatedPr = associatedPrKeys.size > 0;
 
               if (hasAssociatedPr) {
                 core.info(`#${issue.number}: skipped (associated PR found)`);


### PR DESCRIPTION
### Motivation
- Reduce backlog noise by automatically closing issues that have had no updates for 7+ days and have no associated PR, while informing contributors how to move the request forward.

### Description
- Add a new GitHub Actions workflow at ` .github/workflows/stale-issues.yml` that runs daily (and on manual dispatch) and closes open issues whose `updated_at` is 7+ days old when no `cross-referenced` timeline event links a PR, and posts a comment explaining that submitting a PR or tagging a sponsored developer can reopen momentum.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/stale-issues.yml'); puts 'ok'"` which succeeded.
- Attempted `actionlint .github/workflows/stale-issues.yml` but `actionlint` is not installed in this environment so linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e984d5e7d0832681c99ee065ef929d)