### PR TITLE
sites: limit feedback autocomplete token corpus to apps sources

### DIFF
--- a/apps/sites/autocomplete.py
+++ b/apps/sites/autocomplete.py
@@ -114,7 +114,7 @@ def _repo_common_tokens() -> list[str]:
 
 
 def _iter_repo_token_streams():
-    base_dir = Path(settings.BASE_DIR)
+    base_dir = Path(getattr(settings, "APPS_DIR", Path(settings.BASE_DIR) / "apps"))
     include_suffixes = {".py", ".md", ".html", ".js"}
     exclude_dirs = {".git", ".venv", "node_modules"}
     for directory_name, names, files in os.walk(base_dir, onerror=lambda error: None):

--- a/apps/sites/tests/test_user_story_autocomplete.py
+++ b/apps/sites/tests/test_user_story_autocomplete.py
@@ -157,13 +157,19 @@ def test_repo_autocomplete_completes_active_staff_token(monkeypatch):
 def test_repo_token_streams_excludes_generated_and_dependency_dirs(tmp_path, settings):
     from apps.sites import autocomplete
 
-    (tmp_path / "visible.py").write_text("alpha beta", encoding="utf-8")
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
+    (apps_dir / "visible.py").write_text("alpha beta", encoding="utf-8")
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    (media_dir / "leak.md").write_text("supersecret token", encoding="utf-8")
     for directory in (".git", ".venv", "node_modules"):
-        nested = tmp_path / directory
+        nested = apps_dir / directory
         nested.mkdir()
         (nested / "ignored.py").write_text("hidden token", encoding="utf-8")
 
     settings.BASE_DIR = tmp_path
+    settings.APPS_DIR = apps_dir
 
     assert list(autocomplete._iter_repo_token_streams()) == [["alpha", "beta"]]
 
@@ -182,7 +188,8 @@ def test_repo_token_streams_prunes_excluded_dirs_before_scanning(
     blocked.mkdir()
     (blocked / "ignored.py").write_text("hidden token", encoding="utf-8")
 
-    settings.BASE_DIR = tmp_path
+    settings.BASE_DIR = tmp_path.parent
+    settings.APPS_DIR = tmp_path
 
     def fake_walk(path, onerror=None):
         names = ["node_modules", "visible"]


### PR DESCRIPTION
### Motivation
- The repo-trained feedback autocomplete scanned `settings.BASE_DIR`, which can include uploads and runtime files and exposed tokens to any staff user. 
- Restricting the corpus to source code reduces accidental ingestion of sensitive or untrusted files while preserving staff autocomplete utility.

### Description
- Change `_iter_repo_token_streams()` to walk `settings.APPS_DIR` with a safe fallback to `BASE_DIR / "apps"` instead of scanning `BASE_DIR` directly. 
- Update tests to set `settings.APPS_DIR` and to add a `media/leak.md` file to assert files outside the apps tree are not included. 
- Preserve existing tokenization, model-building, and suggestion behavior; only the corpus root is narrowed.

### Testing
- Bootstrapped dependencies with `./env-refresh.sh --deps-only` and ran tests for the autocomplete suite with `.venv/bin/python manage.py test run -- apps/sites/tests/test_user_story_autocomplete.py`. 
- The targeted test run passed: `10 passed`.
- An initial incorrect test invocation using `apps.sites.tests.test_user_story_autocomplete` collected no tests and exited; this was a test-run selector mistake and not a regression in code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4c0646808326b56f7021393c19fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security: Restrict feedback autocomplete token corpus to app sources

Narrows the filesystem scope scanned by the staff feedback autocomplete to prevent exposure of sensitive files in non-source directories.

### Changes

**apps/sites/autocomplete.py**
- Modified `_iter_repo_token_streams()` to use `settings.APPS_DIR` as the scan root instead of `settings.BASE_DIR`
- Adds safe fallback: if `APPS_DIR` is not configured, uses `BASE_DIR / "apps"`
- This prevents the token model from ingesting files in upload directories, runtime caches, or other non-source locations where credentials or sensitive tokens may reside

**apps/sites/tests/test_user_story_autocomplete.py**
- `test_repo_token_streams_excludes_generated_and_dependency_dirs`: Updated to configure both `BASE_DIR` and `APPS_DIR` separately; adds a `media/leak.md` file outside the apps tree to verify it is not scanned, while verifying that excluded directories (.git, .venv, node_modules) within the apps tree remain excluded
- `test_repo_token_streams_prunes_excluded_dirs_before_scanning`: Adjusted directory configuration to align with the new `APPS_DIR` root

### Behavior

Staff autocomplete suggestions continue to use the repo-trained token model, but the model now builds only from source files under the designated apps directory. Token filtering, frequency analysis, and suggestion ranking logic remain unchanged. Non-staff users continue to receive standard feedback phrase suggestions regardless of this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### No linked issue
- Security maintenance exception: this PR narrows a staff-only autocomplete token corpus that could expose sensitive local/runtime files. No public issue was created to avoid expanding sensitive details before merge.