### PR TITLE
Require recovery SSH key by default; add --skip-recovery-ssh opt-out

### DIFF
--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -108,6 +108,11 @@ class Command(BaseCommand):
                 "May be repeated to avoid bundling key material in repository files."
             ),
         )
+        build_parser.add_argument(
+            "--skip-recovery-ssh",
+            action="store_true",
+            help="Intentionally disable recovery SSH setup for this build.",
+        )
 
         subparsers.add_parser("devices", help="List candidate block devices for image writing.")
         subparsers.add_parser("list", help="List generated Raspberry Pi image artifacts.")
@@ -161,7 +166,18 @@ class Command(BaseCommand):
             file_paths=[str(path) for path in options.get("recovery_authorized_key_file", [])],
             inline_keys=[str(key) for key in options.get("recovery_authorized_key", [])],
         )
+        skip_recovery_ssh = bool(options["skip_recovery_ssh"])
+        customize = not bool(options["skip_customize"])
         recovery_ssh_user = str(options["recovery_ssh_user"]).strip()
+        if skip_recovery_ssh and (recovery_authorized_keys or recovery_ssh_user):
+            raise CommandError(
+                "--skip-recovery-ssh cannot be combined with recovery SSH key options or --recovery-ssh-user."
+            )
+        if customize and not skip_recovery_ssh and not recovery_authorized_keys:
+            raise CommandError(
+                "Recovery SSH is required for customized image builds. "
+                "Provide --recovery-authorized-key-file/--recovery-authorized-key or pass --skip-recovery-ssh to opt out."
+            )
         if recovery_authorized_keys:
             recovery_ssh_user = recovery_ssh_user or DEFAULT_RECOVERY_SSH_USER
 
@@ -172,12 +188,12 @@ class Command(BaseCommand):
                 output_dir=Path(str(options["output_dir"])),
                 download_base_uri=str(options["download_base_uri"]),
                 git_url=str(options["git_url"]),
-                customize=not bool(options["skip_customize"]),
+                customize=customize,
                 build_engine=str(options["build_engine"]),
                 profile=str(options["profile"]),
                 profile_metadata=profile_metadata,
-                recovery_ssh_user=recovery_ssh_user,
-                recovery_authorized_keys=recovery_authorized_keys,
+                recovery_ssh_user="" if skip_recovery_ssh else recovery_ssh_user,
+                recovery_authorized_keys=[] if skip_recovery_ssh else recovery_authorized_keys,
             )
         except ImagerBuildError as exc:
             raise CommandError(str(exc)) from exc
@@ -187,6 +203,8 @@ class Command(BaseCommand):
         self.stdout.write(f"size_bytes={result.size_bytes}")
         if result.download_uri:
             self.stdout.write(f"download_uri={result.download_uri}")
+        if customize and skip_recovery_ssh:
+            self.stdout.write("recovery_ssh=disabled (--skip-recovery-ssh)")
 
     def _read_recovery_authorized_keys(
         self,

--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -166,8 +166,8 @@ class Command(BaseCommand):
             file_paths=[str(path) for path in options.get("recovery_authorized_key_file", [])],
             inline_keys=[str(key) for key in options.get("recovery_authorized_key", [])],
         )
-        skip_recovery_ssh = bool(options["skip_recovery_ssh"])
-        customize = not bool(options["skip_customize"])
+        skip_recovery_ssh = options["skip_recovery_ssh"]
+        customize = not options["skip_customize"]
         recovery_ssh_user = str(options["recovery_ssh_user"]).strip()
         if skip_recovery_ssh and (recovery_authorized_keys or recovery_ssh_user):
             raise CommandError(
@@ -192,8 +192,8 @@ class Command(BaseCommand):
                 build_engine=str(options["build_engine"]),
                 profile=str(options["profile"]),
                 profile_metadata=profile_metadata,
-                recovery_ssh_user="" if skip_recovery_ssh else recovery_ssh_user,
-                recovery_authorized_keys=[] if skip_recovery_ssh else recovery_authorized_keys,
+                recovery_ssh_user=recovery_ssh_user,
+                recovery_authorized_keys=recovery_authorized_keys,
             )
         except ImagerBuildError as exc:
             raise CommandError(str(exc)) from exc

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -175,6 +175,7 @@ def test_imager_build_command_prints_metadata(mock_build, tmp_path: Path) -> Non
         "v0-5-0",
         "--base-image-uri",
         str(output_path),
