### PR TITLE
ci: force install-hourly to use setup-python interpreter

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -84,6 +84,14 @@ jobs:
         id: setup-python
         with:
           python-version: '3.12'
+      - name: Align python executables with setup-python
+        run: |
+          python_bin='${{ steps.setup-python.outputs.python-path }}'
+          echo "ARTHEXIS_PYTHON_BIN=${python_bin}" >> "${GITHUB_ENV}"
+          echo "$(dirname "${python_bin}")" >> "${GITHUB_PATH}"
+          "${python_bin}" --version
+          python --version
+          python3 --version
       - name: Cache pip
         uses: actions/cache@v5
         with:
@@ -102,10 +110,10 @@ jobs:
             venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-
       - name: Validate pyproject dependency ordering
         run: |
-          python3 "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check
+          "${ARTHEXIS_PYTHON_BIN}" "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check
       - name: Validate generated requirements
         run: |
-          python3 "$GITHUB_WORKSPACE/scripts/generate_requirements.py" --check
+          "${ARTHEXIS_PYTHON_BIN}" "$GITHUB_WORKSPACE/scripts/generate_requirements.py" --check
       - name: Install redis CLI
         run: |
           if command -v sudo >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation

- The hourly install-health workflow was showing repeated cross-matrix failures that pointed to interpreter resolution differences inside container jobs, so the workflow needs a deterministic Python interpreter for early dependency validation steps.

### Description

- Add a workflow step after `actions/setup-python` that exports the provisioned interpreter path to `ARTHEXIS_PYTHON_BIN`, prepends its bin directory to `GITHUB_PATH`, and prints interpreter versions for diagnostics.
- Update the dependency-validation steps to invoke the explicit interpreter (`"${ARTHEXIS_PYTHON_BIN}"`) for `scripts/sort_pyproject_deps.py` and `scripts/generate_requirements.py` to remove ambiguity between `python`/`python3` inside containers.
- The changes are confined to `.github/workflows/install-hourly.yml` and aim to make early CI checks consistent across Debian/Ubuntu container runs.

### Testing

- Ran `python3 scripts/sort_pyproject_deps.py --check` and it completed successfully.
- Ran `python3 scripts/generate_requirements.py --check` and it completed successfully.
- Parsed the modified workflow YAML with `yaml.safe_load` to confirm `.github/workflows/install-hourly.yml` parses successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0b96f27c8326a9862e073bc515f7)

### Related Issue

- Related to #7312