### PR TITLE
Add subtle inset border to public-facing pages

### DIFF
--- a/apps/ocpp/templates/ocpp/landing_base.html
+++ b/apps/ocpp/templates/ocpp/landing_base.html
@@ -10,6 +10,9 @@
     <style>
       :root {
         --landing-card-radius: 1.25rem;
+        --public-window-inset-width: calc(var(--bs-border-width) * 2);
+        --public-window-inset-color: color-mix(in srgb, var(--bs-emphasis-color) 12%, transparent);
+        --public-window-inset-shadow: color-mix(in srgb, var(--bs-emphasis-color) 10%, transparent);
       }
       html[data-bs-theme='light'] {
         --bs-body-bg: #f8f9fa;
@@ -22,6 +25,17 @@
         font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         display: flex;
         flex-direction: column;
+        position: relative;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        box-shadow:
+          inset 0 0 0 var(--public-window-inset-width) var(--public-window-inset-color),
+          inset 0 0.2rem 0.3rem var(--public-window-inset-shadow);
+        z-index: 1080;
       }
       main.landing-main {
         width: 100%;

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -14,6 +14,9 @@
   --bs-primary-rgb: var(--site-primary-rgb);
   --bs-link-color: var(--site-primary);
   --bs-link-hover-color: var(--site-primary-strong);
+  --public-window-inset-width: calc(var(--bs-border-width) * 2);
+  --public-window-inset-color: color-mix(in srgb, var(--bs-emphasis-color) 16%, transparent);
+  --public-window-inset-shadow: color-mix(in srgb, var(--bs-emphasis-color) 12%, transparent);
 }
 
 .btn-primary {
@@ -45,6 +48,21 @@ html[data-bs-theme='light'] {
 
 html {
   font-size: clamp(16px, 1.2vw, 24px);
+}
+
+body {
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  box-shadow:
+    inset 0 0 0 var(--public-window-inset-width) var(--public-window-inset-color),
+    inset 0 0.2rem 0.3rem var(--public-window-inset-shadow);
+  z-index: 1080;
 }
 
 @media (min-width: 1600px) {


### PR DESCRIPTION
### Motivation
- Give all public-facing pages a subtle, theme-aware inward border so the site content reads as slightly sunken in across public pages and OCPP landing pages.

### Description
- Introduce theme tokens and a `body::before` inset overlay in `apps/sites/static/pages/css/base.css` and apply matching tokens and the same overlay to `apps/ocpp/templates/ocpp/landing_base.html`, using `--bs-border-width` and emphasis color mixing so the treatment remains subtle and theme-aligned.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and ran the canonical site test suite with `.venv/bin/python manage.py test run -- apps/sites/tests`, which executed 64 tests and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea248b20dc8326938890916623bcb6)