### PR TITLE
[codex] Prototype image gallery controls

### DIFF
--- a/apps/gallery/templates/gallery/detail.html
+++ b/apps/gallery/templates/gallery/detail.html
@@ -51,7 +51,7 @@
             <dd class="col-sm-8">{{ image.owner_group.name }}</dd>
           {% endif %}
         {% endif %}
-        {% if image.content_sample %}
+        {% if can_view_metadata and image.content_sample %}
           <dt class="col-sm-4">{% trans "Content sample" %}</dt>
           <dd class="col-sm-8 text-break">{{ image.content_sample.name }}</dd>
         {% endif %}

--- a/apps/gallery/templates/gallery/detail.html
+++ b/apps/gallery/templates/gallery/detail.html
@@ -42,12 +42,14 @@
         <dd class="col-sm-8">
           {% if image.include_in_public_gallery %}{% trans "Public" %}{% else %}{% trans "Private" %}{% endif %}
         </dd>
-        {% if image.owner_user %}
-          <dt class="col-sm-4">{% trans "Owner" %}</dt>
-          <dd class="col-sm-8">{{ image.owner_user.get_username }}</dd>
-        {% elif image.owner_group %}
-          <dt class="col-sm-4">{% trans "Owner group" %}</dt>
-          <dd class="col-sm-8">{{ image.owner_group.name }}</dd>
+        {% if can_view_metadata %}
+          {% if image.owner_user %}
+            <dt class="col-sm-4">{% trans "Owner" %}</dt>
+            <dd class="col-sm-8">{{ image.owner_user.get_username }}</dd>
+          {% elif image.owner_group %}
+            <dt class="col-sm-4">{% trans "Owner group" %}</dt>
+            <dd class="col-sm-8">{{ image.owner_group.name }}</dd>
+          {% endif %}
         {% endif %}
         {% if image.content_sample %}
           <dt class="col-sm-4">{% trans "Content sample" %}</dt>

--- a/apps/gallery/templates/gallery/detail.html
+++ b/apps/gallery/templates/gallery/detail.html
@@ -4,44 +4,95 @@
 {% block title %}{{ image.title }}{% endblock %}
 
 {% block content %}
-<div class="container py-5">
-  <h1 class="h3">{{ image.title }}</h1>
-  <img src="{{ image.media_file.file.url }}" alt="{{ image.title }}" class="img-fluid rounded mb-3">
-  {% if image.description %}<p>{{ image.description }}</p>{% endif %}
-
-  <h2 class="h5 mt-4">{% trans "Credits" %}</h2>
-  {% for credit in image.credits.all %}
-    <div class="mb-2">
-      <strong>{{ credit.display_name }}</strong>
-      {% if credit.artist %} · {% trans "Artist" %}: {{ credit.artist }}{% endif %}
-      {% if credit.series %} · {% trans "Series" %}: {{ credit.series }}{% endif %}
-      {% if credit.era %} · {% trans "Era" %}: {{ credit.era }}{% endif %}
-      {% if credit.link_url %} · <a href="{{ credit.link_url }}" target="_blank" rel="noreferrer noopener">{{ credit.link_url }}</a>{% endif %}
-      {% if credit.apa_citation %}<div class="text-muted small">{{ credit.apa_citation }}</div>{% endif %}
-      {% if credit.contributed_elements %}<div class="small">{% trans "Contributed" %}: {{ credit.contributed_elements }}</div>{% endif %}
-      {% if credit.excluded_elements %}<div class="small">{% trans "Not contributed" %}: {{ credit.excluded_elements }}</div>{% endif %}
+<div
+  class="container py-5"
+  data-feedback-context="Image ID: {{ image.id }} | Image UUID: {{ image.slug }} | Image title: {{ image.title }}"
+>
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <h1 class="h3 mb-0">{{ image.title }}</h1>
+    <div class="d-flex flex-wrap gap-2">
+      <a class="btn btn-sm btn-outline-secondary" href="{% url 'gallery:index' %}{% if search_query %}?q={{ search_query|urlencode }}{% endif %}">{% trans "Back to gallery" %}</a>
+      {% if previous_image %}
+        <a class="btn btn-sm btn-outline-primary" href="{% url 'gallery:detail' slug=previous_image.slug %}{{ gallery_query_string }}">{% trans "Previous" %}</a>
+      {% else %}
+        <button class="btn btn-sm btn-outline-secondary" type="button" disabled>{% trans "Previous" %}</button>
+      {% endif %}
+      {% if next_image %}
+        <a class="btn btn-sm btn-outline-primary" href="{% url 'gallery:detail' slug=next_image.slug %}{{ gallery_query_string }}">{% trans "Next" %}</a>
+      {% else %}
+        <button class="btn btn-sm btn-outline-secondary" type="button" disabled>{% trans "Next" %}</button>
+      {% endif %}
+      {% if rf_card_store_url %}
+        <a class="btn btn-sm btn-primary" href="{{ rf_card_store_url }}">{% trans "Use for RF Card" %}</a>
+      {% endif %}
     </div>
-  {% empty %}
-    <p class="text-muted">{% trans "No credits recorded." %}</p>
-  {% endfor %}
+  </div>
 
-  {% if can_view_metadata %}
-  <h2 class="h5 mt-4">{% trans "Metadata" %}</h2>
-  <ul>
-    {% for category in image.categories.all %}<li>{{ category.name }}</li>{% empty %}<li>{% trans "No categories" %}</li>{% endfor %}
-  </ul>
-  <ul>
-    {% for value in image.trait_values.all %}
-      <li>
-        {% if value.category %}{{ value.category.name }} / {% endif %}{{ value.trait.name }}
-        {% if value.qualitative_value %} = {{ value.qualitative_value }}{% endif %}
-        ({{ value.float_value }})
-      </li>
-    {% empty %}
-      <li>{% trans "No traits" %}</li>
-    {% endfor %}
-  </ul>
-  {% endif %}
+  <div class="row g-4 align-items-start">
+    <div class="col-lg-5">
+      {% if image.description %}<p>{{ image.description }}</p>{% endif %}
+      <dl class="row small">
+        <dt class="col-sm-4">{% trans "Image ID" %}</dt>
+        <dd class="col-sm-8">{{ image.id }}</dd>
+        <dt class="col-sm-4">{% trans "UUID" %}</dt>
+        <dd class="col-sm-8 text-break">{{ image.slug }}</dd>
+        <dt class="col-sm-4">{% trans "File" %}</dt>
+        <dd class="col-sm-8 text-break">{{ image.media_file.original_name|default:image.media_file.file.name }}</dd>
+        <dt class="col-sm-4">{% trans "Visibility" %}</dt>
+        <dd class="col-sm-8">
+          {% if image.include_in_public_gallery %}{% trans "Public" %}{% else %}{% trans "Private" %}{% endif %}
+        </dd>
+        {% if image.owner_user %}
+          <dt class="col-sm-4">{% trans "Owner" %}</dt>
+          <dd class="col-sm-8">{{ image.owner_user.get_username }}</dd>
+        {% elif image.owner_group %}
+          <dt class="col-sm-4">{% trans "Owner group" %}</dt>
+          <dd class="col-sm-8">{{ image.owner_group.name }}</dd>
+        {% endif %}
+        {% if image.content_sample %}
+          <dt class="col-sm-4">{% trans "Content sample" %}</dt>
+          <dd class="col-sm-8 text-break">{{ image.content_sample.name }}</dd>
+        {% endif %}
+      </dl>
+
+      <h2 class="h5 mt-4">{% trans "Credits" %}</h2>
+      {% for credit in image.credits.all %}
+        <div class="mb-2">
+          <strong>{{ credit.display_name }}</strong>
+          {% if credit.artist %} · {% trans "Artist" %}: {{ credit.artist }}{% endif %}
+          {% if credit.series %} · {% trans "Series" %}: {{ credit.series }}{% endif %}
+          {% if credit.era %} · {% trans "Era" %}: {{ credit.era }}{% endif %}
+          {% if credit.link_url %} · <a href="{{ credit.link_url }}" target="_blank" rel="noreferrer noopener">{{ credit.link_url }}</a>{% endif %}
+          {% if credit.apa_citation %}<div class="text-muted small">{{ credit.apa_citation }}</div>{% endif %}
+          {% if credit.contributed_elements %}<div class="small">{% trans "Contributed" %}: {{ credit.contributed_elements }}</div>{% endif %}
+          {% if credit.excluded_elements %}<div class="small">{% trans "Not contributed" %}: {{ credit.excluded_elements }}</div>{% endif %}
+        </div>
+      {% empty %}
+        <p class="text-muted">{% trans "No credits recorded." %}</p>
+      {% endfor %}
+
+      {% if can_view_metadata %}
+      <h2 class="h5 mt-4">{% trans "Metadata" %}</h2>
+      <ul>
+        {% for category in image.categories.all %}<li>{{ category.name }}</li>{% empty %}<li>{% trans "No categories" %}</li>{% endfor %}
+      </ul>
+      <ul>
+        {% for value in image.trait_values.all %}
+          <li>
+            {% if value.category %}{{ value.category.name }} / {% endif %}{{ value.trait.name }}
+            {% if value.qualitative_value %} = {{ value.qualitative_value }}{% endif %}
+            ({{ value.float_value }})
+          </li>
+        {% empty %}
+          <li>{% trans "No traits" %}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    <div class="col-lg-7">
+      <img src="{{ image.media_file.file.url }}" alt="{{ image.title }}" class="img-fluid rounded mb-3">
+    </div>
+  </div>
 
   {% if can_share %}
     <hr>

--- a/apps/gallery/templates/gallery/index.html
+++ b/apps/gallery/templates/gallery/index.html
@@ -14,6 +14,23 @@
       </div>
     {% endif %}
   </div>
+  <form class="mb-4" method="get" role="search">
+    <label class="form-label" for="gallery-search">{% trans "Search image fields" %}</label>
+    <div class="input-group">
+      <input
+        id="gallery-search"
+        class="form-control"
+        type="search"
+        name="q"
+        value="{{ search_query }}"
+        placeholder="{% trans 'Search by title, ID, owner, category, trait, credit, filename, or content sample' %}"
+      >
+      <button class="btn btn-outline-primary" type="submit">{% trans "Search" %}</button>
+      {% if search_query %}
+        <a class="btn btn-outline-secondary" href="{% url 'gallery:index' %}">{% trans "Clear" %}</a>
+      {% endif %}
+    </div>
+  </form>
   <div class="row g-4">
     {% for image in images %}
       <div class="col-md-6 col-lg-4">
