### PR TITLE
docs: add UI style contract for CSS naming and token usage

### DIFF
--- a/docs/development/ui-style-contract.md
+++ b/docs/development/ui-style-contract.md
@@ -78,13 +78,13 @@ Avoid ad-hoc or ambiguous class names, including:
 
 - Generic utility-like names without semantic intent (for example, `.left`, `.big`).
 - Numbered style names that do not communicate purpose (for example, `.button2`).
-- Visual-only replacement classes where a state or component class should exist.
+- Visual-only replacement classes where a state or component class should exist (for example, using `.text-red` instead of `.is-error`).
 
 ## Token usage and sizing policy
 
 Do not hardcode `rem` or `px` for control sizing when a design token already exists.
 
-- Prefer framework tokens such as `--admin-ui-control-height` and related spacing/radius tokens from the admin UI framework.
+- Prefer framework tokens such as `--admin-ui-control-height` and related spacing/radius tokens from the admin UI framework (for example, `--admin-ui-spacing-md`, `--admin-ui-radius-sm`).
 - Hardcoded lengths are acceptable only when no suitable token exists and the value is truly app-specific.
 - If the same hardcoded value appears in multiple places, promote it to a shared token or shared primitive.
 
@@ -96,7 +96,7 @@ When migrating legacy templates and CSS:
 
 1. Audit classes in the target template and stylesheet.
 2. Map global layout/action/control patterns to `admin-ui-*` primitives first.
-3. Rename app-specific structures to `ui-<component>`, `__<element>`, and `--<variant>`.
+3. Rename app-specific structures to the full BEM-style patterns: `ui-<component>`, `ui-<component>__<element>`, and `ui-<component>--<variant>`.
 4. Convert visual state toggles to `is-*` classes.
 5. Move JavaScript selectors to `js-*` classes where behavior hooks are needed.
 6. Replace hardcoded control sizing with existing tokens where available.

--- a/docs/development/ui-style-contract.md
+++ b/docs/development/ui-style-contract.md
@@ -84,7 +84,7 @@ Avoid ad-hoc or ambiguous class names, including:
 
 Do not hardcode `rem` or `px` for control sizing when a design token already exists.
 
-- Prefer framework tokens such as `--admin-ui-control-height` and related spacing/radius tokens from the admin UI framework (for example, `--admin-ui-spacing-md`, `--admin-ui-radius-sm`).
+- Prefer framework tokens such as `--admin-ui-control-height` and related spacing/radius tokens from the admin UI framework (for example, `--admin-ui-space-4`, `--admin-ui-radius-sm`).
 - Hardcoded lengths are acceptable only when no suitable token exists and the value is truly app-specific.
 - If the same hardcoded value appears in multiple places, promote it to a shared token or shared primitive.
 

