### PR TITLE
meta: enforce recipient match for keyed Attention responses

### DIFF
--- a/apps/meta/models.py
+++ b/apps/meta/models.py
@@ -436,6 +436,13 @@ class Attention(Entity):
                 queryset = queryset.filter(bridge_id=bridge_id)
             if key:
                 attention = queryset.filter(key__iexact=key).first()
+                if attention and attention.recipient != from_phone:
+                    logger.info(
+                        "Skipped keyed Attention response for %s; sender %s did not match recipient",
+                        attention.key,
+                        from_phone,
+                    )
+                    return None
             elif from_phone and not require_key:
                 candidates = list(queryset.filter(recipient=from_phone)[:2])
                 attention = candidates[0] if len(candidates) == 1 else None

--- a/apps/meta/models.py
+++ b/apps/meta/models.py
@@ -14,12 +14,12 @@ from django.db import models, transaction
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 
 from apps.chats.models import ChatBridge, ChatBridgeManager
 from apps.core.entity import Entity
 from apps.features.utils import is_suite_feature_enabled
-
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +234,9 @@ class WhatsAppWebhook(Entity):
     def verify_querystring(self) -> str:
         """Return helper query parameters expected by webhook verification requests."""
 
-        return urlencode({"hub.mode": "subscribe", "hub.verify_token": self.verify_token})
+        return urlencode(
+            {"hub.mode": "subscribe", "hub.verify_token": self.verify_token}
+        )
 
     def suite_feature_disable_summary(self) -> str:
         """Return the disable contract that operators should expect for this webhook."""
@@ -343,6 +345,11 @@ class Attention(Entity):
         super().save(*args, **kwargs)
 
     @staticmethod
+    def normalize_phone_identifier(value: str) -> str:
+        normalized = re.sub(r"\s+", "", value or "")
+        return normalized.removeprefix("+")
+
+    @staticmethod
     def _new_key() -> str:
         return f"ATT-{secrets.token_hex(6).upper()}"
 
@@ -380,7 +387,9 @@ class Attention(Entity):
     def send(self) -> bool:
         if not self.bridge_id or not self.bridge or not self.recipient:
             return False
-        if not is_suite_feature_enabled(WHATSAPP_CHAT_BRIDGE_FEATURE_SLUG, default=True):
+        if not is_suite_feature_enabled(
+            WHATSAPP_CHAT_BRIDGE_FEATURE_SLUG, default=True
+        ):
             return False
         sent = self.bridge.send_message(
             recipient=self.recipient,
@@ -427,7 +436,7 @@ class Attention(Entity):
         payload: dict | None = None,
         require_key: bool = False,
         bridge: WhatsAppChatBridge | None = None,
-    ) -> "Attention | None":
+    ) -> Attention | None:
         key = cls.find_key(text)
         bridge_id = getattr(bridge, "pk", None)
         with transaction.atomic():
@@ -436,7 +445,12 @@ class Attention(Entity):
                 queryset = queryset.filter(bridge_id=bridge_id)
             if key:
                 attention = queryset.filter(key__iexact=key).first()
