### PR TITLE
imager: use guestfish rm-f for stale recovery cleanup

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -544,7 +544,7 @@ def _guestfish_mkdir_p(image_path: Path, remote_path: str) -> None:
 def _guestfish_remove_file(image_path: Path, remote_path: str) -> None:
     """Remove a file from the disk image using guestfish, ignoring missing paths."""
 
-    script = f'sh "rm -f -- {remote_path}"\n'
+    script = f"rm-f {shlex.quote(remote_path)}\n"
     result = subprocess.run(
         ["guestfish", "--rw", "-a", str(image_path), "-i"],
         input=script,

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -20,6 +20,7 @@ from apps.imager.services import (
     _build_download_uri,
     _customize_image,
     _download_remote_base_image,
+    _guestfish_remove_file,
     _resolve_root_disk_path,
     _validate_remote_base_image_url,
     build_rpi4b_image,
@@ -105,6 +106,19 @@ def test_resolve_root_disk_path_walks_to_disk_parent() -> None:
         root_disk = _resolve_root_disk_path()
 
     assert root_disk == "/dev/nvme0n1"
+
+
+def test_guestfish_remove_file_uses_architecture_neutral_rm_f(tmp_path: Path) -> None:
+    """Regression: stale-file cleanup should not depend on guest /bin/sh architecture."""
+
+    image_path = tmp_path / "image.img"
+    image_path.write_bytes(b"img")
+    result = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch("apps.imager.services.subprocess.run", return_value=result) as run_mock:
+        _guestfish_remove_file(image_path, "/etc/ssh/sshd_config.d/20-arthexis-recovery.conf")
+
+    assert run_mock.call_args.kwargs["input"] == "rm-f /etc/ssh/sshd_config.d/20-arthexis-recovery.conf\n"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation

- Avoid invoking the guest shell when removing stale recovery files because `sh "rm -f -- ..."` requires a compatible guest `/bin/sh` and can fail when building ARM images on x86 hosts.

### Description

- Replace guest-shell cleanup in `_guestfish_remove_file` with a native guestfish `rm-f` invocation (`rm-f {remote_path}`).
- Add a regression test `test_guestfish_remove_file_uses_architecture_neutral_rm_f` in `apps/imager/tests/test_imager_command.py` that asserts the guestfish command payload uses `rm-f` (architecture-neutral) rather than `sh` execution.
- Files changed: `apps/imager/services.py` and `apps/imager/tests/test_imager_command.py`.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and ran the imager test suite target with `.venv/bin/python manage.py test run -- apps/imager/tests/test_imager_command.py`.
- Test results: the targeted test module passed (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa86a0ea083268e2ec84616fca727)