### PR TITLE
Fix predictable temp-file race in turn boundary state writes

### DIFF
--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -12,6 +12,7 @@ import os
 import re
 import signal
 import sys
+import tempfile
 import time
 import uuid
 from contextlib import contextmanager
@@ -25,7 +26,6 @@ EVENT_LOG = STATE_DIR / "events.jsonl"
 LOCK_PATH = STATE_DIR / "state.lock"
 ARCHIVE_DIR = STATE_DIR / "turns"
 CADENCE_STATE = STATE_DIR / "cadence-rest.json"
-WRITE_TMP_NAME = ".write-json.tmp"
 DEFAULT_CLEANUP_TIMEOUT_SECONDS = 600
 DEFAULT_TURN_CADENCE_SECONDS = 600
 TERM_GRACE_SECONDS = 15
@@ -136,14 +136,16 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     if path.parent not in {checked_state_path(STATE_DIR), checked_state_path(ARCHIVE_DIR)}:
         raise ValueError(f"refusing unsupported turn state file path: {path}")
     content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    dir_fd = os.open(path.parent, os.O_RDONLY)
+    temp_path: Path | None = None
     try:
-        fd = os.open(WRITE_TMP_NAME, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600, dir_fd=dir_fd)
+        fd, temp_name = tempfile.mkstemp(prefix=".write-json-", suffix=".tmp", dir=path.parent)
+        temp_path = Path(temp_name)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)
-        os.replace(WRITE_TMP_NAME, path.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        temp_path.replace(path)
     finally:
-        os.close(dir_fd)
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def append_event(event: dict[str, Any]) -> None:


### PR DESCRIPTION
### Motivation

- The previous `write_json` used a fixed temporary filename inside the state directory, enabling a local TOCTOU symlink swap that could overwrite arbitrary files when the state directory was writable by another local user.
- Remediate the symlink race with a minimal change that preserves the current atomic replace behavior while removing the predictable temp filename.

### Description

- Replaced the fixed temp filename with a unique per-write temporary file created via `tempfile.mkstemp(..., dir=path.parent)` inside `write_json` in `skills/arthexis-cleanup-step/scripts/turn_boundary.py`.
- Atomically install the new content by calling `Path.replace` on the generated temp file to move it into place and removed the `WRITE_TMP_NAME` constant.
- Imported `tempfile` and added a `finally` cleanup to unlink any leftover temporary file if an error occurs.

### Testing

- Ran environment bootstrap with `./env-refresh.sh --deps-only` which completed successfully.
- Executed the suite target `(.venv)/bin/python manage.py test run -- tests/test_turn_boundary_cadence.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3947cdf48326a4290b2f899f4a98)

### Related Issue
- No linked issue: duplicate security maintenance candidate for turn-boundary state writes; likely superseded by #7444.