### PR TITLE
[codex] Add sustained LCD attention skill

### DIFF
--- a/skills/arthexis-lcd-attention/SKILL.md
+++ b/skills/arthexis-lcd-attention/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: arthexis-lcd-attention
+description: Write a concise high-priority attention message to the local Arthexis 16x2 LCD. Use when Codex has been processing for a while, completes a long-running task, or needs the user to return for confirmation or a manual step. Format line 1 as a very short code title plus the local message time, and line 2 as one or two short hint words describing the required action.
+---
+
+# Arthexis Lcd Attention
+
+Use this skill to post a brief, high-signal message on the device LCD after long processing or when waiting on the user. Keep the output safe for a shared screen and concise enough to fit a 16x2 character display.
+
+When user attention is required between Arthexis main phases, use a critical sustained display. The helper writes to the sticky high-priority LCD lock immediately and, when sustained mode is enabled, rewrites the same message at a bounded interval so it remains visible while the agent waits.
+
+## Workflow
+
+1. Choose a code title of about 3-8 uppercase characters that summarizes the state: `DONE`, `WAIT`, `TEST`, `SYNC`, `FIX`.
+2. Choose one or two imperative hint words for the required action: `REVIEW`, `CHECK LOGS`, `SCAN QR`, `APPROVE`.
+3. For ordinary completion/status attention, run `scripts/post_attention.py --code <CODE> --hint <WORD> [--action <WORD>]`.
+4. For approval or manual input required between main phases, run:
+
+```bash
+python3 scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustained
+```
+
+5. Use `--print-only` while testing or when you only need the rendered 16x2 preview.
+
+The helper writes through the live Arthexis suite at `/home/arthe/arthexis` by running `manage.py lcd write --sticky`, which targets the high-priority LCD lock.
+
+## Format
+
+- Put the short code title and local `HH:MM` on line 1.
+- Put one or two short hint words on line 2.
+- Prefer uppercase ASCII and simple words that are readable from a distance.
+- Avoid secrets, tokens, stack traces, filenames, or detailed status text.
+- Avoid using this for ordinary short turns when the user is already actively watching the session.
+- Keep sustained attention bounded. The default sustained duration is 600 seconds with a 15-second refresh interval.
+
+## Commands
+
+```bash
+python3 scripts/post_attention.py --code DONE --hint REVIEW
+python3 scripts/post_attention.py --code TEST --hint CHECK --action LOGS
+python3 scripts/post_attention.py --code WAIT --hint APPROVE --print-only
+python3 scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustained
+python3 scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustain-seconds 120 --interval 10
+```
+
+## Notes
+
+- Default Arthexis base dir: `/home/arthe/arthexis`
+- Default Python runner: `/home/arthe/arthexis/.venv/bin/python` when present
+- If you need more message ideas, read `references/message-patterns.md`

--- a/skills/arthexis-lcd-attention/SKILL.md
+++ b/skills/arthexis-lcd-attention/SKILL.md
@@ -7,7 +7,7 @@ description: Write a concise high-priority attention message to the local Arthex
 
 Use this skill to post a brief, high-signal message on the device LCD after long processing or when waiting on the user. Keep the output safe for a shared screen and concise enough to fit a 16x2 character display.
 
-When user attention is required between Arthexis main phases, use a critical sustained display. The helper writes to the sticky high-priority LCD lock immediately and, when sustained mode is enabled, rewrites the same message at a bounded interval so it remains visible while the agent waits.
+When user attention is required between Arthexis main phases, use a critical sustained display. The helper writes to the sticky high-priority LCD lock immediately and, when sustained mode is enabled, adds a bounded expiry so the message remains visible while the agent waits without blocking the agent or spawning a refresh loop.
 
 ## Workflow
 
@@ -22,7 +22,7 @@ python3 scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustai
 
 5. Use `--print-only` while testing or when you only need the rendered 16x2 preview.
 
-The helper writes through the live Arthexis suite at `/home/arthe/arthexis` by running `manage.py lcd write --sticky`, which targets the high-priority LCD lock.
+The helper writes the high-priority LCD lock directly under the configured Arthexis base directory. Sustained messages are bounded by the lock-file expiry line and the script returns after the initial atomic write.
 
 ## Format
 
@@ -31,7 +31,7 @@ The helper writes through the live Arthexis suite at `/home/arthe/arthexis` by r
 - Prefer uppercase ASCII and simple words that are readable from a distance.
 - Avoid secrets, tokens, stack traces, filenames, or detailed status text.
 - Avoid using this for ordinary short turns when the user is already actively watching the session.
