### PR TITLE
Add subtle inset viewport border to public pages

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -47,6 +47,27 @@ html {
   font-size: clamp(16px, 1.2vw, 24px);
 }
 
+body {
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  border: var(--bs-border-width) solid color-mix(in srgb, var(--bs-body-color) 16%, transparent);
+  box-shadow: inset 0 0 0 calc(var(--bs-border-width) * 2) color-mix(in srgb, #000 12%, transparent);
+  pointer-events: none;
+  z-index: 2147483647;
+}
+
+html[data-bs-theme='light'] body::before {
+  border-color: color-mix(in srgb, #0f172a 10%, transparent);
+  box-shadow:
+    inset 0 0 0 calc(var(--bs-border-width) * 2) color-mix(in srgb, #0f172a 8%, transparent),
+    inset 0 1px 0 color-mix(in srgb, #fff 45%, transparent);
+}
+
 @media (min-width: 1600px) {
   .container {
     max-width: 90%;


### PR DESCRIPTION
### Motivation
- Add a tiny, theme-aware inner border across public pages to give the view a slightly sunken window look, applied globally via the shared base stylesheet.

### Description
- Modify `apps/sites/static/pages/css/base.css` to add a `body::before` fixed overlay that draws a thin border and subtle inset shadow using Bootstrap tokens (`--bs-border-width`, `--bs-body-color`) with a tuned light-mode variant.

### Testing
- Ran `./env-refresh.sh --deps-only` (succeeded) and `.venv/bin/python manage.py check` (system check reported no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f9322a883269c0997ec0a3a937f)