### PR TITLE
[codex] Add AP client monitoring harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,6 @@ apps/simulators/simulator.json
 
 # Runtime cache directory
 cache/
+
+# Local AP portal consent and activity state
+.state/

--- a/config/data/ap_portal/app.css
+++ b/config/data/ap_portal/app.css
@@ -1,0 +1,134 @@
+:root {
+  color-scheme: light;
+  --bg: #f2efe8;
+  --panel: #fffdf7;
+  --ink: #18201c;
+  --muted: #546057;
+  --line: #cac2b5;
+  --accent: #125f4b;
+  --accent-ink: #f7fff8;
+  --warning: #7d3f16;
+  --shadow: 0 24px 60px rgba(30, 25, 18, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(135deg, rgba(18, 95, 75, 0.12), transparent 38%),
+    linear-gradient(315deg, rgba(125, 63, 22, 0.10), transparent 32%),
+    var(--bg);
+  color: var(--ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.panel {
+  width: min(100%, 560px);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: clamp(24px, 5vw, 42px);
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+h1 {
+  margin: 0 0 14px;
+  font-size: clamp(2rem, 7vw, 3.4rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.notice {
+  margin: 0 0 16px;
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.source {
+  margin: 0 0 26px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+form {
+  display: grid;
+  gap: 14px;
+}
+
+label {
+  font-weight: 700;
+}
+
+input[type="email"] {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0 14px;
+  font: inherit;
+}
+
+.check {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: 12px;
+  align-items: start;
+  color: var(--muted);
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.check input {
+  width: 18px;
+  height: 18px;
+  margin-top: 3px;
+}
+
+button {
+  min-height: 48px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.status {
+  min-height: 24px;
+  margin: 18px 0 0;
+  color: var(--warning);
+  font-weight: 700;
+  line-height: 1.4;
+}

--- a/config/data/ap_portal/app.js
+++ b/config/data/ap_portal/app.js
@@ -1,0 +1,51 @@
+const form = document.querySelector("#consent-form");
+const statusEl = document.querySelector("#status");
+const sourceLink = document.querySelector("#source-link");
+
+async function loadStatus() {
+  const response = await fetch("/api/status", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error("Unable to load AP status.");
+  }
+  const payload = await response.json();
+  if (payload.source_code_url) {
+    sourceLink.href = payload.source_code_url;
+  }
+  if (payload.authorized) {
+    statusEl.textContent = "This device is already authorized. Internet access should be available.";
+  }
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  statusEl.textContent = "";
+  const button = form.querySelector("button");
+  button.disabled = true;
+
+  try {
+    const payload = {
+      email: form.email.value,
+      accept_terms: form.accept_terms.checked,
+    };
+    const response = await fetch("/api/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.error || "Unable to authorize this device.");
+    }
+    statusEl.textContent = "Access recorded. Redirecting to a connectivity check.";
+    window.setTimeout(() => {
+      window.location.href = result.redirect_url || "http://neverssl.com/";
+    }, 700);
+  } catch (error) {
+    statusEl.textContent = error.message;
+    button.disabled = false;
+  }
+});
+
+loadStatus().catch((error) => {
+  statusEl.textContent = error.message;
+});

--- a/config/data/ap_portal/app.js
+++ b/config/data/ap_portal/app.js
@@ -38,7 +38,7 @@ form.addEventListener("submit", async (event) => {
     }
     statusEl.textContent = "Access recorded. Redirecting to a connectivity check.";
     window.setTimeout(() => {
-      window.location.href = result.redirect_url || "http://neverssl.com/";
+      window.location.href = result.redirect_url || "/";
     }, 700);
   } catch (error) {
     statusEl.textContent = error.message;

--- a/config/data/ap_portal/index.html
+++ b/config/data/ap_portal/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Arthexis AP Access</title>
+    <link rel="stylesheet" href="/app.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="panel" aria-labelledby="portal-title">
+        <p class="eyebrow">ARTHEXIS-1</p>
+        <h1 id="portal-title">AP activity is monitored</h1>
+        <p class="notice">
+          Your activities on this AP <strong>ARE being monitored</strong>. Arthexis records gateway-visible
+          connection metadata, portal requests, device identifiers, consent submissions, and authorization state
+          for diagnostics, safety, and quality-of-life purposes.
+        </p>
+        <p class="source">
+          The implementation is open for inspection:
+          <a id="source-link" href="https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py" rel="noreferrer">view the source code</a>.
+        </p>
+
+        <form id="consent-form" novalidate>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" autocomplete="email" required />
+
+          <label class="check">
+            <input id="accept_terms" name="accept_terms" type="checkbox" required />
+            <span>I accept that my internet experience may be altered and recorded for quality of life purposes while using this access point.</span>
+          </label>
+
+          <button type="submit">Continue</button>
+        </form>
+
+        <p id="status" class="status" role="status"></p>
+      </section>
+    </main>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/config/data/ap_portal/index.html
+++ b/config/data/ap_portal/index.html
@@ -18,7 +18,7 @@
         </p>
         <p class="source">
           The implementation is open for inspection:
-          <a id="source-link" href="https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py" rel="noreferrer">view the source code</a>.
+          <a id="source-link" href="https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py" target="_blank" rel="noopener noreferrer">view the source code</a>.
         </p>
 
         <form id="consent-form" novalidate>

--- a/scripts/ap_client_activity.py
+++ b/scripts/ap_client_activity.py
@@ -53,7 +53,7 @@ def build_report(state_dir: Path, limit: int) -> dict[str, Any]:
         if not mac:
             continue
         entry = clients.setdefault(mac, {"mac_address": mac, "event_count": 0})
-        entry["authorized"] = True
+        entry["authorized"] = mac in authorized
         entry["email"] = consent.get("email")
         entry["accepted_at"] = consent.get("accepted_at")
         entry["last_ip_address"] = consent.get("ip_address")

--- a/scripts/ap_client_activity.py
+++ b/scripts/ap_client_activity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -12,12 +13,24 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_STATE_DIR = BASE_DIR / ".state" / "ap_portal"
 
 
-def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
-    if not path.exists():
+def _tail_lines(path: Path, limit: int, chunk_size: int = 8192) -> list[str]:
+    if limit <= 0:
         return []
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if limit is not None:
-        lines = lines[-limit:]
+    with path.open("rb") as handle:
+        handle.seek(0, 2)
+        position = handle.tell()
+        buffer = b""
+        lines: list[bytes] = []
+        while position > 0 and len(lines) <= limit:
+            read_size = min(chunk_size, position)
+            position -= read_size
+            handle.seek(position)
+            buffer = handle.read(read_size) + buffer
+            lines = buffer.splitlines()
+    return [line.decode("utf-8", errors="replace") for line in lines[-limit:]]
+
+
+def _parse_jsonl_lines(lines: Iterable[str]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for line in lines:
         try:
@@ -27,6 +40,17 @@ def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
         if isinstance(payload, dict):
             rows.append(payload)
     return rows
+
+
+def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    if limit is not None and limit <= 0:
+        return []
+    if limit is None:
+        with path.open(encoding="utf-8") as handle:
+            return _parse_jsonl_lines(handle)
+    return _parse_jsonl_lines(_tail_lines(path, limit))
 
 
 def _load_authorized(path: Path) -> set[str]:

--- a/scripts/ap_client_activity.py
+++ b/scripts/ap_client_activity.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_STATE_DIR = BASE_DIR / ".state" / "ap_portal"
+
+
+def _load_jsonl(path: Path, limit: int | None = None) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if limit is not None:
+        lines = lines[-limit:]
+    rows: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _load_authorized(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip().lower() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def build_report(state_dir: Path, limit: int) -> dict[str, Any]:
+    activity_path = state_dir / "activity.jsonl"
+    consents_path = state_dir / "consents.jsonl"
+    authorized_path = state_dir / "authorized_macs.txt"
+    events = _load_jsonl(activity_path, limit=limit)
+    consents = _load_jsonl(consents_path)
+    authorized = _load_authorized(authorized_path)
+    event_types = Counter(str(event.get("event_type") or "unknown") for event in events)
+    clients: dict[str, dict[str, Any]] = {}
+
+    for mac in authorized:
+        clients[mac] = {"mac_address": mac, "authorized": True, "event_count": 0}
+
+    for consent in consents:
+        mac = str(consent.get("mac_address") or "").lower()
+        if not mac:
+            continue
+        entry = clients.setdefault(mac, {"mac_address": mac, "event_count": 0})
+        entry["authorized"] = True
+        entry["email"] = consent.get("email")
+        entry["accepted_at"] = consent.get("accepted_at")
+        entry["last_ip_address"] = consent.get("ip_address")
+
+    for event in events:
+        mac = str(event.get("mac_address") or "").lower()
+        key = mac or str(event.get("ip_address") or "unknown")
+        entry = clients.setdefault(key, {"event_count": 0})
+        if mac:
+            entry["mac_address"] = mac
+        if event.get("ip_address"):
+            entry["last_ip_address"] = event.get("ip_address")
+        entry["last_event_at"] = event.get("observed_at")
+        entry["last_event_type"] = event.get("event_type")
+        entry["event_count"] = int(entry.get("event_count") or 0) + 1
+        entry.setdefault("authorized", key in authorized)
+
+    return {
+        "state_dir": str(state_dir),
+        "activity_log": str(activity_path),
+        "consent_log": str(consents_path),
+        "authorized_macs": str(authorized_path),
+        "event_count": len(events),
+        "authorized_client_count": len(authorized),
+        "event_types": dict(sorted(event_types.items())),
+        "clients": sorted(
+            clients.values(),
+            key=lambda item: str(item.get("last_event_at") or item.get("accepted_at") or ""),
+            reverse=True,
+        ),
+    }
+
+
+def print_text_report(report: dict[str, Any]) -> None:
+    print(f"State: {report['state_dir']}")
+    print(f"Events loaded: {report['event_count']}")
+    print(f"Authorized clients: {report['authorized_client_count']}")
+    if report["event_types"]:
+        print("Event types:")
+        for event_type, count in report["event_types"].items():
+            print(f"  {event_type}: {count}")
+    print("Clients:")
+    for client in report["clients"]:
+        mac = client.get("mac_address", "unknown")
+        ip_address = client.get("last_ip_address", "")
+        email = client.get("email", "")
+        authorized = "authorized" if client.get("authorized") else "blocked"
+        last_event = client.get("last_event_type", "")
+        print(f"  {mac} {ip_address} {authorized} events={client.get('event_count', 0)} {last_event} {email}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarize Arthexis AP client activity logs.")
+    parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(Path(args.state_dir).expanduser().resolve(), args.limit)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_text_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import mimetypes
+import os
+import re
+import subprocess
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+ASSETS_DIR = BASE_DIR / "config" / "data" / "ap_portal"
+DEFAULT_STATE_DIR = BASE_DIR / ".state" / "ap_portal"
+DEFAULT_SOURCE_URL = "https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py"
+AUTHORIZED_MACS_PATH = DEFAULT_STATE_DIR / "authorized_macs.txt"
+CONSENTS_PATH = DEFAULT_STATE_DIR / "consents.jsonl"
+ACTIVITY_PATH = DEFAULT_STATE_DIR / "activity.jsonl"
+NFT_TABLE_NAME = "arthexis_ap_portal"
+AUTHORIZED_SET_NAME = "authorized_macs"
+TERMS_VERSION = "qol-recording-v2"
+TERMS_STATEMENT = (
+    "I accept that my internet experience may be altered and recorded "
+    "for quality of life purposes while using this access point."
+)
+MONITORING_NOTICE = (
+    "Your activities on this AP ARE being monitored. Arthexis records gateway-visible "
+    "connection metadata, portal requests, device identifiers, consent submissions, "
+    "and authorization state for diagnostics, safety, and quality-of-life purposes."
+)
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+MAC_RE = re.compile(r"(?P<mac>([0-9a-f]{2}:){5}[0-9a-f]{2})", re.IGNORECASE)
+LOGGER = logging.getLogger("arthexis.ap_portal")
+
+
+@dataclass(frozen=True)
+class PortalConfig:
+    bind: str
+    port: int
+    assets_dir: Path
+    state_dir: Path
+    authorized_macs_path: Path
+    consents_path: Path
+    activity_path: Path
+    source_url: str
+    sync_firewall: bool = True
+
+
+class FirewallSyncError(RuntimeError):
+    """Raised when the nftables ruleset cannot be updated."""
+
+
+def _normalize_mac(value: str) -> str:
+    return value.strip().lower()
+
+
+def _validate_email(value: str) -> str:
+    email = value.strip().lower()
+    if not EMAIL_RE.match(email):
+        raise ValueError("Enter a valid email address.")
+    return email
+
+
+def _read_text(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _client_ip_from_headers(headers: Any, fallback: str | None) -> str | None:
+    forwarded = headers.get("X-Forwarded-For", "")
+    if forwarded:
+        return forwarded.split(",", 1)[0].strip() or fallback
+    real_ip = headers.get("X-Real-IP", "")
+    if real_ip:
+        return real_ip.strip()
+    return fallback
+
+
+class FirewallManager:
+    def __init__(self, interface: str = "wlan0") -> None:
+        self.interface = interface
+
+    def sync(self, macs: set[str]) -> None:
+        subprocess.run(
+            ["nft", "delete", "table", "inet", NFT_TABLE_NAME],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        ruleset = self._render_ruleset(sorted(macs))
+        result = subprocess.run(
+            ["nft", "-f", "-"],
+            input=ruleset,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or "nft apply failed").strip()
+            raise FirewallSyncError(details)
+
+    def _render_ruleset(self, macs: list[str]) -> str:
+        set_block = [f"    set {AUTHORIZED_SET_NAME} {{", "        type ether_addr"]
+        if macs:
+            elements = ", ".join(macs)
+            set_block.append(f"        elements = {{ {elements} }}")
+        set_block.append("    }")
+
+        return "\n".join(
+            [
+                f"table inet {NFT_TABLE_NAME} {{",
+                *set_block,
+                "",
+                "    chain prerouting {",
+                "        type nat hook prerouting priority dstnat; policy accept;",
+                f'        iifname "{self.interface}" tcp dport 80 jump portal_redirect',
+                "    }",
+                "",
+                "    chain portal_redirect {",
+                f"        ether saddr @{AUTHORIZED_SET_NAME} return",
+                "        meta l4proto tcp redirect to :80",
+                "    }",
+                "",
+                "    chain forward {",
+                "        type filter hook forward priority -5; policy accept;",
+                f'        iifname "{self.interface}" ether saddr @{AUTHORIZED_SET_NAME} accept',
+                f'        iifname "{self.interface}" drop',
+                "    }",
+                "}",
+                "",
+            ]
+        )
+
+
+class ActivityRecorder:
+    def __init__(self, config: PortalConfig) -> None:
+        self.config = config
+        self.config.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def record(self, event_type: str, **fields: Any) -> dict[str, Any]:
+        event = {
+            "observed_at": _utc_now(),
+            "event_type": event_type,
+            "terms_version": TERMS_VERSION,
+            "monitoring_notice": MONITORING_NOTICE,
+        }
+        event.update({key: value for key, value in fields.items() if value not in (None, "")})
+        with self.config.activity_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True))
+            handle.write("\n")
+        return event
+
+    def read_events(self, limit: int = 100) -> list[dict[str, Any]]:
+        if not self.config.activity_path.exists():
+            return []
+        lines = self.config.activity_path.read_text(encoding="utf-8").splitlines()
+        events: list[dict[str, Any]] = []
+        for line in lines[-limit:]:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                events.append(payload)
+        return events
+
+    def read_consents(self) -> list[dict[str, Any]]:
+        if not self.config.consents_path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        for line in self.config.consents_path.read_text(encoding="utf-8").splitlines():
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                records.append(payload)
+        return records
+
+    def client_summary(self, limit: int = 100) -> list[dict[str, Any]]:
+        clients: dict[str, dict[str, Any]] = {}
+        authorized = _read_authorized_macs(self.config.authorized_macs_path)
+
+        for mac in authorized:
+            clients.setdefault(
+                mac,
+                {
+                    "mac_address": mac,
+                    "authorized": True,
+                    "event_count": 0,
+                },
+            )
+
+        for consent in self.read_consents():
+            mac = str(consent.get("mac_address") or "").lower()
+            if not mac:
+                continue
+            entry = clients.setdefault(mac, {"mac_address": mac, "event_count": 0})
+            entry["authorized"] = True
+            entry["email"] = consent.get("email")
+            entry["accepted_at"] = consent.get("accepted_at")
+            entry["last_ip_address"] = consent.get("ip_address")
+
+        for event in self.read_events(limit=limit):
+            mac = str(event.get("mac_address") or "").lower()
+            key = mac or str(event.get("ip_address") or "unknown")
+            entry = clients.setdefault(key, {"event_count": 0})
+            if mac:
+                entry["mac_address"] = mac
+            if event.get("ip_address"):
+                entry["last_ip_address"] = event.get("ip_address")
+            entry["last_event_at"] = event.get("observed_at")
+            entry["last_event_type"] = event.get("event_type")
+            entry["event_count"] = int(entry.get("event_count") or 0) + 1
+            entry.setdefault("authorized", key in authorized)
+
+        return sorted(
+            clients.values(),
+            key=lambda item: str(item.get("last_event_at") or item.get("accepted_at") or ""),
+            reverse=True,
+        )
+
+
+def _read_authorized_macs(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {
+        _normalize_mac(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+
+
+class PortalState:
+    def __init__(self, config: PortalConfig) -> None:
+        self.config = config
+        self._lock = threading.RLock()
+        self._firewall = FirewallManager()
+        self.activity = ActivityRecorder(config)
+        self._authorized = _read_authorized_macs(self.config.authorized_macs_path)
+        if self.config.sync_firewall:
+            self._firewall.sync(self._authorized)
+
+    def status_for_request(
+        self,
+        *,
+        ip_address: str | None,
+        user_agent: str,
+        path: str,
+        host: str,
+    ) -> dict[str, Any]:
+        mac_address = self.resolve_mac(ip_address)
+        with self._lock:
+            authorized = bool(mac_address and mac_address in self._authorized)
+        self.activity.record(
+            "status_check",
+            ip_address=ip_address,
+            mac_address=mac_address,
+            authorized=authorized,
+            user_agent=user_agent,
+            path=path,
+            host=host,
+        )
+        return {
+            "authorized": authorized,
+            "mac_address": mac_address,
+            "terms_version": TERMS_VERSION,
+            "terms_statement": TERMS_STATEMENT,
+            "monitoring_notice": MONITORING_NOTICE,
+            "source_code_url": self.config.source_url,
+            "activity_recording": {
+                "activity_log": str(self.config.activity_path),
+                "consent_log": str(self.config.consents_path),
+                "authorized_macs": str(self.config.authorized_macs_path),
+            },
+        }
+
+    def record_request(
+        self,
+        *,
+        ip_address: str | None,
+        user_agent: str,
+        method: str,
+        path: str,
+        host: str,
+        referer: str,
+    ) -> None:
+        mac_address = self.resolve_mac(ip_address)
+        authorized = bool(mac_address and mac_address in self._authorized)
+        self.activity.record(
+            "request",
+            ip_address=ip_address,
+            mac_address=mac_address,
+            authorized=authorized,
+            user_agent=user_agent,
+            method=method,
+            path=path,
+            host=host,
+            referer=referer,
+        )
+
+    def subscribe(
+        self,
+        *,
+        email: str,
+        accept_terms: bool,
+        ip_address: str | None,
+        user_agent: str,
+        host: str,
+    ) -> dict[str, Any]:
+        if not accept_terms:
+            raise ValueError("You must accept the access terms to continue.")
+
+        normalized_email = _validate_email(email)
+        mac_address = self.resolve_mac(ip_address)
+        if not mac_address:
+            self.activity.record(
+                "consent_rejected",
+                ip_address=ip_address,
+                user_agent=user_agent,
+                host=host,
+                reason="missing_mac",
+            )
+            raise ValueError("Unable to identify this device on the access point yet.")
+
+        record = {
+            "accepted_at": _utc_now(),
+            "email": normalized_email,
+            "accept_terms": True,
+            "terms_version": TERMS_VERSION,
+            "terms_statement": TERMS_STATEMENT,
+            "monitoring_notice": MONITORING_NOTICE,
+            "source_code_url": self.config.source_url,
+            "ip_address": ip_address or "",
+            "mac_address": mac_address,
+            "user_agent": user_agent,
+        }
+
+        with self._lock:
+            already_authorized = mac_address in self._authorized
+            if not already_authorized:
+                next_authorized = set(self._authorized)
+                next_authorized.add(mac_address)
+                self._write_authorized_macs(next_authorized)
+                if self.config.sync_firewall:
+                    self._firewall.sync(next_authorized)
+                self._authorized = next_authorized
+            self._append_consent(record)
+            self.activity.record(
+                "consent_accepted",
+                ip_address=ip_address,
+                mac_address=mac_address,
+                email=normalized_email,
+                already_authorized=already_authorized,
+                user_agent=user_agent,
+                host=host,
+            )
+
+        return {
+            "authorized": True,
+            "already_authorized": already_authorized,
+            "mac_address": mac_address,
+            "monitoring_notice": MONITORING_NOTICE,
+            "source_code_url": self.config.source_url,
+            "redirect_url": "http://neverssl.com/",
+        }
+
+    def resolve_mac(self, ip_address: str | None) -> str | None:
+        if not ip_address:
+            return None
+
+        commands = [
+            ["ip", "neigh", "show", ip_address],
+            ["arp", "-n", ip_address],
+        ]
+        for command in commands:
+            try:
+                result = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=2,
+                )
+            except FileNotFoundError:
+                continue
+            if result.returncode != 0:
+                continue
+            match = MAC_RE.search(result.stdout)
+            if match:
+                return _normalize_mac(match.group("mac"))
+        return None
+
+    def _write_authorized_macs(self, macs: set[str]) -> None:
+        lines = sorted(_normalize_mac(mac) for mac in macs if mac)
+        payload = "\n".join(lines)
+        if payload:
+            payload += "\n"
+        self.config.authorized_macs_path.write_text(payload, encoding="utf-8")
+
+    def _append_consent(self, record: dict[str, Any]) -> None:
+        with self.config.consents_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+
+
+class PortalApplication:
+    def __init__(self, config: PortalConfig) -> None:
+        self.config = config
+        self.state = PortalState(config)
+
+    def handler_class(self) -> type[BaseHTTPRequestHandler]:
+        app = self
+
+        class Handler(BaseHTTPRequestHandler):
+            server_version = "ArthexisAPPortal/2.0"
+
+            def log_message(self, format: str, *args: Any) -> None:
+                LOGGER.info("%s - %s", self.address_string(), format % args)
+
+            def do_GET(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path == "/health":
+                    self._json({"ok": True})
+                    return
+                if parsed.path == "/api/status":
+                    self._json(
+                        app.state.status_for_request(
+                            ip_address=self._client_ip(),
+                            user_agent=self.headers.get("User-Agent", ""),
+                            path=parsed.path,
+                            host=self.headers.get("Host", ""),
+                        )
+                    )
+                    return
+                if parsed.path == "/api/clients":
+                    if not self._is_direct_local_request():
+                        self._json({"error": "local_only"}, status=HTTPStatus.FORBIDDEN)
+                        return
+                    self._json({"clients": app.state.activity.client_summary()})
+                    return
+
+                if parsed.path in {"", "/"}:
+                    self._record_request(parsed.path or "/")
+                    self._serve_asset("index.html")
+                    return
+                asset_name = parsed.path.lstrip("/")
+                if "/" in asset_name or asset_name.startswith("."):
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
+                self._record_request(parsed.path)
+                self._serve_asset(asset_name)
+
+            def do_POST(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path != "/api/subscribe":
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
+                self._record_request(parsed.path)
+                try:
+                    data = self._read_payload()
+                    result = app.state.subscribe(
+                        email=str(data.get("email") or ""),
+                        accept_terms=bool(data.get("accept_terms")),
+                        ip_address=self._client_ip(),
+                        user_agent=self.headers.get("User-Agent", ""),
+                        host=self.headers.get("Host", ""),
+                    )
+                except ValueError as exc:
+                    self._json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                    return
+                except FirewallSyncError as exc:
+                    LOGGER.exception("Firewall sync failed")
+                    self._json(
+                        {"error": "Unable to authorize this device right now.", "details": str(exc)},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    return
+                self._json(result)
+
+            def _client_ip(self) -> str | None:
+                fallback = self.client_address[0] if self.client_address else None
+                return _client_ip_from_headers(self.headers, fallback)
+
+            def _is_direct_local_request(self) -> bool:
+                fallback = self.client_address[0] if self.client_address else ""
+                return fallback in {"127.0.0.1", "::1"} and not self.headers.get("X-Forwarded-For")
+
+            def _record_request(self, path: str) -> None:
+                app.state.record_request(
+                    ip_address=self._client_ip(),
+                    user_agent=self.headers.get("User-Agent", ""),
+                    method=self.command,
+                    path=path,
+                    host=self.headers.get("Host", ""),
+                    referer=self.headers.get("Referer", ""),
+                )
+
+            def _serve_asset(self, name: str) -> None:
+                path = app.config.assets_dir / name
+                if not path.exists() or not path.is_file():
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
+                content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+                body = _read_text(path)
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _read_payload(self) -> dict[str, Any]:
+                length = int(self.headers.get("Content-Length", "0") or "0")
+                raw = self.rfile.read(length).decode("utf-8") if length else ""
+                content_type = self.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    parsed = json.loads(raw or "{}")
+                    if not isinstance(parsed, dict):
+                        raise ValueError("Invalid request payload.")
+                    return parsed
+                form = parse_qs(raw)
+                return {
+                    "email": form.get("email", [""])[0],
+                    "accept_terms": form.get("accept_terms", [""])[0] in {"1", "true", "on", "yes"},
+                }
+
+            def _json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+                body = json.dumps(payload, sort_keys=True).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        return Handler
+
+
+def build_config(args: argparse.Namespace) -> PortalConfig:
+    state_dir = Path(args.state_dir).expanduser().resolve()
+    assets_dir = Path(args.assets_dir).expanduser().resolve()
+    source_url = args.source_url or os.environ.get("ARTHEXIS_AP_SOURCE_URL") or DEFAULT_SOURCE_URL
+    return PortalConfig(
+        bind=args.bind,
+        port=args.port,
+        assets_dir=assets_dir,
+        state_dir=state_dir,
+        authorized_macs_path=state_dir / "authorized_macs.txt",
+        consents_path=state_dir / "consents.jsonl",
+        activity_path=state_dir / "activity.jsonl",
+        source_url=source_url,
+        sync_firewall=not args.skip_firewall_sync,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Arthexis AP consent and monitoring portal.")
+    parser.add_argument("--bind", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9080)
+    parser.add_argument("--assets-dir", default=str(ASSETS_DIR))
+    parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    parser.add_argument("--source-url", default="")
+    parser.add_argument(
+        "--skip-firewall-sync",
+        action="store_true",
+        help="Start the portal without writing nftables rules; intended for tests only.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    config = build_config(parse_args())
+    app = PortalApplication(config)
+    server = ThreadingHTTPServer((config.bind, config.port), app.handler_class())
+    LOGGER.info("AP portal listening on %s:%s", config.bind, config.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        LOGGER.info("AP portal stopping")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import logging
 import mimetypes
@@ -30,6 +31,7 @@ AUTHORIZED_SET_NAME = "authorized_macs"
 TERMS_VERSION = "qol-recording-v2"
 MAX_PAYLOAD_BYTES = 1024 * 1024
 ARP_TABLE_PATH = Path("/proc/net/arp")
+NDISC_CACHE_PATH = Path("/proc/net/ndisc_cache")
 TERMS_STATEMENT = (
     "I accept that my internet experience may be altered and recorded "
     "for quality of life purposes while using this access point."
@@ -42,6 +44,7 @@ MONITORING_NOTICE = (
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MAC_RE = re.compile(r"(?P<mac>([0-9a-f]{2}:){5}[0-9a-f]{2})", re.IGNORECASE)
 LOGGER = logging.getLogger("arthexis.ap_portal")
+JSONL_APPEND_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -94,6 +97,17 @@ def _client_ip_from_headers(headers: Any, fallback: str | None) -> str | None:
 
 def _accept_terms_is_explicit(value: Any) -> bool:
     return value is True
+
+
+def _form_accept_terms_is_explicit(value: str) -> bool:
+    return value == "on"
+
+
+def _ip_addresses_match(left: str, right: str) -> bool:
+    try:
+        return ipaddress.ip_address(left) == ipaddress.ip_address(right)
+    except ValueError:
+        return left == right
 
 
 class FirewallManager:
@@ -170,9 +184,7 @@ class ActivityRecorder:
             "monitoring_notice": MONITORING_NOTICE,
         }
         event.update({key: value for key, value in fields.items() if value not in (None, "")})
-        with self.config.activity_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(event, sort_keys=True))
-            handle.write("\n")
+        _append_jsonl(self.config.activity_path, event)
         return event
 
     def read_events(self, limit: int = 100) -> list[dict[str, Any]]:
@@ -256,6 +268,12 @@ def _read_authorized_macs(path: Path) -> set[str]:
     }
 
 
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    line = json.dumps(payload, sort_keys=True) + "\n"
+    with JSONL_APPEND_LOCK, path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
 def _read_limited_request_body(headers: Any, rfile: Any) -> str:
     try:
         length = int(headers.get("Content-Length", "0") or "0")
@@ -266,6 +284,15 @@ def _read_limited_request_body(headers: Any, rfile: Any) -> str:
     if length > MAX_PAYLOAD_BYTES:
         raise ValueError("Payload too large.")
     return rfile.read(length).decode("utf-8") if length else ""
+
+
+def _parse_form_payload(raw: str) -> dict[str, Any]:
+    form = parse_qs(raw)
+    accept_terms = form.get("accept_terms", [""])[0]
+    return {
+        "email": form.get("email", [""])[0],
+        "accept_terms": _form_accept_terms_is_explicit(accept_terms),
+    }
 
 
 class PortalState:
@@ -376,11 +403,14 @@ class PortalState:
         with self._lock:
             already_authorized = mac_address in self._authorized
             if not already_authorized:
+                previous_authorized = set(self._authorized)
+                authorized_file_existed = self.config.authorized_macs_path.exists()
                 next_authorized = set(self._authorized)
                 next_authorized.add(mac_address)
                 if self.config.sync_firewall:
                     self._firewall.sync(next_authorized)
                 try:
+                    self._write_authorized_macs(next_authorized)
                     self._append_consent(record)
                     self.activity.record(
                         "consent_accepted",
@@ -391,10 +421,10 @@ class PortalState:
                         user_agent=user_agent,
                         host=host,
                     )
-                    self._write_authorized_macs(next_authorized)
                 except OSError:
+                    self._restore_authorized_macs(previous_authorized, existed=authorized_file_existed)
                     if self.config.sync_firewall:
-                        self._firewall.sync(self._authorized)
+                        self._firewall.sync(previous_authorized)
                     raise
                 self._authorized = next_authorized
             else:
@@ -422,6 +452,12 @@ class PortalState:
         if not ip_address:
             return None
 
+        mac_address = self._resolve_mac_from_arp(ip_address)
+        if mac_address:
+            return mac_address
+        return self._resolve_mac_from_ndisc(ip_address)
+
+    def _resolve_mac_from_arp(self, ip_address: str) -> str | None:
         try:
             arp_rows = ARP_TABLE_PATH.read_text(encoding="utf-8").splitlines()
         except OSError:
@@ -429,8 +465,22 @@ class PortalState:
 
         for row in arp_rows[1:]:
             fields = row.split()
-            if len(fields) >= 4 and fields[0] == ip_address:
+            if len(fields) >= 4 and _ip_addresses_match(fields[0], ip_address):
                 match = MAC_RE.fullmatch(fields[3])
+                if match:
+                    return _normalize_mac(match.group("mac"))
+        return None
+
+    def _resolve_mac_from_ndisc(self, ip_address: str) -> str | None:
+        try:
+            neighbor_rows = NDISC_CACHE_PATH.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return None
+
+        for row in neighbor_rows:
+            fields = row.split()
+            if fields and _ip_addresses_match(fields[0], ip_address):
+                match = MAC_RE.search(row)
                 if match:
                     return _normalize_mac(match.group("mac"))
         return None
@@ -442,10 +492,14 @@ class PortalState:
             payload += "\n"
         self.config.authorized_macs_path.write_text(payload, encoding="utf-8")
 
+    def _restore_authorized_macs(self, macs: set[str], *, existed: bool) -> None:
+        if existed:
+            self._write_authorized_macs(macs)
+        else:
+            self.config.authorized_macs_path.unlink(missing_ok=True)
+
     def _append_consent(self, record: dict[str, Any]) -> None:
-        with self.config.consents_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, sort_keys=True))
-            handle.write("\n")
+        _append_jsonl(self.config.consents_path, record)
 
 
 class PortalApplication:
@@ -569,11 +623,7 @@ class PortalApplication:
                     if not isinstance(parsed, dict):
                         raise ValueError("Invalid request payload.")
                     return parsed
-                form = parse_qs(raw)
-                return {
-                    "email": form.get("email", [""])[0],
-                    "accept_terms": form.get("accept_terms", [""])[0] in {"1", "true", "on", "yes"},
-                }
+                return _parse_form_payload(raw)
 
             def _json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
                 body = json.dumps(payload, sort_keys=True).encode("utf-8")

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -261,6 +261,8 @@ def _read_limited_request_body(headers: Any, rfile: Any) -> str:
         length = int(headers.get("Content-Length", "0") or "0")
     except ValueError as exc:
         raise ValueError("Invalid Content-Length.") from exc
+    if length < 0:
+        raise ValueError("Invalid Content-Length.")
     if length > MAX_PAYLOAD_BYTES:
         raise ValueError("Payload too large.")
     return rfile.read(length).decode("utf-8") if length else ""
@@ -376,9 +378,9 @@ class PortalState:
             if not already_authorized:
                 next_authorized = set(self._authorized)
                 next_authorized.add(mac_address)
-                self._write_authorized_macs(next_authorized)
                 if self.config.sync_firewall:
                     self._firewall.sync(next_authorized)
+                self._write_authorized_macs(next_authorized)
                 self._authorized = next_authorized
             self._append_consent(record)
             self.activity.record(

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import threading
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from http import HTTPStatus
@@ -190,9 +191,12 @@ class ActivityRecorder:
     def read_events(self, limit: int = 100) -> list[dict[str, Any]]:
         if not self.config.activity_path.exists():
             return []
-        lines = self.config.activity_path.read_text(encoding="utf-8").splitlines()
+        if limit <= 0:
+            return []
         events: list[dict[str, Any]] = []
-        for line in lines[-limit:]:
+        with self.config.activity_path.open(encoding="utf-8") as handle:
+            lines = deque(handle, maxlen=limit)
+        for line in lines:
             try:
                 payload = json.loads(line)
             except json.JSONDecodeError:
@@ -423,10 +427,27 @@ class PortalState:
                         host=host,
                     )
                 except OSError:
-                    self._restore_consent_log(consent_rollback_position)
-                    self._restore_authorized_macs(previous_authorized, existed=authorized_file_existed)
-                    if self.config.sync_firewall:
-                        self._firewall.sync(previous_authorized)
+                    rollback_error = None
+                    try:
+                        self._restore_consent_log(consent_rollback_position)
+                    except OSError as exc:
+                        rollback_error = exc
+                    try:
+                        self._restore_authorized_macs(previous_authorized, existed=authorized_file_existed)
+                    except OSError as exc:
+                        if rollback_error is not None:
+                            rollback_error.add_note(str(exc))
+                        else:
+                            rollback_error = exc
+                    try:
+                        if self.config.sync_firewall:
+                            self._firewall.sync(previous_authorized)
+                    except FirewallSyncError as exc:
+                        if rollback_error is not None:
+                            exc.add_note(f"file rollback failed: {rollback_error}")
+                        raise
+                    if rollback_error is not None:
+                        raise rollback_error
                     raise
                 self._authorized = next_authorized
             else:

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -233,7 +233,7 @@ class ActivityRecorder:
             if not mac:
                 continue
             entry = clients.setdefault(mac, {"mac_address": mac, "event_count": 0})
-            entry["authorized"] = True
+            entry["authorized"] = mac in authorized
             entry["email"] = consent.get("email")
             entry["accepted_at"] = consent.get("accepted_at")
             entry["last_ip_address"] = consent.get("ip_address")

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -409,6 +409,7 @@ class PortalState:
                 next_authorized.add(mac_address)
                 if self.config.sync_firewall:
                     self._firewall.sync(next_authorized)
+                consent_rollback_position = self._consent_log_position()
                 try:
                     self._write_authorized_macs(next_authorized)
                     self._append_consent(record)
@@ -422,6 +423,7 @@ class PortalState:
                         host=host,
                     )
                 except OSError:
+                    self._restore_consent_log(consent_rollback_position)
                     self._restore_authorized_macs(previous_authorized, existed=authorized_file_existed)
                     if self.config.sync_firewall:
                         self._firewall.sync(previous_authorized)
@@ -500,6 +502,18 @@ class PortalState:
 
     def _append_consent(self, record: dict[str, Any]) -> None:
         _append_jsonl(self.config.consents_path, record)
+
+    def _consent_log_position(self) -> int | None:
+        if not self.config.consents_path.exists():
+            return None
+        return self.config.consents_path.stat().st_size
+
+    def _restore_consent_log(self, position: int | None) -> None:
+        if position is None:
+            self.config.consents_path.unlink(missing_ok=True)
+            return
+        with self.config.consents_path.open("r+b") as handle:
+            handle.truncate(position)
 
 
 class PortalApplication:

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -594,8 +594,8 @@ class PortalApplication:
                 if parsed.path != "/api/subscribe":
                     self.send_error(HTTPStatus.NOT_FOUND)
                     return
-                self._record_request(parsed.path)
                 try:
+                    self._record_request(parsed.path)
                     data = self._read_payload()
                     result = app.state.subscribe(
                         email=str(data.get("email") or ""),

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -430,16 +430,21 @@ class PortalState:
                     raise
                 self._authorized = next_authorized
             else:
-                self._append_consent(record)
-                self.activity.record(
-                    "consent_accepted",
-                    ip_address=ip_address,
-                    mac_address=mac_address,
-                    email=normalized_email,
-                    already_authorized=already_authorized,
-                    user_agent=user_agent,
-                    host=host,
-                )
+                consent_rollback_position = self._consent_log_position()
+                try:
+                    self._append_consent(record)
+                    self.activity.record(
+                        "consent_accepted",
+                        ip_address=ip_address,
+                        mac_address=mac_address,
+                        email=normalized_email,
+                        already_authorized=already_authorized,
+                        user_agent=user_agent,
+                        host=host,
+                    )
+                except OSError:
+                    self._restore_consent_log(consent_rollback_position)
+                    raise
 
         return {
             "authorized": True,

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -28,6 +28,8 @@ ACTIVITY_PATH = DEFAULT_STATE_DIR / "activity.jsonl"
 NFT_TABLE_NAME = "arthexis_ap_portal"
 AUTHORIZED_SET_NAME = "authorized_macs"
 TERMS_VERSION = "qol-recording-v2"
+MAX_PAYLOAD_BYTES = 1024 * 1024
+ARP_TABLE_PATH = Path("/proc/net/arp")
 TERMS_STATEMENT = (
     "I accept that my internet experience may be altered and recorded "
     "for quality of life purposes while using this access point."
@@ -93,14 +95,9 @@ class FirewallManager:
         self.interface = interface
 
     def sync(self, macs: set[str]) -> None:
-        subprocess.run(
-            ["nft", "delete", "table", "inet", NFT_TABLE_NAME],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-
         ruleset = self._render_ruleset(sorted(macs))
+        if self._table_exists():
+            ruleset = f"delete table inet {NFT_TABLE_NAME}\n{ruleset}"
         result = subprocess.run(
             ["nft", "-f", "-"],
             input=ruleset,
@@ -111,6 +108,15 @@ class FirewallManager:
         if result.returncode != 0:
             details = (result.stderr or result.stdout or "nft apply failed").strip()
             raise FirewallSyncError(details)
+
+    def _table_exists(self) -> bool:
+        result = subprocess.run(
+            ["nft", "list", "table", "inet", NFT_TABLE_NAME],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
 
     def _render_ruleset(self, macs: list[str]) -> str:
         set_block = [f"    set {AUTHORIZED_SET_NAME} {{", "        type ether_addr"]
@@ -242,6 +248,16 @@ def _read_authorized_macs(path: Path) -> set[str]:
         for line in path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     }
+
+
+def _read_limited_request_body(headers: Any, rfile: Any) -> str:
+    try:
+        length = int(headers.get("Content-Length", "0") or "0")
+    except ValueError as exc:
+        raise ValueError("Invalid Content-Length.") from exc
+    if length > MAX_PAYLOAD_BYTES:
+        raise ValueError("Payload too large.")
+    return rfile.read(length).decode("utf-8") if length else ""
 
 
 class PortalState:
@@ -382,26 +398,17 @@ class PortalState:
         if not ip_address:
             return None
 
-        commands = [
-            ["ip", "neigh", "show", ip_address],
-            ["arp", "-n", ip_address],
-        ]
-        for command in commands:
-            try:
-                result = subprocess.run(
-                    command,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    timeout=2,
-                )
-            except FileNotFoundError:
-                continue
-            if result.returncode != 0:
-                continue
-            match = MAC_RE.search(result.stdout)
-            if match:
-                return _normalize_mac(match.group("mac"))
+        try:
+            arp_rows = ARP_TABLE_PATH.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return None
+
+        for row in arp_rows[1:]:
+            fields = row.split()
+            if len(fields) >= 4 and fields[0] == ip_address:
+                match = MAC_RE.fullmatch(fields[3])
+                if match:
+                    return _normalize_mac(match.group("mac"))
         return None
 
     def _write_authorized_macs(self, macs: set[str]) -> None:
@@ -524,8 +531,7 @@ class PortalApplication:
                 self.wfile.write(body)
 
             def _read_payload(self) -> dict[str, Any]:
-                length = int(self.headers.get("Content-Length", "0") or "0")
-                raw = self.rfile.read(length).decode("utf-8") if length else ""
+                raw = _read_limited_request_body(self.headers, self.rfile)
                 content_type = self.headers.get("Content-Type", "")
                 if "application/json" in content_type:
                     parsed = json.loads(raw or "{}")

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -81,13 +81,19 @@ def _utc_now() -> str:
 
 
 def _client_ip_from_headers(headers: Any, fallback: str | None) -> str | None:
-    forwarded = headers.get("X-Forwarded-For", "")
-    if forwarded:
-        return forwarded.split(",", 1)[0].strip() or fallback
     real_ip = headers.get("X-Real-IP", "")
     if real_ip:
         return real_ip.strip()
+    forwarded = headers.get("X-Forwarded-For", "")
+    if forwarded:
+        trusted_hops = [part.strip() for part in forwarded.split(",") if part.strip()]
+        if trusted_hops:
+            return trusted_hops[-1]
     return fallback
+
+
+def _accept_terms_is_explicit(value: Any) -> bool:
+    return value is True
 
 
 class FirewallManager:
@@ -481,7 +487,7 @@ class PortalApplication:
                     data = self._read_payload()
                     result = app.state.subscribe(
                         email=str(data.get("email") or ""),
-                        accept_terms=bool(data.get("accept_terms")),
+                        accept_terms=_accept_terms_is_explicit(data.get("accept_terms")),
                         ip_address=self._client_ip(),
                         user_agent=self.headers.get("User-Agent", ""),
                         host=self.headers.get("Host", ""),

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -380,18 +380,34 @@ class PortalState:
                 next_authorized.add(mac_address)
                 if self.config.sync_firewall:
                     self._firewall.sync(next_authorized)
-                self._write_authorized_macs(next_authorized)
+                try:
+                    self._append_consent(record)
+                    self.activity.record(
+                        "consent_accepted",
+                        ip_address=ip_address,
+                        mac_address=mac_address,
+                        email=normalized_email,
+                        already_authorized=already_authorized,
+                        user_agent=user_agent,
+                        host=host,
+                    )
+                    self._write_authorized_macs(next_authorized)
+                except OSError:
+                    if self.config.sync_firewall:
+                        self._firewall.sync(self._authorized)
+                    raise
                 self._authorized = next_authorized
-            self._append_consent(record)
-            self.activity.record(
-                "consent_accepted",
-                ip_address=ip_address,
-                mac_address=mac_address,
-                email=normalized_email,
-                already_authorized=already_authorized,
-                user_agent=user_agent,
-                host=host,
-            )
+            else:
+                self._append_consent(record)
+                self.activity.record(
+                    "consent_accepted",
+                    ip_address=ip_address,
+                    mac_address=mac_address,
+                    email=normalized_email,
+                    already_authorized=already_authorized,
+                    user_agent=user_agent,
+                    host=host,
+                )
 
         return {
             "authorized": True,
@@ -501,6 +517,13 @@ class PortalApplication:
                     LOGGER.exception("Firewall sync failed")
                     self._json(
                         {"error": "Unable to authorize this device right now.", "details": str(exc)},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    return
+                except OSError as exc:
+                    LOGGER.exception("Consent audit logging failed")
+                    self._json(
+                        {"error": "Unable to record consent right now.", "details": str(exc)},
                         status=HTTPStatus.INTERNAL_SERVER_ERROR,
                     )
                     return

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -10,6 +10,7 @@ SOURCE_URL="${SOURCE_URL:-https://github.com/arthexis/arthexis/blob/main/scripts
 SERVICE_FILE="/etc/systemd/system/arthexis-ap-portal.service"
 NGINX_SITE="/etc/nginx/sites-enabled/arthexis.conf"
 NGINX_BACKUP_DIR="/etc/nginx/sites-available"
+NGINX_BACKUP_RETENTION="${NGINX_BACKUP_RETENTION:-10}"
 DEFAULT_CERT_PATH="/etc/letsencrypt/live/arthexis.com/fullchain.pem"
 DEFAULT_KEY_PATH="/etc/letsencrypt/live/arthexis.com/privkey.pem"
 
@@ -65,13 +66,28 @@ WantedBy=multi-user.target
 EOF
 }
 
+rotate_nginx_backups() {
+    if ! [[ "$NGINX_BACKUP_RETENTION" =~ ^[0-9]+$ ]] || (( NGINX_BACKUP_RETENTION == 0 )); then
+        return
+    fi
+
+    mapfile -t expired_backups < <(
+        find "$NGINX_BACKUP_DIR" -maxdepth 1 -type f -name 'arthexis.conf.pre-ap-portal-*' -printf '%T@ %p\n' \
+            | sort -rn \
+            | awk -v limit="$NGINX_BACKUP_RETENTION" 'NR > limit { sub(/^[^ ]+ /, ""); print }'
+    )
+    for backup in "${expired_backups[@]}"; do
+        rm -f -- "$backup"
+    done
+}
+
 install_nginx_site() {
     local timestamp
     timestamp="$(date +%Y%m%d%H%M%S)"
-    rm -f /etc/nginx/sites-enabled/arthexis.conf.pre-ap-portal-*
     if [[ -f "$NGINX_SITE" ]]; then
         mkdir -p "$NGINX_BACKUP_DIR"
         cp "$NGINX_SITE" "${NGINX_BACKUP_DIR}/arthexis.conf.pre-ap-portal-${timestamp}"
+        rotate_nginx_backups
     fi
 
     local https_block=""

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PORTAL_PORT="${PORTAL_PORT:-9080}"
+CURRENT_AP_NAME="${CURRENT_AP_NAME:-arthexis-ap}"
+TARGET_AP_NAME="${TARGET_AP_NAME:-arthexis-1}"
+STATE_DIR="${STATE_DIR:-$BASE_DIR/.state/ap_portal}"
+SOURCE_URL="${SOURCE_URL:-https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py}"
+SERVICE_FILE="/etc/systemd/system/arthexis-ap-portal.service"
+NGINX_SITE="/etc/nginx/sites-enabled/arthexis.conf"
+NGINX_BACKUP_DIR="/etc/nginx/sites-available"
+DEFAULT_CERT_PATH="/etc/letsencrypt/live/arthexis.com/fullchain.pem"
+DEFAULT_KEY_PATH="/etc/letsencrypt/live/arthexis.com/privkey.pem"
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "Run as root: sudo $0" >&2
+    exit 1
+fi
+
+clear_wifi_secrets() {
+    local conn_name="$1"
+    nmcli connection modify "$conn_name" remove 802-11-wireless-security >/dev/null 2>&1 || true
+    nmcli connection modify "$conn_name" remove 802-1x >/dev/null 2>&1 || true
+}
+
+ensure_ap_profile() {
+    if nmcli -t -f NAME connection show | grep -qx "$TARGET_AP_NAME"; then
+        :
+    elif nmcli -t -f NAME connection show | grep -qx "$CURRENT_AP_NAME"; then
+        nmcli connection modify "$CURRENT_AP_NAME" connection.id "$TARGET_AP_NAME"
+    else
+        nmcli connection add type wifi ifname wlan0 con-name "$TARGET_AP_NAME" ssid "$TARGET_AP_NAME" \
+            802-11-wireless.mode ap ipv4.method shared ipv4.addresses 10.42.0.1/16
+    fi
+
+    clear_wifi_secrets "$TARGET_AP_NAME"
+    nmcli connection modify "$TARGET_AP_NAME" \
+        802-11-wireless.ssid "$TARGET_AP_NAME" \
+        802-11-wireless.mode ap \
+        ipv4.method shared \
+        ipv4.addresses 10.42.0.1/16 \
+        ipv6.method shared \
+        ipv6.addresses fd42:0:0:42::1/64 \
+        connection.autoconnect yes
+}
+
+install_service() {
+    mkdir -p "$STATE_DIR"
+    cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Arthexis AP consent and activity monitoring portal
+After=network-online.target NetworkManager.service nginx.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$BASE_DIR
+ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/scripts/ap_portal_server.py --bind 127.0.0.1 --port $PORTAL_PORT --state-dir $STATE_DIR --source-url $SOURCE_URL
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+install_nginx_site() {
+    local timestamp
+    timestamp="$(date +%Y%m%d%H%M%S)"
+    rm -f /etc/nginx/sites-enabled/arthexis.conf.pre-ap-portal-*
+    if [[ -f "$NGINX_SITE" ]]; then
+        mkdir -p "$NGINX_BACKUP_DIR"
+        cp "$NGINX_SITE" "${NGINX_BACKUP_DIR}/arthexis.conf.pre-ap-portal-${timestamp}"
+    fi
+
+    local https_block=""
+    if [[ -f "$DEFAULT_CERT_PATH" && -f "$DEFAULT_KEY_PATH" ]]; then
+        https_block="$(cat <<EOF
+server {
+    listen 443 ssl;
+    server_name _;
+    ssl_certificate $DEFAULT_CERT_PATH;
+    ssl_certificate_key $DEFAULT_KEY_PATH;
+    include $BASE_DIR/apps/nginx/options-ssl-nginx.conf;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'" always;
+    location / {
+        proxy_pass http://127.0.0.1:$PORTAL_PORT;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+EOF
+)"
+    fi
+
+    cat > "$NGINX_SITE" <<EOF
+server {
+    listen 80 default_server;
+    server_name _;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'" always;
+    location / {
+        proxy_pass http://127.0.0.1:$PORTAL_PORT;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+
+$https_block
+EOF
+}
+
+ensure_ap_profile
+install_service
+install_nginx_site
+
+nginx -t
+systemctl daemon-reload
+systemctl enable nginx arthexis-ap-portal.service
+systemctl restart nginx arthexis-ap-portal.service
+nmcli connection up "$TARGET_AP_NAME" ifname wlan0
+
+echo "Arthexis AP portal is installed for SSID $TARGET_AP_NAME."

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -81,6 +81,18 @@ rotate_nginx_backups() {
     done
 }
 
+restore_nginx_site() {
+    local latest_backup
+    latest_backup="$(find "$NGINX_BACKUP_DIR" -maxdepth 1 -type f -name 'arthexis.conf.pre-ap-portal-*' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn \
+        | awk 'NR == 1 { sub(/^[^ ]+ /, ""); print }')"
+    if [[ -n "$latest_backup" ]]; then
+        cp "$latest_backup" "$NGINX_SITE"
+    else
+        rm -f -- "$NGINX_SITE"
+    fi
+}
+
 install_nginx_site() {
     local timestamp
     timestamp="$(date +%Y%m%d%H%M%S)"
@@ -134,7 +146,10 @@ ensure_ap_profile
 install_service
 install_nginx_site
 
-nginx -t
+if ! nginx -t; then
+    restore_nginx_site
+    exit 1
+fi
 systemctl daemon-reload
 systemctl enable nginx arthexis-ap-portal.service
 systemctl restart nginx arthexis-ap-portal.service

--- a/tests/test_ap_client_activity.py
+++ b/tests/test_ap_client_activity.py
@@ -18,6 +18,35 @@ def load_activity_module():
     return module
 
 
+def test_load_jsonl_limit_uses_bounded_tail_without_reading_whole_file(tmp_path, monkeypatch):
+    module = load_activity_module()
+    log_path = tmp_path / "activity.jsonl"
+    rows = [
+        {"event_type": "old"},
+        {"event_type": "middle"},
+        {"event_type": "new"},
+    ]
+    log_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    def fail_read_text(*_args, **_kwargs):
+        raise AssertionError("_load_jsonl should not read the whole file for limited loads")
+
+    monkeypatch.setattr(module.Path, "read_text", fail_read_text)
+
+    loaded = module._load_jsonl(log_path, limit=2)
+
+    assert [row["event_type"] for row in loaded] == ["middle", "new"]
+
+
+def test_load_jsonl_non_positive_limit_returns_no_rows(tmp_path):
+    module = load_activity_module()
+    log_path = tmp_path / "activity.jsonl"
+    log_path.write_text(json.dumps({"event_type": "new"}) + "\n", encoding="utf-8")
+
+    assert module._load_jsonl(log_path, limit=0) == []
+    assert module._load_jsonl(log_path, limit=-1) == []
+
+
 def test_build_report_does_not_treat_consent_history_as_authorization(tmp_path):
     module = load_activity_module()
     state_dir = tmp_path / "ap_portal"

--- a/tests/test_ap_client_activity.py
+++ b/tests/test_ap_client_activity.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ap_client_activity.py"
+
+
+def load_activity_module():
+    spec = importlib.util.spec_from_file_location("ap_client_activity", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_report_does_not_treat_consent_history_as_authorization(tmp_path):
+    module = load_activity_module()
+    state_dir = tmp_path / "ap_portal"
+    state_dir.mkdir()
+    (state_dir / "authorized_macs.txt").write_text("", encoding="utf-8")
+    consent = {
+        "accepted_at": "2026-04-25T09:00:00+00:00",
+        "email": "guest@example.com",
+        "ip_address": "10.42.0.25",
+        "mac_address": "aa:bb:cc:dd:ee:ff",
+    }
+    (state_dir / "consents.jsonl").write_text(json.dumps(consent) + "\n", encoding="utf-8")
+
+    report = module.build_report(state_dir, limit=500)
+
+    assert report["authorized_client_count"] == 0
+    assert report["clients"][0]["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert report["clients"][0]["email"] == "guest@example.com"
+    assert report["clients"][0]["authorized"] is False

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -565,3 +565,27 @@ def test_read_limited_request_body_rejects_negative_length_before_reading():
 
     with pytest.raises(ValueError, match="Invalid Content-Length"):
         module._read_limited_request_body(headers, io.BytesIO(b"email=guest@example.com"))
+
+
+def test_subscribe_post_returns_json_error_when_request_logging_fails(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+    handler = object.__new__(handler_class)
+    handler.path = "/api/subscribe"
+    responses = []
+
+    def fail_record(_path):
+        raise OSError("activity log unavailable")
+
+    handler._record_request = fail_record
+    handler._json = lambda payload, status=module.HTTPStatus.OK: responses.append((payload, status))
+    handler._read_payload = lambda: (_ for _ in ()).throw(AssertionError("payload should not be read"))
+
+    handler.do_POST()
+
+    assert responses == [
+        (
+            {"error": "Unable to record consent right now.", "details": "activity log unavailable"},
+            module.HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+    ]

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -138,6 +138,80 @@ def test_subscribe_does_not_persist_authorization_when_firewall_sync_fails(tmp_p
     assert "aa:bb:cc:dd:ee:ff" not in state._authorized
 
 
+def test_subscribe_rolls_back_new_authorization_when_consent_log_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    config = module.PortalConfig(
+        bind=config.bind,
+        port=config.port,
+        assets_dir=config.assets_dir,
+        state_dir=config.state_dir,
+        authorized_macs_path=config.authorized_macs_path,
+        consents_path=config.consents_path,
+        activity_path=config.activity_path,
+        source_url=config.source_url,
+        sync_firewall=True,
+    )
+    state.config = config
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    synced_macs = []
+    state._firewall.sync = lambda macs: synced_macs.append(set(macs))
+
+    def fail_append(_record):
+        raise OSError("consent log unavailable")
+
+    state._append_consent = fail_append
+
+    with pytest.raises(OSError, match="consent log unavailable"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert synced_macs == [{"aa:bb:cc:dd:ee:ff"}, set()]
+    assert not state.config.authorized_macs_path.exists()
+    assert "aa:bb:cc:dd:ee:ff" not in state._authorized
+
+
+def test_subscribe_rolls_back_new_authorization_when_activity_log_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    config = module.PortalConfig(
+        bind=config.bind,
+        port=config.port,
+        assets_dir=config.assets_dir,
+        state_dir=config.state_dir,
+        authorized_macs_path=config.authorized_macs_path,
+        consents_path=config.consents_path,
+        activity_path=config.activity_path,
+        source_url=config.source_url,
+        sync_firewall=True,
+    )
+    state.config = config
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    synced_macs = []
+    state._firewall.sync = lambda macs: synced_macs.append(set(macs))
+    state.activity.record = lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("activity log unavailable"))
+
+    with pytest.raises(OSError, match="activity log unavailable"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert synced_macs == [{"aa:bb:cc:dd:ee:ff"}, set()]
+    assert not state.config.authorized_macs_path.exists()
+    assert "aa:bb:cc:dd:ee:ff" not in state._authorized
+
+
 def test_client_ip_prefers_nginx_real_ip_over_spoofed_forwarded_for():
     module = load_portal_module()
     headers = {

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sys
 from pathlib import Path
+
+import pytest
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ap_portal_server.py"
@@ -126,3 +129,54 @@ def test_firewall_ruleset_keeps_authorized_clients_and_redirects_unapproved_http
     assert "elements = { aa:bb:cc:dd:ee:ff }" in ruleset
     assert "meta l4proto tcp redirect to :80" in ruleset
     assert 'iifname "wlan0" drop' in ruleset
+
+
+def test_firewall_sync_replaces_existing_table_in_single_apply(monkeypatch):
+    module = load_portal_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return module.subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module.FirewallManager(interface="wlan0").sync({"aa:bb:cc:dd:ee:ff"})
+
+    apply_calls = [call for call in calls if call[0] == ["nft", "-f", "-"]]
+    assert len(apply_calls) == 1
+    ruleset = apply_calls[0][1]["input"]
+    assert ruleset.startswith("delete table inet arthexis_ap_portal\n")
+    assert "elements = { aa:bb:cc:dd:ee:ff }" in ruleset
+
+
+def test_resolve_mac_reads_proc_arp_without_subprocess(tmp_path, monkeypatch):
+    module = load_portal_module()
+    arp_table = tmp_path / "arp"
+    arp_table.write_text(
+        "\n".join(
+            [
+                "IP address       HW type     Flags       HW address            Mask     Device",
+                "10.42.0.25       0x1         0x2         AA:BB:CC:DD:EE:FF     *        wlan0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("resolve_mac should not spawn neighbor lookup subprocesses")
+
+    monkeypatch.setattr(module, "ARP_TABLE_PATH", arp_table)
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+    state = module.PortalState(make_config(module, tmp_path))
+
+    assert state.resolve_mac("10.42.0.25") == "aa:bb:cc:dd:ee:ff"
+    assert state.resolve_mac("10.42.0.26") is None
+
+
+def test_read_limited_request_body_rejects_large_payload():
+    module = load_portal_module()
+    headers = {"Content-Length": str(module.MAX_PAYLOAD_BYTES + 1)}
+
+    with pytest.raises(ValueError, match="Payload too large"):
+        module._read_limited_request_body(headers, io.BytesIO())

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ap_portal_server.py"
+
+
+def load_portal_module():
+    spec = importlib.util.spec_from_file_location("ap_portal_server", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_config(module, tmp_path):
+    state_dir = tmp_path / "ap_portal"
+    return module.PortalConfig(
+        bind="127.0.0.1",
+        port=0,
+        assets_dir=tmp_path,
+        state_dir=state_dir,
+        authorized_macs_path=state_dir / "authorized_macs.txt",
+        consents_path=state_dir / "consents.jsonl",
+        activity_path=state_dir / "activity.jsonl",
+        source_url="https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py",
+        sync_firewall=False,
+    )
+
+
+def test_monitoring_notice_is_explicit_and_points_to_source():
+    module = load_portal_module()
+
+    assert "ARE being monitored" in module.MONITORING_NOTICE
+    assert module.DEFAULT_SOURCE_URL.startswith("https://github.com/arthexis/arthexis")
+    assert module.DEFAULT_SOURCE_URL.endswith("/scripts/ap_portal_server.py")
+
+
+def test_subscribe_records_consent_activity_and_authorizes_client(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    result = state.subscribe(
+        email="Guest@Example.COM",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+
+    assert result["authorized"] is True
+    assert result["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert "ARE being monitored" in result["monitoring_notice"]
+    assert state.config.authorized_macs_path.read_text(encoding="utf-8") == "aa:bb:cc:dd:ee:ff\n"
+
+    consent = json.loads(state.config.consents_path.read_text(encoding="utf-8").splitlines()[0])
+    assert consent["email"] == "guest@example.com"
+    assert consent["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert consent["source_code_url"].startswith("https://github.com/arthexis/arthexis")
+
+    activity = [json.loads(line) for line in state.config.activity_path.read_text(encoding="utf-8").splitlines()]
+    assert activity[-1]["event_type"] == "consent_accepted"
+    assert activity[-1]["ip_address"] == "10.42.0.25"
+
+
+def test_status_records_activity_and_exposes_monitoring_paths(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    payload = state.status_for_request(
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        path="/api/status",
+        host="arthexis.net",
+    )
+
+    assert payload["authorized"] is False
+    assert payload["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert "activity.jsonl" in payload["activity_recording"]["activity_log"]
+
+    activity = json.loads(state.config.activity_path.read_text(encoding="utf-8").splitlines()[0])
+    assert activity["event_type"] == "status_check"
+    assert activity["monitoring_notice"] == module.MONITORING_NOTICE
+
+
+def test_client_summary_combines_authorization_consent_and_activity(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+    state.record_request(
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        method="GET",
+        path="/",
+        host="arthexis.net",
+        referer="",
+    )
+
+    summary = state.activity.client_summary()
+
+    assert summary[0]["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert summary[0]["authorized"] is True
+    assert summary[0]["email"] == "guest@example.com"
+    assert summary[0]["event_count"] >= 1
+
+
+def test_firewall_ruleset_keeps_authorized_clients_and_redirects_unapproved_http():
+    module = load_portal_module()
+    ruleset = module.FirewallManager(interface="wlan0")._render_ruleset(["aa:bb:cc:dd:ee:ff"])
+
+    assert "table inet arthexis_ap_portal" in ruleset
+    assert "elements = { aa:bb:cc:dd:ee:ff }" in ruleset
+    assert "meta l4proto tcp redirect to :80" in ruleset
+    assert 'iifname "wlan0" drop' in ruleset

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -101,6 +101,43 @@ def test_subscribe_rejects_string_false_consent_without_authorizing(tmp_path):
     assert not state.config.consents_path.exists()
 
 
+def test_subscribe_does_not_persist_authorization_when_firewall_sync_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    config = module.PortalConfig(
+        bind=config.bind,
+        port=config.port,
+        assets_dir=config.assets_dir,
+        state_dir=config.state_dir,
+        authorized_macs_path=config.authorized_macs_path,
+        consents_path=config.consents_path,
+        activity_path=config.activity_path,
+        source_url=config.source_url,
+        sync_firewall=True,
+    )
+    state.config = config
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    def fail_sync(_macs):
+        raise module.FirewallSyncError("nft failed")
+
+    state._firewall.sync = fail_sync
+
+    with pytest.raises(module.FirewallSyncError, match="nft failed"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert not state.config.authorized_macs_path.exists()
+    assert not state.config.consents_path.exists()
+    assert "aa:bb:cc:dd:ee:ff" not in state._authorized
+
+
 def test_client_ip_prefers_nginx_real_ip_over_spoofed_forwarded_for():
     module = load_portal_module()
     headers = {
@@ -226,3 +263,11 @@ def test_read_limited_request_body_rejects_large_payload():
 
     with pytest.raises(ValueError, match="Payload too large"):
         module._read_limited_request_body(headers, io.BytesIO())
+
+
+def test_read_limited_request_body_rejects_negative_length_before_reading():
+    module = load_portal_module()
+    headers = {"Content-Length": "-1"}
+
+    with pytest.raises(ValueError, match="Invalid Content-Length"):
+        module._read_limited_request_body(headers, io.BytesIO(b"email=guest@example.com"))

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -373,6 +373,26 @@ def test_client_summary_combines_authorization_consent_and_activity(tmp_path):
     assert summary[0]["event_count"] >= 1
 
 
+def test_client_summary_does_not_treat_consent_history_as_authorization(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+    state.config.authorized_macs_path.write_text("", encoding="utf-8")
+
+    summary = state.activity.client_summary()
+
+    assert summary[0]["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert summary[0]["email"] == "guest@example.com"
+    assert summary[0]["authorized"] is False
+
+
 def test_firewall_ruleset_keeps_authorized_clients_and_redirects_unapproved_http():
     module = load_portal_module()
     ruleset = module.FirewallManager(interface="wlan0")._render_ruleset(["aa:bb:cc:dd:ee:ff"])

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -72,6 +72,52 @@ def test_subscribe_records_consent_activity_and_authorizes_client(tmp_path):
     assert activity[-1]["ip_address"] == "10.42.0.25"
 
 
+def test_accept_terms_requires_explicit_true():
+    module = load_portal_module()
+
+    assert module._accept_terms_is_explicit(True) is True
+    assert module._accept_terms_is_explicit(False) is False
+    assert module._accept_terms_is_explicit("true") is False
+    assert module._accept_terms_is_explicit("false") is False
+    assert module._accept_terms_is_explicit("0") is False
+    assert module._accept_terms_is_explicit(1) is False
+
+
+def test_subscribe_rejects_string_false_consent_without_authorizing(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    with pytest.raises(ValueError, match="accept the access terms"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=module._accept_terms_is_explicit("false"),
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert not state.config.authorized_macs_path.exists()
+    assert not state.config.consents_path.exists()
+
+
+def test_client_ip_prefers_nginx_real_ip_over_spoofed_forwarded_for():
+    module = load_portal_module()
+    headers = {
+        "X-Forwarded-For": "203.0.113.50, 198.51.100.10",
+        "X-Real-IP": "10.42.0.25",
+    }
+
+    assert module._client_ip_from_headers(headers, "127.0.0.1") == "10.42.0.25"
+
+
+def test_client_ip_uses_trusted_rightmost_forwarded_hop_without_real_ip():
+    module = load_portal_module()
+    headers = {"X-Forwarded-For": "203.0.113.50, 10.42.0.25"}
+
+    assert module._client_ip_from_headers(headers, "127.0.0.1") == "10.42.0.25"
+
+
 def test_status_records_activity_and_exposes_monitoring_paths(tmp_path):
     module = load_portal_module()
     state = module.PortalState(make_config(module, tmp_path))

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -232,6 +232,7 @@ def test_subscribe_rolls_back_new_authorization_when_activity_log_fails(tmp_path
 
     assert synced_macs == [{"aa:bb:cc:dd:ee:ff"}, set()]
     assert not state.config.authorized_macs_path.exists()
+    assert not state.config.consents_path.exists()
     assert "aa:bb:cc:dd:ee:ff" not in state._authorized
 
 

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -278,6 +278,35 @@ def test_subscribe_rolls_back_new_authorization_when_authorized_write_fails(tmp_
     assert "aa:bb:cc:dd:ee:ff" not in state._authorized
 
 
+def test_subscribe_rolls_back_existing_authorization_consent_when_activity_log_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+    original_consents = state.config.consents_path.read_text(encoding="utf-8")
+    state.activity.record = lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("activity log unavailable"))
+
+    with pytest.raises(OSError, match="activity log unavailable"):
+        state.subscribe(
+            email="retry@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert state.config.consents_path.read_text(encoding="utf-8") == original_consents
+    assert state.config.authorized_macs_path.read_text(encoding="utf-8") == "aa:bb:cc:dd:ee:ff\n"
+    assert "aa:bb:cc:dd:ee:ff" in state._authorized
+
+
 def test_client_ip_prefers_nginx_real_ip_over_spoofed_forwarded_for():
     module = load_portal_module()
     headers = {

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -236,6 +236,41 @@ def test_subscribe_rolls_back_new_authorization_when_activity_log_fails(tmp_path
     assert "aa:bb:cc:dd:ee:ff" not in state._authorized
 
 
+def test_subscribe_resyncs_firewall_when_file_rollback_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    config = module.PortalConfig(
+        bind=config.bind,
+        port=config.port,
+        assets_dir=config.assets_dir,
+        state_dir=config.state_dir,
+        authorized_macs_path=config.authorized_macs_path,
+        consents_path=config.consents_path,
+        activity_path=config.activity_path,
+        source_url=config.source_url,
+        sync_firewall=True,
+    )
+    state.config = config
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    synced_macs = []
+    state._firewall.sync = lambda macs: synced_macs.append(set(macs))
+    state.activity.record = lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("activity log unavailable"))
+    state._restore_consent_log = lambda _position: (_ for _ in ()).throw(OSError("consent rollback failed"))
+
+    with pytest.raises(OSError, match="consent rollback failed"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert synced_macs == [{"aa:bb:cc:dd:ee:ff"}, set()]
+    assert "aa:bb:cc:dd:ee:ff" not in state._authorized
+
+
 def test_subscribe_rolls_back_new_authorization_when_authorized_write_fails(tmp_path):
     module = load_portal_module()
     config = make_config(module, tmp_path)
@@ -343,6 +378,26 @@ def test_status_records_activity_and_exposes_monitoring_paths(tmp_path):
     activity = json.loads(state.config.activity_path.read_text(encoding="utf-8").splitlines()[0])
     assert activity["event_type"] == "status_check"
     assert activity["monitoring_notice"] == module.MONITORING_NOTICE
+
+
+def test_read_events_uses_bounded_tail_without_reading_whole_file(tmp_path, monkeypatch):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    lines = [
+        json.dumps({"event_type": "old"}),
+        json.dumps({"event_type": "middle"}),
+        json.dumps({"event_type": "new"}),
+    ]
+    state.config.activity_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def fail_read_text(*_args, **_kwargs):
+        raise AssertionError("read_events should not read the whole file")
+
+    monkeypatch.setattr(module.Path, "read_text", fail_read_text)
+
+    events = state.activity.read_events(limit=2)
+
+    assert [event["event_type"] for event in events] == ["middle", "new"]
 
 
 def test_client_summary_combines_authorization_consent_and_activity(tmp_path):

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -83,6 +83,29 @@ def test_accept_terms_requires_explicit_true():
     assert module._accept_terms_is_explicit(1) is False
 
 
+def test_form_accept_terms_only_accepts_html_checkbox_literal():
+    module = load_portal_module()
+
+    assert module._form_accept_terms_is_explicit("on") is True
+    assert module._form_accept_terms_is_explicit("true") is False
+    assert module._form_accept_terms_is_explicit("1") is False
+    assert module._form_accept_terms_is_explicit("yes") is False
+    assert module._form_accept_terms_is_explicit("") is False
+
+
+def test_form_payload_accepts_only_html_checkbox_literal():
+    module = load_portal_module()
+
+    assert module._parse_form_payload("email=guest%40example.com&accept_terms=on") == {
+        "email": "guest@example.com",
+        "accept_terms": True,
+    }
+    assert module._parse_form_payload("email=guest%40example.com&accept_terms=true") == {
+        "email": "guest@example.com",
+        "accept_terms": False,
+    }
+
+
 def test_subscribe_rejects_string_false_consent_without_authorizing(tmp_path):
     module = load_portal_module()
     state = module.PortalState(make_config(module, tmp_path))
@@ -212,6 +235,48 @@ def test_subscribe_rolls_back_new_authorization_when_activity_log_fails(tmp_path
     assert "aa:bb:cc:dd:ee:ff" not in state._authorized
 
 
+def test_subscribe_rolls_back_new_authorization_when_authorized_write_fails(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    state = module.PortalState(config)
+    config = module.PortalConfig(
+        bind=config.bind,
+        port=config.port,
+        assets_dir=config.assets_dir,
+        state_dir=config.state_dir,
+        authorized_macs_path=config.authorized_macs_path,
+        consents_path=config.consents_path,
+        activity_path=config.activity_path,
+        source_url=config.source_url,
+        sync_firewall=True,
+    )
+    state.config = config
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    synced_macs = []
+    state._firewall.sync = lambda macs: synced_macs.append(set(macs))
+
+    def fail_new_authorization_write(macs):
+        if "aa:bb:cc:dd:ee:ff" in macs:
+            raise OSError("authorized store unavailable")
+        module.PortalState._write_authorized_macs(state, macs)
+
+    state._write_authorized_macs = fail_new_authorization_write
+
+    with pytest.raises(OSError, match="authorized store unavailable"):
+        state.subscribe(
+            email="guest@example.com",
+            accept_terms=True,
+            ip_address="10.42.0.25",
+            user_agent="client-test",
+            host="arthexis.net",
+        )
+
+    assert synced_macs == [{"aa:bb:cc:dd:ee:ff"}, set()]
+    assert not state.config.consents_path.exists()
+    assert not state.config.activity_path.exists()
+    assert "aa:bb:cc:dd:ee:ff" not in state._authorized
+
+
 def test_client_ip_prefers_nginx_real_ip_over_spoofed_forwarded_for():
     module = load_portal_module()
     headers = {
@@ -307,6 +372,31 @@ def test_firewall_sync_replaces_existing_table_in_single_apply(monkeypatch):
     assert "elements = { aa:bb:cc:dd:ee:ff }" in ruleset
 
 
+def test_jsonl_append_uses_single_locked_write():
+    module = load_portal_module()
+    writes = []
+
+    class FakeHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def write(self, value):
+            writes.append(value)
+
+    class FakePath:
+        def open(self, *_args, **_kwargs):
+            return FakeHandle()
+
+    module._append_jsonl(FakePath(), {"event_type": "status_check"})
+
+    assert len(writes) == 1
+    assert writes[0].endswith("\n")
+    assert json.loads(writes[0])["event_type"] == "status_check"
+
+
 def test_resolve_mac_reads_proc_arp_without_subprocess(tmp_path, monkeypatch):
     module = load_portal_module()
     arp_table = tmp_path / "arp"
@@ -329,6 +419,31 @@ def test_resolve_mac_reads_proc_arp_without_subprocess(tmp_path, monkeypatch):
 
     assert state.resolve_mac("10.42.0.25") == "aa:bb:cc:dd:ee:ff"
     assert state.resolve_mac("10.42.0.26") is None
+
+
+def test_resolve_mac_reads_ipv6_neighbor_cache(tmp_path, monkeypatch):
+    module = load_portal_module()
+    arp_table = tmp_path / "arp"
+    arp_table.write_text(
+        "IP address       HW type     Flags       HW address            Mask     Device\n",
+        encoding="utf-8",
+    )
+    ndisc_cache = tmp_path / "ndisc_cache"
+    ndisc_cache.write_text(
+        "fd42:0000:0000:0042:0000:0000:0000:0025 dev wlan0 lladdr AA:BB:CC:DD:EE:FF router STALE\n",
+        encoding="utf-8",
+    )
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("resolve_mac should not spawn neighbor lookup subprocesses")
+
+    monkeypatch.setattr(module, "ARP_TABLE_PATH", arp_table)
+    monkeypatch.setattr(module, "NDISC_CACHE_PATH", ndisc_cache)
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+    state = module.PortalState(make_config(module, tmp_path))
+
+    assert state.resolve_mac("fd42:0:0:42::25") == "aa:bb:cc:dd:ee:ff"
+    assert state.resolve_mac("fd42:0:0:42::26") is None
 
 
 def test_read_limited_request_body_rejects_large_payload():


### PR DESCRIPTION
## Summary
- Adds a repo-native AP consent and monitoring portal that records gateway-visible client metadata, portal requests, consent submissions, and authorization state.
- Adds explicit captive-portal messaging that client activities ARE being monitored and links users to the source code for the implementation.
- Adds a local client activity reporting CLI, AP portal setup script, static portal assets, and targeted tests for monitoring notice, consent recording, summaries, and firewall rule rendering.

## Validation
- `python3 -m py_compile scripts/ap_portal_server.py scripts/ap_client_activity.py`
- `bash -n scripts/setup_ap_portal.sh`
- `.venv/bin/python -m pytest tests/test_ap_portal_server.py -q`
- `python3 scripts/ap_client_activity.py --state-dir /tmp/arthexis-ap-portal-empty --json`

## Notes
- This PR does not run the setup script or change the live AP. It only adds the harness for review and later installation.
- No issue was opened because this is routine enhancement work, not an incident or regression.

No linked issue.