### PR TITLE
Handle unexpected visitor proxy registration failures

### DIFF
--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -926,141 +926,158 @@ def register_visitor_proxy(request):
             status=400,
         )
 
-    visitor_info_url = append_token(visitor_info_url, token)
-    factory = RequestFactory()
-    host_info_request = factory.get("/nodes/info/", {"token": token} if token else {})
-    host_info_request.user = request.user
-    host_info_request._cached_user = request.user
     try:
-        host_info = _parse_json_response_mapping(node_info(host_info_request))
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
-        return JsonResponse({"detail": "host info unavailable"}, status=502)
+        visitor_info_url = append_token(visitor_info_url, token)
+        factory = RequestFactory()
+        host_info_request = factory.get(
+            "/nodes/info/", {"token": token} if token else {}
+        )
+        host_info_request.user = request.user
+        host_info_request._cached_user = request.user
+        try:
+            host_info = _parse_json_response_mapping(node_info(host_info_request))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            return JsonResponse({"detail": "host info unavailable"}, status=502)
 
-    session = requests.Session()
-    timeout_seconds = 45
+        session = requests.Session()
+        timeout_seconds = 45
 
-    try:
-        visitor_info, visitor_info_url, last_error, info_attempt = (
-            _try_proxy_json_request(
-                session=session,
-                url=visitor_info_url,
-                timeout_seconds=timeout_seconds,
-                method="get",
-                log_prefix="Visitor registration proxy",
-                request_error_message="info request failed",
-                response_error_message="info response json parse failed",
+        try:
+            visitor_info, visitor_info_url, last_error, info_attempt = (
+                _try_proxy_json_request(
+                    session=session,
+                    url=visitor_info_url,
+                    timeout_seconds=timeout_seconds,
+                    method="get",
+                    log_prefix="Visitor registration proxy",
+                    request_error_message="info request failed",
+                    response_error_message="info response json parse failed",
+                )
             )
-        )
-    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
-        registration_logger.warning(
-            "Visitor registration proxy: unexpected visitor info proxy failure",
-            extra={
-                "target": redact_url_token(visitor_info_url),
-                "attempt": "visitor_info_proxy",
-                "exception_class": exc.__class__.__name__,
-            },
-        )
-        return JsonResponse({"detail": "visitor info unavailable"}, status=502)
-    if visitor_info is None:
-        registration_logger.warning(
-            "Visitor registration proxy: unable to fetch visitor info from %s: %s",
-            redact_url_token(visitor_info_url),
-            last_error,
-            extra={
-                "target": redact_url_token(visitor_info_url),
-                "attempt": info_attempt,
-                "exception_class": (
-                    last_error.__class__.__name__ if last_error else ""
-                ),
-            },
-        )
-        return JsonResponse({"detail": "visitor info unavailable"}, status=502)
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            registration_logger.warning(
+                "Visitor registration proxy: unexpected visitor info proxy failure",
+                extra={
+                    "target": redact_url_token(visitor_info_url),
+                    "attempt": "visitor_info_proxy",
+                    "exception_class": exc.__class__.__name__,
+                },
+            )
+            return JsonResponse({"detail": "visitor info unavailable"}, status=502)
+        if visitor_info is None:
+            registration_logger.warning(
+                "Visitor registration proxy: unable to fetch visitor info from %s: %s",
+                redact_url_token(visitor_info_url),
+                last_error,
+                extra={
+                    "target": redact_url_token(visitor_info_url),
+                    "attempt": info_attempt,
+                    "exception_class": (
+                        last_error.__class__.__name__ if last_error else ""
+                    ),
+                },
+            )
+            return JsonResponse({"detail": "visitor info unavailable"}, status=502)
 
-    host_payload = _build_registration_payload(visitor_info, "Downstream")
-    _apply_token_signature(host_payload, visitor_info, token)
-    host_register_request = factory.post(
-        "/nodes/register/",
-        data=json.dumps(host_payload),
-        content_type="application/json",
-    )
-    host_register_request.user = request.user
-    host_register_request._cached_user = request.user
-    host_register_response = register_node(host_register_request)
-    try:
-        host_register_body = _parse_json_response_mapping(host_register_response)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
-        return JsonResponse({"detail": "host registration failed"}, status=502)
-    if host_register_response.status_code != 200 or not host_register_body.get("id"):
-        status_code = host_register_response.status_code or 400
-        if 200 <= status_code < 300:
-            status_code = 400
+        host_payload = _build_registration_payload(visitor_info, "Downstream")
+        _apply_token_signature(host_payload, visitor_info, token)
+        host_register_request = factory.post(
+            "/nodes/register/",
+            data=json.dumps(host_payload),
+            content_type="application/json",
+        )
+        host_register_request.user = request.user
+        host_register_request._cached_user = request.user
+        host_register_response = register_node(host_register_request)
+        try:
+            host_register_body = _parse_json_response_mapping(host_register_response)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            return JsonResponse({"detail": "host registration failed"}, status=502)
+        if host_register_response.status_code != 200 or not host_register_body.get(
+            "id"
+        ):
+            status_code = host_register_response.status_code or 400
+            if 200 <= status_code < 300:
+                status_code = 400
+            return JsonResponse(
+                {"detail": "host registration failed"},
+                status=status_code,
+            )
+
+        visitor_payload = _build_registration_payload(host_info, "Upstream")
+        _apply_token_signature(visitor_payload, host_info, token)
+
+        try:
+            visitor_register_body, visitor_register_url, last_error, register_attempt = (
+                _try_proxy_json_request(
+                    session=session,
+                    url=visitor_register_url,
+                    timeout_seconds=timeout_seconds,
+                    method="post",
+                    payload=visitor_payload,
+                    log_prefix="Visitor registration proxy",
+                    request_error_message="visitor notification request failed",
+                    response_error_message="visitor response json parse failed",
+                )
+            )
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            registration_logger.warning(
+                "Visitor registration proxy: unexpected visitor confirmation proxy failure",
+                extra={
+                    "target": redact_url_token(visitor_register_url),
+                    "attempt": "visitor_register_proxy",
+                    "exception_class": exc.__class__.__name__,
+                },
+            )
+            return JsonResponse({"detail": "visitor confirmation failed"}, status=502)
+        if visitor_register_body is None:
+            registration_logger.warning(
+                "Visitor registration proxy: unable to notify visitor at %s: %s",
+                redact_url_token(visitor_register_url),
+                last_error,
+                extra={
+                    "target": redact_url_token(visitor_register_url),
+                    "attempt": register_attempt,
+                    "exception_class": (
+                        last_error.__class__.__name__ if last_error else ""
+                    ),
+                },
+            )
+            return JsonResponse({"detail": "visitor confirmation failed"}, status=502)
+
+        visitor_id = visitor_register_body.get("id")
+        visitor_detail = (
+            "visitor confirmation accepted"
+            if visitor_id
+            else "visitor confirmation failed"
+        )
+
         return JsonResponse(
-            {"detail": "host registration failed"},
-            status=status_code,
+            {
+                "host": {
+                    "detail": "host registration accepted",
+                    "id": host_register_body.get("id"),
+                },
+                "visitor": {
+                    "detail": visitor_detail,
+                    "id": visitor_id,
+                },
+                "host_requires_https": bool(host_info.get("base_site_requires_https")),
+                "visitor_requires_https": bool(
+                    visitor_info.get("base_site_requires_https")
+                ),
+            }
         )
-
-    visitor_payload = _build_registration_payload(host_info, "Upstream")
-    _apply_token_signature(visitor_payload, host_info, token)
-
-    try:
-        visitor_register_body, visitor_register_url, last_error, register_attempt = (
-            _try_proxy_json_request(
-                session=session,
-                url=visitor_register_url,
-                timeout_seconds=timeout_seconds,
-                method="post",
-                payload=visitor_payload,
-                log_prefix="Visitor registration proxy",
-                request_error_message="visitor notification request failed",
-                response_error_message="visitor response json parse failed",
-            )
-        )
-    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+    except Exception as exc:
         registration_logger.warning(
-            "Visitor registration proxy: unexpected visitor confirmation proxy failure",
+            "Visitor registration proxy: unexpected registration flow failure",
             extra={
-                "target": redact_url_token(visitor_register_url),
-                "attempt": "visitor_register_proxy",
+                "target": redact_url_token(visitor_info_url),
+                "attempt": "registration_flow",
                 "exception_class": exc.__class__.__name__,
             },
         )
-        return JsonResponse({"detail": "visitor confirmation failed"}, status=502)
-    if visitor_register_body is None:
-        registration_logger.warning(
-            "Visitor registration proxy: unable to notify visitor at %s: %s",
-            redact_url_token(visitor_register_url),
-            last_error,
-            extra={
-                "target": redact_url_token(visitor_register_url),
-                "attempt": register_attempt,
-                "exception_class": (
-                    last_error.__class__.__name__ if last_error else ""
-                ),
-            },
-        )
-        return JsonResponse({"detail": "visitor confirmation failed"}, status=502)
-
-    visitor_id = visitor_register_body.get("id")
-    visitor_detail = (
-        "visitor confirmation accepted" if visitor_id else "visitor confirmation failed"
-    )
-
-    return JsonResponse(
-        {
-            "host": {
-                "detail": "host registration accepted",
-                "id": host_register_body.get("id"),
-            },
-            "visitor": {
-                "detail": visitor_detail,
-                "id": visitor_id,
-            },
-            "host_requires_https": bool(host_info.get("base_site_requires_https")),
-            "visitor_requires_https": bool(
-                visitor_info.get("base_site_requires_https")
-            ),
-        }
-    )
+        return JsonResponse({"detail": "registration failed"}, status=502)
 
 
 @csrf_exempt

--- a/tests/test_nodes_registration.py
+++ b/tests/test_nodes_registration.py
@@ -459,6 +459,10 @@ def test_register_visitor_proxy_handles_unexpected_registration_errors(
     admin_client, monkeypatch
 ):
     """Regression: unexpected registration errors should return a safe proxy response."""
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
     node = Node.objects.create(
         hostname="local-unexpected-failure",
         address="198.51.100.3",
@@ -484,7 +488,7 @@ def test_register_visitor_proxy_handles_unexpected_registration_errors(
     )
     monkeypatch.setattr(
         "apps.nodes.views.registration.handlers._build_registration_payload",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        _raise_runtime_error,
     )
     class FakeResponse:
         status_code = 200

--- a/tests/test_nodes_registration.py
+++ b/tests/test_nodes_registration.py
@@ -455,6 +455,79 @@ def test_register_visitor_proxy_reports_partial_failure_on_visitor_confirmation(
 
 
 @pytest.mark.django_db
+def test_register_visitor_proxy_handles_unexpected_registration_errors(
+    admin_client, monkeypatch
+):
+    """Regression: unexpected registration errors should return a safe proxy response."""
+    node = Node.objects.create(
+        hostname="local-unexpected-failure",
+        address="198.51.100.3",
+        mac_address="00:11:22:33:44:77",
+        port=8888,
+        public_endpoint="local-unexpected-failure",
+        public_key="local-key",
+    )
+
+    monkeypatch.setattr(Node, "get_local", classmethod(lambda cls: node))
+    monkeypatch.setattr(
+        registration_views.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "apps.nodes.views.registration.handlers._build_registration_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "hostname": "visitor-host",
+                "mac_address": "aa:bb:cc:dd:ee:aa",
+                "address": "203.0.113.11",
+                "port": 8000,
+                "public_key": "visitor-key",
+                "features": [],
+            }
+
+    class FakeSession:
+        def mount(self, prefix, adapter):
+            return None
+
+        def get(self, url, timeout=None, headers=None):
+            return FakeResponse()
+
+    monkeypatch.setattr(requests, "Session", lambda: FakeSession())
+
+    response = admin_client.post(
+        reverse("register-visitor-proxy"),
+        data=json.dumps(
+            {
+                "visitor_info_url": "https://visitor.test/nodes/info/",
+                "visitor_register_url": "https://visitor.test/nodes/register/",
+                "token": "",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "registration failed"
+
+
+@pytest.mark.django_db
 def test_register_visitor_telemetry_logs(client, caplog):
     """Telemetry endpoint should record structured registration diagnostics."""
     url = reverse("register-telemetry")


### PR DESCRIPTION
### Motivation

- Prevent unexpected exceptions in the visitor registration proxy flow from leaking stack traces or producing user-facing 500 responses and instead return a safe, generic failure payload.
- Preserve existing, explicit error handling for host info, visitor info, host registration, and visitor confirmation failure cases.

### Description

- Wrap the core `register_visitor_proxy` flow in a top-level `try/except Exception` safety boundary and convert unexpected errors into `JsonResponse({"detail": "registration failed"}, status=502)` while logging the exception class and a redacted target URL; the handler lives in `apps/nodes/views/registration/handlers.py`.
- Keep the existing specific error responses intact (`host info unavailable`, `visitor info unavailable`, `host registration failed`, `visitor confirmation failed`).
- Adjust the logging message to `"Visitor registration proxy: unexpected registration flow failure"` when the top-level boundary catches an exception.
- Add a regression test `test_register_visitor_proxy_handles_unexpected_registration_errors` to `tests/test_nodes_registration.py` that forces an unexpected internal error during payload building and asserts the safe `registration failed` 502 response.

### Testing

- Ran environment dependency refresh with `./env-refresh.sh --deps-only` to prepare the test environment, which completed successfully.
- Ran the node registration tests with `.venv/bin/python manage.py test run -- tests/test_nodes_registration.py` and verified the final test result: all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a103a4c88326b079a85b4c279c3f)