### PR TITLE
Add release readiness test pruning gate

### DIFF
--- a/apps/core/templates/core/release_progress.html
+++ b/apps/core/templates/core/release_progress.html
@@ -325,6 +325,20 @@
       </li>
     {% endfor %}
     </ol>
+    {% if test_pruning_required %}
+    <div class="token-card">
+      <h2>{% trans "Test pruning evidence required" %}</h2>
+      <p>{% trans "Enter the pull request URL that prunes the lowest-value tests for this release." %}</p>
+      {% if test_pruning_error %}
+      <p class="error">{{ test_pruning_error }}</p>
+      {% endif %}
+      <form method="post">
+        {% csrf_token %}
+        <input type="url" name="test_pruning_pr_url" value="{{ test_pruning_pr_url }}" placeholder="https://github.com/org/repo/pull/123" aria-label="{% trans 'Test pruning PR URL' %}">
+        <button type="submit" name="set_test_pruning_evidence" value="1">{% trans "Record evidence" %}</button>
+      </form>
+    </div>
+    {% endif %}
     {% if not done %}
     {% if github_credentials_missing or github_token_using_stored %}
     <div class="token-card">

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -7,11 +7,15 @@ import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
 
+import apps.core.views.reports.release_publish.workflow as workflow_module
 from apps.core.views.reports.release_publish import pipeline
 from apps.core.views.reports.release_publish.exceptions import PublishPending
 from apps.core.views.reports.release_publish.workflow import ReleasePublishContext
 
-def test_publish_workflow_polling_pauses_when_run_in_progress(monkeypatch, tmp_path: Path):
+
+def test_publish_workflow_polling_pauses_when_run_in_progress(
+    monkeypatch, tmp_path: Path
+):
     class DummyRelease:
         pk = 1
         version = "1.2.3"
