### PR TITLE
ci: scope dependency-submission workflow to main branch

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
     paths:
       - '**/pyproject.toml'
       - '**/requirements*.txt'
@@ -22,6 +21,7 @@ permissions:
 jobs:
   dependency-submission:
     name: Submit dependencies
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     continue-on-error: true
     env:


### PR DESCRIPTION
### Motivation
- Prevent noisy PR-branch CI failures caused by transient GitHub Dependency Graph snapshot API errors by restricting dependency snapshot submission to the primary branch.

### Description
- Removed `release/**` from the workflow push triggers and added a job-level guard `if: github.ref == 'refs/heads/main'` in `.github/workflows/dependency-submission.yml` so the submission job only runs on `main`.

### Testing
- Verified the change locally by inspecting the workflow with `git diff -- .github/workflows/dependency-submission.yml`, `git diff --check HEAD~1..HEAD`, and `nl -ba .github/workflows/dependency-submission.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2d89dfb483268c5b5514e6e440ab)