### PR TITLE
[codex] Fix sites migration conflict precheck

### DIFF
--- a/scripts/check_migration_conflicts.py
+++ b/scripts/check_migration_conflicts.py
@@ -33,6 +33,7 @@ class MigrationFile:
     """Metadata parsed from a migration file path."""
 
     app_label: str
+    migration_label: str
     name: str
     number: int
     path: Path
@@ -180,6 +181,60 @@ def _parse_replaces(path: Path) -> list[tuple[str, str]]:
     return _parse_assignment_tuples(path, "replaces")
 
 
+def _app_migration_label(app_dir: Path) -> str:
+    """Return the Django migration label for ``app_dir``.
+
+    Most local app directories use their directory name as the Django app label.
+    ``apps.sites`` is an intentional exception: its runtime package is
+    ``apps.sites`` while its historical migration/model label remains ``pages``.
+    The static conflict check must follow dependencies by Django label, not by
+    filesystem directory name.
+    """
+
+    apps_py = app_dir / "apps.py"
+    if not apps_py.exists():
+        return app_dir.name
+
+    try:
+        module = ast.parse(apps_py.read_text(encoding="utf-8"), filename=str(apps_py))
+    except (OSError, SyntaxError):
+        return app_dir.name
+
+    expected_name = f"apps.{app_dir.name}"
+    fallback_label: str | None = None
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        config_name: str | None = None
+        config_label: str | None = None
+        for statement in node.body:
+            if not isinstance(statement, ast.Assign):
+                continue
+            for target in statement.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                if (
+                    target.id == "name"
+                    and isinstance(statement.value, ast.Constant)
+                    and isinstance(statement.value.value, str)
+                ):
+                    config_name = statement.value.value
+                if (
+                    target.id == "label"
+                    and isinstance(statement.value, ast.Constant)
+                    and isinstance(statement.value.value, str)
+                ):
+                    config_label = statement.value.value
+
+        if config_name == expected_name:
+            return config_label or app_dir.name
+        if config_name is None and config_label is not None:
+            fallback_label = config_label
+
+    return fallback_label or app_dir.name
+
+
 def _migration_files_for_app(app_dir: Path) -> list[MigrationFile]:
     """Collect migration files for ``app_dir`` sorted by number and name."""
 
@@ -187,6 +242,7 @@ def _migration_files_for_app(app_dir: Path) -> list[MigrationFile]:
     if not migrations_dir.exists():
         return []
 
+    migration_label = _app_migration_label(app_dir)
     files: list[MigrationFile] = []
     for path in migrations_dir.glob("*.py"):
         if path.name == "__init__.py":