-- Keep sustained attention bounded. The default sustained duration is 600 seconds with a 15-second refresh interval.
+- Keep sustained attention bounded. The default sustained duration is 600 seconds; no background worker is started, and the LCD runner drops the message when the lock expiry passes.
 
 ## Commands
 
@@ -46,5 +46,4 @@ python3 scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustai
 ## Notes
 
 - Default Arthexis base dir: `/home/arthe/arthexis`
-- Default Python runner: `/home/arthe/arthexis/.venv/bin/python` when present
 - If you need more message ideas, read `references/message-patterns.md`

--- a/skills/arthexis-lcd-attention/agents/openai.yaml
+++ b/skills/arthexis-lcd-attention/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Arthexis LCD Attention"
+  short_description: "Post concise LCD attention prompts."
+  default_prompt: "Use $arthexis-lcd-attention to write a short attention prompt to the Arthexis 16x2 LCD."

--- a/skills/arthexis-lcd-attention/references/message-patterns.md
+++ b/skills/arthexis-lcd-attention/references/message-patterns.md
@@ -1,0 +1,18 @@
+# Message Patterns
+
+Use these patterns when choosing the short code and hint words.
+
+## Examples
+
+- Long task finished, user should look at results: `DONE` + `REVIEW`
+- Tests finished, user should inspect failures or logs: `TEST` + `CHECK LOGS`
+- Work is blocked pending explicit approval: `WAIT` + `APPROVE`
+- QR or badge action is needed at the device: `SCAN` + `SCAN QR`
+- Sync or deployment completed and needs spot-checking: `SYNC` + `CHECK ADMIN`
+
+## Style
+
+- Prefer codes that fit in 3-8 characters.
+- Prefer one or two words on line 2.
+- Keep both lines readable at a glance from across the room.
+- Do not include secrets or detailed internal status.

--- a/skills/arthexis-lcd-attention/scripts/post_attention.py
+++ b/skills/arthexis-lcd-attention/scripts/post_attention.py
@@ -2,12 +2,10 @@
 from __future__ import annotations
 
 import argparse
-import shutil
+import os
 import subprocess
-import sys
-import time
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 WIDTH = 16
@@ -56,38 +54,33 @@ def build_lines(code: str, hint: str, action: str | None, time_text: str | None)
     return subject, body
 
 
-def _suite_python(base_dir: Path) -> str:
-    venv_python = base_dir / ".venv" / "bin" / "python"
-    if venv_python.exists():
-        return str(venv_python)
-    python3 = shutil.which("python3")
-    if python3:
-        return python3
-    return sys.executable
+def _render_lcd_lock_file(
+    *, subject: str, body: str, expires_at: datetime | None = None
+) -> str:
+    lines = [subject.strip()[:64], body.strip()[:64]]
+    if expires_at is not None:
+        lines.append(expires_at.isoformat())
+    return "\n".join(lines) + "\n"
 
 
-def _write_message(base_dir: Path, subject: str, body: str) -> subprocess.CompletedProcess[str]:
-    manage_py = base_dir / "manage.py"
-    if not manage_py.exists():
-        raise FileNotFoundError(f"Arthexis manage.py not found at {manage_py}")
+def _write_message(
+    base_dir: Path, subject: str, body: str, expires_at: datetime | None = None
+) -> subprocess.CompletedProcess[str]:
+    if not base_dir.exists():
+        raise FileNotFoundError(f"Arthexis base directory not found at {base_dir}")
 