-                if attention and attention.recipient != from_phone:
+                normalized_from_phone = cls.normalize_phone_identifier(from_phone)
+                if (
+                    attention
+                    and cls.normalize_phone_identifier(attention.recipient)
+                    != normalized_from_phone
+                ):
                     logger.info(
                         "Skipped keyed Attention response for %s; sender %s did not match recipient",
                         attention.key,

--- a/apps/meta/tests/test_webhooks.py
+++ b/apps/meta/tests/test_webhooks.py
@@ -147,6 +147,64 @@ def test_whatsapp_webhook_captures_attention_response(client):
 
 
 @pytest.mark.django_db
+def test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender(client):
+    site = Site.objects.create(domain="attention-wrong-sender.example.test", name="attention")
+    bridge = WhatsAppChatBridge.objects.create(
+        site=site,
+        phone_number_id="12345",
+        access_token="token",
+    )
+    webhook = WhatsAppWebhook.objects.create(
+        bridge=bridge,
+        route_key="route-key-attention-wrong-sender",
+        verify_token="verify-token-attention-wrong-sender",
+    )
+    attention = Attention.objects.create(
+        bridge=bridge,
+        recipient="15551234567",
+        title="Attention",
+        message="Continue?",
+    )
+
+    payload = {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "messages": [
+                                {
+                                    "id": "wamid.ATTENTION.WRONG.SENDER",
+                                    "from": "15557654321",
+                                    "type": "text",
+                                    "text": {"body": f"{attention.key} approved"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    response = client.post(
+        reverse("meta:whatsapp-webhook", kwargs={"route_key": webhook.route_key}),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    attention.refresh_from_db()
+    assert attention.status == Attention.Status.PENDING
+    assert attention.response_text == ""
+    assert attention.response_from_phone == ""
+    assert WhatsAppWebhookMessage.objects.filter(
+        webhook=webhook,
+        message_id="wamid.ATTENTION.WRONG.SENDER",
+    ).exists()
+
+
+@pytest.mark.django_db
 def test_whatsapp_webhook_does_not_capture_keyed_response_across_bridges(client):
     site_a = Site.objects.create(domain="key-bridge-a.example.test", name="key bridge a")
     site_b = Site.objects.create(domain="key-bridge-b.example.test", name="key bridge b")

--- a/apps/meta/tests/test_webhooks.py
+++ b/apps/meta/tests/test_webhooks.py
@@ -7,7 +7,12 @@ from django.contrib.sites.models import Site
 from django.urls import reverse
 
 from apps.features.models import Feature
-from apps.meta.models import Attention, WhatsAppChatBridge, WhatsAppWebhook, WhatsAppWebhookMessage
+from apps.meta.models import (
+    Attention,
+    WhatsAppChatBridge,
+    WhatsAppWebhook,
+    WhatsAppWebhookMessage,
+)
 
 
 @pytest.mark.django_db
@@ -75,12 +80,10 @@ def test_whatsapp_webhook_disabled_feature_still_stores_messages_for_audit(clien
     )
 
     assert response.status_code == 202
-    assert (
-        WhatsAppWebhookMessage.objects.filter(
-            webhook=webhook,
-            message_id="wamid.DISABLED",
-        ).exists()
-    )
+    assert WhatsAppWebhookMessage.objects.filter(
+        webhook=webhook,
+        message_id="wamid.DISABLED",
+    ).exists()
 
 
 @pytest.mark.django_db
@@ -103,6 +106,7 @@ def test_whatsapp_webhook_captures_attention_response(client):
         title="Attention",
         message="Continue?",
     )
+    Attention.objects.filter(pk=attention.pk).update(recipient=" +15551234567 ")
 
     payload = {
         "entry": [
@@ -111,7 +115,9 @@ def test_whatsapp_webhook_captures_attention_response(client):
                     {
                         "value": {
                             "messaging_product": "whatsapp",
-                            "contacts": [{"wa_id": "15551234567", "profile": {"name": "Ops"}}],
+                            "contacts": [
+                                {"wa_id": "15551234567", "profile": {"name": "Ops"}}
+                            ],
                             "metadata": {"phone_number_id": "12345"},
                             "messages": [
                                 {
@@ -137,6 +143,7 @@ def test_whatsapp_webhook_captures_attention_response(client):
 
     assert response.status_code == 200
     attention.refresh_from_db()
+    assert attention.recipient == " +15551234567 "
     assert attention.status == Attention.Status.RESPONDED
     assert attention.response_text == "approved"
     assert attention.response_from_phone == "15551234567"
@@ -148,7 +155,9 @@ def test_whatsapp_webhook_captures_attention_response(client):
 
 @pytest.mark.django_db
 def test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender(client):
-    site = Site.objects.create(domain="attention-wrong-sender.example.test", name="attention")
+    site = Site.objects.create(
+        domain="attention-wrong-sender.example.test", name="attention"
+    )
     bridge = WhatsAppChatBridge.objects.create(
         site=site,
         phone_number_id="12345",
@@ -165,6 +174,7 @@ def test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender(clie
         title="Attention",
         message="Continue?",
     )
+    Attention.objects.filter(pk=attention.pk).update(recipient=" +15551234567 ")
 
     payload = {
         "entry": [
@@ -195,6 +205,7 @@ def test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender(clie
 
     assert response.status_code == 200
     attention.refresh_from_db()
+    assert attention.recipient == " +15551234567 "
     assert attention.status == Attention.Status.PENDING
     assert attention.response_text == ""
     assert attention.response_from_phone == ""
@@ -206,8 +217,12 @@ def test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender(clie
 
 @pytest.mark.django_db
 def test_whatsapp_webhook_does_not_capture_keyed_response_across_bridges(client):
-    site_a = Site.objects.create(domain="key-bridge-a.example.test", name="key bridge a")
-    site_b = Site.objects.create(domain="key-bridge-b.example.test", name="key bridge b")
+    site_a = Site.objects.create(
+        domain="key-bridge-a.example.test", name="key bridge a"
+    )
+    site_b = Site.objects.create(
+        domain="key-bridge-b.example.test", name="key bridge b"
+    )
     bridge_a = WhatsAppChatBridge.objects.create(
         site=site_a,
         phone_number_id="12345",
@@ -393,7 +408,9 @@ def test_whatsapp_webhook_disabled_feature_does_not_capture_attention_response(c
         slug="whatsapp-chat-bridge",
         defaults={"display": "WhatsApp Chat Bridge", "is_enabled": False},
     )
-    site = Site.objects.create(domain="attention-disabled.example.test", name="attention disabled")
+    site = Site.objects.create(
+        domain="attention-disabled.example.test", name="attention disabled"
+    )
     bridge = WhatsAppChatBridge.objects.create(
         site=site,
         phone_number_id="12345",


### PR DESCRIPTION
### Motivation
- Close an authorization gap where possession of an `ATT-*` key alone could let any sender close an `Attention` via webhook.
- Prevent accidental or malicious approval of sensitive actions by ensuring only the intended recipient can resolve a keyed attention.

### Description
- Hardened `Attention.capture_response` so keyed matches (`ATT-*`) only succeed when the incoming `from_phone` equals the pending Attention's `recipient`, logging and returning `None` otherwise.
- Kept existing bridge scoping, select-for-update locking and the phone-fallback behavior unchanged.
- Added a regression test `test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender` in `apps/meta/tests/test_webhooks.py` that posts a keyed webhook from the wrong sender and asserts the `Attention` remains pending and the webhook message is recorded.

### Testing
- Bootstrapped environment dependencies with `./env-refresh.sh --deps-only` which completed successfully.
- Ran webhook tests with `.venv/bin/python manage.py test run -- apps/meta/tests/test_webhooks.py` and observed `8 passed`.
- Ran attention tests with `.venv/bin/python manage.py test run -- apps/meta/tests/test_attention.py` and observed `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3572120883268ee7a516eaf4a132)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR hardens the `Attention.capture_response` method to close a security vulnerability where possession of an `ATT-*` key alone could allow any sender to resolve an Attention response via webhook. The fix ensures that only the intended recipient can successfully capture a response for a keyed Attention.

## Changes

**apps/meta/models.py**
- Enhanced `Attention.capture_response` with a recipient consistency check: when an Attention is selected via an extracted key, the method now verifies that the webhook sender's `from_phone` matches the pending Attention's `recipient`. If they don't match, the method logs an informational message and returns `None` without transitioning the Attention state.
- Existing behavior for bridge scoping, select-for-update locking, and phone-fallback logic remains unchanged.

**apps/meta/tests/test_webhooks.py**
- Added regression test `test_whatsapp_webhook_does_not_capture_keyed_response_from_wrong_sender` that verifies the vulnerability is blocked: posts a keyed webhook message from an unauthorized sender and confirms the Attention remains in `PENDING` status with `response_text` and `response_from_phone` unpopulated. The test also validates that the webhook request returns HTTP 200 and that the webhook message is persisted.

## Testing
- Webhook tests: 8 passed
- Attention tests: 10 passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Related Issue
- No linked issue: security maintenance PR generated from vulnerability review for the Attention response path.