### PR TITLE
Harden lifecycle scripts: docs, contract comments, and regression tests

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -47,6 +47,7 @@ if [ ! -d .venv ]; then
 fi
 source .venv/bin/activate
 
+# Lifecycle CLI contract: this public interface is documented in install-lifecycle-scripts-manual.md and regression-tested.
 # Supported interface:
 #   Usage: ./command.sh <operational-command> [args...]
 #   Usage: ./command.sh list

--- a/command.sh
+++ b/command.sh
@@ -51,5 +51,6 @@ source .venv/bin/activate
 # Supported interface:
 #   Usage: ./command.sh <operational-command> [args...]
 #   Usage: ./command.sh list
-# For non-operational/admin commands, use ./manage.py directly.
+# For non-operational/admin commands, use .venv/bin/python manage.py ...
+# Keep ./command.sh for operator-facing runtime actions.
 python -m utils.command_api "$@"

--- a/configure.sh
+++ b/configure.sh
@@ -48,6 +48,7 @@ FEATURE_PARAM_SPEC=""
 
 LOCK_DIR="$BASE_DIR/.locks"
 
+# Lifecycle CLI contract: keep reconfiguration flags aligned with docs/development/install-lifecycle-scripts-manual.md and contract tests.
 usage() {
     echo "Usage: $0 [--service NAME] [--port PORT] [--latest|--stable|--regular|--normal|--unstable] [--fixed] [--check] [--auto-upgrade|--no-auto-upgrade] [--debug|--no-debug] [--celery|--no-celery] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--feature SLUG [--kind suite|node] [--enabled|--disabled]] [--feature-param FEATURE:KEY=VALUE] [--satellite|--terminal|--control|--watchtower] [--repair [--failover ROLE]]" >&2
     exit 1

--- a/docs/development/install-lifecycle-scripts-manual.md
+++ b/docs/development/install-lifecycle-scripts-manual.md
@@ -2,7 +2,37 @@
 
 > **Single source of truth:** Keep operational flag and behavior details in this file. Update `apps/docs/cookbooks/install-start-stop-upgrade-uninstall.md` only with role-oriented guidance and a link back here.
 
-This is the canonical reference for Linux lifecycle scripts: `install.sh`, `start.sh`, `stop.sh`, `upgrade.sh`, `configure.sh`, and `uninstall.sh`.
+This is the canonical reference for Linux lifecycle scripts: `install.sh`, `start.sh`, `stop.sh`, `status.sh`, `command.sh`, `upgrade.sh`, `configure.sh`, and `uninstall.sh`.
+
+
+## Lifecycle map (operator contract)
+
+```mermaid
+flowchart TD
+    I[install.sh
+Bootstrap node] --> C[configure.sh
+Adjust role/features/locks]
+    I --> S[start.sh
+Launch services]
+    C --> S
+    S --> T[status.sh
+Inspect readiness and metadata]
+    S --> O[command.sh
+Run allowlisted ops commands]
+    S --> P[stop.sh
+Graceful shutdown]
+    P --> U[upgrade.sh
+Pull/update/migrate]
+    U --> S
+    U --> T
+    P --> X[uninstall.sh
+Retire node]
+
+    classDef safety fill:#fff8e6,stroke:#b36b00,color:#3d2500;
+    class T,O safety;
+```
+
+This map is a regression guardrail: lifecycle changes should preserve these operator touchpoints unless the manual and tests are updated together.
 
 ## Git remotes for preloaded environments
 
@@ -148,7 +178,32 @@ Both supported backends emit a consistent reconciliation report that includes co
 | `--repair` | Restore lock state from existing role and lock files. |
 | `--failover ROLE` | Provide role fallback for repair when role lock cannot be resolved. |
 
-## 5. Uninstall (`uninstall.sh`)
+
+## 5. Runtime status (`status.sh`)
+
+`status.sh` reports installation metadata, configured role/service/port state, upgrade in-progress markers, and service reachability probes.
+
+### Supported flags
+
+| Flag | Notes |
+| --- | --- |
+| `-h`, `--help` | Print usage and exit successfully. |
+| `--wait` | Poll until reachability checks succeed or timeout windows expire. |
+
+## 6. Operational command entrypoint (`command.sh`)
+
+`command.sh` is the allowlisted operational command wrapper. It validates the runtime environment, logs invocation metadata safely, and dispatches to `utils.command_api`.
+
+### Interface contract
+
+| Invocation | Notes |
+| --- | --- |
+| `./command.sh list` | Show allowlisted operational commands. |
+| `./command.sh <operational-command> [args...]` | Run one allowlisted ops command. |
+
+For non-ops/admin Django commands, use `.venv/bin/python manage.py ...` directly.
+
+## 7. Uninstall (`uninstall.sh`)
 
 `uninstall.sh` tears down managed units, local locks, and local SQLite DB.
 
@@ -160,7 +215,7 @@ Both supported backends emit a consistent reconciliation report that includes co
 | `--no-warn` | Skip DB deletion warning prompt. |
 | `--rfid-service`, `--no-rfid-service` | Control whether RFID unit/lock is removed during uninstall. |
 
-## 6. Documentation maintenance check
+## 8. Documentation maintenance check
 
 When lifecycle script docs are updated:
 

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,7 @@ is_debian_host() {
     return 1
 }
 
+# Lifecycle CLI contract: keep this usage block aligned with docs/development/install-lifecycle-scripts-manual.md and lifecycle contract tests.
 usage() {
     echo "Usage: $0 [--service NAME] [--port PORT] [--upgrade] [--fixed] [--stable|--regular|--normal|--unstable|--latest] [--satellite] [--terminal] [--control] [--watchtower] [--celery] [--embedded|--systemd] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--clean] [--start|--no-start] [--repair]" >&2
     exit 1

--- a/start.sh
+++ b/start.sh
@@ -35,6 +35,7 @@ SHOW_LEVEL=""
 SERVICE_ARGS=()
 RELOAD_REQUESTED=false
 CLEAR_LOGS=false
+# Lifecycle CLI contract: argument parsing must stay in sync with docs/development/install-lifecycle-scripts-manual.md.
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --silent)

--- a/status.sh
+++ b/status.sh
@@ -8,6 +8,7 @@ STATUS_WAIT_TIMEOUT=60
 exit_code=0
 WAIT_FOR_REACHABLE=false
 
+# Lifecycle CLI contract: keep help/options aligned with docs/development/install-lifecycle-scripts-manual.md.
 usage() {
   cat <<'EOF'
 Usage: ./status.sh [options]

--- a/stop.sh
+++ b/stop.sh
@@ -68,6 +68,7 @@ CONFIRM=false
 DEFAULT_PORT="$(arthexis_detect_backend_port "$BASE_DIR")"
 PORT="$DEFAULT_PORT"
 
+# Lifecycle CLI contract: stop flags are operator-facing and guarded by lifecycle contract tests.
 while [[ $# -gt 0 ]]; do
     case "$1" in
       --all)

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -89,6 +89,7 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
             "--stop",
             "--branch",
         ),
+        "uninstall.sh": ("--service NAME", "--no-warn", "--rfid-service", "--no-rfid-service"),
     }
 
     for script_name, tokens in scripts_and_tokens.items():

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 ROOT = Path(__file__).resolve().parents[1]
 MANUAL = ROOT / "docs/development/install-lifecycle-scripts-manual.md"
@@ -8,6 +9,12 @@ MANUAL = ROOT / "docs/development/install-lifecycle-scripts-manual.md"
 
 def _read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _read_shell_contract(path: str) -> str:
+    return "\n".join(
+        line for line in _read(path).splitlines() if not line.lstrip().startswith("#")
+    )
 
 
 def test_lifecycle_manual_covers_operator_entrypoints() -> None:
@@ -32,10 +39,10 @@ def test_lifecycle_manual_covers_operator_entrypoints() -> None:
 
 
 def test_install_usage_keeps_core_lifecycle_flags() -> None:
-    install_script = _read("install.sh")
+    install_script = _read_shell_contract("install.sh")
     expected_flags = (
-        "--service NAME",
-        "--port PORT",
+        "--service",
+        "--port",
         "--upgrade",
         "--clean",
         "--repair",
@@ -48,7 +55,9 @@ def test_install_usage_keeps_core_lifecycle_flags() -> None:
     )
 
     for flag in expected_flags:
-        assert flag in install_script, f"install.sh usage is missing lifecycle flag: {flag}"
+        assert re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", install_script), (
+            f"install.sh usage is missing lifecycle flag: {flag}"
+        )
 
 
 def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