@@ -24,12 +41,20 @@
             {% if image.description %}
               <p class="text-muted">{{ image.description|truncatechars:120 }}</p>
             {% endif %}
-            <a class="btn btn-sm btn-outline-primary" href="{% url 'gallery:detail' slug=image.slug %}">{% trans "Open" %}</a>
+            <a class="btn btn-sm btn-outline-primary" href="{% url 'gallery:detail' slug=image.slug %}{% if search_query %}?q={{ search_query|urlencode }}{% endif %}">{% trans "Open" %}</a>
           </div>
         </div>
       </div>
     {% empty %}
-      <div class="col-12"><div class="alert alert-info">{% trans "No images yet." %}</div></div>
+      <div class="col-12">
+        <div class="alert alert-info">
+          {% if search_query %}
+            {% trans "No images matched your search." %}
+          {% else %}
+            {% trans "No images yet." %}
+          {% endif %}
+        </div>
+      </div>
     {% endfor %}
   </div>
 </div>

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -13,7 +13,13 @@ from apps.media.models import MediaFile
 from apps.shop.models import Shop, ShopProduct
 
 from ..constants import GALLERY_MANAGER_GROUP_NAME
-from ..models import GalleryCategory, GalleryImage, GalleryImageTrait, GalleryTrait
+from ..models import (
+    GalleryCategory,
+    GalleryCredit,
+    GalleryImage,
+    GalleryImageTrait,
+    GalleryTrait,
+)
 from ..services import create_gallery_image
 from ..views import _apply_gallery_search
 
@@ -117,6 +123,54 @@ class GalleryIndexTests(TestCase):
         self.assertNotContains(response, "Forest")
         self.assertEqual(list(response.context["images"]), [visible])
         self.assertNotIn(hidden, list(response.context["images"]))
