### PR TITLE
[codex] Fix RFID scanner service polling fallback

### DIFF
--- a/apps/cards/background_reader.py
+++ b/apps/cards/background_reader.py
@@ -183,36 +183,11 @@ def lock_file_path() -> Path:
     return _lock_path()
 
 
-def _read_lock_marker(lock: Path) -> str | None:
-    """Return the stored suite marker for a lock file when available."""
-
-    try:
-        contents = lock.read_text(encoding="utf-8").strip()
-        return contents or None
-    except Exception:
-        return None
-
-
-def _lock_matches_current(lock: Path) -> bool:
-    """Return ``True`` when the lock file belongs to this suite instance."""
-
-    marker = _read_lock_marker(lock)
-    return bool(marker and marker == _suite_marker)
-
-
 def lock_file_active() -> tuple[bool, Path]:
     """Return whether a current-suite lock file exists and its path."""
 
     lock = lock_file_path()
-    if lock.exists():
-        if _lock_matches_current(lock):
-            return True, lock
-        try:
-            lock.unlink()
-            logger.info("Removed stale RFID lock file from previous suite: %s", lock)
-        except Exception as exc:  # pragma: no cover - defensive filesystem guard
-            logger.debug("Unable to remove stale RFID lock file %s: %s", lock, exc)
-    return False, lock
+    return lock.exists(), lock
 
 
 def _mark_scanner_used() -> None:
@@ -221,7 +196,10 @@ def _mark_scanner_used() -> None:
     lock = _lock_path()
     try:
         lock.parent.mkdir(parents=True, exist_ok=True)
-        lock.write_text(_suite_marker, encoding="utf-8")
+        if lock.exists():
+            lock.touch()
+        else:
+            lock.write_text(_suite_marker, encoding="utf-8")
     except Exception as exc:  # pragma: no cover - defensive filesystem fallback
         logger.debug("RFID auto-detect: unable to update lock file %s: %s", lock, exc)
 
@@ -410,15 +388,6 @@ def _worker():  # pragma: no cover - background thread
     if not _setup_hardware():
         _record_setup_failure("initialization", _hardware_disabled_reason)
         _log_fd_snapshot("worker-setup-failed")
-        lock = lock_file_path()
-        if lock.exists():
-            try:
-                lock.unlink()
-                logger.info("Removed stale RFID lock file after setup failure: %s", lock)
-            except Exception as exc:
-                logger.debug(
-                    "Unable to remove RFID lock file %s after setup failure: %s", lock, exc
-                )
         _thread = None
         return
     _last_setup_failure = None
@@ -519,7 +488,6 @@ def get_next_tag(timeout: float | None = 0) -> Optional[dict]:
     if timeout is None:
         timeout = 0.0
     timeout = max(0.0, timeout)
-    start_time = time.monotonic()
     try:
         result = _tag_queue.get(timeout=timeout)
         if result and result.get("rfid"):
@@ -532,9 +500,8 @@ def get_next_tag(timeout: float | None = 0) -> Optional[dict]:
         try:
             from .reader import read_rfid
 
-            elapsed = time.monotonic() - start_time
-            remaining_timeout = max(0.0, timeout - elapsed)
-            res = read_rfid(mfrc=_reader, cleanup=False, timeout=remaining_timeout)
+            poll_timeout = max(0.0, timeout)
+            res = read_rfid(mfrc=_reader, cleanup=False, timeout=poll_timeout)
             if res.get("rfid") or res.get("error"):
                 _irq_empty_tracker.log_summary("polling read")
                 logger.debug("Polling read result: %s", res)

--- a/apps/cards/background_reader.py
+++ b/apps/cards/background_reader.py
@@ -184,7 +184,7 @@ def lock_file_path() -> Path:
 
 
 def lock_file_active() -> tuple[bool, Path]:
-    """Return whether a current-suite lock file exists and its path."""
+    """Return whether the RFID service lock file exists and its path."""
 
     lock = lock_file_path()
     return lock.exists(), lock

