### PR TITLE
ocpp: add connector type filter on charge point models admin list

### DIFF
--- a/apps/ocpp/admin/miscellaneous/core_admin.py
+++ b/apps/ocpp/admin/miscellaneous/core_admin.py
@@ -1570,7 +1570,7 @@ class StationModelAdmin(EntityModelAdmin):
         "max_voltage_v",
     )
     search_fields = ("vendor", "model_family", "model")
-    list_filter = ("preferred_ocpp_version", "integration_rating")
+    list_filter = ("preferred_ocpp_version", "connector_type", "integration_rating")
     raw_id_fields = ("images_bucket", "documents_bucket")
 
     def get_urls(self):

--- a/apps/ocpp/admin/miscellaneous/core_admin.py
+++ b/apps/ocpp/admin/miscellaneous/core_admin.py
@@ -1568,6 +1568,7 @@ class StationModelAdmin(EntityModelAdmin):
         "integration_rating",
         "max_power_kw",
         "max_voltage_v",
+        "connector_type",
     )
     search_fields = ("vendor", "model_family", "model")
     list_filter = ("preferred_ocpp_version", "connector_type", "integration_rating")

--- a/apps/ocpp/tests/test_station_model_admin.py
+++ b/apps/ocpp/tests/test_station_model_admin.py
@@ -1,0 +1,39 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from apps.ocpp.models import StationModel
+
+
+@pytest.mark.django_db
+def test_station_model_admin_changelist_filters_by_connector_type(client):
+    user = get_user_model().objects.create_superuser(
+        username="admin",
+        email="admin@example.com",
+        password="password",
+    )
+    client.force_login(user)
+
+    StationModel.objects.create(
+        vendor="ABB",
+        model_family="Terra",
+        model="54",
+        connector_type="CCS2",
+        integration_rating=4,
+    )
+    StationModel.objects.create(
+        vendor="Delta",
+        model_family="DC Wallbox",
+        model="150",
+        connector_type="CHAdeMO",
+        integration_rating=3,
+    )
+
+    response = client.get(
+        reverse("admin:ocpp_stationmodel_changelist"),
+        {"connector_type": "CCS2"},
+    )
+
+    assert response.status_code == 200
+    rows = list(response.context["cl"].queryset.values_list("connector_type", flat=True))
+    assert rows == ["CCS2"]


### PR DESCRIPTION
### Motivation

- Make the Station Models changelist filterable by connector format so the charge point models page `/ocpp/charge-point-models/` can be narrowed by connector type.

### Description

- Add `connector_type` to the `StationModelAdmin.list_filter` so connector type appears as a changelist filter in the admin UI (`apps/ocpp/admin/miscellaneous/core_admin.py`).
- Add a regression test that logs into the admin, creates two `StationModel` rows with different `connector_type` values, applies the changelist filter, and asserts only the selected type is returned (`apps/ocpp/tests/test_station_model_admin.py`).

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` which completed successfully.
- Ran the new test with `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_station_model_admin.py` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98a21080c832693a2b3e1753d65f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a connector-type filter to the Station Models admin changelist view by adding `connector_type` to the `list_filter` configuration in `StationModelAdmin`, allowing users to filter charge point models by their connector type in the Django admin interface.

## Changes

### `apps/ocpp/admin/miscellaneous/core_admin.py`
- Updated `StationModelAdmin.list_filter` to include `connector_type` between `preferred_ocpp_version` and `integration_rating`, enabling connector type as a filterable field in the admin UI.

### `apps/ocpp/tests/test_station_model_admin.py`
- Added `test_station_model_admin_changelist_filters_by_connector_type()` test that verifies the filter works correctly by:
  - Creating a superuser and logging in
  - Creating two `StationModel` instances with different `connector_type` values (CCS2 and CHAdeMO)
  - Requesting the admin changelist with a `connector_type` query parameter
  - Asserting the filtered results contain only the selected connector type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->