### PR TITLE
Require issue links on ready PRs

### DIFF
--- a/.github/workflows/require-pr-issue-link.yml
+++ b/.github/workflows/require-pr-issue-link.yml
@@ -1,0 +1,57 @@
+name: Require PR issue link
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-issue-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require ready PRs to name their closing issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+
+            if (!pullRequest) {
+              core.setFailed('This workflow only supports pull_request_target events.');
+              return;
+            }
+
+            if (pullRequest.draft) {
+              core.info('Draft PR; issue-link requirement is deferred until ready for review.');
+              return;
+            }
+
+            const body = pullRequest.body || '';
+            const closingReferencePattern =
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
+            const noLinkedIssuePattern = /\bno linked issue\b/i;
+
+            if (closingReferencePattern.test(body)) {
+              core.info('PR body includes a closing issue reference.');
+              return;
+            }
+
+            if (noLinkedIssuePattern.test(body)) {
+              core.info('PR body explicitly declares no linked issue.');
+              return;
+            }
+
+            core.setFailed(
+              [
+                'Ready PRs must include a closing issue reference in the PR body.',
+                '',
+                'Add a line such as `Closes #123`, `Fixes #123`, or `Resolves #123` so the merged PR closes its originating issue automatically.',
+                'For rare maintenance PRs that intentionally do not close an issue, add `No linked issue` to the PR body.',
+              ].join('\n'),
+            );

--- a/.github/workflows/require-pr-issue-link.yml
+++ b/.github/workflows/require-pr-issue-link.yml
@@ -32,9 +32,17 @@ jobs:
               return;
             }
 
+            const defaultBranch = context.payload.repository?.default_branch;
+            if (defaultBranch && pullRequest.base.ref !== defaultBranch) {
+              core.info(
+                `PR targets ${pullRequest.base.ref}, not the default branch ${defaultBranch}; GitHub will not auto-close issues from this merge.`,
+              );
+              return;
+            }
+
             const body = pullRequest.body || '';
             const closingReferencePattern =
-              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
             const noLinkedIssuePattern = /\bno linked issue\b/i;
 
             if (closingReferencePattern.test(body)) {
@@ -51,7 +59,7 @@ jobs:
               [
                 'Ready PRs must include a closing issue reference in the PR body.',
                 '',
-                'Add a line such as `Closes #123`, `Fixes #123`, or `Resolves #123` so the merged PR closes its originating issue automatically.',
+                'Add a line such as `Closes #123`, `Fixes: #123`, or `Resolves #123` so the merged PR closes its originating issue automatically.',
                 'For rare maintenance PRs that intentionally do not close an issue, add `No linked issue` to the PR body.',
               ].join('\n'),
             );


### PR DESCRIPTION
## Summary

- add a pull_request_target guard that checks ready PR bodies for closing issue references
- skip draft PRs until they are marked ready for review
- allow an explicit `No linked issue` marker for intentional maintenance PRs

## Why

This prevents the #7387/#7370 maintenance gap where a merged PR lacked a closing issue reference, so the existing scheduled linked-issue closer could not close the originating issue automatically.

Closes #7396

## Testing

- `git diff --check`