--- a/apps/cards/management/commands/rfid.py
+++ b/apps/cards/management/commands/rfid.py
@@ -157,7 +157,8 @@ class Command(BaseCommand):
         if timeout is None or timeout <= 0:
             raise CommandError("Timeout must be a positive number of seconds")
 
-        if options.get("no_irq"):
+        no_irq = options.get("no_irq")
+        if no_irq:
             result = scan_sources(timeout=timeout, no_irq=True)
         else:
             start = time.monotonic()
@@ -172,7 +173,7 @@ class Command(BaseCommand):
         if result.get("error"):
             return result
         if not result.get("rfid"):
-            if not service_available():
+            if not no_irq and not service_available():
                 return {"error": "RFID scanner service not configured or detected"}
             return {"error": "No RFID detected before timeout"}
         return result

--- a/apps/cards/management/commands/rfid.py
+++ b/apps/cards/management/commands/rfid.py
@@ -159,7 +159,7 @@ class Command(BaseCommand):
 
         no_irq = options.get("no_irq")
         if no_irq:
-            result = scan_sources(timeout=timeout, no_irq=True)
+            result = self._scan_via_local(timeout, no_irq=True)
         else:
             start = time.monotonic()
             result = self._scan_via_attempt(timeout)
@@ -205,7 +205,7 @@ class Command(BaseCommand):
             payload.setdefault("label_id", attempt.label_id)
         return payload
 
-    def _scan_via_local(self, timeout: float) -> dict:
+    def _scan_via_local(self, timeout: float, *, no_irq: bool = False) -> dict:
         interactive = sys.stdin.isatty()
         if interactive:
             self.stdout.write("Press any key to stop scanning.")
@@ -215,10 +215,13 @@ class Command(BaseCommand):
         while True:
             if interactive and user_requested_stop():
                 return {"error": "Scan cancelled by user"}
-            remaining = max(0.0, timeout - (time.monotonic() - start))
-            if remaining <= 0:
-                return {"rfid": None, "label_id": None}
-            result = scan_sources(timeout=min(0.2, remaining))
+            chunk_timeout = 0.2
+            if not interactive:
+                remaining = max(0.0, timeout - (time.monotonic() - start))
+                if remaining <= 0:
+                    return {"rfid": None, "label_id": None}
+                chunk_timeout = min(chunk_timeout, remaining)
+            result = scan_sources(timeout=chunk_timeout, no_irq=no_irq)
             if result.get("rfid") or result.get("error"):
                 return result
             if not interactive and time.monotonic() - start >= timeout:

--- a/apps/cards/management/commands/rfid.py
+++ b/apps/cards/management/commands/rfid.py
@@ -157,9 +157,12 @@ class Command(BaseCommand):
         if timeout is None or timeout <= 0:
             raise CommandError("Timeout must be a positive number of seconds")
 
-        result = self._scan_via_attempt(timeout)
-        if (result.get("rfid") is None) and not result.get("error"):
-            result = self._scan_via_local(timeout)
+        if options.get("no_irq"):
+            result = scan_sources(timeout=timeout, no_irq=True)
+        else:
+            result = self._scan_via_attempt(timeout)
+            if (result.get("rfid") is None) and not result.get("error"):
+                result = self._scan_via_local(timeout)
         if result.get("error"):
             return result
         if not result.get("rfid"):

--- a/apps/cards/management/commands/rfid.py
+++ b/apps/cards/management/commands/rfid.py
@@ -160,9 +160,15 @@ class Command(BaseCommand):
         if options.get("no_irq"):
             result = scan_sources(timeout=timeout, no_irq=True)
         else:
+            start = time.monotonic()
             result = self._scan_via_attempt(timeout)
             if (result.get("rfid") is None) and not result.get("error"):
-                result = self._scan_via_local(timeout)
+                elapsed = time.monotonic() - start
+                remaining = max(0.0, timeout - elapsed)
+                if remaining <= 0:
+                    result = {"rfid": None, "label_id": None}
+                else:
+                    result = self._scan_via_local(remaining)
         if result.get("error"):
             return result
         if not result.get("rfid"):
@@ -208,7 +214,10 @@ class Command(BaseCommand):
         while True:
             if interactive and user_requested_stop():
                 return {"error": "Scan cancelled by user"}
