### PR TITLE
Bound the upgrade safety gate to upgrade-smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ env:
   NODE_OPTIONS: '--no-deprecation'
   ARTHEXIS_DB_BACKEND: sqlite
   PYTEST_WORKERS: 'auto'
+  UPGRADE_GATE_MARKER: gate_upgrade
 
 concurrency:
   group: upgrade-gate-${{ github.ref }}
@@ -96,7 +97,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh', 'upgrade.sh') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh', 'env-refresh.sh', 'upgrade.sh') }}
           restore-keys: |
             venv-${{ runner.os }}-
 
@@ -110,15 +111,13 @@ jobs:
         run: |
           python "$GITHUB_WORKSPACE/scripts/generate_requirements.py" --check
 
+      # install.sh already performs env-refresh.sh --install-and-refresh.
+      # Keep CI on that single bootstrap path so the gate does not add a
+      # standalone refresh pass with slightly different environment behavior.
       - name: Install suite from repository
         id: install_suite
         run: |
           ./install.sh --no-start
-
-      - name: Refresh environment dependencies
-        id: refresh_dependencies
-        run: |
-          ./env-refresh.sh
 
       - name: Install CI dependencies
         id: install_ci_dependencies
@@ -169,7 +168,7 @@ jobs:
           ./scripts/preflight-env.sh --pytest
           source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
-          python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 | tee pytest.log
+          python -m pytest "${xdist_args[@]}" -m "${UPGRADE_GATE_MARKER}" --maxfail=1 --disable-warnings -q --timeout=180 | tee pytest.log
 
       - name: Summarize failure context
         if: failure()
@@ -183,7 +182,6 @@ jobs:
               ("Validate pyproject dependency ordering", "${{ steps.validate_pyproject_ordering.conclusion }}"),
               ("Validate generated requirements", "${{ steps.validate_generated_requirements.conclusion }}"),
               ("Install suite from repository", "${{ steps.install_suite.conclusion }}"),
-              ("Refresh environment dependencies", "${{ steps.refresh_dependencies.conclusion }}"),
               ("Install CI dependencies", "${{ steps.install_ci_dependencies.conclusion }}"),
               ("Verify editable install import", "${{ steps.verify_editable_install.conclusion }}"),
               ("Apply upgrade smoke path", "${{ steps.apply_upgrade_smoke.conclusion }}"),

