### PR TITLE
sites: brighten feedback widget accents to lime/yellow tones

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -65,8 +65,32 @@ jobs:
         with:
           detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
 
-      - name: Track persistent submission failures
+      - name: Extended backoff before retry
         if: steps.submit_snapshot_attempt_3.outcome == 'failure'
+        run: sleep 90
+
+      - name: Submit dependency snapshot (attempt 4)
+        id: submit_snapshot_attempt_4
+        if: steps.submit_snapshot_attempt_3.outcome == 'failure'
+        continue-on-error: true
+        uses: advanced-security/component-detection-dependency-submission-action@7c766a0966c66533ae37f76556cf9a33be50e5f8
+        with:
+          detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
+
+      - name: Extended backoff before final retry
+        if: steps.submit_snapshot_attempt_4.outcome == 'failure'
+        run: sleep 120
+
+      - name: Submit dependency snapshot (attempt 5)
+        id: submit_snapshot_attempt_5
+        if: steps.submit_snapshot_attempt_4.outcome == 'failure'
+        continue-on-error: true
+        uses: advanced-security/component-detection-dependency-submission-action@7c766a0966c66533ae37f76556cf9a33be50e5f8
+        with:
+          detectorArgs: ${{ env.DEPENDENCY_DETECTOR_ARGS }}
+
+      - name: Track persistent submission failures
+        if: steps.submit_snapshot_attempt_5.outcome == 'failure'
         uses: actions/github-script@v9
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -467,6 +467,14 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
   --user-story-accent-text: #f8fafc;
 }
 
+html[data-bs-theme='dark'] .user-story-toggle,
+html[data-bs-theme='dark'] .user-story-overlay {
+  --user-story-accent: #84cc16;
+  --user-story-accent-rgb: 132, 204, 22;
+  --user-story-accent-strong: #bef264;
+  --user-story-accent-text: #1f2937;
+}
+
 .user-story-toggle {
   position: fixed;
   right: 1.75rem;

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -459,6 +459,13 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
   }
 }
 