+        "--skip-recovery-ssh",
         stdout=out,
     )
 
@@ -215,6 +216,7 @@ def test_imager_build_command_passes_connect_ota_profile_metadata(mock_build, tm
         "ota-v1",
         "--base-image-uri",
         str(output_path),
+        "--skip-recovery-ssh",
         "--profile",
         "connect-ota",
         "--profile-metadata",
@@ -386,6 +388,81 @@ def test_imager_build_command_reports_non_utf8_recovery_key_file(tmp_path: Path)
             "--recovery-authorized-key-file",
             str(authorized_key_file),
         )
+
+
+def test_imager_build_command_requires_recovery_ssh_key_by_default(tmp_path: Path) -> None:
+    """Regression: customized builds should fail fast unless recovery SSH is explicit."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+
+    with pytest.raises(CommandError, match="Recovery SSH is required for customized image builds"):
+        call_command(
+            "imager",
+            "build",
+            "--name",
+            "recovery-required",
+            "--base-image-uri",
+            str(output_path),
+        )
+
+
+def test_imager_build_command_rejects_skip_recovery_ssh_with_keys(tmp_path: Path) -> None:
+    """Regression: skip flag should not allow contradictory key arguments."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+
+    with pytest.raises(CommandError, match="cannot be combined"):
+        call_command(
+            "imager",
+            "build",
+            "--name",
+            "recovery-skip-conflict",
+            "--base-image-uri",
+            str(output_path),
+            "--skip-recovery-ssh",
+            "--recovery-authorized-key",
+            VALID_RECOVERY_KEY_ONE,
+        )
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_allows_explicit_skip_recovery_ssh(mock_build, tmp_path: Path) -> None:
+    """Regression: operators can intentionally opt out of recovery SSH lane."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+        },
+    )()
+
+    stdout = StringIO()
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "recovery-skip",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        stdout=stdout,
+    )
+
+    assert mock_build.call_args.kwargs["recovery_authorized_keys"] == []
+    assert mock_build.call_args.kwargs["recovery_ssh_user"] == ""
+    assert "recovery_ssh=disabled (--skip-recovery-ssh)" in stdout.getvalue()
 
 
 def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided(tmp_path: Path) -> None:

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -15,6 +15,7 @@ Build a Raspberry Pi image artifact with first-boot bootstrap scripts:
 .venv/bin/python manage.py imager build \
   --name stable \
   --base-image-uri /path/to/raspios.img.xz \
+  --skip-recovery-ssh \
   --download-base-uri https://downloads.example.com/images
 ```
 
@@ -118,3 +119,5 @@ What this adds:
 - password login disabled in the generated image's SSH config
 
 This is intended to give operators a safe default recovery path over the address the device gets on `eth0` before Arthexis finishes bootstrapping.
+
+Recovery SSH key provisioning is required for customized builds unless you intentionally opt out with `--skip-recovery-ssh`.


### PR DESCRIPTION
### Motivation

- Make imager recovery builds safer by requiring key-only recovery SSH for customized images unless an operator explicitly opts out. 

### Description

- Add a new `--skip-recovery-ssh` flag to `manage.py imager build` and validate inputs so the flag cannot be combined with recovery key/user options. 
- Enforce fail-fast behavior for customized builds by requiring recovery authorized keys unless `--skip-recovery-ssh` is given, and propagate the skip to `build_rpi4b_image` by sending empty recovery args when skipped. 
- Surface operator-facing output for skip usage with `recovery_ssh=disabled (--skip-recovery-ssh)` and update tests in `apps/imager/tests/test_imager_command.py` to cover the required-by-default path, explicit skip path, and skip+key conflict handling as well as adjust existing tests to use the explicit opt-out where appropriate. 
- Update documentation in `docs/operations/imager-sd-card-recovery.md` to show the skip usage and note that recovery SSH key provisioning is required for customized builds unless intentionally skipped. 

### Testing

- Bootstrapped dependencies with `./env-refresh.sh --deps-only`, which completed successfully. 
- Ran the imager command tests with `.venv/bin/python manage.py test run -- apps/imager/tests/test_imager_command.py`, and all tests passed (`44 passed`). 
- No model changes or migrations were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec037b47e483268d93f93165f7a3f3)

### Linked issue

Closes #7370