@@ -67,16 +76,19 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
             "--reconcile",
             "--migrate",
             "--stop",
-            "--branch)",
+            "--branch",
         ),
         "command.sh": (
-            "Usage: ./command.sh <operational-command> [args...]",
-            "Usage: ./command.sh list",
             "python -m utils.command_api",
         ),
     }
 
     for script_name, tokens in scripts_and_tokens.items():
-        script_text = _read(script_name)
+        script_text = _read_shell_contract(script_name)
         for token in tokens:
             assert token in script_text, f"{script_name} is missing expected token: {token}"
+
+    upgrade_script = _read_shell_contract("upgrade.sh")
+    assert re.search(r"^\s*--branch\)\s*$", upgrade_script, re.MULTILINE), (
+        "upgrade.sh is missing expected parser label: --branch)"
+    )

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MANUAL = ROOT / "docs/development/install-lifecycle-scripts-manual.md"
@@ -15,6 +15,17 @@ def _read_shell_contract(path: str) -> str:
     return "\n".join(
         line for line in _read(path).splitlines() if not line.lstrip().startswith("#")
     )
+
+
+def _read_usage_block(path: str) -> str:
+    script_text = _read(path)
+    usage_match = re.search(
+        r"^usage\(\)\s*\{\n(?P<body>.*?)^\}\n",
+        script_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert usage_match, f"{path} is missing usage() block"
+    return usage_match.group("body")
 
 
 def test_lifecycle_manual_covers_operator_entrypoints() -> None:
@@ -39,7 +50,7 @@ def test_lifecycle_manual_covers_operator_entrypoints() -> None:
 
 
 def test_install_usage_keeps_core_lifecycle_flags() -> None:
-    install_script = _read_shell_contract("install.sh")
+    install_usage = _read_usage_block("install.sh")
     expected_flags = (
         "--service",
         "--port",
@@ -55,7 +66,7 @@ def test_install_usage_keeps_core_lifecycle_flags() -> None:
     )
 
     for flag in expected_flags:
-        assert re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", install_script), (
+        assert re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", install_usage), (
             f"install.sh usage is missing lifecycle flag: {flag}"
         )
 
