### PR TITLE
ops: add skip path for provision-ops-superuser journey step

### DIFF
--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -327,7 +327,7 @@
         </div>
         <div class="operator-journey-form-actions">
           <button type="submit" name="journey_action" value="provision" class="button default operator-journey-primary-button">{% translate "Create account and complete step" %}</button>
-          <button type="submit" name="journey_action" value="skip" class="button">{% translate "Skip this step and continue" %}</button>
+          <button type="submit" name="journey_action" value="skip" formnovalidate class="button">{% translate "Skip this step and continue" %}</button>
         </div>
       </form>
     {% elif github_access_form %}

--- a/apps/ops/templates/admin/ops/operator_journey_step.html
+++ b/apps/ops/templates/admin/ops/operator_journey_step.html
@@ -248,6 +248,12 @@
           min-height: var(--admin-ui-control-height-sm, 2.125rem);
           padding: 0 var(--admin-ui-control-padding-x, 0.875rem);
         }
+        .operator-journey-form-actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--admin-ui-space-2, 0.5rem);
+          margin-top: var(--admin-ui-space-3, 0.75rem);
+        }
         @media (max-width: 980px) {
           .operator-journey-provision-layout {
             grid-template-columns: 1fr;
@@ -319,7 +325,10 @@
             </fieldset>
           </section>
         </div>
-        <button type="submit" class="button default operator-journey-primary-button">{% translate "Create account and complete step" %}</button>
+        <div class="operator-journey-form-actions">
+          <button type="submit" name="journey_action" value="provision" class="button default operator-journey-primary-button">{% translate "Create account and complete step" %}</button>
+          <button type="submit" name="journey_action" value="skip" class="button">{% translate "Skip this step and continue" %}</button>
+        </div>
       </form>
     {% elif github_access_form %}
       <p>{{ step.instruction }}</p>

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -1005,6 +1005,11 @@ class OperatorJourneyViewTests(TestCase):
         )
 
         self.assertContains(response, "Skip this step and continue")
+        self.assertContains(
+            response,
+            'name="journey_action" value="skip" formnovalidate',
+            html=False,
+        )
 
     def test_tag_returns_empty_status_without_request_context(self):
         rendered = Template(

--- a/apps/ops/tests/test_operator_journey.py
+++ b/apps/ops/tests/test_operator_journey.py
@@ -904,6 +904,108 @@ class OperatorJourneyViewTests(TestCase):
             get_user_model().objects.filter(username="ops-not-allowed").exists()
         )
 
+    def test_provision_step_allows_skip_without_creating_user(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        follow_up_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Continue setup",
+            slug="continue-setup",
+            instruction="Continue setup.",
+            iframe_url="/admin/",
+            order=4,
+        )
+        self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": self.step_1.journey.slug,
+                    "step_slug": self.step_1.slug,
+                },
+            )
+        )
+        self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": self.step_2.journey.slug,
+                    "step_slug": self.step_2.slug,
+                },
+            )
+        )
+
+        response = self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": provision_step.journey.slug,
+                    "step_slug": provision_step.slug,
+                },
+            ),
+            {"journey_action": "skip"},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "ops:operator-journey-step",
+                kwargs={
+                    "journey_slug": follow_up_step.journey.slug,
+                    "step_slug": follow_up_step.slug,
+                },
+            ),
+        )
+        self.assertTrue(provision_step.completions.filter(user=self.user).exists())
+        self.assertFalse(
+            get_user_model().objects.filter(username="ops-skip-account").exists()
+        )
+
+    def test_provision_step_view_includes_skip_button(self):
+        provision_step = OperatorJourneyStep.objects.create(
+            journey=self.journey,
+            title="Create ops superuser",
+            slug="provision-ops-superuser",
+            instruction="Create account.",
+            iframe_url="/admin/",
+            order=3,
+        )
+        self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": self.step_1.journey.slug,
+                    "step_slug": self.step_1.slug,
+                },
+            )
+        )
+        self.client.post(
+            reverse(
+                "ops:operator-journey-step-complete",
+                kwargs={
+                    "journey_slug": self.step_2.journey.slug,
+                    "step_slug": self.step_2.slug,
+                },
+            )
+        )
+
+        response = self.client.get(
+            reverse(
+                "ops:operator-journey-step",
+                kwargs={
+                    "journey_slug": provision_step.journey.slug,
+                    "step_slug": provision_step.slug,
+                },
+            )
+        )
+
+        self.assertContains(response, "Skip this step and continue")
+
     def test_tag_returns_empty_status_without_request_context(self):
         rendered = Template(
             "{% load operator_journey %}"

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -286,6 +286,24 @@ def _resolve_oauth_step_or_redirect(
     return step, None
 
 
+def _complete_current_step_with_lock(
+    request: HttpRequest, *, step: OperatorJourneyStep
+) -> HttpResponseRedirect | None:
+    """Complete the current step under a user lock or redirect with warning."""
+
+    request.user.__class__._default_manager.select_for_update().get(pk=request.user.pk)
+    if complete_step_for_user(user=request.user, step=step):
+        return None
+    locked_step = next_step_for_user(user=request.user)
+    messages.warning(
+        request,
+        "That step is not available yet. Finish the current required operator step first.",
+    )
+    if locked_step is None:
+        return redirect(reverse(ADMIN_INDEX_URL_NAME))
+    return redirect(operator_journey_step_url(step=locked_step))
+
+
 @staff_member_required
 def clear_active_operation(request: HttpRequest):
     """Clear the active operation from session storage."""
@@ -459,24 +477,11 @@ def complete_operator_journey_step(
         action = (request.POST.get("journey_action") or "").strip().lower()
         if action == "skip":
             with transaction.atomic():
-                request.user.__class__._default_manager.select_for_update().get(
-                    pk=request.user.pk
+                redirect_response = _complete_current_step_with_lock(
+                    request, step=step
                 )
-                locked_step = next_step_for_user(user=request.user)
-                if locked_step is None:
-                    return redirect(reverse(ADMIN_INDEX_URL_NAME))
-                if locked_step.pk != step.pk:
-                    messages.warning(
-                        request,
-                        "That step is not available yet. Finish the current required operator step first.",
-                    )
-                    return redirect(operator_journey_step_url(step=locked_step))
-                if not complete_step_for_user(user=request.user, step=step):
-                    messages.warning(
-                        request,
-                        "That step is not available yet. Finish the current required operator step first.",
-                    )
-                    return redirect(operator_journey_step_url(step=locked_step))
+                if redirect_response is not None:
+                    return redirect_response
             next_step = next_step_for_user(user=request.user)
             if next_step is None:
                 return render(request, "admin/ops/operator_journey_complete.html")
@@ -495,24 +500,9 @@ def complete_operator_journey_step(
                 context,
             )
         with transaction.atomic():
-            request.user.__class__._default_manager.select_for_update().get(
-                pk=request.user.pk
-            )
-            locked_step = next_step_for_user(user=request.user)
-            if locked_step is None:
-                return redirect(reverse(ADMIN_INDEX_URL_NAME))
-            if locked_step.pk != step.pk:
-                messages.warning(
-                    request,
-                    "That step is not available yet. Finish the current required operator step first.",
-                )
-                return redirect(operator_journey_step_url(step=locked_step))
-            if not complete_step_for_user(user=request.user, step=step):
-                messages.warning(
-                    request,
-                    "That step is not available yet. Finish the current required operator step first.",
-                )
-                return redirect(operator_journey_step_url(step=locked_step))
+            redirect_response = _complete_current_step_with_lock(request, step=step)
+            if redirect_response is not None:
+                return redirect_response
             new_user, password, created_user = provision_form.save()
         next_step = next_step_for_user(user=request.user)
         return render(

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -456,6 +456,31 @@ def complete_operator_journey_step(
     if step.slug == PROVISION_SUPERUSER_STEP_SLUG:
         if not request.user.is_superuser:
             raise PermissionDenied
+        action = (request.POST.get("journey_action") or "").strip().lower()
+        if action == "skip":
+            with transaction.atomic():
+                request.user.__class__._default_manager.select_for_update().get(
+                    pk=request.user.pk
+                )
+                locked_step = next_step_for_user(user=request.user)
+                if locked_step is None:
+                    return redirect(reverse(ADMIN_INDEX_URL_NAME))
+                if locked_step.pk != step.pk:
+                    messages.warning(
+                        request,
+                        "That step is not available yet. Finish the current required operator step first.",
+                    )
+                    return redirect(operator_journey_step_url(step=locked_step))
+                if not complete_step_for_user(user=request.user, step=step):
+                    messages.warning(
+                        request,
+                        "That step is not available yet. Finish the current required operator step first.",
+                    )
+                    return redirect(operator_journey_step_url(step=locked_step))
+            next_step = next_step_for_user(user=request.user)
+            if next_step is None:
+                return render(request, "admin/ops/operator_journey_complete.html")
+            return redirect(operator_journey_step_url(step=next_step))
         provision_form = OperatorJourneyProvisionSuperuserForm(request.POST)
         if not provision_form.is_valid():
             context = {


### PR DESCRIPTION
### Motivation

- Allow operators to mark the `provision-ops-superuser` step complete without creating/updating a user when account provisioning should happen outside the admin UI.
- Preserve the existing concurrency and step-order checks while providing a lower-friction onboarding path for constrained environments.
- Surface an explicit UI affordance to make the skip behavior discoverable and intentional.

### Description

- Add handling for `journey_action=skip` in `complete_operator_journey_step` to mark the `provision-ops-superuser` step complete inside the same transactional/select-for-update flow used by provisioning. (changed: `apps/ops/views.py`).
- Add a secondary action button labeled "Skip this step and continue" and accompanying action-layout CSS to the provision step template. (changed: `apps/ops/templates/admin/ops/operator_journey_step.html`).
- Add two regression tests to validate skip behavior and that the skip button is rendered in the provision step view. (changed: `apps/ops/tests/test_operator_journey.py`).

### Testing

- Bootstrapped deps with `./env-refresh.sh --deps-only` which completed successfully.
- An initial incorrect test invocation (`.venv/bin/python manage.py test run -- apps.ops.tests.test_operator_journey.OperatorJourneyViewTests`) failed due to an invalid test target (no tests collected) and is not indicative of regressions.
- Ran the targeted view tests with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py::OperatorJourneyViewTests` and received `21 passed` indicating the new behavior and related coverage are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9324345083269938a60fd982797f)