--- a/apps/core/tests/test_runserver_preflight.py
+++ b/apps/core/tests/test_runserver_preflight.py
@@ -7,6 +7,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+from gate_markers import gate
+
+
+pytestmark = [gate.upgrade]
+
 
 def _write_fake_manage(path: Path) -> None:
     path.write_text(

--- a/apps/core/tests/test_startup_orchestrate_command.py
+++ b/apps/core/tests/test_startup_orchestrate_command.py
@@ -7,6 +7,10 @@ from types import SimpleNamespace
 from django.core.management import call_command
 
 from apps.core.management.commands.startup_orchestrate import Command
+from gate_markers import gate
+
+
+pytestmark = [gate.upgrade]
 
 
 def _invoke_startup_orchestrate(

--- a/apps/services/tests/test_lifecycle_reconcile.py
+++ b/apps/services/tests/test_lifecycle_reconcile.py
@@ -8,20 +8,27 @@ import pytest
 from django.core.management import call_command
 from django.test import override_settings
 
+from gate_markers import gate
 from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
 from apps.services.lifecycle import write_lifecycle_config
 from apps.services.models import LifecycleService
 
 
+pytestmark = [gate.upgrade]
+
+
 @pytest.mark.django_db
 @override_settings(BASE_DIR="/tmp")
-def test_write_lifecycle_config_reconciles_camera_lock_from_feature_assignment(tmp_path, settings):
+def test_write_lifecycle_config_reconciles_camera_lock_from_feature_assignment(
+    monkeypatch, tmp_path, settings
+):
     """Feature-activated camera service should drive lockfile and unit lock output."""
 
     settings.BASE_DIR = tmp_path
     lock_dir = tmp_path / ".locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
     (lock_dir / "service.lck").write_text("suite", encoding="utf-8")
+    monkeypatch.setattr(Node, "_detect_auto_feature", lambda self, slug, **kwargs: False)
 
     node = Node.objects.create(
         hostname="suite-node",
@@ -67,15 +74,6 @@ def test_reconcile_node_features_services_command_uses_auto_detection(monkeypatc
     lock_dir.mkdir(parents=True, exist_ok=True)
     (lock_dir / "service.lck").write_text("suite", encoding="utf-8")
 
-    Node.objects.create(
-        hostname="auto-video-node",
-        mac_address=Node.get_current_mac(),
-        current_relation=Node.Relation.SELF,
-        public_endpoint="auto-video-node",
-        base_path=str(tmp_path),
-    )
-    NodeFeature.objects.create(slug="video-cam", display="Video Camera")
-
     LifecycleService.objects.update_or_create(
         slug="camera-service",
         defaults={
@@ -92,6 +90,15 @@ def test_reconcile_node_features_services_command_uses_auto_detection(monkeypatc
         "_detect_auto_feature",
         lambda self, slug, **kwargs: slug == "video-cam",
     )
+
+    Node.objects.create(
+        hostname="auto-video-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="auto-video-node",
+        base_path=str(tmp_path),
+    )
+    NodeFeature.objects.create(slug="video-cam", display="Video Camera")
 
     call_command("reconcile_node_features_services")
 

--- a/apps/services/tests/test_lifecycle_reconcile.py
+++ b/apps/services/tests/test_lifecycle_reconcile.py
@@ -8,11 +8,11 @@ import pytest
 from django.core.management import call_command
 from django.test import override_settings
 
-from gate_markers import gate
+from apps.nodes.feature_detection import node_feature_detection_registry
 from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
 from apps.services.lifecycle import write_lifecycle_config
 from apps.services.models import LifecycleService
-
+from gate_markers import gate
 
 pytestmark = [gate.upgrade]
 
@@ -28,7 +28,9 @@ def test_write_lifecycle_config_reconciles_camera_lock_from_feature_assignment(
     lock_dir = tmp_path / ".locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
     (lock_dir / "service.lck").write_text("suite", encoding="utf-8")
-    monkeypatch.setattr(Node, "_detect_auto_feature", lambda self, slug, **kwargs: False)
+    monkeypatch.setattr(
+        node_feature_detection_registry, "detect", lambda slug, **kwargs: False
+    )
 
     node = Node.objects.create(
         hostname="suite-node",
@@ -66,7 +68,9 @@ def test_write_lifecycle_config_reconciles_camera_lock_from_feature_assignment(
 
 @pytest.mark.django_db
 @override_settings(BASE_DIR="/tmp")
-def test_reconcile_node_features_services_command_uses_auto_detection(monkeypatch, tmp_path, settings):
+def test_reconcile_node_features_services_command_uses_auto_detection(
+    monkeypatch, tmp_path, settings
+):
     """Reconciliation command should refresh auto features before lifecycle writes."""
 
     settings.BASE_DIR = tmp_path
@@ -86,9 +90,9 @@ def test_reconcile_node_features_services_command_uses_auto_detection(monkeypatc
     )
 
     monkeypatch.setattr(
-        Node,
-        "_detect_auto_feature",
-        lambda self, slug, **kwargs: slug == "video-cam",
+        node_feature_detection_registry,
+        "detect",
+        lambda slug, **kwargs: slug == "video-cam",
     )
 
     Node.objects.create(
@@ -103,5 +107,7 @@ def test_reconcile_node_features_services_command_uses_auto_detection(monkeypatc
     call_command("reconcile_node_features_services")
 
     assert (lock_dir / "camera-service.lck").exists()
-    payload = json.loads((lock_dir / "lifecycle_services.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        (lock_dir / "lifecycle_services.json").read_text(encoding="utf-8")
+    )
     assert "camera-suite.service" in payload["systemd_units"]

--- a/apps/sites/tests/test_upgrade_gate_smoke.py
+++ b/apps/sites/tests/test_upgrade_gate_smoke.py
@@ -1,23 +1,46 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import pytest
 from django.urls import reverse
 
 from gate_markers import gate
 
-
 pytestmark = [pytest.mark.django_db, gate.upgrade]
+
+
+def _response_contexts(response) -> Iterable:
+    """Yield response contexts in a normalized iterable form."""
+
+    contexts = response.context
+    if contexts is None:
+        return []
+    if isinstance(contexts, list):
+        return contexts
+    return [contexts]
+
+
+def _assert_username_field_present(response) -> None:
+    assert response.status_code == 200
+
+    for context in _response_contexts(response):
+        form = context.get("form") if hasattr(context, "get") else None
+        if form is not None and "username" in form.fields:
+            return
+
+    raise AssertionError(
+        "Expected a login form exposing a username field in response context."
+    )
 
 
 def test_public_login_route_renders(client):
     response = client.get(reverse("pages:login"))
 
-    assert response.status_code == 200
-    assert 'name="username"' in response.content.decode()
+    _assert_username_field_present(response)
 
 
 def test_admin_login_route_renders(client):
     response = client.get(reverse("admin:login"))
 
-    assert response.status_code == 200
-    assert 'name="username"' in response.content.decode()
+    _assert_username_field_present(response)

--- a/apps/sites/tests/test_upgrade_gate_smoke.py
+++ b/apps/sites/tests/test_upgrade_gate_smoke.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+from gate_markers import gate
+
+
+pytestmark = [pytest.mark.django_db, gate.upgrade]
+
+
+def test_public_login_route_renders(client):
+    response = client.get(reverse("pages:login"))
+
+    assert response.status_code == 200
+    assert 'name="username"' in response.content.decode()
+
+
+def test_admin_login_route_renders(client):
+    response = client.get(reverse("admin:login"))
+
+    assert response.status_code == 200
+    assert 'name="username"' in response.content.decode()

--- a/gate_markers.py
+++ b/gate_markers.py
@@ -1,0 +1,18 @@
+"""Shared pytest gate marker helpers.
+
+Pytest marker names must be valid identifiers, so the ``gate.upgrade`` syntax
+used in test modules maps to the registered ``gate_upgrade`` marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _GateMarkers:
+    upgrade = pytest.mark.gate_upgrade
+
+
+gate = _GateMarkers()
+
+__all__ = ["gate"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ norecursedirs =
     node_modules
     venv
 markers =
+    gate_upgrade: blocks upgrade regressions that would leave installs crashing, stalled, or unusable after upgrade
     sigil_roots: loads SigilRoot fixtures for tests that require default sigils
 filterwarnings =
     # Temporary global suppression for websocket live-server runs; local markers

--- a/tests/test_env_refresh_migration_mismatch.py
+++ b/tests/test_env_refresh_migration_mismatch.py
@@ -10,7 +10,11 @@ import pytest
 
 from django.core.management.base import CommandError
 
+from gate_markers import gate
 from utils.migration_branches import BranchTagConflictError
+
+
+pytestmark = [gate.upgrade]
 
 
 @pytest.fixture

--- a/tests/test_manage_embedded_celery.py
+++ b/tests/test_manage_embedded_celery.py
@@ -5,6 +5,10 @@ import subprocess
 from pathlib import Path
 
 import manage
+from gate_markers import gate
+
+
+pytestmark = [gate.upgrade]
 
 
 def test_service_mode_allows_embedded_celery_by_default(tmp_path: Path) -> None:

--- a/tests/test_migration_reconcile.py
+++ b/tests/test_migration_reconcile.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 
+from gate_markers import gate
 from scripts.helpers.migration_reconcile import reconcile_sqlite_tables
+
+
+pytestmark = [gate.upgrade]
 
 
 def _exec_many(db_path: Path, statements: list[str]) -> None:

--- a/tests/test_startup_orchestration.py
+++ b/tests/test_startup_orchestration.py
@@ -4,7 +4,11 @@ import json
 
 import pytest
 
+from gate_markers import gate
 from scripts.startup_orchestration import extract_payload
+
+
+pytestmark = [gate.upgrade]
 
 
 def test_extract_payload_reads_last_json_object() -> None:


### PR DESCRIPTION
## Summary
- add a `gate.upgrade` test namespace backed by the `gate_upgrade` pytest marker
- mark a curated set of migration, startup, reconciliation, and reachability tests for the required upgrade lane
- run only that marker in the required upgrade gate and drop the standalone CI `env-refresh.sh` pass because `install.sh` already performs the bootstrap refresh
- keep the environment-sensitive script change narrow by leaving the install and upgrade scripts themselves alone, aside from tightening one lifecycle test that was hanging in unrelated Playwright auto-detection

Closes #7343

## Testing
- `cd /home/arthe/prototype && source .venv/bin/activate && python -m pytest -m gate_upgrade --maxfail=1 --disable-warnings -q`
  - `28 passed, 3 skipped, 1384 deselected, 2 warnings in 43.12s`
  - shell timing: `elapsed=59.235`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements a focused upgrade safety gate by introducing an explicit `gate.upgrade` pytest marker that bounds upgrade-smoke coverage to essential migration, startup, reconciliation, and reachability tests.

## Key Changes

**New Marker System:**
- Created `gate_markers.py` module that provides a `gate` object with `gate.upgrade` attribute mapping to `pytest.mark.gate_upgrade`
- Registered the `gate_upgrade` marker in `pytest.ini`

**Marked Test Modules for Upgrade Gate:**
- `tests/test_env_refresh_migration_mismatch.py` — migration validation tests
- `tests/test_startup_orchestration.py` — startup orchestration tests
- `tests/test_migration_reconcile.py` — migration reconciliation tests
- `tests/test_manage_embedded_celery.py` — celery management tests
- `apps/core/tests/test_startup_orchestrate_command.py` — Django startup command tests
- `apps/core/tests/test_runserver_preflight.py` — runserver preflight tests
- `apps/services/tests/test_lifecycle_reconcile.py` — lifecycle reconciliation tests with updated mocking strategy

**New Smoke Test:**
- `apps/sites/tests/test_upgrade_gate_smoke.py` — adds Django smoke tests for post-upgrade reachability, verifying public and admin login routes render correctly with proper form context

**CI Workflow Updates:**
- Removed standalone `env-refresh.sh` CI step, consolidating bootstrap refresh into the `install.sh` flow
- Updated cache key to include `env-refresh.sh` hash
- Configured the upgrade gate to run `pytest -m gate_upgrade`, selecting only the marked tests

**Lifecycle Test Tightening:**
- Modified `apps/services/tests/test_lifecycle_reconcile.py` to mock `node_feature_detection_registry.detect` instead of `Node._detect_auto_feature` and adjust mock application timing to prevent test hangs

## Testing
Local validation: `pytest -m gate_upgrade` resulted in **28 passed, 3 skipped, 1384 deselected**

## Related
Closes issue #7343

<!-- end of auto-generated comment: release notes by coderabbit.ai -->