### PR TITLE
ocpp: refine supported charger toolbar spacing without container padding

### DIFF
--- a/apps/ocpp/templates/ocpp/supported_chargers.html
+++ b/apps/ocpp/templates/ocpp/supported_chargers.html
@@ -10,7 +10,6 @@
     border: 1px solid var(--bs-border-color-translucent);
     border-radius: var(--landing-card-radius);
     background: var(--bs-body-bg);
-    padding: var(--bs-spacer);
   }
   .supported-toolbar .chip-label {
     font-size: var(--landing-meta-font-size);
@@ -23,10 +22,6 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-  }
-  .supported-toolbar-row {
-    --bs-gutter-x: var(--bs-spacer);
-    --bs-gutter-y: calc(var(--bs-spacer) * 0.75);
   }
   .supported-chip {
     border-radius: 999px;
@@ -82,17 +77,17 @@
       </div>
       <div class="card-body pt-2">
         <div class="supported-toolbar mb-3 mb-sm-4" data-supported-filter-toolbar>
-          <div class="row align-items-start supported-toolbar-row">
-            <div class="col-12 col-md-4">
-              <p class="chip-label mb-0">{% trans "Vendor" %}</p>
+          <div class="row align-items-start g-0">
+            <div class="col-12 col-md-4 px-3 py-3">
+              <p class="chip-label mb-2">{% trans "Vendor" %}</p>
               <div class="supported-chip-group" data-chip-group="vendor"></div>
             </div>
-            <div class="col-12 col-md-4">
-              <p class="chip-label mb-0">{% trans "OCPP preference" %}</p>
+            <div class="col-12 col-md-4 px-3 py-3">
+              <p class="chip-label mb-2">{% trans "OCPP preference" %}</p>
               <div class="supported-chip-group" data-chip-group="ocpp"></div>
             </div>
-            <div class="col-12 col-md-4">
-              <p class="chip-label mb-0">{% trans "Integration rating" %}</p>
+            <div class="col-12 col-md-4 px-3 py-3">
+              <p class="chip-label mb-2">{% trans "Integration rating" %}</p>
               <div class="supported-chip-group" data-chip-group="rating"></div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation

- Align the toolbar outer border with the title/description content block by removing container-level padding while keeping the visual card border, radius and background intact.  
- Remove a temporary gutter workaround that introduced custom CSS and return to standard Bootstrap row/column layout.  
- Move spacing to the filter content so chips and labels retain comfortable breathing room from the border using token-driven spacing.  

### Description

- Removed `padding: var(--bs-spacer);` from `.supported-toolbar` while preserving `border`, `border-radius`, and `background` in the inline stylesheet of `apps/ocpp/templates/ocpp/supported_chargers.html`.  
- Deleted the `.supported-toolbar-row` CSS rule and replaced the row markup with a standard `row align-items-start g-0`.  
- Added content-level spacing by applying Bootstrap spacing utilities `px-3 py-3` to each filter column and `mb-2` to labels so chips keep token-driven spacing and do not touch the border.  
- Left chip/group styles intact (flex wrap and `gap`) to preserve wrapping and responsive behavior.  

### Testing

- Ran `./env-refresh.sh --deps-only` successfully.  
- Ran `.venv/bin/python manage.py test run -- apps/ocpp` and observed all tests in the app passed (`340 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b74befd08326abb3fadc893a0faf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refines the toolbar styling in the supported chargers template by standardizing the grid layout to use Bootstrap utilities instead of custom CSS, and removing outer padding from the toolbar container.

## Changes

**apps/ocpp/templates/ocpp/supported_chargers.html**
- Removed `padding: var(--bs-spacer)` from `.supported-toolbar` inline styles while retaining border, border-radius, and background declarations
- Deleted the `.supported-toolbar-row` CSS rule and its temporary gutter workaround
- Updated grid markup from custom-styled row to standard Bootstrap: `row align-items-start g-0`
- Applied per-column spacing using Bootstrap utilities: `px-3 py-3` on each filter column (Vendor, OCPP preference, Integration rating)
- Changed label spacing from `mb-0` to `mb-2` for consistent spacing between labels and content chips
- Preserved chip and group flex layout (flex-wrap and gap) for responsive behavior

The refactoring returns to standard Bootstrap conventions while maintaining visual spacing through per-column padding and label margins rather than outer container padding.

## Testing

- Environment setup verified with `./env-refresh.sh --deps-only`
- All app tests passed: 340 passed, 1 skipped

Lines changed: +7/-12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->