### PR TITLE
Add 15-minute workflow to auto-close issues after linked PR merge

### DIFF
--- a/.github/workflows/close-issues-with-merged-prs.yml
+++ b/.github/workflows/close-issues-with-merged-prs.yml
@@ -1,0 +1,137 @@
+name: Close issues linked to merged PRs
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close open issues when a linked PR is merged to default branch
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const defaultBranch = context.payload.repository?.default_branch || 'main';
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const issuesOnly = openIssues.filter((issue) => !issue.pull_request);
+            core.info(`Evaluating ${issuesOnly.length} open issues.`);
+
+            for (const issue of issuesOnly) {
+              const timelineEvents = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              const orderedEvents = [...timelineEvents].sort((left, right) => {
+                const leftTime = Date.parse(left.created_at ?? '');
+                const rightTime = Date.parse(right.created_at ?? '');
+
+                if (Number.isNaN(leftTime) || Number.isNaN(rightTime) || leftTime === rightTime) {
+                  return (left.id ?? 0) - (right.id ?? 0);
+                }
+
+                return leftTime - rightTime;
+              });
+
+              const linkedPullRequestNumbers = new Set();
+
+              for (const event of orderedEvents) {
+                if (!['cross-referenced', 'connected', 'disconnected'].includes(event.event)) {
+                  continue;
+                }
+
+                const sourceIssue = event.source?.issue;
+                const sourceIssueNumber = sourceIssue?.number;
+
+                if (!sourceIssue?.pull_request || !sourceIssueNumber) {
+                  continue;
+                }
+
+                if (event.event === 'disconnected') {
+                  linkedPullRequestNumbers.delete(sourceIssueNumber);
+                  continue;
+                }
+
+                linkedPullRequestNumbers.add(sourceIssueNumber);
+              }
+
+              if (linkedPullRequestNumbers.size === 0) {
+                continue;
+              }
+
+              const mergedToDefaultBranch = [];
+              for (const pullNumber of linkedPullRequestNumbers) {
+                try {
+                  const { data: pullRequest } = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pullNumber,
+                  });
+
+                  if (!pullRequest.merged_at) {
+                    continue;
+                  }
+
+                  if (pullRequest.base?.ref !== defaultBranch) {
+                    continue;
+                  }
+
+                  mergedToDefaultBranch.push(pullRequest.number);
+                } catch (error) {
+                  if (error.status === 404) {
+                    core.info(`#${issue.number}: linked PR #${pullNumber} is unavailable.`);
+                    continue;
+                  }
+
+                  throw error;
+                }
+              }
+
+              if (mergedToDefaultBranch.length === 0) {
+                core.info(`#${issue.number}: linked PR(s) found, but none merged to ${defaultBranch}.`);
+                continue;
+              }
+
+              const linkedPullsText = mergedToDefaultBranch
+                .sort((a, b) => a - b)
+                .map((number) => `#${number}`)
+                .join(', ');
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: [
+                  `Closing automatically because linked PR(s) ${linkedPullsText} were merged into \`${defaultBranch}\`.`,
+                  '',
+                  'If this issue still needs follow-up work, please reopen it with details.',
+                ].join('\n'),
+              });
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+
+              core.info(`#${issue.number}: closed (merged PR(s): ${linkedPullsText}).`);
+            }

--- a/.github/workflows/close-issues-with-merged-prs.yml
+++ b/.github/workflows/close-issues-with-merged-prs.yml
@@ -52,6 +52,7 @@ jobs:
               });
 
               const linkedPullRequests = new Map();
+              const reopenedTimestamps = [];
 
               const getSourcePullRequest = (event) => {
                 const sourceIssue = event.source?.issue;
@@ -83,6 +84,13 @@ jobs:
               };
 
               for (const event of orderedEvents) {
+                if (event.event === 'reopened') {
+                  const reopenedTime = Date.parse(event.created_at ?? '');
+                  if (!Number.isNaN(reopenedTime)) {
+                    reopenedTimestamps.push(reopenedTime);
+                  }
+                }
+
                 if (!['cross-referenced', 'connected', 'disconnected'].includes(event.event)) {
                   continue;
                 }
@@ -121,10 +129,18 @@ jobs:
                     continue;
                   }
 
+                  if (
+                    pullRequest.base?.repo?.owner?.login !== owner ||
+                    pullRequest.base?.repo?.name !== repo
+                  ) {
+                    continue;
+                  }
+
                   mergedToDefaultBranch.push({
                     number: pullRequest.number,
                     owner: linkedPullRequest.owner,
                     repo: linkedPullRequest.repo,
+                    mergedAt: pullRequest.merged_at,
                   });
                 } catch (error) {
                   if (error.status === 404) {
@@ -141,6 +157,19 @@ jobs:
               if (mergedToDefaultBranch.length === 0) {
                 core.info(`#${issue.number}: linked PR(s) found, but none merged to ${defaultBranch}.`);
                 continue;
+              }
+
+              const latestReopenedAt = reopenedTimestamps.length > 0 ? Math.max(...reopenedTimestamps) : null;
+              if (latestReopenedAt !== null) {
+                const latestMergedAt = Math.max(
+                  ...mergedToDefaultBranch.map((pullRequest) => Date.parse(pullRequest.mergedAt ?? '')),
+                );
+                if (!Number.isNaN(latestMergedAt) && latestReopenedAt > latestMergedAt) {
+                  core.info(
+                    `#${issue.number}: skipped because issue was reopened after linked PR(s) merged to ${defaultBranch}.`,
+                  );
+                  continue;
+                }
               }
 
               const linkedPullsText = mergedToDefaultBranch

--- a/.github/workflows/close-issues-with-merged-prs.yml
+++ b/.github/workflows/close-issues-with-merged-prs.yml
@@ -51,39 +51,66 @@ jobs:
                 return leftTime - rightTime;
               });
 
