### PR TITLE
Harden turn_boundary write_json against symlink temp-file clobbering

### DIFF
--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -136,12 +136,21 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     if path.parent not in {checked_state_path(STATE_DIR), checked_state_path(ARCHIVE_DIR)}:
         raise ValueError(f"refusing unsupported turn state file path: {path}")
     content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    tmp_name = f"{WRITE_TMP_NAME}.{uuid.uuid4().hex}"
     dir_fd = os.open(path.parent, os.O_RDONLY)
     try:
-        fd = os.open(WRITE_TMP_NAME, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600, dir_fd=dir_fd)
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(tmp_name, flags, 0o600, dir_fd=dir_fd)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)
-        os.replace(WRITE_TMP_NAME, path.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        os.replace(tmp_name, path.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    except Exception:
+        try:
+            os.unlink(tmp_name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            pass
+        raise
     finally:
         os.close(dir_fd)
 

--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -148,7 +148,7 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     except Exception:
         try:
             os.unlink(tmp_name, dir_fd=dir_fd)
-        except FileNotFoundError:
+        except OSError:
             pass
         raise
     finally:


### PR DESCRIPTION
### Motivation

- Prevent a local attacker from pre-creating a symlink on the predictable temporary filename and causing `write_json` to overwrite an arbitrary file, which was introduced by using a fixed `WRITE_TMP_NAME` without symlink protections.

### Description

- Generate a unique temporary filename per write using `WRITE_TMP_NAME` plus a `uuid.uuid4().hex` suffix to avoid predictable names.
- Open the temporary file with `O_CREAT | O_EXCL | O_WRONLY` and include `O_NOFOLLOW` when available to prevent following preexisting symlinks during creation.
- Atomically replace the destination using `os.replace(..., src_dir_fd=..., dst_dir_fd=...)` and perform best-effort cleanup of the temp file on error via `os.unlink(..., dir_fd=...)`.
- Preserve existing directory-relative `dir_fd` usage and the overall atomic write behavior while hardening the temp-write step.

### Testing

- Ran `python3 -m py_compile skills/arthexis-cleanup-step/scripts/turn_boundary.py` and it succeeded.
- Ran `python3 skills/arthexis-cleanup-step/scripts/turn_boundary.py --help` and it returned the usage output successfully.
- Executed an import-based smoke test that sets `STATE_DIR`/`ARCHIVE_DIR` to a temporary directory and invoked `write_json` to write `ACTIVE_STATE`, and verified the resulting file contents matched the expected JSON payload.
- Note: the repository virtualenv entrypoint was not available in this environment (checked ` .venv/bin/python`) so tests used `python3` interpreter; all automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3851cfa48326963da6a3763be13a)

### Related Issue
- No linked issue: security maintenance PR generated from vulnerability review for turn-boundary state writes.