@@ -78,9 +89,6 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
             "--stop",
             "--branch",
         ),
-        "command.sh": (
-            "python -m utils.command_api",
-        ),
     }
 
     for script_name, tokens in scripts_and_tokens.items():
@@ -92,3 +100,10 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
     assert re.search(r"^\s*--branch\)\s*$", upgrade_script, re.MULTILINE), (
         "upgrade.sh is missing expected parser label: --branch)"
     )
+
+    command_script = _read_shell_contract("command.sh")
+    assert 'python -m utils.command_api "$@"' in command_script
+
+    manual = MANUAL.read_text(encoding="utf-8")
+    assert "`./command.sh list`" in manual
+    assert "`./command.sh <operational-command> [args...]`" in manual

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANUAL = ROOT / "docs/development/install-lifecycle-scripts-manual.md"
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_lifecycle_manual_covers_operator_entrypoints() -> None:
+    manual = MANUAL.read_text(encoding="utf-8")
+
+    expected_sections = (
+        "## 1. Installation (`install.sh`)",
+        "## 2.1 Startup (`start.sh`)",
+        "## 2.2 Shutdown (`stop.sh`)",
+        "## 3. Upgrades (`upgrade.sh`)",
+        "## 4. Runtime reconfiguration (`configure.sh`)",
+        "## 5. Runtime status (`status.sh`)",
+        "## 6. Operational command entrypoint (`command.sh`)",
+        "## 7. Uninstall (`uninstall.sh`)",
+    )
+
+    for section in expected_sections:
+        assert section in manual, f"Missing manual section: {section}"
+
+    assert "flowchart TD" in manual
+    assert "install.sh" in manual and "status.sh" in manual and "command.sh" in manual
+
+
+def test_install_usage_keeps_core_lifecycle_flags() -> None:
+    install_script = _read("install.sh")
+    expected_flags = (
+        "--service NAME",
+        "--port PORT",
+        "--upgrade",
+        "--clean",
+        "--repair",
+        "--start",
+        "--no-start",
+        "--satellite",
+        "--terminal",
+        "--control",
+        "--watchtower",
+    )
+
+    for flag in expected_flags:
+        assert flag in install_script, f"install.sh usage is missing lifecycle flag: {flag}"
+
+
+def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
+    scripts_and_tokens = {
+        "start.sh": ("--clear-logs", "--show LEVEL", "--reload", "--silent"),
+        "stop.sh": ("--all", "--force", "--confirm"),
+        "status.sh": ("Usage: ./status.sh", "--wait", "--help"),
+        "configure.sh": (
+            "--feature SLUG",
+            "--feature-param FEATURE:KEY=VALUE",
+            "--repair",
+            "--check",
+        ),
+        "upgrade.sh": (
+            "--detached",
+            "--reconcile",
+            "--migrate",
+            "--stop",
+            "--branch)",
+        ),
+        "command.sh": (
+            "Usage: ./command.sh <operational-command> [args...]",
+            "Usage: ./command.sh list",
+            "python -m utils.command_api",
+        ),
+    }
+
+    for script_name, tokens in scripts_and_tokens.items():
+        script_text = _read(script_name)
+        for token in tokens:
+            assert token in script_text, f"{script_name} is missing expected token: {token}"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -196,6 +196,8 @@ fi
 
 arthexis_timing_setup "upgrade"
 