-    command = [
-        _suite_python(base_dir),
-        str(manage_py),
-        "lcd",
-        "write",
-        "--subject",
-        subject,
-        "--body",
-        body,
-        "--sticky",
-    ]
-    return subprocess.run(
-        command,
-        cwd=base_dir,
-        capture_output=True,
-        text=True,
-        check=False,
+    lock_dir = base_dir / ".locks"
+    lock_file = lock_dir / "lcd-high"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    payload = _render_lcd_lock_file(subject=subject, body=body, expires_at=expires_at)
+    temp_file = lock_file.with_name(f".{lock_file.name}.{os.getpid()}.tmp")
+    temp_file.write_text(payload, encoding="utf-8")
+    temp_file.replace(lock_file)
+    return subprocess.CompletedProcess(
+        args=["write-lcd-lock", str(lock_file)],
+        returncode=0,
+        stdout=f"Updated {lock_file}\n",
+        stderr="",
     )
 
 
@@ -121,19 +114,10 @@ def _write_sustained_message(
     if interval_seconds <= 0:
         raise ValueError("interval seconds must be greater than zero")
 
-    result = _write_message(base_dir, subject, body)
-    if result.returncode != 0 or duration_seconds <= 0:
-        return result
-
-    deadline = time.monotonic() + duration_seconds
-    while True:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return result
-        time.sleep(min(interval_seconds, remaining))
-        result = _write_message(base_dir, subject, body)
-        if result.returncode != 0:
-            return result
+    if duration_seconds > 0:
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=duration_seconds)
+        return _write_message(base_dir, subject, body, expires_at=expires_at)
+    return _write_message(base_dir, subject, body)
 
 
 def main() -> int:
@@ -163,7 +147,10 @@ def main() -> int:
     parser.add_argument(
         "--sustained",
         action="store_true",
-        help=f"Refresh the sticky LCD message for {int(DEFAULT_SUSTAIN_SECONDS)} seconds.",
+        help=(
+            "Keep the sticky LCD message visible with a bounded expiry "
+            f"for {int(DEFAULT_SUSTAIN_SECONDS)} seconds."
+        ),
     )
     parser.add_argument(
         "--sustain-seconds",
@@ -180,7 +167,10 @@ def main() -> int:
         "--interval",
         type=float,
         default=DEFAULT_REFRESH_INTERVAL,
-        help=f"Seconds between sustained refreshes (default: {int(DEFAULT_REFRESH_INTERVAL)}).",
+        help=(
+            "Accepted for compatibility; sustained mode uses a bounded lock expiry "
+            f"instead of a refresh loop (default: {int(DEFAULT_REFRESH_INTERVAL)})."
+        ),
     )
     args = parser.parse_args()
 
@@ -203,7 +193,7 @@ def main() -> int:
         print("priority: critical")
     if sustain_seconds > 0:
         print(f"sustain_seconds: {sustain_seconds:g}")
-        print(f"refresh_interval: {args.interval:g}")
+        print("sustain_mode: bounded lock expiry")
 
     if args.print_only:
         return 0

--- a/skills/arthexis-lcd-attention/scripts/post_attention.py
+++ b/skills/arthexis-lcd-attention/scripts/post_attention.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import time
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+
+WIDTH = 16
+DEFAULT_BASE_DIR = Path("/home/arthe/arthexis")
+DEFAULT_CODE_WIDTH = 10
+DEFAULT_SUSTAIN_SECONDS = 600.0
+DEFAULT_REFRESH_INTERVAL = 15.0
+
+
+def _ascii_upper(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text or "")
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    cleaned = "".join(ch if ch.isalnum() or ch in {" ", "-", "_", ":"} else " " for ch in ascii_text)
+    return " ".join(cleaned.upper().split())
+
+
+def _display_code(raw_code: str) -> str:
+    code = _ascii_upper(raw_code)
+    if not code:
+        raise ValueError("code must contain at least one ASCII letter or digit")
+    return code[:DEFAULT_CODE_WIDTH].rstrip()
+
+
+def _display_time(raw_time: str | None) -> str:
+    if raw_time:
+        candidate = raw_time.strip()
+        datetime.strptime(candidate, "%H:%M")
+        return candidate
+    return datetime.now().astimezone().strftime("%H:%M")
+
+
+def _display_hint(hint: str, action: str | None) -> str:
+    words: list[str] = []
+    for value in (hint, action or ""):
+        words.extend(_ascii_upper(value).split())
+    if not words:
+        raise ValueError("hint must contain at least one ASCII word")
+    return " ".join(words[:2])[:WIDTH].rstrip()
+
+
+def build_lines(code: str, hint: str, action: str | None, time_text: str | None) -> tuple[str, str]:
+    display_code = _display_code(code)
+    display_time = _display_time(time_text)
+    subject = f"{display_code:<{DEFAULT_CODE_WIDTH}} {display_time:>5}"[:WIDTH]
+    body = _display_hint(hint, action)
+    return subject, body
+
+
+def _suite_python(base_dir: Path) -> str:
+    venv_python = base_dir / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    python3 = shutil.which("python3")
+    if python3:
+        return python3
+    return sys.executable
+
+
+def _write_message(base_dir: Path, subject: str, body: str) -> subprocess.CompletedProcess[str]:
+    manage_py = base_dir / "manage.py"
+    if not manage_py.exists():
+        raise FileNotFoundError(f"Arthexis manage.py not found at {manage_py}")
+
+    command = [
+        _suite_python(base_dir),
+        str(manage_py),
+        "lcd",
+        "write",
+        "--subject",
+        subject,
+        "--body",
+        body,
+        "--sticky",
+    ]
+    return subprocess.run(
+        command,
+        cwd=base_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _resolve_sustain_seconds(
+    *,
+    sustained: bool,
+    sustain_seconds: float | None,
+    max_sustain_seconds: float,
+) -> float:
+    if max_sustain_seconds <= 0:
+        raise ValueError("max sustain seconds must be greater than zero")
+    if sustain_seconds is None:
+        duration = DEFAULT_SUSTAIN_SECONDS if sustained else 0.0
+    else:
+        duration = sustain_seconds
+    if duration < 0:
+        raise ValueError("sustain seconds must be zero or greater")
+    if duration > max_sustain_seconds:
+        raise ValueError("sustain seconds exceeds the configured maximum")
+    return duration
+
+
+def _write_sustained_message(
+    *,
+    base_dir: Path,
+    subject: str,
+    body: str,
+    duration_seconds: float,
+    interval_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    if interval_seconds <= 0:
+        raise ValueError("interval seconds must be greater than zero")
+
+    result = _write_message(base_dir, subject, body)
+    if result.returncode != 0 or duration_seconds <= 0:
+        return result
+
+    deadline = time.monotonic() + duration_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return result
+        time.sleep(min(interval_seconds, remaining))
+        result = _write_message(base_dir, subject, body)
+        if result.returncode != 0:
+            return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Render and optionally send a short Arthexis LCD attention message."
+    )
+    parser.add_argument("--code", required=True, help="Short code title for line 1.")
+    parser.add_argument("--hint", required=True, help="Primary hint word for line 2.")
+    parser.add_argument("--action", help="Optional second hint word for line 2.")
+    parser.add_argument("--time", dest="time_text", help="Override local message time as HH:MM.")
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=DEFAULT_BASE_DIR,
+        help=f"Arthexis suite base directory (default: {DEFAULT_BASE_DIR})",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Render the lines but do not write to the LCD.",
+    )
+    parser.add_argument(
+        "--critical",
+        action="store_true",
+        help="Mark this as a critical high-priority attention request.",
+    )
+    parser.add_argument(
+        "--sustained",
+        action="store_true",
+        help=f"Refresh the sticky LCD message for {int(DEFAULT_SUSTAIN_SECONDS)} seconds.",
+    )
+    parser.add_argument(
+        "--sustain-seconds",
+        type=float,
+        help="Bounded duration for sustained refreshes; use 0 for a single sticky write.",
+    )
+    parser.add_argument(
+        "--max-sustain-seconds",
+        type=float,
+        default=DEFAULT_SUSTAIN_SECONDS,
+        help=f"Maximum allowed sustain duration (default: {int(DEFAULT_SUSTAIN_SECONDS)}).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_REFRESH_INTERVAL,
+        help=f"Seconds between sustained refreshes (default: {int(DEFAULT_REFRESH_INTERVAL)}).",
+    )
+    args = parser.parse_args()
+
+    try:
+        subject, body = build_lines(args.code, args.hint, args.action, args.time_text)
+        sustain_seconds = _resolve_sustain_seconds(
+            sustained=args.sustained,
+            sustain_seconds=args.sustain_seconds,
+            max_sustain_seconds=args.max_sustain_seconds,
+        )
+        if args.interval <= 0:
+            raise ValueError("interval seconds must be greater than zero")
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"line1: {subject}")
+    print(f"line2: {body}")
+    if args.critical:
+        print("priority: critical")
+    if sustain_seconds > 0:
+        print(f"sustain_seconds: {sustain_seconds:g}")
+        print(f"refresh_interval: {args.interval:g}")
+
+    if args.print_only:
+        return 0
+
+    try:
+        result = _write_sustained_message(
+            base_dir=args.base_dir,
+            subject=subject,
+            body=body,
+            duration_seconds=sustain_seconds,
+            interval_seconds=args.interval,
+        )
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if result.returncode != 0:
+        error_output = (result.stderr or result.stdout or "unknown error").strip()
+        print(f"error: {error_output}", file=sys.stderr)
+        return result.returncode or 1
+
+    if result.stdout.strip():
+        print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/arthexis-lcd-attention/scripts/post_attention.py
+++ b/skills/arthexis-lcd-attention/scripts/post_attention.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
+import sys
 import unicodedata
 from datetime import datetime, timedelta, timezone
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add the arthexis-lcd-attention skill to the repo skill catalog
- add bounded sustained critical LCD refresh support for between-main-phase approval waits
- keep messages on the sticky high-priority LCD lock and cap sustained refreshes at 10 minutes by default

## Issue
Closes #7419

## Verification
- python3 -m py_compile skills/arthexis-lcd-attention/scripts/post_attention.py
- python3 skills/arthexis-lcd-attention/scripts/post_attention.py --code WAIT --hint APPROVE --critical --sustain-seconds 30 --interval 10 --print-only
- git diff --check