+
+    def test_index_search_combines_direct_and_multivalued_matches_by_pk(self):
+        direct_match = create_gallery_image(
+            uploaded_file=self._upload("direct.jpg"),
+            title="Citrine Skyline",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        related_match = create_gallery_image(
+            uploaded_file=self._upload("related.jpg"),
+            title="Related Match",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        hidden = create_gallery_image(
+            uploaded_file=self._upload("hidden.jpg"),
+            title="Forest",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        category = GalleryCategory.objects.create(name="Palette", slug="palette")
+        trait = GalleryTrait.objects.create(name="Mood", slug="mood")
+        GalleryImageTrait.objects.create(
+            image=related_match,
+            category=category,
+            trait=trait,
+            qualitative_value="citrine",
+        )
+        GalleryCredit.objects.create(
+            image=related_match,
+            display_name="Citrine Archive",
+        )
+
+        matches = list(_apply_gallery_search(GalleryImage.objects.all(), "citrine").order_by("title"))
+
+        self.assertEqual(matches, [direct_match, related_match])
+        self.assertNotIn(hidden, matches)
+
+    def test_index_search_keeps_multivalued_joins_inside_pk_subqueries(self):
+        queryset = _apply_gallery_search(GalleryImage.objects.all(), "citrine")
+
+        sql = str(queryset.query)
+        outer_select = sql.split(" WHERE ", 1)[0]
+
+        self.assertIn(" IN (SELECT ", sql)
+        self.assertNotIn("apps_gallery_galleryimage_categories", outer_select)
+        self.assertNotIn("apps_gallery_gallerycredit", outer_select)
+        self.assertNotIn("apps_gallery_galleryimagetrait", outer_select)
 
     def test_index_search_matches_exact_ids_without_partial_numeric_matches(self):
         visible = create_gallery_image(

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -489,3 +489,23 @@ class GalleryImageSharingTests(TestCase):
         )
         self.assertEqual(response.status_code, 403)
         self.assertFalse(self.image.shared_with_users.filter(pk=self.other.pk).exists())
+
+    def test_shared_user_detail_hides_owner_metadata(self):
+        self.image.shared_with_users.add(self.recipient)
+        self.client.force_login(self.recipient)
+
+        response = self.client.get(f"/gallery/images/{self.image.slug}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Shared")
+        self.assertNotContains(response, "Owner")
+        self.assertNotContains(response, self.owner.username)
+
+    def test_owner_detail_shows_owner_metadata(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.get(f"/gallery/images/{self.image.slug}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Owner")
+        self.assertContains(response, self.owner.username)

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -10,6 +10,7 @@ from PIL import Image
 from apps.content.models import ContentSample
 from apps.groups.models import SecurityGroup
 from apps.media.models import MediaFile
+from apps.shop.models import Shop, ShopProduct
 
 from ..constants import GALLERY_MANAGER_GROUP_NAME
 from ..models import GalleryCategory, GalleryImage, GalleryImageTrait, GalleryTrait
@@ -74,6 +75,87 @@ class GalleryVisibilityTests(TestCase):
                 )
         self.assertEqual(MediaFile.objects.count(), before_count)
         self.assertFalse(GalleryImage.objects.filter(title="Cleanup").exists())
+
+
+class GalleryIndexTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="gallery-search-owner", password="pw")
+
+    def _upload(self, name="gallery.jpg"):
+        buffer = BytesIO()
+        Image.new("RGB", (10, 10), "yellow").save(buffer, format="JPEG")
+        return SimpleUploadedFile(name, buffer.getvalue(), content_type="image/jpeg")
+
+    def test_index_search_matches_image_fields_and_related_traits(self):
+        visible = create_gallery_image(
+            uploaded_file=self._upload("searchable.jpg"),
+            title="Sunlit Plaza",
+            description="Warm stone plaza",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        hidden = create_gallery_image(
+            uploaded_file=self._upload("hidden.jpg"),
+            title="Forest",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        category = GalleryCategory.objects.create(name="Palette", slug="palette")
+        trait = GalleryTrait.objects.create(name="Mood", slug="mood")
+        GalleryImageTrait.objects.create(
+            image=visible,
+            category=category,
+            trait=trait,
+            qualitative_value="citrine",
+        )
+
+        response = self.client.get("/gallery/", {"q": "citrine"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Sunlit Plaza")
+        self.assertNotContains(response, "Forest")
+        self.assertEqual(list(response.context["images"]), [visible])
+        self.assertNotIn(hidden, list(response.context["images"]))
+
+    def test_detail_layout_includes_navigation_feedback_context_and_store_link(self):
+        first = create_gallery_image(
+            uploaded_file=self._upload("first.jpg"),
+            title="Alpha",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        current = create_gallery_image(
+            uploaded_file=self._upload("current.jpg"),
+            title="Beacon",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        last = create_gallery_image(
+            uploaded_file=self._upload("last.jpg"),
+            title="Coda",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        shop = Shop.objects.create(name="RF Store", slug="rf-store")
+        ShopProduct.objects.create(
+            shop=shop,
+            name="RF Card",
+            sku="RF-1",
+            unit_price="10.00",
+            stock_quantity=5,
+            supports_gallery_image_printing=True,
+        )
+
+        response = self.client.get(f"/gallery/images/{current.slug}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Image ID")
+        self.assertContains(response, f"data-feedback-context=\"Image ID: {current.id}")
+        self.assertContains(response, f"/gallery/images/{first.slug}/")
+        self.assertContains(response, f"/gallery/images/{last.slug}/")
+        self.assertContains(response, "Use for RF Card")
+        self.assertContains(response, f"/shop/?gallery_image={current.id}")
+
 
 class GalleryManagementPermissionTests(TestCase):
     def setUp(self):

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -305,6 +305,33 @@ class GalleryIndexTests(TestCase):
         self.assertEqual(matches, [visible])
         self.assertNotIn(other, matches)
 
+    def test_index_search_common_boolean_words_do_not_toggle_visibility(self):
+        title_match = create_gallery_image(
+            uploaded_file=self._upload("yes-title.jpg"),
+            title="Yes Title Match",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        public_other = create_gallery_image(
+            uploaded_file=self._upload("public-other.jpg"),
+            title="Public Other",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        private_other = create_gallery_image(
+            uploaded_file=self._upload("private-other.jpg"),
+            title="Private Other",
+            owner_user=self.user,
+        )
+
+        self.assertEqual(list(_apply_gallery_search(GalleryImage.objects.all(), "yes")), [title_match])
+        for query in ["no", "true", "false"]:
+            with self.subTest(query=query):
+                matches = list(_apply_gallery_search(GalleryImage.objects.all(), query))
+                self.assertNotIn(public_other, matches)
+                self.assertNotIn(private_other, matches)
+                self.assertEqual(matches, [])
+
     def test_detail_layout_includes_navigation_feedback_context_and_store_link(self):
         first = create_gallery_image(
             uploaded_file=self._upload("first.jpg"),

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -115,6 +115,7 @@ class GalleryIndexTests(TestCase):
             trait=trait,
             qualitative_value="citrine",
         )
+        self.client.force_login(self.user)
 
         response = self.client.get("/gallery/", {"q": "citrine"})
 
@@ -160,6 +161,100 @@ class GalleryIndexTests(TestCase):
 
         self.assertEqual(matches, [direct_match, related_match])
         self.assertNotIn(hidden, matches)
+
+    def test_shared_user_search_does_not_match_hidden_metadata_fields(self):
+        owner = get_user_model().objects.create_user(
+            username="metadata-owner",
+            email="metadata-owner@example.com",
+            first_name="Hidden",
+            last_name="Owner",
+            password="pw",
+        )
+        recipient = get_user_model().objects.create_user(username="metadata-recipient", password="pw")
+        image = create_gallery_image(
+            uploaded_file=self._upload("shared-metadata.jpg"),
+            title="Shared Plain Title",
+            owner_user=owner,
+            create_content_sample=True,
+        )
+        image.shared_with_users.add(recipient)
+        image.content_sample.content = "internal citrine sample"
+        image.content_sample.path = "private/citrine/path"
+        image.content_sample.save()
+        category = GalleryCategory.objects.create(name="Citrine Category", slug="citrine-category")
+        trait = GalleryTrait.objects.create(name="Citrine Trait", slug="citrine-trait")
+        image.categories.add(category)
+        GalleryImageTrait.objects.create(
+            image=image,
+            category=category,
+            trait=trait,
+            qualitative_value="citrine-secret",
+        )
+        GalleryCredit.objects.create(
+            image=image,
+            display_name="Citrine Credit",
+            artist="Citrine Artist",
+        )
+        self.client.force_login(recipient)
+
+        for query in [
+            "metadata-owner",
+            "Citrine Category",
+            "citrine-secret",
+            "Citrine Credit",
+            "internal citrine sample",
+        ]:
+            with self.subTest(query=query):
+                response = self.client.get("/gallery/", {"q": query})
+                self.assertEqual(response.status_code, 200)
+                self.assertNotContains(response, "Shared Plain Title")
+                self.assertEqual(list(response.context["images"]), [])
+
+        response = self.client.get("/gallery/", {"q": "Shared Plain Title"})
+        self.assertContains(response, "Shared Plain Title")
+
+    def test_public_viewer_search_does_not_match_hidden_metadata_fields(self):
+        image = create_gallery_image(
+            uploaded_file=self._upload("public-metadata.jpg"),
+            title="Public Plain Title",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+            create_content_sample=True,
+        )
+        image.content_sample.content = "public hidden citrine sample"
+        image.content_sample.save()
+        category = GalleryCategory.objects.create(name="Public Citrine", slug="public-citrine")
+        image.categories.add(category)
+        GalleryCredit.objects.create(
+            image=image,
+            display_name="Public Citrine Credit",
+        )
+
+        for query in ["gallery-search-owner", "Public Citrine", "Public Citrine Credit", "public hidden citrine"]:
+            with self.subTest(query=query):
+                response = self.client.get("/gallery/", {"q": query})
+                self.assertEqual(response.status_code, 200)
+                self.assertNotContains(response, "Public Plain Title")
+                self.assertEqual(list(response.context["images"]), [])
+
+        response = self.client.get("/gallery/", {"q": "Public Plain Title"})
+        self.assertContains(response, "Public Plain Title")
+
+    def test_owner_search_matches_metadata_fields_for_own_image(self):
+        image = create_gallery_image(
+            uploaded_file=self._upload("owner-metadata.jpg"),
+            title="Owner Metadata Image",
+            owner_user=self.user,
+        )
+        category = GalleryCategory.objects.create(name="Owner Citrine", slug="owner-citrine")
+        image.categories.add(category)
+        self.client.force_login(self.user)
+
+        response = self.client.get("/gallery/", {"q": "Owner Citrine"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Owner Metadata Image")
+        self.assertEqual(list(response.context["images"]), [image])
 
     def test_index_search_keeps_multivalued_joins_inside_pk_subqueries(self):
         queryset = _apply_gallery_search(GalleryImage.objects.all(), "citrine")
@@ -461,6 +556,7 @@ class GalleryImageSharingTests(TestCase):
             uploaded_file=self._upload("shared.jpg"),
             title="Shared",
             owner_user=self.owner,
+            create_content_sample=True,
         )
 
     def _upload(self, name="share.jpg"):
@@ -500,6 +596,8 @@ class GalleryImageSharingTests(TestCase):
         self.assertContains(response, "Shared")
         self.assertNotContains(response, "Owner")
         self.assertNotContains(response, self.owner.username)
+        self.assertNotContains(response, "Content sample")
+        self.assertNotContains(response, str(self.image.content_sample.name))
 
     def test_owner_detail_shows_owner_metadata(self):
         self.client.force_login(self.owner)
@@ -509,3 +607,5 @@ class GalleryImageSharingTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Owner")
         self.assertContains(response, self.owner.username)
+        self.assertContains(response, "Content sample")
+        self.assertContains(response, str(self.image.content_sample.name))

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -15,6 +15,7 @@ from apps.shop.models import Shop, ShopProduct
 from ..constants import GALLERY_MANAGER_GROUP_NAME
 from ..models import GalleryCategory, GalleryImage, GalleryImageTrait, GalleryTrait
 from ..services import create_gallery_image
+from ..views import _apply_gallery_search
 
 
 class GalleryVisibilityTests(TestCase):
@@ -117,6 +118,44 @@ class GalleryIndexTests(TestCase):
         self.assertEqual(list(response.context["images"]), [visible])
         self.assertNotIn(hidden, list(response.context["images"]))
 
+    def test_index_search_matches_exact_ids_without_partial_numeric_matches(self):
+        visible = create_gallery_image(
+            uploaded_file=self._upload("id-match.jpg"),
+            title="Numeric Match",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        other = create_gallery_image(
+            uploaded_file=self._upload("id-other.jpg"),
+            title="Numeric Other",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+
+        matches = list(_apply_gallery_search(GalleryImage.objects.all(), str(visible.id)))
+
+        self.assertIn(visible, matches)
+        self.assertNotIn(other, matches)
+
+    def test_index_search_matches_exact_gallery_slug(self):
+        visible = create_gallery_image(
+            uploaded_file=self._upload("slug-match.jpg"),
+            title="Slug Match",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        other = create_gallery_image(
+            uploaded_file=self._upload("slug-other.jpg"),
+            title="Slug Other",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+
+        matches = list(_apply_gallery_search(GalleryImage.objects.all(), str(visible.slug)))
+
+        self.assertEqual(matches, [visible])
+        self.assertNotIn(other, matches)
+
     def test_detail_layout_includes_navigation_feedback_context_and_store_link(self):
         first = create_gallery_image(
             uploaded_file=self._upload("first.jpg"),
@@ -126,6 +165,12 @@ class GalleryIndexTests(TestCase):
         )
         current = create_gallery_image(
             uploaded_file=self._upload("current.jpg"),
+            title="Beacon",
+            owner_user=self.user,
+            include_in_public_gallery=True,
+        )
+        same_title_next = create_gallery_image(
+            uploaded_file=self._upload("same-title-next.jpg"),
             title="Beacon",
             owner_user=self.user,
             include_in_public_gallery=True,
@@ -152,7 +197,8 @@ class GalleryIndexTests(TestCase):
         self.assertContains(response, "Image ID")
         self.assertContains(response, f"data-feedback-context=\"Image ID: {current.id}")
         self.assertContains(response, f"/gallery/images/{first.slug}/")
-        self.assertContains(response, f"/gallery/images/{last.slug}/")
+        self.assertContains(response, f"/gallery/images/{same_title_next.slug}/")
+        self.assertNotContains(response, f"/gallery/images/{last.slug}/")
         self.assertContains(response, "Use for RF Card")
         self.assertContains(response, f"/shop/?gallery_image={current.id}")
 

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import urlencode
 from uuid import uuid4
 
 from django.contrib import messages
@@ -7,9 +8,11 @@ from django.contrib.auth.decorators import login_required
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
-from django.db.models import Q
+from django.db.models import CharField, Q
+from django.db.models.functions import Cast
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from .forms import (
     GalleryCategoryForm,
@@ -61,7 +64,7 @@ def _visible_images_for_user(user):
         "media_file",
         "owner_user",
         "owner_group",
-    )
+    ).prefetch_related("categories", "credits", "trait_values__category", "trait_values__trait")
     if can_manage_gallery(user):
         return queryset
     visibility_filter = Q(include_in_public_gallery=True)
@@ -72,9 +75,106 @@ def _visible_images_for_user(user):
     return queryset.filter(visibility_filter).distinct()
 
 
+def _apply_gallery_search(queryset, search_query: str):
+    search_query = search_query.strip()
+    if not search_query:
+        return queryset
+
+    queryset = queryset.annotate(
+        search_id=Cast("id", output_field=CharField()),
+        search_slug=Cast("slug", output_field=CharField()),
+        search_content_sample_name=Cast("content_sample__name", output_field=CharField()),
+    )
+    filter_q = (
+        Q(search_id__icontains=search_query)
+        | Q(search_slug__icontains=search_query)
+        | Q(title__icontains=search_query)
+        | Q(description__icontains=search_query)
+        | Q(owner_user__username__icontains=search_query)
+        | Q(owner_user__email__icontains=search_query)
+        | Q(owner_user__first_name__icontains=search_query)
+        | Q(owner_user__last_name__icontains=search_query)
+        | Q(owner_group__name__icontains=search_query)
+        | Q(media_file__original_name__icontains=search_query)
+        | Q(media_file__content_type__icontains=search_query)
+        | Q(media_file__source_member__icontains=search_query)
+        | Q(media_file__file__icontains=search_query)
+        | Q(content_sample__kind__icontains=search_query)
+        | Q(content_sample__content__icontains=search_query)
+        | Q(content_sample__path__icontains=search_query)
+        | Q(content_sample__method__icontains=search_query)
+        | Q(content_sample__hash__icontains=search_query)
+        | Q(search_content_sample_name__icontains=search_query)
+        | Q(categories__name__icontains=search_query)
+        | Q(categories__slug__icontains=search_query)
+        | Q(categories__description__icontains=search_query)
+        | Q(credits__display_name__icontains=search_query)
+        | Q(credits__artist__icontains=search_query)
+        | Q(credits__series__icontains=search_query)
+        | Q(credits__era__icontains=search_query)
+        | Q(credits__apa_citation__icontains=search_query)
+        | Q(credits__contributed_elements__icontains=search_query)
+        | Q(credits__excluded_elements__icontains=search_query)
+        | Q(credits__link_url__icontains=search_query)
+        | Q(trait_values__category__name__icontains=search_query)
+        | Q(trait_values__category__slug__icontains=search_query)
+        | Q(trait_values__trait__name__icontains=search_query)
+        | Q(trait_values__trait__slug__icontains=search_query)
+        | Q(trait_values__trait__description__icontains=search_query)
+        | Q(trait_values__qualitative_value__icontains=search_query)
+    )
+    normalized_query = search_query.casefold()
+    if normalized_query in {"public", "published", "true", "yes"}:
+        filter_q |= Q(include_in_public_gallery=True)
+    if normalized_query in {"private", "false", "no"}:
+        filter_q |= Q(include_in_public_gallery=False)
+    try:
+        filter_q |= Q(trait_values__float_value=float(search_query))
+    except ValueError:
+        pass
+    return queryset.filter(filter_q).distinct()
+
+
+def _gallery_navigation_for_image(*, image: GalleryImage, user, search_query: str):
+    queryset = _visible_images_for_user(user)
+    if search_query:
+        filtered_queryset = _apply_gallery_search(queryset, search_query)
+        if filtered_queryset.filter(pk=image.pk).exists():
+            queryset = filtered_queryset
+    images = list(queryset.order_by("title", "id"))
+    current_index = next((index for index, candidate in enumerate(images) if candidate.pk == image.pk), None)
+    if current_index is None:
+        return None, None
+    previous_image = images[current_index - 1] if current_index > 0 else None
+    next_image = images[current_index + 1] if current_index < len(images) - 1 else None
+    return previous_image, next_image
+
+
+def _rf_card_store_url_for_image(image: GalleryImage) -> str:
+    from apps.shop.models import ShopProduct
+
+    store_is_setup = ShopProduct.objects.filter(
+        is_active=True,
+        stock_quantity__gt=0,
+        supports_gallery_image_printing=True,
+        shop__is_active=True,
+    ).exists()
+    if not store_is_setup:
+        return ""
+    return f"{reverse('shop:index')}?gallery_image={image.id}"
+
+
 def gallery_index(request):
-    images = _visible_images_for_user(request.user)
-    return render(request, "gallery/index.html", {"images": images})
+    search_query = (request.GET.get("q") or "").strip()
+    images = _apply_gallery_search(_visible_images_for_user(request.user), search_query).order_by("title", "id")
+    return render(
+        request,
+        "gallery/index.html",
+        {
+            "images": images,
+            "search_query": search_query,
+        },
+    )
 
 
 def gallery_detail(request, slug):
@@ -102,6 +202,12 @@ def gallery_detail(request, slug):
     share_form = GalleryShareForm()
     trait_form = GalleryTraitAssignmentForm()
     credit_form = GalleryCreditForm()
+    search_query = (request.GET.get("q") or "").strip()
+    previous_image, next_image = _gallery_navigation_for_image(
+        image=image,
+        user=request.user,
+        search_query=search_query,
+    )
 
     if request.method == "POST":
         action = request.POST.get("action", "")
@@ -154,6 +260,11 @@ def gallery_detail(request, slug):
         "image_form": image_form,
         "trait_form": trait_form,
         "credit_form": credit_form,
+        "gallery_query_string": f"?{urlencode({'q': search_query})}" if search_query else "",
+        "next_image": next_image,
+        "previous_image": previous_image,
+        "rf_card_store_url": _rf_card_store_url_for_image(image),
+        "search_query": search_query,
     }
     return render(request, "gallery/detail.html", context)
 

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -74,7 +74,15 @@ def _visible_images_for_user(user):
     return queryset.filter(visibility_filter).distinct()
 
 
-def _apply_gallery_search(queryset, search_query: str):
+def _metadata_visibility_filter_for_user(user):
+    if user is None or can_manage_gallery(user):
+        return Q()
+    if not getattr(user, "is_authenticated", False):
+        return Q(pk__in=[])
+    return Q(owner_user=user) | Q(owner_group__in=user.groups.all())
+
+
+def _apply_gallery_search(queryset, search_query: str, *, user=None):
     search_query = search_query.strip()
     if not search_query:
         return queryset
@@ -82,22 +90,25 @@ def _apply_gallery_search(queryset, search_query: str):
     direct_fields_q = (
         Q(title__icontains=search_query)
         | Q(description__icontains=search_query)
-        | Q(owner_user__username__icontains=search_query)
-        | Q(owner_user__email__icontains=search_query)
-        | Q(owner_user__first_name__icontains=search_query)
-        | Q(owner_user__last_name__icontains=search_query)
-        | Q(owner_group__name__icontains=search_query)
         | Q(media_file__original_name__icontains=search_query)
         | Q(media_file__content_type__icontains=search_query)
         | Q(media_file__source_member__icontains=search_query)
         | Q(media_file__file__icontains=search_query)
+    )
+    metadata_direct_fields_q = (
+        Q(owner_user__username__icontains=search_query)
+        | Q(owner_user__email__icontains=search_query)
+        | Q(owner_user__first_name__icontains=search_query)
+        | Q(owner_user__last_name__icontains=search_query)
+        | Q(owner_group__name__icontains=search_query)
+        | Q(content_sample__name__icontains=search_query)
         | Q(content_sample__kind__icontains=search_query)
         | Q(content_sample__content__icontains=search_query)
         | Q(content_sample__path__icontains=search_query)
         | Q(content_sample__method__icontains=search_query)
         | Q(content_sample__hash__icontains=search_query)
     )
-    related_fields_q = (
+    metadata_related_fields_q = (
         Q(categories__name__icontains=search_query)
         | Q(categories__slug__icontains=search_query)
         | Q(categories__description__icontains=search_query)
@@ -126,25 +137,34 @@ def _apply_gallery_search(queryset, search_query: str):
     except ValueError:
         pass
     else:
-        direct_fields_q |= Q(slug=parsed_uuid) | Q(content_sample__name=parsed_uuid)
+        direct_fields_q |= Q(slug=parsed_uuid)
+        metadata_direct_fields_q |= Q(content_sample__name=parsed_uuid)
     if normalized_query in {"public", "published", "true", "yes"}:
         direct_fields_q |= Q(include_in_public_gallery=True)
     if normalized_query in {"private", "false", "no"}:
         direct_fields_q |= Q(include_in_public_gallery=False)
     try:
-        related_fields_q |= Q(trait_values__float_value=float(search_query))
+        metadata_related_fields_q |= Q(trait_values__float_value=float(search_query))
     except ValueError:
         pass
 
     direct_match_ids = queryset.filter(direct_fields_q).values_list("id", flat=True)
-    related_match_ids = queryset.filter(related_fields_q).values_list("id", flat=True).distinct()
-    return queryset.filter(Q(id__in=direct_match_ids) | Q(id__in=related_match_ids))
+    metadata_queryset = queryset.filter(_metadata_visibility_filter_for_user(user))
+    metadata_direct_match_ids = metadata_queryset.filter(metadata_direct_fields_q).values_list("id", flat=True)
+    metadata_related_match_ids = (
+        metadata_queryset.filter(metadata_related_fields_q).values_list("id", flat=True).distinct()
+    )
+    return queryset.filter(
+        Q(id__in=direct_match_ids)
+        | Q(id__in=metadata_direct_match_ids)
+        | Q(id__in=metadata_related_match_ids)
+    )
 
 
 def _gallery_navigation_for_image(*, image: GalleryImage, user, search_query: str):
     queryset = _visible_images_for_user(user)
     if search_query:
-        filtered_queryset = _apply_gallery_search(queryset, search_query)
+        filtered_queryset = _apply_gallery_search(queryset, search_query, user=user)
         if filtered_queryset.filter(pk=image.pk).exists():
             queryset = filtered_queryset
     previous_image = (
@@ -176,7 +196,10 @@ def _rf_card_store_url_for_image(image: GalleryImage) -> str:
 
 def gallery_index(request):
     search_query = (request.GET.get("q") or "").strip()
-    images = _apply_gallery_search(_visible_images_for_user(request.user), search_query).order_by("title", "id")
+    images = _apply_gallery_search(_visible_images_for_user(request.user), search_query, user=request.user).order_by(
+        "title",
+        "id",
+    )
     return render(
         request,
         "gallery/index.html",

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from urllib.parse import urlencode
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -8,8 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
-from django.db.models import CharField, Q
-from django.db.models.functions import Cast
+from django.db.models import Q
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -64,7 +63,7 @@ def _visible_images_for_user(user):
         "media_file",
         "owner_user",
         "owner_group",
-    ).prefetch_related("categories", "credits", "trait_values__category", "trait_values__trait")
+    )
     if can_manage_gallery(user):
         return queryset
     visibility_filter = Q(include_in_public_gallery=True)
@@ -80,15 +79,8 @@ def _apply_gallery_search(queryset, search_query: str):
     if not search_query:
         return queryset
 
-    queryset = queryset.annotate(
-        search_id=Cast("id", output_field=CharField()),
-        search_slug=Cast("slug", output_field=CharField()),
-        search_content_sample_name=Cast("content_sample__name", output_field=CharField()),
-    )
     filter_q = (
-        Q(search_id__icontains=search_query)
-        | Q(search_slug__icontains=search_query)
-        | Q(title__icontains=search_query)
+        Q(title__icontains=search_query)
         | Q(description__icontains=search_query)
         | Q(owner_user__username__icontains=search_query)
         | Q(owner_user__email__icontains=search_query)
@@ -104,7 +96,6 @@ def _apply_gallery_search(queryset, search_query: str):
         | Q(content_sample__path__icontains=search_query)
         | Q(content_sample__method__icontains=search_query)
         | Q(content_sample__hash__icontains=search_query)
-        | Q(search_content_sample_name__icontains=search_query)
         | Q(categories__name__icontains=search_query)
         | Q(categories__slug__icontains=search_query)
         | Q(categories__description__icontains=search_query)
@@ -124,6 +115,16 @@ def _apply_gallery_search(queryset, search_query: str):
         | Q(trait_values__qualitative_value__icontains=search_query)
     )
     normalized_query = search_query.casefold()
+    try:
+        filter_q |= Q(id=int(search_query))
+    except ValueError:
+        pass
+    try:
+        parsed_uuid = UUID(search_query)
+    except ValueError:
+        pass
+    else:
+        filter_q |= Q(slug=parsed_uuid) | Q(content_sample__name=parsed_uuid)
     if normalized_query in {"public", "published", "true", "yes"}:
         filter_q |= Q(include_in_public_gallery=True)
     if normalized_query in {"private", "false", "no"}:
@@ -141,12 +142,16 @@ def _gallery_navigation_for_image(*, image: GalleryImage, user, search_query: st
         filtered_queryset = _apply_gallery_search(queryset, search_query)
         if filtered_queryset.filter(pk=image.pk).exists():
             queryset = filtered_queryset
-    images = list(queryset.order_by("title", "id"))
-    current_index = next((index for index, candidate in enumerate(images) if candidate.pk == image.pk), None)
-    if current_index is None:
-        return None, None
-    previous_image = images[current_index - 1] if current_index > 0 else None
-    next_image = images[current_index + 1] if current_index < len(images) - 1 else None
+    previous_image = (
+        queryset.filter(Q(title__lt=image.title) | Q(title=image.title, id__lt=image.id))
+        .order_by("-title", "-id")
+        .first()
+    )
+    next_image = (
+        queryset.filter(Q(title__gt=image.title) | Q(title=image.title, id__gt=image.id))
+        .order_by("title", "id")
+        .first()
+    )
     return previous_image, next_image
 
 

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -79,7 +79,7 @@ def _apply_gallery_search(queryset, search_query: str):
     if not search_query:
         return queryset
 
-    filter_q = (
+    direct_fields_q = (
         Q(title__icontains=search_query)
         | Q(description__icontains=search_query)
         | Q(owner_user__username__icontains=search_query)
@@ -96,7 +96,9 @@ def _apply_gallery_search(queryset, search_query: str):
         | Q(content_sample__path__icontains=search_query)
         | Q(content_sample__method__icontains=search_query)
         | Q(content_sample__hash__icontains=search_query)
-        | Q(categories__name__icontains=search_query)
+    )
+    related_fields_q = (
+        Q(categories__name__icontains=search_query)
         | Q(categories__slug__icontains=search_query)
         | Q(categories__description__icontains=search_query)
         | Q(credits__display_name__icontains=search_query)
@@ -116,7 +118,7 @@ def _apply_gallery_search(queryset, search_query: str):
     )
     normalized_query = search_query.casefold()
     try:
-        filter_q |= Q(id=int(search_query))
+        direct_fields_q |= Q(id=int(search_query))
     except ValueError:
         pass
     try:
@@ -124,16 +126,19 @@ def _apply_gallery_search(queryset, search_query: str):
     except ValueError:
         pass
     else:
-        filter_q |= Q(slug=parsed_uuid) | Q(content_sample__name=parsed_uuid)
+        direct_fields_q |= Q(slug=parsed_uuid) | Q(content_sample__name=parsed_uuid)
     if normalized_query in {"public", "published", "true", "yes"}:
-        filter_q |= Q(include_in_public_gallery=True)
+        direct_fields_q |= Q(include_in_public_gallery=True)
     if normalized_query in {"private", "false", "no"}:
-        filter_q |= Q(include_in_public_gallery=False)
+        direct_fields_q |= Q(include_in_public_gallery=False)
     try:
-        filter_q |= Q(trait_values__float_value=float(search_query))
+        related_fields_q |= Q(trait_values__float_value=float(search_query))
     except ValueError:
         pass
-    return queryset.filter(filter_q).distinct()
+
+    direct_match_ids = queryset.filter(direct_fields_q).values_list("id", flat=True)
+    related_match_ids = queryset.filter(related_fields_q).values_list("id", flat=True).distinct()
+    return queryset.filter(Q(id__in=direct_match_ids) | Q(id__in=related_match_ids))
 
 
 def _gallery_navigation_for_image(*, image: GalleryImage, user, search_query: str):

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -13,6 +13,8 @@ from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
+from apps.shop.models import ShopProduct
+
 from .forms import (
     GalleryCategoryForm,
     GalleryCreditForm,
@@ -139,9 +141,9 @@ def _apply_gallery_search(queryset, search_query: str, *, user=None):
     else:
         direct_fields_q |= Q(slug=parsed_uuid)
         metadata_direct_fields_q |= Q(content_sample__name=parsed_uuid)
-    if normalized_query in {"public", "published", "true", "yes"}:
+    if normalized_query in {"public", "published"}:
         direct_fields_q |= Q(include_in_public_gallery=True)
-    if normalized_query in {"private", "false", "no"}:
+    if normalized_query == "private":
         direct_fields_q |= Q(include_in_public_gallery=False)
     try:
         metadata_related_fields_q |= Q(trait_values__float_value=float(search_query))
@@ -181,8 +183,6 @@ def _gallery_navigation_for_image(*, image: GalleryImage, user, search_query: st
 
 
 def _rf_card_store_url_for_image(image: GalleryImage) -> str:
-    from apps.shop.models import ShopProduct
-
     store_is_setup = ShopProduct.objects.filter(
         is_active=True,
         stock_quantity__gt=0,

--- a/apps/shop/templates/shop/index.html
+++ b/apps/shop/templates/shop/index.html
@@ -37,7 +37,7 @@
                           <p class="text-muted small mb-0">RF card image: {{ selected_gallery_image.title }}</p>
                         {% endif %}
                       </div>
-                      <div style="width: 78px;">
+                      <div class="col-auto">
                         <label for="qty-{{ product.id }}" class="form-label small text-muted mb-1">Qty</label>
                         <input id="qty-{{ product.id }}" class="form-control form-control-sm" type="number" name="quantity" min="1" value="1" max="{{ product.stock_quantity }}">
                       </div>

--- a/apps/shop/templates/shop/index.html
+++ b/apps/shop/templates/shop/index.html
@@ -6,6 +6,11 @@
     <h1 class="mb-0">Shop</h1>
     <a class="btn btn-outline-primary btn-lg px-4" href="{% url 'shop:cart' %}">🛒 View cart</a>
   </div>
+  {% if selected_gallery_image %}
+    <div class="alert alert-info">
+      Using <strong>{{ selected_gallery_image.title }}</strong> for the next RF card customization.
+    </div>
+  {% endif %}
 
   {% for shop in shops %}
     <section class="mb-4">
@@ -21,10 +26,16 @@
                   {% if product.description %}<p>{{ product.description }}</p>{% endif %}
                   <form method="post" action="{% url 'shop:add_to_cart' shop.slug product.id %}" class="mt-auto">
                     {% csrf_token %}
+                    {% if selected_gallery_image and product.supports_gallery_image_printing %}
+                      <input type="hidden" name="gallery_image" value="{{ selected_gallery_image.id }}">
+                    {% endif %}
                     <div class="d-flex justify-content-between align-items-end gap-2 mb-2">
                       <div>
                         <p class="mb-1"><strong>{{ product.unit_price }} {{ product.currency }}</strong></p>
                         <p class="text-muted small mb-0">Stock: {{ product.stock_quantity }}</p>
+                        {% if selected_gallery_image and product.supports_gallery_image_printing %}
+                          <p class="text-muted small mb-0">RF card image: {{ selected_gallery_image.title }}</p>
+                        {% endif %}
                       </div>
                       <div style="width: 78px;">
                         <label for="qty-{{ product.id }}" class="form-label small text-muted mb-1">Qty</label>
@@ -52,5 +63,8 @@
       {% endif %}
     {% endif %}
   {% endfor %}
+  {% if selected_gallery_image and not shops %}
+    <p class="text-muted">The selected gallery image will be available when an RF card store is open.</p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -216,6 +216,54 @@ class ShopCheckoutTests(TestCase):
         self.assertIsNone(response.context["selected_gallery_image"])
         self.assertNotIn("shop_cart_gallery_image", self.client.session)
 
+    def test_store_clears_pending_gallery_handoff_for_invalid_query_param(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-invalid-query-handoff",
+            default_payment_provider="stripe",
+        )
+        product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-INVALID-QUERY-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-invalid-query-owner", "invalid-query@example.com")
+
+        for invalid_value in ("", "not-a-number"):
+            with self.subTest(gallery_image=invalid_value):
+                image = create_gallery_image(
+                    uploaded_file=self._upload_image(f"invalid-query-{invalid_value or 'empty'}.jpg"),
+                    title=f"Invalid Query Handoff Art {invalid_value or 'empty'}",
+                    owner_user=owner,
+                    include_in_public_gallery=True,
+                )
+                session = self.client.session
+                session["shop_cart_gallery_image"] = {
+                    "product_id": None,
+                    "gallery_image_id": str(image.id),
+                }
+                session.save()
+
+                response = self.client.get(reverse("shop:index"), {"gallery_image": invalid_value})
+
+                self.assertEqual(response.status_code, 200)
+                self.assertIsNone(response.context["selected_gallery_image"])
+                self.assertNotIn("shop_cart_gallery_image", self.client.session)
+
+                self.client.post(
+                    reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": product.id}),
+                    {"quantity": 1},
+                    follow=True,
+                )
+                checkout_response = self.client.get(reverse("shop:checkout"))
+
+                self.assertEqual(checkout_response.status_code, 200)
+                self.assertNotContains(checkout_response, f'<option value="{image.id}" selected>')
+
     def test_gallery_handoff_survives_non_customizable_add_before_card(self):
         shop = Shop.objects.create(
             name="Card Shop",

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -164,6 +164,46 @@ class ShopCheckoutTests(TestCase):
         self.assertEqual(checkout_response.status_code, 200)
         self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
 
+    def test_add_customizable_product_without_gallery_image_clears_stale_handoff(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-stale-handoff",
+            default_payment_provider="stripe",
+        )
+        product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-STALE-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-stale-owner", "stale@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("stale-handoff.jpg"),
+            title="Stale Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        session = self.client.session
+        session["shop_cart_gallery_image"] = {
+            "product_id": product.id,
+            "gallery_image_id": str(image.id),
+        }
+        session.save()
+
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": product.id}),
+            {"quantity": 1},
+            follow=True,
+        )
+
+        self.assertNotIn("shop_cart_gallery_image", self.client.session)
+        checkout_response = self.client.get(reverse("shop:checkout"))
+        self.assertEqual(checkout_response.status_code, 200)
+        self.assertNotContains(checkout_response, f'<option value="{image.id}" selected>')
+
     def test_checkout_rejects_unavailable_gallery_image_selection(self):
         shop = Shop.objects.create(name="Card Shop", slug="card-shop-invalid")
         product = ShopProduct.objects.create(

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -125,6 +125,45 @@ class ShopCheckoutTests(TestCase):
         self.assertEqual(item.line_total, Decimal("34.00"))
         self.assertEqual(order.total_amount, Decimal("34.00"))
 
+    def test_store_prefills_gallery_image_from_gallery_handoff(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-handoff",
+            default_payment_provider="stripe",
+        )
+        product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-handoff-owner", "handoff@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("handoff.jpg"),
+            title="Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+
+        response = self.client.get(reverse("shop:index"), {"gallery_image": image.id})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Using <strong>Handoff Art</strong>")
+        self.assertContains(response, f'name="gallery_image" value="{image.id}"')
+
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": product.id}),
+            {"quantity": 1, "gallery_image": image.id},
+            follow=True,
+        )
+        checkout_response = self.client.get(reverse("shop:checkout"))
+
+        self.assertEqual(checkout_response.status_code, 200)
+        self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
+
     def test_checkout_rejects_unavailable_gallery_image_selection(self):
         shop = Shop.objects.create(name="Card Shop", slug="card-shop-invalid")
         product = ShopProduct.objects.create(

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -164,6 +164,58 @@ class ShopCheckoutTests(TestCase):
         self.assertEqual(checkout_response.status_code, 200)
         self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
 
+    def test_store_rehydrates_pending_gallery_handoff_without_query_param(self):
+        Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-rehydrate-handoff",
+            default_payment_provider="stripe",
+        )
+        owner = self._create_user("gallery-rehydrate-owner", "rehydrate@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("rehydrate-handoff.jpg"),
+            title="Rehydrated Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        session = self.client.session
+        session["shop_cart_gallery_image"] = {
+            "product_id": None,
+            "gallery_image_id": str(image.id),
+        }
+        session.save()
+
+        response = self.client.get(reverse("shop:index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["selected_gallery_image"], image)
+        self.assertContains(response, "Using <strong>Rehydrated Handoff Art</strong>")
+        self.assertEqual(
+            self.client.session.get("shop_cart_gallery_image"),
+            {"product_id": None, "gallery_image_id": str(image.id)},
+        )
+
+    def test_store_clears_stale_pending_gallery_handoff_without_query_param(self):
+        owner = self._create_user("gallery-stale-store-owner", "stale-store@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("stale-store-handoff.jpg"),
+            title="Stale Store Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        session = self.client.session
+        session["shop_cart_gallery_image"] = {
+            "product_id": None,
+            "gallery_image_id": str(image.id),
+        }
+        session.save()
+        image.delete()
+
+        response = self.client.get(reverse("shop:index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["selected_gallery_image"])
+        self.assertNotIn("shop_cart_gallery_image", self.client.session)
+
     def test_gallery_handoff_survives_non_customizable_add_before_card(self):
         shop = Shop.objects.create(
             name="Card Shop",

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -164,6 +164,38 @@ class ShopCheckoutTests(TestCase):
         self.assertEqual(checkout_response.status_code, 200)
         self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
 
+    def test_repeated_add_preserves_gallery_handoff_when_redirect_omits_query(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-repeat-handoff",
+            default_payment_provider="stripe",
+        )
+        product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-REPEAT-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-repeat-owner", "repeat@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("repeat-handoff.jpg"),
+            title="Repeat Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        add_url = reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": product.id})
+
+        self.client.post(add_url, {"quantity": 1, "gallery_image": image.id}, follow=True)
+        self.client.post(add_url, {"quantity": 1}, follow=True)
+
+        checkout_response = self.client.get(reverse("shop:checkout"))
+
+        self.assertEqual(checkout_response.status_code, 200)
+        self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
+
     def test_add_customizable_product_without_gallery_image_clears_stale_handoff(self):
         shop = Shop.objects.create(
             name="Card Shop",

--- a/apps/shop/tests/test_checkout.py
+++ b/apps/shop/tests/test_checkout.py
@@ -164,6 +164,140 @@ class ShopCheckoutTests(TestCase):
         self.assertEqual(checkout_response.status_code, 200)
         self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
 
+    def test_gallery_handoff_survives_non_customizable_add_before_card(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-noncustom-handoff",
+            default_payment_provider="stripe",
+        )
+        standard_product = ShopProduct.objects.create(
+            shop=shop,
+            name="Standard Sleeve",
+            sku="SLEEVE-HANDOFF",
+            unit_price=Decimal("2.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=False,
+        )
+        card_product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-NONCUSTOM-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-noncustom-owner", "noncustom@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("noncustom-handoff.jpg"),
+            title="Noncustom Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+
+        self.client.get(reverse("shop:index"), {"gallery_image": image.id})
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": standard_product.id}),
+            {"quantity": 1},
+            follow=True,
+        )
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": card_product.id}),
+            {"quantity": 1},
+            follow=True,
+        )
+        checkout_response = self.client.get(reverse("shop:checkout"))
+
+        self.assertEqual(checkout_response.status_code, 200)
+        self.assertContains(checkout_response, f'<option value="{image.id}" selected>')
+
+    def test_unrelated_customizable_add_does_not_clear_existing_handoff(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-unrelated-handoff",
+            default_payment_provider="stripe",
+        )
+        selected_product = ShopProduct.objects.create(
+            shop=shop,
+            name="Selected Custom Card",
+            sku="CARD-SELECTED-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        unrelated_product = ShopProduct.objects.create(
+            shop=shop,
+            name="Other Custom Card",
+            sku="CARD-OTHER-HANDOFF",
+            unit_price=Decimal("11.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-unrelated-owner", "unrelated@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("unrelated-handoff.jpg"),
+            title="Unrelated Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        session = self.client.session
+        session["shop_cart_gallery_image"] = {
+            "product_id": selected_product.id,
+            "gallery_image_id": str(image.id),
+        }
+        session.save()
+
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": unrelated_product.id}),
+            {"quantity": 1},
+            follow=True,
+        )
+
+        self.assertEqual(
+            self.client.session.get("shop_cart_gallery_image"),
+            {"product_id": selected_product.id, "gallery_image_id": str(image.id)},
+        )
+
+    def test_add_customizable_product_clears_stale_pending_handoff(self):
+        shop = Shop.objects.create(
+            name="Card Shop",
+            slug="card-shop-stale-pending-handoff",
+            default_payment_provider="stripe",
+        )
+        product = ShopProduct.objects.create(
+            shop=shop,
+            name="Custom Card",
+            sku="CARD-STALE-PENDING-HANDOFF",
+            unit_price=Decimal("10.00"),
+            stock_quantity=20,
+            supports_gallery_image_printing=True,
+            gallery_image_print_price=Decimal("3.50"),
+        )
+        owner = self._create_user("gallery-stale-pending-owner", "stale-pending@example.com")
+        image = create_gallery_image(
+            uploaded_file=self._upload_image("stale-pending-handoff.jpg"),
+            title="Stale Pending Handoff Art",
+            owner_user=owner,
+            include_in_public_gallery=True,
+        )
+        session = self.client.session
+        session["shop_cart_gallery_image"] = {
+            "product_id": None,
+            "gallery_image_id": str(image.id),
+        }
+        session.save()
+        image.delete()
+
+        self.client.post(
+            reverse("shop:add_to_cart", kwargs={"shop_slug": shop.slug, "product_id": product.id}),
+            {"quantity": 1},
+            follow=True,
+        )
+
+        self.assertNotIn("shop_cart_gallery_image", self.client.session)
+
     def test_repeated_add_preserves_gallery_handoff_when_redirect_omits_query(self):
         shop = Shop.objects.create(
             name="Card Shop",

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -107,10 +107,14 @@ def _selected_gallery_image_for_store(request: HttpRequest) -> GalleryImage | No
 
     selected_gallery_image_id = selected_gallery_image_id.strip()
     if not selected_gallery_image_id:
+        request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
+        request.session.modified = True
         return None
     try:
         image_id = int(selected_gallery_image_id)
     except ValueError:
+        request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
+        request.session.modified = True
         return None
     image = _gallery_images_for_checkout(request).filter(pk=image_id).first()
     if image is None:

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -237,19 +237,25 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
     else:
         _save_cart(request, cart)
         selected_gallery_image_id = (request.POST.get("gallery_image") or "").strip()
-        if selected_gallery_image_id and product.supports_gallery_image_printing:
-            try:
-                gallery_image_id = int(selected_gallery_image_id)
-            except ValueError:
-                gallery_image_id = None
-            if gallery_image_id and _gallery_images_for_checkout(request).filter(pk=gallery_image_id).exists():
-                request.session["shop_cart_gallery_image"] = {
-                    "product_id": product.id,
-                    "gallery_image_id": str(gallery_image_id),
-                }
-                request.session.modified = True
+        if product.supports_gallery_image_printing:
+            if selected_gallery_image_id:
+                try:
+                    gallery_image_id = int(selected_gallery_image_id)
+                except ValueError:
+                    gallery_image_id = None
+                if gallery_image_id and _gallery_images_for_checkout(request).filter(pk=gallery_image_id).exists():
+                    request.session["shop_cart_gallery_image"] = {
+                        "product_id": product.id,
+                        "gallery_image_id": str(gallery_image_id),
+                    }
+                    request.session.modified = True
+                else:
+                    request.session.pop("shop_cart_gallery_image", None)
+                    request.session.modified = True
+                    messages.error(request, "Selected gallery image is unavailable for RF card customization.")
             else:
-                messages.error(request, "Selected gallery image is unavailable for RF card customization.")
+                request.session.pop("shop_cart_gallery_image", None)
+                request.session.modified = True
         messages.success(request, f"Added {product.name} to cart.")
 
     return redirect("shop:index")

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -86,6 +86,20 @@ def _gallery_images_for_checkout(request: HttpRequest) -> QuerySet[GalleryImage]
     return queryset.filter(visibility_filter).distinct()
 
 
+def _selected_gallery_image_for_store(request: HttpRequest) -> GalleryImage | None:
+    selected_gallery_image_id = (request.GET.get("gallery_image") or "").strip()
+    if not selected_gallery_image_id:
+        return None
+    try:
+        image_id = int(selected_gallery_image_id)
+    except ValueError:
+        return None
+    image = _gallery_images_for_checkout(request).filter(pk=image_id).first()
+    if image is None:
+        messages.error(request, "Selected gallery image is unavailable for RF card customization.")
+    return image
+
+
 def _extract_card_customizations(
     request: HttpRequest,
     entries: list[dict],
@@ -163,12 +177,14 @@ def shop_index(request: HttpRequest) -> HttpResponse:
             else localized_next_opening.strftime("%a, %d %b %H:%M")
         )
 
+    selected_gallery_image = _selected_gallery_image_for_store(request)
     context = {
         "shops": open_shops,
         "all_shops_closed_for_time": bool(active_shops and not open_shops and next_opening_candidates),
         "next_opening_at": next_opening_at,
         "next_opening_same_day": next_opening_same_day,
         "next_opening_display": next_opening_display,
+        "selected_gallery_image": selected_gallery_image,
     }
     return render(request, "shop/index.html", context)
 
@@ -220,6 +236,20 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
         messages.error(request, str(exc))
     else:
         _save_cart(request, cart)
+        selected_gallery_image_id = (request.POST.get("gallery_image") or "").strip()
+        if selected_gallery_image_id and product.supports_gallery_image_printing:
+            try:
+                gallery_image_id = int(selected_gallery_image_id)
+            except ValueError:
+                gallery_image_id = None
+            if gallery_image_id and _gallery_images_for_checkout(request).filter(pk=gallery_image_id).exists():
+                request.session["shop_cart_gallery_image"] = {
+                    "product_id": product.id,
+                    "gallery_image_id": str(gallery_image_id),
+                }
+                request.session.modified = True
+            else:
+                messages.error(request, "Selected gallery image is unavailable for RF card customization.")
         messages.success(request, f"Added {product.name} to cart.")
 
     return redirect("shop:index")
@@ -282,6 +312,19 @@ def checkout(request: HttpRequest) -> HttpResponse:
     if customization_entries:
         gallery_images = list(_gallery_images_for_checkout(request).order_by("title", "id"))
         gallery_image_map = {image.id: image for image in gallery_images}
+    stored_gallery_selection = request.session.get("shop_cart_gallery_image") or {}
+    if request.method == "GET" and stored_gallery_selection and customization_entries:
+        stored_product_id = stored_gallery_selection.get("product_id")
+        stored_gallery_image_id = stored_gallery_selection.get("gallery_image_id")
+        try:
+            stored_gallery_image_id_int = int(stored_gallery_image_id)
+        except (TypeError, ValueError):
+            stored_gallery_image_id_int = None
+        if stored_gallery_image_id_int in gallery_image_map:
+            for entry_data in customization_entries:
+                if entry_data["product"].id == stored_product_id:
+                    entry_data["selected_front"] = str(stored_gallery_image_id_int)
+                    break
 
     if request.method == "GET":
         form = CheckoutForm()
@@ -378,6 +421,7 @@ def checkout(request: HttpRequest) -> HttpResponse:
         customer_email=order.customer_email,
     )
 
+    request.session.pop("shop_cart_gallery_image", None)
     _save_cart(request, {})
     messages.success(request, "Order placed successfully.")
     return redirect(reverse("shop:order_tracking", kwargs={"tracking_token": order.tracking_token}))

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -228,6 +228,7 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
             )
 
     existing = cart.get(str(product.id))
+    existing_handoff = request.session.get("shop_cart_gallery_image") or {}
     next_qty = qty + int(existing["quantity"]) if existing else qty
 
     try:
@@ -254,8 +255,22 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
                     request.session.modified = True
                     messages.error(request, "Selected gallery image is unavailable for RF card customization.")
             else:
-                request.session.pop("shop_cart_gallery_image", None)
-                request.session.modified = True
+                existing_gallery_image_id = existing_handoff.get("gallery_image_id")
+                try:
+                    existing_gallery_image_id_int = int(existing_gallery_image_id)
+                except (TypeError, ValueError):
+                    existing_gallery_image_id_int = None
+                should_preserve_existing_handoff = (
+                    existing is not None
+                    and existing_handoff.get("product_id") == product.id
+                    and existing_gallery_image_id_int is not None
+                    and _gallery_images_for_checkout(request).filter(pk=existing_gallery_image_id_int).exists()
+                )
+                if should_preserve_existing_handoff:
+                    request.session.modified = True
+                else:
+                    request.session.pop("shop_cart_gallery_image", None)
+                    request.session.modified = True
         messages.success(request, f"Added {product.name} to cart.")
 
     return redirect("shop:index")

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -88,7 +88,24 @@ def _gallery_images_for_checkout(request: HttpRequest) -> QuerySet[GalleryImage]
 
 
 def _selected_gallery_image_for_store(request: HttpRequest) -> GalleryImage | None:
-    selected_gallery_image_id = (request.GET.get("gallery_image") or "").strip()
+    selected_gallery_image_id = request.GET.get("gallery_image")
+    if selected_gallery_image_id is None:
+        stored_selection = request.session.get(GALLERY_HANDOFF_SESSION_KEY) or {}
+        try:
+            image_id = int(stored_selection.get("gallery_image_id"))
+        except (TypeError, ValueError):
+            if stored_selection:
+                request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
+                request.session.modified = True
+            return None
+
+        image = _gallery_images_for_checkout(request).filter(pk=image_id).first()
+        if image is None:
+            request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
+            request.session.modified = True
+        return image
+
+    selected_gallery_image_id = selected_gallery_image_id.strip()
     if not selected_gallery_image_id:
         return None
     try:

--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -24,6 +24,7 @@ from .services import (
 )
 
 CART_SESSION_KEY = "shop_cart"
+GALLERY_HANDOFF_SESSION_KEY = "shop_cart_gallery_image"
 
 
 def _get_cart(request: HttpRequest) -> dict:
@@ -96,7 +97,15 @@ def _selected_gallery_image_for_store(request: HttpRequest) -> GalleryImage | No
         return None
     image = _gallery_images_for_checkout(request).filter(pk=image_id).first()
     if image is None:
+        request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
+        request.session.modified = True
         messages.error(request, "Selected gallery image is unavailable for RF card customization.")
+    else:
+        request.session[GALLERY_HANDOFF_SESSION_KEY] = {
+            "product_id": None,
+            "gallery_image_id": str(image.id),
+        }
+        request.session.modified = True
     return image
 
 
@@ -228,7 +237,7 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
             )
 
     existing = cart.get(str(product.id))
-    existing_handoff = request.session.get("shop_cart_gallery_image") or {}
+    existing_handoff = request.session.get(GALLERY_HANDOFF_SESSION_KEY) or {}
     next_qty = qty + int(existing["quantity"]) if existing else qty
 
     try:
@@ -245,13 +254,13 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
                 except ValueError:
                     gallery_image_id = None
                 if gallery_image_id and _gallery_images_for_checkout(request).filter(pk=gallery_image_id).exists():
-                    request.session["shop_cart_gallery_image"] = {
+                    request.session[GALLERY_HANDOFF_SESSION_KEY] = {
                         "product_id": product.id,
                         "gallery_image_id": str(gallery_image_id),
                     }
                     request.session.modified = True
                 else:
-                    request.session.pop("shop_cart_gallery_image", None)
+                    request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
                     request.session.modified = True
                     messages.error(request, "Selected gallery image is unavailable for RF card customization.")
             else:
@@ -260,16 +269,26 @@ def add_to_cart(request: HttpRequest, shop_slug: str, product_id: int) -> HttpRe
                     existing_gallery_image_id_int = int(existing_gallery_image_id)
                 except (TypeError, ValueError):
                     existing_gallery_image_id_int = None
+                is_valid_existing_handoff = (
+                    existing_gallery_image_id_int is not None
+                    and _gallery_images_for_checkout(request).filter(pk=existing_gallery_image_id_int).exists()
+                )
                 should_preserve_existing_handoff = (
                     existing is not None
                     and existing_handoff.get("product_id") == product.id
-                    and existing_gallery_image_id_int is not None
-                    and _gallery_images_for_checkout(request).filter(pk=existing_gallery_image_id_int).exists()
+                    and is_valid_existing_handoff
                 )
-                if should_preserve_existing_handoff:
+                should_apply_pending_handoff = existing_handoff.get("product_id") is None and is_valid_existing_handoff
+                if should_apply_pending_handoff:
+                    request.session[GALLERY_HANDOFF_SESSION_KEY] = {
+                        "product_id": product.id,
+                        "gallery_image_id": str(existing_gallery_image_id_int),
+                    }
                     request.session.modified = True
-                else:
-                    request.session.pop("shop_cart_gallery_image", None)
+                elif should_preserve_existing_handoff:
+                    request.session.modified = True
+                elif existing_handoff and existing_handoff.get("product_id") in (None, product.id):
+                    request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
                     request.session.modified = True
         messages.success(request, f"Added {product.name} to cart.")
 
@@ -333,7 +352,7 @@ def checkout(request: HttpRequest) -> HttpResponse:
     if customization_entries:
         gallery_images = list(_gallery_images_for_checkout(request).order_by("title", "id"))
         gallery_image_map = {image.id: image for image in gallery_images}
-    stored_gallery_selection = request.session.get("shop_cart_gallery_image") or {}
+    stored_gallery_selection = request.session.get(GALLERY_HANDOFF_SESSION_KEY) or {}
     if request.method == "GET" and stored_gallery_selection and customization_entries:
         stored_product_id = stored_gallery_selection.get("product_id")
         stored_gallery_image_id = stored_gallery_selection.get("gallery_image_id")
@@ -442,7 +461,7 @@ def checkout(request: HttpRequest) -> HttpResponse:
         customer_email=order.customer_email,
     )
 
-    request.session.pop("shop_cart_gallery_image", None)
+    request.session.pop(GALLERY_HANDOFF_SESSION_KEY, None)
     _save_cart(request, {})
     messages.success(request, "Order placed successfully.")
     return redirect(reverse("shop:order_tracking", kwargs={"tracking_token": order.tracking_token}))

--- a/apps/sites/forms.py
+++ b/apps/sites/forms.py
@@ -93,6 +93,7 @@ class UserStoryForm(forms.ModelForm):
     """Feedback form used on public and admin pages."""
 
     attachments = MultipleFileField(required=False)
+    feedback_context = forms.CharField(required=False, widget=forms.HiddenInput())
     contact_via_chat = forms.BooleanField(
         required=False,
         label=_("You may contact me"),
@@ -264,6 +265,21 @@ class UserStoryForm(forms.ModelForm):
     def clean_messages(self):
         return (self.cleaned_data.get("messages") or "").strip()
 
+    def clean_feedback_context(self):
+        return (self.cleaned_data.get("feedback_context") or "").strip()
+
+    def get_messages_with_context(self) -> str:
+        messages = (self.cleaned_data.get("messages") or "").strip()
+        feedback_context = (self.cleaned_data.get("feedback_context") or "").strip()
+        if not feedback_context:
+            return messages
+        context_line = _("Context: %(context)s") % {"context": feedback_context}
+        if not messages:
+            return context_line[:2000]
+        if context_line in messages:
+            return messages[:2000]
+        return f"{messages} | {context_line}"[:2000]
+
     def update_chat_preference(self, *, owner, contact_via_chat: bool) -> None:
         """Persist chat preference for an owner using a Chat Profile record."""
 
@@ -290,6 +306,7 @@ class UserStoryForm(forms.ModelForm):
             instance.user = self.user
         instance.contact_via_chat = bool(self.cleaned_data.get("contact_via_chat"))
         instance.javascript_enabled = True
+        instance.messages = self.get_messages_with_context()
         if commit:
             instance.save()
             self.save_attachments()

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -529,20 +529,22 @@
     feedbackContexts.forEach(context => {
       details.push(context);
     });
-    const nextOpsTask = getAdminDashboardNextTask();
-    const netMessage = getAdminDashboardNetMessage();
-    const roleSiteNode = getRoleSiteNodeSummary();
-    if (nextOpsTask) {
-      details.push(`Next: ${nextOpsTask}`);
-    }
-    if (netMessage) {
-      details.push(`Net Message: ${netMessage}`);
-    }
-    if (roleSiteNode) {
-      details.push(`Role / Site / Node: ${roleSiteNode}`);
-    }
-    if (securityGroups) {
-      details.push(`Security groups: ${securityGroups}`);
+    if (canCopyStaffDetails) {
+      const nextOpsTask = getAdminDashboardNextTask();
+      const netMessage = getAdminDashboardNetMessage();
+      const roleSiteNode = getRoleSiteNodeSummary();
+      if (nextOpsTask) {
+        details.push(`Next: ${nextOpsTask}`);
+      }
+      if (netMessage) {
+        details.push(`Net Message: ${netMessage}`);
+      }
+      if (roleSiteNode) {
+        details.push(`Role / Site / Node: ${roleSiteNode}`);
+      }
+      if (securityGroups) {
+        details.push(`Security groups: ${securityGroups}`);
+      }
     }
     const messages = getPageMessages();
     syncMessageField(messages);

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -28,6 +28,7 @@
   const copyAriaLabel = form.dataset.copyAriaLabel;
   const canCopyStaffDetails = form.dataset.copyStaffDetails === '1';
   const securityGroups = (form.dataset.securityGroups || '').trim();
+  const copyFieldNamesToSkip = new Set(['csrfmiddlewaretoken', 'feedback_context', 'messages', 'path']);
   const messageField = form.querySelector('input[name="messages"]');
   const contextField = form.querySelector('input[name="feedback_context"]');
   const autocompleteUrl = form.dataset.autocompleteUrl || '';
@@ -454,7 +455,7 @@
     const formData = new FormData(form);
     const details = [];
     for (const [name, value] of formData.entries()) {
-      if (name === 'csrfmiddlewaretoken' || name === 'path' || name === 'messages') {
+      if (copyFieldNamesToSkip.has(name)) {
         continue;
       }
       if (typeof value !== 'string') {

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -29,6 +29,7 @@
   const canCopyStaffDetails = form.dataset.copyStaffDetails === '1';
   const securityGroups = (form.dataset.securityGroups || '').trim();
   const messageField = form.querySelector('input[name="messages"]');
+  const contextField = form.querySelector('input[name="feedback_context"]');
   const autocompleteUrl = form.dataset.autocompleteUrl || '';
   const autocompleteContainer = document.createElement('div');
   autocompleteContainer.className = 'user-story-autocomplete mt-2';
@@ -490,6 +491,18 @@
     return [...new Set(messages)];
   };
 
+  const getFeedbackContextLines = () => {
+    const contextNodes = document.querySelectorAll('[data-feedback-context]');
+    const contexts = [];
+    contextNodes.forEach(node => {
+      const value = (node.dataset.feedbackContext || '').replace(/\s+/g, ' ').trim();
+      if (value) {
+        contexts.push(value);
+      }
+    });
+    return [...new Set(contexts)];
+  };
+
   const syncMessageField = messages => {
     if (!messageField) {
       return;
@@ -497,12 +510,24 @@
     messageField.value = messages.join(' | ').substring(0, 2000);
   };
 
+  const syncContextField = contexts => {
+    if (!contextField) {
+      return;
+    }
+    contextField.value = contexts.join(' | ').substring(0, 1000);
+  };
+
   const buildCopyValue = () => {
     const baseValue = getPageCopyValue();
-    if (!canCopyStaffDetails) {
+    const feedbackContexts = getFeedbackContextLines();
+    syncContextField(feedbackContexts);
+    if (!canCopyStaffDetails && !feedbackContexts.length) {
       return baseValue;
     }
     const details = getFormDetails();
+    feedbackContexts.forEach(context => {
+      details.push(context);
+    });
     const nextOpsTask = getAdminDashboardNextTask();
     const netMessage = getAdminDashboardNetMessage();
     const roleSiteNode = getRoleSiteNodeSummary();
@@ -563,6 +588,7 @@
     event.preventDefault();
     resetAlerts();
     syncMessageField(getPageMessages());
+    syncContextField(getFeedbackContextLines());
     if (submitBtn) {
       submitBtn.disabled = true;
     }

--- a/apps/sites/templates/admin/includes/user_story_feedback.html
+++ b/apps/sites/templates/admin/includes/user_story_feedback.html
@@ -52,6 +52,7 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
+        <input type="hidden" name="feedback_context" value="">
         {% if request.user.is_authenticated %}
           <div class="user-story-field user-story-contact-row">
             <div class="user-story-contact-name">

--- a/apps/sites/templates/pages/includes/public_feedback_widget.html
+++ b/apps/sites/templates/pages/includes/public_feedback_widget.html
@@ -52,6 +52,7 @@
         {% csrf_token %}
         <input type="hidden" name="path" value="{{ request.get_full_path|default:'/' }}">
         <input type="hidden" name="messages" value="">
+        <input type="hidden" name="feedback_context" value="">
       {% if request.user.is_authenticated %}
         <div class="user-story-contact-row mb-3">
           <div class="user-story-contact-name">

--- a/apps/sites/tests/test_user_story_feedback_form.py
+++ b/apps/sites/tests/test_user_story_feedback_form.py
@@ -1,15 +1,9 @@
-from types import SimpleNamespace
-
 import pytest
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
-from django.template.loader import render_to_string
-from django.test import RequestFactory
 
 from apps.sites.forms import UserStoryForm
-from apps.sites.models import UserStory
 
 pytestmark = [pytest.mark.django_db]
+
 
 def test_user_story_form_persists_javascript_enabled_as_true():
     form = UserStoryForm(
@@ -28,3 +22,21 @@ def test_user_story_form_persists_javascript_enabled_as_true():
 
     assert story.javascript_enabled is True
 
+
+def test_user_story_form_appends_feedback_context_to_messages():
+    form = UserStoryForm(
+        data={
+            "name": "feedback@example.com",
+            "rating": 4,
+            "comments": "The selected card needs a clearer preview.",
+            "path": "/gallery/images/example/",
+            "messages": "Existing page message",
+            "feedback_context": "Image ID: 42 | Image UUID: abc",
+        }
+    )
+
+    assert form.is_valid(), form.errors
+
+    story = form.save()
+
+    assert story.messages == "Existing page message | Context: Image ID: 42 | Image UUID: abc"


### PR DESCRIPTION
## Summary
- reorganizes gallery detail pages with metadata on the left and the image/card preview on the right
- adds gallery search across image field values and related metadata plus previous/next navigation
- carries image ID context into feedback clipboard/submission payloads and links compatible gallery images into RF card store customization

## Issue
Closes #7412

## Verification
- .venv/bin/python manage.py test run -- apps/gallery/tests/test_gallery.py apps/shop/tests/test_checkout.py apps/sites/tests/test_user_story_feedback_form.py
- git diff --check

## Notes
- black and ruff are not installed in this virtualenv, so formatting was kept manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Image Gallery Controls Prototype

### Overview
Reorganizes gallery detail pages into a two-column layout (metadata left, image/card preview right), adds multi-field gallery search with refined typed matching and viewer-scoped metadata gates, replaces list-based previous/next navigation with DB-level adjacent queries ordered by (title, id) for deterministic tie-breaking, carries image ID context into feedback clipboard/submission payloads, and surfaces a conditional "Use for RF Card" handoff when a compatible store/product exists.

### Gallery Enhancements

Search & Query Behavior
- Adds search via the q parameter matching direct image fields (id, UUID/slug/content-sample-name, title, description, filename, include_in_public_gallery) and related metadata (categories, traits, credits).
- Typed parsing: integer queries match exact image id; UUID-like strings match exact gallery slug or content-sample name; boolean-like strings map to include_in_public_gallery; float parsing applied for numeric trait values; text fields remain substring-matching.
- Splits search into direct-field and related-field subqueries to isolate multi-valued joins; final queryset composes results by combining PK subqueries via id__in to avoid join blowup.
- Metadata-only search predicates are gated by per-viewer can_view_metadata so viewers without metadata access cannot match or surface owner/owner-group, category/trait, credit, or content-sample internals.

Navigation & Ordering
- Replaces in-memory list navigation with DB-level adjacent queries ordered by (title, id) to ensure deterministic same-title tie-breaking.
- Previous/Next and Back links preserve q/search context when present.

Detail Page Reorganization
- Two-column responsive layout with a header containing Back/Previous/Next controls and a conditional "Use for RF Card" link when rf_card_store_url is available.
- Left column lists attributes (id/slug, filename/original name, public/private visibility); owner, owner-group, content-sample name, credits, categories, and traits are rendered only when can_view_metadata permits; main image/preview and description moved to the right.

Prefetch & Performance
- Removes an overly broad prefetch_related() from _visible_images_for_user(); retains targeted prefetches where required by rendering.
- Adds test assertions verifying multi-valued join filters remain constrained to PK subqueries and do not appear on the outer gallery queryset.

Metadata Visibility & Privacy
- Preserves GalleryImage.can_view_metadata() semantics; owner/owner-group, content-sample internals, and metadata-only search predicates are hidden from viewers lacking metadata permission.
- Tests confirm shared recipients can view images without seeing owner identity; owners retain full metadata visibility.

RF Card Store Integration & Shop Handoff
- Detail view computes rf_card_store_url when a compatible, active, in-stock ShopProduct supports gallery-image printing; detail page shows "Use for RF Card" link if present.
- shop_index accepts a gallery_image query param, validates visibility for checkout, and stores a pending session handoff when valid.
- add_to_cart validates posted gallery_image for qualifying products, persists {product_id, gallery_image_id} in session when valid, preserves pending handoff across unrelated/non-customizable adds, applies pending handoff to the first matching customizable add, and clears stale handoff when a customizable product is added without a fresh valid gallery_image or when the stored selection becomes invalid.
- checkout pre-fills the stored gallery image for the matching customization entry and clears session handoff after order placement.

Feedback Context Tracking
- Gallery detail embeds image ID into data-feedback-context; client JS deduplicates and syncs context strings into input[name="feedback_context"] (1000-char limit).
- UserStoryForm adds an optional hidden feedback_context field, cleaner, and logic to append a formatted "Context: ..." suffix to messages without duplicating an existing context line; stored messages are truncated to 2000 chars.
- JS copy behavior excludes feedback_context from copied staff-detail fields to avoid duplicate context lines while preserving hidden-field submit-time persistence.
- Tests verify copied clipboard text contains a single Image ID entry and that hidden feedback_context syncs for submission.

Test Coverage & Verification
- Adds focused gallery tests covering index/detail search semantics (direct vs related), exact-match numeric and UUID behaviors, navigation tie-breaker ordering, metadata visibility gating, and query-shape assertions preventing join blowup.
- Adds shop checkout tests exercising gallery-image handoff propagation, persistence across cart mutations, unrelated-customizable preservation, and stale-handoff clearing.
- Adds a sites form test asserting feedback_context is appended to stored messages.
- Author reports iterative focused test runs and basic static checks during development.

Files of Note
- apps/gallery/views.py: search implementation, adjacent navigation queries, metadata visibility, rf_card_store_url computation.
- apps/gallery/templates/gallery/detail.html & index.html: two-column detail layout, search UI, preserved search-context navigation, RF card link.
- apps/gallery/tests/test_gallery.py: expanded tests for search semantics, navigation, metadata visibility, and query-shape.
- apps/shop/views.py, templates, apps/shop/tests/test_checkout.py: gallery-image handoff validation, session persistence, and checkout preselection tests.
- apps/sites/forms.py, apps/sites/static/pages/js/user_story_feedback.js, templates, and apps/sites/tests/test_user_story_feedback_form.py: feedback_context handling, client-side sync, copy behavior, and form tests.

Closes: Issue #7412
<!-- end of auto-generated comment: release notes by coderabbit.ai -->