### PR TITLE
Add admin wizard to import Odoo templates, products and employees

### DIFF
--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -1,11 +1,10 @@
 import logging
-import socket
 from xmlrpc.client import Fault, ProtocolError
 
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -104,27 +103,10 @@ class OdooTemplateSetupCreateForm(forms.Form):
         self.fields["products"].queryset = OdooProduct.objects.order_by("name")
         self.fields["employees"].queryset = OdooEmployee.objects.order_by("username")
 
-    @staticmethod
-    def _resolve_unique_factor_code(name_prefix: str) -> str:
-        base_code = slugify(f"{name_prefix} Products")[:64] or "setup-template-products"
-        if not OdooSaleFactor.objects.filter(code=base_code).exists():
-            return base_code
-
-        max_base_length = 64 - len("-99")
-        trimmed_base = base_code[:max_base_length]
-        counter = 2
-        while counter < 100:
-            candidate = f"{trimmed_base}-{counter}"
-            if not OdooSaleFactor.objects.filter(code=candidate).exists():
-                return candidate
-            counter += 1
-        raise ValidationError(_("Unable to generate a unique sale factor code."))
-
     def clean(self):
         cleaned_data = super().clean()
         name_prefix = (cleaned_data.get("name_prefix") or "").strip() or "Setup Template"
         cleaned_data["name_prefix"] = name_prefix
-        cleaned_data["factor_code"] = self._resolve_unique_factor_code(name_prefix)
         return cleaned_data
 
 
@@ -471,7 +453,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         return reverse("admin:odoo_odoosaleordertemplate_setup_templates_create")
 
     def get_dashboard_actions(self, request):
-        if not self.has_change_permission(request):
+        if not self._can_access_setup_wizard(request):
             return []
         return ["setup_templates"]
 
@@ -479,10 +461,15 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         extra_context = extra_context or {}
         links = list(extra_context.get("public_view_links") or [])
         setup_url = self._setup_templates_url()
-        if not any(link.get("url") == setup_url for link in links):
+        if self._can_access_setup_wizard(request) and not any(
+            link.get("url") == setup_url for link in links
+        ):
             links.append({"label": self.setup_templates.label, "url": setup_url})
         extra_context["public_view_links"] = links
         return super().changelist_view(request, extra_context=extra_context)
+
+    def _can_access_setup_wizard(self, request) -> bool:
+        return self.has_change_permission(request) and self.has_add_permission(request)
 
     def _verified_profile_or_redirect(self, request):
         profile = getattr(request.user, "odoo_employee", None)
@@ -597,14 +584,21 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
 
     def _resolve_unique_username(self, base_username: str, odoo_uid: int) -> str:
         user_model = get_user_model()
+        username_field_name = user_model.USERNAME_FIELD
+        username_max_length = user_model._meta.get_field(username_field_name).max_length or 150
+        base_username = (base_username or "").strip() or f"odoo-user-{odoo_uid}"
+        base_username = base_username[:username_max_length]
         user_manager = getattr(user_model, "all_objects", user_model.objects)
-        if not user_manager.filter(username=base_username).exists():
+        if not user_manager.filter(**{username_field_name: base_username}).exists():
             return base_username
         suffix = f"-odoo-{odoo_uid}"
-        candidate = f"{base_username}{suffix}"
+        candidate = f"{base_username[: max(username_max_length - len(suffix), 1)]}{suffix}"
+        candidate = candidate[:username_max_length]
         counter = 2
-        while user_manager.filter(username=candidate).exists():
-            candidate = f"{base_username}{suffix}-{counter}"
+        while user_manager.filter(**{username_field_name: candidate}).exists():
+            counter_suffix = f"{suffix}-{counter}"
+            trimmed = base_username[: max(username_max_length - len(counter_suffix), 1)]
+            candidate = f"{trimmed}{counter_suffix}"[:username_max_length]
             counter += 1
         return candidate
 
@@ -658,7 +652,10 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         ).first()
         login = str(source_row.get("login") or "").strip()
         email = str(source_row.get("email") or "").strip()
-        username_base = login or email or f"odoo-user-{source_id}"
+        user_model = get_user_model()
+        username_field_name = user_model.USERNAME_FIELD
+        username_max_length = user_model._meta.get_field(username_field_name).max_length or 150
+        username_base = (login or email or f"odoo-user-{source_id}")[:username_max_length]
         partner_id = self._extract_partner_id(source_row)
         if existing:
             desired_username = login or existing.username
@@ -689,23 +686,23 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 existing.save(update_fields=existing_updated_fields)
             return existing, False
 
-        user_model = get_user_model()
         username = self._resolve_unique_username(username_base, source_id)
-        user = user_model.objects.create(username=username, email=email)
-        user.set_unusable_password()
-        user.save(update_fields=["password"])
+        with transaction.atomic():
+            user = user_model.objects.create(**{username_field_name: username, "email": email})
+            user.set_unusable_password()
+            user.save(update_fields=["password"])
 
-        employee = OdooEmployee.objects.create(
-            user=user,
-            host=profile.host,
-            database=profile.database,
-            username=login or username,
-            password="",
-            odoo_uid=source_id,
-            name=str(source_row.get("name") or ""),
-            email=email,
-            partner_id=partner_id,
-        )
+            employee = OdooEmployee.objects.create(
+                user=user,
+                host=profile.host,
+                database=profile.database,
+                username=login or username,
+                password="",
+                odoo_uid=source_id,
+                name=str(source_row.get("name") or ""),
+                email=email,
+                partner_id=partner_id,
+            )
         return employee, True
 
     def _import_source_selection(self, profile, source_type: str, selected_ids: list[str]) -> tuple[int, int]:
@@ -759,7 +756,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
 
         try:
             options = self._remote_options(profile, source_type)
-        except (Fault, OSError, ProtocolError, TimeoutError, socket.timeout):
+        except (Fault, OSError, ProtocolError):
             logger.exception("Could not fetch Odoo records for source_type=%s", source_type)
             self.message_user(
                 request,
@@ -784,7 +781,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                     source_type=form.cleaned_data["source_type"],
                     selected_ids=form.cleaned_data["selected_ids"],
                 )
