### PR TITLE
[codex] video: report disconnected camera probe state

### DIFF
--- a/apps/video/__init__.py
+++ b/apps/video/__init__.py
@@ -1,17 +1,21 @@
 from .utils import (
+    CameraStackProbe,
     CAMERA_DIR,
     RPI_CAMERA_BINARIES,
     RPI_CAMERA_DEVICE,
     capture_rpi_snapshot,
     has_rpi_camera_stack,
     record_rpi_video,
+    probe_rpi_camera_stack,
 )
 
 __all__ = [
+    "CameraStackProbe",
     "CAMERA_DIR",
     "RPI_CAMERA_BINARIES",
     "RPI_CAMERA_DEVICE",
     "capture_rpi_snapshot",
     "has_rpi_camera_stack",
+    "probe_rpi_camera_stack",
     "record_rpi_video",
 ]

--- a/apps/video/management/commands/video.py
+++ b/apps/video/management/commands/video.py
@@ -27,7 +27,7 @@ from apps.video.frame_cache import (
     store_status,
 )
 from apps.video.models import MjpegDependencyError, MjpegStream, VideoDevice
-from apps.video.utils import WORK_DIR, has_rpi_camera_stack
+from apps.video.utils import WORK_DIR, probe_rpi_camera_stack
 
 logger = logging.getLogger("apps.video.camera_service")
 
@@ -631,11 +631,19 @@ class Command(BaseCommand):
                 f"Video Camera feature: {status_label} ({assignment_label})"
             )
 
-        feature_available = bool(node and is_feature_active_for_node(node=node, slug="video-cam"))
+        feature_available = bool(
+            node and is_feature_active_for_node(node=node, slug="video-cam")
+        )
         feature_status = "available" if feature_available else "missing"
         self.stdout.write(f"Video feature detection: {feature_status}")
-        camera_stack = "available" if has_rpi_camera_stack() else "missing"
-        self.stdout.write(f"Camera stack probe: {camera_stack}")
+        camera_probe = probe_rpi_camera_stack()
+        camera_stack = "available" if camera_probe.available else "missing"
+        probe_detail = (
+            f"{camera_probe.backend}: {camera_probe.reason}"
+            if camera_probe.available
+            else camera_probe.reason
+        )
+        self.stdout.write(f"Camera stack probe: {camera_stack} ({probe_detail})")
 
         self._report_devices(node)
         self._report_streams()

--- a/apps/video/models/device.py
+++ b/apps/video/models/device.py
@@ -19,8 +19,7 @@ from apps.video.utils import (
     RPI_CAMERA_BINARIES,
     RPI_CAMERA_DEVICE,
     capture_rpi_snapshot,
-    has_rpi_camera_stack,
-    has_rpicam_binaries,
+    probe_rpi_camera_stack,
 )
 
 
@@ -103,15 +102,19 @@ class VideoDevice(Ownable):
     def detect_devices(cls) -> list[DetectedVideoDevice]:
         """Return detected video devices for the Raspberry Pi stack."""
 
-        if not has_rpi_camera_stack():
+        probe = probe_rpi_camera_stack()
+        if not probe.available:
             return []
         identifier = str(RPI_CAMERA_DEVICE)
-        if has_rpicam_binaries():
+        if probe.backend == "rpicam":
             description = "Raspberry Pi Camera"
-            raw_info = f"device={identifier} binaries={', '.join(RPI_CAMERA_BINARIES)}"
+            raw_info = (
+                f"device={identifier} binaries={', '.join(RPI_CAMERA_BINARIES)} "
+                f"cameras={probe.detected_cameras}"
+            )
         else:
             description = "Video4Linux Camera"