@@ -197,6 +253,7 @@ def _migration_files_for_app(app_dir: Path) -> list[MigrationFile]:
         files.append(
             MigrationFile(
                 app_label=app_dir.name,
+                migration_label=migration_label,
                 name=path.stem,
                 number=int(match.group("number")),
                 path=path,
@@ -209,7 +266,7 @@ def _leaf_migrations(files: list[MigrationFile], dependencies_by_name: dict[str,
     """Return migrations that are not depended on by another local migration."""
 
     pointed_to: set[str] = set()
-    app_label = files[0].app_label if files else ""
+    app_label = files[0].migration_label if files else ""
     for dependencies in dependencies_by_name.values():
         for dep_app, dep_name in dependencies:
             if dep_app == app_label:
@@ -255,7 +312,7 @@ def _check_app(files: list[MigrationFile], *, repo_root: Path = REPO_ROOT) -> li
         replace_name
         for replaces in replaces_by_name.values()
         for replace_app, replace_name in replaces
-        if replace_app == files[0].app_label
+        if replace_app == files[0].migration_label
     }
 
     active_files = [migration for migration in files if migration.name not in replaced_names]
@@ -274,7 +331,7 @@ def _check_app(files: list[MigrationFile], *, repo_root: Path = REPO_ROOT) -> li
     merge_chain = [
         migration
         for migration in merge_files
-        if any(dep_app == files[0].app_label and dep_name in merge_name_set for dep_app, dep_name in dependencies_by_name[migration.name])
+        if any(dep_app == files[0].migration_label and dep_name in merge_name_set for dep_app, dep_name in dependencies_by_name[migration.name])
     ]
     if len(merge_files) > 1 and (len(merge_chain) > 0 or len([leaf for leaf in leaves if _is_merge_migration(leaf.name)]) > 1):
         merge_paths = ", ".join(
@@ -429,6 +486,7 @@ def _local_installed_app_labels(repo_root: Path) -> list[str]:
         except ValueError:
             continue
         labels.append(app_config.label)
+        labels.append(Path(app_config.path).name)
     return labels
 
 def run_checks(repo_root: Path = REPO_ROOT, *, app_labels: set[str] | None = None) -> int:

--- a/tests/test_check_migration_conflicts.py
+++ b/tests/test_check_migration_conflicts.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from scripts import check_migration_conflicts as conflicts
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _migration(dependencies: list[tuple[str, str]]) -> str:
+    dependency_lines = "\n".join(f"        ({app!r}, {migration!r})," for app, migration in dependencies)
+    return f"""from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+{dependency_lines}
+    ]
+    operations = []
+"""
+
+
+def test_alias_app_label_dependencies_do_not_create_false_duplicate_leaves(tmp_path):
+    app_dir = tmp_path / "apps" / "sites"
+    _write(
+        app_dir / "apps.py",
+        'from django.apps import AppConfig\n\n\nclass PagesConfig(AppConfig):\n    name = "apps.sites"\n    label = "pages"\n',
+    )
+    _write(app_dir / "migrations" / "0001_initial.py", _migration([]))
+    _write(
+        app_dir / "migrations" / "0002_initial.py",
+        _migration([("pages", "0001_initial")]),
+    )
+    _write(
+        app_dir / "migrations" / "0003_initial.py",
+        _migration([("pages", "0002_initial")]),
+    )
+
+    files = conflicts._migration_files_for_app(app_dir)
+
+    assert {migration.migration_label for migration in files} == {"pages"}
+    assert conflicts._check_app(files, repo_root=tmp_path) == []
+
+
+def test_duplicate_leaf_detection_still_uses_default_directory_label(tmp_path):
+    app_dir = tmp_path / "apps" / "widgets"
+    _write(app_dir / "migrations" / "0001_initial.py", _migration([]))
+    _write(
+        app_dir / "migrations" / "0002_add_name_pr7424.py",
+        _migration([("widgets", "0001_initial")]),
+    )
+    _write(
+        app_dir / "migrations" / "0003_add_slug_pr7424.py",
+        _migration([("widgets", "0001_initial")]),
+    )
+
+    errors = conflicts._check_app(conflicts._migration_files_for_app(app_dir), repo_root=tmp_path)
+
+    assert len(errors) == 1
+    assert "duplicate leaf migrations detected" in errors[0]
+    assert "app 'widgets'" in errors[0]


### PR DESCRIPTION
## Summary

Addresses the sites migration pre-check half of #7424.

The failing install-health job reported duplicate leaf migrations for app `sites`, listing `apps/sites/migrations/0002_initial.py` through `0010_alter_sitehighlight_options_sitehighlight_updated_at.py`. Django itself treats the runtime package `apps.sites` as app label `pages`, and those migrations correctly depend on `("pages", ...)`. The static conflict checker was following local dependencies by filesystem directory name (`sites`), so it missed the `pages` dependency chain and produced false duplicate leaves.

This patch teaches the checker to parse the app config migration label, preserves directory-label targeting for changed migration paths, and adds regression coverage for alias-labeled apps plus the normal duplicate-leaf path.

## Verification

All commands were run inside Docker container `rook-7424-sites` in `/workspace/arthexis`.

- `python -m pytest tests/test_check_migration_conflicts.py` -> 2 passed
- `python -m py_compile scripts/check_migration_conflicts.py tests/test_check_migration_conflicts.py` -> passed
- `python scripts/check_migration_conflicts.py` -> passed/skipped because no changed migration files were detected
- `python - <<PY ... run_checks(app_labels={"sites"}) ... PY` -> Migration conflict pre-check passed
- `ARTHEXIS_DB_BACKEND=sqlite python manage.py makemigrations --check --dry-run` -> No changes detected
- `ARTHEXIS_DB_BACKEND=sqlite python manage.py migrate --noinput` -> completed successfully
