### PR TITLE
[codex] Add classification training image import prototype

### DIFF
--- a/apps/classification/ingest.py
+++ b/apps/classification/ingest.py
@@ -9,21 +9,20 @@ from django.core.files.base import ContentFile
 
 from apps.media.utils import ensure_media_bucket
 
-SUPPORTED_IMAGE_PATTERNS = "\n".join(
-    [
-        "*.jpg",
-        "*.jpeg",
-        "*.png",
-        "*.webp",
-        "*.gif",
-        "*.bmp",
-        "*.tif",
-        "*.tiff",
-        "*.avif",
-        "*.heic",
-        "*.heif",
-    ]
+SUPPORTED_IMAGE_EXTENSIONS = (
+    ".avif",
+    ".bmp",
+    ".gif",
+    ".heic",
+    ".heif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
 )
+SUPPORTED_IMAGE_PATTERNS = "\n".join(f"*{extension}" for extension in SUPPORTED_IMAGE_EXTENSIONS)
 
 
 def guess_image_content_type(path: Path, *, default: str = "image/png") -> str:

--- a/apps/classification/ingest.py
+++ b/apps/classification/ingest.py
@@ -9,6 +9,22 @@ from django.core.files.base import ContentFile
 
 from apps.media.utils import ensure_media_bucket
 
+SUPPORTED_IMAGE_PATTERNS = "\n".join(
+    [
+        "*.jpg",
+        "*.jpeg",
+        "*.png",
+        "*.webp",
+        "*.gif",
+        "*.bmp",
+        "*.tif",
+        "*.tiff",
+        "*.avif",
+        "*.heic",
+        "*.heif",
+    ]
+)
+
 
 def guess_image_content_type(path: Path, *, default: str = "image/png") -> str:
     """Return the best-effort MIME type for an image path."""
@@ -38,7 +54,7 @@ def create_media_file_from_bytes(
     bucket = ensure_media_bucket(
         slug=bucket_slug,
         name=bucket_name,
-        allowed_patterns="*.jpg\n*.jpeg\n*.png",
+        allowed_patterns=SUPPORTED_IMAGE_PATTERNS,
     )
     initial_content_type = content_type if queue_for_classification else ""
     media_file = MediaFile(

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -1,0 +1,263 @@
+"""Import local image folders as classifier training samples."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.text import slugify
+from PIL import Image, UnidentifiedImageError
+
+from apps.classification.ingest import (
+    SUPPORTED_IMAGE_PATTERNS,
+    create_media_file_from_path,
+)
+from apps.classification.models import ClassificationTag, TrainingSample
+from apps.media.models import MediaFile
+from apps.media.utils import ensure_media_bucket
+
+IMAGE_EXTENSIONS = {
+    ".avif",
+    ".bmp",
+    ".gif",
+    ".heic",
+    ".heif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+
+
+@dataclass
+class ImportStats:
+    """Counters reported by the import command."""
+
+    scanned: int = 0
+    imported: int = 0
+    reused: int = 0
+    samples_created: int = 0
+    samples_existing: int = 0
+    tags_created: int = 0
+    skipped_extension: int = 0
+    skipped_unreadable: int = 0
+
+
+class Command(BaseCommand):
+    help = "Import a local image folder into classification training samples."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("path", help="Folder containing images to import.")
+        parser.add_argument(
+            "--bucket-slug",
+            default="classification-training",
+            help="Media bucket slug for imported training images.",
+        )
+        parser.add_argument(
+            "--bucket-name",
+            default="Classification Training Images",
+            help="Media bucket display name for imported training images.",
+        )
+        parser.add_argument(
+            "--tag",
+            help="Use one explicit tag slug for every imported image.",
+        )
+        parser.add_argument(
+            "--label-source",
+            choices=("parent-directory", "top-directory"),
+            default="parent-directory",
+            help="Derive labels from each image's parent folder or top-level folder.",
+        )
+        parser.add_argument(
+            "--split",
+            choices=[choice for choice, _label in TrainingSample.Split.choices],
+            default=TrainingSample.Split.TRAIN,
+            help="Dataset split assigned to created samples.",
+        )
+        parser.add_argument(
+            "--verified",
+            action="store_true",
+            help="Mark created training samples as verified.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Scan and report without creating media files, tags, or samples.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Stop after importing this many readable images.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        root = Path(options["path"]).expanduser().resolve()
+        if not root.exists():
+            raise CommandError(f"Import path does not exist: {root}")
+        if not root.is_dir():
+            raise CommandError(f"Import path is not a directory: {root}")
+        if options["limit"] is not None and options["limit"] < 1:
+            raise CommandError("--limit must be greater than zero.")
+
+        bucket = None
+        if not options["dry_run"]:
+            bucket = ensure_media_bucket(
+                slug=options["bucket_slug"],
+                name=options["bucket_name"],
+                allowed_patterns=SUPPORTED_IMAGE_PATTERNS,
+            )
+
+        stats = ImportStats()
+        explicit_tag = self._explicit_tag(options.get("tag"))
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            stats.scanned += 1
+            if path.suffix.lower() not in IMAGE_EXTENSIONS:
+                stats.skipped_extension += 1
+                continue
+            if not self._is_readable_image(path):
+                stats.skipped_unreadable += 1
+                continue
+            if options["dry_run"]:
+                stats.imported += 1
+                if options["limit"] and stats.imported >= options["limit"]:
+                    break
+                continue
+
+            assert bucket is not None
+            media_file, created = self._get_or_create_media_file(
+                root=root,
+                path=path,
+                bucket_slug=options["bucket_slug"],
+                bucket_name=options["bucket_name"],
+            )
+            if created:
+                stats.imported += 1
+            else:
+                stats.reused += 1
+
+            tag, tag_created = self._get_or_create_tag(
+                root=root,
+                path=path,
+                explicit_tag=explicit_tag,
+                label_source=options["label_source"],
+            )
+            if tag_created:
+                stats.tags_created += 1
+
+            sample, sample_created = TrainingSample.objects.get_or_create(
+                media_file=media_file,
+                tag=tag,
+                defaults={
+                    "split": options["split"],
+                    "source": self._compact_value(
+                        f"folder-import:{path.relative_to(root).as_posix()}",
+                        TrainingSample._meta.get_field("source").max_length,
+                    ),
+                    "is_verified": bool(options["verified"]),
+                },
+            )
+            if sample_created:
+                stats.samples_created += 1
+            else:
+                stats.samples_existing += 1
+                updates = {}
+                if sample.split != options["split"]:
+                    updates["split"] = options["split"]
+                if options["verified"] and not sample.is_verified:
+                    updates["is_verified"] = True
+                if updates:
+                    TrainingSample.objects.filter(pk=sample.pk).update(**updates)
+
+            if options["limit"] and (stats.imported + stats.reused) >= options["limit"]:
+                break
+
+        self.stdout.write(self._summary(stats=stats, root=root, dry_run=options["dry_run"]))
+
+    def _explicit_tag(self, value: str | None) -> tuple[str, str] | None:
+        if not value:
+            return None
+        slug = slugify(value)
+        if not slug:
+            raise CommandError("--tag must contain at least one slug character.")
+        return slug, value.replace("-", " ").replace("_", " ").strip().title() or slug
+
+    def _get_or_create_media_file(
+        self,
+        *,
+        root: Path,
+        path: Path,
+        bucket_slug: str,
+        bucket_name: str,
+    ) -> tuple[MediaFile, bool]:
+        original_name = self._compact_value(
+            path.relative_to(root).as_posix(),
+            MediaFile._meta.get_field("original_name").max_length,
+        )
+        size = path.stat().st_size
+        existing = MediaFile.objects.filter(
+            bucket__slug=bucket_slug,
+            original_name=original_name,
+            size=size,
+        ).first()
+        if existing:
+            return existing, False
+        media_file = create_media_file_from_path(
+            path,
+            bucket_slug=bucket_slug,
+            bucket_name=bucket_name,
+            original_name=original_name,
+            queue_for_classification=False,
+        )
+        return media_file, True
+
+    def _get_or_create_tag(
+        self,
+        *,
+        root: Path,
+        path: Path,
+        explicit_tag: tuple[str, str] | None,
+        label_source: str,
+    ) -> tuple[ClassificationTag, bool]:
+        if explicit_tag is not None:
+            slug, name = explicit_tag
+            return ClassificationTag.objects.get_or_create(slug=slug, defaults={"name": name})
+
+        relative = path.relative_to(root)
+        if label_source == "top-directory" and len(relative.parts) > 1:
+            label = relative.parts[0]
+        else:
+            label = path.parent.name if path.parent != root else root.name
+        name = label.replace("-", " ").replace("_", " ").strip().title() or "Unlabeled"
+        slug = slugify(label) or "unlabeled"
+        return ClassificationTag.objects.get_or_create(slug=slug, defaults={"name": name})
+
+    def _is_readable_image(self, path: Path) -> bool:
+        try:
+            with Image.open(path) as image:
+                image.verify()
+        except (OSError, UnidentifiedImageError, ValueError):
+            return False
+        return True
+
+    def _compact_value(self, value: str, max_length: int) -> str:
+        if len(value) <= max_length:
+            return value
+        digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+        suffix_width = max(max_length - len(digest) - 1, 1)
+        return f"{digest}:{value[-suffix_width:]}"
+
+    def _summary(self, *, stats: ImportStats, root: Path, dry_run: bool) -> str:
+        mode = "dry-run" if dry_run else "import"
+        return (
+            f"{mode} complete for {root}: "
+            f"scanned={stats.scanned}, imported={stats.imported}, reused={stats.reused}, "
+            f"samples_created={stats.samples_created}, samples_existing={stats.samples_existing}, "
+            f"tags_created={stats.tags_created}, skipped_extension={stats.skipped_extension}, "
+            f"skipped_unreadable={stats.skipped_unreadable}"
+        )

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -175,7 +175,8 @@ class Command(BaseCommand):
         slug = slugify(value)
         if not slug:
             raise CommandError("--tag must contain at least one slug character.")
-        return slug, value.replace("-", " ").replace("_", " ").strip().title() or slug
+        name = value.replace("-", " ").replace("_", " ").strip().title() or slug
+        return self._compact_tag_slug(slug), self._compact_tag_name(name)
 
     def _get_or_create_media_file(
         self,
@@ -244,8 +245,8 @@ class Command(BaseCommand):
                 label = path.parent.name if path.parent != root else root.name
             name = label.replace("-", " ").replace("_", " ").strip().title() or "Unlabeled"
             slug = slugify(label) or "unlabeled"
-            slug = self._compact_value(slug, ClassificationTag._meta.get_field("slug").max_length)
-            name = self._compact_value(name, ClassificationTag._meta.get_field("name").max_length)
+            slug = self._compact_tag_slug(slug)
+            name = self._compact_tag_name(name)
 
         cached_tag = self._tag_cache.get(slug)
         if cached_tag is not None:
@@ -269,6 +270,17 @@ class Command(BaseCommand):
         digest = f"{zlib.crc32(value.encode('utf-8')):08x}"
         suffix_width = max(max_length - len(digest) - 1, 1)
         return f"{digest}:{value[-suffix_width:]}"
+
+    def _compact_tag_slug(self, value: str) -> str:
+        max_length = ClassificationTag._meta.get_field("slug").max_length
+        if len(value) <= max_length:
+            return value
+        digest = f"{zlib.crc32(value.encode('utf-8')):08x}"
+        suffix_width = max(max_length - len(digest) - 1, 1)
+        return f"{digest}-{value[-suffix_width:]}"
+
+    def _compact_tag_name(self, value: str) -> str:
+        return self._compact_value(value, ClassificationTag._meta.get_field("name").max_length)
 
     def _summary(self, *, stats: ImportStats, root: Path, dry_run: bool) -> str:
         mode = "dry-run" if dry_run else "import"

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -244,6 +244,8 @@ class Command(BaseCommand):
                 label = path.parent.name if path.parent != root else root.name
             name = label.replace("-", " ").replace("_", " ").strip().title() or "Unlabeled"
             slug = slugify(label) or "unlabeled"
+            slug = self._compact_value(slug, ClassificationTag._meta.get_field("slug").max_length)
+            name = self._compact_value(name, ClassificationTag._meta.get_field("name").max_length)
 
         cached_tag = self._tag_cache.get(slug)
         if cached_tag is not None:

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -164,7 +164,7 @@ class Command(BaseCommand):
                 if updates:
                     TrainingSample.objects.filter(pk=sample.pk).update(**updates)
 
-            if options["limit"] and (stats.imported + stats.reused) >= options["limit"]:
+            if options["limit"] and stats.imported >= options["limit"]:
                 break
 
         self.stdout.write(self._summary(stats=stats, root=root, dry_run=options["dry_run"]))

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -190,11 +190,12 @@ class Command(BaseCommand):
             MediaFile._meta.get_field("original_name").max_length,
         )
         size = path.stat().st_size
-        existing = MediaFile.objects.filter(
+        existing = self._find_matching_media_file(
             bucket__slug=bucket_slug,
             original_name=original_name,
             size=size,
-        ).first()
+            path=path,
+        )
         if existing:
             return existing, False
         media_file = create_media_file_from_path(
@@ -205,6 +206,25 @@ class Command(BaseCommand):
             queue_for_classification=False,
         )
         return media_file, True
+
+    def _find_matching_media_file(self, *, path: Path, **filters) -> MediaFile | None:
+        for media_file in MediaFile.objects.filter(**filters):
+            if self._media_file_matches_path(media_file=media_file, path=path):
+                return media_file
+        return None
+
+    def _media_file_matches_path(self, *, media_file: MediaFile, path: Path) -> bool:
+        if not media_file.file:
+            return False
+        try:
+            media_file.file.open("rb")
+            with media_file.file as stored_file, path.open("rb") as incoming_file:
+                while stored_chunk := stored_file.read(1024 * 1024):
+                    if stored_chunk != incoming_file.read(len(stored_chunk)):
+                        return False
+                return incoming_file.read(1) == b""
+        except (OSError, ValueError):
+            return False
 
     def _get_or_create_tag(
         self,
@@ -237,7 +257,7 @@ class Command(BaseCommand):
         try:
             with Image.open(path) as image:
                 image.verify()
-        except (OSError, UnidentifiedImageError, ValueError):
+        except (OSError, UnidentifiedImageError, ValueError, Image.DecompressionBombError):
             return False
         return True
 

--- a/apps/classification/management/commands/import_training_images.py
+++ b/apps/classification/management/commands/import_training_images.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
+import zlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +11,7 @@ from django.utils.text import slugify
 from PIL import Image, UnidentifiedImageError
 
 from apps.classification.ingest import (
+    SUPPORTED_IMAGE_EXTENSIONS,
     SUPPORTED_IMAGE_PATTERNS,
     create_media_file_from_path,
 )
@@ -18,19 +19,7 @@ from apps.classification.models import ClassificationTag, TrainingSample
 from apps.media.models import MediaFile
 from apps.media.utils import ensure_media_bucket
 
-IMAGE_EXTENSIONS = {
-    ".avif",
-    ".bmp",
-    ".gif",
-    ".heic",
-    ".heif",
-    ".jpeg",
-    ".jpg",
-    ".png",
-    ".tif",
-    ".tiff",
-    ".webp",
-}
+IMAGE_EXTENSIONS = set(SUPPORTED_IMAGE_EXTENSIONS)
 
 
 @dataclass
@@ -113,7 +102,8 @@ class Command(BaseCommand):
 
         stats = ImportStats()
         explicit_tag = self._explicit_tag(options.get("tag"))
-        for path in sorted(root.rglob("*")):
+        self._tag_cache: dict[str, ClassificationTag] = {}
+        for path in root.rglob("*"):
             if not path.is_file():
                 continue
             stats.scanned += 1
@@ -226,16 +216,22 @@ class Command(BaseCommand):
     ) -> tuple[ClassificationTag, bool]:
         if explicit_tag is not None:
             slug, name = explicit_tag
-            return ClassificationTag.objects.get_or_create(slug=slug, defaults={"name": name})
-
-        relative = path.relative_to(root)
-        if label_source == "top-directory" and len(relative.parts) > 1:
-            label = relative.parts[0]
         else:
-            label = path.parent.name if path.parent != root else root.name
-        name = label.replace("-", " ").replace("_", " ").strip().title() or "Unlabeled"
-        slug = slugify(label) or "unlabeled"
-        return ClassificationTag.objects.get_or_create(slug=slug, defaults={"name": name})
+            relative = path.relative_to(root)
+            if label_source == "top-directory" and len(relative.parts) > 1:
+                label = relative.parts[0]
+            else:
+                label = path.parent.name if path.parent != root else root.name
+            name = label.replace("-", " ").replace("_", " ").strip().title() or "Unlabeled"
+            slug = slugify(label) or "unlabeled"
+
+        cached_tag = self._tag_cache.get(slug)
+        if cached_tag is not None:
+            return cached_tag, False
+
+        tag, tag_created = ClassificationTag.objects.get_or_create(slug=slug, defaults={"name": name})
+        self._tag_cache[slug] = tag
+        return tag, tag_created
 
     def _is_readable_image(self, path: Path) -> bool:
         try:
@@ -248,7 +244,7 @@ class Command(BaseCommand):
     def _compact_value(self, value: str, max_length: int) -> str:
         if len(value) <= max_length:
             return value
-        digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+        digest = f"{zlib.crc32(value.encode('utf-8')):08x}"
         suffix_width = max(max_length - len(digest) - 1, 1)
         return f"{digest}:{value[-suffix_width:]}"
 

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from django.core.management import call_command
+from django.core.validators import validate_slug
 from PIL import Image
 
 from apps.classification.ingest import (
@@ -66,8 +67,26 @@ def test_import_training_images_compacts_long_folder_labels(tmp_path):
     assert len(tags) == 2
     assert {len(tag.slug) for tag in tags} == {ClassificationTag._meta.get_field("slug").max_length}
     assert all(len(tag.name) <= ClassificationTag._meta.get_field("name").max_length for tag in tags)
+    assert all(":" not in tag.slug for tag in tags)
+    for tag in tags:
+        validate_slug(tag.slug)
     assert tags[0].slug != tags[1].slug
     assert TrainingSample.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_import_training_images_compacts_long_explicit_tag(tmp_path):
+    _write_image(tmp_path / "seed" / "first.png", (20, 200, 20))
+    explicit_tag = f"{'explicit-' * 20}training-tag"
+
+    call_command("import_training_images", str(tmp_path), "--tag", explicit_tag)
+
+    tag = ClassificationTag.objects.get()
+    assert len(tag.slug) == ClassificationTag._meta.get_field("slug").max_length
+    assert len(tag.name) <= ClassificationTag._meta.get_field("name").max_length
+    assert ":" not in tag.slug
+    validate_slug(tag.slug)
+    assert TrainingSample.objects.count() == 1
 
 
 @pytest.mark.django_db

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -53,6 +53,24 @@ def test_import_training_images_creates_unverified_samples_from_parent_folders(t
 
 
 @pytest.mark.django_db
+def test_import_training_images_compacts_long_folder_labels(tmp_path):
+    prefix_a = "alpha-" * 18
+    prefix_b = "bravo-" * 18
+    shared_suffix = "shared-long-training-label"
+    _write_image(tmp_path / f"{prefix_a}{shared_suffix}" / "first.png", (200, 20, 20))
+    _write_image(tmp_path / f"{prefix_b}{shared_suffix}" / "second.png", (20, 20, 200))
+
+    call_command("import_training_images", str(tmp_path))
+
+    tags = list(ClassificationTag.objects.order_by("slug"))
+    assert len(tags) == 2
+    assert {len(tag.slug) for tag in tags} == {ClassificationTag._meta.get_field("slug").max_length}
+    assert all(len(tag.name) <= ClassificationTag._meta.get_field("name").max_length for tag in tags)
+    assert tags[0].slug != tags[1].slug
+    assert TrainingSample.objects.count() == 2
+
+
+@pytest.mark.django_db
 def test_import_training_images_can_verify_and_reuse_existing_samples(tmp_path):
     _write_image(tmp_path / "seed" / "first.png", (20, 200, 20))
 

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from io import BytesIO, StringIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+from PIL import Image
+
+from apps.classification.models import ClassificationTag, TrainingSample
+from apps.media.models import MediaFile
+
+
+def _write_image(path: Path, color: tuple[int, int, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", (16, 16), color=color)
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    path.write_bytes(buffer.getvalue())
+
+
+@pytest.mark.django_db
+def test_import_training_images_creates_unverified_samples_from_parent_folders(tmp_path):
+    _write_image(tmp_path / "cats" / "cat-a.png", (200, 20, 20))
+    _write_image(tmp_path / "dogs" / "dog-a.png", (20, 20, 200))
+    (tmp_path / "notes.txt").write_text("not an image", encoding="utf-8")
+
+    stdout = StringIO()
+    call_command("import_training_images", str(tmp_path), stdout=stdout)
+
+    assert ClassificationTag.objects.filter(slug__in=["cats", "dogs"]).count() == 2
+    assert MediaFile.objects.count() == 2
+    assert TrainingSample.objects.count() == 2
+    assert TrainingSample.objects.filter(is_verified=False).count() == 2
+    assert "samples_created=2" in stdout.getvalue()
+    assert "skipped_extension=1" in stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_training_images_can_verify_and_reuse_existing_samples(tmp_path):
+    _write_image(tmp_path / "seed" / "first.png", (20, 200, 20))
+
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image")
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image", "--verified")
+
+    assert ClassificationTag.objects.get().slug == "seed-image"
+    assert MediaFile.objects.count() == 1
+    sample = TrainingSample.objects.get()
+    assert sample.is_verified is True
+
+
+@pytest.mark.django_db
+def test_import_training_images_dry_run_does_not_create_records(tmp_path):
+    _write_image(tmp_path / "root-a.png", (200, 200, 20))
+
+    stdout = StringIO()
+    call_command("import_training_images", str(tmp_path), "--dry-run", stdout=stdout)
+
+    assert "dry-run complete" in stdout.getvalue()
+    assert MediaFile.objects.count() == 0
+    assert TrainingSample.objects.count() == 0

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -11,8 +11,10 @@ from apps.classification.ingest import (
     SUPPORTED_IMAGE_EXTENSIONS,
     SUPPORTED_IMAGE_PATTERNS,
 )
+from apps.classification.management.commands import import_training_images
 from apps.classification.management.commands.import_training_images import (
     IMAGE_EXTENSIONS,
+    Command,
 )
 from apps.classification.models import ClassificationTag, TrainingSample
 from apps.media.models import MediaFile
@@ -61,6 +63,54 @@ def test_import_training_images_can_verify_and_reuse_existing_samples(tmp_path):
     assert MediaFile.objects.count() == 1
     sample = TrainingSample.objects.get()
     assert sample.is_verified is True
+
+
+@pytest.mark.django_db
+def test_import_training_images_imports_changed_file_with_same_name_and_size(tmp_path, monkeypatch):
+    image_path = tmp_path / "seed" / "first.png"
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(b"first-payload")
+
+    monkeypatch.setattr(Command, "_is_readable_image", lambda self, path: True)
+
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image")
+    image_path.write_bytes(b"secondpayload")
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image")
+
+    assert MediaFile.objects.count() == 2
+    assert TrainingSample.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_import_training_images_reuses_same_file_bytes(tmp_path, monkeypatch):
+    image_path = tmp_path / "seed" / "first.png"
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(b"same-payload")
+
+    monkeypatch.setattr(Command, "_is_readable_image", lambda self, path: True)
+
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image")
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image")
+
+    assert MediaFile.objects.count() == 1
+    assert TrainingSample.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_import_training_images_counts_decompression_bombs_as_unreadable(tmp_path, monkeypatch):
+    image_path = tmp_path / "oversized.png"
+    image_path.write_bytes(b"oversized")
+
+    def raise_decompression_bomb(path):
+        raise Image.DecompressionBombError("too large")
+
+    monkeypatch.setattr(import_training_images.Image, "open", raise_decompression_bomb)
+
+    stdout = StringIO()
+    call_command("import_training_images", str(tmp_path), stdout=stdout)
+
+    assert "skipped_unreadable=1" in stdout.getvalue()
+    assert MediaFile.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -7,6 +7,13 @@ import pytest
 from django.core.management import call_command
 from PIL import Image
 
+from apps.classification.ingest import (
+    SUPPORTED_IMAGE_EXTENSIONS,
+    SUPPORTED_IMAGE_PATTERNS,
+)
+from apps.classification.management.commands.import_training_images import (
+    IMAGE_EXTENSIONS,
+)
 from apps.classification.models import ClassificationTag, TrainingSample
 from apps.media.models import MediaFile
 
@@ -17,6 +24,13 @@ def _write_image(path: Path, color: tuple[int, int, int]) -> None:
     buffer = BytesIO()
     image.save(buffer, format="PNG")
     path.write_bytes(buffer.getvalue())
+
+
+def test_supported_image_patterns_are_derived_from_extensions():
+    assert IMAGE_EXTENSIONS == set(SUPPORTED_IMAGE_EXTENSIONS)
+    assert SUPPORTED_IMAGE_PATTERNS.splitlines() == [
+        f"*{extension}" for extension in SUPPORTED_IMAGE_EXTENSIONS
+    ]
 
 
 @pytest.mark.django_db
@@ -59,3 +73,24 @@ def test_import_training_images_dry_run_does_not_create_records(tmp_path):
     assert "dry-run complete" in stdout.getvalue()
     assert MediaFile.objects.count() == 0
     assert TrainingSample.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_import_training_images_caches_repeated_tag_lookups(tmp_path, monkeypatch):
+    _write_image(tmp_path / "same-label" / "first.png", (20, 200, 20))
+    _write_image(tmp_path / "same-label" / "second.png", (20, 120, 20))
+
+    original_get_or_create = ClassificationTag.objects.get_or_create
+    calls = []
+
+    def counting_get_or_create(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_get_or_create(*args, **kwargs)
+
+    monkeypatch.setattr(ClassificationTag.objects, "get_or_create", counting_get_or_create)
+
+    call_command("import_training_images", str(tmp_path))
+
+    assert len(calls) == 1
+    assert ClassificationTag.objects.get().slug == "same-label"
+    assert TrainingSample.objects.count() == 2

--- a/apps/classification/tests/test_import_training_images_command.py
+++ b/apps/classification/tests/test_import_training_images_command.py
@@ -103,6 +103,24 @@ def test_import_training_images_can_verify_and_reuse_existing_samples(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_training_images_limit_counts_new_imports_not_reused_rows(tmp_path):
+    _write_image(tmp_path / "seed" / "01-first.png", (20, 200, 20))
+    _write_image(tmp_path / "seed" / "02-second.png", (20, 120, 20))
+
+    first_stdout = StringIO()
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image", "--limit", "1", stdout=first_stdout)
+    second_stdout = StringIO()
+    call_command("import_training_images", str(tmp_path), "--tag", "seed-image", "--limit", "1", stdout=second_stdout)
+
+    assert "imported=1" in first_stdout.getvalue()
+    assert "reused=0" in first_stdout.getvalue()
+    assert "imported=1" in second_stdout.getvalue()
+    assert "reused=1" in second_stdout.getvalue()
+    assert MediaFile.objects.count() == 2
+    assert TrainingSample.objects.count() == 2
+
+
+@pytest.mark.django_db
 def test_import_training_images_imports_changed_file_with_same_name_and_size(tmp_path, monkeypatch):
     image_path = tmp_path / "seed" / "first.png"
     image_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- add `import_training_images` to import local image folders into media-backed classification training samples
- derive labels from parent/top-level folders or an explicit tag, with unverified samples by default
- expand classification image bucket patterns beyond jpg/jpeg/png for common local archive formats

Closes #7373

## Validation

- `.venv/bin/python -m ruff check apps/classification/ingest.py apps/classification/management/commands/import_training_images.py apps/classification/tests/test_import_training_images_command.py`
- `.venv/bin/python manage.py test run -- apps/classification/tests`
- `.venv/bin/python manage.py migrations check`
- `.venv/bin/python manage.py import_training_images /mnt/c/Users/arthe/Downloads/archive --dry-run` saw `scanned=698`, `imported=690`, `skipped_unreadable=8`