### PR TITLE
💖 HIGH PRIORITY: Show funding banner on arthexis.com

### DIFF
--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -47,6 +47,10 @@ _ROLE_FAVICONS = {
     for role, filename in _FAVICON_FILENAMES.items()
     if role != "default"
 }
+ARTHEXIS_FUNDING_HOST = "arthexis.com"
+DEFAULT_FUNDING_ISSUE_URL = (
+    "https://github.com/arthexis/arthexis/issues/7433"
+)
 
 
 def _parse_user_story_attachment_limit() -> int:
@@ -61,6 +65,34 @@ def _parse_user_story_attachment_limit() -> int:
         return int(raw_limit)
     except (TypeError, ValueError):
         return 3
+
+
+def _is_arthexis_dot_com_request(request) -> bool:
+    """Return whether the current request is for the canonical public host."""
+
+    try:
+        host = request.get_host().split(":", 1)[0].lower()
+    except Exception:
+        return False
+    return host == ARTHEXIS_FUNDING_HOST
+
+
+def _build_funding_banner(request):
+    """Build the public funding banner, shown only on arthexis.com."""
+
+    if not _is_arthexis_dot_com_request(request):
+        return None
+
+    issue_url = getattr(settings, "ARTHEXIS_FUNDING_ISSUE_URL", "")
+    return {
+        "title": "Arthexis needs funding to keep maintenance running",
+        "message": (
+            "The PR Overseer and supporting maintenance automation depend on "
+            "available operating credits. Funding helps keep reviews, fixes, "
+            "and continuity work moving."
+        ),
+        "issue_url": issue_url or DEFAULT_FUNDING_ISSUE_URL,
+    }
 
 
 def _resolve_landing_visibility(
@@ -581,6 +613,7 @@ def nav_links(request):
         "favicon_url": _select_favicon_url(current_module, site, node),
         "header_references": _load_header_references(request, site, node),
         "site_highlight": _load_latest_site_highlight(),
+        "funding_banner": _build_funding_banner(request),
         "login_url": resolve_url(settings.LOGIN_URL),
         "site_template": _select_site_template(site, user),
         "operator_interface_mode": operator_interface_mode,

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -8,6 +8,7 @@ from django.db.utils import OperationalError, ProgrammingError
 from django.shortcuts import resolve_url
 from django.urls import Resolver404, resolve
 from django.utils.encoding import force_str
+from django.utils.translation import gettext as _
 
 from apps.features.utils import is_suite_feature_enabled
 from apps.groups.models import SecurityGroup
@@ -48,9 +49,7 @@ _ROLE_FAVICONS = {
     if role != "default"
 }
 ARTHEXIS_FUNDING_HOST = "arthexis.com"
-DEFAULT_FUNDING_ISSUE_URL = (
-    "https://github.com/arthexis/arthexis/issues/7433"
-)
+DEFAULT_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/7433"
 
 
 def _parse_user_story_attachment_limit() -> int:
@@ -85,8 +84,8 @@ def _build_funding_banner(request):
 
     issue_url = getattr(settings, "ARTHEXIS_FUNDING_ISSUE_URL", "")
     return {
-        "title": "Arthexis needs funding to keep maintenance running",
-        "message": (
+        "title": _("Arthexis needs funding to keep maintenance running"),
+        "message": _(
             "The PR Overseer and supporting maintenance automation depend on "
             "available operating credits. Funding helps keep reviews, fixes, "
             "and continuity work moving."

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -757,3 +757,43 @@ body.user-story-open {
     display: flex;
   }
 }
+.funding-banner {
+  align-items: center;
+  background: #1f2937;
+  border: 1px solid #facc15;
+  border-radius: 0.375rem;
+  color: #f8fafc;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.875rem 1rem;
+}
+
+.funding-banner p {
+  color: #d1d5db;
+}
+
+.funding-banner__mark {
+  color: #f472b6;
+  flex: 0 0 auto;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.funding-banner__link {
+  color: #fde68a;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.funding-banner__link:focus,
+.funding-banner__link:hover {
+  color: #fef3c7;
+}
+
+@media (max-width: 640px) {
+  .funding-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -760,7 +760,7 @@ body.user-story-open {
 .funding-banner {
   align-items: center;
   background: #1f2937;
-  border: 1px solid #facc15;
+  border: 1px solid var(--site-accent);
   border-radius: 0.375rem;
   color: #f8fafc;
   display: flex;
@@ -791,7 +791,7 @@ body.user-story-open {
   color: #fef3c7;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 575.98px) {
   .funding-banner {
     align-items: flex-start;
     flex-direction: column;

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -193,6 +193,18 @@
         </div>
       </nav>
       {% endif %}
+      {% if funding_banner %}
+        <section class="funding-banner mt-3" aria-labelledby="funding-banner-title">
+          <span class="funding-banner__mark" aria-hidden="true">💖</span>
+          <div>
+            <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
+            <p class="mb-0">{{ funding_banner.message }}</p>
+          </div>
+          <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
+            {% trans "View funding issue" %}
+          </a>
+        </section>
+      {% endif %}
       {% if site_highlight %}
         <div
           id="site-highlight"

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -98,3 +98,20 @@ def test_nav_links_includes_selected_site_highlight(
 
     assert context["site_highlight"] is not None
     assert context["site_highlight"].pk == highlight.pk
+
+
+def test_funding_banner_only_shows_on_arthexis_dot_com(
+    rf: RequestFactory,
+    settings,
+) -> None:
+    settings.ALLOWED_HOSTS = ["arthexis.com", "example.com"]
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/1"
+
+    canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
+    other_request = rf.get("/", HTTP_HOST="example.com")
+
+    banner = context_processors._build_funding_banner(canonical_request)
+
+    assert banner is not None
+    assert banner["issue_url"] == "https://github.com/arthexis/arthexis/issues/1"
+    assert context_processors._build_funding_banner(other_request) is None


### PR DESCRIPTION
## Summary
- show a funding-continuity banner only when the suite is served from the exact host arthexis.com
- point the banner to #7433 and include a heart mark for PR Overseer/direct-work prioritization
- add focused host-gating coverage for the funding banner context

## Issue linkage
No linked issue: this companion banner intentionally references the funding-continuity issue without closing it, because #7433 remains open until funding/credits are restored.

Refs #7433

## Verification
- .venv\Scripts\python.exe -m py_compile apps\sites\context_processors.py
- Attempted pytest for apps/sites/tests/test_site_highlight.py and the focused test, but this local environment timed out before completion.