+# Lifecycle CLI contract: top-level upgrade flags and aliases are validated by tests to prevent accidental drift.
+
 is_non_terminal_role() {
   case "$1" in
     Control|Constellation|Watchtower)


### PR DESCRIPTION
### Motivation
- Prevent repeated accidental drift of lifecycle scripts by making the expected operator-facing interface and docs a single, testable contract.
- Make it explicit in-code where lifecycle CLI behavior must remain compatible with the canonical manual so future edits are obvious and auditable.

### Description
- Expanded `docs/development/install-lifecycle-scripts-manual.md` to explicitly include `status.sh` and `command.sh` and added a single operator lifecycle mermaid flowchart mapping `install -> configure -> start -> status/command -> stop -> upgrade -> uninstall` as a guardrail.
- Added short "Lifecycle CLI contract" comments to the top of the lifecycle entrypoint scripts to tie script arguments/usage to the canonical manual (`install.sh`, `start.sh`, `stop.sh`, `status.sh`, `configure.sh`, `upgrade.sh`, `command.sh`).
- Added `tests/test_lifecycle_script_contracts.py` which asserts the manual contains the expected lifecycle sections and that each script exposes documented flags/entrypoints so regressions in CLI surface as failing tests.

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` which completed successfully.
- Ran the contract tests with `.venv/bin/python manage.py test run -- tests/test_lifecycle_script_contracts.py`; the first run revealed a strict token mismatch which was corrected, and the final run reports `3 passed` so the new regression tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a1de98348326b6a4724796789690)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR establishes a documented, testable contract for lifecycle script CLI interfaces to prevent accidental drift between documentation, operator-facing flags, and code.

### Key Changes

**Documentation**
- Expanded `docs/development/install-lifecycle-scripts-manual.md` to document `status.sh` and `command.sh` alongside existing scripts
- Added "Lifecycle map (operator contract)" Mermaid flowchart showing the expected operator interaction sequence: install → configure → start → status/command → stop → upgrade → uninstall
- Added new documentation sections for `status.sh` (reporting behavior, `--wait` flag, help output) and `command.sh` (allowlisted operations dispatcher with `list` subcommand and `<operational-command> [args...]` pattern)

**Contract Comments**
- Added inline "Lifecycle CLI contract" comments to all seven lifecycle entrypoint scripts (`install.sh`, `start.sh`, `stop.sh`, `status.sh`, `configure.sh`, `upgrade.sh`, `command.sh`)
- Comments reference the manual and contract tests, clarifying that script flags and help output must remain aligned with documented behavior
- No functional logic changes to any script

**Test Suite**
- New `tests/test_lifecycle_script_contracts.py` (82 lines) enforces three contract assertions:
  1. Manual contains expected section headings for each lifecycle script and includes flowchart and script references
  2. `install.sh` usage preserves core lifecycle flags (12 expected flags including `--service`, `--port`, `--upgrade`, `--clean`, `--repair`, role presets, etc.)
  3. Each lifecycle script exposes documented CLI tokens matching manual specifications (e.g., `start.sh` supports `--clear-logs`, `--show LEVEL`, `--reload`, `--silent`; `stop.sh` supports `--all`, `--force`, `--confirm`; `command.sh` supports the documented `<operational-command>` and `list` patterns)

### Testing Status
- Contract tests pass (3 passed reported)
- No changes to production logic or behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->