### PR TITLE
Run PR CI workflows on draft/non-draft transitions consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ concurrency:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - "**/*.py"
       - "**/*.json"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,12 @@ on:
       - '**/Dockerfile'
       - '**/*.sh'
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - '**/*.py'
       - '**/requirements*.txt'

--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -17,6 +17,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
   push:
     branches:
       - main

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,12 @@ env:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - '**/*.py'
       - '**/*.js'


### PR DESCRIPTION
### Motivation

- Ensure CI and security workflows run the same way when a PR is converted to or from draft state by making `converted_to_draft` an explicit `pull_request` type. 
- Remove inconsistent trigger behavior across PR lifecycle events so transitions like open/update/reopen/ready-for-review/convert-to-draft behave uniformly. 
- Keep workflow trigger lists explicit and aligned to avoid invisible differences between draft and non-draft PR runs.

### Description

- Added an explicit `pull_request.types` list (including `converted_to_draft`) to `ci.yml`, `codeql.yml`, and `security-scan.yml`. 
- Extended the existing explicit PR `types` in `secret-scan.yml` and `dashboard-screenshot.yml` to include `converted_to_draft` for consistent handling. 
- Modified the following workflow files: ` .github/workflows/ci.yml`, ` .github/workflows/codeql.yml`, ` .github/workflows/security-scan.yml`, ` .github/workflows/secret-scan.yml`, and ` .github/workflows/dashboard-screenshot.yml`.

### Testing

- Parsed all updated workflow YAML files with `yaml.safe_load` invoked via `.venv/bin/python` (falling back to `python3`) to validate syntax and they parsed successfully. 
- No workflow YAML syntax errors were detected during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fb740d08326a373dc722f50c2c5)