### PR TITLE
Cap OCPP security alert messages

### DIFF
--- a/apps/ocpp/consumers/csms/persistence.py
+++ b/apps/ocpp/consumers/csms/persistence.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 
 from apps.ocpp.models import Charger
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -55,7 +54,12 @@ def persist_legacy_meter_values(*, charger_pk: int, payload: dict) -> None:
     Charger.objects.filter(pk=charger_pk).update(last_meter_values=payload)
 
 
-def _ocpp_security_event_key(*, charger_id: str, connector_value: int | str | None) -> str:
+SECURITY_ALERT_MESSAGE_MAX_LENGTH = 255
+
+
+def _ocpp_security_event_key(
+    *, charger_id: str, connector_value: int | str | None
+) -> str:
     """Return a deterministic security event key for a charger status stream."""
 
     connector_label = "aggregate" if connector_value is None else str(connector_value)
@@ -66,6 +70,17 @@ def _ocpp_security_event_key(*, charger_id: str, connector_value: int | str | No
     charger_hash = hashlib.sha256(charger_id.encode("utf-8")).hexdigest()[:40]
     connector_hash = hashlib.sha256(connector_label.encode("utf-8")).hexdigest()[:16]
     return f"ocpp-charger-{charger_hash}-{connector_hash}-error"
+
+
+def _truncate_security_alert_message(message: str) -> str:
+    """Fit an OCPP alert summary into the ops message column."""
+
+    if len(message) <= SECURITY_ALERT_MESSAGE_MAX_LENGTH:
+        return message
+
+    digest = hashlib.sha256(message.encode("utf-8")).hexdigest()[:12]
+    suffix = f" [sha256:{digest}]"
+    return f"{message[: SECURITY_ALERT_MESSAGE_MAX_LENGTH - len(suffix)]}{suffix}"
 
 
 def sync_charger_error_security_event(
@@ -108,7 +123,9 @@ def sync_charger_error_security_event(
         f"charger_id={charger_id}; connector={connector_label}; "
         f"status={status_label}; error_code={normalized_error_code or 'None'}"
     )
-    message = f"OCPP charger {charger_id} connector {connector_label} reported {status_label}."
+    message = _truncate_security_alert_message(
+        f"OCPP charger {charger_id} connector {connector_label} reported {status_label}."
+    )
     event_timestamp = status_timestamp or timezone.now()
 
     if existing and existing.is_active and existing.last_occurred_at == event_timestamp:
@@ -117,7 +134,13 @@ def sync_charger_error_security_event(
         existing.detail = detail
         existing.remediation_url = existing.remediation_url or "/admin/ocpp/charger/"
         existing.save(
-            update_fields=["severity", "message", "detail", "remediation_url", "updated_at"]
+            update_fields=[
+                "severity",
+                "message",
+                "detail",
+                "remediation_url",
+                "updated_at",
+            ]
         )
         return
 

--- a/apps/ocpp/tests/test_csms_persistence.py
+++ b/apps/ocpp/tests/test_csms_persistence.py
@@ -16,6 +16,7 @@ from apps.ocpp.consumers.csms.persistence import (
 from apps.ocpp.models import Charger
 from apps.ops.models import SecurityAlertEvent
 
+
 @pytest.fixture
 def charger_rows(db):
     """Create one aggregate row and multiple connector rows for one charger_id."""
@@ -51,6 +52,7 @@ def charger_rows(db):
         "other_aggregate": other_aggregate,
     }
 
+
 @pytest.mark.django_db
 def test_update_status_notification_records_updates_aggregate_when_connector_is_none(
     charger_rows,
@@ -74,6 +76,7 @@ def test_update_status_notification_records_updates_aggregate_when_connector_is_
     assert aggregate.last_status == "Unavailable"
     assert aggregate.last_error_code == "E100"
     assert connector_one.last_status == "Preparing"
+
 
 @pytest.mark.django_db
 def test_update_status_notification_records_updates_connector_without_corrupting_aggregate(
@@ -100,6 +103,7 @@ def test_update_status_notification_records_updates_connector_without_corrupting
     assert aggregate.last_status == "Available"
     assert aggregate.last_error_code == ""
 
+
 @pytest.mark.django_db
 def test_update_status_notification_records_falls_back_to_aggregate_when_connector_missing(
     charger_rows,
@@ -121,8 +125,11 @@ def test_update_status_notification_records_falls_back_to_aggregate_when_connect
     assert aggregate.last_status == "Unavailable"
     assert aggregate.last_error_code == "E-MISSING"
 
+
 @pytest.mark.django_db
-def test_update_availability_state_records_updates_only_matching_connector_rows(charger_rows):
+def test_update_availability_state_records_updates_only_matching_connector_rows(
+    charger_rows,
+):
     """Connector-specific availability updates must only touch matching connectors."""
 
     connector_one = charger_rows["connector_one"]
@@ -143,6 +150,7 @@ def test_update_availability_state_records_updates_only_matching_connector_rows(
     assert connector_one.availability_state == "Inoperative"
     assert connector_two.availability_state == "Operative"
     assert aggregate.availability_state == "Operative"
+
 
 @pytest.mark.django_db
 def test_update_availability_state_records_updates_only_aggregate_rows(charger_rows):
@@ -167,8 +175,11 @@ def test_update_availability_state_records_updates_only_aggregate_rows(charger_r
     assert aggregate.availability_state_updated_at == updated_at
     assert connector_one.availability_state == "Operative"
 
+
 @pytest.mark.django_db
-def test_update_availability_state_records_returns_empty_when_no_rows_match(charger_rows):
+def test_update_availability_state_records_returns_empty_when_no_rows_match(
+    charger_rows,
+):
     """No matching rows should result in no writes and an empty touched set."""
 
     touched = update_availability_state_records(
@@ -179,6 +190,7 @@ def test_update_availability_state_records_returns_empty_when_no_rows_match(char
     )
 
     assert touched == []
+
 
 @pytest.mark.django_db
 def test_sync_charger_error_security_event_records_faulted_status(charger_rows):
@@ -201,8 +213,11 @@ def test_sync_charger_error_security_event_records_faulted_status(charger_rows):
     assert event.last_occurred_at == timestamp
     assert "Faulted" in event.message
 
+
 @pytest.mark.django_db
-def test_sync_charger_error_security_event_avoids_duplicate_same_timestamp(charger_rows):
+def test_sync_charger_error_security_event_avoids_duplicate_same_timestamp(
+    charger_rows,
+):
     """Repeated payloads with same timestamp should not inflate occurrence counts."""
 
     timestamp = timezone.now()
@@ -225,8 +240,11 @@ def test_sync_charger_error_security_event_avoids_duplicate_same_timestamp(charg
     event = SecurityAlertEvent.objects.get(key="ocpp-charger-CP-100-2-error")
     assert event.occurrence_count == 1
 
+
 @pytest.mark.django_db
-def test_sync_charger_error_security_event_deactivates_when_status_recovers(charger_rows):
+def test_sync_charger_error_security_event_deactivates_when_status_recovers(
+    charger_rows,
+):
     """Recovered chargers should deactivate previously active OCPP security events."""
 
     timestamp = timezone.now()
@@ -249,8 +267,11 @@ def test_sync_charger_error_security_event_deactivates_when_status_recovers(char
     event = SecurityAlertEvent.objects.get(key="ocpp-charger-CP-100-aggregate-error")
     assert event.is_active is False
 
+
 @pytest.mark.django_db
-def test_sync_charger_error_security_event_ignores_stale_fault_after_recovery(charger_rows):
+def test_sync_charger_error_security_event_ignores_stale_fault_after_recovery(
+    charger_rows,
+):
     """Older fault replays should not reactivate an event after a newer recovery."""
 
     faulted_at = timezone.now()
@@ -282,6 +303,7 @@ def test_sync_charger_error_security_event_ignores_stale_fault_after_recovery(ch
     assert event.is_active is False
     assert event.last_occurred_at == recovered_at
 
+
 @pytest.mark.django_db
 def test_sync_charger_error_security_event_supports_long_charger_id_key(charger_rows):
     """Long charger IDs should persist without exceeding key length limits."""
@@ -296,8 +318,11 @@ def test_sync_charger_error_security_event_supports_long_charger_id_key(charger_
         status_timestamp=timezone.now(),
     )
 
-    event = SecurityAlertEvent.objects.get(key=f"ocpp-charger-{long_charger_id}-aggregate-error")
+    event = SecurityAlertEvent.objects.get(
+        key=f"ocpp-charger-{long_charger_id}-aggregate-error"
+    )
     assert len(event.key) > 120
+
 
 @pytest.mark.django_db
 def test_sync_charger_error_security_event_hashes_very_long_key(charger_rows):
@@ -317,3 +342,7 @@ def test_sync_charger_error_security_event_hashes_very_long_key(charger_rows):
     assert len(event.key) <= 255
     assert event.key.startswith("ocpp-charger-")
     assert event.key.endswith("-error")
+    assert len(event.message) <= 255
+    assert event.message.endswith("]")
+    assert long_charger_id in event.detail
+    assert "connector-with-very-long-label-" in event.detail


### PR DESCRIPTION
Closes #7432

## Summary
- cap the OCPP security alert summary before writing to `SecurityAlertEvent.message` (`varchar(255)`)
- preserve the full charger id, connector label, status, and error code in `SecurityAlertEvent.detail`
- extend the existing very-long OCPP key regression to assert the message also fits the PostgreSQL column

## Tradeoff
This keeps the existing ops schema unchanged. Very long alert summaries are truncated with a short SHA-256 suffix for correlation, while full detail remains available in the text field.
