### PR TITLE
[codex] Add reusable release simulator command

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -155,161 +155,26 @@ jobs:
     permissions:
       contents: read
     outputs:
-      simulated_ok: ${{ steps.finalize.outputs.simulated_ok }}
-      summary_markdown: ${{ steps.finalize.outputs.summary_markdown }}
+      simulated_ok: ${{ steps.simulate.outputs.simulated_ok }}
+      summary_markdown: ${{ steps.simulate.outputs.summary_markdown }}
     steps:
       - uses: actions/checkout@v6
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         with:
           clean: false
       - uses: actions/setup-python@v6
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
         with:
           python-version: '3.11'
-      - name: Validate release tag version gate (simulated)
-        id: validate_version_gate
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
+      - name: Run release simulator
+        id: simulate
+        env:
+          BLOCKERS_JSON: ${{ needs.evaluate.outputs.blockers_json }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import tomllib
-
-          root = Path('.')
-          expected_version = (root / 'VERSION').read_text(encoding='utf-8').strip()
-          pyproject = tomllib.loads((root / 'pyproject.toml').read_text(encoding='utf-8'))
-          dynamic_version_files = (
-              pyproject.get('tool', {})
-              .get('setuptools', {})
-              .get('dynamic', {})
-              .get('version', {})
-              .get('file', [])
-          )
-          if isinstance(dynamic_version_files, str):
-              dynamic_version_files = [dynamic_version_files]
-
-          if dynamic_version_files:
-              dynamic_path = root / dynamic_version_files[0]
-              dynamic_version = dynamic_path.read_text(encoding='utf-8').strip()
-              if dynamic_version != expected_version:
-                  raise SystemExit(
-                      'Release simulation blocked: VERSION and setuptools dynamic version file differ. '
-                      f'VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.'
-                  )
-
-          print(f'Simulated tag/version gate passed for VERSION={expected_version!r}.')
-          PY
-      - name: Preflight PyPI version availability (simulated)
-        id: preflight_pypi
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
-        run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-          from urllib.error import HTTPError, URLError
-          from urllib.request import urlopen
-
-          package_name = 'arthexis'
-          package_version = Path('VERSION').read_text(encoding='utf-8').strip()
-          pypi_url = f'https://pypi.org/pypi/{package_name}/json'
-
-          try:
-              with urlopen(pypi_url, timeout=15) as response:
-                  payload = json.load(response)
-          except HTTPError as exc:
-              if exc.code == 404:
-                  payload = {'releases': {}}
-              else:
-                  raise SystemExit(
-                      'Release simulation blocked: unable to verify existing PyPI versions '
-                      f'(HTTP {exc.code} from {pypi_url}).'
-                  ) from exc
-          except URLError as exc:
-              raise SystemExit(
-                  'Release simulation blocked: network failure while checking PyPI for an existing release '
-                  f'({exc.reason}).'
-              ) from exc
-
-          releases = payload.get('releases', {})
-          if package_version in releases:
-              raise SystemExit(
-                  f'Release simulation blocked: {package_name} {package_version} is already available on PyPI.'
-              )
-
-          print(f'Simulated PyPI preflight passed for {package_name} {package_version}.')
-          PY
-      - name: Install build backend
-        id: install_build_backend
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine
-      - name: Build sdist and wheel (simulated)
-        id: build_package
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
-        run: |
-          python -m build
-      - name: Validate package metadata (simulated)
-        id: validate_metadata
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
-        run: |
-          python -m twine check dist/*
-      - name: Stop before authorization-required publish step
-        id: authorization_boundary
-        if: ${{ needs.evaluate.outputs.can_simulate == 'true' }}
-        run: |
-          echo "Release simulator intentionally stopped before PyPI trusted-publisher authorization/publish."
-      - name: Generate release simulation summary
-        id: finalize
-        if: ${{ always() }}
-        run: |
-          if [ "${{ needs.evaluate.outputs.can_simulate }}" = "true" ]; then
-            if [ "${{ job.status }}" = "success" ]; then
-              {
-                echo 'summary_markdown<<EOF'
-                echo '### Simulation result'
-                echo ''
-                echo '- ✅ Release simulation reached the authorization boundary successfully.'
-                echo '- ℹ️ Publish to PyPI was intentionally skipped because authorization is required.'
-                echo '- ✅ Recommendation: release is ready if maintainers approve and trigger a real publish.'
-                echo 'EOF'
-                echo 'simulated_ok=true'
-              } >> "$GITHUB_OUTPUT"
-            else
-              FAILED_STEP='the simulation pipeline'
-              if [ "${{ steps.validate_version_gate.outcome }}" = "failure" ]; then
-                FAILED_STEP='validate_version_gate'
-              elif [ "${{ steps.preflight_pypi.outcome }}" = "failure" ]; then
-                FAILED_STEP='preflight_pypi'
-              elif [ "${{ steps.install_build_backend.outcome }}" = "failure" ]; then
-                FAILED_STEP='install_build_backend'
-              elif [ "${{ steps.build_package.outcome }}" = "failure" ]; then
-                FAILED_STEP='build_package'
-              elif [ "${{ steps.validate_metadata.outcome }}" = "failure" ]; then
-                FAILED_STEP='validate_metadata'
-              elif [ "${{ steps.authorization_boundary.outcome }}" = "failure" ]; then
-                FAILED_STEP='authorization_boundary'
-              fi
-              {
-                echo 'summary_markdown<<EOF'
-                echo '### Simulation result'
-                echo ''
-                echo '- ❌ Release simulation failed before reaching the authorization boundary.'
-                echo "- ❌ First failing step: \`$FAILED_STEP\`."
-                echo "- 🔎 Inspect this workflow run for detailed logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                echo 'EOF'
-                echo 'simulated_ok=false'
-              } >> "$GITHUB_OUTPUT"
-            fi
-          else
-            {
-              echo 'summary_markdown<<EOF'
-              echo '### Simulation result'
-              echo ''
-              echo '- ⏭️ Release simulation was skipped because install/upgrade blockers are open.'
-              echo 'EOF'
-              echo 'simulated_ok=false'
-            } >> "$GITHUB_OUTPUT"
-          fi
+          python -m apps.release.simulator \
+            --blockers-json "$BLOCKERS_JSON" \
+            --github-output "$GITHUB_OUTPUT" \
+            --install-missing-tools \
+            --run-url "$RUN_URL"
 
   report:
     if: ${{ always() && github.event_name != 'push' }}

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -152,6 +152,7 @@ jobs:
     needs:
       - evaluate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:

--- a/apps/release/management/commands/release.py
+++ b/apps/release/management/commands/release.py
@@ -22,6 +22,12 @@ from apps.release.domain import (
 )
 from apps.release.models import Package as PackageModel
 from apps.release.models import PackageRelease
+from apps.release.simulator import (
+    ReleaseSimulationError,
+    emit_result,
+    parse_blockers_json,
+    run_release_simulation,
+)
 
 REQUIRED_PACKAGE_FIELDS = (
     "name",
@@ -77,7 +83,7 @@ class Command(BaseCommand):
 
     help = (
         "Run release actions (prepare, build, snap/capture-state, clean/clean-logs, "
-        "check-pypi, migrate/apply-migrations, xforms/run-data-transforms)."
+        "check-pypi, simulate, migrate/apply-migrations, xforms/run-data-transforms)."
     )
 
     def add_arguments(self, parser):
@@ -154,6 +160,54 @@ class Command(BaseCommand):
                 "Defaults to the latest release for the active package."
             ),
         )
+
+        simulate_parser = subparsers.add_parser(
+            "simulate",
+            help="Run the release-readiness simulator without publishing.",
+        )
+        simulate_parser.add_argument(
+            "--root",
+            help="Repository root. Defaults to Django BASE_DIR.",
+        )
+        simulate_parser.add_argument("--package-name", default="arthexis")
+        simulate_parser.add_argument("--version-file", default="VERSION")
+        simulate_parser.add_argument("--pyproject", default="pyproject.toml")
+        simulate_parser.add_argument("--dist-dir", default="dist")
+        simulate_parser.add_argument(
+            "--blockers-json",
+            default="",
+            help="JSON list of precomputed install/upgrade blockers.",
+        )
+        simulate_parser.add_argument(
+            "--skip-pypi",
+            action="store_true",
+            help="Skip the PyPI duplicate-version preflight for offline local runs.",
+        )
+        simulate_parser.add_argument(
+            "--skip-build",
+            action="store_true",
+            help="Skip package build and twine metadata validation.",
+        )
+        simulate_parser.add_argument(
+            "--no-clean",
+            action="store_false",
+            dest="clean",
+            default=True,
+            help="Do not remove prior dist/build artifacts before building.",
+        )
+        simulate_parser.add_argument(
+            "--install-missing-tools",
+            action="store_true",
+            help="Install/upgrade pip, build, and twine before building.",
+        )
+        simulate_parser.add_argument("--pypi-timeout", type=float, default=15.0)
+        simulate_parser.add_argument("--run-url", default="")
+        simulate_parser.add_argument(
+            "--github-output",
+            help="Append GitHub Actions outputs to this file.",
+        )
+        simulate_parser.add_argument("--summary-file", help="Write markdown summary to this file.")
+        simulate_parser.add_argument("--json", action="store_true", dest="json_output")
 
         migration_parser = subparsers.add_parser(
             "apply-migrations",
@@ -325,6 +379,43 @@ class Command(BaseCommand):
             stdout=self.stdout,
             stderr=self.stderr,
         )
+
+    def _handle_simulate(self, options: dict[str, object]) -> None:
+        root = Path(str(options.get("root") or settings.BASE_DIR))
+        try:
+            blockers = parse_blockers_json(str(options.get("blockers_json") or ""))
+            result = run_release_simulation(
+                root=root,
+                package_name=str(options.get("package_name") or "arthexis"),
+                version_file=Path(str(options.get("version_file") or "VERSION")),
+                pyproject_path=Path(str(options.get("pyproject") or "pyproject.toml")),
+                dist_dir=Path(str(options.get("dist_dir") or "dist")),
+                blockers=blockers,
+                skip_pypi=bool(options.get("skip_pypi")),
+                skip_build=bool(options.get("skip_build")),
+                clean=bool(options.get("clean", True)),
+                install_missing_tools=bool(options.get("install_missing_tools")),
+                pypi_timeout=float(options.get("pypi_timeout") or 15.0),
+                run_url=str(options.get("run_url") or ""),
+            )
+        except ReleaseSimulationError as exc:
+            raise CommandError(exc.message) from exc
+
+        emit_result(
+            result,
+            github_output=Path(str(options["github_output"]))
+            if options.get("github_output")
+            else None,
+            summary_file=Path(str(options["summary_file"]))
+            if options.get("summary_file")
+            else None,
+            json_output=bool(options.get("json_output")),
+            stdout=self.stdout,
+        )
+        if not result.ok and not result.skipped:
+            raise CommandError(
+                f"Release simulation failed at {result.failed_step}: {result.error}"
+            )
 
     def _handle_run_data_transforms(self, options: dict[str, object]) -> None:
         max_batches = int(options["max_batches"])

--- a/apps/release/management/commands/release.py
+++ b/apps/release/management/commands/release.py
@@ -23,6 +23,7 @@ from apps.release.domain import (
 from apps.release.models import Package as PackageModel
 from apps.release.models import PackageRelease
 from apps.release.simulator import (
+    DEFAULT_PACKAGE_NAME,
     ReleaseSimulationError,
     emit_result,
     parse_blockers_json,
@@ -169,7 +170,7 @@ class Command(BaseCommand):
             "--root",
             help="Repository root. Defaults to Django BASE_DIR.",
         )
-        simulate_parser.add_argument("--package-name", default="arthexis")
+        simulate_parser.add_argument("--package-name", default=DEFAULT_PACKAGE_NAME)
         simulate_parser.add_argument("--version-file", default="VERSION")
         simulate_parser.add_argument("--pyproject", default="pyproject.toml")
         simulate_parser.add_argument("--dist-dir", default="dist")
@@ -381,12 +382,12 @@ class Command(BaseCommand):
         )
 
     def _handle_simulate(self, options: dict[str, object]) -> None:
-        root = Path(str(options.get("root") or settings.BASE_DIR))
+        root = Path(options.get("root") or settings.BASE_DIR)
         try:
             blockers = parse_blockers_json(str(options.get("blockers_json") or ""))
             result = run_release_simulation(
                 root=root,
-                package_name=str(options.get("package_name") or "arthexis"),
+                package_name=str(options.get("package_name") or DEFAULT_PACKAGE_NAME),
                 version_file=Path(str(options.get("version_file") or "VERSION")),
                 pyproject_path=Path(str(options.get("pyproject") or "pyproject.toml")),
                 dist_dir=Path(str(options.get("dist_dir") or "dist")),
@@ -395,7 +396,7 @@ class Command(BaseCommand):
                 skip_build=bool(options.get("skip_build")),
                 clean=bool(options.get("clean", True)),
                 install_missing_tools=bool(options.get("install_missing_tools")),
-                pypi_timeout=float(options.get("pypi_timeout") or 15.0),
+                pypi_timeout=float(options.get("pypi_timeout", 15.0)),
                 run_url=str(options.get("run_url") or ""),
             )
         except ReleaseSimulationError as exc:

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -8,20 +8,25 @@ import secrets
 import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 try:  # Python 3.11+
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
-    import toml as tomllib  # type: ignore[no-redef]
+    import tomli as tomllib  # type: ignore[no-redef]
 
 
 DEFAULT_PACKAGE_NAME = "arthexis"
+BUILD_SKIPPED_DETAIL = "Build was skipped by caller."
+PYPI_USER_AGENT = "arthexis-release-simulator"
+SIMULATION_RESULT_HEADING = "### Simulation result"
+SUBPROCESS_TIMEOUT_SECONDS = 1800.0
 
 
 @dataclass
@@ -144,17 +149,17 @@ def run_release_simulation(
                     SimulationStep(
                         name="install_build_backend",
                         outcome="skipped",
-                        detail="Build was skipped by caller.",
+                        detail=BUILD_SKIPPED_DETAIL,
                     ),
                     SimulationStep(
                         name="build_package",
                         outcome="skipped",
-                        detail="Build was skipped by caller.",
+                        detail=BUILD_SKIPPED_DETAIL,
                     ),
                     SimulationStep(
                         name="validate_metadata",
                         outcome="skipped",
-                        detail="Build was skipped by caller.",
+                        detail=BUILD_SKIPPED_DETAIL,
                     ),
                 ]
             )
@@ -186,14 +191,14 @@ def run_release_simulation(
                     )
                 )
 
-            if clean:
-                _clean_artifacts(root=root, dist_dir=dist_dir)
             resolved_dist = _resolve_child_path(
                 root,
                 dist_dir,
                 label="dist directory",
                 step="build_package",
             )
+            if clean:
+                _clean_artifacts(root=root, resolved_dist=resolved_dist)
             _run_subprocess(
                 [
                     sys.executable,
@@ -396,8 +401,12 @@ def _preflight_pypi(
     timeout: float,
 ) -> None:
     pypi_url = f"https://pypi.org/pypi/{quote(package_name, safe='')}/json"
+    request = Request(
+        pypi_url,
+        headers={"User-Agent": f"{PYPI_USER_AGENT}/{package_version}"},
+    )
     try:
-        with urlopen(pypi_url, timeout=timeout) as response:
+        with urlopen(request, timeout=timeout) as response:
             try:
                 payload = json.load(response)
             except json.JSONDecodeError as exc:
@@ -434,11 +443,23 @@ def _preflight_pypi(
         )
 
 
-def _run_subprocess(cmd: list[str], *, cwd: Path, step: str) -> None:
+def _run_subprocess(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    step: str,
+    timeout_seconds: float = SUBPROCESS_TIMEOUT_SECONDS,
+) -> None:
     try:
-        completed = subprocess.run(cmd, cwd=cwd, check=False)
+        completed = subprocess.run(cmd, cwd=cwd, check=False, timeout=timeout_seconds)
     except FileNotFoundError as exc:
         raise ReleaseSimulationError(step, f"Unable to run {cmd[0]!r}: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        rendered = " ".join(cmd)
+        raise ReleaseSimulationError(
+            step,
+            f"`{rendered}` timed out after {timeout_seconds:.0f}s.",
+        ) from exc
     if completed.returncode != 0:
         rendered = " ".join(cmd)
         raise ReleaseSimulationError(
@@ -447,14 +468,9 @@ def _run_subprocess(cmd: list[str], *, cwd: Path, step: str) -> None:
         )
 
 
-def _clean_artifacts(*, root: Path, dist_dir: Path) -> None:
+def _clean_artifacts(*, root: Path, resolved_dist: Path) -> None:
     for target in (
-        _resolve_child_path(
-            root,
-            dist_dir,
-            label="dist directory",
-            step="build_package",
-        ),
+        resolved_dist,
         root / "build",
     ):
         if target.is_dir():
@@ -485,7 +501,7 @@ def _resolve_child_path(
 def _success_summary() -> str:
     return "\n".join(
         [
-            "### Simulation result",
+            SIMULATION_RESULT_HEADING,
             "",
             "- OK Release simulation reached the authorization boundary successfully.",
             "- INFO Publish to PyPI was intentionally skipped because authorization is required.",
@@ -497,7 +513,7 @@ def _success_summary() -> str:
 
 def _failure_summary(failed_step: str, *, run_url: str = "") -> str:
     lines = [
-        "### Simulation result",
+        SIMULATION_RESULT_HEADING,
         "",
         "- FAIL Release simulation failed before reaching the authorization boundary.",
         f"- FAIL First failing step: `{failed_step}`.",
@@ -510,7 +526,7 @@ def _failure_summary(failed_step: str, *, run_url: str = "") -> str:
 def _skipped_summary() -> str:
     return "\n".join(
         [
-            "### Simulation result",
+            SIMULATION_RESULT_HEADING,
             "",
             "- SKIP Release simulation was skipped because install/upgrade blockers are open.",
         ]

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 
 DEFAULT_PACKAGE_NAME = "arthexis"
+DIST_ARTIFACT_SUFFIXES = (".tar.gz", ".whl", ".zip")
 BUILD_SKIPPED_DETAIL = "Build was skipped by caller."
 PYPI_USER_AGENT = "arthexis-release-simulator"
 SIMULATION_RESULT_HEADING = "### Simulation result"
@@ -491,6 +492,19 @@ def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:
             "build_package",
             f"Dist directory exists but is not a directory: {resolved_dist}",
         )
+    if resolved_dist.is_dir():
+        unsafe_children = [
+            child
+            for child in resolved_dist.iterdir()
+            if child.is_dir()
+            or not any(child.name.endswith(suffix) for suffix in DIST_ARTIFACT_SUFFIXES)
+        ]
+        if unsafe_children:
+            raise ReleaseSimulationError(
+                "build_package",
+                "Dist directory contains non-artifact files and will not be cleaned: "
+                f"{resolved_dist}",
+            )
 
 
 def _resolve_child_path(

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -192,7 +192,7 @@ def run_release_simulation(
                     )
                 )
 
-            resolved_dist = _resolve_child_path(
+            resolved_dist = _resolve_dist_directory(
                 root,
                 dist_dir,
                 label="dist directory",
@@ -475,7 +475,9 @@ def _clean_artifacts(*, root: Path, resolved_dist: Path) -> None:
         resolved_dist,
         root / "build",
     ):
-        if target.is_dir():
+        if target.is_symlink():
+            target.unlink()
+        elif target.is_dir():
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
@@ -492,6 +494,8 @@ def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:
             "build_package",
             f"Dist directory exists but is not a directory: {resolved_dist}",
         )
+    if resolved_dist.is_symlink():
+        return
     if resolved_dist.is_dir():
         unsafe_children = [
             child
@@ -505,6 +509,29 @@ def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:
                 "Dist directory contains non-artifact files and will not be cleaned: "
                 f"{resolved_dist}",
             )
+
+
+def _resolve_dist_directory(
+    root: Path,
+    path: Path,
+    *,
+    label: str,
+    step: str,
+) -> Path:
+    candidate = path if path.is_absolute() else root / path
+    resolved = (
+        candidate.parent.resolve() / candidate.name
+        if candidate.is_symlink()
+        else candidate.resolve()
+    )
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ReleaseSimulationError(
+            step,
+            f"{label.capitalize()} escapes repository root: {resolved}",
+        ) from exc
+    return resolved
 
 
 def _resolve_child_path(

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -397,7 +397,13 @@ def _read_required_file_text(path: Path, *, label: str) -> str:
             "validate_version_gate",
             f"{label} is not a regular file: {path}",
         )
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"Failed to read {label.lower()}: {exc}",
+        ) from exc
 
 
 def _dynamic_version_files(pyproject_data: dict[str, Any]) -> list[str]:
@@ -629,7 +635,7 @@ def _skipped_summary() -> str:
 def _safe_read_text(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
 
 

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -11,6 +11,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Sequence
 from urllib.error import HTTPError, URLError
+from urllib.parse import quote
 from urllib.request import urlopen
 
 try:  # Python 3.11+
@@ -336,7 +337,13 @@ def _validate_version_gate(
             f"Version file is empty: {version_path}",
         )
 
-    pyproject_data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    try:
+        pyproject_data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"Failed to parse pyproject file: {exc}",
+        ) from exc
     dynamic_version_files = (
         pyproject_data.get("tool", {})
         .get("setuptools", {})
@@ -374,10 +381,16 @@ def _preflight_pypi(
     package_version: str,
     timeout: float,
 ) -> None:
-    pypi_url = f"https://pypi.org/pypi/{package_name}/json"
+    pypi_url = f"https://pypi.org/pypi/{quote(package_name, safe='')}/json"
     try:
         with urlopen(pypi_url, timeout=timeout) as response:
-            payload = json.load(response)
+            try:
+                payload = json.load(response)
+            except json.JSONDecodeError as exc:
+                raise ReleaseSimulationError(
+                    "preflight_pypi",
+                    f"Received invalid JSON from PyPI: {exc}",
+                ) from exc
     except HTTPError as exc:
         if exc.code == 404:
             payload = {"releases": {}}

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -200,7 +200,7 @@ def run_release_simulation(
             )
             _validate_dist_directory(root=root, resolved_dist=resolved_dist)
             if clean:
-                _clean_artifacts(root=root, resolved_dist=resolved_dist)
+                _clean_artifacts(resolved_dist=resolved_dist)
             _run_subprocess(
                 [
                     sys.executable,
@@ -479,17 +479,13 @@ def _run_subprocess(
         )
 
 
-def _clean_artifacts(*, root: Path, resolved_dist: Path) -> None:
-    for target in (
-        resolved_dist,
-        root / "build",
-    ):
-        if target.is_symlink():
-            target.unlink()
-        elif target.is_dir():
-            shutil.rmtree(target)
-        elif target.exists():
-            target.unlink()
+def _clean_artifacts(*, resolved_dist: Path) -> None:
+    if resolved_dist.is_symlink():
+        resolved_dist.unlink()
+    elif resolved_dist.is_dir():
+        shutil.rmtree(resolved_dist)
+    elif resolved_dist.exists():
+        resolved_dist.unlink()
 
 
 def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import secrets
 import shutil
 import subprocess
 import sys
@@ -21,7 +22,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 
 DEFAULT_PACKAGE_NAME = "arthexis"
-GITHUB_OUTPUT_DELIMITER = "__ARTHEXIS_RELEASE_SIMULATE__"
 
 
 @dataclass
@@ -188,7 +188,12 @@ def run_release_simulation(
 
             if clean:
                 _clean_artifacts(root=root, dist_dir=dist_dir)
-            resolved_dist = _resolve_child_path(root, dist_dir, label="dist directory")
+            resolved_dist = _resolve_child_path(
+                root,
+                dist_dir,
+                label="dist directory",
+                step="build_package",
+            )
             _run_subprocess(
                 [
                     sys.executable,
@@ -251,7 +256,7 @@ def run_release_simulation(
         summary = _failure_summary(exc.step, run_url=run_url)
         return ReleaseSimulationResult(
             package_name=package_name,
-            version=_safe_read_text(root / version_file),
+            version=_safe_read_child_text(root, version_file),
             ok=False,
             skipped=False,
             failed_step=exc.step,
@@ -302,13 +307,22 @@ def write_github_output(result: ReleaseSimulationResult, path: Path) -> None:
     """Append GitHub Actions step outputs for the release simulator."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    delimiter = _github_output_delimiter(result.summary_markdown)
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"summary_markdown<<{GITHUB_OUTPUT_DELIMITER}\n")
+        handle.write(f"summary_markdown<<{delimiter}\n")
         handle.write(result.summary_markdown.rstrip() + "\n")
-        handle.write(f"{GITHUB_OUTPUT_DELIMITER}\n")
+        handle.write(f"{delimiter}\n")
         handle.write(f"simulated_ok={str(result.ok).lower()}\n")
         handle.write(f"simulated_skipped={str(result.skipped).lower()}\n")
         handle.write(f"failed_step={result.failed_step}\n")
+
+
+def _github_output_delimiter(markdown: str) -> str:
+    markdown_lines = set(markdown.splitlines())
+    while True:
+        delimiter = f"ghadelim_{secrets.token_hex(16)}"
+        if delimiter not in markdown_lines:
+            return delimiter
 
 
 def _validate_version_gate(
@@ -405,7 +419,14 @@ def _preflight_pypi(
             f"Network failure while checking PyPI for an existing release: {exc.reason}.",
         ) from exc
 
-    releases = payload.get("releases", {})
+    releases = payload.get("releases")
+    if releases is None:
+        releases = {}
+    elif not isinstance(releases, dict):
+        raise ReleaseSimulationError(
+            "preflight_pypi",
+            f"Unexpected 'releases' payload type from PyPI: {type(releases).__name__}.",
+        )
     if package_version in releases:
         raise ReleaseSimulationError(
             "preflight_pypi",
@@ -427,21 +448,35 @@ def _run_subprocess(cmd: list[str], *, cwd: Path, step: str) -> None:
 
 
 def _clean_artifacts(*, root: Path, dist_dir: Path) -> None:
-    for target in (_resolve_child_path(root, dist_dir, label="dist directory"), root / "build"):
+    for target in (
+        _resolve_child_path(
+            root,
+            dist_dir,
+            label="dist directory",
+            step="build_package",
+        ),
+        root / "build",
+    ):
         if target.is_dir():
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
 
 
-def _resolve_child_path(root: Path, path: Path, *, label: str) -> Path:
+def _resolve_child_path(
+    root: Path,
+    path: Path,
+    *,
+    label: str,
+    step: str = "validate_version_gate",
+) -> Path:
     candidate = path if path.is_absolute() else root / path
     resolved = candidate.resolve()
     try:
         resolved.relative_to(root)
     except ValueError as exc:
         raise ReleaseSimulationError(
-            "validate_version_gate",
+            step,
             f"{label.capitalize()} escapes repository root: {resolved}",
         ) from exc
     return resolved
@@ -487,6 +522,14 @@ def _safe_read_text(path: Path) -> str:
         return path.read_text(encoding="utf-8").strip()
     except OSError:
         return ""
+
+
+def _safe_read_child_text(root: Path, path: Path) -> str:
+    try:
+        resolved_path = _resolve_child_path(root, path, label="version file")
+    except ReleaseSimulationError:
+        return ""
+    return _safe_read_text(resolved_path)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -351,7 +351,7 @@ def _validate_version_gate(
             f"pyproject file not found: {pyproject}",
         )
 
-    expected_version = version_path.read_text(encoding="utf-8").strip()
+    expected_version = _read_required_file_text(version_path, label="Version file")
     if not expected_version:
         raise ReleaseSimulationError(
             "validate_version_gate",
@@ -378,7 +378,10 @@ def _validate_version_gate(
                 "validate_version_gate",
                 f"Dynamic version file not found: {dynamic_path}",
             )
-        dynamic_version = dynamic_path.read_text(encoding="utf-8").strip()
+        dynamic_version = _read_required_file_text(
+            dynamic_path,
+            label="Dynamic version file",
+        )
         if dynamic_version != expected_version:
             raise ReleaseSimulationError(
                 "validate_version_gate",
@@ -386,6 +389,15 @@ def _validate_version_gate(
                 f"VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.",
             )
     return expected_version
+
+
+def _read_required_file_text(path: Path, *, label: str) -> str:
+    if not path.is_file():
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"{label} is not a regular file: {path}",
+        )
+    return path.read_text(encoding="utf-8").strip()
 
 
 def _dynamic_version_files(pyproject_data: dict[str, Any]) -> list[str]:

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -450,7 +450,7 @@ def _preflight_pypi(
         with urlopen(request, timeout=timeout) as response:
             try:
                 payload = json.load(response)
-            except json.JSONDecodeError as exc:
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                 raise ReleaseSimulationError(
                     "preflight_pypi",
                     f"Received invalid JSON from PyPI: {exc}",

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -365,13 +365,7 @@ def _validate_version_gate(
             "validate_version_gate",
             f"Failed to parse pyproject file: {exc}",
         ) from exc
-    dynamic_version_files = _normalize_dynamic_version_files(
-        pyproject_data.get("tool", {})
-        .get("setuptools", {})
-        .get("dynamic", {})
-        .get("version", {})
-        .get("file", []),
-    )
+    dynamic_version_files = _dynamic_version_files(pyproject_data)
 
     if dynamic_version_files:
         dynamic_path = _resolve_child_path(
@@ -392,6 +386,24 @@ def _validate_version_gate(
                 f"VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.",
             )
     return expected_version
+
+
+def _dynamic_version_files(pyproject_data: dict[str, Any]) -> list[str]:
+    tool_data = _optional_mapping(pyproject_data, "tool")
+    setuptools_data = _optional_mapping(tool_data, "setuptools")
+    dynamic_data = _optional_mapping(setuptools_data, "dynamic")
+    version_data = _optional_mapping(dynamic_data, "version")
+    return _normalize_dynamic_version_files(version_data.get("file", []))
+
+
+def _optional_mapping(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key, {})
+    if isinstance(value, dict):
+        return value
+    raise ReleaseSimulationError(
+        "validate_version_gate",
+        f"pyproject metadata at {key!r} must be a table.",
+    )
 
 
 def _normalize_dynamic_version_files(value: Any) -> list[str]:

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -1,0 +1,542 @@
+"""Release-readiness simulation shared by local commands and CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import toml as tomllib  # type: ignore[no-redef]
+
+
+DEFAULT_PACKAGE_NAME = "arthexis"
+GITHUB_OUTPUT_DELIMITER = "__ARTHEXIS_RELEASE_SIMULATE__"
+
+
+@dataclass
+class SimulationStep:
+    """One release-simulation step and its outcome."""
+
+    name: str
+    outcome: str
+    detail: str = ""
+
+
+@dataclass
+class ReleaseSimulationResult:
+    """Structured result for the release simulator."""
+
+    package_name: str
+    version: str
+    ok: bool
+    skipped: bool
+    failed_step: str
+    error: str
+    summary_markdown: str
+    blockers: list[str]
+    steps: list[SimulationStep]
+
+
+class ReleaseSimulationError(Exception):
+    """Raised when a simulation step blocks the release."""
+
+    def __init__(self, step: str, message: str) -> None:
+        super().__init__(message)
+        self.step = step
+        self.message = message
+
+
+def run_release_simulation(
+    *,
+    root: Path,
+    package_name: str = DEFAULT_PACKAGE_NAME,
+    version_file: Path = Path("VERSION"),
+    pyproject_path: Path = Path("pyproject.toml"),
+    dist_dir: Path = Path("dist"),
+    blockers: Sequence[str] = (),
+    skip_pypi: bool = False,
+    skip_build: bool = False,
+    clean: bool = True,
+    install_missing_tools: bool = False,
+    pypi_timeout: float = 15.0,
+    run_url: str = "",
+) -> ReleaseSimulationResult:
+    """Run the package-release simulation used by CI.
+
+    The simulator intentionally stops before publishing so it can run both from
+    GitHub Actions and from a local checkout without PyPI credentials.
+    """
+
+    root = root.resolve()
+    steps: list[SimulationStep] = []
+    blocker_list = [str(blocker) for blocker in blockers if str(blocker).strip()]
+    if blocker_list:
+        summary = _skipped_summary()
+        steps.append(
+            SimulationStep(
+                name="evaluate_blockers",
+                outcome="skipped",
+                detail="Install/upgrade blockers are open.",
+            )
+        )
+        return ReleaseSimulationResult(
+            package_name=package_name,
+            version="",
+            ok=False,
+            skipped=True,
+            failed_step="",
+            error="",
+            summary_markdown=summary,
+            blockers=blocker_list,
+            steps=steps,
+        )
+
+    try:
+        version = _validate_version_gate(
+            root=root,
+            version_file=version_file,
+            pyproject_path=pyproject_path,
+        )
+        steps.append(
+            SimulationStep(
+                name="validate_version_gate",
+                outcome="passed",
+                detail=f"VERSION={version!r}",
+            )
+        )
+
+        if skip_pypi:
+            steps.append(
+                SimulationStep(
+                    name="preflight_pypi",
+                    outcome="skipped",
+                    detail="PyPI availability check skipped by caller.",
+                )
+            )
+        else:
+            _preflight_pypi(
+                package_name=package_name,
+                package_version=version,
+                timeout=pypi_timeout,
+            )
+            steps.append(
+                SimulationStep(
+                    name="preflight_pypi",
+                    outcome="passed",
+                    detail=f"{package_name} {version} is not published on PyPI.",
+                )
+            )
+
+        if skip_build:
+            steps.extend(
+                [
+                    SimulationStep(
+                        name="install_build_backend",
+                        outcome="skipped",
+                        detail="Build was skipped by caller.",
+                    ),
+                    SimulationStep(
+                        name="build_package",
+                        outcome="skipped",
+                        detail="Build was skipped by caller.",
+                    ),
+                    SimulationStep(
+                        name="validate_metadata",
+                        outcome="skipped",
+                        detail="Build was skipped by caller.",
+                    ),
+                ]
+            )
+        else:
+            if install_missing_tools:
+                _run_subprocess(
+                    [sys.executable, "-m", "pip", "install", "--upgrade", "pip"],
+                    cwd=root,
+                    step="install_build_backend",
+                )
+                _run_subprocess(
+                    [sys.executable, "-m", "pip", "install", "build", "twine"],
+                    cwd=root,
+                    step="install_build_backend",
+                )
+                steps.append(
+                    SimulationStep(
+                        name="install_build_backend",
+                        outcome="passed",
+                        detail="Ensured build and twine are installed.",
+                    )
+                )
+            else:
+                steps.append(
+                    SimulationStep(
+                        name="install_build_backend",
+                        outcome="skipped",
+                        detail="Assuming build and twine are already installed.",
+                    )
+                )
+
+            if clean:
+                _clean_artifacts(root=root, dist_dir=dist_dir)
+            resolved_dist = _resolve_child_path(root, dist_dir, label="dist directory")
+            _run_subprocess(
+                [
+                    sys.executable,
+                    "-m",
+                    "build",
+                    "--outdir",
+                    str(resolved_dist),
+                ],
+                cwd=root,
+                step="build_package",
+            )
+            steps.append(
+                SimulationStep(
+                    name="build_package",
+                    outcome="passed",
+                    detail=f"Built artifacts in {resolved_dist}.",
+                )
+            )
+
+            dist_files = sorted(path for path in resolved_dist.glob("*") if path.is_file())
+            if not dist_files:
+                raise ReleaseSimulationError(
+                    "validate_metadata",
+                    f"No distribution artifacts found in {resolved_dist}.",
+                )
+            _run_subprocess(
+                [sys.executable, "-m", "twine", "check", *(str(path) for path in dist_files)],
+                cwd=root,
+                step="validate_metadata",
+            )
+            steps.append(
+                SimulationStep(
+                    name="validate_metadata",
+                    outcome="passed",
+                    detail=f"Validated {len(dist_files)} artifact(s) with twine.",
+                )
+            )
+
+        steps.append(
+            SimulationStep(
+                name="authorization_boundary",
+                outcome="passed",
+                detail="Publish intentionally skipped.",
+            )
+        )
+        summary = _success_summary()
+        return ReleaseSimulationResult(
+            package_name=package_name,
+            version=version,
+            ok=True,
+            skipped=False,
+            failed_step="",
+            error="",
+            summary_markdown=summary,
+            blockers=[],
+            steps=steps,
+        )
+    except ReleaseSimulationError as exc:
+        steps.append(SimulationStep(name=exc.step, outcome="failed", detail=exc.message))
+        summary = _failure_summary(exc.step, run_url=run_url)
+        return ReleaseSimulationResult(
+            package_name=package_name,
+            version=_safe_read_text(root / version_file),
+            ok=False,
+            skipped=False,
+            failed_step=exc.step,
+            error=exc.message,
+            summary_markdown=summary,
+            blockers=[],
+            steps=steps,
+        )
+
+
+def parse_blockers_json(raw_value: str) -> list[str]:
+    """Return blocker strings from a JSON list or an empty value."""
+
+    value = raw_value.strip()
+    if not value:
+        return []
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ReleaseSimulationError("evaluate_blockers", f"Invalid blockers JSON: {exc}") from exc
+    if not isinstance(payload, list):
+        raise ReleaseSimulationError("evaluate_blockers", "Blockers JSON must be a list.")
+    return [str(item) for item in payload if str(item).strip()]
+
+
+def emit_result(
+    result: ReleaseSimulationResult,
+    *,
+    github_output: Path | None = None,
+    summary_file: Path | None = None,
+    json_output: bool = False,
+    stdout: Any = sys.stdout,
+) -> None:
+    """Write the simulator result to requested output surfaces."""
+
+    if github_output is not None:
+        write_github_output(result, github_output)
+    if summary_file is not None:
+        summary_file.parent.mkdir(parents=True, exist_ok=True)
+        summary_file.write_text(result.summary_markdown + "\n", encoding="utf-8")
+    if json_output:
+        stdout.write(json.dumps(asdict(result), indent=2) + "\n")
+    else:
+        stdout.write(result.summary_markdown + "\n")
+
+
+def write_github_output(result: ReleaseSimulationResult, path: Path) -> None:
+    """Append GitHub Actions step outputs for the release simulator."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"summary_markdown<<{GITHUB_OUTPUT_DELIMITER}\n")
+        handle.write(result.summary_markdown.rstrip() + "\n")
+        handle.write(f"{GITHUB_OUTPUT_DELIMITER}\n")
+        handle.write(f"simulated_ok={str(result.ok).lower()}\n")
+        handle.write(f"simulated_skipped={str(result.skipped).lower()}\n")
+        handle.write(f"failed_step={result.failed_step}\n")
+
+
+def _validate_version_gate(
+    *,
+    root: Path,
+    version_file: Path,
+    pyproject_path: Path,
+) -> str:
+    version_path = _resolve_child_path(root, version_file, label="version file")
+    pyproject = _resolve_child_path(root, pyproject_path, label="pyproject file")
+    if not version_path.exists():
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"Version file not found: {version_path}",
+        )
+    if not pyproject.exists():
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"pyproject file not found: {pyproject}",
+        )
+
+    expected_version = version_path.read_text(encoding="utf-8").strip()
+    if not expected_version:
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"Version file is empty: {version_path}",
+        )
+
+    pyproject_data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    dynamic_version_files = (
+        pyproject_data.get("tool", {})
+        .get("setuptools", {})
+        .get("dynamic", {})
+        .get("version", {})
+        .get("file", [])
+    )
+    if isinstance(dynamic_version_files, str):
+        dynamic_version_files = [dynamic_version_files]
+
+    if dynamic_version_files:
+        dynamic_path = _resolve_child_path(
+            root,
+            Path(str(dynamic_version_files[0])),
+            label="dynamic version file",
+        )
+        if not dynamic_path.exists():
+            raise ReleaseSimulationError(
+                "validate_version_gate",
+                f"Dynamic version file not found: {dynamic_path}",
+            )
+        dynamic_version = dynamic_path.read_text(encoding="utf-8").strip()
+        if dynamic_version != expected_version:
+            raise ReleaseSimulationError(
+                "validate_version_gate",
+                "VERSION and setuptools dynamic version file differ. "
+                f"VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.",
+            )
+    return expected_version
+
+
+def _preflight_pypi(
+    *,
+    package_name: str,
+    package_version: str,
+    timeout: float,
+) -> None:
+    pypi_url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        with urlopen(pypi_url, timeout=timeout) as response:
+            payload = json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            payload = {"releases": {}}
+        else:
+            raise ReleaseSimulationError(
+                "preflight_pypi",
+                f"Unable to verify existing PyPI versions: HTTP {exc.code} from {pypi_url}.",
+            ) from exc
+    except URLError as exc:
+        raise ReleaseSimulationError(
+            "preflight_pypi",
+            f"Network failure while checking PyPI for an existing release: {exc.reason}.",
+        ) from exc
+
+    releases = payload.get("releases", {})
+    if package_version in releases:
+        raise ReleaseSimulationError(
+            "preflight_pypi",
+            f"{package_name} {package_version} is already available on PyPI.",
+        )
+
+
+def _run_subprocess(cmd: list[str], *, cwd: Path, step: str) -> None:
+    try:
+        completed = subprocess.run(cmd, cwd=cwd, check=False)
+    except FileNotFoundError as exc:
+        raise ReleaseSimulationError(step, f"Unable to run {cmd[0]!r}: {exc}") from exc
+    if completed.returncode != 0:
+        rendered = " ".join(cmd)
+        raise ReleaseSimulationError(
+            step,
+            f"`{rendered}` exited with code {completed.returncode}.",
+        )
+
+
+def _clean_artifacts(*, root: Path, dist_dir: Path) -> None:
+    for target in (_resolve_child_path(root, dist_dir, label="dist directory"), root / "build"):
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+
+
+def _resolve_child_path(root: Path, path: Path, *, label: str) -> Path:
+    candidate = path if path.is_absolute() else root / path
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"{label.capitalize()} escapes repository root: {resolved}",
+        ) from exc
+    return resolved
+
+
+def _success_summary() -> str:
+    return "\n".join(
+        [
+            "### Simulation result",
+            "",
+            "- OK Release simulation reached the authorization boundary successfully.",
+            "- INFO Publish to PyPI was intentionally skipped because authorization is required.",
+            "- OK Recommendation: release is ready if maintainers approve "
+            "and trigger a real publish.",
+        ]
+    )
+
+
+def _failure_summary(failed_step: str, *, run_url: str = "") -> str:
+    lines = [
+        "### Simulation result",
+        "",
+        "- FAIL Release simulation failed before reaching the authorization boundary.",
+        f"- FAIL First failing step: `{failed_step}`.",
+    ]
+    if run_url:
+        lines.append(f"- Inspect this workflow run for detailed logs: {run_url}")
+    return "\n".join(lines)
+
+
+def _skipped_summary() -> str:
+    return "\n".join(
+        [
+            "### Simulation result",
+            "",
+            "- SKIP Release simulation was skipped because install/upgrade blockers are open.",
+        ]
+    )
+
+
+def _safe_read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Simulate release readiness without publishing.")
+    parser.add_argument("--root", default=".", help="Repository root to simulate from.")
+    parser.add_argument("--package-name", default=DEFAULT_PACKAGE_NAME)
+    parser.add_argument("--version-file", default="VERSION")
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument("--dist-dir", default="dist")
+    parser.add_argument("--blockers-json", default="")
+    parser.add_argument("--skip-pypi", action="store_true")
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--no-clean", action="store_false", dest="clean", default=True)
+    parser.add_argument("--install-missing-tools", action="store_true")
+    parser.add_argument("--pypi-timeout", type=float, default=15.0)
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--github-output")
+    parser.add_argument("--summary-file")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        blockers = parse_blockers_json(args.blockers_json)
+        result = run_release_simulation(
+            root=Path(args.root),
+            package_name=args.package_name,
+            version_file=Path(args.version_file),
+            pyproject_path=Path(args.pyproject),
+            dist_dir=Path(args.dist_dir),
+            blockers=blockers,
+            skip_pypi=args.skip_pypi,
+            skip_build=args.skip_build,
+            clean=args.clean,
+            install_missing_tools=args.install_missing_tools,
+            pypi_timeout=args.pypi_timeout,
+            run_url=args.run_url,
+        )
+    except ReleaseSimulationError as exc:
+        result = ReleaseSimulationResult(
+            package_name=args.package_name,
+            version="",
+            ok=False,
+            skipped=False,
+            failed_step=exc.step,
+            error=exc.message,
+            summary_markdown=_failure_summary(exc.step, run_url=args.run_url),
+            blockers=[],
+            steps=[SimulationStep(name=exc.step, outcome="failed", detail=exc.message)],
+        )
+
+    emit_result(
+        result,
+        github_output=Path(args.github_output) if args.github_output else None,
+        summary_file=Path(args.summary_file) if args.summary_file else None,
+        json_output=args.json_output,
+    )
+    return 0 if result.ok or result.skipped else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -441,6 +441,11 @@ def _preflight_pypi(
     package_version: str,
     timeout: float,
 ) -> None:
+    if timeout <= 0:
+        raise ReleaseSimulationError(
+            "preflight_pypi",
+            f"PyPI timeout must be greater than zero seconds: {timeout}.",
+        )
     pypi_url = f"https://pypi.org/pypi/{quote(package_name, safe='')}/json"
     request = Request(
         pypi_url,

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -451,6 +451,12 @@ def _preflight_pypi(
             f"Network failure while checking PyPI for an existing release: {exc.reason}.",
         ) from exc
 
+    if not isinstance(payload, dict):
+        raise ReleaseSimulationError(
+            "preflight_pypi",
+            f"Unexpected PyPI payload type: {type(payload).__name__}.",
+        )
+
     releases = payload.get("releases")
     if releases is None:
         releases = {}

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import secrets
 import shutil
 import subprocess
@@ -368,27 +369,34 @@ def _validate_version_gate(
     dynamic_version_files = _dynamic_version_files(pyproject_data)
 
     if dynamic_version_files:
-        dynamic_path = _resolve_child_path(
-            root,
-            Path(str(dynamic_version_files[0])),
-            label="dynamic version file",
-        )
-        if not dynamic_path.exists():
-            raise ReleaseSimulationError(
-                "validate_version_gate",
-                f"Dynamic version file not found: {dynamic_path}",
-            )
-        dynamic_version = _read_required_file_text(
-            dynamic_path,
-            label="Dynamic version file",
+        dynamic_version = "".join(
+            _read_dynamic_version_file(root=root, dynamic_file=dynamic_file)
+            for dynamic_file in dynamic_version_files
         )
         if dynamic_version != expected_version:
             raise ReleaseSimulationError(
                 "validate_version_gate",
                 "VERSION and setuptools dynamic version file differ. "
-                f"VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.",
+                f"VERSION={expected_version!r}; dynamic version={dynamic_version!r}.",
             )
     return expected_version
+
+
+def _read_dynamic_version_file(*, root: Path, dynamic_file: str) -> str:
+    dynamic_path = _resolve_child_path(
+        root,
+        Path(dynamic_file),
+        label="dynamic version file",
+    )
+    if not dynamic_path.exists():
+        raise ReleaseSimulationError(
+            "validate_version_gate",
+            f"Dynamic version file not found: {dynamic_path}",
+        )
+    return _read_required_file_text(
+        dynamic_path,
+        label="Dynamic version file",
+    )
 
 
 def _read_required_file_text(path: Path, *, label: str) -> str:
@@ -441,10 +449,10 @@ def _preflight_pypi(
     package_version: str,
     timeout: float,
 ) -> None:
-    if timeout <= 0:
+    if not math.isfinite(timeout) or timeout <= 0:
         raise ReleaseSimulationError(
             "preflight_pypi",
-            f"PyPI timeout must be greater than zero seconds: {timeout}.",
+            f"PyPI timeout must be a finite value greater than zero seconds: {timeout}.",
         )
     pypi_url = f"https://pypi.org/pypi/{quote(package_name, safe='')}/json"
     request = Request(

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -495,7 +495,10 @@ def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:
             f"Dist directory exists but is not a directory: {resolved_dist}",
         )
     if resolved_dist.is_symlink():
-        return
+        raise ReleaseSimulationError(
+            "build_package",
+            f"Dist directory must not be a symlink: {resolved_dist}",
+        )
     if resolved_dist.is_dir():
         unsafe_children = [
             child

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -197,6 +197,7 @@ def run_release_simulation(
                 label="dist directory",
                 step="build_package",
             )
+            _validate_dist_directory(root=root, resolved_dist=resolved_dist)
             if clean:
                 _clean_artifacts(root=root, resolved_dist=resolved_dist)
             _run_subprocess(
@@ -477,6 +478,19 @@ def _clean_artifacts(*, root: Path, resolved_dist: Path) -> None:
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+
+def _validate_dist_directory(*, root: Path, resolved_dist: Path) -> None:
+    if resolved_dist == root:
+        raise ReleaseSimulationError(
+            "build_package",
+            "Dist directory must be a dedicated subdirectory, not the repository root.",
+        )
+    if resolved_dist.exists() and not resolved_dist.is_dir():
+        raise ReleaseSimulationError(
+            "build_package",
+            f"Dist directory exists but is not a directory: {resolved_dist}",
+        )
 
 
 def _resolve_child_path(

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -365,15 +365,13 @@ def _validate_version_gate(
             "validate_version_gate",
             f"Failed to parse pyproject file: {exc}",
         ) from exc
-    dynamic_version_files = (
+    dynamic_version_files = _normalize_dynamic_version_files(
         pyproject_data.get("tool", {})
         .get("setuptools", {})
         .get("dynamic", {})
         .get("version", {})
-        .get("file", [])
+        .get("file", []),
     )
-    if isinstance(dynamic_version_files, str):
-        dynamic_version_files = [dynamic_version_files]
 
     if dynamic_version_files:
         dynamic_path = _resolve_child_path(
@@ -394,6 +392,17 @@ def _validate_version_gate(
                 f"VERSION={expected_version!r}; {dynamic_path}={dynamic_version!r}.",
             )
     return expected_version
+
+
+def _normalize_dynamic_version_files(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    raise ReleaseSimulationError(
+        "validate_version_gate",
+        "setuptools dynamic version file metadata must be a string or list.",
+    )
 
 
 def _preflight_pypi(

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -151,6 +151,60 @@ def test_release_simulation_reports_invalid_pypi_json(
     assert "Received invalid JSON from PyPI" in result.error
 
 
+def test_release_simulation_reports_invalid_pypi_releases_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(b'{"releases": []}')
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "Unexpected 'releases' payload type from PyPI: list" in result.error
+
+
+def test_release_simulation_does_not_read_escaped_version_file(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    external_version = tmp_path.parent / "external-version.txt"
+    external_version.write_text("secret-version\n", encoding="utf-8")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        version_file=external_version,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert result.version == ""
+    assert "secret-version" not in result.error
+
+
+def test_release_simulation_reports_escaped_dist_dir_as_build_failure(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        dist_dir=tmp_path.parent / "dist-outside-root",
+        skip_pypi=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "Dist directory escapes repository root" in result.error
+
+
 def test_release_simulation_skips_when_blockers_are_provided(tmp_path: Path) -> None:
     result = run_release_simulation(
         root=tmp_path,
@@ -184,6 +238,37 @@ def test_release_simulation_writes_github_outputs(tmp_path: Path) -> None:
     assert "simulated_ok=true" in rendered
     assert "simulated_skipped=false" in rendered
     assert "failed_step=" in rendered
+
+
+def test_release_simulation_avoids_github_output_delimiter_collisions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+    output_path = tmp_path / "github-output.txt"
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+    result.summary_markdown = "\n".join(
+        [
+            "### Simulation result",
+            "ghadelim_collision",
+            "- OK summary still renders.",
+        ]
+    )
+    tokens = iter(["collision", "safe"])
+    monkeypatch.setattr(
+        "apps.release.simulator.secrets.token_hex",
+        lambda _size: next(tokens),
+    )
+
+    write_github_output(result, output_path)
+
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "summary_markdown<<ghadelim_safe" in rendered
+    assert "\nghadelim_collision\n" in rendered
+    assert rendered.count("\nghadelim_safe\n") == 1
 
 
 def test_release_command_wraps_simulator_for_local_runs(tmp_path: Path) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,7 @@ class _FakeResponse:
     def __init__(self, payload: bytes) -> None:
         self.payload = payload
 
-    def __enter__(self) -> "_FakeResponse":
+    def __enter__(self) -> _FakeResponse:
         return self
 
     def __exit__(self, *_args: Any) -> None:
@@ -113,9 +114,11 @@ def test_release_simulation_quotes_package_name_for_pypi(
 ) -> None:
     _write_project(tmp_path)
     requested_urls: list[str] = []
+    user_agents: list[str | None] = []
 
-    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
-        requested_urls.append(url)
+    def fake_urlopen(url: Any, *, timeout: float) -> _FakeResponse:
+        requested_urls.append(url.full_url if hasattr(url, "full_url") else url)
+        user_agents.append(url.get_header("User-agent") if hasattr(url, "get_header") else None)
         assert timeout == 15.0
         return _FakeResponse(b'{"releases": {}}')
 
@@ -129,6 +132,7 @@ def test_release_simulation_quotes_package_name_for_pypi(
 
     assert result.ok is True
     assert requested_urls == ["https://pypi.org/pypi/arthexis%20suite%2Ftest/json"]
+    assert user_agents == ["arthexis-release-simulator/1.2.3"]
 
 
 def test_release_simulation_reports_invalid_pypi_json(
@@ -171,6 +175,24 @@ def test_release_simulation_reports_invalid_pypi_releases_payload(
     assert "Unexpected 'releases' payload type from PyPI: list" in result.error
 
 
+def test_release_simulation_treats_null_pypi_releases_as_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: Any, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(b'{"releases": null}')
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+    )
+
+    assert result.ok is True
+
+
 def test_release_simulation_does_not_read_escaped_version_file(tmp_path: Path) -> None:
     _write_project(tmp_path)
     external_version = tmp_path.parent / "external-version.txt"
@@ -203,6 +225,27 @@ def test_release_simulation_reports_escaped_dist_dir_as_build_failure(
     assert result.ok is False
     assert result.failed_step == "build_package"
     assert "Dist directory escapes repository root" in result.error
+
+
+def test_release_simulation_reports_build_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd, timeout=1800.0)
+
+    monkeypatch.setattr("apps.release.simulator.subprocess.run", fake_run)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        clean=False,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "timed out after 1800s" in result.error
 
 
 def test_release_simulation_skips_when_blockers_are_provided(tmp_path: Path) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import pytest
 from django.core.management import call_command
@@ -15,6 +16,20 @@ from apps.release.simulator import (
     run_release_simulation,
     write_github_output,
 )
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def read(self, *_args: Any) -> bytes:
+        return self.payload
 
 
 def _write_project(root: Path, *, version: str = "1.2.3", dynamic_path: str = "VERSION") -> None:
@@ -76,6 +91,64 @@ def test_release_simulation_reports_version_gate_mismatch(tmp_path: Path) -> Non
     assert result.failed_step == "validate_version_gate"
     assert "differ" in result.error
     assert "validate_version_gate" in result.summary_markdown
+
+
+def test_release_simulation_reports_malformed_pyproject(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "Failed to parse pyproject file" in result.error
+
+
+def test_release_simulation_quotes_package_name_for_pypi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+    requested_urls: list[str] = []
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        requested_urls.append(url)
+        assert timeout == 15.0
+        return _FakeResponse(b'{"releases": {}}')
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        package_name="arthexis suite/test",
+        skip_build=True,
+    )
+
+    assert result.ok is True
+    assert requested_urls == ["https://pypi.org/pypi/arthexis%20suite%2Ftest/json"]
+
+
+def test_release_simulation_reports_invalid_pypi_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(b"{not json")
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "Received invalid JSON from PyPI" in result.error
 
 
 def test_release_simulation_skips_when_blockers_are_provided(tmp_path: Path) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -110,6 +110,36 @@ def test_release_simulation_reports_malformed_pyproject(tmp_path: Path) -> None:
     assert "Failed to parse pyproject file" in result.error
 
 
+def test_release_simulation_reports_invalid_dynamic_version_file_metadata(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "arthexis"',
+                'dynamic = ["version"]',
+                "",
+                "[tool.setuptools.dynamic.version]",
+                "file = {bad = true}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "dynamic version file metadata must be a string or list" in result.error
+
+
 def test_release_simulation_quotes_package_name_for_pypi(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -227,6 +227,39 @@ def test_release_simulation_reports_escaped_dist_dir_as_build_failure(
     assert "Dist directory escapes repository root" in result.error
 
 
+def test_release_simulation_rejects_root_dist_dir_before_cleanup(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        dist_dir=Path("."),
+        skip_pypi=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "not the repository root" in result.error
+    assert (tmp_path / "VERSION").exists()
+    assert (tmp_path / "pyproject.toml").exists()
+
+
+def test_release_simulation_rejects_file_dist_dir_before_cleanup(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    dist_file = tmp_path / "dist"
+    dist_file.write_text("keep me\n", encoding="utf-8")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        dist_dir=Path("dist"),
+        skip_pypi=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "exists but is not a directory" in result.error
+    assert dist_file.read_text(encoding="utf-8") == "keep me\n"
+
+
 def test_release_simulation_reports_build_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -333,15 +333,14 @@ def test_release_simulation_rejects_symlinked_dist_dir(tmp_path: Path) -> None:
     assert target_file.read_text(encoding="utf-8") == "keep me\n"
 
 
-def test_release_simulation_unlinks_symlinked_build_dir_before_cleanup(
+def test_release_simulation_preserves_existing_build_dir(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     _write_project(tmp_path)
-    target_dir = tmp_path / "existing-build"
-    target_dir.mkdir()
-    target_file = target_dir / "keep.txt"
-    target_file.write_text("keep me\n", encoding="utf-8")
-    (tmp_path / "build").symlink_to(target_dir, target_is_directory=True)
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    build_file = build_dir / "keep.txt"
+    build_file.write_text("keep me\n", encoding="utf-8")
 
     def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
         if cmd[:3] == [sys.executable, "-m", "build"]:
@@ -358,8 +357,7 @@ def test_release_simulation_unlinks_symlinked_build_dir_before_cleanup(
     )
 
     assert result.ok is True
-    assert not (tmp_path / "build").exists()
-    assert target_file.read_text(encoding="utf-8") == "keep me\n"
+    assert build_file.read_text(encoding="utf-8") == "keep me\n"
 
 
 def test_release_simulation_reports_build_timeout(

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -260,6 +260,27 @@ def test_release_simulation_rejects_file_dist_dir_before_cleanup(tmp_path: Path)
     assert dist_file.read_text(encoding="utf-8") == "keep me\n"
 
 
+def test_release_simulation_rejects_non_artifact_dist_dir_before_cleanup(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    source_dir = tmp_path / "apps" / "release"
+    source_dir.mkdir(parents=True)
+    source_file = source_dir / "simulator.py"
+    source_file.write_text("keep me\n", encoding="utf-8")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        dist_dir=Path("apps/release"),
+        skip_pypi=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "contains non-artifact files" in result.error
+    assert source_file.read_text(encoding="utf-8") == "keep me\n"
+
+
 def test_release_simulation_reports_build_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -1,0 +1,145 @@
+"""Tests for the local and CI release simulator."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.release.simulator import (
+    ReleaseSimulationError,
+    parse_blockers_json,
+    run_release_simulation,
+    write_github_output,
+)
+
+
+def _write_project(root: Path, *, version: str = "1.2.3", dynamic_path: str = "VERSION") -> None:
+    (root / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    if dynamic_path != "VERSION":
+        dynamic_file = root / dynamic_path
+        dynamic_file.parent.mkdir(parents=True, exist_ok=True)
+        dynamic_file.write_text(f"{version}\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "arthexis"',
+                'dynamic = ["version"]',
+                "",
+                "[tool.setuptools.dynamic.version]",
+                f'file = ["{dynamic_path}"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_release_simulation_can_run_without_pypi_or_build(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is True
+    assert result.version == "1.2.3"
+    assert result.failed_step == ""
+    assert "authorization boundary" in result.summary_markdown
+    assert [step.name for step in result.steps] == [
+        "validate_version_gate",
+        "preflight_pypi",
+        "install_build_backend",
+        "build_package",
+        "validate_metadata",
+        "authorization_boundary",
+    ]
+
+
+def test_release_simulation_reports_version_gate_mismatch(tmp_path: Path) -> None:
+    _write_project(tmp_path, version="1.2.3", dynamic_path="apps/pkg/VERSION")
+    (tmp_path / "apps/pkg/VERSION").write_text("1.2.4\n", encoding="utf-8")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "differ" in result.error
+    assert "validate_version_gate" in result.summary_markdown
+
+
+def test_release_simulation_skips_when_blockers_are_provided(tmp_path: Path) -> None:
+    result = run_release_simulation(
+        root=tmp_path,
+        blockers=["Open install failure issue: #1"],
+    )
+
+    assert result.ok is False
+    assert result.skipped is True
+    assert result.blockers == ["Open install failure issue: #1"]
+    assert "SKIP" in result.summary_markdown
+
+
+def test_parse_blockers_json_requires_list() -> None:
+    with pytest.raises(ReleaseSimulationError, match="must be a list"):
+        parse_blockers_json('{"blocker": true}')
+
+
+def test_release_simulation_writes_github_outputs(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    output_path = tmp_path / "github-output.txt"
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    write_github_output(result, output_path)
+
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "summary_markdown<<" in rendered
+    assert "simulated_ok=true" in rendered
+    assert "simulated_skipped=false" in rendered
+    assert "failed_step=" in rendered
+
+
+def test_release_command_wraps_simulator_for_local_runs(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    stdout = StringIO()
+
+    call_command(
+        "release",
+        "simulate",
+        "--root",
+        str(tmp_path),
+        "--skip-pypi",
+        "--skip-build",
+        stdout=stdout,
+    )
+
+    assert "Release simulation reached" in stdout.getvalue()
+
+
+def test_release_command_raises_on_failed_simulation(tmp_path: Path) -> None:
+    _write_project(tmp_path, version="1.2.3", dynamic_path="apps/pkg/VERSION")
+    (tmp_path / "apps/pkg/VERSION").write_text("1.2.4\n", encoding="utf-8")
+
+    with pytest.raises(CommandError, match="validate_version_gate"):
+        call_command(
+            "release",
+            "simulate",
+            "--root",
+            str(tmp_path),
+            "--skip-pypi",
+            "--skip-build",
+        )

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -140,6 +140,36 @@ def test_release_simulation_reports_invalid_dynamic_version_file_metadata(
     assert "dynamic version file metadata must be a string or list" in result.error
 
 
+def test_release_simulation_reports_invalid_dynamic_version_metadata_shape(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "arthexis"',
+                'dynamic = ["version"]',
+                "",
+                "[tool.setuptools.dynamic]",
+                'version = "VERSION"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "pyproject metadata at 'version' must be a table" in result.error
+
+
 def test_release_simulation_quotes_package_name_for_pypi(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -279,6 +280,65 @@ def test_release_simulation_rejects_non_artifact_dist_dir_before_cleanup(
     assert result.failed_step == "build_package"
     assert "contains non-artifact files" in result.error
     assert source_file.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_release_simulation_unlinks_symlinked_dist_dir_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+    target_dir = tmp_path / "existing-artifacts"
+    target_dir.mkdir()
+    target_file = target_dir / "keep.txt"
+    target_file.write_text("keep me\n", encoding="utf-8")
+    (tmp_path / "dist").symlink_to(target_dir, target_is_directory=True)
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == [sys.executable, "-m", "build"]:
+            out_dir = Path(cmd[-1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "package.whl").write_text("artifact\n", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("apps.release.simulator.subprocess.run", fake_run)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+    )
+
+    assert result.ok is True
+    assert (tmp_path / "dist").is_dir()
+    assert not (tmp_path / "dist").is_symlink()
+    assert target_file.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_release_simulation_unlinks_symlinked_build_dir_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+    target_dir = tmp_path / "existing-build"
+    target_dir.mkdir()
+    target_file = target_dir / "keep.txt"
+    target_file.write_text("keep me\n", encoding="utf-8")
+    (tmp_path / "build").symlink_to(target_dir, target_is_directory=True)
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == [sys.executable, "-m", "build"]:
+            out_dir = Path(cmd[-1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "package.whl").write_text("artifact\n", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("apps.release.simulator.subprocess.run", fake_run)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+    )
+
+    assert result.ok is True
+    assert not (tmp_path / "build").exists()
+    assert target_file.read_text(encoding="utf-8") == "keep me\n"
 
 
 def test_release_simulation_reports_build_timeout(

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -282,9 +282,7 @@ def test_release_simulation_rejects_non_artifact_dist_dir_before_cleanup(
     assert source_file.read_text(encoding="utf-8") == "keep me\n"
 
 
-def test_release_simulation_unlinks_symlinked_dist_dir_before_cleanup(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_release_simulation_rejects_symlinked_dist_dir(tmp_path: Path) -> None:
     _write_project(tmp_path)
     target_dir = tmp_path / "existing-artifacts"
     target_dir.mkdir()
@@ -292,23 +290,16 @@ def test_release_simulation_unlinks_symlinked_dist_dir_before_cleanup(
     target_file.write_text("keep me\n", encoding="utf-8")
     (tmp_path / "dist").symlink_to(target_dir, target_is_directory=True)
 
-    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        if cmd[:3] == [sys.executable, "-m", "build"]:
-            out_dir = Path(cmd[-1])
-            out_dir.mkdir(parents=True, exist_ok=True)
-            (out_dir / "package.whl").write_text("artifact\n", encoding="utf-8")
-        return subprocess.CompletedProcess(cmd, 0)
-
-    monkeypatch.setattr("apps.release.simulator.subprocess.run", fake_run)
-
     result = run_release_simulation(
         root=tmp_path,
         skip_pypi=True,
+        clean=False,
     )
 
-    assert result.ok is True
-    assert (tmp_path / "dist").is_dir()
-    assert not (tmp_path / "dist").is_symlink()
+    assert result.ok is False
+    assert result.failed_step == "build_package"
+    assert "must not be a symlink" in result.error
+    assert (tmp_path / "dist").is_symlink()
     assert target_file.read_text(encoding="utf-8") == "keep me\n"
 
 

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -110,6 +110,21 @@ def test_release_simulation_reports_directory_version_file(tmp_path: Path) -> No
     assert "Version file is not a regular file" in result.error
 
 
+def test_release_simulation_reports_unreadable_version_file(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "VERSION").write_bytes(b"\xff\xfe\xfa")
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "Failed to read version file" in result.error
+
+
 def test_release_simulation_reports_malformed_pyproject(tmp_path: Path) -> None:
     _write_project(tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -276,6 +276,26 @@ def test_release_simulation_reports_invalid_pypi_json(
     assert "Received invalid JSON from PyPI" in result.error
 
 
+def test_release_simulation_reports_pypi_decode_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(b"\xff\xfe\xfa")
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "Received invalid JSON from PyPI" in result.error
+
+
 def test_release_simulation_reports_invalid_pypi_payload_type(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -95,6 +95,36 @@ def test_release_simulation_reports_version_gate_mismatch(tmp_path: Path) -> Non
     assert "validate_version_gate" in result.summary_markdown
 
 
+def test_release_simulation_accepts_multi_file_dynamic_version(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "VERSION").write_text("1.2.3\n", encoding="utf-8")
+    (tmp_path / "version-prefix.txt").write_text("1.2", encoding="utf-8")
+    (tmp_path / "version-suffix.txt").write_text(".3", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "arthexis"',
+                'dynamic = ["version"]',
+                "",
+                "[tool.setuptools.dynamic.version]",
+                'file = ["version-prefix.txt", "version-suffix.txt"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is True
+    assert result.version == "1.2.3"
+
+
 def test_release_simulation_reports_directory_version_file(tmp_path: Path) -> None:
     _write_project(tmp_path)
 
@@ -274,7 +304,28 @@ def test_release_simulation_reports_invalid_pypi_timeout(
 
     assert result.ok is False
     assert result.failed_step == "preflight_pypi"
-    assert "PyPI timeout must be greater than zero seconds" in result.error
+    assert "PyPI timeout must be a finite value greater than zero seconds" in result.error
+
+
+def test_release_simulation_reports_non_finite_pypi_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        raise AssertionError("urlopen should not be called for invalid timeouts")
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+        pypi_timeout=float("nan"),
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "PyPI timeout must be a finite value greater than zero seconds" in result.error
 
 
 def test_release_simulation_reports_invalid_pypi_json(

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -95,6 +95,21 @@ def test_release_simulation_reports_version_gate_mismatch(tmp_path: Path) -> Non
     assert "validate_version_gate" in result.summary_markdown
 
 
+def test_release_simulation_reports_directory_version_file(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        version_file=Path("."),
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "Version file is not a regular file" in result.error
+
+
 def test_release_simulation_reports_malformed_pyproject(tmp_path: Path) -> None:
     _write_project(tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")
@@ -168,6 +183,36 @@ def test_release_simulation_reports_invalid_dynamic_version_metadata_shape(
     assert result.ok is False
     assert result.failed_step == "validate_version_gate"
     assert "pyproject metadata at 'version' must be a table" in result.error
+
+
+def test_release_simulation_reports_directory_dynamic_version_file(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "arthexis"',
+                'dynamic = ["version"]',
+                "",
+                "[tool.setuptools.dynamic.version]",
+                'file = ["."]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_pypi=True,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "validate_version_gate"
+    assert "Dynamic version file is not a regular file" in result.error
 
 
 def test_release_simulation_quotes_package_name_for_pypi(

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -216,6 +216,26 @@ def test_release_simulation_reports_invalid_pypi_json(
     assert "Received invalid JSON from PyPI" in result.error
 
 
+def test_release_simulation_reports_invalid_pypi_payload_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        return _FakeResponse(b"[]")
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "Unexpected PyPI payload type: list" in result.error
+
+
 def test_release_simulation_reports_invalid_pypi_releases_payload(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -256,6 +256,27 @@ def test_release_simulation_quotes_package_name_for_pypi(
     assert user_agents == ["arthexis-release-simulator/1.2.3"]
 
 
+def test_release_simulation_reports_invalid_pypi_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_project(tmp_path)
+
+    def fake_urlopen(url: str, *, timeout: float) -> _FakeResponse:
+        raise AssertionError("urlopen should not be called for invalid timeouts")
+
+    monkeypatch.setattr("apps.release.simulator.urlopen", fake_urlopen)
+
+    result = run_release_simulation(
+        root=tmp_path,
+        skip_build=True,
+        pypi_timeout=0,
+    )
+
+    assert result.ok is False
+    assert result.failed_step == "preflight_pypi"
+    assert "PyPI timeout must be greater than zero seconds" in result.error
+
+
 def test_release_simulation_reports_invalid_pypi_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
   "tablib==3.9.0",
   "tinycss2==1.5.1",
   "toml==0.10.2",
+  "tomli>=1.1.0; python_version < \"3.11\"",
   "Twisted==25.5.0",
   "txaio==25.9.2",
   "typing_extensions==4.15.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -81,6 +81,7 @@ sqlparse==0.5.5
 tablib==3.9.0
 tinycss2==1.5.1
 toml==0.10.2
+tomli>=1.1.0; python_version < "3.11"
 trio-websocket==0.12.2
 trio==0.31.0
 twine==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ sqlparse==0.5.5
 tablib==3.9.0
 tinycss2==1.5.1
 toml==0.10.2
+tomli>=1.1.0; python_version < "3.11"
 Twisted==25.5.0
 txaio==25.9.2
 typing_extensions==4.15.0


### PR DESCRIPTION
## Summary

Adds a reusable release simulator that can run from CI with GitHub Actions outputs or locally without GitHub context.

- Adds `python -m apps.release.simulator` for version-gate validation, optional PyPI preflight, build artifact generation, twine metadata validation, blocker skips, JSON output, markdown summaries, and GitHub output emission.
- Adds `manage.py release simulate` as the suite-facing wrapper with local escape hatches like `--skip-pypi` and `--skip-build`.
- Replaces the inline release-simulator workflow build/preflight block with the shared simulator command.

Closes #7361.

## Validation

- `/home/arthe/prototype/.venv/bin/python -m py_compile apps/release/simulator.py apps/release/management/commands/release.py apps/release/tests/test_release_simulator.py`
- `/home/arthe/prototype/.venv/bin/python manage.py test run -- apps/release/tests/test_release_simulator.py`
- `/home/arthe/prototype/.venv/bin/python manage.py test run -- apps/release/tests`
- `/home/arthe/prototype/.venv/bin/python -m apps.release.simulator --skip-pypi --skip-build --json`
- `/home/arthe/prototype/.venv/bin/python manage.py release simulate --skip-pypi --skip-build --json`
- Workflow YAML parsed with PyYAML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a reusable release simulator runnable both in CI and locally, consolidating release-readiness validation into a single module and management command and replacing the prior inline workflow logic. It provides a consistent simulation surface for version-gate checks, optional PyPI preflight, build artifact generation, and twine metadata validation while stopping at the publish authorization boundary. Closes #7361.

## Key Changes

### New Module: apps/release/simulator.py
- Adds a standalone CLI entrypoint (python -m apps.release.simulator) and programmatic API:
  - run_release_simulation(...) -> ReleaseSimulationResult
  - ReleaseSimulationResult and SimulationStep dataclasses
  - ReleaseSimulationError exception
  - parse_blockers_json(), emit_result(), write_github_output(), main()
- Implements simulation steps:
  - Version-gate validation by reading pyproject.toml (tomllib/tomli fallback) and the VERSION file
  - Optional PyPI preflight (HTTP JSON check, configurable User-Agent, skip via --skip-pypi)
  - Optional build step (pip/build/twine install, python -m build, python -m twine check; skip via --skip-build)
  - Per-step result recording, detailed markdown summary generation, JSON output, and GitHub Actions output emission (supports GITHUB_OUTPUT and local runs)
- Robust safety and hardening:
  - Validation and rejection of unsafe dist/build targets (reject repo root, reject existing non-directory targets)
  - Allow cleanup only for empty directories or directories containing only expected artifact file types (.tar.gz, .whl, .zip)
  - Symlink-aware handling: resolve custom dist_dir without following final symlink; unlink symlink on cleanup where appropriate; reject symlinked custom dist dirs before builds to avoid write-through
  - Subprocess timeout handling and configurable workflow timeout guidance
  - Blocker handling: immediate skipped result when blockers are present
- Exit behavior: exit code 0 for ok or skipped, 1 for failures.

### New Management Command: apps/release/management/commands/release.py
- Adds a simulate subcommand that:
  - Exposes repository and file path flags, blockers JSON, and boolean controls (--skip-pypi, --skip-build, --no-clean, --install-missing-tools)
  - Converts CLI inputs to typed parameters and calls run_release_simulation
  - Emits results to stdout, optional summary file, and GitHub Actions outputs
  - Raises CommandError when simulation fails (unless marked skipped)
  - Provides local escape hatches for CI-reliant steps

### Workflow Refactor: .github/workflows/release-simulator.yml
- Replaces the inlined multi-step simulated-release logic with a single step that runs python -m apps.release.simulator
- Maps job outputs simulated_ok and summary_markdown directly from the simulator step outputs
- Adds timeout-minutes: 30 to the simulate_release job

### Tests: apps/release/tests/test_release_simulator.py
- Adds a comprehensive pytest suite covering:
  - Successful simulation with PyPI and build skipped
  - Version-gate failures (dynamic version mismatches, malformed pyproject.toml, invalid dynamic metadata)
  - PyPI preflight edge cases (URL encoding, User-Agent, invalid JSON, releases=null handling)
  - Blocker skip behavior and parse_blockers_json validation
  - Filesystem safety checks (reject repo root, reject existing non-dir dist, preserve VERSION/pyproject, non-artifact directory rejection)
  - Symlink safety tests (dist and build symlink handling, no-clean preservation)
  - Build timeout handling (subprocess TimeoutExpired)
  - GitHub Actions output formatting and heredoc delimiter collision avoidance
  - Django management command integration (stdout/CommandError behavior)

### Dependency Updates
- Adds tomli (>=1.1.0) conditionally for Python < 3.11 in pyproject.toml, requirements(-ci).txt to support tomli fallback when tomllib is unavailable.

## Validation Performed
- Byte-compilation and targeted test runs for apps/release simulator files and management wrapper
- Local simulator and management wrapper runs using --skip-pypi --skip-build --json exercised output emission paths
- YAML workflow parsing validation (PyYAML)
- Iterative hardening with regression tests added for unsafe dist/build targets and symlink scenarios
- Subprocess timeout handling and workflow timeout configured

## Notes on Safety and Review Focus
- Significant attention was applied to filesystem safety (dist/build cleanup) and symlink handling; reviewers should focus on those validation paths and the exact semantics around cleanup, symlink unlinking, and rejected targets.
- Reviewers should also validate the PyPI preflight HTTP handling (User-Agent and package-name quoting), twine check invocation, and GitHub Actions output formatting to ensure CI integration behaves as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->