### PR TITLE
ci: force clean checkout in install-hourly workflow

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -147,7 +147,7 @@ jobs:
             ca-certificates curl git sudo python3 python3-venv
       - uses: actions/checkout@v6
         with:
-          clean: false
+          clean: true
       - uses: actions/setup-python@v6
         id: setup-python
         with:


### PR DESCRIPTION
### Motivation
- The scheduled install health run showed a split failure pattern consistent with stale workspace state across matrix jobs, so each job should start from a clean repository checkout to avoid cross-job residue.

### Description
- Updated the hourly install workflow checkout step to set `clean: true` in `.github/workflows/install-hourly.yml`, ensuring each matrix job gets a fresh workspace before validation and install steps.

### Testing
- Parsed the updated workflow with `python - <<'PY' ... yaml.safe_load(...)` and validated dependency ordering with `python scripts/sort_pyproject_deps.py --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9959ca0d08326ab05eacc8ab94b28)