### PR TITLE
Preserve DEBUG for local runserver media

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -405,8 +405,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         _ensure_runserver_default_bind(args)
         if is_debug_session:
             os.environ["DEBUG"] = "1"
-        else:
-            os.environ.pop("DEBUG", None)
         if "--noreload" not in args:
             args.insert(1, "--noreload")
     try:

--- a/tests/test_manage_embedded_celery.py
+++ b/tests/test_manage_embedded_celery.py
@@ -60,6 +60,30 @@ def test_main_skips_embedded_celery_for_systemd_mode(
     assert popen_calls == []
 
 
+def test_main_preserves_environment_debug_for_runserver(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def capture_runserver(
+        _base_dir: Path, argv: list[str], is_debug_session: bool
+    ) -> None:
+        captured["argv"] = argv
+        captured["is_debug_session"] = is_debug_session
+
+    monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setattr(manage, "__file__", str(tmp_path / "manage.py"))
+    monkeypatch.setattr(manage, "loadenv", lambda: None)
+    monkeypatch.setattr(manage, "bootstrap_sqlite_driver", lambda: None)
+    monkeypatch.setattr(manage, "_run_runserver", capture_runserver)
+    monkeypatch.setattr(manage, "_execute_django", lambda *_args, **_kwargs: None)
+
+    manage.main(["runserver"])
+
+    assert manage.os.environ["DEBUG"] == "1"
+    assert captured["is_debug_session"] is False
+
+
 def test_main_allows_explicit_embedded_celery_override(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #7382

## Summary

- Preserve environment-provided `DEBUG` when `manage.py runserver` starts.
- Keep explicit `--debug` behavior intact.
- Add regression coverage so local runserver startup does not clear `DEBUG=1`.

## Validation

- `.venv/bin/python manage.py test run -- tests/test_manage_embedded_celery.py`
- `curl -I http://localhost:8888/media/protocols/buckets/gallery-images/Shards-of-Blowinn-image33.png.png` returned `200 OK` with `Content-Type: image/png` after restarting the local service.
