### PR TITLE
Remove hardcoded DEFAULT_ADMIN_EMAIL and add `configure.sh --email` to persist admin email

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -138,7 +138,7 @@ ASGI_APPLICATION = "config.asgi.application"
 # Email settings
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 DEFAULT_ADMIN_EMAIL = os.environ.get(
-    "DEFAULT_ADMIN_EMAIL", "tecnologia@gelectriic.com"
+    "DEFAULT_ADMIN_EMAIL", ""
 ).strip()
 DEFAULT_ADMIN_USERNAME = (
     os.environ.get("DEFAULT_ADMIN_USERNAME", "arthexis").strip() or "arthexis"

--- a/configure.sh
+++ b/configure.sh
@@ -45,11 +45,12 @@ FEATURE_SLUG=""
 FEATURE_KIND=""
 FEATURE_MODE=""
 FEATURE_PARAM_SPEC=""
+ADMIN_EMAIL=""
 
 LOCK_DIR="$BASE_DIR/.locks"
 
 usage() {
-    echo "Usage: $0 [--service NAME] [--port PORT] [--latest|--stable|--regular|--normal|--unstable] [--fixed] [--check] [--auto-upgrade|--no-auto-upgrade] [--debug|--no-debug] [--celery|--no-celery] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--feature SLUG [--kind suite|node] [--enabled|--disabled]] [--feature-param FEATURE:KEY=VALUE] [--satellite|--terminal|--control|--watchtower] [--repair [--failover ROLE]]" >&2
+    echo "Usage: $0 [--service NAME] [--port PORT] [--latest|--stable|--regular|--normal|--unstable] [--fixed] [--check] [--auto-upgrade|--no-auto-upgrade] [--debug|--no-debug] [--celery|--no-celery] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--feature SLUG [--kind suite|node] [--enabled|--disabled]] [--feature-param FEATURE:KEY=VALUE] [--email ADMIN_EMAIL] [--satellite|--terminal|--control|--watchtower] [--repair [--failover ROLE]]" >&2
     exit 1
 }
 
@@ -57,6 +58,53 @@ write_debug_env() {
     cat > "$BASE_DIR/debug.env" <<EOF
 DEBUG=$1
 EOF
+}
+
+write_default_admin_email_env() {
+    local email="$1"
+    local env_file="$BASE_DIR/arthexis.env"
+    local python_bin=""
+
+    if [ -x "$BASE_DIR/.venv/bin/python" ]; then
+        python_bin="$BASE_DIR/.venv/bin/python"
+    elif command -v python3 >/dev/null 2>&1; then
+        python_bin="$(command -v python3)"
+    else
+        echo "Python 3 is required to configure DEFAULT_ADMIN_EMAIL." >&2
+        exit 1
+    fi
+
+    if [ -z "$email" ] || [[ "$email" =~ [[:space:]] ]]; then
+        echo "--email requires a non-empty email address without spaces." >&2
+        usage
+    fi
+
+    "$python_bin" - "$env_file" "$email" <<'PYCODE'
+from pathlib import Path
+import sys
+
+env_file = Path(sys.argv[1])
+email = sys.argv[2].strip()
+key = "DEFAULT_ADMIN_EMAIL"
+prefix = f"{key}="
+
+lines: list[str] = []
+if env_file.exists():
+    lines = env_file.read_text(encoding="utf-8").splitlines()
+
+updated = False
+for index, line in enumerate(lines):
+    stripped = line.strip()
+    if stripped.startswith(prefix):
+        lines[index] = f"{prefix}{email}"
+        updated = True
+        break
+
+if not updated:
+    lines.append(f"{prefix}{email}")
+
+env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PYCODE
 }
 
 apply_rfid_service_setting() {
@@ -592,6 +640,11 @@ while [[ $# -gt 0 ]]; do
             FEATURE_PARAM_SPEC="$2"
             shift 2
             ;;
+        --email)
+            [ -z "$2" ] && usage
+            ADMIN_EMAIL="$2"
+            shift 2
+            ;;
         --satellite)
             NODE_ROLE="Satellite"
             ENABLE_CELERY=true
@@ -661,7 +714,7 @@ if [ "$REPAIR" = true ]; then
        [ -n "$AUTO_UPGRADE_MODE" ] || [ -n "$DEBUG_MODE" ] || [ -n "$UPGRADE_CHANNEL" ] || \
        [ -n "$RFID_SERVICE_MODE" ] || [ -n "$CAMERA_SERVICE_MODE" ] || [ -n "$BOOT_UPGRADE_MODE" ] || [ -n "$CELERY_MODE" ] || \
        [ -n "$LCD_SCREEN_MODE" ] || [ -n "$FEATURE_SLUG" ] || [ -n "$FEATURE_MODE" ] || \
-       [ -n "$FEATURE_KIND" ] || [ -n "$FEATURE_PARAM_SPEC" ]; then
+       [ -n "$FEATURE_KIND" ] || [ -n "$FEATURE_PARAM_SPEC" ] || [ -n "$ADMIN_EMAIL" ]; then
         echo "--repair cannot be combined with other options" >&2
         usage
     fi
@@ -723,6 +776,7 @@ if [ "$CHECK" = true ]; then
        [ -n "$DEBUG_MODE" ] || [ -n "$UPGRADE_CHANNEL" ] || [ -n "$RFID_SERVICE_MODE" ] || \
        [ -n "$CAMERA_SERVICE_MODE" ] || [ -n "$BOOT_UPGRADE_MODE" ] || [ -n "$CELERY_MODE" ] || [ -n "$LCD_SCREEN_MODE" ] || \
        [ -n "$FEATURE_SLUG" ] || [ -n "$FEATURE_MODE" ] || [ -n "$FEATURE_KIND" ] || \
+       [ -n "$ADMIN_EMAIL" ] || \
        [ -n "$FEATURE_PARAM_SPEC" ]; then
         echo "--check cannot be combined with other options" >&2
         usage
@@ -884,6 +938,12 @@ if [ -n "$FEATURE_PARAM_SPEC" ] && [ -z "$NODE_ROLE" ]; then
         usage
     fi
     run_feature_param_set "$feature_part" "$feature_key" "$feature_value"
+fi
+
+if [ -n "$ADMIN_EMAIL" ] && [ -z "$NODE_ROLE" ]; then
+    ACTION_PERFORMED=true
+    write_default_admin_email_env "$ADMIN_EMAIL"
+    echo "Default admin email configured for upgrade notifications."
 fi
 
 if [ -n "$AUTO_UPGRADE_MODE" ] && [ -z "$NODE_ROLE" ]; then

--- a/configure.sh
+++ b/configure.sh
@@ -88,7 +88,7 @@ email = sys.argv[2].strip()
 key = "DEFAULT_ADMIN_EMAIL"
 prefix = f"{key}="
 
-lines: list[str] = []
+lines = []
 if env_file.exists():
     lines = env_file.read_text(encoding="utf-8").splitlines()
 
@@ -940,7 +940,7 @@ if [ -n "$FEATURE_PARAM_SPEC" ] && [ -z "$NODE_ROLE" ]; then
     run_feature_param_set "$feature_part" "$feature_key" "$feature_value"
 fi
 
-if [ -n "$ADMIN_EMAIL" ] && [ -z "$NODE_ROLE" ]; then
+if [ -n "$ADMIN_EMAIL" ]; then
     ACTION_PERFORMED=true
     write_default_admin_email_env "$ADMIN_EMAIL"
     echo "Default admin email configured for upgrade notifications."

--- a/docs/development/install-lifecycle-scripts-manual.md
+++ b/docs/development/install-lifecycle-scripts-manual.md
@@ -143,6 +143,7 @@ Both supported backends emit a consistent reconciliation report that includes co
 | `--kind suite|node` | Scope for `--feature`. |
 | `--enabled`, `--disabled` | Enable/disable selected feature. |
 | `--feature-param FEATURE:KEY=VALUE` | Set feature metadata parameter. |
+| `--email ADMIN_EMAIL` | Set `DEFAULT_ADMIN_EMAIL` in `arthexis.env` for upgrade notifications. |
 | `--satellite`, `--terminal`, `--control`, `--watchtower` | Set role profile and associated defaults. |
 | `--check` | Print current role/port/upgrade/debug/feature state. |
 | `--repair` | Restore lock state from existing role and lock files. |


### PR DESCRIPTION
### Motivation
- Prevent automatic fallback to a developer-controlled hardcoded admin email that caused temporary admin passwords to be emailed to an unsafe address.
- Make the admin notification address an explicit operator configuration instead of a hidden default.
- Provide an operational way to set the admin email via the existing lifecycle tooling so deployments can persist the value consistently.

### Description
- Removed the hardcoded fallback `DEFAULT_ADMIN_EMAIL = "tecnologia@gelectriic.com"` so `DEFAULT_ADMIN_EMAIL` now defaults to an empty string unless provided via environment. (`config/settings/base.py`).
- Added a `--email ADMIN_EMAIL` option to `configure.sh` which validates the value and writes `DEFAULT_ADMIN_EMAIL=<email>` into `arthexis.env` (script: `configure.sh`).
- Updated `configure.sh` usage text and its option parsing to include `--email`, and added `write_default_admin_email_env()` implementation to persist the env value into `arthexis.env`.
- Documented the new flag in the lifecycle scripts manual (`docs/development/install-lifecycle-scripts-manual.md`).

### Testing
- Ran dependency bootstrap with `./env-refresh.sh --deps-only`, which completed successfully.
- Ran unit tests with `.venv/bin/python manage.py test run -- apps/core/tests/test_upgrade_notifications.py apps/users/tests/test_system_user.py`, and all tests passed (`7 passed`).
- Performed a syntax check on the modified script with `bash -n configure.sh`, which reported no syntax errors.
- Attempted a runtime smoke test `./configure.sh --email security@example.com` but the container execution policy blocked running the command, so the script behavior was validated via static checks and unit tests only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea44ee08688326a00ccc00c4f855e6)