### PR TITLE
Tighten superuser provisioning UI and feedback dialog spacing

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -175,14 +175,15 @@
       <style>
         .operator-journey-provision-layout {
           display: grid;
-          gap: 1rem;
+          align-items: start;
+          gap: var(--admin-ui-space-4, 1rem);
           grid-template-columns: minmax(380px, 1.2fr) minmax(320px, 1fr);
-          margin-top: 1rem;
+          margin-top: var(--admin-ui-space-4, 1rem);
         }
         .operator-journey-provision-panel {
           border: 1px solid var(--hairline-color);
-          border-radius: 8px;
-          padding: 1rem;
+          border-radius: var(--admin-ui-radius-md, 0.5rem);
+          padding: var(--admin-ui-space-4, 1rem);
         }
         .operator-journey-provision-panel h2 {
           margin-top: 0;
@@ -194,18 +195,18 @@
         .operator-journey-sg-table th,
         .operator-journey-sg-table td {
           border-bottom: 1px solid var(--hairline-color);
-          padding: 0.6rem;
+          padding: var(--admin-ui-space-2, 0.5rem) var(--admin-ui-space-3, 0.75rem);
           text-align: left;
-          vertical-align: top;
+          vertical-align: middle;
         }
         .operator-journey-sg-table td:first-child,
         .operator-journey-sg-table th:first-child {
-          width: calc(var(--admin-ui-control-height, 2.5rem) + var(--admin-ui-space-4, 1rem));
+          width: calc(var(--admin-ui-control-height-sm, 2.125rem) + var(--admin-ui-space-3, 0.75rem));
         }
         .operator-journey-checkbox {
-          block-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-3, 0.75rem));
+          block-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-4, 1rem));
           cursor: pointer;
-          inline-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-3, 0.75rem));
+          inline-size: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-4, 1rem));
           margin: 0;
         }
         .operator-journey-checkbox-hitarea {
@@ -215,9 +216,32 @@
           cursor: pointer;
           display: inline-flex;
           justify-content: center;
-          min-height: var(--admin-ui-control-height-sm, 2.125rem);
-          min-width: var(--admin-ui-control-height-sm, 2.125rem);
+          min-height: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-2, 0.5rem));
+          min-width: calc(var(--admin-ui-control-height-sm, 2.125rem) - var(--admin-ui-space-2, 0.5rem));
           padding: var(--admin-ui-space-1, 0.25rem);
