### PR TITLE
Limit Card Shop module visibility to Watchtower roles

### DIFF
--- a/apps/modules/migrations/0004_limit_card_shop_module_to_watchtower.py
+++ b/apps/modules/migrations/0004_limit_card_shop_module_to_watchtower.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+
+CARD_SHOP_PATH = "/shop/"
+WATCHTOWER_ROLE_NAMES = ("Watchtower", "Constellation")
+
+
+def limit_card_shop_module_to_watchtower(apps, schema_editor):
+    Module = apps.get_model("modules", "Module")
+    NodeRole = apps.get_model("nodes", "NodeRole")
+
+    module = Module.objects.filter(path=CARD_SHOP_PATH).first()
+    if module is None:
+        return
+
+    watchtower_roles = list(NodeRole.objects.filter(name__in=WATCHTOWER_ROLE_NAMES))
+    if not watchtower_roles:
+        return
+
+    module.roles.set(watchtower_roles)
+
+
+def restore_card_shop_module_terminal_role(apps, schema_editor):
+    Module = apps.get_model("modules", "Module")
+    NodeRole = apps.get_model("nodes", "NodeRole")
+
+    module = Module.objects.filter(path=CARD_SHOP_PATH).first()
+    if module is None:
+        return
+
+    terminal_roles = list(NodeRole.objects.filter(name="Terminal"))
+    module.roles.set(terminal_roles)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("modules", "0003_rename_docs_module_pill"),
+        ("nodes", "0010_cleanup_retired_node_feature_slugs"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            limit_card_shop_module_to_watchtower,
+            restore_card_shop_module_terminal_role,
+        ),
+    ]

--- a/apps/sites/fixtures/default__modules_terminal.json
+++ b/apps/sites/fixtures/default__modules_terminal.json
@@ -98,7 +98,7 @@
       "is_deleted": false,
       "roles": [
         [
-          "Terminal"
+          "Watchtower"
         ]
       ],
       "application": [


### PR DESCRIPTION
### Motivation

- The Card Shop navigation pill should only be shown on Watchtower-role nodes so terminal deployments do not display the shop UI.

### Description

- Updated the seeded `Card Shop` module in `apps/sites/fixtures/default__modules_terminal.json` to target the `Watchtower` role instead of `Terminal` so fresh installs default to Watchtower visibility.
- Added a data migration `apps/modules/migrations/0004_limit_card_shop_module_to_watchtower.py` that assigns the `/shop/` module to `Watchtower` (and `Constellation` alias) for existing databases.
- The migration includes a reversible operation that restores the previous `Terminal` assignment when rolled back and depends on the existing nodes migration `0010_cleanup_retired_node_feature_slugs`.

### Testing

- Ran `./env-refresh.sh --deps-only` to install and prepare the environment, which completed successfully. 
- Ran `.venv/bin/python manage.py migrations check` with no pending changes detected, which succeeded. 
- Ran `.venv/bin/python manage.py test run -- apps/shop/tests/test_checkout.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e987f6f6ec83269971a60fffdb08b9)