### PR TITLE
[codex] Fix install health container runtime setup

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -26,15 +26,19 @@ jobs:
         include:
           - os_flavor: ubuntu
             container_image: ubuntu:24.04
+            python_cache_version: python3.12
             db_backend: sqlite
           - os_flavor: ubuntu
             container_image: ubuntu:24.04
+            python_cache_version: python3.12
             db_backend: postgres
           - os_flavor: debian
             container_image: debian:12
+            python_cache_version: python3.11
             db_backend: sqlite
           - os_flavor: debian
             container_image: debian:12
+            python_cache_version: python3.11
             db_backend: postgres
     permissions:
       contents: read
@@ -76,38 +80,46 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            ca-certificates curl git sudo python3 python3-venv
+            ca-certificates curl git sudo python3 python3-venv \
+            libcairo2 libgdk-pixbuf-2.0-0 libpango-1.0-0 \
+            libpangocairo-1.0-0 shared-mime-info
       - uses: actions/checkout@v6
         with:
           clean: true
       - uses: actions/setup-python@v6
         id: setup-python
+        if: matrix.os_flavor == 'ubuntu'
         with:
           python-version: '3.12'
-      - name: Align python executables with setup-python
+      - name: Select Python runtime
         run: |
-          python_bin='${{ steps.setup-python.outputs.python-path }}'
+          if [ '${{ matrix.os_flavor }}' = 'ubuntu' ]; then
+            python_bin='${{ steps.setup-python.outputs.python-path }}'
+          else
+            python_bin="$(command -v python3)"
+          fi
           echo "ARTHEXIS_PYTHON_BIN=${python_bin}" >> "${GITHUB_ENV}"
           echo "$(dirname "${python_bin}")" >> "${GITHUB_PATH}"
           "${python_bin}" --version
-          python --version
+          if command -v python >/dev/null 2>&1; then
+            python --version
+          fi
           python3 --version
       - name: Cache pip
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
+          key: pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.python_cache_version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
           restore-keys: |
-            pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-
             pip-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-
             pip-${{ runner.os }}-${{ matrix.os_flavor }}-
       - name: Cache virtualenv
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
+          key: venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.python_cache_version }}-${{ hashFiles('requirements*.txt', 'pyproject.toml', 'install.sh') }}
           restore-keys: |
-            venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ steps.setup-python.outputs.python-version }}-
+            venv-${{ runner.os }}-${{ matrix.os_flavor }}-${{ matrix.db_backend }}-${{ matrix.python_cache_version }}-
       - name: Validate pyproject dependency ordering
         run: |
           "${ARTHEXIS_PYTHON_BIN}" "$GITHUB_WORKSPACE/scripts/sort_pyproject_deps.py" --check


### PR DESCRIPTION
## Summary

Fixes #7394

This updates the install health workflow so the Debian 12 matrix no longer tries to run the hosted `actions/setup-python` CPython inside the Debian container. Ubuntu continues to use setup-python 3.12, while Debian now selects the distro `python3` already installed by apt, avoiding the CPython 3.12.13 `GLIBC_2.38` mismatch on Debian bookworm.

The base system dependency install also now includes the native Cairo/Pango/GDK-Pixbuf/GLib runtime chain needed before the install/env-refresh path imports WeasyPrint through reports. This addresses the Ubuntu failure where `libgobject-2.0-0` could not be loaded.

## Verification

All verification was run inside Docker/container workspaces, not the live local instance:

- Parsed `.github/workflows/install-hourly.yml` with Python/YAML and asserted the expected setup-python condition, distro Python fallback, cache keys, and WeasyPrint runtime packages.
- `python3 scripts/sort_pyproject_deps.py --check`
- `python3 scripts/generate_requirements.py --check`
- `git diff --check`
- Debian 12 container apt probe installed the exact workflow package set and verified `python3`, `libglib2.0-0`, `libpangocairo-1.0-0`, and `libcairo2` are present.
- Ubuntu 24.04 container apt probe installed the exact workflow package set and verified `python3`, `libglib2.0-0t64`, `libpangocairo-1.0-0`, and `libcairo2` are present.

I did not run the full GitHub Actions workflow locally because this workflow depends on GitHub Actions services/actions behavior (`actions/setup-python`, `actions/cache`, hosted service containers, and scheduled workflow issue automation) that is not faithfully runnable inside the local Docker container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes failures in the install health check workflow on Debian 12 (Bookworm) and resolves WeasyPrint runtime import failures by addressing a GLIBC version mismatch and missing system dependencies.

## Changes

**Workflow**: `.github/workflows/install-hourly.yml`

- **Python version selection**: `actions/setup-python@v6` now runs only on Ubuntu targets. Debian jobs use the distro-installed `python3` from apt instead, preventing the GLIBC_2.38 mismatch that occurred when using the hosted CPython inside the Debian container.

- **Caching strategy**: The matrix now specifies an explicit `python_cache_version` per OS/container target. Caching logic for both pip and the `.venv` virtual environment is keyed using this per-target version rather than the `setup-python` output.

- **Python executable selection**: The script that selects `ARTHEXIS_PYTHON_BIN` is updated to use the setup-python python path on Ubuntu but fall back to the system `python3` on Debian.

- **Version output**: Added conditional check to only run `python --version` when a `python` executable is present.

- **System dependencies**: Extended the base apt installation with native runtime packages required by WeasyPrint (Cairo, Pango, GDK-Pixbuf, GLib) and related GTK/shared-mime libraries, ensuring these dependencies are available for the import and install/env-refresh paths.

## Verification

Verification was performed in Docker/container workspaces and included:
- Validation of workflow matrix conditions for setup-python usage by OS
- Confirmation that Debian jobs use system Python and Ubuntu continues with setup-python 3.12
- Verification of cache key structure and WeasyPrint runtime packages in Debian 12 and Ubuntu 24.04 containers
- Dependency scripts validated with `--check` flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->