@@ -19,12 +23,20 @@ def test_publish_workflow_polling_pauses_when_run_in_progress(monkeypatch, tmp_p
     ctx: dict[str, object] = {}
     log_path = tmp_path / "publish.log"
 
-    monkeypatch.setattr(pipeline, "_resolve_github_token", lambda *_args, **_kwargs: "token")
-    monkeypatch.setattr(pipeline, "_resolve_github_repository", lambda _release: ("acme", "widget"))
+    monkeypatch.setattr(
+        pipeline, "_resolve_github_token", lambda *_args, **_kwargs: "token"
+    )
+    monkeypatch.setattr(
+        pipeline, "_resolve_github_repository", lambda _release: ("acme", "widget")
+    )
     monkeypatch.setattr(
         pipeline,
         "_fetch_publish_workflow_run",
-        lambda **_kwargs: {"id": 1, "status": "in_progress", "html_url": "https://example/run/1"},
+        lambda **_kwargs: {
+            "id": 1,
+            "status": "in_progress",
+            "html_url": "https://example/run/1",
+        },
     )
 
     with pytest.raises(PublishPending):
@@ -32,6 +44,7 @@ def test_publish_workflow_polling_pauses_when_run_in_progress(monkeypatch, tmp_p
 
     assert ctx.get("publish_pending") is True
     assert ctx.get("publish_workflow_url") == "https://example/run/1"
+
 
 def test_release_artifact_collection_finds_wheel_and_sdist(tmp_path: Path, monkeypatch):
     dist = tmp_path / "dist"
@@ -47,6 +60,7 @@ def test_release_artifact_collection_finds_wheel_and_sdist(tmp_path: Path, monke
     assert {path.name for path in artifacts} == {wheel.name, sdist.name}
     assert len(artifacts) == 2
 
+
 def test_prepare_step_progress_invalid_restart_counter_defaults_to_zero(tmp_path: Path):
     restart_path = tmp_path / "release.restarts"
     restart_path.write_text("bad-counter", encoding="utf-8")
@@ -61,13 +75,17 @@ def test_prepare_step_progress_invalid_restart_counter_defaults_to_zero(tmp_path
     assert restart_count == 0
     assert step_param == "4"
 
+
 def test_current_git_revision_returns_empty_on_subprocess_failure(monkeypatch):
     def boom(_args):
-        raise subprocess.CalledProcessError(returncode=2, cmd=["git", "rev-parse", "HEAD"])
+        raise subprocess.CalledProcessError(
+            returncode=2, cmd=["git", "rev-parse", "HEAD"]
+        )
 
     monkeypatch.setattr(pipeline, "_git_stdout", boom)
 
     assert pipeline._current_git_revision() == ""
+
 
 def test_broadcast_release_message_logs_failures(monkeypatch, caplog):
     class DummyRelease:
@@ -84,6 +102,7 @@ def test_broadcast_release_message_logs_failures(monkeypatch, caplog):
         pipeline._broadcast_release_message(DummyRelease())
 
     assert "Failed to broadcast release Net Message" in caplog.text
+
 
 def test_release_progress_uses_mutated_context_for_advance(monkeypatch, tmp_path: Path):
     class DummyRelease:
@@ -143,16 +162,26 @@ def test_release_progress_uses_mutated_context_for_advance(monkeypatch, tmp_path
             assert done is False
 
     monkeypatch.setattr(pipeline, "ReleasePublishWorkflow", FakeWorkflow)
-    monkeypatch.setattr(pipeline, "_get_release_or_response", lambda *_args: (DummyRelease(), None))
-    monkeypatch.setattr(pipeline, "_resolve_release_log_dir", lambda _path: (tmp_path, None))
-    monkeypatch.setattr(pipeline, "_handle_release_sync", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(pipeline, "_handle_release_restart", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        pipeline, "_get_release_or_response", lambda *_args: (DummyRelease(), None)
+    )
+    monkeypatch.setattr(
+        pipeline, "_resolve_release_log_dir", lambda _path: (tmp_path, None)
+    )
+    monkeypatch.setattr(
+        pipeline, "_handle_release_sync", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        pipeline, "_handle_release_restart", lambda *_args, **_kwargs: None
+    )
     monkeypatch.setattr(
         pipeline,
         "_prepare_logging",
         lambda ctx, *_args, **_kwargs: (ctx, tmp_path / "publish.log", ctx["step"]),
     )
-    monkeypatch.setattr(pipeline, "_build_artifacts_stale", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        pipeline, "_build_artifacts_stale", lambda *_args, **_kwargs: False
+    )
     monkeypatch.setattr(
         pipeline,
         "_handle_dirty_repository_action",
@@ -167,13 +196,19 @@ def test_release_progress_uses_mutated_context_for_advance(monkeypatch, tmp_path
         "_handle_manual_git_push_action",
         lambda _request, ctx, _log_path: ctx,
     )
-    monkeypatch.setattr(pipeline, "_resolve_release_log_display", lambda *_args, **_kwargs: (False, ""))
+    monkeypatch.setattr(
+        pipeline, "_resolve_release_log_display", lambda *_args, **_kwargs: (False, "")
+    )
     monkeypatch.setattr(pipeline, "_resolve_next_step", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(pipeline, "_build_release_step_states", lambda **_kwargs: [])
     monkeypatch.setattr(pipeline, "_get_user_github_token", lambda _user: None)
-    monkeypatch.setattr(pipeline, "_resolve_github_token", lambda *_args, **_kwargs: "token")
+    monkeypatch.setattr(
+        pipeline, "_resolve_github_token", lambda *_args, **_kwargs: "token"
+    )
     monkeypatch.setattr(pipeline, "build_release_guidance", lambda **_kwargs: {})
-    monkeypatch.setattr(pipeline, "_build_release_progress_context", lambda **_kwargs: {})
+    monkeypatch.setattr(
+        pipeline, "_build_release_progress_context", lambda **_kwargs: {}
+    )
     monkeypatch.setattr(
         pipeline,
         "_finalize_release_progress_response",
@@ -188,6 +223,7 @@ def test_release_progress_uses_mutated_context_for_advance(monkeypatch, tmp_path
     assert captured["ctx"].paused is True
     assert captured["ctx"].extras["pending_git_push"] == {"branch": "main"}
 
+
 def test_publish_step_compatibility_resets_inflight_session():
     typed_ctx = ReleasePublishContext(
         step=3,
@@ -196,7 +232,9 @@ def test_publish_step_compatibility_resets_inflight_session():
         extras={"publish_steps_schema": "old-step-order"},
     )
 
-    result = pipeline._ensure_publish_step_compatibility(typed_ctx, pipeline.PUBLISH_STEPS)
+    result = pipeline._ensure_publish_step_compatibility(
+        typed_ctx, pipeline.PUBLISH_STEPS
+    )
 
     assert result.step == 0
     assert result.started is False
@@ -208,10 +246,13 @@ def test_publish_step_compatibility_resets_inflight_session():
         name for name, _func in pipeline.PUBLISH_STEPS
     )
 
+
 def test_publish_step_compatibility_records_schema_for_new_session():
     typed_ctx = ReleasePublishContext(step=0, started=False, paused=False, extras={})
 
-    result = pipeline._ensure_publish_step_compatibility(typed_ctx, pipeline.PUBLISH_STEPS)
+    result = pipeline._ensure_publish_step_compatibility(
+        typed_ctx, pipeline.PUBLISH_STEPS
+    )
 
     assert result.step == 0
     assert result.started is False
@@ -220,9 +261,11 @@ def test_publish_step_compatibility_records_schema_for_new_session():
         name for name, _func in pipeline.PUBLISH_STEPS
     )
 
+
 def test_resolve_safe_child_path_rejects_parent_traversal(tmp_path: Path):
     with pytest.raises(ValueError):
         pipeline._resolve_safe_child_path(tmp_path, "../escape.txt")
+
 
 def test_release_progress_returns_400_for_invalid_state_path(monkeypatch):
     class DummyRelease:
@@ -231,7 +274,9 @@ def test_release_progress_returns_400_for_invalid_state_path(monkeypatch):
     def raise_unsafe_path(*_args, **_kwargs):
         raise ValueError("unsafe")
 
-    monkeypatch.setattr(pipeline, "_get_release_or_response", lambda *_args: (DummyRelease(), None))
+    monkeypatch.setattr(
+        pipeline, "_get_release_or_response", lambda *_args: (DummyRelease(), None)
+    )
     monkeypatch.setattr(
         pipeline,
         "_resolve_safe_child_path",
@@ -250,6 +295,7 @@ def test_release_progress_returns_400_for_invalid_state_path(monkeypatch):
 
     assert response.status_code == 400
 
+
 def test_step_run_tests_accepts_recorded_successful_test_evidence(tmp_path: Path):
     ctx = {
         "tests_verified_at": "2026-04-10T00:00:00+00:00",
@@ -260,6 +306,7 @@ def test_step_run_tests_accepts_recorded_successful_test_evidence(tmp_path: Path
     pipeline._step_run_tests(object(), ctx, tmp_path / "publish.log")
 
     assert ctx["tests_result"]["success"] is True
+
 
 def test_step_run_tests_requires_evidence_or_configured_command(
     monkeypatch, settings, tmp_path: Path
@@ -276,6 +323,7 @@ def test_step_run_tests_requires_evidence_or_configured_command(
         pipeline._step_run_tests(object(), ctx, tmp_path / "publish.log")
 
     assert "tests_verified_at" in ctx["error"]
+
 
 def test_step_run_tests_executes_configured_validation_command(
     monkeypatch, settings, tmp_path: Path
@@ -294,6 +342,7 @@ def test_step_run_tests_executes_configured_validation_command(
     assert ctx["tests_result"]["source"] == "pipeline_command"
     assert ctx["tests_command"] == "echo 'release tests ok'"
     assert "tests_verified_at" in ctx
+
 
 def test_step_run_tests_passes_configured_timeout_to_subprocess_run(
     monkeypatch, settings, tmp_path: Path
@@ -325,6 +374,7 @@ def test_step_run_tests_passes_configured_timeout_to_subprocess_run(
     assert call["command"] == ["echo", "release", "tests", "ok"]
     assert call["kwargs"]["timeout"] == 42
     assert ctx["tests_result"]["success"] is True
+
 
 def test_step_run_tests_records_timeout_result_and_logs_gate_failure(
     monkeypatch, settings, tmp_path: Path
@@ -359,6 +409,7 @@ def test_step_run_tests_records_timeout_result_and_logs_gate_failure(
     assert any("timeout=15s" in message for message in logged_messages)
     assert any("timed out after 15 seconds" in message for message in logged_messages)
 
+
 def test_step_confirm_pypi_trusted_publisher_settings_validates_expected_workflow_metadata(
     monkeypatch, tmp_path: Path
 ):
@@ -388,6 +439,7 @@ def test_step_confirm_pypi_trusted_publisher_settings_validates_expected_workflo
     assert ctx["trusted_publisher_environment"] == "pypi"
     assert "trusted_publisher_verified_at" in ctx
 
+
 def test_step_confirm_pypi_trusted_publisher_settings_accepts_yaml_variants(
     monkeypatch, tmp_path: Path
 ):
@@ -414,6 +466,116 @@ def test_step_confirm_pypi_trusted_publisher_settings_accepts_yaml_variants(
 
     assert ctx["trusted_publisher_ref"] == "refs/tags/v*"
     assert ctx["trusted_publisher_environment"] == "pypi"
+
+
+def test_step_prune_low_value_tests_pauses_for_operator_evidence(
+    monkeypatch, settings, tmp_path: Path
+):
+    settings.RELEASE_PUBLISH_TEST_PRUNING_PR_URL = ""
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx: dict[str, object] = {}
+
+    with pytest.raises(PublishPending):
+        pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert ctx["paused"] is True
+    assert ctx["test_pruning_required"] is True
+    assert "worst 1% of tests" in ctx["test_pruning_error"]
+    assert "error" not in ctx
+
+
+def test_step_prune_low_value_tests_accepts_scheduled_setting(
+    monkeypatch, settings, tmp_path: Path
+):
+    settings.RELEASE_PUBLISH_TEST_PRUNING_PR_URL = (
+        "https://github.com/arthexis/arthexis/pull/7000"
+    )
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx: dict[str, object] = {"auto_release": True}
+
+    pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert (
+        ctx["test_pruning_pr_url"] == "https://github.com/arthexis/arthexis/pull/7000"
+    )
+    assert ctx["test_pruning_result"] == {
+        "success": True,
+        "source": "settings",
+        "pr_url": "https://github.com/arthexis/arthexis/pull/7000",
+        "criteria": list(pipeline.TEST_PRUNING_CRITERIA),
+    }
+
+
+def test_step_prune_low_value_tests_rejects_explicit_failure(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx = {
+        "test_pruning_result": {"success": False},
+        "test_pruning_pr_url": "https://github.com/arthexis/arthexis/pull/7000",
+    }
+
+    with pytest.raises(PublishPending):
+        pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert "explicitly failed" in ctx["error"]
+
+
+def test_publish_workflow_records_operator_test_pruning_evidence(
+    monkeypatch, tmp_path: Path
+):
+    captured: dict[str, object] = {}
+    request = RequestFactory().post(
+        "/release/publish",
+        {
+            "set_test_pruning_evidence": "1",
+            "test_pruning_pr_url": "https://github.com/arthexis/arthexis/pull/7000",
+        },
+    )
+    request.user = type("User", (), {"is_authenticated": False})()
+    request.session = {}
+    monkeypatch.setattr(
+        workflow_module.messages, "success", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "persist_release_context",
+        lambda _request, _session_key, ctx, _lock_path: captured.update(ctx),
+    )
+
+    workflow = workflow_module.ReleasePublishWorkflow(
+        request=request,
+        session_key="release_publish_1",
+        lock_path=tmp_path / "release.lock",
+        restart_path=tmp_path / "release.restarts",
+        clean_redirect_path=lambda _request, path: path,
+        collect_dirty_files=lambda: [],
+        validate_manual_git_push=lambda _pending_push: True,
+        append_log=lambda *_args, **_kwargs: None,
+    )
+    ctx = workflow_module.ReleasePublishContext(
+        step=5,
+        started=True,
+        paused=True,
+        extras={"test_pruning_required": True},
+    )
+
+    result, resume_requested, response = workflow.resume(ctx)
+
+    assert resume_requested is False
+    assert response.status_code == 302
+    assert response["Location"] == "/release/publish?resume=1&step=5"
+    assert result.paused is False
+    assert result.extras["test_pruning_result"] == {
+        "success": True,
+        "source": "operator",
+        "pr_url": "https://github.com/arthexis/arthexis/pull/7000",
+    }
+    assert (
+        captured["test_pruning_pr_url"]
+        == "https://github.com/arthexis/arthexis/pull/7000"
+    )
+
 
 def test_step_confirm_pypi_trusted_publisher_settings_fails_on_mismatch(
     monkeypatch, tmp_path: Path
@@ -534,4 +696,3 @@ def test_step_confirm_pypi_trusted_publisher_settings_allows_non_publish_step_to
     )
 
     assert "trusted_publisher_verified_at" in ctx
-

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -506,6 +506,23 @@ def test_step_prune_low_value_tests_accepts_scheduled_setting(
     }
 
 
+def test_step_prune_low_value_tests_ignores_setting_for_interactive_release(
+    monkeypatch, settings, tmp_path: Path
+):
+    settings.RELEASE_PUBLISH_TEST_PRUNING_PR_URL = (
+        "https://github.com/arthexis/arthexis/pull/7000"
+    )
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx: dict[str, object] = {}
+
+    with pytest.raises(PublishPending):
+        pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert ctx["test_pruning_required"] is True
+    assert "test_pruning_result" not in ctx
+    assert "test_pruning_pr_url" not in ctx
+
+
 def test_step_prune_low_value_tests_rejects_explicit_failure(
     monkeypatch, tmp_path: Path
 ):
@@ -575,6 +592,56 @@ def test_publish_workflow_records_operator_test_pruning_evidence(
         captured["test_pruning_pr_url"]
         == "https://github.com/arthexis/arthexis/pull/7000"
     )
+
+
+def test_publish_workflow_rejects_invalid_test_pruning_url(monkeypatch, tmp_path: Path):
+    captured: dict[str, object] = {}
+    request = RequestFactory().post(
+        "/release/publish",
+        {
+            "set_test_pruning_evidence": "1",
+            "test_pruning_pr_url": "https://github.com/arthexis/arthexis/issues/7000",
+        },
+    )
+    request.user = type("User", (), {"is_authenticated": False})()
+    request.session = {}
+    monkeypatch.setattr(
+        workflow_module.messages, "error", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "store_release_context",
+        lambda _request, _session_key, ctx: captured.update(ctx),
+    )
+
+    workflow = workflow_module.ReleasePublishWorkflow(
+        request=request,
+        session_key="release_publish_1",
+        lock_path=tmp_path / "release.lock",
+        restart_path=tmp_path / "release.restarts",
+        clean_redirect_path=lambda _request, path: path,
+        collect_dirty_files=lambda: [],
+        validate_manual_git_push=lambda _pending_push: True,
+        append_log=lambda *_args, **_kwargs: None,
+    )
+    ctx = workflow_module.ReleasePublishContext(
+        step=5,
+        started=True,
+        paused=True,
+        extras={"test_pruning_required": True},
+    )
+
+    result, resume_requested, response = workflow.resume(ctx)
+
+    assert resume_requested is False
+    assert response.status_code == 302
+    assert response["Location"] == "/release/publish"
+    assert result.paused is True
+    assert result.extras["test_pruning_required"] is True
+    assert "valid GitHub pull request URL" in result.extras["test_pruning_error"]
+    assert "test_pruning_result" not in result.extras
+    assert captured["test_pruning_required"] is True
+    assert "test_pruning_result" not in captured
 
 
 def test_step_confirm_pypi_trusted_publisher_settings_fails_on_mismatch(

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -523,6 +523,37 @@ def test_step_prune_low_value_tests_ignores_setting_for_interactive_release(
     assert "test_pruning_pr_url" not in ctx
 
 
+def test_step_prune_low_value_tests_rejects_invalid_scheduled_setting(
+    monkeypatch, settings, tmp_path: Path
+):
+    settings.RELEASE_PUBLISH_TEST_PRUNING_PR_URL = (
+        "https://github.com/arthexis/arthexis/issues/7000"
+    )
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx: dict[str, object] = {"auto_release": True}
+
+    with pytest.raises(PublishPending):
+        pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert "GitHub pull request URL" in ctx["error"]
+    assert "test_pruning_result" not in ctx
+
+
+def test_step_prune_low_value_tests_rejects_invalid_prepopulated_url(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+    ctx: dict[str, object] = {
+        "test_pruning_pr_url": "https://example.com/arthexis/arthexis/pull/7000"
+    }
+
+    with pytest.raises(PublishPending):
+        pipeline._step_prune_low_value_tests(object(), ctx, tmp_path / "publish.log")
+
+    assert "GitHub pull request URL" in ctx["error"]
+    assert "test_pruning_result" not in ctx
+
+
 def test_step_prune_low_value_tests_rejects_explicit_failure(
     monkeypatch, tmp_path: Path
 ):

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -1684,7 +1684,7 @@ def _step_prune_low_value_tests(release, ctx, log_path: Path, *, user=None) -> N
             pruning_pr_url = str(pruning_result.get("pr_url") or pruning_pr_url).strip()
             pruning_source = str(pruning_result.get("source") or pruning_source)
 
-    if not pruning_pr_url:
+    if not pruning_pr_url and ctx.get("auto_release"):
         pruning_pr_url = str(
             getattr(settings, TEST_PRUNING_PR_URL_SETTING, "") or ""
         ).strip()

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -1642,6 +1642,48 @@ def _step_run_tests(release, ctx, log_path: Path, *, user=None) -> None:
     _append_log(log_path, "Release test gate passed")
 
 
+def _step_prune_low_value_tests(release, ctx, log_path: Path, *, user=None) -> None:
+    """Require per-release test-suite pruning evidence.
+
+    Prerequisites: release test gate completed.
+    Side effects: records the pruning PR evidence in release context/logs.
+    Rollback expectations: no rollback; missing evidence pauses progression.
+    """
+    _ = release, user
+    _append_log(log_path, "Prune worst 1% of tests by PR")
+    pruning_result = ctx.get("test_pruning_result")
+    pruning_pr_url = str(ctx.get("test_pruning_pr_url") or "").strip()
+    if isinstance(pruning_result, dict) and pruning_result.get("success") is True:
+        pruning_pr_url = str(pruning_result.get("pr_url") or pruning_pr_url).strip()
+    elif not pruning_pr_url:
+        _fail_release_gate(
+            ctx,
+            log_path,
+            "Release readiness blocked: prune the worst 1% of tests by PR before "
+            "publishing. Prioritize low-value, duplicate, over-mocked, confusing, "
+            "or misleading tests. Record test_pruning_pr_url or "
+            "test_pruning_result.success=true in the release context and rerun.",
+        )
+
+    ctx["test_pruning_result"] = {
+        "success": True,
+        "source": "release_context",
+        "pr_url": pruning_pr_url,
+        "criteria": [
+            "low value",
+            "duplicate",
+            "over-mocked",
+            "confusing",
+            "misleading",
+        ],
+    }
+    _append_log(
+        log_path,
+        "Test pruning gate passed"
+        + (f" using PR {pruning_pr_url}" if pruning_pr_url else ""),
+    )
+
+
 def _step_confirm_pypi_trusted_publisher_settings(
     release, ctx, log_path: Path, *, user=None
 ) -> None:
@@ -2339,6 +2381,7 @@ _STEP_HANDLER_MAP = {
     "_step_pre_release_actions": _step_pre_release_actions,
     "_step_promote_build": _step_promote_build,
     "_step_record_publish_metadata": _step_record_publish_metadata,
+    "_step_prune_low_value_tests": _step_prune_low_value_tests,
     "_step_run_tests": _step_run_tests,
     "_step_verify_release_environment": _step_verify_release_environment,
     "_step_wait_for_github_actions_publish": _step_wait_for_github_actions_publish,

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -120,7 +120,11 @@ from .github_ops import (
     upload_release_assets as gh_upload_release_assets,
 )
 from .steps import StepDefinition, run_release_step
-from .workflow import ReleasePublishContext, ReleasePublishWorkflow
+from .workflow import (
+    ReleasePublishContext,
+    ReleasePublishWorkflow,
+    _is_pull_request_url,
+)
 
 logger = logging.getLogger(__name__)
 GIT_ADAPTER = SubprocessGitAdapter()
@@ -1704,6 +1708,14 @@ def _step_prune_low_value_tests(release, ctx, log_path: Path, *, user=None) -> N
         ctx["test_pruning_error"] = _(message)
         _append_log(log_path, message)
         raise PublishPending()
+
+    if not _is_pull_request_url(pruning_pr_url):
+        _fail_release_gate(
+            ctx,
+            log_path,
+            "Release test pruning gate failed: recorded pruning evidence must be "
+            "a GitHub pull request URL.",
+        )
 
     ctx.pop("test_pruning_required", None)
     ctx.pop("test_pruning_error", None)

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -130,6 +130,14 @@ EXPECTED_PUBLISH_ENVIRONMENT = "pypi"
 RELEASE_VALIDATION_COMMAND_SETTING = "RELEASE_PUBLISH_VALIDATION_COMMAND"
 RELEASE_VALIDATION_TIMEOUT_SETTING = "RELEASE_PUBLISH_VALIDATION_TIMEOUT_SECONDS"
 DEFAULT_RELEASE_VALIDATION_TIMEOUT_SECONDS = 900
+TEST_PRUNING_PR_URL_SETTING = "RELEASE_PUBLISH_TEST_PRUNING_PR_URL"
+TEST_PRUNING_CRITERIA = (
+    "low value",
+    "duplicate",
+    "over-mocked",
+    "confusing",
+    "misleading",
+)
 
 
 def _resolve_github_token(
@@ -312,9 +320,7 @@ def _handle_release_sync(
             request,
             release,
             action,
-            _(
-                "Another release already exists for %(package)s %(version)s."
-            )
+            _("Another release already exists for %(package)s %(version)s.")
             % {
                 "package": release.package.name,
                 "version": conflicting_release.version,
@@ -460,7 +466,9 @@ def _update_publish_controls(
                     group=None,
                     defaults={"token": token},
                 )
-                message = _("GitHub token stored for this publish session and your account.")
+                message = _(
+                    "GitHub token stored for this publish session and your account."
+                )
             else:
                 message = _("GitHub token stored for this publish session.")
             messages.success(request, message)
@@ -494,8 +502,12 @@ def _update_publish_controls(
             ctx["started"] = True
         ctx["paused"] = bool(ctx.get("pending_git_push") or ctx.get("dirty_files"))
         _store_release_context(request, session_key, ctx)
-        return ctx, False, redirect(
-            _clean_redirect_path(request, request.path),
+        return (
+            ctx,
+            False,
+            redirect(
+                _clean_redirect_path(request, request.path),
+            ),
         )
 
     if request.GET.get("set_dry_run") is not None:
@@ -584,7 +596,11 @@ def _build_artifacts_stale(
     ctx: dict, step_count: int, steps: Sequence[tuple[str, object]]
 ) -> bool:
     build_step_index = next(
-        (index for index, (name, _) in enumerate(steps) if name == BUILD_RELEASE_ARTIFACTS_STEP_NAME),
+        (
+            index
+            for index, (name, _) in enumerate(steps)
+            if name == BUILD_RELEASE_ARTIFACTS_STEP_NAME
+        ),
         None,
     )
     if build_step_index is None:
@@ -639,7 +655,9 @@ def _handle_dirty_repository_action(request, ctx: dict, log_path: Path):
         elif dirty_action == "commit":
             message = request.POST.get("dirty_message", "").strip()
             if not message:
-                message = ctx.get("dirty_commit_message") or DIRTY_COMMIT_DEFAULT_MESSAGE
+                message = (
+                    ctx.get("dirty_commit_message") or DIRTY_COMMIT_DEFAULT_MESSAGE
+                )
             ctx["dirty_commit_message"] = message
             try:
                 GIT_ADAPTER.run(["git", "add", "--all"], check=True)
@@ -656,8 +674,7 @@ def _handle_dirty_repository_action(request, ctx: dict, log_path: Path):
                     ctx.pop("dirty_log_message", None)
                 _append_log(
                     log_path,
-                    _("Committed pending changes: %(message)s")
-                    % {"message": message},
+                    _("Committed pending changes: %(message)s") % {"message": message},
                 )
     return ctx
 
@@ -753,7 +770,9 @@ def _sync_with_origin_main(log_path: Path) -> None:
     """Ensure the current branch is rebased onto ``origin/main``."""
 
     if not _has_remote("origin"):
-        _append_log(log_path, "No git remote configured; skipping sync with origin/main")
+        _append_log(
+            log_path, "No git remote configured; skipping sync with origin/main"
+        )
         return
 
     try:
@@ -898,7 +917,9 @@ def _resolve_github_repository(release: PackageRelease) -> tuple[str, str]:
     parsed = _parse_github_repository(repo_url)
     if parsed:
         return parsed
-    remote_url = git_utils.git_remote_url("origin", use_push_url=True) or git_utils.git_remote_url("origin")
+    remote_url = git_utils.git_remote_url(
+        "origin", use_push_url=True
+    ) or git_utils.git_remote_url("origin")
     if remote_url:
         parsed = _parse_github_repository(remote_url)
         if parsed:
@@ -1191,9 +1212,7 @@ def _push_release_changes(log_path: Path, ctx: dict, *, step_name: str) -> bool:
                 details=details or None,
             )
             raise PublishPending() from exc
-        _append_log(
-            log_path, f"Failed to push release changes to origin: {details}"
-        )
+        _append_log(log_path, f"Failed to push release changes to origin: {details}")
         raise RuntimeError("Failed to push release changes") from exc
 
     _append_log(log_path, "Pushed release changes to origin")
@@ -1357,7 +1376,9 @@ def _handle_version_step_dirty_repository(ctx: dict, log_path: Path) -> bool:
     ctx.setdefault("dirty_commit_message", DIRTY_COMMIT_DEFAULT_MESSAGE)
     ctx.pop("fixtures", None)
     ctx.pop("dirty_commit_error", None)
-    details = ", ".join(entry["path"] for entry in dirty_entries) if dirty_entries else ""
+    details = (
+        ", ".join(entry["path"] for entry in dirty_entries) if dirty_entries else ""
+    )
     message = "Git repository has uncommitted changes"
     if details:
         message += f": {details}"
@@ -1521,9 +1542,7 @@ def _step_pre_release_actions(release, ctx, log_path: Path, *, user=None) -> Non
             check=True,
         )
         staged_release_fixtures = [Path(path) for path in release_fixture_status]
-        formatted = ", ".join(
-            _format_path(path) for path in staged_release_fixtures
-        )
+        formatted = ", ".join(_format_path(path) for path in staged_release_fixtures)
         _append_log(log_path, "Staged release fixtures " + formatted)
     version_path = Path("VERSION")
     previous_version_text = (
@@ -1548,9 +1567,7 @@ def _step_pre_release_actions(release, ctx, log_path: Path, *, user=None) -> Non
         )
         _append_log(log_path, f"Committed VERSION update for {release.version}")
     else:
-        _append_log(
-            log_path, "No release metadata changes detected; skipping commit"
-        )
+        _append_log(log_path, "No release metadata changes detected; skipping commit")
     _append_log(log_path, "Pre-release actions complete")
 
 
@@ -1649,39 +1666,55 @@ def _step_prune_low_value_tests(release, ctx, log_path: Path, *, user=None) -> N
     Side effects: records the pruning PR evidence in release context/logs.
     Rollback expectations: no rollback; missing evidence pauses progression.
     """
-    _ = release, user
+    del release, user
     _append_log(log_path, "Prune worst 1% of tests by PR")
     pruning_result = ctx.get("test_pruning_result")
     pruning_pr_url = str(ctx.get("test_pruning_pr_url") or "").strip()
-    if isinstance(pruning_result, dict) and pruning_result.get("success") is True:
-        pruning_pr_url = str(pruning_result.get("pr_url") or pruning_pr_url).strip()
-    elif not pruning_pr_url:
-        _fail_release_gate(
-            ctx,
-            log_path,
-            "Release readiness blocked: prune the worst 1% of tests by PR before "
-            "publishing. Prioritize low-value, duplicate, over-mocked, confusing, "
-            "or misleading tests. Record test_pruning_pr_url or "
-            "test_pruning_result.success=true in the release context and rerun.",
-        )
+    pruning_source = "release_context"
 
+    if isinstance(pruning_result, dict):
+        if pruning_result.get("success") is False:
+            _fail_release_gate(
+                ctx,
+                log_path,
+                "Release test pruning gate failed: recorded pruning evidence "
+                "explicitly failed. Fix the pruning PR and rerun this step.",
+            )
+        if pruning_result.get("success") is True:
+            pruning_pr_url = str(pruning_result.get("pr_url") or pruning_pr_url).strip()
+            pruning_source = str(pruning_result.get("source") or pruning_source)
+
+    if not pruning_pr_url:
+        pruning_pr_url = str(
+            getattr(settings, TEST_PRUNING_PR_URL_SETTING, "") or ""
+        ).strip()
+        if pruning_pr_url:
+            pruning_source = "settings"
+
+    if not pruning_pr_url:
+        message = (
+            "Release readiness paused: prune the worst 1% of tests by PR before "
+            "publishing. Prioritize low-value, duplicate, over-mocked, confusing, "
+            "or misleading tests. Record a test pruning PR URL in the publish "
+            "workflow or configure RELEASE_PUBLISH_TEST_PRUNING_PR_URL for "
+            "scheduled releases, then rerun this step."
+        )
+        ctx["paused"] = True
+        ctx["test_pruning_required"] = True
+        ctx["test_pruning_error"] = _(message)
+        _append_log(log_path, message)
+        raise PublishPending()
+
+    ctx.pop("test_pruning_required", None)
+    ctx.pop("test_pruning_error", None)
+    ctx["test_pruning_pr_url"] = pruning_pr_url
     ctx["test_pruning_result"] = {
         "success": True,
-        "source": "release_context",
+        "source": pruning_source,
         "pr_url": pruning_pr_url,
-        "criteria": [
-            "low value",
-            "duplicate",
-            "over-mocked",
-            "confusing",
-            "misleading",
-        ],
+        "criteria": list(TEST_PRUNING_CRITERIA),
     }
-    _append_log(
-        log_path,
-        "Test pruning gate passed"
-        + (f" using PR {pruning_pr_url}" if pruning_pr_url else ""),
-    )
+    _append_log(log_path, f"Test pruning gate passed using PR {pruning_pr_url}")
 
 
 def _step_confirm_pypi_trusted_publisher_settings(
@@ -1927,7 +1960,8 @@ def _step_promote_build(release, ctx, log_path: Path, *, user=None) -> None:
         if status_output:
             _append_log(
                 log_path,
-                "Git repository is not clean; git status --porcelain:\n" + status_output,
+                "Git repository is not clean; git status --porcelain:\n"
+                + status_output,
             )
         release_utils.promote(
             package=release.to_package(),
@@ -2020,9 +2054,7 @@ def _step_verify_release_environment(
         release,
         ctx,
         log_path,
-        message=_(
-            "GitHub token missing. Provide a token to continue publishing."
-        ),
+        message=_("GitHub token missing. Provide a token to continue publishing."),
         user=user,
     )
 
@@ -2070,9 +2102,7 @@ def _step_export_and_dispatch(release, ctx, log_path: Path, *, user=None) -> Non
         release,
         ctx,
         log_path,
-        message=_(
-            "GitHub token missing. Provide a token to continue publishing."
-        ),
+        message=_("GitHub token missing. Provide a token to continue publishing."),
         user=user,
     )
     tag_name = _ensure_release_tag(release, log_path)
@@ -2172,9 +2202,7 @@ def _step_wait_for_github_actions_publish(
         release,
         ctx,
         log_path,
-        message=_(
-            "GitHub token missing. Provide a token to continue publishing."
-        ),
+        message=_("GitHub token missing. Provide a token to continue publishing."),
         user=user,
     )
     _wait_for_publish_workflow_completion(
@@ -2219,8 +2247,7 @@ def _pypi_release_available(release) -> bool:
             if not same_version:
                 continue
             if any(
-                isinstance(file_data, dict)
-                and not file_data.get("yanked", False)
+                isinstance(file_data, dict) and not file_data.get("yanked", False)
                 for file_data in files or []
             ):
                 return True
@@ -2310,9 +2337,7 @@ def _step_capture_publish_logs(release, ctx, log_path: Path, *, user=None) -> No
                     "GitHub token missing; PyPI publish logs were not captured."
                 ),
                 "followups": [
-                    _(
-                        "Provide a GitHub token in the publish workflow to capture logs."
-                    )
+                    _("Provide a GitHub token in the publish workflow to capture logs.")
                 ],
             }
         )
@@ -2373,18 +2398,18 @@ def _step_capture_publish_logs(release, ctx, log_path: Path, *, user=None) -> No
 
 
 _STEP_HANDLER_MAP = {
-    "_step_capture_publish_logs": _step_capture_publish_logs,
     "_step_check_version": _step_check_version,
-    "_step_confirm_pypi_trusted_publisher_settings": _step_confirm_pypi_trusted_publisher_settings,
-    "_step_export_and_dispatch": _step_export_and_dispatch,
     "_step_handle_migrations": _step_handle_migrations,
     "_step_pre_release_actions": _step_pre_release_actions,
     "_step_promote_build": _step_promote_build,
-    "_step_record_publish_metadata": _step_record_publish_metadata,
-    "_step_prune_low_value_tests": _step_prune_low_value_tests,
     "_step_run_tests": _step_run_tests,
+    "_step_prune_low_value_tests": _step_prune_low_value_tests,
+    "_step_confirm_pypi_trusted_publisher_settings": _step_confirm_pypi_trusted_publisher_settings,
     "_step_verify_release_environment": _step_verify_release_environment,
+    "_step_export_and_dispatch": _step_export_and_dispatch,
     "_step_wait_for_github_actions_publish": _step_wait_for_github_actions_publish,
+    "_step_record_publish_metadata": _step_record_publish_metadata,
+    "_step_capture_publish_logs": _step_capture_publish_logs,
 }
 
 PUBLISH_STEPS = [
@@ -2525,7 +2550,7 @@ def release_progress_impl(request, pk: int, action: str):
             message_text=_(
                 "Source changes detected after build. Restarting publish workflow."
             ),
-    )
+        )
 
     ctx = _handle_dirty_repository_action(request, ctx, log_path)
     ctx = _handle_manual_git_push_action(request, ctx, log_path)
@@ -2561,7 +2586,9 @@ def release_progress_impl(request, pk: int, action: str):
         _broadcast_release_message(release)
         ctx["release_net_message_sent"] = True
 
-    show_log, log_content = _resolve_release_log_display(ctx, step_count, done, log_path)
+    show_log, log_content = _resolve_release_log_display(
+        ctx, step_count, done, log_path
+    )
     next_step = _resolve_next_step(ctx, step_count, done)
     dirty_files = ctx.get("dirty_files")
     if dirty_files:
@@ -2683,15 +2710,24 @@ def _is_release_start_enabled(ctx: dict, step_count: int, total_steps: int) -> b
     return (not started_flag or paused_flag) and not done_flag and not error_flag
 
 
-def _resolve_release_log_display(ctx: dict, step_count: int, done: bool, log_path: Path):
-    show_log = bool(ctx.get("started")) or step_count > 0 or done or bool(ctx.get("error"))
+def _resolve_release_log_display(
+    ctx: dict, step_count: int, done: bool, log_path: Path
+):
+    show_log = (
+        bool(ctx.get("started")) or step_count > 0 or done or bool(ctx.get("error"))
+    )
     if show_log and log_path.exists():
         return show_log, log_path.read_text(encoding="utf-8")
     return show_log, ""
 
 
 def _resolve_next_step(ctx: dict, step_count: int, done: bool):
-    if ctx.get("started") and not ctx.get("paused") and not done and not ctx.get("error"):
+    if (
+        ctx.get("started")
+        and not ctx.get("paused")
+        and not done
+        and not ctx.get("error")
+    ):
         return step_count
     return None
 
@@ -2786,7 +2822,9 @@ def _build_release_progress_context(
         "cert_log": ctx.get("cert_log"),
         "fixtures": fixtures_summary,
         "dirty_files": dirty_files,
-        "dirty_commit_message": ctx.get("dirty_commit_message", DIRTY_COMMIT_DEFAULT_MESSAGE),
+        "dirty_commit_message": ctx.get(
+            "dirty_commit_message", DIRTY_COMMIT_DEFAULT_MESSAGE
+        ),
         "dirty_commit_error": ctx.get("dirty_commit_error"),
         "restart_count": restart_count,
         "started": ctx.get("started", False),
@@ -2811,6 +2849,9 @@ def _build_release_progress_context(
         "manual_git_push_error": ctx.get("pending_git_push_error"),
         "publish_pending": publish_pending,
         "publish_workflow_url": ctx.get("publish_workflow_url", ""),
+        "test_pruning_required": ctx.get("test_pruning_required", False),
+        "test_pruning_error": ctx.get("test_pruning_error"),
+        "test_pruning_pr_url": ctx.get("test_pruning_pr_url", ""),
         "status_guidance": status_guidance,
     }
 

--- a/apps/core/views/reports/release_publish/workflow.py
+++ b/apps/core/views/reports/release_publish/workflow.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from django.contrib import messages
 from django.shortcuts import redirect
@@ -22,6 +22,16 @@ from .context import (
     store_release_context,
 )
 from .steps import StepDefinition, run_release_step
+
+
+def _is_pull_request_url(value: str) -> bool:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    if parsed.netloc.lower() != "github.com":
+        return False
+    parts = [part for part in parsed.path.split("/") if part]
+    return len(parts) == 4 and parts[2] == "pull" and parts[3].isdigit()
 
 
 @dataclass(slots=True)
@@ -247,7 +257,7 @@ class ReleasePublishWorkflow:
 
     def _resume_with_test_pruning_evidence(self, state: dict[str, Any]):
         pr_url = (self.request.POST.get("test_pruning_pr_url") or "").strip()
-        if pr_url:
+        if pr_url and _is_pull_request_url(pr_url):
             state["test_pruning_pr_url"] = pr_url
             state["test_pruning_result"] = {
                 "success": True,
@@ -270,8 +280,12 @@ class ReleasePublishWorkflow:
             return ReleasePublishContext.from_dict(state), False, redirect(target)
 
         state["test_pruning_required"] = True
-        state["test_pruning_error"] = _("Enter the test pruning PR URL to continue.")
-        messages.error(self.request, _("Enter the test pruning PR URL to continue."))
+        if pr_url:
+            message = _("Enter a valid GitHub pull request URL to continue.")
+        else:
+            message = _("Enter the test pruning PR URL to continue.")
+        state["test_pruning_error"] = message
+        messages.error(self.request, message)
         self._store(state)
         target = self.clean_redirect_path(self.request, self.request.path)
         return ReleasePublishContext.from_dict(state), False, redirect(target)

--- a/apps/core/views/reports/release_publish/workflow.py
+++ b/apps/core/views/reports/release_publish/workflow.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.shortcuts import redirect
@@ -34,7 +36,7 @@ class ReleasePublishContext:
     extras: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, payload: dict[str, Any] | None) -> "ReleasePublishContext":
+    def from_dict(cls, payload: dict[str, Any] | None) -> ReleasePublishContext:
         payload = dict(payload or {})
         return cls(
             step=int(payload.pop("step", 0) or 0),
@@ -84,7 +86,9 @@ class ReleasePublishWorkflow:
         self.validate_manual_git_push = validate_manual_git_push
         self.append_log = append_log
 
-    def load(self, log_dir_warning_message: str | None) -> tuple[ReleasePublishContext, str | None]:
+    def load(
+        self, log_dir_warning_message: str | None
+    ) -> tuple[ReleasePublishContext, str | None]:
         session_ctx = self.request.session.get(self.session_key)
         loaded_ctx = load_release_context(session_ctx, self.lock_path)
         typed_ctx = ReleasePublishContext.from_dict(
@@ -102,7 +106,9 @@ class ReleasePublishWorkflow:
 
         return typed_ctx, log_dir_warning_message
 
-    def start(self, ctx: ReleasePublishContext, *, start_enabled: bool) -> ReleasePublishContext:
+    def start(
+        self, ctx: ReleasePublishContext, *, start_enabled: bool
+    ) -> ReleasePublishContext:
         state = ctx.to_dict()
         if self.request.GET.get("set_dry_run") is not None:
             if start_enabled:
@@ -117,12 +123,19 @@ class ReleasePublishWorkflow:
             state["paused"] = False
         return ReleasePublishContext.from_dict(state)
 
-    def resume(self, ctx: ReleasePublishContext) -> tuple[ReleasePublishContext, bool, Any | None]:
+    def resume(
+        self, ctx: ReleasePublishContext
+    ) -> tuple[ReleasePublishContext, bool, Any | None]:
         state = ctx.to_dict()
         state["dry_run"] = bool(state.get("dry_run"))
 
         if self.request.method == "POST" and self.request.POST.get("set_github_token"):
             return self._resume_with_github_token(state)
+
+        if self.request.method == "POST" and self.request.POST.get(
+            "set_test_pruning_evidence"
+        ):
+            return self._resume_with_test_pruning_evidence(state)
 
         if self.request.method == "POST" and self.request.POST.get("ack_error"):
             return self._resume_ack_error(state)
@@ -142,7 +155,9 @@ class ReleasePublishWorkflow:
 
     def poll(self, ctx: ReleasePublishContext) -> tuple[bool, bool]:
         poll_requested = self.request.GET.get("poll") == "1"
-        return poll_requested, bool(poll_requested and ctx.extras.get("publish_pending"))
+        return poll_requested, bool(
+            poll_requested and ctx.extras.get("publish_pending")
+        )
 
     def advance(
         self,
@@ -183,7 +198,9 @@ class ReleasePublishWorkflow:
 
         return ctx.to_dict()
 
-    def step_progress(self, ctx: ReleasePublishContext, *, resume_requested: bool) -> tuple[int, str | None]:
+    def step_progress(
+        self, ctx: ReleasePublishContext, *, resume_requested: bool
+    ) -> tuple[int, str | None]:
         restart_count = 0
         if self.restart_path.exists():
             try:
@@ -213,7 +230,9 @@ class ReleasePublishWorkflow:
                     group=None,
                     user=self.request.user,
                 )
-                message = _("GitHub token stored for this publish session and your account.")
+                message = _(
+                    "GitHub token stored for this publish session and your account."
+                )
             else:
                 message = _("GitHub token stored for this publish session.")
             messages.success(self.request, message)
@@ -223,6 +242,37 @@ class ReleasePublishWorkflow:
             messages.error(self.request, _("Enter a GitHub token to continue."))
             self._store(state)
 
+        target = self.clean_redirect_path(self.request, self.request.path)
+        return ReleasePublishContext.from_dict(state), False, redirect(target)
+
+    def _resume_with_test_pruning_evidence(self, state: dict[str, Any]):
+        pr_url = (self.request.POST.get("test_pruning_pr_url") or "").strip()
+        if pr_url:
+            state["test_pruning_pr_url"] = pr_url
+            state["test_pruning_result"] = {
+                "success": True,
+                "source": "operator",
+                "pr_url": pr_url,
+            }
+            state.pop("test_pruning_required", None)
+            state.pop("test_pruning_error", None)
+            state.pop("error", None)
+            if not state.get("started"):
+                state["started"] = True
+            if not state.get("dirty_files") and not state.get("pending_git_push"):
+                state["paused"] = False
+            messages.success(self.request, _("Test pruning evidence recorded."))
+            self._persist(state)
+            query = urlencode({"resume": "1", "step": state.get("step", 0)})
+            target = (
+                f"{self.clean_redirect_path(self.request, self.request.path)}?{query}"
+            )
+            return ReleasePublishContext.from_dict(state), False, redirect(target)
+
+        state["test_pruning_required"] = True
+        state["test_pruning_error"] = _("Enter the test pruning PR URL to continue.")
+        messages.error(self.request, _("Enter the test pruning PR URL to continue."))
+        self._store(state)
         target = self.clean_redirect_path(self.request, self.request.path)
         return ReleasePublishContext.from_dict(state), False, redirect(target)
 
@@ -249,7 +299,9 @@ class ReleasePublishWorkflow:
 
         if not state.get("started"):
             state["started"] = True
-        state["paused"] = bool(state.get("pending_git_push") or state.get("dirty_files"))
+        state["paused"] = bool(
+            state.get("pending_git_push") or state.get("dirty_files")
+        )
         self._store(state)
 
         target = self.clean_redirect_path(self.request, self.request.path)

--- a/apps/release/domain/publish_steps.py
+++ b/apps/release/domain/publish_steps.py
@@ -32,6 +32,8 @@ PUBLISH_STEPS: list[tuple[str, str]] = [
     ("Execute pre-release actions", "_step_pre_release_actions"),
     (BUILD_RELEASE_ARTIFACTS_STEP_NAME, "_step_promote_build"),
     ("Complete test suite with --all flag", "_step_run_tests"),
+    # Pruning evidence is reviewed after the full suite proves releasability and
+    # before any external publish prerequisite can advance.
     (TEST_PRUNING_STEP_NAME, "_step_prune_low_value_tests"),
     (
         "Confirm PyPI Trusted Publisher settings",

--- a/apps/release/domain/publish_steps.py
+++ b/apps/release/domain/publish_steps.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 
 BUILD_RELEASE_ARTIFACTS_STEP_NAME = "Build release artifacts"
 FIXTURE_REVIEW_STEP_NAME = "Freeze, squash and approve migrations"
+TEST_PRUNING_STEP_NAME = "Prune worst 1% of tests by PR"
 
 
 class ReleaseStep(Protocol):
@@ -31,6 +32,7 @@ PUBLISH_STEPS: list[tuple[str, str]] = [
     ("Execute pre-release actions", "_step_pre_release_actions"),
     (BUILD_RELEASE_ARTIFACTS_STEP_NAME, "_step_promote_build"),
     ("Complete test suite with --all flag", "_step_run_tests"),
+    (TEST_PRUNING_STEP_NAME, "_step_prune_low_value_tests"),
     (
         "Confirm PyPI Trusted Publisher settings",
         "_step_confirm_pypi_trusted_publisher_settings",
@@ -50,4 +52,5 @@ __all__ = [
     "BUILD_RELEASE_ARTIFACTS_STEP_NAME",
     "FIXTURE_REVIEW_STEP_NAME",
     "PUBLISH_STEPS",
+    "TEST_PRUNING_STEP_NAME",
 ]

--- a/apps/release/release_workflow.py
+++ b/apps/release/release_workflow.py
@@ -115,7 +115,10 @@ def run_headless_publish(release, *, auto_release: bool = False) -> Path:
             logger.warning("%s: %s", release, message)
             raise ReleaseWorkflowBlocked(message, log_path=log_path) from exc
         except PublishPending as exc:
-            message = "Scheduled release awaiting publish completion"
+            if context.get("test_pruning_required"):
+                message = "Scheduled release awaiting test pruning evidence"
+            else:
+                message = "Scheduled release awaiting publish completion"
             _append_log(log_path, message)
             context["error"] = message
             logger.warning("%s: %s", release, message)

--- a/apps/release/simulator.py
+++ b/apps/release/simulator.py
@@ -29,6 +29,10 @@ BUILD_SKIPPED_DETAIL = "Build was skipped by caller."
 PYPI_USER_AGENT = "arthexis-release-simulator"
 SIMULATION_RESULT_HEADING = "### Simulation result"
 SUBPROCESS_TIMEOUT_SECONDS = 1800.0
+TEST_PRUNING_CHECKLIST_ACTIVITY = (
+    "Prune the worst 1% of tests by PR, prioritizing low-value, duplicate, "
+    "over-mocked, confusing, or misleading tests."
+)
 
 
 @dataclass
@@ -240,6 +244,13 @@ def run_release_simulation(
                 )
             )
 
+        steps.append(
+            SimulationStep(
+                name="release_readiness_checklist",
+                outcome="passed",
+                detail=TEST_PRUNING_CHECKLIST_ACTIVITY,
+            )
+        )
         steps.append(
             SimulationStep(
                 name="authorization_boundary",
@@ -617,6 +628,7 @@ def _success_summary() -> str:
             "",
             "- OK Release simulation reached the authorization boundary successfully.",
             "- INFO Publish to PyPI was intentionally skipped because authorization is required.",
+            "- TODO Release readiness: prune the worst 1% of tests by PR before every release.",
             "- OK Recommendation: release is ready if maintainers approve "
             "and trigger a real publish.",
         ]

--- a/apps/release/tests/test_publish_steps.py
+++ b/apps/release/tests/test_publish_steps.py
@@ -14,6 +14,7 @@ EXPECTED_STEP_ORDER = [
     "Execute pre-release actions",
     "Build release artifacts",
     "Complete test suite with --all flag",
+    "Prune worst 1% of tests by PR",
     "Confirm PyPI Trusted Publisher settings",
     "Verify release environment",
     "Export artifacts and push release tag",
@@ -21,4 +22,15 @@ EXPECTED_STEP_ORDER = [
     "Record publish URLs & update fixtures",
     "Capture PyPI publish logs",
 ]
+
+
+def test_release_publish_steps_share_canonical_order() -> None:
+    assert [name for name, _handler in DOMAIN_PUBLISH_STEPS] == EXPECTED_STEP_ORDER
+    assert [name for name, _handler in UI_PUBLISH_STEPS] == EXPECTED_STEP_ORDER
+
+
+def test_headless_release_workflow_uses_canonical_order() -> None:
+    workflow = _build_release_workflow()
+
+    assert [step.name for step in workflow.steps] == EXPECTED_STEP_ORDER
 

--- a/apps/release/tests/test_publish_steps.py
+++ b/apps/release/tests/test_publish_steps.py
@@ -34,3 +34,13 @@ def test_headless_release_workflow_uses_canonical_order() -> None:
 
     assert [step.name for step in workflow.steps] == EXPECTED_STEP_ORDER
 
+
+def test_test_pruning_step_order_is_intentional() -> None:
+    step_names = [name for name, _handler in DOMAIN_PUBLISH_STEPS]
+
+    assert step_names.index("Complete test suite with --all flag") < step_names.index(
+        "Prune worst 1% of tests by PR"
+    )
+    assert step_names.index("Prune worst 1% of tests by PR") < step_names.index(
+        "Confirm PyPI Trusted Publisher settings"
+    )

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -75,8 +75,13 @@ def test_release_simulation_can_run_without_pypi_or_build(tmp_path: Path) -> Non
         "install_build_backend",
         "build_package",
         "validate_metadata",
+        "release_readiness_checklist",
         "authorization_boundary",
     ]
+    checklist_step = result.steps[-2]
+    assert "worst 1% of tests" in checklist_step.detail
+    assert "over-mocked" in checklist_step.detail
+    assert "prune the worst 1% of tests by PR" in result.summary_markdown
 
 
 def test_release_simulation_reports_version_gate_mismatch(tmp_path: Path) -> None:

--- a/apps/release/tests/test_release_simulator.py
+++ b/apps/release/tests/test_release_simulator.py
@@ -34,7 +34,9 @@ class _FakeResponse:
         return self.payload
 
 
-def _write_project(root: Path, *, version: str = "1.2.3", dynamic_path: str = "VERSION") -> None:
+def _write_project(
+    root: Path, *, version: str = "1.2.3", dynamic_path: str = "VERSION"
+) -> None:
     (root / "VERSION").write_text(f"{version}\n", encoding="utf-8")
     if dynamic_path != "VERSION":
         dynamic_file = root / dynamic_path
@@ -78,7 +80,9 @@ def test_release_simulation_can_run_without_pypi_or_build(tmp_path: Path) -> Non
         "release_readiness_checklist",
         "authorization_boundary",
     ]
-    checklist_step = result.steps[-2]
+    checklist_step = next(
+        step for step in result.steps if step.name == "release_readiness_checklist"
+    )
     assert "worst 1% of tests" in checklist_step.detail
     assert "over-mocked" in checklist_step.detail
     assert "prune the worst 1% of tests by PR" in result.summary_markdown
@@ -274,7 +278,9 @@ def test_release_simulation_quotes_package_name_for_pypi(
 
     def fake_urlopen(url: Any, *, timeout: float) -> _FakeResponse:
         requested_urls.append(url.full_url if hasattr(url, "full_url") else url)
-        user_agents.append(url.get_header("User-agent") if hasattr(url, "get_header") else None)
+        user_agents.append(
+            url.get_header("User-agent") if hasattr(url, "get_header") else None
+        )
         assert timeout == 15.0
         return _FakeResponse(b'{"releases": {}}')
 
@@ -309,7 +315,9 @@ def test_release_simulation_reports_invalid_pypi_timeout(
 
     assert result.ok is False
     assert result.failed_step == "preflight_pypi"
-    assert "PyPI timeout must be a finite value greater than zero seconds" in result.error
+    assert (
+        "PyPI timeout must be a finite value greater than zero seconds" in result.error
+    )
 
 
 def test_release_simulation_reports_non_finite_pypi_timeout(
@@ -330,7 +338,9 @@ def test_release_simulation_reports_non_finite_pypi_timeout(
 
     assert result.ok is False
     assert result.failed_step == "preflight_pypi"
-    assert "PyPI timeout must be a finite value greater than zero seconds" in result.error
+    assert (
+        "PyPI timeout must be a finite value greater than zero seconds" in result.error
+    )
 
 
 def test_release_simulation_reports_invalid_pypi_json(
@@ -465,7 +475,9 @@ def test_release_simulation_reports_escaped_dist_dir_as_build_failure(
     assert "Dist directory escapes repository root" in result.error
 
 
-def test_release_simulation_rejects_root_dist_dir_before_cleanup(tmp_path: Path) -> None:
+def test_release_simulation_rejects_root_dist_dir_before_cleanup(
+    tmp_path: Path,
+) -> None:
     _write_project(tmp_path)
 
     result = run_release_simulation(
@@ -481,7 +493,9 @@ def test_release_simulation_rejects_root_dist_dir_before_cleanup(tmp_path: Path)
     assert (tmp_path / "pyproject.toml").exists()
 
 
-def test_release_simulation_rejects_file_dist_dir_before_cleanup(tmp_path: Path) -> None:
+def test_release_simulation_rejects_file_dist_dir_before_cleanup(
+    tmp_path: Path,
+) -> None:
     _write_project(tmp_path)
     dist_file = tmp_path / "dist"
     dist_file.write_text("keep me\n", encoding="utf-8")

--- a/apps/sites/templates/core/release_progress.html
+++ b/apps/sites/templates/core/release_progress.html
@@ -217,6 +217,20 @@
       </li>
     {% endfor %}
     </ol>
+    {% if test_pruning_required %}
+    <div class="token-card">
+      <h2>{% trans "Test pruning evidence required" %}</h2>
+      <p>{% trans "Enter the pull request URL that prunes the lowest-value tests for this release." %}</p>
+      {% if test_pruning_error %}
+      <p class="error">{{ test_pruning_error }}</p>
+      {% endif %}
+      <form method="post">
+        {% csrf_token %}
+        <input type="url" name="test_pruning_pr_url" value="{{ test_pruning_pr_url }}" placeholder="https://github.com/org/repo/pull/123" aria-label="{% trans 'Test pruning PR URL' %}">
+        <button type="submit" name="set_test_pruning_evidence" value="1">{% trans "Record evidence" %}</button>
+      </form>
+    </div>
+    {% endif %}
     {% if not done %}
     {% if github_credentials_missing or github_token_using_stored %}
     <div class="token-card">


### PR DESCRIPTION
## Summary
- add a release publish gate requiring a PR that prunes the worst 1% of tests every release
- define bad-test traits in the gate: low-value, duplicate, over-mocked, confusing, or misleading tests
- include the checklist activity in the release-readiness simulator output and cover canonical step ordering

## Issue linkage
No linked issue: this release-readiness maintenance gate is part of the release process itself and does not close a separate issue.

## Verification
- .venv\Scripts\python.exe -m py_compile apps\release\simulator.py apps\release\domain\publish_steps.py apps\core\views\reports\release_publish\pipeline.py apps\release\tests\test_publish_steps.py apps\release\tests\test_release_simulator.py
- Attempted pytest for apps/release/tests/test_publish_steps.py and apps/release/tests/test_release_simulator.py::test_release_simulation_can_run_without_pypi_or_build, but local pytest timed out after 180s in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a release publish gate that requires test suite pruning evidence (worst 1% of tests) to be submitted via PR before each release. The implementation defines bad-test traits as: low-value, duplicate, over-mocked, confusing, or misleading tests.

## Changes Overview

**Core Implementation:**
- **Release Publish Pipeline** (`apps/core/views/reports/release_publish/pipeline.py`): Adds `_step_prune_low_value_tests` gate that checks for `test_pruning_result` evidence. When missing, the gate pauses release progression and exposes `test_pruning_required`, `test_pruning_error`, and `test_pruning_pr_url` to the UI. Accepts and normalizes pruning PR URLs from user input or fallback configuration.

- **Step Registration** (`apps/release/domain/publish_steps.py`): Registers new `TEST_PRUNING_STEP_NAME` step in the publish pipeline, positioned after the full test suite execution.

- **Simulator Updates** (`apps/release/simulator.py`): Records `release_readiness_checklist` step with test pruning guidance in simulator output and adds TODO instruction to mark 1% test pruning requirement.

**UI & User Interaction:**
- **Release Progress Template** (`apps/core/templates/core/release_progress.html` and `apps/sites/templates/core/release_progress.html`): Adds conditional form section when `test_pruning_required` is true. Collects `test_pruning_pr_url` via POST with error display and pre-fill support.

- **Workflow Handler** (`apps/core/views/reports/release_publish/workflow.py`): Implements `_resume_with_test_pruning_evidence` POST handler that validates submitted PR URLs, updates workflow state (clears required/error flags, adjusts paused state), persists context, and redirects with resume parameters.

**Error Messaging:**
- **Release Workflow** (`apps/release/release_workflow.py`): Branches error messaging to report "awaiting test-pruning evidence" when pruning is required versus previous "awaiting publish completion" wording.

**Test Coverage:**
- **Step Ordering Tests** (`apps/release/tests/test_publish_steps.py`): Adds validation that pruning step appears in canonical order after full test suite execution and before PyPI Trusted Publisher confirmation. Ensures domain, UI, and headless workflow orchestrations maintain consistent step ordering.

- **Simulator Tests** (`apps/release/tests/test_release_simulator.py`): Updates simulator test to verify checklist step presence with guidance on worst 1% of tests and over-mocked conditions, plus summary markdown instruction.

- **Regression Tests** (`apps/core/tests/reports/test_release_publish_regressions.py`): Adds comprehensive workflow-level tests covering gate pause behavior when evidence missing, rejection on explicit failure, acceptance of configured/operator-provided pruning URLs, and persistence of `test_pruning_result` with proper source attribution.

## Testing Status

Python byte-compile verification succeeded for all modified modules. Local pytest execution timed out in contributor environment (180s limit exceeded), but the comprehensive test suite addition and regression coverage indicates proper implementation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->