--- a/docs/development/ui-style-contract.md
+++ b/docs/development/ui-style-contract.md
@@ -1,0 +1,105 @@
+# UI style contract
+
+This document is the single source of truth for CSS naming and design-token usage in Arthexis admin and app UI templates.
+
+Use this contract with `docs/development/admin-ui-framework.md` to keep implementation aligned with shared primitives while preserving app flexibility.
+
+## Scope split
+
+### Global admin primitives
+
+Global primitives are shared, reusable classes defined by the admin UI framework and intended for cross-app consistency.
+
+- Prefix: `admin-ui-*`
+- Examples: layout containers, spacing stacks, action rows, control styles, muted text helpers.
+- Ownership: shared framework CSS and admin base templates.
+- Usage rule: prefer these first for common layout and controls before adding app-local classes.
+
+### App-local classes
+
+App-local classes are component classes scoped to one app or feature when a shared primitive does not express the UI intent clearly.
+
+- Prefix family: `ui-*` (component structure), `is-*` (state), `js-*` (behavior hooks).
+- Ownership: app CSS/templates.
+- Usage rule: app-local classes may extend but should not silently replace framework primitives for common controls.
+
+## Naming rules
+
+Use these naming patterns exactly.
+
+### Shared primitives
+
+- Format: `admin-ui-*`
+- Purpose: cross-app layout/control primitives owned by the shared admin UI framework.
+
+### Component block
+
+- Format: `ui-<component>`
+- Example: `ui-simulator-card`
+
+### Element
+
+- Format: `ui-<component>__<element>`
+- Example: `ui-simulator-card__summary`
+
+### Variant/modifier
+
+- Format: `ui-<component>--<variant>`
+- Example: `ui-simulator-card--compact`
+
+### State
+
+- Format: `is-<state>`
+- Example: `is-loading`
+- Constraint: state classes are state-only and must never be used as styling-only replacement for a proper component block.
+
+### JavaScript hooks
+
+- Format: `js-<behavior>`
+- Example: `js-toggle-advanced`
+- Constraint: use only for behavior targeting. Never use `js-*` classes to apply visual styling.
+
+## Reserved prefixes and forbidden patterns
+
+### Reserved prefixes
+
+The following prefixes are reserved and mandatory for their intended purpose:
+
+- `admin-ui-`
+- `ui-`
+- `is-`
+- `js-`
+
+Do not invent alternate project-wide prefixes for the same concerns.
+
+### Forbidden patterns
+
+Avoid ad-hoc or ambiguous class names, including:
+
+- Generic utility-like names without semantic intent (for example, `.left`, `.big`).
+- Numbered style names that do not communicate purpose (for example, `.button2`).
+- Visual-only replacement classes where a state or component class should exist.
+
+## Token usage and sizing policy
+
+Do not hardcode `rem` or `px` for control sizing when a design token already exists.
+
+- Prefer framework tokens such as `--admin-ui-control-height` and related spacing/radius tokens from the admin UI framework.
+- Hardcoded lengths are acceptable only when no suitable token exists and the value is truly app-specific.
+- If the same hardcoded value appears in multiple places, promote it to a shared token or shared primitive.
+
+This policy is aligned with current AGENTS guidance and the admin UI framework documentation.
+
+## Migration guidance for legacy ad-hoc class names
+
+When migrating legacy templates and CSS:
+
+1. Audit classes in the target template and stylesheet.
+2. Map global layout/action/control patterns to `admin-ui-*` primitives first.
+3. Rename app-specific structures to `ui-<component>`, `__<element>`, and `--<variant>`.
+4. Convert visual state toggles to `is-*` classes.
+5. Move JavaScript selectors to `js-*` classes where behavior hooks are needed.
+6. Replace hardcoded control sizing with existing tokens where available.
+7. Remove obsolete legacy classes after template and CSS updates are complete.
+
+Migration goal: reduce style drift while keeping Arthexis extensible through shared primitives plus explicit app-local component structure.


### PR DESCRIPTION
### Motivation

- Centralize CSS naming and design-token usage as a single source of truth for Arthexis admin and app UI work. 
- Reduce style drift across apps by distinguishing global admin primitives from app-local component classes and behavior hooks. 
- Encourage token-first sizing and clearer migration paths away from legacy ad-hoc class names.

### Description

- Add `docs/development/ui-style-contract.md` containing the new UI style contract. 
- Define a scope split between global admin primitives (prefix `admin-ui-*`) and app-local classes using `ui-*`, `is-*`, and `js-*`. 
- Specify naming conventions for component blocks, elements, modifiers, state classes, and JavaScript hooks, and list reserved prefixes and forbidden ambiguous patterns. 
- Document token usage and sizing policy that prefers design tokens (for example `--admin-ui-control-height`) and provide migration guidance for legacy ad-hoc class names.

### Testing

- This is a documentation-only change and no runtime code paths were modified. 
- Repository pre-merge checks and style/lint checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebba0d43788326a8a058bf67447005)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## UI Style Contract Documentation

This PR introduces a new documentation file (`docs/development/ui-style-contract.md`) that establishes a centralized style contract for CSS naming conventions and design-token usage across Arthexis admin and app UIs.

### Key Specifications

The documentation defines:

- **Scope boundaries**: Global admin primitives using `admin-ui-*` prefix vs. app-local classes using `ui-*`, `is-*`, and `js-*` prefixes
- **Naming conventions**: 
  - Component blocks: `ui-<component>`
  - Elements: `ui-<component>__<element>`
  - Variants: `ui-<component>--<variant>`
  - State classes: `is-<state>`
  - JavaScript hooks: `js-<behavior>`
- **Token-first sizing policy**: Requires using design tokens (e.g., `--admin-ui-control-height`) instead of hardcoded `rem`/`px` values, with app-specific hardcoding only as a fallback
- **Reserved prefixes and forbidden patterns** to prevent ambiguous naming

### Migration Guidance

The document includes a numbered migration procedure for mapping legacy ad-hoc class names to the appropriate primitives, component structure, state classes, JavaScript hooks, and design tokens.

This is a documentation-only change with no runtime code modifications. (+105 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->