### PR TITLE
Harden imager recovery builds

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import hashlib
+import gzip
 import ipaddress
 import json
+import lzma
 import os
 import re
 import shlex
 import shutil
 import socket
 import subprocess
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -349,6 +352,46 @@ def _download_remote_base_image(base_image_uri: str, destination: Path) -> None:
     raise ImagerBuildError(f"Remote base image URL '{base_image_uri}' exceeded redirect limit.")
 
 
+def _copy_stream_to_file(source_handle, destination: Path) -> Path:
+    """Copy a binary stream into a destination file path."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as output_handle:
+        shutil.copyfileobj(source_handle, output_handle)
+    return destination
+
+
+def _extract_base_image_archive(source_path: Path, workspace: Path) -> Path:
+    """Expand compressed base image formats into a local raw image path."""
+
+    suffix = source_path.suffix.lower()
+    if suffix not in {".xz", ".gz", ".zip"}:
+        return source_path
+
+    if suffix == ".zip":
+        with zipfile.ZipFile(source_path) as archive:
+            members = [member for member in archive.infolist() if not member.is_dir()]
+            image_members = [
+                member for member in members if Path(member.filename).suffix.lower() == ".img"
+            ]
+            if len(image_members) == 1:
+                selected_member = image_members[0]
+            elif len(members) == 1:
+                selected_member = members[0]
+            else:
+                raise ImagerBuildError(
+                    f"Base image archive '{source_path.name}' must contain exactly one image file."
+                )
+            destination = workspace / Path(selected_member.filename).name
+            with archive.open(selected_member) as input_handle:
+                return _copy_stream_to_file(input_handle, destination)
+
+    destination = workspace / source_path.stem
+    opener = lzma.open if suffix == ".xz" else gzip.open
+    with opener(source_path, "rb") as input_handle:
+        return _copy_stream_to_file(input_handle, destination)
+
+
 def _resolve_base_image(base_image_uri: str, workspace: Path) -> Path:
     """Resolve local/file/http(s) base image inputs to a local filesystem path."""
 
@@ -358,7 +401,7 @@ def _resolve_base_image(base_image_uri: str, workspace: Path) -> Path:
         path = local_path.expanduser().resolve()
         if not path.exists():
             raise ImagerBuildError(f"Base image does not exist: {path}")
-        return path
+        return _extract_base_image_archive(path, workspace)
 
     if parsed.scheme not in {"http", "https"}:
         raise ImagerBuildError("Only file, http, and https base image URIs are supported.")
@@ -370,7 +413,7 @@ def _resolve_base_image(base_image_uri: str, workspace: Path) -> Path:
     except (HTTPError, URLError) as exc:
         reason = getattr(exc, "reason", str(exc))
         raise ImagerBuildError(f"Could not download base image: {reason}") from exc
-    return destination
+    return _extract_base_image_archive(destination, workspace)
 
 
 def _is_disallowed_remote_host_address(
@@ -454,12 +497,21 @@ def _guestfish_write(image_path: Path, local_path: Path, remote_path: str, chmod
     if chmod_mode:
         script_parts.append(f"chmod {chmod_mode} {shlex.quote(remote_path)}")
     script = "\n".join(script_parts) + "\n"
+    temp_dir = image_path.parent / ".libguestfs-tmp"
+    cache_dir = image_path.parent / ".libguestfs-cache"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    guestfish_env = os.environ.copy()
+    guestfish_env["TMPDIR"] = str(temp_dir)
+    guestfish_env["LIBGUESTFS_TMPDIR"] = str(temp_dir)
+    guestfish_env["LIBGUESTFS_CACHEDIR"] = str(cache_dir)
     result = subprocess.run(
         ["guestfish", "--rw", "-a", str(image_path), "-i"],
         input=script,
         text=True,
         capture_output=True,
         check=False,
+        env=guestfish_env,
     )
     if result.returncode != 0:
         raise ImagerBuildError(result.stderr.strip() or "guestfish failed while writing files")
@@ -610,6 +662,7 @@ def list_block_devices() -> list[BlockDeviceInfo]:
             for mount in (child.get("mountpoints") or [])
             if mount
         )
+        normalized_mountpoints = sorted(set(mountpoints))
         partitions = [child.get("path", "") for child in descendants if child.get("path")]
         devices.append(
             BlockDeviceInfo(
@@ -617,9 +670,9 @@ def list_block_devices() -> list[BlockDeviceInfo]:
                 size_bytes=int(entry.get("size") or 0),
                 transport=str(entry.get("tran") or ""),
                 removable=bool(entry.get("rm")),
-                mountpoints=sorted(set(mountpoints)),
+                mountpoints=normalized_mountpoints,
                 partitions=partitions,
-                protected=str(entry.get("path", "")) == root_disk,
+                protected=str(entry.get("path", "")) == root_disk or "/" in normalized_mountpoints,
             )
         )
     return sorted(devices, key=lambda item: item.path)

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -368,28 +368,33 @@ def _extract_base_image_archive(source_path: Path, workspace: Path) -> Path:
     if suffix not in {".xz", ".gz", ".zip"}:
         return source_path
 
-    if suffix == ".zip":
-        with zipfile.ZipFile(source_path) as archive:
-            members = [member for member in archive.infolist() if not member.is_dir()]
-            image_members = [
-                member for member in members if Path(member.filename).suffix.lower() == ".img"
-            ]
-            if len(image_members) == 1:
-                selected_member = image_members[0]
-            elif len(members) == 1:
-                selected_member = members[0]
-            else:
-                raise ImagerBuildError(
-                    f"Base image archive '{source_path.name}' must contain exactly one image file."
-                )
-            destination = workspace / Path(selected_member.filename).name
-            with archive.open(selected_member) as input_handle:
-                return _copy_stream_to_file(input_handle, destination)
+    try:
+        if suffix == ".zip":
+            with zipfile.ZipFile(source_path) as archive:
+                members = [member for member in archive.infolist() if not member.is_dir()]
+                image_members = [
+                    member for member in members if Path(member.filename).suffix.lower() == ".img"
+                ]
+                if len(image_members) == 1:
+                    selected_member = image_members[0]
+                elif len(members) == 1:
+                    selected_member = members[0]
+                else:
+                    raise ImagerBuildError(
+                        f"Base image archive '{source_path.name}' must contain exactly one image file."
+                    )
+                destination = workspace / Path(selected_member.filename).name
+                with archive.open(selected_member) as input_handle:
+                    return _copy_stream_to_file(input_handle, destination)
 
-    destination = workspace / source_path.stem
-    opener = lzma.open if suffix == ".xz" else gzip.open
-    with opener(source_path, "rb") as input_handle:
-        return _copy_stream_to_file(input_handle, destination)
+        destination = workspace / source_path.stem
+        opener = lzma.open if suffix == ".xz" else gzip.open
+        with opener(source_path, "rb") as input_handle:
+            return _copy_stream_to_file(input_handle, destination)
+    except (EOFError, gzip.BadGzipFile, lzma.LZMAError, zipfile.BadZipFile) as exc:
+        raise ImagerBuildError(
+            f"Base image archive '{source_path.name}' is invalid or corrupted: {exc}"
+        ) from exc
 
 
 def _resolve_base_image(base_image_uri: str, workspace: Path) -> Path:
@@ -497,24 +502,23 @@ def _guestfish_write(image_path: Path, local_path: Path, remote_path: str, chmod
     if chmod_mode:
         script_parts.append(f"chmod {chmod_mode} {shlex.quote(remote_path)}")
     script = "\n".join(script_parts) + "\n"
-    temp_dir = image_path.parent / ".libguestfs-tmp"
     cache_dir = image_path.parent / ".libguestfs-cache"
-    temp_dir.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
-    guestfish_env = os.environ.copy()
-    guestfish_env["TMPDIR"] = str(temp_dir)
-    guestfish_env["LIBGUESTFS_TMPDIR"] = str(temp_dir)
-    guestfish_env["LIBGUESTFS_CACHEDIR"] = str(cache_dir)
-    result = subprocess.run(
-        ["guestfish", "--rw", "-a", str(image_path), "-i"],
-        input=script,
-        text=True,
-        capture_output=True,
-        check=False,
-        env=guestfish_env,
-    )
-    if result.returncode != 0:
-        raise ImagerBuildError(result.stderr.strip() or "guestfish failed while writing files")
+    with TemporaryDirectory(dir=image_path.parent) as temp_dir:
+        guestfish_env = os.environ.copy()
+        guestfish_env["TMPDIR"] = temp_dir
+        guestfish_env["LIBGUESTFS_TMPDIR"] = temp_dir
+        guestfish_env["LIBGUESTFS_CACHEDIR"] = str(cache_dir)
+        result = subprocess.run(
+            ["guestfish", "--rw", "-a", str(image_path), "-i"],
+            input=script,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=guestfish_env,
+        )
+        if result.returncode != 0:
+            raise ImagerBuildError(result.stderr.strip() or "guestfish failed while writing files")
 
 
 def _customize_image(image_path: Path, *, git_url: str) -> None:

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -540,7 +540,7 @@ def test_imager_devices_command_lists_discovery_metadata(list_devices_mock) -> N
 
 
 def test_guestfish_write_scopes_temp_dirs_to_image_output_directory(tmp_path: Path) -> None:
-    """Regression: guestfish temp/cache paths should stay under the artifact workspace."""
+    """Regression: guestfish temp dir should be scoped and cleaned while cache persists."""
 
     image_path = tmp_path / "artifact.img"
     image_path.write_bytes(b"img")
@@ -552,11 +552,39 @@ def test_guestfish_write_scopes_temp_dirs_to_image_output_directory(tmp_path: Pa
         _guestfish_write(image_path, local_path, "/usr/local/bin/arthexis-bootstrap.sh", chmod_mode="0755")
 
     env = run_mock.call_args.kwargs["env"]
-    assert env["TMPDIR"] == str(tmp_path / ".libguestfs-tmp")
-    assert env["LIBGUESTFS_TMPDIR"] == str(tmp_path / ".libguestfs-tmp")
+    assert env["TMPDIR"].startswith(str(tmp_path))
+    assert env["LIBGUESTFS_TMPDIR"] == env["TMPDIR"]
     assert env["LIBGUESTFS_CACHEDIR"] == str(tmp_path / ".libguestfs-cache")
-    assert (tmp_path / ".libguestfs-tmp").is_dir()
+    assert not Path(env["TMPDIR"]).exists()
     assert (tmp_path / ".libguestfs-cache").is_dir()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("extension", "writer"),
+    [
+        (".img.xz", lambda path: path.write_bytes(b"not-xz")),
+        (".img.gz", lambda path: path.write_bytes(b"not-gzip")),
+        (".zip", lambda path: path.write_bytes(b"not-zip")),
+    ],
+)
+def test_build_rpi4b_image_rejects_corrupted_archives(tmp_path: Path, extension: str, writer) -> None:
+    """Regression: malformed compressed base images should raise a user-facing build error."""
+
+    compressed_source = tmp_path / f"base{extension}"
+    writer(compressed_source)
+
+    with patch("apps.imager.services._customize_image"), pytest.raises(
+        ImagerBuildError, match="invalid or corrupted"
+    ):
+        build_rpi4b_image(
+            name=f"corrupt-{extension.replace('.', '-')}",
+            base_image_uri=str(compressed_source),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+        )
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -1,5 +1,6 @@
 """Regression tests for Raspberry Pi imager workflows."""
 
+import lzma
 import socket
 from contextlib import nullcontext
 from io import BytesIO, StringIO
@@ -18,6 +19,7 @@ from apps.imager.services import (
     ImagerBuildError,
     _build_download_uri,
     _download_remote_base_image,
+    _guestfish_write,
     _resolve_root_disk_path,
     _validate_remote_base_image_url,
     build_rpi4b_image,
@@ -65,6 +67,29 @@ def test_list_block_devices_collects_mountpoints_from_nested_descendants() -> No
 
     assert devices[0].mountpoints == ["/media/card"]
     assert devices[0].partitions == ["/dev/sdb1", "/dev/mapper/crypt"]
+
+
+def test_list_block_devices_marks_root_mount_disk_protected_when_findmnt_uses_dev_root() -> None:
+    """Regression: root disks must stay protected even when findmnt reports /dev/root."""
+
+    lsblk_result = SimpleNamespace(
+        returncode=0,
+        stdout='{"blockdevices":[{"path":"/dev/mmcblk0","size":"64","rm":false,"tran":null,"type":"disk","mountpoints":[null],"children":[{"path":"/dev/mmcblk0p2","mountpoints":["/","/home/arthe"]}]},{"path":"/dev/sdb","size":"64","rm":true,"tran":"usb","type":"disk","mountpoints":[null],"children":[{"path":"/dev/sdb1","mountpoints":[null]}]}]}',
+        stderr="",
+    )
+    root_findmnt = SimpleNamespace(returncode=0, stdout="/dev/root\n", stderr="")
+    dev_root_info = SimpleNamespace(returncode=32, stdout="", stderr="not a block device")
+
+    with patch(
+        "apps.imager.services.subprocess.run",
+        side_effect=[lsblk_result, root_findmnt, dev_root_info],
+    ):
+        devices = list_block_devices()
+
+    assert devices[0].path == "/dev/mmcblk0"
+    assert devices[0].protected is True
+    assert devices[1].path == "/dev/sdb"
+    assert devices[1].protected is False
 
 
 def test_list_block_devices_raises_operator_error_when_lsblk_missing() -> None:
@@ -204,6 +229,28 @@ def test_build_rpi4b_image_creates_artifact_with_download_uri(tmp_path: Path) ->
 
 
 @pytest.mark.django_db
+def test_build_rpi4b_image_decompresses_local_xz_source(tmp_path: Path) -> None:
+    """Regression: .img.xz sources should expand automatically before build copy."""
+
+    source_bytes = b"raspberrypi"
+    compressed_source = tmp_path / "base.img.xz"
+    with lzma.open(compressed_source, "wb") as handle:
+        handle.write(source_bytes)
+
+    with patch("apps.imager.services._customize_image"):
+        result = build_rpi4b_image(
+            name="stable-xz",
+            base_image_uri=str(compressed_source),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+        )
+
+    assert result.output_path.read_bytes() == source_bytes
+
+
+@pytest.mark.django_db
 def test_build_rpi4b_image_persists_connect_ota_engine_profile_metadata(tmp_path: Path) -> None:
     """Regression: connect-ota profile metadata must persist for rollout eligibility checks."""
 
@@ -329,6 +376,37 @@ def test_build_rpi4b_image_downloads_percent_encoded_http_source(
 
     assert result.output_path.exists()
     assert result.output_path.read_bytes() == source_bytes
+
+
+@pytest.mark.django_db
+@patch("apps.imager.services._download_remote_base_image")
+def test_build_rpi4b_image_downloads_and_decompresses_remote_xz_source(
+    download_mock, tmp_path: Path
+) -> None:
+    """Regression: downloaded .img.xz sources should expand automatically before copy."""
+
+    source_bytes = b"http-image-xz"
+
+    def write_download(uri: str, destination: Path) -> None:
+        assert uri == "https://example.com/Raspberry%20Pi%20OS.img.xz"
+        with lzma.open(destination, "wb") as handle:
+            handle.write(source_bytes)
+
+    download_mock.side_effect = write_download
+
+    with patch("apps.imager.services._customize_image"):
+        result = build_rpi4b_image(
+            name="httpstable-xz",
+            base_image_uri="https://example.com/Raspberry%20Pi%20OS.img.xz",
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+        )
+
+    assert result.output_path.exists()
+    assert result.output_path.read_bytes() == source_bytes
+
 
 @pytest.mark.django_db
 @override_settings(IMAGER_BLOCK_PRIVATE_REMOTE_IMAGE_HOSTS=True)
@@ -459,6 +537,26 @@ def test_imager_devices_command_lists_discovery_metadata(list_devices_mock) -> N
     assert "/dev/sda" in output
     assert "removable=yes" in output
     assert "protected=no" in output
+
+
+def test_guestfish_write_scopes_temp_dirs_to_image_output_directory(tmp_path: Path) -> None:
+    """Regression: guestfish temp/cache paths should stay under the artifact workspace."""
+
+    image_path = tmp_path / "artifact.img"
+    image_path.write_bytes(b"img")
+    local_path = tmp_path / "bootstrap.sh"
+    local_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    guestfish_result = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch("apps.imager.services.subprocess.run", return_value=guestfish_result) as run_mock:
+        _guestfish_write(image_path, local_path, "/usr/local/bin/arthexis-bootstrap.sh", chmod_mode="0755")
+
+    env = run_mock.call_args.kwargs["env"]
+    assert env["TMPDIR"] == str(tmp_path / ".libguestfs-tmp")
+    assert env["LIBGUESTFS_TMPDIR"] == str(tmp_path / ".libguestfs-tmp")
+    assert env["LIBGUESTFS_CACHEDIR"] == str(tmp_path / ".libguestfs-cache")
+    assert (tmp_path / ".libguestfs-tmp").is_dir()
+    assert (tmp_path / ".libguestfs-cache").is_dir()
 
 
 @pytest.mark.django_db

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -14,9 +14,17 @@ Build a Raspberry Pi image artifact with first-boot bootstrap scripts:
 ```bash
 .venv/bin/python manage.py imager build \
   --name stable \
-  --base-image-uri /path/to/raspios.img \
+  --base-image-uri /path/to/raspios.img.xz \
   --download-base-uri https://downloads.example.com/images
 ```
+
+Accepted base image inputs include:
+
+- raw `.img` files
+- compressed `.img.xz` and `.img.gz` files
+- `.zip` archives that contain a single image file
+
+When bootstrap customization is enabled, the build now keeps `guestfish` temp and cache files under `build/rpi-imager` instead of relying on `/var/tmp`.
 
 List registered artifacts:
 
@@ -38,6 +46,8 @@ This output includes:
 - transport and removable indicators
 - mountpoints/partitions
 - `protected=yes/no` to identify the current system/root disk
+
+The protection check falls back to mountpoint inspection, so hosts that expose the live root disk as `/dev/root` still keep that disk marked as protected.
 
 ## 3) Write an artifact to removable media
 


### PR DESCRIPTION
## Summary

- accept compressed Raspberry Pi base images during `manage.py imager build`
- keep libguestfs temp and cache files under `build/rpi-imager`
- protect the live root disk when hosts expose `/` as `/dev/root`
- document the updated recovery workflow

## Testing

- `pytest apps/imager/tests/test_imager_command.py`
- `pytest apps/imager/tests`

Closes #7309
