### PR TITLE
Add subtle inset border for public pages

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -47,6 +47,15 @@ html {
   font-size: clamp(16px, 1.2vw, 24px);
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 2px var(--bs-border-color-translucent, rgba(108, 117, 125, 0.35));
+  z-index: 1090;
+}
+
 @media (min-width: 1600px) {
   .container {
     max-width: 90%;


### PR DESCRIPTION
### Motivation

- Provide a small visual affordance on the public site that makes the viewport look slightly sunken by a couple of pixels using the shared public base stylesheet.

### Description

- Add a fixed, non-interactive overlay using `body::before` in `apps/sites/static/pages/css/base.css` that draws a 2px inset border via `box-shadow: inset 0 0 0 2px ...`.
- Tie the color to the existing theme token with a fallback using `var(--bs-border-color-translucent, rgba(108, 117, 125, 0.35))` so it blends with light/dark themes and does not affect layout or interactions.

### Testing

- Ran `./env-refresh.sh --deps-only` to prepare the environment and dependencies, which completed successfully.
- Executed `.venv/bin/python manage.py test run -- apps/sites/tests/test_public_routes.py` and observed `14 passed` with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea248b20dc8326938890916623bcb6)