+.user-story-toggle,
+.user-story-overlay {
+  --user-story-accent: #84cc16;
+  --user-story-accent-strong: #bef264;
+  --user-story-accent-text: #1f2937;
+}
+
 .user-story-toggle {
   position: fixed;
   right: 1.75rem;
@@ -467,8 +474,8 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
   height: 3rem;
   border-radius: 50%;
   border: 0;
-  background: linear-gradient(135deg, var(--site-support), var(--site-support-strong));
-  color: var(--site-support-icon);
+  background: linear-gradient(135deg, var(--user-story-accent), var(--user-story-accent-strong));
+  color: var(--user-story-accent-text);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -537,25 +544,25 @@ body.user-story-open {
 }
 
 .user-story-card .card-title {
-  color: var(--site-support);
+  color: var(--user-story-accent);
 }
 
 .user-story-card .btn-primary {
-  --bs-btn-bg: var(--site-support);
-  --bs-btn-border-color: var(--site-support);
-  --bs-btn-hover-bg: var(--site-support-strong);
-  --bs-btn-hover-border-color: var(--site-support-strong);
-  --bs-btn-active-bg: var(--site-support-strong);
-  --bs-btn-active-border-color: var(--site-support-strong);
-  --bs-btn-focus-shadow-rgb: var(--site-support-rgb);
-  --bs-btn-color: var(--site-support-icon);
-  --bs-btn-hover-color: var(--site-support-icon);
-  --bs-btn-active-color: var(--site-support-icon);
+  --bs-btn-bg: var(--user-story-accent);
+  --bs-btn-border-color: var(--user-story-accent);
+  --bs-btn-hover-bg: var(--user-story-accent-strong);
+  --bs-btn-hover-border-color: var(--user-story-accent-strong);
+  --bs-btn-active-bg: var(--user-story-accent-strong);
+  --bs-btn-active-border-color: var(--user-story-accent-strong);
+  --bs-btn-focus-shadow-rgb: 132, 204, 22;
+  --bs-btn-color: var(--user-story-accent-text);
+  --bs-btn-hover-color: var(--user-story-accent-text);
+  --bs-btn-active-color: var(--user-story-accent-text);
 }
 
 .user-story-card .btn-link {
-  --bs-btn-color: var(--site-support);
-  --bs-btn-hover-color: var(--site-support-strong);
+  --bs-btn-color: var(--user-story-accent);
+  --bs-btn-hover-color: var(--user-story-accent-strong);
 }
 
 .user-story-card,
@@ -665,11 +672,11 @@ body.user-story-open {
 .user-story-rating label:hover,
 .user-story-rating label:focus-visible,
 .user-story-rating label:hover ~ label {
-  color: var(--site-support-strong);
+  color: var(--user-story-accent-strong);
 }
 
 .user-story-rating input:checked ~ label {
-  color: var(--site-support);
+  color: var(--user-story-accent);
 }
 
 .user-story-rating label:active {

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -461,9 +461,10 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
 
 .user-story-toggle,
 .user-story-overlay {
-  --user-story-accent: #84cc16;
-  --user-story-accent-strong: #bef264;
-  --user-story-accent-text: #1f2937;
+  --user-story-accent: #4d7c0f;
+  --user-story-accent-rgb: 77, 124, 15;
+  --user-story-accent-strong: #3f6212;
+  --user-story-accent-text: #f8fafc;
 }
 
 .user-story-toggle {
@@ -554,7 +555,7 @@ body.user-story-open {
   --bs-btn-hover-border-color: var(--user-story-accent-strong);
   --bs-btn-active-bg: var(--user-story-accent-strong);
   --bs-btn-active-border-color: var(--user-story-accent-strong);
-  --bs-btn-focus-shadow-rgb: 132, 204, 22;
+  --bs-btn-focus-shadow-rgb: var(--user-story-accent-rgb);
   --bs-btn-color: var(--user-story-accent-text);
   --bs-btn-hover-color: var(--user-story-accent-text);
   --bs-btn-active-color: var(--user-story-accent-text);

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -10,6 +10,10 @@
   --site-support-rgb: 21, 128, 61;
   --site-support-icon: #0f172a;
   --site-support-text: #f0fdf4;
+  --user-story-accent: #4d7c0f;
+  --user-story-accent-rgb: 77, 124, 15;
+  --user-story-accent-strong: #3f6212;
+  --user-story-accent-text: #f8fafc;
   --bs-primary: var(--site-primary);
   --bs-primary-rgb: var(--site-primary-rgb);
   --bs-link-color: var(--site-primary);
@@ -41,6 +45,13 @@
 html[data-bs-theme='light'] {
   --bs-body-bg: #ffffff;
   --bs-body-bg-rgb: 255, 255, 255;
+}
+
+html[data-bs-theme='dark'] {
+  --user-story-accent: #84cc16;
+  --user-story-accent-rgb: 132, 204, 22;
+  --user-story-accent-strong: #bef264;
+  --user-story-accent-text: #1f2937;
 }
 
 html {
@@ -116,6 +127,15 @@ nav.toc a:hover {
 
 .navbar .navbar-nav {
   --bs-nav-link-padding-y: var(--site-navbar-item-padding-y);
+}
+
+.navbar .navbar-brand {
+  color: var(--user-story-accent);
+}
+
+.navbar .navbar-brand:focus-visible,
+.navbar .navbar-brand:hover {
+  color: var(--user-story-accent-strong);
 }
 
 @media (min-width: 992px) {
@@ -457,22 +477,6 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
     padding: 0.65rem 0.75rem;
     min-width: 10.5rem;
   }
-}
-
-.user-story-toggle,
-.user-story-overlay {
-  --user-story-accent: #4d7c0f;
-  --user-story-accent-rgb: 77, 124, 15;
-  --user-story-accent-strong: #3f6212;
-  --user-story-accent-text: #f8fafc;
-}
-
-html[data-bs-theme='dark'] .user-story-toggle,
-html[data-bs-theme='dark'] .user-story-overlay {
-  --user-story-accent: #84cc16;
-  --user-story-accent-rgb: 132, 204, 22;
-  --user-story-accent-strong: #bef264;
-  --user-story-accent-text: #1f2937;
 }
 
 .user-story-toggle {

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -129,15 +129,6 @@ nav.toc a:hover {
   --bs-nav-link-padding-y: var(--site-navbar-item-padding-y);
 }
 
-.navbar .navbar-brand {
-  color: var(--user-story-accent);
-}
-
-.navbar .navbar-brand:focus-visible,
-.navbar .navbar-brand:hover {
-  color: var(--user-story-accent-strong);
-}
-
 @media (min-width: 992px) {
   .reader-sidebar {
     position: sticky;

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -34,6 +34,10 @@
     --user-story-alert-danger-border: rgba(248, 113, 113, 0.35);
     --user-story-alert-danger-fg: #b91c1c;
     --user-story-close-hover-bg: rgba(15, 23, 42, 0.08);
+    --user-story-accent: #4d7c0f;
+    --user-story-accent-rgb: 77, 124, 15;
+    --user-story-accent-strong: #3f6212;
+    --user-story-accent-text: #f8fafc;
     --user-story-contact-gap: var(--admin-ui-space-3, 0.75rem);
     --user-story-contact-optin-offset: var(--admin-ui-space-2, 0.5rem);
     --user-story-contact-breakpoint: 48rem;
@@ -779,14 +783,6 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
 
 .selector-chosen {
     order: 2;
-}
-
-.user-story-toggle,
-.user-story-overlay {
-    --user-story-accent: #4d7c0f;
-    --user-story-accent-rgb: 77, 124, 15;
-    --user-story-accent-strong: #3f6212;
-    --user-story-accent-text: #f8fafc;
 }
 
 .user-story-toggle {

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -410,6 +410,10 @@ body.chat-open {
     --user-story-alert-danger-border: rgba(248, 113, 113, 0.45);
     --user-story-alert-danger-fg: #fca5a5;
     --user-story-close-hover-bg: rgba(148, 163, 184, 0.25);
+    --user-story-accent: #84cc16;
+    --user-story-accent-rgb: 132, 204, 22;
+    --user-story-accent-strong: #bef264;
+    --user-story-accent-text: #1f2937;
 }
 
 body.login #header {

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -26,7 +26,7 @@
     --user-story-input-border: rgba(15, 23, 42, 0.15);
     --user-story-checkbox-border: rgba(15, 23, 42, 0.25);
     --user-story-muted: rgba(15, 23, 42, 0.6);
-    --user-story-focus-ring: rgba(132, 204, 22, 0.35);
+    --user-story-focus-ring: color-mix(in srgb, var(--admin-primary-accent) 35%, transparent);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.12);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.35);
     --user-story-alert-success-fg: #047857;
@@ -402,7 +402,7 @@ body.chat-open {
     --user-story-input-border: rgba(148, 163, 184, 0.35);
     --user-story-checkbox-border: rgba(148, 163, 184, 0.35);
     --user-story-muted: rgba(148, 163, 184, 0.85);
-    --user-story-focus-ring: rgba(163, 230, 53, 0.45);
+    --user-story-focus-ring: color-mix(in srgb, var(--admin-accent-strong) 45%, transparent);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.16);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.45);
     --user-story-alert-success-fg: #22c55e;
@@ -779,9 +779,10 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
 
 .user-story-toggle,
 .user-story-overlay {
-    --user-story-accent: #84cc16;
-    --user-story-accent-strong: #bef264;
-    --user-story-accent-text: #1f2937;
+    --user-story-accent: #4d7c0f;
+    --user-story-accent-rgb: 77, 124, 15;
+    --user-story-accent-strong: #3f6212;
+    --user-story-accent-text: #f8fafc;
 }
 
 .user-story-toggle {
@@ -914,7 +915,7 @@ body.user-story-open {
 .user-story-card .user-story-submit:hover,
 .user-story-card .user-story-submit:focus-visible {
     transform: translateY(-1px);
-    box-shadow: 0 1rem 2rem rgba(132, 204, 22, 0.35);
+    box-shadow: 0 1rem 2rem color-mix(in srgb, var(--admin-primary-accent) 35%, transparent);
     text-decoration: none;
 }
 

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -26,7 +26,7 @@
     --user-story-input-border: rgba(15, 23, 42, 0.15);
     --user-story-checkbox-border: rgba(15, 23, 42, 0.25);
     --user-story-muted: rgba(15, 23, 42, 0.6);
-    --user-story-focus-ring: color-mix(in srgb, var(--admin-primary-accent) 35%, transparent);
+    --user-story-focus-ring: color-mix(in srgb, var(--admin-primary-accent, var(--user-story-accent)) 35%, transparent);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.12);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.35);
     --user-story-alert-success-fg: #047857;
@@ -402,7 +402,7 @@ body.chat-open {
     --user-story-input-border: rgba(148, 163, 184, 0.35);
     --user-story-checkbox-border: rgba(148, 163, 184, 0.35);
     --user-story-muted: rgba(148, 163, 184, 0.85);
-    --user-story-focus-ring: color-mix(in srgb, var(--admin-accent-strong) 45%, transparent);
+    --user-story-focus-ring: color-mix(in srgb, var(--admin-accent-strong, var(--user-story-accent-strong)) 45%, transparent);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.16);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.45);
     --user-story-alert-success-fg: #22c55e;
@@ -919,7 +919,7 @@ body.user-story-open {
 .user-story-card .user-story-submit:hover,
 .user-story-card .user-story-submit:focus-visible {
     transform: translateY(-1px);
-    box-shadow: 0 1rem 2rem color-mix(in srgb, var(--admin-primary-accent) 35%, transparent);
+    box-shadow: 0 1rem 2rem color-mix(in srgb, var(--admin-primary-accent, var(--user-story-accent)) 35%, transparent);
     text-decoration: none;
 }
 

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -26,7 +26,7 @@
     --user-story-input-border: rgba(15, 23, 42, 0.15);
     --user-story-checkbox-border: rgba(15, 23, 42, 0.25);
     --user-story-muted: rgba(15, 23, 42, 0.6);
-    --user-story-focus-ring: color-mix(in srgb, var(--site-support) 30%, transparent);
+    --user-story-focus-ring: rgba(132, 204, 22, 0.35);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.12);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.35);
     --user-story-alert-success-fg: #047857;
@@ -402,7 +402,7 @@ body.chat-open {
     --user-story-input-border: rgba(148, 163, 184, 0.35);
     --user-story-checkbox-border: rgba(148, 163, 184, 0.35);
     --user-story-muted: rgba(148, 163, 184, 0.85);
-    --user-story-focus-ring: rgba(59, 130, 246, 0.45);
+    --user-story-focus-ring: rgba(163, 230, 53, 0.45);
     --user-story-alert-success-bg: rgba(34, 197, 94, 0.16);
     --user-story-alert-success-border: rgba(34, 197, 94, 0.45);
     --user-story-alert-success-fg: #22c55e;
@@ -777,6 +777,13 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     order: 2;
 }
 
+.user-story-toggle,
+.user-story-overlay {
+    --user-story-accent: #84cc16;
+    --user-story-accent-strong: #bef264;
+    --user-story-accent-text: #1f2937;
+}
+
 .user-story-toggle {
     position: fixed;
     right: 1.75rem;
@@ -785,8 +792,8 @@ body:not(.login) .badge-unknown {background-color:#6c757d;}
     height: 3rem;
     border-radius: 50%;
     border: 0;
-    background: linear-gradient(135deg, var(--site-support), var(--site-support-strong));
-    color: var(--site-support-icon);
+    background: linear-gradient(135deg, var(--user-story-accent), var(--user-story-accent-strong));
+    color: var(--user-story-accent-text);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -879,7 +886,7 @@ body.user-story-open {
 
 .user-story-card .user-story-title {
     margin-bottom: 0.25rem;
-    color: var(--site-support);
+    color: var(--user-story-accent);
 }
 
 .user-story-card .user-story-subtitle {
@@ -898,8 +905,8 @@ body.user-story-open {
     border-radius: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.02em;
-    background: linear-gradient(135deg, var(--site-support), var(--site-support-strong));
-    color: var(--site-support-icon);
+    background: linear-gradient(135deg, var(--user-story-accent), var(--user-story-accent-strong));
+    color: var(--user-story-accent-text);
     cursor: pointer;
     transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
 }
@@ -907,7 +914,7 @@ body.user-story-open {
 .user-story-card .user-story-submit:hover,
 .user-story-card .user-story-submit:focus-visible {
     transform: translateY(-1px);
-    box-shadow: 0 1rem 2rem rgba(21, 128, 61, 0.35);
+    box-shadow: 0 1rem 2rem rgba(132, 204, 22, 0.35);
     text-decoration: none;
 }
 
@@ -962,7 +969,7 @@ body.user-story-open {
 
 .user-story-card .user-story-input:focus,
 .user-story-card textarea:focus {
-    border-color: var(--site-support);
+    border-color: var(--user-story-accent);
     box-shadow: 0 0 0 0.2rem var(--user-story-focus-ring);
     outline: none;
 }
@@ -986,7 +993,7 @@ body.user-story-open {
 }
 
 .user-story-card .form-check-input:focus {
-    border-color: var(--site-support);
+    border-color: var(--user-story-accent);
     box-shadow: 0 0 0 0.2rem var(--user-story-focus-ring);
 }
 
@@ -1109,11 +1116,11 @@ body.user-story-open {
 .user-story-rating label:hover,
 .user-story-rating label:focus-visible,
 .user-story-rating label:hover ~ label {
-    color: var(--site-support-strong);
+    color: var(--user-story-accent-strong);
 }
 
 .user-story-rating input:checked ~ label {
-    color: var(--site-support);
+    color: var(--user-story-accent);
 }
 
 .user-story-rating label:active {


### PR DESCRIPTION
### Motivation

- Make the feedback star toggle, rating highlights, and primary action in the feedback form use brighter green/yellow-lime tones so the widget reads as more vivid and closer to lime/yellow than the previous deeper green.

### Description

- Added new feedback-specific CSS tokens (`--user-story-accent`, `--user-story-accent-strong`, `--user-story-accent-text`) and applied them to the public feedback widget styles in `apps/sites/static/pages/css/base.css` so the floating star toggle, submit button, and rating states use the new palette.
- Updated the admin feedback widget styles in `apps/sites/static/sites/css/admin/base_site.css` to use the same accent tokens for the admin variant of the widget, including submit button, star hover/selected states, and focus visuals.
- Adjusted feedback focus-ring variables for both the light and dark admin themes so focus outlines align with the brighter accent direction instead of the former tone.
- Scoped changes to `user-story-*` classes and variables so broader site and admin accent tokens remain unchanged.

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only` which completed successfully.
- Ran the widget unit tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_feedback_form.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea45b11a908326871341240a7084e6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR brightens the feedback widget accents to use lime/yellow-green tones and extends the dependency submission workflow with additional retry attempts to address transient API failures.

### Key Changes

**Feedback Widget Color Palette Update**
- Introduced three new feedback-specific CSS tokens (`--user-story-accent`, `--user-story-accent-strong`, `--user-story-accent-text`) with theme-aware values:
  - Light mode: darker lime green (#4d7c0f) for contrast
  - Dark mode: bright lime yellow (#84cc16) for vividity
- Applied these tokens across public feedback widget (floating star toggle, submit button, rating star states) in `apps/sites/static/pages/css/base.css`
- Applied same tokens to admin feedback widget in `apps/sites/static/sites/css/admin/base_site.css` with updated focus-ring computation via `color-mix`
- Scoped changes to user-story-specific classes and variables to avoid affecting broader site/admin accent tokens

**Dependency Submission Workflow Enhancement**
- Extended submission retry flow from 3 to 5 attempts in `.github/workflows/dependency-submission.yml`
- Added extended backoff delays between new retry attempts: 90 seconds before attempt 4, 120 seconds before attempt 5
- Updated failure tracking step to depend on the final attempt (attempt 5) instead of the third attempt
- Maintains non-blocking workflow configuration to tolerate transient GitHub Dependency Graph API errors

### Testing
- Widget unit tests (5 passed): `apps/sites/tests/test_user_story_feedback_form.py`
- Dependencies bootstrapped via `./env-refresh.sh --deps-only`

### Motivation
Brighten feedback widget visuals for increased prominence and better UX, while adding resilience to transient dependency submission service outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->