### PR TITLE
Harden dependency submission workflow against transient GitHub API failures

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  dependency-graph: write
   issues: write
 
 jobs:
@@ -24,10 +25,12 @@ jobs:
     name: Submit dependencies
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 15
     env:
       DEPENDENCY_DETECTOR_ARGS: Pip=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff,Poetry=EnableIfDefaultOff,UvLock=EnableIfDefaultOff
       DEPENDENCY_SUBMISSION_FAIL_AFTER: '0'
       DEPENDENCY_SUBMISSION_TRACKING_LABEL: dependency-submission-failure
+      GH_DEPENDENCY_SUBMISSION_SKIP_CACHE: 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### Motivation
- The dependency snapshot submission job was encountering transient GitHub Dependency Graph API errors and lacked explicit permissions and runtime guards to handle API instability without impacting CI capacity.

### Description
- Add explicit `dependency-graph: write` permission so the snapshot submission step has the required scoped access for the Dependency Graph API. 
- Add `timeout-minutes: 15` on the `dependency-submission` job to prevent long-hanging retries from tying up runners. 
- Set `GH_DEPENDENCY_SUBMISSION_SKIP_CACHE: 'true'` in the job environment to avoid cache-related autosubmission instability while keeping the job non-blocking.

### Testing
- Validated the modified workflow YAML parses with `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/dependency-submission.yml').read_text())"`, which succeeded. 
- Confirmed the change was committed locally and the workflow file loads cleanly, with no automated test-suite changes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2d89dfb483268c5b5514e6e440ab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Hardens the dependency submission workflow against transient GitHub API failures by adding runtime guards and explicit permissions.

## Changes

**`.github/workflows/dependency-submission.yml`**

- Added `dependency-graph: write` permission to grant the dependency submission step explicit scoped access to the Dependency Graph API
- Added `timeout-minutes: 15` to the `dependency-submission` job to prevent long-hanging retries from tying up CI runners
- Set `GH_DEPENDENCY_SUBMISSION_SKIP_CACHE: 'true'` in the job environment to avoid cache-related autosubmission instability

## Rationale

The dependency snapshot submission job was experiencing transient GitHub API errors without explicit permissions or runtime guards, which caused hanging retries to consume CI capacity. These changes introduce necessary guards while keeping the job non-blocking.

## Testing

The modified workflow YAML was validated to parse correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->