### PR TITLE
ci: stabilize install-hourly Python version and invocation

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/setup-python@v6
         id: setup-python
         with:
-          python-version: '3.13'
+          python-version: '3.12'
       - name: Cache pip
         uses: actions/cache@v5
         with:
@@ -170,10 +170,10 @@ jobs:
             venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.role }}-${{ steps.setup-python.outputs.python-version }}-
       - name: Validate pyproject dependency ordering
         run: |
-          python "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check
+          python3 "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check
       - name: Validate generated requirements
         run: |
-          python "$GITHUB_WORKSPACE/scripts/generate_requirements.py" --check
+          python3 "$GITHUB_WORKSPACE/scripts/generate_requirements.py" --check
       - name: Install redis CLI
         if: ${{ matrix.role == 'control' || matrix.role == 'satellite' || matrix.role == 'watchtower' }}
         run: |


### PR DESCRIPTION
### Motivation
- The hourly "Install Health Check" matrix was repeatedly failing in containerized Debian/Ubuntu runs because container images do not always provide a `python` alias and Python 3.13 introduced instability for this path, so the workflow needs to run a known-good interpreter and call it explicitly.

### Description
- Updated `.github/workflows/install-hourly.yml` to use `python-version: '3.12'` and to invoke the validation scripts with `python3` (`scripts/sort_pyproject_deps.py` and `scripts/generate_requirements.py`).

### Testing
- Ran `python3 scripts/sort_pyproject_deps.py --check` which printed "pyproject.toml dependencies are normalized" and exited successfully. 
- Ran `python3 scripts/generate_requirements.py --check` which printed "requirements.txt and requirements-ci.txt are up to date" and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4df4ae688326a8f61b28cf917ca0)