### PR TITLE
[codex] Fix imager bootstrap prerequisites

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -44,7 +44,7 @@ fi
 
 if [ "${#missing_packages[@]}" -gt 0 ]; then
   export DEBIAN_FRONTEND=noninteractive
-  apt-get update
+  apt-get update || { sleep 10; apt-get update; }
   apt-get install -y --no-install-recommends "${missing_packages[@]}"
 fi
 

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -35,6 +35,19 @@ RECOVERY_SSH_FORBIDDEN_USERS = frozenset({"root"})
 BOOTSTRAP_SCRIPT = """#!/usr/bin/env bash
 set -euo pipefail
 
+missing_packages=()
+if ! command -v git >/dev/null 2>&1; then
+  missing_packages+=(git ca-certificates)
+elif [ ! -e /etc/ssl/certs/ca-certificates.crt ]; then
+  missing_packages+=(ca-certificates)
+fi
+
+if [ "${#missing_packages[@]}" -gt 0 ]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends "${missing_packages[@]}"
+fi
+
 APP_HOME=/opt/arthexis
 if [ ! -d "$APP_HOME/.git" ]; then
   git clone --depth 1 "${ARTHEXIS_GIT_URL}" "$APP_HOME"

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -568,6 +568,7 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
     assert "/etc/ssh/sshd_config.d/20-arthexis-recovery.conf" in written_files
     assert "/boot/firstrun.sh" in written_files
 
+    bootstrap_script, bootstrap_mode = written_files["/usr/local/bin/arthexis-bootstrap.sh"]
     recovery_script, recovery_mode = written_files["/usr/local/bin/arthexis-recovery-access.sh"]
     recovery_keys, keys_mode = written_files["/usr/local/share/arthexis/recovery_authorized_keys"]
     recovery_service, recovery_service_mode = written_files[
@@ -576,6 +577,10 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
     firstrun_script, _firstrun_mode = written_files["/boot/firstrun.sh"]
     sshd_config, sshd_mode = written_files["/etc/ssh/sshd_config.d/20-arthexis-recovery.conf"]
 
+    assert bootstrap_mode == "0755"
+    assert "missing_packages+=(git ca-certificates)" in bootstrap_script
+    assert "apt-get install -y --no-install-recommends" in bootstrap_script
+    assert bootstrap_script.index("apt-get install") < bootstrap_script.index("git clone")
     assert recovery_mode == "0755"
     assert keys_mode == "0600"
     assert sshd_mode == "0644"

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -579,7 +579,10 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
 
     assert bootstrap_mode == "0755"
     assert "missing_packages+=(git ca-certificates)" in bootstrap_script
+    apt_update_retry = "apt-get update || { sleep 10; apt-get update; }"
+    assert apt_update_retry in bootstrap_script
     assert "apt-get install -y --no-install-recommends" in bootstrap_script
+    assert bootstrap_script.index(apt_update_retry) < bootstrap_script.index("apt-get install")
     assert bootstrap_script.index("apt-get install") < bootstrap_script.index("git clone")
     assert recovery_mode == "0755"
     assert keys_mode == "0600"


### PR DESCRIPTION
## Summary
- install missing first-boot bootstrap packages before the generated SD image script runs git clone
- include git and CA certificates when git is absent on the Raspberry Pi OS Lite base image
- assert the generated bootstrap script installs prerequisites before cloning

## Root cause
The customized recovery SD bootstrap script assumed git was already present in the base Raspberry Pi OS Lite image. On a freshly burned recovery SD, the bootstrap service could fail before cloning Arthexis.

Fixes #7402

## Tests
- /home/arthe/experiment/.venv/bin/pytest apps/imager/tests/test_imager_command.py