-            raw_info = f"device={identifier} binaries=ffmpeg"
+            raw_info = f"device={identifier} backend=ffmpeg reason={probe.reason}"
         return [
             DetectedVideoDevice(
                 identifier=identifier,

--- a/apps/video/tests/test_management_command.py
+++ b/apps/video/tests/test_management_command.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import io
+
+from apps.video.management.commands import video as video_command
+from apps.video.utils import CameraStackProbe
+
+
+def test_run_doctor_reports_camera_probe_reason(monkeypatch):
+    """Video doctor should include the camera probe reason in its output."""
+
+    command = video_command.Command()
+    command.stdout = io.StringIO()
+
+    monkeypatch.setattr(video_command.Node, "get_local", staticmethod(lambda: None))
+
+    class _EmptyQuerySet:
+        @staticmethod
+        def first():
+            return None
+
+    class _EmptyManager:
+        @staticmethod
+        def filter(**_kwargs):
+            return _EmptyQuerySet()
+
+    monkeypatch.setattr(
+        video_command,
+        "NodeFeature",
+        type("NodeFeatureStub", (), {"objects": _EmptyManager()}),
+    )
+    monkeypatch.setattr(
+        video_command,
+        "probe_rpi_camera_stack",
+        lambda: CameraStackProbe(
+            available=False,
+            backend="missing",
+            reason="No attached cameras detected",
+        ),
+    )
+    monkeypatch.setattr(command, "_report_devices", lambda node: None)
+    monkeypatch.setattr(command, "_report_streams", lambda: None)
+    monkeypatch.setattr(command, "_report_frame_cache_status", lambda: None)
+
+    command._run_doctor()
+
+    output = command.stdout.getvalue()
+    assert "Camera stack probe: missing (No attached cameras detected)" in output

--- a/apps/video/tests/test_models_device.py
+++ b/apps/video/tests/test_models_device.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from apps.video.models import device as device_module
+from apps.video.models.device import VideoDevice
+from apps.video.utils import CameraStackProbe
+
+
+def test_detect_devices_skips_missing_camera_stack(monkeypatch):
+    monkeypatch.setattr(
+        device_module,
+        "probe_rpi_camera_stack",
+        lambda: CameraStackProbe(
+            available=False,
+            backend="missing",
+            reason="No attached cameras detected",
+        ),
+    )
+
+    assert VideoDevice.detect_devices() == []
+
+
+def test_detect_devices_describes_attached_rpicam(monkeypatch):
+    monkeypatch.setattr(
+        device_module,
+        "probe_rpi_camera_stack",
+        lambda: CameraStackProbe(
+            available=True,
+            backend="rpicam",
+            reason="2 attached cameras detected",
+            detected_cameras=2,
+        ),
+    )
+
+    devices = VideoDevice.detect_devices()
+
+    assert len(devices) == 1
+    assert devices[0].identifier == str(device_module.RPI_CAMERA_DEVICE)
+    assert devices[0].description == "Raspberry Pi Camera"
+    assert "cameras=2" in devices[0].raw_info
+
+
+def test_detect_devices_describes_ffmpeg_fallback(monkeypatch):
+    monkeypatch.setattr(
+        device_module,
+        "probe_rpi_camera_stack",
+        lambda: CameraStackProbe(
+            available=True,
+            backend="ffmpeg",
+            reason="Video4Linux device /dev/video0 is available",
+        ),
+    )
+
+    devices = VideoDevice.detect_devices()
+
+    assert len(devices) == 1
+    assert devices[0].description == "Video4Linux Camera"
+    assert "backend=ffmpeg" in devices[0].raw_info

--- a/apps/video/tests/test_utils.py
+++ b/apps/video/tests/test_utils.py
@@ -81,3 +81,64 @@ def test_probe_rpi_camera_stack_uses_ffmpeg_fallback(monkeypatch):
     assert probe.available is True
     assert probe.backend == "ffmpeg"
     assert str(utils.RPI_CAMERA_DEVICE) in probe.reason
+
+
+def test_get_camera_resolutions_reuses_single_rpicam_probe(monkeypatch):
+    """Resolution discovery should not run a second camera-list subprocess."""
+
+    calls = []
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: f"/usr/bin/{binary}" for binary in utils.RPI_CAMERA_BINARIES},
+    )
+
+    def _run(command, **_kwargs):
+        calls.append(command)
+        assert command == ["/usr/bin/rpicam-hello", "--list-cameras"]
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=(
+                "Available cameras\n"
+                "0 : imx708 [4608x2592]\n"
+                "    Modes: 'SRGGB10_CSI2P' : 2304x1296 1536x864\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    assert utils.get_camera_resolutions() == [(2304, 1296), (1536, 864)]
+    assert len(calls) == 1
+
+
+def test_get_camera_resolutions_uses_rpicam_still_fallback(monkeypatch):
+    """Resolution discovery should match rpicam probe binary fallback behavior."""
+
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {
+            "rpicam-hello": None,
+            "rpicam-still": "/usr/bin/rpicam-still",
+            "rpicam-vid": "/usr/bin/rpicam-vid",
+        },
+    )
+
+    def _run(command, **_kwargs):
+        assert command == ["/usr/bin/rpicam-still", "--list-cameras"]
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=(
+                "Available cameras\n"
+                "0 : imx708 [4608x2592]\n"
+                "    Modes: 'SRGGB10_CSI2P' : 1920x1080 1280x720\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    assert utils.get_camera_resolutions() == [(1920, 1080), (1280, 720)]

--- a/apps/video/tests/test_utils.py
+++ b/apps/video/tests/test_utils.py
@@ -1,8 +1,79 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 from apps.video import utils
+
+
+def test_has_rpicam_binaries_rejects_unrunnable_binary(monkeypatch):
+    """Binaries on PATH still need to execute successfully."""
+
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: f"/usr/bin/{binary}" for binary in utils.RPI_CAMERA_BINARIES},
+    )
+
+    def _run(command, **_kwargs):
+        if command[0] == "/usr/bin/rpicam-still":
+            raise OSError("broken loader")
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    assert utils.has_rpicam_binaries() is False
+
+
+def test_capture_rpi_snapshot_falls_back_when_rpicam_binary_is_unrunnable(
+    monkeypatch, tmp_path
+):
+    """Unrunnable rpicam binaries should not block ffmpeg capture fallback."""
+
+    monkeypatch.setattr(utils, "CAMERA_DIR", tmp_path)
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: f"/usr/bin/{binary}" for binary in utils.RPI_CAMERA_BINARIES},
+    )
+    monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: True)
+    monkeypatch.setattr(
+        utils.shutil,
+        "which",
+        lambda binary: f"/usr/bin/{binary}",
+    )
+
+    def _run(command, **_kwargs):
+        if command == ["/usr/bin/rpicam-hello", "--help"]:
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+        if command == ["/usr/bin/rpicam-still", "--help"]:
+            raise OSError("broken loader")
+        if command[0] == "/usr/bin/ffmpeg":
+            Path(command[-1]).write_bytes(b"jpeg")
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command!r}")
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    snapshot = utils.capture_rpi_snapshot()
+
+    assert snapshot.exists()
+    assert snapshot.parent == tmp_path
 
 
 def test_probe_rpi_camera_stack_reports_disconnected_rpicam(monkeypatch):