+        }
+        .operator-journey-account-fields {
+          display: grid;
+          gap: var(--admin-ui-space-3, 0.75rem);
+          margin-top: 0;
+          padding: 0;
+        }
+        .operator-journey-account-row {
+          display: grid;
+          gap: var(--admin-ui-space-2, 0.5rem);
+          margin: 0;
+        }
+        .operator-journey-account-row label {
+          display: block;
+          font-weight: 600;
+          margin: 0;
+        }
+        .operator-journey-account-row .help {
+          margin: var(--admin-ui-space-1, 0.25rem) 0 0;
+        }
+        .operator-journey-account-row input,
+        .operator-journey-account-row select {
+          width: 100%;
         }
         .operator-journey-primary-button {
           font-size: 0.95rem;
@@ -264,7 +288,7 @@
                       </label>
                     </td>
                     <td>
-                      <label for="id_security_groups_{{ row.id }}"><strong>{{ row.name }}</strong></label>
+                      <label for="id_security_groups_{{ row.id }}"><strong>{{ row.name_label }}</strong></label>
                     </td>
                     <td>
                       {% if row.is_staff_group %}{% translate "Yes" %}{% else %}{% translate "No" %}{% endif %}
@@ -279,14 +303,14 @@
           </section>
           <section class="operator-journey-provision-panel" aria-labelledby="account-details-title">
             <h2 id="account-details-title">{% translate "User details" %}</h2>
-            <fieldset class="module aligned" style="padding: 0;">
+            <fieldset class="module aligned operator-journey-account-fields">
               {% for field in provision_superuser_form %}
                 {% if field.name != "security_groups" %}
-                  <div class="form-row" style="margin-bottom: var(--admin-ui-space-3, 0.75rem);">
-                    <label for="{{ field.id_for_label }}" style="display: block; font-weight: 600;">{{ field.label }}</label>
+                  <div class="form-row operator-journey-account-row">
+                    <label for="{{ field.id_for_label }}">{{ field.label }}</label>
                     {{ field }}
                     {% if field.help_text %}
-                      <p class="help" style="margin: var(--admin-ui-space-1, 0.25rem) 0 0;">{{ field.help_text }}</p>
+                      <p class="help">{{ field.help_text }}</p>
                     {% endif %}
                     {{ field.errors }}
                   </div>

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -239,7 +239,7 @@
         .operator-journey-account-row .help {
           margin: var(--admin-ui-space-1, 0.25rem) 0 0;
         }
-        .operator-journey-account-row input,
+        .operator-journey-account-row input:not([type="checkbox"]):not([type="radio"]),
         .operator-journey-account-row select {
           width: 100%;
         }

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1293,6 +1293,21 @@ class OperatorJourneyViewTests(TestCase):
         self.assertEqual(rows_by_name[SITE_OPERATOR_GROUP_NAME]["apps"], "—")
         self.assertFalse(rows_by_name["Custom app group"]["is_staff_group"])
         self.assertEqual(rows_by_name["Custom app group"]["apps"], "billing")
+        self.assertEqual(
+            rows_by_name["Custom app group"]["name_label"],
+            "Custom app group",
+        )
+
+    def test_security_group_rows_show_name_fallback_for_blank_names(self):
+        SecurityGroup.objects.create(name="")
+        provision_form = OperatorJourneyProvisionSuperuserForm()
+
+        security_group_rows = _build_security_group_rows(provision_form)
+
+        self.assertIn(
+            "Unnamed security group",
+            {row["name_label"] for row in security_group_rows},
+        )
 
     def test_provision_step_creates_superuser_with_assigned_groups(self):
         provision_step = OperatorJourneyStep.objects.create(

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -21,6 +21,7 @@ from django.http import (
 )
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from apps.repos.services import github as github_service
 
@@ -155,7 +156,7 @@ def _build_security_group_rows(
                 "apps": app_names,
                 "is_staff_group": group.is_canonical_staff_group,
                 "name": group.name,
-                "name_label": group.name or "Unnamed security group",
+                "name_label": group.name or _("Unnamed security group"),
                 "selected": str(group.pk) in selected_group_ids,
             }
         )

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -155,6 +155,7 @@ def _build_security_group_rows(
                 "apps": app_names,
                 "is_staff_group": group.is_canonical_staff_group,
                 "name": group.name,
+                "name_label": group.name or "Unnamed security group",
                 "selected": str(group.pk) in selected_group_ids,
             }
         )

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -874,7 +874,7 @@ body.user-story-open {
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    padding: 1.25rem 1.25rem 0.75rem;
+    padding: var(--admin-ui-space-3, 0.75rem) var(--admin-ui-space-4, 1rem) var(--admin-ui-space-2, 0.5rem);
     border-bottom: 1px solid var(--user-story-card-border);
 }
 


### PR DESCRIPTION
### Motivation
- Address operator feedback about the provisioning UI showing an empty security-group label and overly-tall, misaligned rows. 
- Make account-detail fields on the right panel align and fill the available space for clearer data entry. 
- Reduce the top margin in the feedback admin dialog so the close button sits closer to the top edge.

### Description
- Add a normalized display label `name_label` with a blank-name fallback (`"Unnamed security group"`) in `_build_security_group_rows` so empty group names never render as a blank table cell (`apps/ops/views.py`).
- Update the provision step template to use `name_label`, reduce table row padding, center-align row content vertically, tighten checkbox hit area, and add grid rules so right-side account fields align and stretch (`apps/ops/templates/admin/ops/operator_journey_step.html`).
- Introduce a small spacing tweak to the feedback dialog header padding using admin CSS variables so the close button sits nearer the top edge (`apps/sites/static/sites/css/admin/base_site.css`).
- Add a unit test to cover the blank-name fallback and update an existing test to assert `name_label` behavior (`apps/ops/tests/test_operator_journey.py`).

### Testing
- Executed dependency bootstrap with `./env-refresh.sh --deps-only` which completed successfully. 
- Ran the operator-journey test suite with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py` and all tests passed (`45 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaa30a54c832687df2115a80c34f7)