### PR TITLE
Restore admin login header badges while keeping clock hidden

### DIFF
--- a/apps/sites/templates/admin/base_site.html
+++ b/apps/sites/templates/admin/base_site.html
@@ -565,6 +565,7 @@ document.addEventListener('DOMContentLoaded', function () {
   <h1 id="site-name">
     <a href="{% url 'admin:index' %}"><span id="server-clock"></span></a>
   </h1>
+{% endif %}
   <div id="site-badges">
     {% for admin_badge in admin_badges %}
       <span class="badge {% if not admin_badge.is_present %}badge-unknown{% endif %}" style="background-color: {{ admin_badge.color }};">
@@ -582,7 +583,6 @@ document.addEventListener('DOMContentLoaded', function () {
       </span>
     {% endfor %}
   </div>
-{% endif %}
 {% endblock %}
 {% block userlinks %}
   {% include "admin/includes/user_tools.html" %}


### PR DESCRIPTION
### Motivation
- Bring back the three admin header badges inside the admin login box while preserving the existing behavior that hides the server clock on the login page.

### Description
- Render `#site-badges` on the login view by adjusting the `branding` block in `apps/sites/templates/admin/base_site.html` so the `if` guard only hides `#site-name`/`#server-clock` and no longer prevents the badges from rendering.

### Testing
- Attempted to run `python manage.py test run -- apps/sites/tests/test_login_view.py`, but the test invocation failed in this environment due to a missing virtualenv Python (`missing_venv_python` remediation); no repository tests were executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa6e061b8832696f33ce60a221eb2)