@@ -16,6 +87,13 @@ def test_probe_rpi_camera_stack_reports_disconnected_rpicam(monkeypatch):
     monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: False)
 
     def _run(command, **_kwargs):
+        if command[-1] == "--help":
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
         assert command[-1] == "--list-cameras"
         return subprocess.CompletedProcess(
             args=command,
@@ -44,6 +122,13 @@ def test_probe_rpi_camera_stack_reports_attached_rpicam(monkeypatch):
     monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: False)
 
     def _run(command, **_kwargs):
+        if command[-1] == "--help":
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
         assert command[-1] == "--list-cameras"
         return subprocess.CompletedProcess(
             args=command,

--- a/apps/video/tests/test_utils.py
+++ b/apps/video/tests/test_utils.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import subprocess
+
+from apps.video import utils
+
+
+def test_probe_rpi_camera_stack_reports_disconnected_rpicam(monkeypatch):
+    """The probe should report disconnected cameras before capture is attempted."""
+
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: f"/usr/bin/{binary}" for binary in utils.RPI_CAMERA_BINARIES},
+    )
+    monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: False)
+
+    def _run(command, **_kwargs):
+        assert command[-1] == "--list-cameras"
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="No cameras available!\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    probe = utils.probe_rpi_camera_stack()
+
+    assert probe.available is False
+    assert probe.backend == "missing"
+    assert probe.reason == "No attached cameras detected"
+
+
+def test_probe_rpi_camera_stack_reports_attached_rpicam(monkeypatch):
+    """A listed rpicam sensor should produce an available rpicam probe."""
+
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: f"/usr/bin/{binary}" for binary in utils.RPI_CAMERA_BINARIES},
+    )
+    monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: False)
+
+    def _run(command, **_kwargs):
+        assert command[-1] == "--list-cameras"
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=(
+                "Available cameras\n"
+                "0 : imx708 [4608x2592]\n"
+                "1 : ov5647 [2592x1944]\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(utils.subprocess, "run", _run)
+
+    probe = utils.probe_rpi_camera_stack()
+
+    assert probe.available is True
+    assert probe.backend == "rpicam"
+    assert probe.detected_cameras == 2
+    assert probe.reason == "2 attached cameras detected"
+
+
+def test_probe_rpi_camera_stack_uses_ffmpeg_fallback(monkeypatch):
+    """A live V4L2 device should still count as an available camera stack."""
+
+    monkeypatch.setattr(
+        utils,
+        "_rpicam_binary_paths",
+        lambda: {binary: None for binary in utils.RPI_CAMERA_BINARIES},
+    )
+    monkeypatch.setattr(utils, "_has_ffmpeg_capture_support", lambda: True)
+
+    probe = utils.probe_rpi_camera_stack()
+
+    assert probe.available is True
+    assert probe.backend == "ffmpeg"
+    assert str(utils.RPI_CAMERA_DEVICE) in probe.reason

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -108,7 +108,22 @@ def _list_rpicam_cameras(timeout: int = 5) -> tuple[int, str, str]:
 def has_rpicam_binaries() -> bool:
     """Return ``True`` when the Raspberry Pi camera binaries are available."""
 
-    return all(_rpicam_binary_paths().values())
+    for tool_path in _rpicam_binary_paths().values():
+        if not tool_path:
+            return False
+        try:
+            result = subprocess.run(
+                [tool_path, "--help"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        if result.returncode != 0:
+            return False
+    return True
 
 
 def _has_ffmpeg_capture_support() -> bool:

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -71,13 +71,13 @@ def _parse_rpicam_camera_count(output: str) -> int:
     return count
 
 
-def _list_rpicam_cameras(timeout: int = 5) -> tuple[int, str]:
-    """Return attached-camera count and the best probe message."""
+def _list_rpicam_cameras(timeout: int = 5) -> tuple[int, str, str]:
+    """Return attached-camera count, the best probe message, and raw output."""
 
     binary_paths = _rpicam_binary_paths()
     tool_path = binary_paths.get("rpicam-hello") or binary_paths.get("rpicam-still")
     if not tool_path:
-        return (0, "rpicam-hello is not available")
+        return (0, "rpicam-hello is not available", "")
 
     try:
         result = subprocess.run(
@@ -88,21 +88,21 @@ def _list_rpicam_cameras(timeout: int = 5) -> tuple[int, str]:
             timeout=timeout,
         )
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
-        return (0, f"Unable to list cameras: {exc}")
+        return (0, f"Unable to list cameras: {exc}", "")
 
     output = (result.stdout or result.stderr or "").strip()
     if result.returncode != 0:
-        return (0, output or "Unable to list cameras")
+        return (0, output or "Unable to list cameras", output)
     if not output:
-        return (0, "No camera information returned")
+        return (0, "No camera information returned", "")
     if "No cameras available" in output:
-        return (0, "No attached cameras detected")
+        return (0, "No attached cameras detected", output)
 
     camera_count = _parse_rpicam_camera_count(output)
     if camera_count > 0:
         suffix = "camera" if camera_count == 1 else "cameras"
-        return (camera_count, f"{camera_count} attached {suffix} detected")
-    return (0, "Unable to determine attached cameras")
+        return (camera_count, f"{camera_count} attached {suffix} detected", output)
+    return (0, "Unable to determine attached cameras", output)
 
 
 def has_rpicam_binaries() -> bool:
@@ -125,7 +125,7 @@ def probe_rpi_camera_stack(timeout: int = 5) -> CameraStackProbe:
     rpicam_available = has_rpicam_binaries()
     rpicam_reason = ""
     if rpicam_available:
-        camera_count, rpicam_reason = _list_rpicam_cameras(timeout=timeout)
+        camera_count, rpicam_reason, _output = _list_rpicam_cameras(timeout=timeout)
         if camera_count > 0:
             return CameraStackProbe(
                 available=True,
@@ -171,30 +171,12 @@ def has_rpi_camera_stack() -> bool:
 def get_camera_resolutions() -> list[tuple[int, int]]:
     """Return supported camera resolutions when available."""
 
-    probe = probe_rpi_camera_stack()
-    if not probe.available or probe.backend != "rpicam":
-        return list(FALLBACK_CAMERA_RESOLUTIONS)
-
-    tool_path = shutil.which("rpicam-hello")
-    if not tool_path:
-        return list(FALLBACK_CAMERA_RESOLUTIONS)
-
-    try:
-        result = subprocess.run(
-            [tool_path, "--list-cameras"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return list(FALLBACK_CAMERA_RESOLUTIONS)
-
-    if result.returncode != 0:
+    camera_count, _reason, output = _list_rpicam_cameras()
+    if camera_count <= 0:
         return list(FALLBACK_CAMERA_RESOLUTIONS)
 
     resolutions: set[tuple[int, int]] = set()
-    for line in result.stdout.splitlines():
+    for line in output.splitlines():
         if "x" not in line:
             continue
         for chunk in line.split():

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -1,10 +1,12 @@
 import logging
 import os
+import re
 import shutil
 import stat
 import subprocess
 import threading
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,6 +30,16 @@ FALLBACK_CAMERA_RESOLUTIONS = (
 _CAMERA_LOCK = threading.Lock()
 
 
+@dataclass(frozen=True)
+class CameraStackProbe:
+    """Summarize camera-stack availability and the first useful reason."""
+
+    available: bool
+    backend: str
+    reason: str
+    detected_cameras: int = 0
+
+
 def _is_video_device_available(device: Path) -> bool:
     """Return ``True`` when ``device`` exists and is a readable char device."""
 
@@ -43,29 +55,60 @@ def _is_video_device_available(device: Path) -> bool:
     return True
 
 
+def _rpicam_binary_paths() -> dict[str, str | None]:
+    """Return resolved paths for Raspberry Pi camera binaries."""
+
+    return {binary: shutil.which(binary) for binary in RPI_CAMERA_BINARIES}
+
+
+def _parse_rpicam_camera_count(output: str) -> int:
+    """Return the number of attached cameras listed by ``--list-cameras``."""
+
+    count = 0
+    for line in output.splitlines():
+        if re.match(r"^\s*\d+\s*:", line):
+            count += 1
+    return count
+
+
+def _list_rpicam_cameras(timeout: int = 5) -> tuple[int, str]:
+    """Return attached-camera count and the best probe message."""
+
+    binary_paths = _rpicam_binary_paths()
+    tool_path = binary_paths.get("rpicam-hello") or binary_paths.get("rpicam-still")
+    if not tool_path:
+        return (0, "rpicam-hello is not available")
+
+    try:
+        result = subprocess.run(
+            [tool_path, "--list-cameras"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
+        return (0, f"Unable to list cameras: {exc}")
+
+    output = (result.stdout or result.stderr or "").strip()
+    if result.returncode != 0:
+        return (0, output or "Unable to list cameras")
+    if not output:
+        return (0, "No camera information returned")
+    if "No cameras available" in output:
+        return (0, "No attached cameras detected")
+
+    camera_count = _parse_rpicam_camera_count(output)
+    if camera_count > 0:
+        suffix = "camera" if camera_count == 1 else "cameras"
+        return (camera_count, f"{camera_count} attached {suffix} detected")
+    return (0, "Unable to determine attached cameras")
+
+
 def has_rpicam_binaries() -> bool:
     """Return ``True`` when the Raspberry Pi camera binaries are available."""
 
-    device = RPI_CAMERA_DEVICE
-    if not _is_video_device_available(device):
-        return False
-    for binary in RPI_CAMERA_BINARIES:
-        tool_path = shutil.which(binary)
-        if not tool_path:
-            return False
-        try:
-            result = subprocess.run(
-                [tool_path, "--help"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=5,
-            )
-        except Exception:
-            return False
-        if result.returncode != 0:
-            return False
-    return True
+    return all(_rpicam_binary_paths().values())
 
 
 def _has_ffmpeg_capture_support() -> bool:
@@ -76,16 +119,60 @@ def _has_ffmpeg_capture_support() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
+def probe_rpi_camera_stack(timeout: int = 5) -> CameraStackProbe:
+    """Return whether a usable camera stack is available and why."""
+
+    rpicam_available = has_rpicam_binaries()
+    rpicam_reason = ""
+    if rpicam_available:
+        camera_count, rpicam_reason = _list_rpicam_cameras(timeout=timeout)
+        if camera_count > 0:
+            return CameraStackProbe(
+                available=True,
+                backend="rpicam",
+                reason=rpicam_reason,
+                detected_cameras=camera_count,
+            )
+
+    if _has_ffmpeg_capture_support():
+        return CameraStackProbe(
+            available=True,
+            backend="ffmpeg",
+            reason=f"Video4Linux device {RPI_CAMERA_DEVICE} is available",
+        )
+
+    if rpicam_available:
+        return CameraStackProbe(
+            available=False,
+            backend="missing",
+            reason=rpicam_reason,
+        )
+
+    missing_binaries = [
+        binary for binary, path in _rpicam_binary_paths().items() if not path
+    ]
+    reasons: list[str] = []
+    if missing_binaries:
+        reasons.append(f"missing rpicam binaries: {', '.join(missing_binaries)}")
+    if shutil.which("ffmpeg") is None:
+        reasons.append("ffmpeg is unavailable")
+    if not _is_video_device_available(RPI_CAMERA_DEVICE):
+        reasons.append(f"{RPI_CAMERA_DEVICE} is unavailable")
+    reason = "; ".join(reasons) or "No supported camera stack is available"
+    return CameraStackProbe(available=False, backend="missing", reason=reason)
+
+
 def has_rpi_camera_stack() -> bool:
     """Return ``True`` when any supported camera stack is available."""
 
-    return has_rpicam_binaries() or _has_ffmpeg_capture_support()
+    return probe_rpi_camera_stack().available
 
 
 def get_camera_resolutions() -> list[tuple[int, int]]:
     """Return supported camera resolutions when available."""
 
-    if not has_rpi_camera_stack():
+    probe = probe_rpi_camera_stack()
+    if not probe.available or probe.backend != "rpicam":
         return list(FALLBACK_CAMERA_RESOLUTIONS)
 
     tool_path = shutil.which("rpicam-hello")
@@ -100,7 +187,7 @@ def get_camera_resolutions() -> list[tuple[int, int]]:
             check=False,
             timeout=5,
         )
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return list(FALLBACK_CAMERA_RESOLUTIONS)
 
     if result.returncode != 0:
@@ -264,6 +351,7 @@ def record_rpi_video(duration_seconds: int = 5, timeout: int = 15) -> Path:
 
 
 __all__ = [
+    "CameraStackProbe",
     "CAMERA_DIR",
     "DEFAULT_CAMERA_RESOLUTION",
     "FALLBACK_CAMERA_RESOLUTIONS",
@@ -273,5 +361,6 @@ __all__ = [
     "capture_rpi_snapshot",
     "get_camera_resolutions",
     "has_rpi_camera_stack",
+    "probe_rpi_camera_stack",
     "record_rpi_video",
 ]


### PR DESCRIPTION
## Summary
- Add a structured camera stack probe that distinguishes attached rpicam sensors, disconnected rpicam hardware, and ffmpeg/V4L2 fallback support.
- Surface the probe backend and reason in `video doctor` output.
- Route video device discovery through the probe and add focused tests for missing, rpicam, and ffmpeg cases.

## Why
The previous detection path treated installed rpicam binaries as enough to consider the camera stack available. On a box with camera tooling installed but no attached camera, the suite could report camera support before capture was actually possible.

## Validation
- `.venv/bin/python manage.py test run -- apps/video/tests` -> 7 passed, 1 warning
- `git diff --check HEAD~1..HEAD` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a structured camera stack probe that accurately reports actual camera capture capability rather than relying solely on whether rpicam binaries are installed. It distinguishes between three states: attached rpicam sensors, disconnected rpicam hardware, and ffmpeg/V4L2 fallback support.

## Changes

**Core implementation** (`apps/video/utils.py`):
- Adds `CameraStackProbe` dataclass with fields for availability, backend, reason, and detected cameras
- Implements `probe_rpi_camera_stack()` function that performs actual subprocess checks to determine camera stack state
- Refactors `has_rpi_camera_stack()` to delegate to the probe's availability status
- Introduces shared helpers for resolving rpicam binary paths, parsing `--list-cameras` output, and listing attached cameras
- Updates `get_camera_resolutions()` to reuse the probe's camera list output, eliminating duplicate subprocess calls and ensuring consistent tool selection between `rpicam-hello` and `rpicam-still`

**Diagnostic output** (`apps/video/management/commands/video.py`):
- Replaces simple boolean check with structured probe result
- Updates `video doctor` output to display probe backend and reason for both available and unavailable states

**Device detection** (`apps/video/models/device.py`):
- Replaces separate `has_rpi_camera_stack()` and `has_rpicam_binaries()` checks with single `probe_rpi_camera_stack()` call
- Enhances `raw_info` diagnostic string with detected camera count (for rpicam) and backend/reason (for non-rpicam paths)

**Public API** (`apps/video/__init__.py`):
- Exports `CameraStackProbe` type and `probe_rpi_camera_stack()` function

## Testing

- 7 tests added covering disconnected camera, rpicam available, and ffmpeg fallback scenarios
- Tests verify single subprocess usage for resolution discovery and correct fallback behavior
- All tests passing; git diff clean

## Motivation

Previous implementation marked camera support available if rpicam binaries were installed, even on systems with no attached camera. This change ensures actual capture capability is verified through subprocess invocation and camera enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->