-              const linkedPullRequestNumbers = new Set();
+              const linkedPullRequests = new Map();
+
+              const getSourcePullRequest = (event) => {
+                const sourceIssue = event.source?.issue;
+                const sourceIssueNumber = sourceIssue?.number;
+
+                if (!sourceIssue?.pull_request || !sourceIssueNumber) {
+                  return null;
+                }
+
+                const repositoryUrl = sourceIssue.repository_url;
+                if (!repositoryUrl) {
+                  return null;
+                }
+
+                const repoMatch = repositoryUrl.match(/\/repos\/([^/]+)\/([^/]+)$/);
+                if (!repoMatch) {
+                  return null;
+                }
+
+                const sourceOwner = repoMatch[1];
+                const sourceRepo = repoMatch[2];
+
+                return {
+                  key: `${sourceOwner}/${sourceRepo}#${sourceIssueNumber}`,
+                  number: sourceIssueNumber,
+                  owner: sourceOwner,
+                  repo: sourceRepo,
+                };
+              };
 
               for (const event of orderedEvents) {
                 if (!['cross-referenced', 'connected', 'disconnected'].includes(event.event)) {
                   continue;
                 }
 
-                const sourceIssue = event.source?.issue;
-                const sourceIssueNumber = sourceIssue?.number;
-
-                if (!sourceIssue?.pull_request || !sourceIssueNumber) {
+                const sourcePullRequest = getSourcePullRequest(event);
+                if (!sourcePullRequest) {
                   continue;
                 }
 
                 if (event.event === 'disconnected') {
-                  linkedPullRequestNumbers.delete(sourceIssueNumber);
+                  linkedPullRequests.delete(sourcePullRequest.key);
                   continue;
                 }
 
-                linkedPullRequestNumbers.add(sourceIssueNumber);
+                linkedPullRequests.set(sourcePullRequest.key, sourcePullRequest);
               }
 
-              if (linkedPullRequestNumbers.size === 0) {
+              if (linkedPullRequests.size === 0) {
                 continue;
               }
 
               const mergedToDefaultBranch = [];
-              for (const pullNumber of linkedPullRequestNumbers) {
+              for (const linkedPullRequest of linkedPullRequests.values()) {
                 try {
                   const { data: pullRequest } = await github.rest.pulls.get({
-                    owner,
-                    repo,
-                    pull_number: pullNumber,
+                    owner: linkedPullRequest.owner,
+                    repo: linkedPullRequest.repo,
+                    pull_number: linkedPullRequest.number,
                   });
 
                   if (!pullRequest.merged_at) {
@@ -94,10 +121,16 @@ jobs:
                     continue;
                   }
 
-                  mergedToDefaultBranch.push(pullRequest.number);
+                  mergedToDefaultBranch.push({
+                    number: pullRequest.number,
+                    owner: linkedPullRequest.owner,
+                    repo: linkedPullRequest.repo,
+                  });
                 } catch (error) {
                   if (error.status === 404) {
-                    core.info(`#${issue.number}: linked PR #${pullNumber} is unavailable.`);
+                    core.info(
+                      `#${issue.number}: linked PR ${linkedPullRequest.owner}/${linkedPullRequest.repo}#${linkedPullRequest.number} is unavailable.`,
+                    );
                     continue;
                   }
 
@@ -111,8 +144,16 @@ jobs:
               }
 
               const linkedPullsText = mergedToDefaultBranch
-                .sort((a, b) => a - b)
-                .map((number) => `#${number}`)
+                .sort((left, right) =>
+                  `${left.owner}/${left.repo}#${left.number}`.localeCompare(
+                    `${right.owner}/${right.repo}#${right.number}`,
+                  ),
+                )
+                .map((pullRequest) =>
+                  pullRequest.owner === owner && pullRequest.repo === repo
+                    ? `#${pullRequest.number}`
+                    : `${pullRequest.owner}/${pullRequest.repo}#${pullRequest.number}`,
+                )
                 .join(', ');
 
               await github.rest.issues.createComment({


### PR DESCRIPTION
### Motivation
- Reduce manual triage by automatically closing open issues that have an associated pull request merged to the repository default branch.
- Ensure Issues that are resolved by merged PRs are cleaned up on a regular cadence without human intervention.

### Description
- Add a new GitHub Actions workflow at `/.github/workflows/close-issues-with-merged-prs.yml` scheduled to run every 15 minutes and triggerable via `workflow_dispatch`.
- Use `actions/github-script@v9` to enumerate open issues, inspect timeline events (`cross-referenced`, `connected`, `disconnected`) to track currently linked PR numbers, and ignore non-issue items.
- For each linked PR the workflow fetches the PR via the REST API and only treats it as resolving if `merged_at` is set and `base.ref` equals the repository default branch, then posts a closing comment and closes the issue.
- Workflow permissions are scoped to `issues: write`, `pull-requests: read`, and `contents: read`.

### Testing
- Validated the workflow YAML with `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/close-issues-with-merged-prs.yml"))'`, which succeeded.
- Ran `git diff --check` and committed the new file, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2049279083269cd44c5c29eba624)