-            result = scan_sources(timeout=0.2)
+            remaining = max(0.0, timeout - (time.monotonic() - start))
+            if remaining <= 0:
+                return {"rfid": None, "label_id": None}
+            result = scan_sources(timeout=min(0.2, remaining))
             if result.get("rfid") or result.get("error"):
                 return result
             if not interactive and time.monotonic() - start >= timeout:

--- a/apps/cards/rfid_service.py
+++ b/apps/cards/rfid_service.py
@@ -478,7 +478,12 @@ def run_service(host: str | None = None, port: int | None = None) -> None:
 
     def _handle_signal(signum, frame) -> None:  # pragma: no cover - signal handling
         logger.info("RFID service received shutdown signal %s", signum)
-        runner.shutdown()
+        shutdown_thread = threading.Thread(
+            target=runner.shutdown,
+            name="rfid-service-shutdown",
+            daemon=True,
+        )
+        shutdown_thread.start()
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)

--- a/apps/cards/scanner.py
+++ b/apps/cards/scanner.py
@@ -233,6 +233,21 @@ def scan_sources(
 ):
     """Read the next RFID tag from the scanner service."""
     timeout_value = timeout if timeout is not None else 0.5
+    if no_irq:
+        from .reader import read_rfid
+
+        result = read_rfid(timeout=timeout_value, poll_interval=0.05, use_irq=False)
+        if result.get("rfid"):
+            attempt = record_scan_attempt(
+                result,
+                source=RFIDAttempt.Source.ON_DEMAND,
+                status=RFIDAttempt.Status.SCANNED,
+            )
+            if attempt is not None:
+                return build_attempt_response(attempt, endianness=endianness)
+            result["service_mode"] = "on-demand"
+        return result
+
     result = request_service("scan", payload={"timeout": timeout_value}, timeout=timeout_value + 0.2)
     if result is None:
         return {"error": "scanner service unavailable", "service_mode": "service"}

--- a/apps/cards/scanner.py
+++ b/apps/cards/scanner.py
@@ -243,9 +243,7 @@ def scan_sources(
                 source=RFIDAttempt.Source.ON_DEMAND,
                 status=RFIDAttempt.Status.SCANNED,
             )
-            if attempt is not None:
-                return build_attempt_response(attempt, endianness=endianness)
-            result["service_mode"] = "on-demand"
+            return build_attempt_response(attempt, endianness=endianness)
         return result
 
     result = request_service("scan", payload={"timeout": timeout_value}, timeout=timeout_value + 0.2)

--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import queue
+from types import SimpleNamespace
 
 from apps.cards import background_reader
+from apps.cards import reader
 
 
 def test_setup_hardware_gpio_missing_disables_reader(caplog, monkeypatch):
@@ -94,3 +97,57 @@ def test_start_disables_hardware_when_gpio_unavailable(monkeypatch):
     background_reader.start()
 
     assert background_reader._hardware_disabled_reason == "GPIO library not available"