-            except (Fault, OSError, ProtocolError, TimeoutError, socket.timeout):
+            except (Fault, OSError, ProtocolError):
                 logger.exception(
                     "Odoo import failed for source_type=%s",
                     form.cleaned_data["source_type"],
@@ -872,7 +869,16 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                         except IntegrityError:
                             continue
                     if factor is None:
-                        raise ValidationError(_("Unable to generate a unique sale factor code."))
+                        self.message_user(
+                            request,
+                            _(
+                                "Unable to generate a unique sale factor code. "
+                                "Please adjust the template name prefix and try again."
+                            ),
+                            level=messages.ERROR,
+                        )
+                        transaction.set_rollback(True)
+                        return HttpResponseRedirect(self._setup_templates_create_url())
                     factor.templates.set(created_templates)
                     for product in products:
                         OdooSaleFactorProductRule.objects.create(

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -106,11 +106,11 @@ class OdooTemplateSetupCreateForm(forms.Form):
         label=_("Products"),
         widget=forms.CheckboxSelectMultiple,
     )
-    employees = forms.ModelMultipleChoiceField(
+    employees = forms.ModelChoiceField(
         queryset=OdooEmployee.objects.none(),
         required=False,
-        label=_("Employees"),
-        widget=forms.CheckboxSelectMultiple,
+        label=_("Salesperson"),
+        help_text=_("Optionally assign one salesperson to the created templates."),
     )
 
     def __init__(self, *args, **kwargs):
@@ -130,6 +130,13 @@ class OdooTemplateSetupCreateForm(forms.Form):
                 _("Select only products imported from Odoo before creating product rules."),
             )
         return cleaned_data
+
+    def clean_employees(self):
+        if self.is_bound and hasattr(self.data, "getlist"):
+            selected_employees = [value for value in self.data.getlist(self.add_prefix("employees")) if value]
+            if len(selected_employees) > 1:
+                raise forms.ValidationError(_("Select only one salesperson."))
+        return self.cleaned_data["employees"]
 
 
 @admin.register(OdooDeployment)
@@ -913,9 +920,8 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         if request.method == "POST" and form.is_valid():
             templates = list(form.cleaned_data["templates"])
             products = list(form.cleaned_data["products"])
-            employees = list(form.cleaned_data["employees"])
+            primary_employee = form.cleaned_data["employees"]
             name_prefix = form.cleaned_data["name_prefix"]
-            primary_employee = employees[0] if employees else None
             template_name_max_length = (
                 OdooSaleOrderTemplate._meta.get_field("name").max_length or 255
             )

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -40,6 +40,18 @@ from .sync_features import (
 logger = logging.getLogger(__name__)
 
 
+def _has_valid_odoo_product_payload(product: OdooProduct) -> bool:
+    payload = product.odoo_product or {}
+    if not isinstance(payload, dict):
+        return False
+    value = payload.get("id")
+    try:
+        int(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 class OdooTemplateSetupImportForm(forms.Form):
     SOURCE_TEMPLATES = "templates"
     SOURCE_PRODUCTS = "products"
@@ -104,24 +116,12 @@ class OdooTemplateSetupCreateForm(forms.Form):
         self.fields["products"].queryset = OdooProduct.objects.order_by("name")
         self.fields["employees"].queryset = OdooEmployee.objects.order_by("username")
 
-    @staticmethod
-    def _has_valid_odoo_product(product: OdooProduct) -> bool:
-        payload = product.odoo_product or {}
-        if not isinstance(payload, dict):
-            return False
-        value = payload.get("id")
-        try:
-            int(value)
-        except (TypeError, ValueError):
-            return False
-        return True
-
     def clean(self):
         cleaned_data = super().clean()
         name_prefix = (cleaned_data.get("name_prefix") or "").strip() or "Setup Template"
         cleaned_data["name_prefix"] = name_prefix
         products = cleaned_data.get("products") or []
-        if any(not self._has_valid_odoo_product(product) for product in products):
+        if any(not _has_valid_odoo_product_payload(product) for product in products):
             self.add_error(
                 "products",
                 _("Select only products imported from Odoo before creating product rules."),
@@ -907,6 +907,14 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 raise PermissionDenied
             if products and not self._has_add_and_change_permission(request, OdooSaleFactorProductRule):
                 raise PermissionDenied
+
+            if any(not _has_valid_odoo_product_payload(product) for product in products):
+                self.message_user(
+                    request,
+                    _("Select only products imported from Odoo before creating product rules."),
+                    level=messages.ERROR,
+                )
+                return HttpResponseRedirect(self._setup_templates_create_url())
 
             invalid_template_name = next(
                 (

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -504,7 +504,19 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         }
         model = model_by_source[source_type]
         if self._has_add_and_change_permission(request, model):
-            return True
+            if source_type != OdooTemplateSetupImportForm.SOURCE_EMPLOYEES:
+                return True
+            if self._has_add_and_change_permission(request, get_user_model()):
+                return True
+            self.message_user(
+                request,
+                _(
+                    "You do not have permission to synchronize authentication users "
+                    "during employee import."
+                ),
+                level=messages.ERROR,
+            )
+            return False
         self.message_user(
             request,
             _("You do not have permission to import %(kind)s records.") % {"kind": source_type},
@@ -833,11 +845,33 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             employees = list(form.cleaned_data["employees"])
             name_prefix = form.cleaned_data["name_prefix"]
             primary_employee = employees[0] if employees else None
+            template_name_max_length = (
+                OdooSaleOrderTemplate._meta.get_field("name").max_length or 255
+            )
 
             if products and not self._has_add_and_change_permission(request, OdooSaleFactor):
                 raise PermissionDenied
             if products and not self._has_add_and_change_permission(request, OdooSaleFactorProductRule):
                 raise PermissionDenied
+
+            invalid_template_name = next(
+                (
+                    f"{name_prefix}: {source_template.name}"
+                    for source_template in templates
+                    if len(f"{name_prefix}: {source_template.name}") > template_name_max_length
+                ),
+                None,
+            )
+            if invalid_template_name is not None:
+                self.message_user(
+                    request,
+                    _(
+                        "Template name is too long after applying the prefix. "
+                        "Please shorten the template name prefix and try again."
+                    ),
+                    level=messages.ERROR,
+                )
+                return HttpResponseRedirect(self._setup_templates_create_url())
 
             with transaction.atomic():
                 created_templates: list[OdooSaleOrderTemplate] = []

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -6,6 +6,7 @@ from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
@@ -624,12 +625,27 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         except (TypeError, ValueError):
             return None
 
-    def _import_template(self, source_row: dict[str, object]) -> tuple[OdooSaleOrderTemplate, bool]:
+    def _import_template(self, profile, source_row: dict[str, object]) -> tuple[OdooSaleOrderTemplate, bool]:
         source_id = int(source_row["id"])
-        existing = OdooSaleOrderTemplate.objects.filter(odoo_template__id=source_id).first()
+        existing = OdooSaleOrderTemplate.objects.filter(
+            odoo_template__id=source_id,
+            odoo_template__host=profile.host,
+            odoo_template__database=profile.database,
+        ).first()
+        if existing is None:
+            existing = OdooSaleOrderTemplate.objects.filter(
+                odoo_template__id=source_id,
+            ).filter(
+                Q(odoo_template__host__isnull=True) | Q(odoo_template__database__isnull=True)
+            ).first()
         defaults = {
             "name": str(source_row.get("name") or f"Odoo Template {source_id}"),
-            "odoo_template": {"id": source_id, "name": source_row.get("name") or f"Template {source_id}"},
+            "odoo_template": {
+                "id": source_id,
+                "name": source_row.get("name") or f"Template {source_id}",
+                "host": profile.host,
+                "database": profile.database,
+            },
             "note_template": str(source_row.get("note") or ""),
         }
         if existing:
@@ -639,14 +655,29 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             return existing, False
         return OdooSaleOrderTemplate.objects.create(**defaults), True
 
-    def _import_product(self, source_row: dict[str, object]) -> tuple[OdooProduct, bool]:
+    def _import_product(self, profile, source_row: dict[str, object]) -> tuple[OdooProduct, bool]:
         source_id = int(source_row["id"])
-        existing = OdooProduct.objects.filter(odoo_product__id=source_id).first()
+        existing = OdooProduct.objects.filter(
+            odoo_product__id=source_id,
+            odoo_product__host=profile.host,
+            odoo_product__database=profile.database,
+        ).first()
+        if existing is None:
+            existing = OdooProduct.objects.filter(odoo_product__id=source_id).filter(
+                Q(odoo_product__host__isnull=True) | Q(odoo_product__database__isnull=True)
+            ).first()
+        name_max_length = OdooProduct._meta.get_field("name").max_length or 100
+        bounded_name = str(source_row.get("name") or f"Odoo Product {source_id}")[:name_max_length]
         defaults = {
-            "name": str(source_row.get("name") or f"Odoo Product {source_id}"),
+            "name": bounded_name,
             "description": str(source_row.get("description_sale") or ""),
             "renewal_period": 30,
-            "odoo_product": {"id": source_id, "name": source_row.get("name") or f"Product {source_id}"},
+            "odoo_product": {
+                "id": source_id,
+                "name": source_row.get("name") or f"Product {source_id}",
+                "host": profile.host,
+                "database": profile.database,
+            },
         }
         if existing:
             for key, value in defaults.items():
@@ -729,9 +760,9 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             if not source_row:
                 continue
             if source_type == OdooTemplateSetupImportForm.SOURCE_TEMPLATES:
-                _, was_created = self._import_template(source_row)
+                _, was_created = self._import_template(profile, source_row)
             elif source_type == OdooTemplateSetupImportForm.SOURCE_PRODUCTS:
-                _, was_created = self._import_product(source_row)
+                _, was_created = self._import_product(profile, source_row)
             else:
                 _, was_created = self._import_employee(profile, source_row)
             if was_created:

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -1,9 +1,11 @@
 from django import forms
 from django.contrib import admin, messages
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django_object_actions import DjangoObjectActions
 
@@ -12,6 +14,8 @@ from apps.locals.user_data import EntityModelAdmin
 
 from .models import (
     OdooDeployment,
+    OdooEmployee,
+    OdooProduct,
     OdooQuery,
     OdooQueryVariable,
     OdooSaleFactor,
@@ -27,6 +31,71 @@ from .sync_features import (
     ODOO_SYNC_DEPLOYMENT_DISCOVERY_PARAMETER_KEY,
     is_odoo_sync_integration_enabled,
 )
+
+
+class OdooTemplateSetupImportForm(forms.Form):
+    SOURCE_TEMPLATES = "templates"
+    SOURCE_PRODUCTS = "products"
+    SOURCE_EMPLOYEES = "employees"
+    SOURCE_CHOICES = (
+        (SOURCE_TEMPLATES, _("Quotation templates")),
+        (SOURCE_PRODUCTS, _("Extra products")),
+        (SOURCE_EMPLOYEES, _("Employees")),
+    )
+
+    source_type = forms.ChoiceField(
+        choices=SOURCE_CHOICES,
+        label=_("Object type"),
+    )
+    selected_ids = forms.MultipleChoiceField(
+        required=False,
+        choices=(),
+        widget=forms.CheckboxSelectMultiple,
+        label=_("Records to import"),
+        help_text=_("Select one or more records to import from Odoo."),
+    )
+
+    def __init__(
+        self,
+        *args,
+        source_options: list[tuple[str, str]] | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.fields["selected_ids"].choices = source_options or []
+
+
+class OdooTemplateSetupCreateForm(forms.Form):
+    name_prefix = forms.CharField(
+        max_length=120,
+        initial="Setup Template",
+        label=_("Template name prefix"),
+    )
+    templates = forms.ModelMultipleChoiceField(
+        queryset=OdooSaleOrderTemplate.objects.none(),
+        required=True,
+        label=_("Templates"),
+        help_text=_("Pick at least one local template imported from Odoo."),
+        widget=forms.CheckboxSelectMultiple,
+    )
+    products = forms.ModelMultipleChoiceField(
+        queryset=OdooProduct.objects.none(),
+        required=False,
+        label=_("Products"),
+        widget=forms.CheckboxSelectMultiple,
+    )
+    employees = forms.ModelMultipleChoiceField(
+        queryset=OdooEmployee.objects.none(),
+        required=False,
+        label=_("Employees"),
+        widget=forms.CheckboxSelectMultiple,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["templates"].queryset = OdooSaleOrderTemplate.objects.order_by("name")
+        self.fields["products"].queryset = OdooProduct.objects.order_by("name")
+        self.fields["employees"].queryset = OdooEmployee.objects.order_by("username")
 
 
 @admin.register(OdooDeployment)
@@ -314,6 +383,7 @@ class OdooSaleFactorProductRuleInline(admin.TabularInline):
 
 @admin.register(OdooSaleOrderTemplate)
 class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
+    changelist_actions = ["setup_templates"]
     list_display = (
         "name",
         "default_new_customer_language",
@@ -346,6 +416,370 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             },
         ),
     )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "setup-templates/",
+                self.admin_site.admin_view(self.setup_templates_view),
+                name="odoo_odoosaleordertemplate_setup_templates",
+            ),
+            path(
+                "setup-templates/create/",
+                self.admin_site.admin_view(self.setup_templates_create_view),
+                name="odoo_odoosaleordertemplate_setup_templates_create",
+            ),
+        ]
+        return custom + urls
+
+    def _setup_templates_url(self) -> str:
+        return reverse("admin:odoo_odoosaleordertemplate_setup_templates")
+
+    def _setup_templates_create_url(self) -> str:
+        return reverse("admin:odoo_odoosaleordertemplate_setup_templates_create")
+
+    def get_dashboard_actions(self, request):
+        if not self.has_change_permission(request):
+            return []
+        return ["setup_templates"]
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        links = list(extra_context.get("public_view_links") or [])
+        setup_url = self._setup_templates_url()
+        if not any(link.get("url") == setup_url for link in links):
+            links.append({"label": self.setup_templates.label, "url": setup_url})
+        extra_context["public_view_links"] = links
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def _verified_profile_or_redirect(self, request):
+        profile = getattr(request.user, "odoo_employee", None)
+        if not profile or not profile.is_verified:
+            self.message_user(
+                request,
+                _("Configure and verify your Odoo employee before running template setup."),
+                level=messages.ERROR,
+            )
+            return None
+        return profile
+
+    def _remote_options(self, profile, source_type: str) -> list[tuple[str, str]]:
+        if source_type == OdooTemplateSetupImportForm.SOURCE_TEMPLATES:
+            rows = profile.execute(
+                "sale.order.template",
+                "search_read",
+                [[]],
+                fields=["id", "name"],
+                order="name asc",
+                limit=0,
+            )
+            return [
+                (str(row["id"]), row.get("name") or f"Template {row['id']}")
+                for row in rows
+                if row.get("id")
+            ]
+        if source_type == OdooTemplateSetupImportForm.SOURCE_PRODUCTS:
+            rows = profile.execute(
+                "product.product",
+                "search_read",
+                [[]],
+                fields=["id", "name"],
+                order="name asc",
+                limit=0,
+            )
+            return [
+                (str(row["id"]), row.get("name") or f"Product {row['id']}")
+                for row in rows
+                if row.get("id")
+            ]
+        rows = profile.execute(
+            "res.users",
+            "search_read",
+            [[("active", "=", True), ("share", "=", False)]],
+            fields=["id", "name", "email", "login", "partner_id"],
+            order="name asc",
+            limit=0,
+        )
+        return [
+            (
+                str(row["id"]),
+                row.get("name") or row.get("login") or f"Employee {row['id']}",
+            )
+            for row in rows
+            if row.get("id")
+        ]
+
+    def _find_remote_row(
+        self, profile, source_type: str, source_id: int
+    ) -> dict[str, object] | None:
+        model_map = {
+            OdooTemplateSetupImportForm.SOURCE_TEMPLATES: "sale.order.template",
+            OdooTemplateSetupImportForm.SOURCE_PRODUCTS: "product.product",
+            OdooTemplateSetupImportForm.SOURCE_EMPLOYEES: "res.users",
+        }
+        fields_map = {
+            OdooTemplateSetupImportForm.SOURCE_TEMPLATES: ["id", "name", "note"],
+            OdooTemplateSetupImportForm.SOURCE_PRODUCTS: ["id", "name", "description_sale"],
+            OdooTemplateSetupImportForm.SOURCE_EMPLOYEES: ["id", "name", "email", "login", "partner_id"],
+        }
+        rows = profile.execute(
+            model_map[source_type],
+            "search_read",
+            [[("id", "=", source_id)]],
+            fields=fields_map[source_type],
+            limit=1,
+        )
+        if not rows:
+            return None
+        return rows[0]
+
+    def _resolve_unique_username(self, base_username: str, odoo_uid: int) -> str:
+        user_model = get_user_model()
+        if not user_model.all_objects.filter(username=base_username).exists():
+            return base_username
+        suffix = f"-odoo-{odoo_uid}"
+        candidate = f"{base_username}{suffix}"
+        counter = 2
+        while user_model.all_objects.filter(username=candidate).exists():
+            candidate = f"{base_username}{suffix}-{counter}"
+            counter += 1
+        return candidate
+
+    def _import_template(self, source_row: dict[str, object]) -> tuple[OdooSaleOrderTemplate, bool]:
+        source_id = int(source_row["id"])
+        existing = OdooSaleOrderTemplate.objects.filter(odoo_template__id=source_id).first()
+        defaults = {
+            "name": str(source_row.get("name") or f"Odoo Template {source_id}"),
+            "odoo_template": {"id": source_id, "name": source_row.get("name") or f"Template {source_id}"},
+            "note_template": str(source_row.get("note") or ""),
+        }
+        if existing:
+            for key, value in defaults.items():
+                setattr(existing, key, value)
+            existing.save(update_fields=list(defaults.keys()))
+            return existing, False
+        return OdooSaleOrderTemplate.objects.create(**defaults), True
+
+    def _import_product(self, source_row: dict[str, object]) -> tuple[OdooProduct, bool]:
+        source_id = int(source_row["id"])
+        existing = OdooProduct.objects.filter(odoo_product__id=source_id).first()
+        defaults = {
+            "name": str(source_row.get("name") or f"Odoo Product {source_id}"),
+            "description": str(source_row.get("description_sale") or ""),
+            "renewal_period": 30,
+            "odoo_product": {"id": source_id, "name": source_row.get("name") or f"Product {source_id}"},
+        }
+        if existing:
+            for key, value in defaults.items():
+                setattr(existing, key, value)
+            existing.save(update_fields=list(defaults.keys()))
+            return existing, False
+        return OdooProduct.objects.create(**defaults), True
+
+    def _import_employee(self, profile, source_row: dict[str, object]) -> tuple[OdooEmployee, bool]:
+        source_id = int(source_row["id"])
+        existing = OdooEmployee.objects.filter(
+            host=profile.host,
+            database=profile.database,
+            odoo_uid=source_id,
+        ).first()
+        login = str(source_row.get("login") or "").strip()
+        email = str(source_row.get("email") or "").strip()
+        username_base = login or email or f"odoo-user-{source_id}"
+        if existing:
+            existing.username = login or existing.username
+            existing.email = email
+            existing.name = str(source_row.get("name") or existing.name)
+            existing.partner_id = None
+            partner_id = source_row.get("partner_id")
+            if isinstance(partner_id, (list, tuple)) and partner_id:
+                try:
+                    existing.partner_id = int(partner_id[0])
+                except (TypeError, ValueError):
+                    existing.partner_id = None
+            existing.save(update_fields=["username", "email", "name", "partner_id"])
+            return existing, False
+
+        user_model = get_user_model()
+        username = self._resolve_unique_username(username_base, source_id)
+        user = user_model.objects.create(username=username, email=email)
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+        partner_data = source_row.get("partner_id")
+        partner_id = None
+        if isinstance(partner_data, (list, tuple)) and partner_data:
+            try:
+                partner_id = int(partner_data[0])
+            except (TypeError, ValueError):
+                partner_id = None
+
+        employee = OdooEmployee.objects.create(
+            user=user,
+            host=profile.host,
+            database=profile.database,
+            username=login or username,
+            password="",
+            odoo_uid=source_id,
+            name=str(source_row.get("name") or ""),
+            email=email,
+            partner_id=partner_id,
+        )
+        return employee, True
+
+    def _import_source_selection(self, profile, source_type: str, selected_ids: list[str]) -> tuple[int, int]:
+        created = 0
+        updated = 0
+        for raw_id in selected_ids:
+            try:
+                source_id = int(raw_id)
+            except (TypeError, ValueError):
+                continue
+            source_row = self._find_remote_row(profile, source_type, source_id)
+            if not source_row:
+                continue
+            if source_type == OdooTemplateSetupImportForm.SOURCE_TEMPLATES:
+                _, was_created = self._import_template(source_row)
+            elif source_type == OdooTemplateSetupImportForm.SOURCE_PRODUCTS:
+                _, was_created = self._import_product(source_row)
+            else:
+                _, was_created = self._import_employee(profile, source_row)
+            if was_created:
+                created += 1
+            else:
+                updated += 1
+        return created, updated
+
+    def setup_templates(self, request, queryset=None):
+        return HttpResponseRedirect(self._setup_templates_url())
+
+    setup_templates.label = _("Setup Templates")
+    setup_templates.short_description = _("Setup Templates")
+    setup_templates.requires_queryset = False
+    setup_templates.dashboard_url = "admin:odoo_odoosaleordertemplate_setup_templates"
+
+    def setup_templates_view(self, request):
+        if not self.has_change_permission(request):
+            raise PermissionDenied
+
+        profile = self._verified_profile_or_redirect(request)
+        if profile is None:
+            return HttpResponseRedirect(
+                reverse(f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist")
+            )
+
+        source_type = request.POST.get("source_type") or request.GET.get("source_type")
+        if source_type not in dict(OdooTemplateSetupImportForm.SOURCE_CHOICES):
+            source_type = OdooTemplateSetupImportForm.SOURCE_TEMPLATES
+
+        options = self._remote_options(profile, source_type)
+        form = OdooTemplateSetupImportForm(
+            request.POST or None,
+            initial={"source_type": source_type},
+            source_options=options,
+        )
+
+        if request.method == "POST" and form.is_valid():
+            created, updated = self._import_source_selection(
+                profile,
+                source_type=form.cleaned_data["source_type"],
+                selected_ids=form.cleaned_data["selected_ids"],
+            )
+            self.message_user(
+                request,
+                _("Imported from Odoo. Created: %(created)s | Updated: %(updated)s")
+                % {"created": created, "updated": updated},
+                level=messages.SUCCESS,
+            )
+            return HttpResponseRedirect(
+                f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
+            )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "title": _("Setup Templates"),
+            "form": form,
+            "step_two_url": self._setup_templates_create_url(),
+            "changelist_url": reverse(
+                f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist"
+            ),
+        }
+        return TemplateResponse(
+            request,
+            "admin/odoo/odoosaleordertemplate/setup_templates_step1.html",
+            context,
+        )
+
+    def setup_templates_create_view(self, request):
+        if not self.has_change_permission(request):
+            raise PermissionDenied
+
+        form = OdooTemplateSetupCreateForm(request.POST or None)
+        if request.method == "POST" and form.is_valid():
+            templates = list(form.cleaned_data["templates"])
+            products = list(form.cleaned_data["products"])
+            employees = list(form.cleaned_data["employees"])
+            name_prefix = form.cleaned_data["name_prefix"].strip() or "Setup Template"
+            primary_employee = employees[0] if employees else None
+
+            created_templates: list[OdooSaleOrderTemplate] = []
+            for source_template in templates:
+                copied = OdooSaleOrderTemplate.objects.create(
+                    name=f"{name_prefix}: {source_template.name}",
+                    odoo_template=source_template.odoo_template,
+                    note_template=source_template.note_template,
+                    resolve_note_sigils=source_template.resolve_note_sigils,
+                    default_new_customer_language=source_template.default_new_customer_language,
+                    fallback_new_customer_language=source_template.fallback_new_customer_language,
+                    salesperson=primary_employee,
+                )
+                created_templates.append(copied)
+
+            factor = None
+            created_rules = 0
+            if created_templates:
+                factor_name = f"{name_prefix} Products"
+                factor = OdooSaleFactor.objects.create(
+                    name=factor_name,
+                    code=slugify(factor_name)[:64] or "setup-template-products",
+                )
+                factor.templates.set(created_templates)
+                for product in products:
+                    OdooSaleFactorProductRule.objects.create(
+                        factor=factor,
+                        name=product.name,
+                        odoo_product=product.odoo_product,
+                    )
+                    created_rules += 1
+
+            self.message_user(
+                request,
+                _(
+                    "Template setup completed. Templates created: %(templates)s | Product rules created: %(rules)s"
+                )
+                % {"templates": len(created_templates), "rules": created_rules},
+                level=messages.SUCCESS,
+            )
+            return HttpResponseRedirect(
+                reverse(f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist")
+            )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "title": _("Setup Templates · Step 2"),
+            "form": form,
+            "step_one_url": self._setup_templates_url(),
+            "changelist_url": reverse(
+                f"admin:{self.opts.app_label}_{self.opts.model_name}_changelist"
+            ),
+        }
+        return TemplateResponse(
+            request,
+            "admin/odoo/odoosaleordertemplate/setup_templates_step2.html",
+            context,
+        )
 
 
 @admin.register(OdooSaleFactor)

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -5,7 +5,7 @@ from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -693,7 +693,6 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         defaults = {
             "name": bounded_name,
             "description": str(source_row.get("description_sale") or ""),
-            "renewal_period": 30,
             "odoo_product": {
                 "id": source_id,
                 "name": source_row.get("name") or f"Product {source_id}",
@@ -706,7 +705,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 setattr(existing, key, value)
             existing.save(update_fields=list(defaults.keys()))
             return existing, False
-        return OdooProduct.objects.create(**defaults), True
+        return OdooProduct.objects.create(**defaults, renewal_period=30), True
 
     def _import_employee(self, profile, source_row: dict[str, object]) -> tuple[OdooEmployee, bool]:
         source_id = int(source_row["id"])
@@ -860,6 +859,19 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 return HttpResponseRedirect(
                     f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
                 )
+            except DatabaseError:
+                logger.exception(
+                    "Could not persist Odoo import for source_type=%s",
+                    form.cleaned_data["source_type"],
+                )
+                self.message_user(
+                    request,
+                    _("Import failed while saving local records. Please try again."),
+                    level=messages.ERROR,
+                )
+                return HttpResponseRedirect(
+                    f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
+                )
             self.message_user(
                 request,
                 _("Imported from Odoo. Created: %(created)s | Updated: %(updated)s")
@@ -977,6 +989,17 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                         return HttpResponseRedirect(self._setup_templates_create_url())
                     factor.templates.set(created_templates)
                     for product in products:
+                        if not _has_valid_odoo_product_payload(product):
+                            self.message_user(
+                                request,
+                                _(
+                                    "Select only products imported from Odoo before creating "
+                                    "product rules."
+                                ),
+                                level=messages.ERROR,
+                            )
+                            transaction.set_rollback(True)
+                            return HttpResponseRedirect(self._setup_templates_create_url())
                         OdooSaleFactorProductRule.objects.create(
                             factor=factor,
                             name=product.name,

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -1,8 +1,12 @@
+import logging
+import socket
+from xmlrpc.client import Fault, ProtocolError
+
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
@@ -32,6 +36,8 @@ from .sync_features import (
     ODOO_SYNC_DEPLOYMENT_DISCOVERY_PARAMETER_KEY,
     is_odoo_sync_integration_enabled,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OdooTemplateSetupImportForm(forms.Form):
@@ -489,6 +495,36 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             return None
         return profile
 
+    def _has_add_and_change_permission(self, request, model) -> bool:
+        model_admin = self.admin_site._registry.get(model)
+        if model_admin is not None:
+            return model_admin.has_add_permission(request) and model_admin.has_change_permission(
+                request
+            )
+        opts = model._meta
+        return request.user.has_perms(
+            (
+                f"{opts.app_label}.add_{opts.model_name}",
+                f"{opts.app_label}.change_{opts.model_name}",
+            )
+        )
+
+    def _source_permissions_ok(self, request, source_type: str) -> bool:
+        model_by_source = {
+            OdooTemplateSetupImportForm.SOURCE_TEMPLATES: OdooSaleOrderTemplate,
+            OdooTemplateSetupImportForm.SOURCE_PRODUCTS: OdooProduct,
+            OdooTemplateSetupImportForm.SOURCE_EMPLOYEES: OdooEmployee,
+        }
+        model = model_by_source[source_type]
+        if self._has_add_and_change_permission(request, model):
+            return True
+        self.message_user(
+            request,
+            _("You do not have permission to import %(kind)s records.") % {"kind": source_type},
+            level=messages.ERROR,
+        )
+        return False
+
     def _remote_options(self, profile, source_type: str) -> list[tuple[str, str]]:
         if source_type == OdooTemplateSetupImportForm.SOURCE_TEMPLATES:
             rows = profile.execute(
@@ -628,15 +664,29 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             desired_username = login or existing.username
             user = existing.user
             if user is not None:
+                user_updated_fields: list[str] = []
                 if user.username != desired_username:
                     desired_username = self._resolve_unique_username(desired_username, source_id)
-                user.username = desired_username
-                user.email = email
-                user.save(update_fields=["username", "email"])
-            existing.email = email
-            existing.name = str(source_row.get("name") or existing.name)
-            existing.partner_id = partner_id
-            existing.save(update_fields=["email", "name", "partner_id"])
+                    user.username = desired_username
+                    user_updated_fields.append("username")
+                if email and user.email != email:
+                    user.email = email
+                    user_updated_fields.append("email")
+                if user_updated_fields:
+                    user.save(update_fields=user_updated_fields)
+            existing_updated_fields: list[str] = []
+            if email and existing.email != email:
+                existing.email = email
+                existing_updated_fields.append("email")
+            name = str(source_row.get("name") or existing.name)
+            if existing.name != name:
+                existing.name = name
+                existing_updated_fields.append("name")
+            if existing.partner_id != partner_id:
+                existing.partner_id = partner_id
+                existing_updated_fields.append("partner_id")
+            if existing_updated_fields:
+                existing.save(update_fields=existing_updated_fields)
             return existing, False
 
         user_model = get_user_model()
@@ -704,10 +754,13 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         source_type = request.POST.get("source_type") or request.GET.get("source_type")
         if source_type not in dict(OdooTemplateSetupImportForm.SOURCE_CHOICES):
             source_type = OdooTemplateSetupImportForm.SOURCE_TEMPLATES
+        if not self._source_permissions_ok(request, source_type):
+            source_type = OdooTemplateSetupImportForm.SOURCE_TEMPLATES
 
         try:
             options = self._remote_options(profile, source_type)
-        except Exception:
+        except (Fault, OSError, ProtocolError, TimeoutError, socket.timeout):
+            logger.exception("Could not fetch Odoo records for source_type=%s", source_type)
             self.message_user(
                 request,
                 _("Could not fetch Odoo records right now. Please verify your Odoo connection."),
@@ -721,13 +774,21 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         )
 
         if request.method == "POST" and form.is_valid():
+            if not self._source_permissions_ok(request, form.cleaned_data["source_type"]):
+                return HttpResponseRedirect(
+                    f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
+                )
             try:
                 created, updated = self._import_source_selection(
                     profile,
                     source_type=form.cleaned_data["source_type"],
                     selected_ids=form.cleaned_data["selected_ids"],
                 )
-            except Exception:
+            except (Fault, OSError, ProtocolError, TimeoutError, socket.timeout):
+                logger.exception(
+                    "Odoo import failed for source_type=%s",
+                    form.cleaned_data["source_type"],
+                )
                 self.message_user(
                     request,
                     _("Import failed due to an Odoo communication error. Please try again."),
@@ -774,8 +835,12 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             products = list(form.cleaned_data["products"])
             employees = list(form.cleaned_data["employees"])
             name_prefix = form.cleaned_data["name_prefix"]
-            factor_code = form.cleaned_data["factor_code"]
             primary_employee = employees[0] if employees else None
+
+            if products and not self._has_add_and_change_permission(request, OdooSaleFactor):
+                raise PermissionDenied
+            if products and not self._has_add_and_change_permission(request, OdooSaleFactorProductRule):
+                raise PermissionDenied
 
             with transaction.atomic():
                 created_templates: list[OdooSaleOrderTemplate] = []
@@ -792,11 +857,22 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                     created_templates.append(copied)
 
                 created_rules = 0
-                if created_templates:
-                    factor = OdooSaleFactor.objects.create(
-                        name=f"{name_prefix} Products",
-                        code=factor_code,
-                    )
+                if created_templates and products:
+                    factor = None
+                    base_code = slugify(f"{name_prefix} Products")[:64] or "setup-template-products"
+                    for counter in range(1, 101):
+                        candidate = base_code if counter == 1 else f"{base_code[: 64 - len(str(counter)) - 1]}-{counter}"
+                        try:
+                            with transaction.atomic():
+                                factor = OdooSaleFactor.objects.create(
+                                    name=f"{name_prefix} Products",
+                                    code=candidate,
+                                )
+                            break
+                        except IntegrityError:
+                            continue
+                    if factor is None:
+                        raise ValidationError(_("Unable to generate a unique sale factor code."))
                     factor.templates.set(created_templates)
                     for product in products:
                         OdooSaleFactorProductRule.objects.create(

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -104,10 +104,28 @@ class OdooTemplateSetupCreateForm(forms.Form):
         self.fields["products"].queryset = OdooProduct.objects.order_by("name")
         self.fields["employees"].queryset = OdooEmployee.objects.order_by("username")
 
+    @staticmethod
+    def _has_valid_odoo_product(product: OdooProduct) -> bool:
+        payload = product.odoo_product or {}
+        if not isinstance(payload, dict):
+            return False
+        value = payload.get("id")
+        try:
+            int(value)
+        except (TypeError, ValueError):
+            return False
+        return True
+
     def clean(self):
         cleaned_data = super().clean()
         name_prefix = (cleaned_data.get("name_prefix") or "").strip() or "Setup Template"
         cleaned_data["name_prefix"] = name_prefix
+        products = cleaned_data.get("products") or []
+        if any(not self._has_valid_odoo_product(product) for product in products):
+            self.add_error(
+                "products",
+                _("Select only products imported from Odoo before creating product rules."),
+            )
         return cleaned_data
 
 
@@ -638,8 +656,12 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             ).filter(
                 Q(odoo_template__host__isnull=True) | Q(odoo_template__database__isnull=True)
             ).first()
+        name_max_length = OdooSaleOrderTemplate._meta.get_field("name").max_length or 255
+        bounded_name = str(source_row.get("name") or f"Odoo Template {source_id}")[
+            :name_max_length
+        ]
         defaults = {
-            "name": str(source_row.get("name") or f"Odoo Template {source_id}"),
+            "name": bounded_name,
             "odoo_template": {
                 "id": source_id,
                 "name": source_row.get("name") or f"Template {source_id}",
@@ -714,19 +736,20 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                     user_updated_fields.append("email")
                 if user_updated_fields:
                     user.save(update_fields=user_updated_fields)
-            existing_updated_fields: list[str] = []
+            existing_updates = {}
+            if existing.username != desired_username:
+                existing_updates["username"] = desired_username
             if email and existing.email != email:
-                existing.email = email
-                existing_updated_fields.append("email")
+                existing_updates["email"] = email
             name = str(source_row.get("name") or existing.name)
             if existing.name != name:
-                existing.name = name
-                existing_updated_fields.append("name")
+                existing_updates["name"] = name
             if existing.partner_id != partner_id:
-                existing.partner_id = partner_id
-                existing_updated_fields.append("partner_id")
-            if existing_updated_fields:
-                existing.save(update_fields=existing_updated_fields)
+                existing_updates["partner_id"] = partner_id
+            if existing_updates:
+                OdooEmployee.objects.filter(pk=existing.pk).update(**existing_updates)
+                for key, value in existing_updates.items():
+                    setattr(existing, key, value)
             return existing, False
 
         username = self._resolve_unique_username(username_base, source_id)

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -6,7 +6,6 @@ from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db import DatabaseError, IntegrityError, transaction
-from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
@@ -40,16 +39,20 @@ from .sync_features import (
 logger = logging.getLogger(__name__)
 
 
-def _has_valid_odoo_product_payload(product: OdooProduct) -> bool:
+def _get_valid_odoo_product_payload(product: OdooProduct) -> dict[str, object] | None:
     payload = product.odoo_product or {}
     if not isinstance(payload, dict):
-        return False
+        return None
     value = payload.get("id")
     try:
         int(value)
     except (TypeError, ValueError):
-        return False
-    return True
+        return None
+    return payload
+
+
+def _has_valid_odoo_product_payload(product: OdooProduct) -> bool:
+    return _get_valid_odoo_product_payload(product) is not None
 
 
 class OdooTemplateSetupImportForm(forms.Form):
@@ -654,7 +657,8 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             existing = OdooSaleOrderTemplate.objects.filter(
                 odoo_template__id=source_id,
             ).filter(
-                Q(odoo_template__host__isnull=True) | Q(odoo_template__database__isnull=True)
+                odoo_template__host__isnull=True,
+                odoo_template__database__isnull=True,
             ).first()
         name_max_length = OdooSaleOrderTemplate._meta.get_field("name").max_length or 255
         bounded_name = str(source_row.get("name") or f"Odoo Template {source_id}")[
@@ -686,7 +690,8 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         ).first()
         if existing is None:
             existing = OdooProduct.objects.filter(odoo_product__id=source_id).filter(
-                Q(odoo_product__host__isnull=True) | Q(odoo_product__database__isnull=True)
+                odoo_product__host__isnull=True,
+                odoo_product__database__isnull=True,
             ).first()
         name_max_length = OdooProduct._meta.get_field("name").max_length or 100
         bounded_name = str(source_row.get("name") or f"Odoo Product {source_id}")[:name_max_length]
@@ -846,19 +851,6 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                     source_type=form.cleaned_data["source_type"],
                     selected_ids=form.cleaned_data["selected_ids"],
                 )
-            except (Fault, OSError, ProtocolError):
-                logger.exception(
-                    "Odoo import failed for source_type=%s",
-                    form.cleaned_data["source_type"],
-                )
-                self.message_user(
-                    request,
-                    _("Import failed due to an Odoo communication error. Please try again."),
-                    level=messages.ERROR,
-                )
-                return HttpResponseRedirect(
-                    f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
-                )
             except DatabaseError:
                 logger.exception(
                     "Could not persist Odoo import for source_type=%s",
@@ -867,6 +859,19 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 self.message_user(
                     request,
                     _("Import failed while saving local records. Please try again."),
+                    level=messages.ERROR,
+                )
+                return HttpResponseRedirect(
+                    f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
+                )
+            except (Fault, OSError, ProtocolError):
+                logger.exception(
+                    "Odoo import failed for source_type=%s",
+                    form.cleaned_data["source_type"],
+                )
+                self.message_user(
+                    request,
+                    _("Import failed due to an Odoo communication error. Please try again."),
                     level=messages.ERROR,
                 )
                 return HttpResponseRedirect(
@@ -989,7 +994,8 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                         return HttpResponseRedirect(self._setup_templates_create_url())
                     factor.templates.set(created_templates)
                     for product in products:
-                        if not _has_valid_odoo_product_payload(product):
+                        odoo_product_payload = _get_valid_odoo_product_payload(product)
+                        if odoo_product_payload is None:
                             self.message_user(
                                 request,
                                 _(
@@ -1003,7 +1009,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                         OdooSaleFactorProductRule.objects.create(
                             factor=factor,
                             name=product.name,
-                            odoo_product=product.odoo_product,
+                            odoo_product=odoo_product_payload,
                         )
                         created_rules += 1
 

--- a/apps/odoo/admin.py
+++ b/apps/odoo/admin.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
@@ -96,6 +97,29 @@ class OdooTemplateSetupCreateForm(forms.Form):
         self.fields["templates"].queryset = OdooSaleOrderTemplate.objects.order_by("name")
         self.fields["products"].queryset = OdooProduct.objects.order_by("name")
         self.fields["employees"].queryset = OdooEmployee.objects.order_by("username")
+
+    @staticmethod
+    def _resolve_unique_factor_code(name_prefix: str) -> str:
+        base_code = slugify(f"{name_prefix} Products")[:64] or "setup-template-products"
+        if not OdooSaleFactor.objects.filter(code=base_code).exists():
+            return base_code
+
+        max_base_length = 64 - len("-99")
+        trimmed_base = base_code[:max_base_length]
+        counter = 2
+        while counter < 100:
+            candidate = f"{trimmed_base}-{counter}"
+            if not OdooSaleFactor.objects.filter(code=candidate).exists():
+                return candidate
+            counter += 1
+        raise ValidationError(_("Unable to generate a unique sale factor code."))
+
+    def clean(self):
+        cleaned_data = super().clean()
+        name_prefix = (cleaned_data.get("name_prefix") or "").strip() or "Setup Template"
+        cleaned_data["name_prefix"] = name_prefix
+        cleaned_data["factor_code"] = self._resolve_unique_factor_code(name_prefix)
+        return cleaned_data
 
 
 @admin.register(OdooDeployment)
@@ -384,6 +408,7 @@ class OdooSaleFactorProductRuleInline(admin.TabularInline):
 @admin.register(OdooSaleOrderTemplate)
 class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
     changelist_actions = ["setup_templates"]
+    remote_selection_limit = 200
     list_display = (
         "name",
         "default_new_customer_language",
@@ -472,7 +497,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 [[]],
                 fields=["id", "name"],
                 order="name asc",
-                limit=0,
+                limit=self.remote_selection_limit,
             )
             return [
                 (str(row["id"]), row.get("name") or f"Template {row['id']}")
@@ -486,7 +511,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
                 [[]],
                 fields=["id", "name"],
                 order="name asc",
-                limit=0,
+                limit=self.remote_selection_limit,
             )
             return [
                 (str(row["id"]), row.get("name") or f"Product {row['id']}")
@@ -499,7 +524,7 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
             [[("active", "=", True), ("share", "=", False)]],
             fields=["id", "name", "email", "login", "partner_id"],
             order="name asc",
-            limit=0,
+            limit=self.remote_selection_limit,
         )
         return [
             (
@@ -536,15 +561,26 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
 
     def _resolve_unique_username(self, base_username: str, odoo_uid: int) -> str:
         user_model = get_user_model()
-        if not user_model.all_objects.filter(username=base_username).exists():
+        user_manager = getattr(user_model, "all_objects", user_model.objects)
+        if not user_manager.filter(username=base_username).exists():
             return base_username
         suffix = f"-odoo-{odoo_uid}"
         candidate = f"{base_username}{suffix}"
         counter = 2
-        while user_model.all_objects.filter(username=candidate).exists():
+        while user_manager.filter(username=candidate).exists():
             candidate = f"{base_username}{suffix}-{counter}"
             counter += 1
         return candidate
+
+    @staticmethod
+    def _extract_partner_id(source_row: dict[str, object]) -> int | None:
+        partner_data = source_row.get("partner_id")
+        if not isinstance(partner_data, (list, tuple)) or not partner_data:
+            return None
+        try:
+            return int(partner_data[0])
+        except (TypeError, ValueError):
+            return None
 
     def _import_template(self, source_row: dict[str, object]) -> tuple[OdooSaleOrderTemplate, bool]:
         source_id = int(source_row["id"])
@@ -587,18 +623,20 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         login = str(source_row.get("login") or "").strip()
         email = str(source_row.get("email") or "").strip()
         username_base = login or email or f"odoo-user-{source_id}"
+        partner_id = self._extract_partner_id(source_row)
         if existing:
-            existing.username = login or existing.username
+            desired_username = login or existing.username
+            user = existing.user
+            if user is not None:
+                if user.username != desired_username:
+                    desired_username = self._resolve_unique_username(desired_username, source_id)
+                user.username = desired_username
+                user.email = email
+                user.save(update_fields=["username", "email"])
             existing.email = email
             existing.name = str(source_row.get("name") or existing.name)
-            existing.partner_id = None
-            partner_id = source_row.get("partner_id")
-            if isinstance(partner_id, (list, tuple)) and partner_id:
-                try:
-                    existing.partner_id = int(partner_id[0])
-                except (TypeError, ValueError):
-                    existing.partner_id = None
-            existing.save(update_fields=["username", "email", "name", "partner_id"])
+            existing.partner_id = partner_id
+            existing.save(update_fields=["email", "name", "partner_id"])
             return existing, False
 
         user_model = get_user_model()
@@ -606,13 +644,6 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         user = user_model.objects.create(username=username, email=email)
         user.set_unusable_password()
         user.save(update_fields=["password"])
-        partner_data = source_row.get("partner_id")
-        partner_id = None
-        if isinstance(partner_data, (list, tuple)) and partner_data:
-            try:
-                partner_id = int(partner_data[0])
-            except (TypeError, ValueError):
-                partner_id = None
 
         employee = OdooEmployee.objects.create(
             user=user,
@@ -661,6 +692,8 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
     def setup_templates_view(self, request):
         if not self.has_change_permission(request):
             raise PermissionDenied
+        if not self.has_add_permission(request):
+            raise PermissionDenied
 
         profile = self._verified_profile_or_redirect(request)
         if profile is None:
@@ -672,7 +705,15 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         if source_type not in dict(OdooTemplateSetupImportForm.SOURCE_CHOICES):
             source_type = OdooTemplateSetupImportForm.SOURCE_TEMPLATES
 
-        options = self._remote_options(profile, source_type)
+        try:
+            options = self._remote_options(profile, source_type)
+        except Exception:
+            self.message_user(
+                request,
+                _("Could not fetch Odoo records right now. Please verify your Odoo connection."),
+                level=messages.ERROR,
+            )
+            options = []
         form = OdooTemplateSetupImportForm(
             request.POST or None,
             initial={"source_type": source_type},
@@ -680,11 +721,21 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
         )
 
         if request.method == "POST" and form.is_valid():
-            created, updated = self._import_source_selection(
-                profile,
-                source_type=form.cleaned_data["source_type"],
-                selected_ids=form.cleaned_data["selected_ids"],
-            )
+            try:
+                created, updated = self._import_source_selection(
+                    profile,
+                    source_type=form.cleaned_data["source_type"],
+                    selected_ids=form.cleaned_data["selected_ids"],
+                )
+            except Exception:
+                self.message_user(
+                    request,
+                    _("Import failed due to an Odoo communication error. Please try again."),
+                    level=messages.ERROR,
+                )
+                return HttpResponseRedirect(
+                    f"{self._setup_templates_url()}?source_type={form.cleaned_data['source_type']}"
+                )
             self.message_user(
                 request,
                 _("Imported from Odoo. Created: %(created)s | Updated: %(updated)s")
@@ -714,44 +765,46 @@ class OdooSaleOrderTemplateAdmin(EntityModelAdmin):
     def setup_templates_create_view(self, request):
         if not self.has_change_permission(request):
             raise PermissionDenied
+        if not self.has_add_permission(request):
+            raise PermissionDenied
 
         form = OdooTemplateSetupCreateForm(request.POST or None)
         if request.method == "POST" and form.is_valid():
             templates = list(form.cleaned_data["templates"])
             products = list(form.cleaned_data["products"])
             employees = list(form.cleaned_data["employees"])
-            name_prefix = form.cleaned_data["name_prefix"].strip() or "Setup Template"
+            name_prefix = form.cleaned_data["name_prefix"]
+            factor_code = form.cleaned_data["factor_code"]
             primary_employee = employees[0] if employees else None
 
-            created_templates: list[OdooSaleOrderTemplate] = []
-            for source_template in templates:
-                copied = OdooSaleOrderTemplate.objects.create(
-                    name=f"{name_prefix}: {source_template.name}",
-                    odoo_template=source_template.odoo_template,
-                    note_template=source_template.note_template,
-                    resolve_note_sigils=source_template.resolve_note_sigils,
-                    default_new_customer_language=source_template.default_new_customer_language,
-                    fallback_new_customer_language=source_template.fallback_new_customer_language,
-                    salesperson=primary_employee,
-                )
-                created_templates.append(copied)
-
-            factor = None
-            created_rules = 0
-            if created_templates:
-                factor_name = f"{name_prefix} Products"
-                factor = OdooSaleFactor.objects.create(
-                    name=factor_name,
-                    code=slugify(factor_name)[:64] or "setup-template-products",
-                )
-                factor.templates.set(created_templates)
-                for product in products:
-                    OdooSaleFactorProductRule.objects.create(
-                        factor=factor,
-                        name=product.name,
-                        odoo_product=product.odoo_product,
+            with transaction.atomic():
+                created_templates: list[OdooSaleOrderTemplate] = []
+                for source_template in templates:
+                    copied = OdooSaleOrderTemplate.objects.create(
+                        name=f"{name_prefix}: {source_template.name}",
+                        odoo_template=source_template.odoo_template,
+                        note_template=source_template.note_template,
+                        resolve_note_sigils=source_template.resolve_note_sigils,
+                        default_new_customer_language=source_template.default_new_customer_language,
+                        fallback_new_customer_language=source_template.fallback_new_customer_language,
+                        salesperson=primary_employee,
                     )
-                    created_rules += 1
+                    created_templates.append(copied)
+
+                created_rules = 0
+                if created_templates:
+                    factor = OdooSaleFactor.objects.create(
+                        name=f"{name_prefix} Products",
+                        code=factor_code,
+                    )
+                    factor.templates.set(created_templates)
+                    for product in products:
+                        OdooSaleFactorProductRule.objects.create(
+                            factor=factor,
+                            name=product.name,
+                            odoo_product=product.odoo_product,
+                        )
+                        created_rules += 1
 
             self.message_user(
                 request,

--- a/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step1.html
+++ b/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step1.html
@@ -1,0 +1,31 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {% trans "Setup Templates" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{% trans "Setup Templates" %}</h1>
+  <p class="help">
+    {% trans "Step 1: choose one source object type, select one or more Odoo records, and import them into Arthexis." %}
+  </p>
+
+  <form method="post" novalidate>
+    {% csrf_token %}
+    <fieldset class="module aligned">
+      {{ form.as_p }}
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" class="default" value="{% trans 'Import selected records' %}">
+      <a class="button" href="{{ step_two_url }}">{% trans "Continue to Step 2" %}</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step2.html
+++ b/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step2.html
@@ -15,7 +15,7 @@
 <div id="content-main">
   <h1>{% trans "Setup Templates · Step 2" %}</h1>
   <p class="help">
-    {% trans "Pick one or more templates (required), plus optional products and employees, then create linked local objects you can edit later." %}
+    {% trans "Pick one or more templates (required), plus optional products and one salesperson, then create linked local objects you can edit later." %}
   </p>
 
   <form method="post" novalidate>

--- a/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step2.html
+++ b/apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step2.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; <a href="{{ step_one_url }}">{% trans "Setup Templates" %}</a>
+  &rsaquo; {% trans "Step 2" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{% trans "Setup Templates · Step 2" %}</h1>
+  <p class="help">
+    {% trans "Pick one or more templates (required), plus optional products and employees, then create linked local objects you can edit later." %}
+  </p>
+
+  <form method="post" novalidate>
+    {% csrf_token %}
+    <fieldset class="module aligned">
+      {{ form.as_p }}
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" class="default" value="{% trans 'Create linked objects' %}">
+      <a class="button" href="{{ step_one_url }}">{% trans "Back to Step 1" %}</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -71,6 +71,63 @@ def test_setup_templates_step_one_imports_selected_records(admin_client, admin_u
     assert response.status_code == 302
     created = OdooSaleOrderTemplate.objects.get(odoo_template__id=100)
     assert created.name == "Starter Quote"
+    assert created.odoo_template["host"] == profile.host
+    assert created.odoo_template["database"] == profile.database
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_scopes_template_upsert_by_odoo_instance(
+    admin_client, admin_user, monkeypatch
+):
+    profile = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.two.example.com",
+        database="odoo-two",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    OdooSaleOrderTemplate.objects.create(
+        name="Original Other Instance",
+        odoo_template={
+            "id": 100,
+            "name": "Starter Quote",
+            "host": "https://odoo.one.example.com",
+            "database": "odoo-one",
+        },
+    )
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model == "sale.order.template":
+            fields = kwargs.get("fields") or []
+            if fields == ["id", "name"]:
+                return [{"id": 100, "name": "Starter Quote"}]
+            return [{"id": 100, "name": "Starter Quote", "note": "Generated"}]
+        raise AssertionError(f"Unexpected model: {model}")
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "templates",
+            "selected_ids": ["100"],
+        },
+    )
+
+    assert response.status_code == 302
+    assert OdooSaleOrderTemplate.objects.filter(odoo_template__id=100).count() == 2
+    assert OdooSaleOrderTemplate.objects.filter(
+        odoo_template__id=100,
+        odoo_template__host=profile.host,
+        odoo_template__database=profile.database,
+    ).exists()
 
 
 @pytest.mark.django_db
@@ -104,6 +161,51 @@ def test_setup_templates_step_two_creates_linked_objects(admin_client):
         factor=factor,
         odoo_product__id=501,
     ).exists()
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_truncates_imported_product_name(
+    admin_client, admin_user, monkeypatch
+):
+    OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    product_name_max = OdooProduct._meta.get_field("name").max_length or 100
+    long_name = "P" * (product_name_max + 20)
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model != "product.product":
+            raise AssertionError(f"Unexpected model: {model}")
+        fields = kwargs.get("fields") or []
+        if fields == ["id", "name"]:
+            return [{"id": 701, "name": long_name}]
+        return [{"id": 701, "name": long_name, "description_sale": "Remote description"}]
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "products",
+            "selected_ids": ["701"],
+        },
+    )
+
+    assert response.status_code == 302
+    created = OdooProduct.objects.get(odoo_product__id=701)
+    assert len(created.name) == product_name_max
+    assert created.odoo_product["host"] == "https://odoo.example.com"
 
 
 @pytest.mark.django_db

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -25,7 +25,7 @@ def test_setup_templates_step_one_imports_selected_records(admin_client, admin_u
         verified_on=timezone.now(),
     )
 
-    def execute(model, method, domain, **kwargs):
+    def execute(model, method, *args, **kwargs):
         assert method == "search_read"
         if model == "sale.order.template":
             fields = kwargs.get("fields") or []
@@ -37,8 +37,8 @@ def test_setup_templates_step_one_imports_selected_records(admin_client, admin_u
     monkeypatch.setattr(
         OdooEmployee,
         "execute",
-        lambda self, model, method, domain, **kwargs: execute(
-            model, method, domain, **kwargs
+        lambda self, model, method, *args, **kwargs: execute(
+            model, method, *args, **kwargs
         ),
     )
 
@@ -94,11 +94,16 @@ def test_setup_templates_step_two_generates_unique_factor_code(admin_client):
         name="Base",
         odoo_template={"id": 90, "name": "Base"},
     )
+    product = OdooProduct.objects.create(
+        name="Addon",
+        renewal_period=30,
+        odoo_product={"id": 501, "name": "Addon"},
+    )
 
     payload = {
         "name_prefix": "Setup",
         "templates": [str(source_template.pk)],
-        "products": [],
+        "products": [str(product.pk)],
         "employees": [],
     }
 
@@ -149,8 +154,9 @@ def test_setup_templates_step_one_employee_update_syncs_user(
         verified_on=timezone.now(),
     )
 
-    def execute(model, method, domain, **kwargs):
+    def execute(model, method, *args, **kwargs):
         assert method == "search_read"
+        domain = args[0] if args else kwargs.get("domain")
         if model == "res.users":
             if domain == [[("active", "=", True), ("share", "=", False)]]:
                 return [
@@ -176,8 +182,8 @@ def test_setup_templates_step_one_employee_update_syncs_user(
     monkeypatch.setattr(
         OdooEmployee,
         "execute",
-        lambda self, model, method, domain, **kwargs: execute(
-            model, method, domain, **kwargs
+        lambda self, model, method, *args, **kwargs: execute(
+            model, method, *args, **kwargs
         ),
     )
 

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.odoo.models import (
+    OdooEmployee,
+    OdooProduct,
+    OdooSaleFactor,
+    OdooSaleFactorProductRule,
+    OdooSaleOrderTemplate,
+)
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_imports_selected_records(admin_client, admin_user, monkeypatch):
+    profile = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+
+    def execute(model, method, domain, **kwargs):
+        assert method == "search_read"
+        if model == "sale.order.template":
+            fields = kwargs.get("fields") or []
+            if fields == ["id", "name"]:
+                return [{"id": 100, "name": "Starter Quote"}]
+            return [{"id": 100, "name": "Starter Quote", "note": "Generated"}]
+        raise AssertionError(f"Unexpected model: {model}")
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, domain, **kwargs: execute(
+            model, method, domain, **kwargs
+        ),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "templates",
+            "selected_ids": ["100"],
+        },
+    )
+
+    assert response.status_code == 302
+    created = OdooSaleOrderTemplate.objects.get(odoo_template__id=100)
+    assert created.name == "Starter Quote"
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_creates_linked_objects(admin_client):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+    product = OdooProduct.objects.create(
+        name="Addon",
+        renewal_period=30,
+        odoo_product={"id": 501, "name": "Addon"},
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "Setup",
+            "templates": [str(source_template.pk)],
+            "products": [str(product.pk)],
+            "employees": [],
+        },
+    )
+
+    assert response.status_code == 302
+    assert OdooSaleOrderTemplate.objects.filter(name="Setup: Base").exists()
+    factor = OdooSaleFactor.objects.get(name="Setup Products")
+    linked_template = OdooSaleOrderTemplate.objects.get(name="Setup: Base")
+    assert factor.templates.filter(pk=linked_template.pk).exists()
+    assert OdooSaleFactorProductRule.objects.filter(
+        factor=factor,
+        odoo_product__id=501,
+    ).exists()

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -99,6 +99,14 @@ def test_setup_templates_step_one_scopes_template_upsert_by_odoo_instance(
             "database": "odoo-one",
         },
     )
+    partially_scoped = OdooSaleOrderTemplate.objects.create(
+        name="Partially Scoped Other Instance",
+        odoo_template={
+            "id": 100,
+            "name": "Starter Quote",
+            "host": "https://odoo.one.example.com",
+        },
+    )
 
     def execute(model, method, *args, **kwargs):
         assert method == "search_read"
@@ -124,12 +132,16 @@ def test_setup_templates_step_one_scopes_template_upsert_by_odoo_instance(
     )
 
     assert response.status_code == 302
-    assert OdooSaleOrderTemplate.objects.filter(odoo_template__id=100).count() == 2
+    assert OdooSaleOrderTemplate.objects.filter(odoo_template__id=100).count() == 3
     assert OdooSaleOrderTemplate.objects.filter(
         odoo_template__id=100,
         odoo_template__host=profile.host,
         odoo_template__database=profile.database,
     ).exists()
+    partially_scoped.refresh_from_db()
+    assert partially_scoped.name == "Partially Scoped Other Instance"
+    assert partially_scoped.odoo_template["host"] == "https://odoo.one.example.com"
+    assert "database" not in partially_scoped.odoo_template
 
 
 @pytest.mark.django_db
@@ -688,8 +700,8 @@ def test_setup_templates_step_two_rechecks_product_payload_before_rule_creation(
 
     monkeypatch.setattr(
         odoo_admin,
-        "_has_valid_odoo_product_payload",
-        lambda product: next(checks),
+        "_get_valid_odoo_product_payload",
+        lambda product: {"id": 501, "name": "Addon"} if next(checks) else None,
     )
 
     response = admin_client.post(

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -86,3 +86,120 @@ def test_setup_templates_step_two_creates_linked_objects(admin_client):
         factor=factor,
         odoo_product__id=501,
     ).exists()
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_generates_unique_factor_code(admin_client):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+
+    payload = {
+        "name_prefix": "Setup",
+        "templates": [str(source_template.pk)],
+        "products": [],
+        "employees": [],
+    }
+
+    first_response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        payload,
+    )
+    second_response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        payload,
+    )
+
+    assert first_response.status_code == 302
+    assert second_response.status_code == 302
+    assert OdooSaleFactor.objects.filter(code="setup-products").exists()
+    assert OdooSaleFactor.objects.filter(code="setup-products-2").exists()
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_employee_update_syncs_user(
+    admin_client,
+    admin_user,
+    django_user_model,
+    monkeypatch,
+):
+    profile = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="profile-admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+
+    linked_user = django_user_model.objects.create_user(
+        username="legacy-login",
+        password="secret",
+        email="legacy@example.com",
+    )
+    OdooEmployee.objects.create(
+        user=linked_user,
+        host=profile.host,
+        database=profile.database,
+        username="legacy-login",
+        password="",
+        odoo_uid=55,
+        verified_on=timezone.now(),
+    )
+
+    def execute(model, method, domain, **kwargs):
+        assert method == "search_read"
+        if model == "res.users":
+            if domain == [[("active", "=", True), ("share", "=", False)]]:
+                return [
+                    {
+                        "id": 55,
+                        "name": "Updated User",
+                        "email": "new@example.com",
+                        "login": "new-login",
+                        "partner_id": [301, "Partner"],
+                    }
+                ]
+            return [
+                {
+                    "id": 55,
+                    "name": "Updated User",
+                    "email": "new@example.com",
+                    "login": "new-login",
+                    "partner_id": [301, "Partner"],
+                }
+            ]
+        raise AssertionError(f"Unexpected model: {model}")
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, domain, **kwargs: execute(
+            model, method, domain, **kwargs
+        ),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "employees",
+            "selected_ids": ["55"],
+        },
+    )
+
+    assert response.status_code == 302
+    updated_employee = OdooEmployee.objects.get(
+        odoo_uid=55,
+        host=profile.host,
+        database=profile.database,
+    )
+    updated_user = updated_employee.user
+    assert updated_user is not None
+    assert updated_user.username.startswith("new-login")
+    assert updated_user.username != "legacy-login"
+    assert updated_user.email == "new@example.com"
+    assert updated_employee.username == "legacy-login"
+    assert updated_employee.email == "new@example.com"
+    assert updated_employee.partner_id == 301

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from django.contrib import admin
+from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.odoo.admin import OdooSaleOrderTemplateAdmin
 from apps.odoo.models import (
     OdooEmployee,
     OdooProduct,
@@ -209,3 +212,105 @@ def test_setup_templates_step_one_employee_update_syncs_user(
     assert updated_employee.username == "legacy-login"
     assert updated_employee.email == "new@example.com"
     assert updated_employee.partner_id == 301
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_employee_import_truncates_long_username(
+    admin_client,
+    admin_user,
+    django_user_model,
+    monkeypatch,
+):
+    OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="profile-admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    username_field = django_user_model._meta.get_field(django_user_model.USERNAME_FIELD)
+    long_login = "x" * (username_field.max_length + 25)
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model != "res.users":
+            raise AssertionError(f"Unexpected model: {model}")
+        domain = args[0] if args else kwargs.get("domain")
+        if domain == [[("active", "=", True), ("share", "=", False)]]:
+            return [
+                {
+                    "id": 75,
+                    "name": "Long Username",
+                    "email": "long@example.com",
+                    "login": long_login,
+                    "partner_id": [401, "Partner"],
+                }
+            ]
+        return [
+            {
+                "id": 75,
+                "name": "Long Username",
+                "email": "long@example.com",
+                "login": long_login,
+                "partner_id": [401, "Partner"],
+            }
+        ]
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "employees",
+            "selected_ids": ["75"],
+        },
+    )
+
+    assert response.status_code == 302
+    employee = OdooEmployee.objects.get(odoo_uid=75)
+    assert len(employee.user.username) <= username_field.max_length  # type: ignore[union-attr]
+
+
+@pytest.mark.django_db
+def test_import_employee_rolls_back_user_when_employee_create_fails(
+    admin_user, django_user_model, monkeypatch
+):
+    profile = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="profile-admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    model_admin = OdooSaleOrderTemplateAdmin(OdooSaleOrderTemplate, admin.site)
+
+    original_create = OdooEmployee.objects.create
+
+    def create_employee(*args, **kwargs):
+        if kwargs.get("odoo_uid") == 99:
+            raise IntegrityError("forced failure")
+        return original_create(*args, **kwargs)
+
+    monkeypatch.setattr(OdooEmployee.objects, "create", create_employee)
+
+    with pytest.raises(IntegrityError):
+        model_admin._import_employee(
+            profile,
+            {
+                "id": 99,
+                "name": "Fail Employee",
+                "email": "fail@example.com",
+                "login": "rollback-test",
+                "partner_id": [999, "Partner"],
+            },
+        )
+
+    assert not django_user_model.objects.filter(username="rollback-test").exists()

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib import admin
+from django.contrib.auth.models import Permission
 from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
@@ -14,6 +15,20 @@ from apps.odoo.models import (
     OdooSaleFactorProductRule,
     OdooSaleOrderTemplate,
 )
+
+
+def _grant_model_perms(user, model):
+    opts = model._meta
+    user.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label=opts.app_label,
+            codename=f"add_{opts.model_name}",
+        ),
+        Permission.objects.get(
+            content_type__app_label=opts.app_label,
+            codename=f"change_{opts.model_name}",
+        ),
+    )
 
 
 @pytest.mark.django_db
@@ -314,3 +329,75 @@ def test_import_employee_rolls_back_user_when_employee_create_fails(
         )
 
     assert not django_user_model.objects.filter(username="rollback-test").exists()
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_one_employee_import_requires_auth_user_permissions(
+    client,
+    django_user_model,
+    monkeypatch,
+):
+    staff_user = django_user_model.objects.create_user(
+        username="staff-importer",
+        password="testpass",
+        is_staff=True,
+    )
+    _grant_model_perms(staff_user, OdooSaleOrderTemplate)
+    _grant_model_perms(staff_user, OdooEmployee)
+    profile = OdooEmployee.objects.create(
+        user=staff_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="staff-importer",
+        password="secret",
+        odoo_uid=1001,
+        verified_on=timezone.now(),
+    )
+    client.force_login(staff_user)
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model == "sale.order.template":
+            return []
+        if model == "res.users":
+            return [{"id": 88, "name": "Employee No Access", "login": "emp-no-access"}]
+        raise AssertionError(f"Unexpected model: {model}")
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {"source_type": "employees", "selected_ids": ["88"]},
+    )
+
+    assert response.status_code == 200
+    assert "do not have permission to synchronize authentication users" in response.content.decode()
+    assert (
+        OdooEmployee.objects.filter(host=profile.host, database=profile.database, odoo_uid=88).count()
+        == 0
+    )
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_rejects_overlong_cloned_template_name(admin_client):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="T" * 200,
+        odoo_template={"id": 90, "name": "Base"},
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "P" * 120,
+            "templates": [str(source_template.pk)],
+            "products": [],
+            "employees": [],
+        },
+    )
+
+    assert response.status_code == 302
+    assert OdooSaleOrderTemplate.objects.count() == 1

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.odoo import admin as odoo_admin
 from apps.odoo.admin import OdooSaleOrderTemplateAdmin
 from apps.odoo.models import (
     OdooEmployee,
@@ -565,6 +566,44 @@ def test_setup_templates_step_two_rejects_products_without_odoo_payload(admin_cl
 
     assert response.status_code == 200
     assert "Select only products imported from Odoo" in response.content.decode()
+    assert OdooSaleOrderTemplate.objects.filter(name="Setup: Base").count() == 0
+    assert OdooSaleFactor.objects.count() == 0
+    assert OdooSaleFactorProductRule.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_rechecks_product_payload_before_rule_creation(
+    admin_client, monkeypatch
+):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+    product = OdooProduct.objects.create(
+        name="Addon",
+        renewal_period=30,
+        odoo_product={"id": 501, "name": "Addon"},
+    )
+    checks = iter([True, False])
+
+    monkeypatch.setattr(
+        odoo_admin,
+        "_has_valid_odoo_product_payload",
+        lambda product: next(checks),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "Setup",
+            "templates": [str(source_template.pk)],
+            "products": [str(product.pk)],
+            "employees": [],
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("admin:odoo_odoosaleordertemplate_setup_templates_create")
     assert OdooSaleOrderTemplate.objects.filter(name="Setup: Base").count() == 0
     assert OdooSaleFactor.objects.count() == 0
     assert OdooSaleFactorProductRule.objects.count() == 0

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -178,6 +178,81 @@ def test_setup_templates_step_two_creates_linked_objects(admin_client):
 
 
 @pytest.mark.django_db
+def test_setup_templates_step_two_assigns_one_salesperson(
+    admin_client, admin_user
+):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+    salesperson = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="salesperson",
+        password="secret",
+        odoo_uid=2,
+        verified_on=timezone.now(),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "Setup",
+            "templates": [str(source_template.pk)],
+            "products": [],
+            "employees": str(salesperson.pk),
+        },
+    )
+
+    assert response.status_code == 302
+    copied = OdooSaleOrderTemplate.objects.get(name="Setup: Base")
+    assert copied.salesperson == salesperson
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_rejects_multiple_salespeople(
+    admin_client, admin_user, django_user_model
+):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+    first = OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="first-salesperson",
+        password="secret",
+        odoo_uid=2,
+        verified_on=timezone.now(),
+    )
+    second_user = django_user_model.objects.create_user(username="second-salesperson")
+    second = OdooEmployee.objects.create(
+        user=second_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="second-salesperson",
+        password="secret",
+        odoo_uid=3,
+        verified_on=timezone.now(),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "Setup",
+            "templates": [str(source_template.pk)],
+            "products": [],
+            "employees": [str(first.pk), str(second.pk)],
+        },
+    )
+
+    assert response.status_code == 200
+    assert OdooSaleOrderTemplate.objects.filter(name="Setup: Base").count() == 0
+
+
+@pytest.mark.django_db
 def test_setup_templates_step_one_truncates_imported_product_name(
     admin_client, admin_user, monkeypatch
 ):

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -211,6 +211,61 @@ def test_setup_templates_step_one_truncates_imported_product_name(
 
 
 @pytest.mark.django_db
+def test_setup_templates_step_one_preserves_product_renewal_period_on_reimport(
+    admin_client, admin_user, monkeypatch
+):
+    OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    product = OdooProduct.objects.create(
+        name="Local Addon",
+        description="Old description",
+        renewal_period=90,
+        odoo_product={
+            "id": 701,
+            "name": "Local Addon",
+            "host": "https://odoo.example.com",
+            "database": "odoo",
+        },
+    )
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model != "product.product":
+            raise AssertionError(f"Unexpected model: {model}")
+        fields = kwargs.get("fields") or []
+        if fields == ["id", "name"]:
+            return [{"id": 701, "name": "Remote Addon"}]
+        return [{"id": 701, "name": "Remote Addon", "description_sale": "Updated"}]
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "products",
+            "selected_ids": ["701"],
+        },
+    )
+
+    assert response.status_code == 302
+    product.refresh_from_db()
+    assert product.name == "Remote Addon"
+    assert product.description == "Updated"
+    assert product.renewal_period == 90
+
+
+@pytest.mark.django_db
 def test_setup_templates_step_one_truncates_imported_template_name(
     admin_client, admin_user, monkeypatch
 ):
@@ -522,6 +577,51 @@ def test_setup_templates_step_one_employee_import_requires_auth_user_permissions
 
 
 @pytest.mark.django_db
+def test_setup_templates_step_one_reports_database_write_failures(
+    admin_client, admin_user, monkeypatch
+):
+    OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model != "product.product":
+            raise AssertionError(f"Unexpected model: {model}")
+        return [{"id": 701, "name": "Remote Addon"}]
+
+    def fail_import(*args, **kwargs):
+        raise IntegrityError("forced write failure")
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+    monkeypatch.setattr(OdooSaleOrderTemplateAdmin, "_import_source_selection", fail_import)
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "products",
+            "selected_ids": ["701"],
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url.endswith("?source_type=products")
+    response = admin_client.get(response.url)
+    response_messages = [str(message) for message in get_messages(response.wsgi_request)]
+    assert any("Import failed while saving local records" in message for message in response_messages)
+
+
+@pytest.mark.django_db
 def test_setup_templates_step_two_rejects_overlong_cloned_template_name(admin_client):
     source_template = OdooSaleOrderTemplate.objects.create(
         name="T" * 200,
@@ -584,7 +684,7 @@ def test_setup_templates_step_two_rechecks_product_payload_before_rule_creation(
         renewal_period=30,
         odoo_product={"id": 501, "name": "Addon"},
     )
-    checks = iter([True, False])
+    checks = iter([True, True, False])
 
     monkeypatch.setattr(
         odoo_admin,

--- a/apps/odoo/tests/test_template_setup_wizard.py
+++ b/apps/odoo/tests/test_template_setup_wizard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from django.contrib import admin
 from django.contrib.auth.models import Permission
+from django.contrib.messages import get_messages
 from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
@@ -209,6 +210,51 @@ def test_setup_templates_step_one_truncates_imported_product_name(
 
 
 @pytest.mark.django_db
+def test_setup_templates_step_one_truncates_imported_template_name(
+    admin_client, admin_user, monkeypatch
+):
+    OdooEmployee.objects.create(
+        user=admin_user,
+        host="https://odoo.example.com",
+        database="odoo",
+        username="admin",
+        password="secret",
+        odoo_uid=1,
+        verified_on=timezone.now(),
+    )
+    template_name_max = OdooSaleOrderTemplate._meta.get_field("name").max_length or 255
+    long_name = "T" * (template_name_max + 20)
+
+    def execute(model, method, *args, **kwargs):
+        assert method == "search_read"
+        if model != "sale.order.template":
+            raise AssertionError(f"Unexpected model: {model}")
+        fields = kwargs.get("fields") or []
+        if fields == ["id", "name"]:
+            return [{"id": 801, "name": long_name}]
+        return [{"id": 801, "name": long_name, "note": "Remote note"}]
+
+    monkeypatch.setattr(
+        OdooEmployee,
+        "execute",
+        lambda self, model, method, *args, **kwargs: execute(model, method, *args, **kwargs),
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates"),
+        {
+            "source_type": "templates",
+            "selected_ids": ["801"],
+        },
+    )
+
+    assert response.status_code == 302
+    created = OdooSaleOrderTemplate.objects.get(odoo_template__id=801)
+    assert len(created.name) == template_name_max
+    assert created.name == long_name[:template_name_max]
+
+
+@pytest.mark.django_db
 def test_setup_templates_step_two_generates_unique_factor_code(admin_client):
     source_template = OdooSaleOrderTemplate.objects.create(
         name="Base",
@@ -278,16 +324,10 @@ def test_setup_templates_step_one_employee_update_syncs_user(
         assert method == "search_read"
         domain = args[0] if args else kwargs.get("domain")
         if model == "res.users":
-            if domain == [[("active", "=", True), ("share", "=", False)]]:
-                return [
-                    {
-                        "id": 55,
-                        "name": "Updated User",
-                        "email": "new@example.com",
-                        "login": "new-login",
-                        "partner_id": [301, "Partner"],
-                    }
-                ]
+            assert domain in (
+                [[("active", "=", True), ("share", "=", False)]],
+                [[("id", "=", 55)]],
+            )
             return [
                 {
                     "id": 55,
@@ -323,10 +363,9 @@ def test_setup_templates_step_one_employee_update_syncs_user(
     )
     updated_user = updated_employee.user
     assert updated_user is not None
-    assert updated_user.username.startswith("new-login")
-    assert updated_user.username != "legacy-login"
+    assert updated_user.username == "new-login"
     assert updated_user.email == "new@example.com"
-    assert updated_employee.username == "legacy-login"
+    assert updated_employee.username == "new-login"
     assert updated_employee.email == "new@example.com"
     assert updated_employee.partner_id == 301
 
@@ -355,16 +394,10 @@ def test_setup_templates_step_one_employee_import_truncates_long_username(
         if model != "res.users":
             raise AssertionError(f"Unexpected model: {model}")
         domain = args[0] if args else kwargs.get("domain")
-        if domain == [[("active", "=", True), ("share", "=", False)]]:
-            return [
-                {
-                    "id": 75,
-                    "name": "Long Username",
-                    "email": "long@example.com",
-                    "login": long_login,
-                    "partner_id": [401, "Partner"],
-                }
-            ]
+        assert domain in (
+            [[("active", "=", True), ("share", "=", False)]],
+            [[("id", "=", 75)]],
+        )
         return [
             {
                 "id": 75,
@@ -476,8 +509,11 @@ def test_setup_templates_step_one_employee_import_requires_auth_user_permissions
         {"source_type": "employees", "selected_ids": ["88"]},
     )
 
-    assert response.status_code == 200
-    assert "do not have permission to synchronize authentication users" in response.content.decode()
+    response_messages = [str(message) for message in get_messages(response.wsgi_request)]
+    assert any(
+        "do not have permission to synchronize authentication users" in message
+        for message in response_messages
+    )
     assert (
         OdooEmployee.objects.filter(host=profile.host, database=profile.database, odoo_uid=88).count()
         == 0
@@ -503,3 +539,32 @@ def test_setup_templates_step_two_rejects_overlong_cloned_template_name(admin_cl
 
     assert response.status_code == 302
     assert OdooSaleOrderTemplate.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_setup_templates_step_two_rejects_products_without_odoo_payload(admin_client):
+    source_template = OdooSaleOrderTemplate.objects.create(
+        name="Base",
+        odoo_template={"id": 90, "name": "Base"},
+    )
+    product = OdooProduct.objects.create(
+        name="Local Only",
+        renewal_period=30,
+        odoo_product=None,
+    )
+
+    response = admin_client.post(
+        reverse("admin:odoo_odoosaleordertemplate_setup_templates_create"),
+        {
+            "name_prefix": "Setup",
+            "templates": [str(source_template.pk)],
+            "products": [str(product.pk)],
+            "employees": [],
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Select only products imported from Odoo" in response.content.decode()
+    assert OdooSaleOrderTemplate.objects.filter(name="Setup: Base").count() == 0
+    assert OdooSaleFactor.objects.count() == 0
+    assert OdooSaleFactorProductRule.objects.count() == 0


### PR DESCRIPTION
### Motivation

- Provide an admin-facing two-step wizard to import sale order templates, products, and employees from a connected Odoo instance so administrators can bootstrap local templates and rules quickly. 
- Allow creating linked local templates and a product-based sale factor in a single flow to streamline onboarding of Odoo data into the system.

### Description

- Added two admin forms `OdooTemplateSetupImportForm` and `OdooTemplateSetupCreateForm` and registered a changelist action `setup_templates` on `OdooSaleOrderTemplateAdmin` to expose a two-step setup wizard. 
- Implemented admin views `setup_templates_view` and `setup_templates_create_view` plus URL entries and changelist/dashboard integration to drive the wizard flow, and added templates `setup_templates_step1.html` and `setup_templates_step2.html` for the UI. 
- Implemented remote lookup and import helpers (`_remote_options`, `_find_remote_row`, `_import_template`, `_import_product`, `_import_employee`, `_import_source_selection`) including employee user creation with `get_user_model()` and username collision resolution via `_resolve_unique_username`, and sale factor creation using `slugify`. 
- Imported models `OdooEmployee` and `OdooProduct` and added creation logic to generate `OdooSaleFactor` and `OdooSaleFactorProductRule` entries when creating linked objects.

### Testing

- Added unit tests in `apps/odoo/tests/test_template_setup_wizard.py` covering step 1 import (`test_setup_templates_step_one_imports_selected_records`) and step 2 creation of linked objects (`test_setup_templates_step_two_creates_linked_objects`).
- Ran the new test module with `pytest apps/odoo/tests/test_template_setup_wizard.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa4c5b7f4832691932ac8d2ff1874)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Two-step Admin Wizard for Odoo Data Import and Onboarding

## Overview
Adds an admin-facing two-step "Setup Templates" wizard to import sale order templates, products, and employees from a connected Odoo instance and to create linked local objects (cloned templates, sale factors, and product rules) in a single flow. Exposed as a changelist/dashboard action on OdooSaleOrderTemplateAdmin and protected by standard model permissions.

## What changed
- Admin UI & routing
  - Added two admin views and templates: setup_templates_view (step 1) and setup_templates_create_view (step 2) with templates setup_templates_step1.html and setup_templates_step2.html.
  - Registered the wizard as a changelist/dashboard action on OdooSaleOrderTemplateAdmin; added custom get_urls(), changelist action, and dashboard metadata.
  - Wired navigation between step 1 and step 2; shows action only to users with the required permissions.

- Forms & validation
  - Added OdooTemplateSetupImportForm (step 1) and OdooTemplateSetupCreateForm (step 2).
  - Enforced template name length bounds for cloned templates and other input validations.

- Remote lookup & import helpers
  - Implemented helpers: _remote_options, _find_remote_row, _import_template, _import_product, _import_employee, _import_source_selection.
  - Network/xmlrpc errors (Fault, OSError, ProtocolError) are caught and surfaced as admin error messages; remote lookups scoped to the source instance when provided.

- Employee/user synchronization
  - Employee import creates/updates OdooEmployee and the linked Django auth user using get_user_model().
  - Username collision handling via _resolve_unique_username: appends "-odoo-<odoo_uid>" and increments suffixes if needed; respects Django username max length (truncation where necessary).
  - Atomic creation for user + employee; rolls back if creating user raises IntegrityError.
  - Permission checks: skipping auth-user sync when the invoking admin lacks required rights (message and no employee created).

- Sale factor, templates & product rules
  - When creating linked objects in step 2: clones selected local templates with a name_prefix, creates an OdooSaleFactor (unique code generated with slugify + numeric retries on IntegrityError), links cloned templates to the factor, and creates OdooSaleFactorProductRule rows for selected products.
  - Slug uniqueness retried up to a bounded count to avoid collisions.

- Models touched / imported
  - Imported/used OdooEmployee and OdooProduct models and created OdooSaleFactor and OdooSaleFactorProductRule rows as part of the creation flow.

## Tests
- New test module apps/odoo/tests/test_template_setup_wizard.py covering:
  - Step 1 imports for templates, products, and employees with mocked remote responses and instance-scoped upserts.
  - Username truncation and uniqueness resolution for employee/user sync.
  - Atomic rollback behavior when user creation fails.
  - Step 2 creation: cloning templates, generating unique factor codes, linking templates to factors, and creating product rules.
  - Constraint validation: rejecting overlong cloned template names.
- Tests run with pytest and passed in the author’s runs.

## Implementation notes / intents preserved
- Uses atomic transactions where consistency is required (user+employee and step-2 creation).
- Enforces RBAC and input bounds added in iterative commits.
- Scopes remote imports by source instance when provided to avoid accidental cross-instance imports.
- Error handling surfaces admin-visible messages and preserves admin redirect behavior.

## Files added/modified (high level)
- apps/odoo/admin.py: new forms, views, helpers, URL integration, and action wiring.
- apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step1.html
- apps/odoo/templates/admin/odoo/odoosaleordertemplate/setup_templates_step2.html
- apps/odoo/tests/test_template_setup_wizard.py: new test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->