### PR TITLE
Align feedback dialog colors with feedback button

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -527,6 +527,28 @@ body.user-story-open {
   transition: transform 0.25s ease;
 }
 
+.user-story-card .card-title {
+  color: var(--site-support);
+}
+
+.user-story-card .btn-primary {
+  --bs-btn-bg: var(--site-support);
+  --bs-btn-border-color: var(--site-support);
+  --bs-btn-hover-bg: var(--site-support-strong);
+  --bs-btn-hover-border-color: var(--site-support-strong);
+  --bs-btn-active-bg: var(--site-support-strong);
+  --bs-btn-active-border-color: var(--site-support-strong);
+  --bs-btn-focus-shadow-rgb: var(--site-support-rgb);
+  --bs-btn-color: var(--site-support-icon);
+  --bs-btn-hover-color: var(--site-support-icon);
+  --bs-btn-active-color: var(--site-support-icon);
+}
+
+.user-story-card .btn-link {
+  --bs-btn-color: var(--site-support);
+  --bs-btn-hover-color: var(--site-support-strong);
+}
+
 .user-story-card,
 .user-story-card *,
 .user-story-card *::before,

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -26,7 +26,7 @@
     --user-story-input-border: rgba(15, 23, 42, 0.15);
     --user-story-checkbox-border: rgba(15, 23, 42, 0.25);
     --user-story-muted: rgba(15, 23, 42, 0.6);
-    --user-story-focus-ring: rgba(37, 99, 235, 0.2);
+    --user-story-focus-ring: color-mix(in srgb, var(--site-support) 30%, transparent);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.12);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.35);
     --user-story-alert-success-fg: #047857;
@@ -879,6 +879,7 @@ body.user-story-open {
 
 .user-story-card .user-story-title {
     margin-bottom: 0.25rem;
+    color: var(--site-support);
 }
 
 .user-story-card .user-story-subtitle {
@@ -961,7 +962,7 @@ body.user-story-open {
 
 .user-story-card .user-story-input:focus,
 .user-story-card textarea:focus {
-    border-color: #2563eb;
+    border-color: var(--site-support);
     box-shadow: 0 0 0 0.2rem var(--user-story-focus-ring);
     outline: none;
 }
@@ -985,7 +986,7 @@ body.user-story-open {
 }
 
 .user-story-card .form-check-input:focus {
-    border-color: #2563eb;
+    border-color: var(--site-support);
     box-shadow: 0 0 0 0.2rem var(--user-story-focus-ring);
 }
 


### PR DESCRIPTION
### Motivation
- Make the feedback dialog visuals consistent with the new floating feedback button by reusing the suite support/accent color family for titles, focused controls, and primary actions.

### Description
- Updated admin feedback dialog CSS in `apps/sites/static/sites/css/admin/base_site.css` to use `--site-support` for focus rings and focused control borders and to tint the dialog title with the support color.
- Updated public feedback dialog CSS in `apps/sites/static/pages/css/base.css` to color the in-dialog title and to set dialog-scoped primary and link button tokens to `--site-support` / `--site-support-strong` so the submit button and dialog links match the feedback button.
- Kept all changes scoped to existing feedback dialog CSS files and did not modify templates or JavaScript behavior.

### Testing
- Ran environment bootstrap with `./env-refresh.sh --deps-only` which completed successfully.
- Executed the feedback form unit tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a0bf48ec8326a94460e755bc8b1a)