+
+
+def test_lock_file_active_keeps_existing_service_lock(tmp_path, settings):
+    settings.BASE_DIR = str(tmp_path)
+    lock = tmp_path / ".locks" / "rfid-service.lck"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("other-process-marker", encoding="utf-8")
+
+    active, path = background_reader.lock_file_active()
+
+    assert active is True
+    assert path == lock
+    assert lock.read_text(encoding="utf-8") == "other-process-marker"
+
+
+def test_worker_setup_failure_does_not_delete_service_lock(tmp_path, settings, monkeypatch):
+    settings.BASE_DIR = str(tmp_path)
+    lock = tmp_path / ".locks" / "rfid-service.lck"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("configured", encoding="utf-8")
+    monkeypatch.setattr(background_reader, "_setup_hardware", lambda: False)
+    monkeypatch.setattr(background_reader, "_record_setup_failure", lambda *args, **kwargs: None)
+    monkeypatch.setattr(background_reader, "_log_fd_snapshot", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(background_reader, "_thread", object())
+
+    background_reader._worker()
+
+    assert lock.exists()
+    assert background_reader._thread is None
+
+
+def test_get_next_tag_polling_fallback_uses_original_timeout(monkeypatch):
+    calls: list[float] = []
+
+    class EmptyQueue:
+        def get(self, timeout=None):
+            raise queue.Empty
+
+    def fake_read_rfid(**kwargs):
+        calls.append(kwargs["timeout"])
+        return {"rfid": None, "label_id": None}
+
+    monkeypatch.setattr(background_reader, "is_configured", lambda: True)
+    monkeypatch.setattr(background_reader, "_tag_queue", EmptyQueue())
+    monkeypatch.setattr(background_reader, "_log_fd_snapshot", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(reader, "read_rfid", fake_read_rfid)
+    monkeypatch.setattr(
+        background_reader,
+        "_irq_empty_tracker",
+        SimpleNamespace(record=lambda: None, log_summary=lambda _event: None),
+    )
+
+    assert background_reader.get_next_tag(timeout=0.2) is None
+    assert calls == [0.2]

--- a/apps/cards/tests/test_rfid_service_command.py
+++ b/apps/cards/tests/test_rfid_service_command.py
@@ -150,3 +150,60 @@ def test_rfid_scan_no_irq_bypasses_attempt_polling(monkeypatch):
     result = command._scan({"timeout": 1.0, "no_irq": True})
 
     assert result == {"rfid": "ABCD1234", "no_irq": True}
+
+
+@pytest.mark.django_db
+def test_rfid_scan_fallback_uses_remaining_timeout(monkeypatch):
+    """Fallback polling should not restart the full scan timeout."""
+
+    rfid_command = importlib.import_module("apps.cards.management.commands.rfid")
+    monotonic_values = iter([10.0, 11.5])
+    captured: dict[str, float] = {}
+    command = rfid_command.Command()
+
+    monkeypatch.setattr(rfid_command.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        command,
+        "_scan_via_attempt",
+        lambda timeout: {"rfid": None, "label_id": None},
+    )
+
+    def fake_scan_via_local(timeout):
+        captured["timeout"] = timeout
+        return {"rfid": None, "label_id": None}
+
+    monkeypatch.setattr(command, "_scan_via_local", fake_scan_via_local)
+    monkeypatch.setattr(rfid_command, "service_available", lambda: True)
+
+    result = command._scan({"timeout": 2.0, "no_irq": False})
+
+    assert result == {"error": "No RFID detected before timeout"}
+    assert captured["timeout"] == pytest.approx(0.5)
+
+
+@pytest.mark.django_db
+def test_rfid_scan_fallback_skips_local_when_timeout_spent(monkeypatch):
+    """Fallback polling should stop when service polling used the budget."""
+
+    rfid_command = importlib.import_module("apps.cards.management.commands.rfid")
+    monotonic_values = iter([10.0, 12.1])
+    command = rfid_command.Command()
+
+    monkeypatch.setattr(rfid_command.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        command,
+        "_scan_via_attempt",
+        lambda timeout: {"rfid": None, "label_id": None},
+    )
+    monkeypatch.setattr(
+        command,
+        "_scan_via_local",
+        lambda timeout: (_ for _ in ()).throw(
+            AssertionError("local fallback should not run")
+        ),
+    )
+    monkeypatch.setattr(rfid_command, "service_available", lambda: True)
+
+    result = command._scan({"timeout": 2.0, "no_irq": False})
+
+    assert result == {"error": "No RFID detected before timeout"}

--- a/apps/cards/tests/test_rfid_service_command.py
+++ b/apps/cards/tests/test_rfid_service_command.py
@@ -153,6 +153,24 @@ def test_rfid_scan_no_irq_bypasses_attempt_polling(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_rfid_scan_no_irq_empty_result_bypasses_service_state(monkeypatch):
+    """Direct polling should report timeout even when the service is unavailable."""
+
+    rfid_command = importlib.import_module("apps.cards.management.commands.rfid")
+    monkeypatch.setattr(
+        rfid_command,
+        "scan_sources",
+        lambda **kwargs: {"rfid": None, "label_id": None, "no_irq": kwargs.get("no_irq")},
+    )
+    monkeypatch.setattr(rfid_command, "service_available", lambda: False)
+
+    command = rfid_command.Command()
+    result = command._scan({"timeout": 1.0, "no_irq": True})
+
+    assert result == {"error": "No RFID detected before timeout"}
+
+
+@pytest.mark.django_db
 def test_rfid_scan_fallback_uses_remaining_timeout(monkeypatch):
     """Fallback polling should not restart the full scan timeout."""
 

--- a/apps/cards/tests/test_rfid_service_command.py
+++ b/apps/cards/tests/test_rfid_service_command.py
@@ -165,9 +165,34 @@ def test_rfid_scan_no_irq_empty_result_bypasses_service_state(monkeypatch):
     monkeypatch.setattr(rfid_command, "service_available", lambda: False)
 
     command = rfid_command.Command()
-    result = command._scan({"timeout": 1.0, "no_irq": True})
+    result = command._scan({"timeout": 0.01, "no_irq": True})
 
     assert result == {"error": "No RFID detected before timeout"}
+
+
+@pytest.mark.django_db
+def test_rfid_scan_no_irq_interactive_cancel(monkeypatch):
+    """Direct polling should preserve interactive cancellation."""
+
+    rfid_command = importlib.import_module("apps.cards.management.commands.rfid")
+    command = rfid_command.Command()
+    drained = []
+
+    monkeypatch.setattr(rfid_command.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(rfid_command, "drain_stdin", lambda: drained.append(True))
+    monkeypatch.setattr(rfid_command, "user_requested_stop", lambda: True)
+    monkeypatch.setattr(
+        rfid_command,
+        "scan_sources",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("scan should not run after interactive cancellation")
+        ),
+    )
+
+    result = command._scan({"timeout": 1.0, "no_irq": True})
+
+    assert result == {"error": "Scan cancelled by user"}
+    assert drained == [True]
 
 
 @pytest.mark.django_db

--- a/apps/cards/tests/test_rfid_service_command.py
+++ b/apps/cards/tests/test_rfid_service_command.py
@@ -125,3 +125,28 @@ def test_rfid_scan_requires_feature(monkeypatch):
 
     with pytest.raises(rfid_command.CommandError, match="rfid-scanner feature is not active"):
         call_command("rfid", "check", "--scan", "--no-irq")
+
+
+@pytest.mark.django_db
+def test_rfid_scan_no_irq_bypasses_attempt_polling(monkeypatch):
+    """`rfid check --scan --no-irq` should use the direct scanner path."""
+
+    rfid_command = importlib.import_module("apps.cards.management.commands.rfid")
+    monkeypatch.setattr(rfid_command.Command, "_scanner_feature_available", lambda _self: True)
+    monkeypatch.setattr(
+        rfid_command.Command,
+        "_scan_via_attempt",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("attempt polling should be bypassed")
+        ),
+    )
+    monkeypatch.setattr(
+        rfid_command,
+        "scan_sources",
+        lambda **kwargs: {"rfid": "ABCD1234", "no_irq": kwargs.get("no_irq")},
+    )
+
+    command = rfid_command.Command()
+    result = command._scan({"timeout": 1.0, "no_irq": True})
+
+    assert result == {"rfid": "ABCD1234", "no_irq": True}

--- a/apps/cards/tests/test_rfid_service_runtime.py
+++ b/apps/cards/tests/test_rfid_service_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from apps.cards import rfid_service
+from apps.cards import reader
 from apps.cards import scanner
 
 
@@ -54,5 +55,37 @@ def test_scan_sources_falls_back_to_attempts_for_lockfile_ingest_error(monkeypat
     monkeypatch.setattr(scanner, "_scan_from_attempts", lambda **kwargs: sentinel)
 
     result = scanner.scan_sources(timeout=0.5)
+
+    assert result == sentinel
+
+
+def test_scan_sources_no_irq_uses_direct_reader(monkeypatch):
+    """`--no-irq` scans should bypass the service and poll the reader directly."""
+
+    sentinel = {"rfid": "ABCD1234", "service_mode": "on-demand"}
+    monkeypatch.setattr(
+        scanner,
+        "request_service",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        reader,
+        "read_rfid",
+        lambda **kwargs: {"rfid": "ABCD1234", "label_id": 7},
+    )
+    monkeypatch.setattr(
+        scanner,
+        "record_scan_attempt",
+        lambda result, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        scanner,
+        "build_attempt_response",
+        lambda attempt, **kwargs: sentinel,
+    )
+
+    result = scanner.scan_sources(timeout=0.5, no_irq=True)
 
     assert result == sentinel

--- a/apps/cards/tests/test_rfid_service_runtime.py
+++ b/apps/cards/tests/test_rfid_service_runtime.py
@@ -89,3 +89,31 @@ def test_scan_sources_no_irq_uses_direct_reader(monkeypatch):
     result = scanner.scan_sources(timeout=0.5, no_irq=True)
 
     assert result == sentinel
+
+
+def test_scan_sources_no_irq_returns_direct_empty_result(monkeypatch):
+    """Empty direct reads should return without recording an attempt."""
+
+    monkeypatch.setattr(
+        scanner,
+        "request_service",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("service should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        reader,
+        "read_rfid",
+        lambda **kwargs: {"rfid": None, "label_id": None},
+    )
+    monkeypatch.setattr(
+        scanner,
+        "record_scan_attempt",
+        lambda result, **kwargs: (_ for _ in ()).throw(
+            AssertionError("empty scan should not be recorded")
+        ),
+    )
+
+    result = scanner.scan_sources(timeout=0.5, no_irq=True)
+
+    assert result == {"rfid": None, "label_id": None}

--- a/scripts/helpers/systemd_locks.sh
+++ b/scripts/helpers/systemd_locks.sh
@@ -102,6 +102,17 @@ arthexis_install_rfid_service_unit() {
   rfid_service_file="${systemd_dir}/${rfid_service}.service"
   local rfid_service_user
   rfid_service_user="$(arthexis_detect_service_user "$base_dir")"
+  local rfid_supplementary_groups=""
+  if getent group gpio >/dev/null 2>&1; then
+    rfid_supplementary_groups="${rfid_supplementary_groups:+$rfid_supplementary_groups }gpio"
+  fi
+  if getent group spi >/dev/null 2>&1; then
+    rfid_supplementary_groups="${rfid_supplementary_groups:+$rfid_supplementary_groups }spi"
+  fi
+  local rfid_supplementary_groups_line=""
+  if [ -n "$rfid_supplementary_groups" ]; then
+    rfid_supplementary_groups_line="SupplementaryGroups=$rfid_supplementary_groups"
+  fi
 
   sudo bash -c "cat > '$rfid_service_file'" <<SERVICEEOF
 [Unit]
@@ -119,9 +130,11 @@ EnvironmentFile=-$base_dir/debug.env
 ExecStart=$base_dir/.venv/bin/python -m apps.cards.rfid_service
 Restart=always
 TimeoutStartSec=500
+TimeoutStopSec=15
 StandardOutput=journal
 StandardError=journal
 User=$rfid_service_user
+$rfid_supplementary_groups_line
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- keep RFID service lock state stable across diagnostic/service processes
- make silent-IRQ scans fall back to real direct polling instead of a zero-timeout poll
- make `rfid check --scan --no-irq` use direct polling and record an on-demand attempt
- generate RFID systemd units with `gpio`/`spi` supplementary groups when available
- shorten RFID service stop timeout to avoid long hangs during restart/upgrade

Fixes #7369.

## Validation
- `python -m py_compile apps/cards/background_reader.py apps/cards/scanner.py apps/cards/management/commands/rfid.py apps/cards/rfid_service.py apps/cards/tests/test_background_reader.py apps/cards/tests/test_rfid_service_runtime.py apps/cards/tests/test_rfid_service_command.py`
- `./command.sh test run -- apps/cards/tests/test_background_reader.py apps/cards/tests/test_rfid_service_runtime.py apps/cards/tests/test_rfid_service_command.py apps/cards/tests/test_node_features.py`
- Result: `21 passed, 1 warning in 43.88s`
