### PR TITLE
Constrain funding banner to docs column and soften styling for light/dark themes

### DIFF
--- a/apps/docs/templates/docs/readme.html
+++ b/apps/docs/templates/docs/readme.html
@@ -29,18 +29,7 @@
   </div>
   {% endif %}
   <div class="{% if toc %}col-12 col-lg-9 order-1 order-lg-2{% else %}col-12{% endif %}">
-    {% if funding_banner %}
-      <section class="funding-banner funding-banner--sidebar mb-4" aria-labelledby="funding-banner-title">
-        <span class="funding-banner__mark" aria-hidden="true">💖</span>
-        <div>
-          <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
-          <p class="mb-0">{{ funding_banner.message }}</p>
-        </div>
-        <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
-          {% trans "View funding issue" %}
-        </a>
-      </section>
-    {% endif %}
+    {% include "pages/includes/funding_banner.html" with funding_banner=funding_banner funding_banner_classes="funding-banner--sidebar mb-4" only %}
     <div class="markdown-body" id="reader-content">
       {{ content|safe }}
       {% if has_remaining_sections %}

--- a/apps/docs/templates/docs/readme.html
+++ b/apps/docs/templates/docs/readme.html
@@ -29,6 +29,18 @@
   </div>
   {% endif %}
   <div class="{% if toc %}col-12 col-lg-9 order-1 order-lg-2{% else %}col-12{% endif %}">
+    {% if funding_banner %}
+      <section class="funding-banner funding-banner--sidebar mb-4" aria-labelledby="funding-banner-title">
+        <span class="funding-banner__mark" aria-hidden="true">💖</span>
+        <div>
+          <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
+          <p class="mb-0">{{ funding_banner.message }}</p>
+        </div>
+        <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
+          {% trans "View funding issue" %}
+        </a>
+      </section>
+    {% endif %}
     <div class="markdown-body" id="reader-content">
       {{ content|safe }}
       {% if has_remaining_sections %}
@@ -85,6 +97,8 @@
   })();
 </script>
 {% endblock %}
+
+{% block funding_banner %}{% endblock %}
 
 {% block extra_scripts %}
   <script src="{% static 'docs/js/qrcode.min.js' %}"></script>

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -764,9 +764,9 @@ body.user-story-open {
   border-radius: var(--bs-border-radius);
   color: var(--bs-body-color);
   display: flex;
-  gap: var(--bs-spacer-3);
+  gap: var(--funding-banner-spacing, var(--bs-spacer, 1rem));
   justify-content: space-between;
-  padding: var(--bs-spacer-3);
+  padding: var(--funding-banner-spacing, var(--bs-spacer, 1rem));
 }
 
 .funding-banner p {
@@ -793,7 +793,7 @@ body.user-story-open {
 
 .funding-banner--sidebar {
   position: sticky;
-  top: var(--bs-spacer-3);
+  top: var(--funding-banner-spacing, var(--bs-spacer, 1rem));
   z-index: 1;
 }
 
@@ -808,8 +808,8 @@ html[data-bs-theme='light'] .funding-banner {
 html[data-bs-theme='dark'] .funding-banner {
   --funding-banner-bg: rgba(var(--bs-emphasis-color-rgb), 0.08);
   --funding-banner-border: rgba(var(--bs-emphasis-color-rgb), 0.24);
-  --funding-banner-link: #9ec5fe;
-  --funding-banner-link-hover: #cfe2ff;
+  --funding-banner-link: var(--bs-link-color);
+  --funding-banner-link-hover: var(--bs-link-hover-color);
   --funding-banner-mark: rgba(var(--bs-emphasis-color-rgb), 0.75);
 }
 

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -759,41 +759,67 @@ body.user-story-open {
 }
 .funding-banner {
   align-items: center;
-  background: #1f2937;
-  border: 1px solid var(--site-accent);
-  border-radius: 0.375rem;
-  color: #f8fafc;
+  background: var(--funding-banner-bg, rgba(var(--bs-emphasis-color-rgb), 0.06));
+  border: var(--bs-border-width) solid var(--funding-banner-border, rgba(var(--bs-emphasis-color-rgb), 0.15));
+  border-radius: var(--bs-border-radius);
+  color: var(--bs-body-color);
   display: flex;
-  gap: 1rem;
+  gap: var(--bs-spacer-3);
   justify-content: space-between;
-  padding: 0.875rem 1rem;
+  padding: var(--bs-spacer-3);
 }
 
 .funding-banner p {
-  color: #d1d5db;
+  color: var(--bs-secondary-color);
 }
 
 .funding-banner__mark {
-  color: #f472b6;
+  color: var(--funding-banner-mark, var(--bs-secondary-color));
   flex: 0 0 auto;
-  font-size: 1.35rem;
+  font-size: 1.25em;
   line-height: 1;
 }
 
 .funding-banner__link {
-  color: #fde68a;
+  color: var(--funding-banner-link, var(--bs-link-color));
   font-weight: 700;
   white-space: nowrap;
 }
 
 .funding-banner__link:focus,
 .funding-banner__link:hover {
-  color: #fef3c7;
+  color: var(--funding-banner-link-hover, var(--bs-link-hover-color));
+}
+
+.funding-banner--sidebar {
+  position: sticky;
+  top: var(--bs-spacer-3);
+  z-index: 1;
+}
+
+html[data-bs-theme='light'] .funding-banner {
+  --funding-banner-bg: rgba(var(--bs-emphasis-color-rgb), 0.035);
+  --funding-banner-border: rgba(var(--bs-emphasis-color-rgb), 0.14);
+  --funding-banner-link: var(--bs-link-color);
+  --funding-banner-link-hover: var(--bs-link-hover-color);
+  --funding-banner-mark: rgba(var(--bs-emphasis-color-rgb), 0.7);
+}
+
+html[data-bs-theme='dark'] .funding-banner {
+  --funding-banner-bg: rgba(var(--bs-emphasis-color-rgb), 0.08);
+  --funding-banner-border: rgba(var(--bs-emphasis-color-rgb), 0.24);
+  --funding-banner-link: #9ec5fe;
+  --funding-banner-link-hover: #cfe2ff;
+  --funding-banner-mark: rgba(var(--bs-emphasis-color-rgb), 0.75);
 }
 
 @media (max-width: 575.98px) {
   .funding-banner {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .funding-banner--sidebar {
+    position: static;
   }
 }

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -193,18 +193,20 @@
         </div>
       </nav>
       {% endif %}
-      {% if funding_banner %}
-        <section class="funding-banner mt-3" aria-labelledby="funding-banner-title">
-          <span class="funding-banner__mark" aria-hidden="true">💖</span>
-          <div>
-            <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
-            <p class="mb-0">{{ funding_banner.message }}</p>
-          </div>
-          <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
-            {% trans "View funding issue" %}
-          </a>
-        </section>
-      {% endif %}
+      {% block funding_banner %}
+        {% if funding_banner %}
+          <section class="funding-banner mt-3" aria-labelledby="funding-banner-title">
+            <span class="funding-banner__mark" aria-hidden="true">💖</span>
+            <div>
+              <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
+              <p class="mb-0">{{ funding_banner.message }}</p>
+            </div>
+            <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
+              {% trans "View funding issue" %}
+            </a>
+          </section>
+        {% endif %}
+      {% endblock %}
       {% if site_highlight %}
         <div
           id="site-highlight"

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -194,18 +194,7 @@
       </nav>
       {% endif %}
       {% block funding_banner %}
-        {% if funding_banner %}
-          <section class="funding-banner mt-3" aria-labelledby="funding-banner-title">
-            <span class="funding-banner__mark" aria-hidden="true">💖</span>
-            <div>
-              <strong id="funding-banner-title">{{ funding_banner.title }}</strong>
-              <p class="mb-0">{{ funding_banner.message }}</p>
-            </div>
-            <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
-              {% trans "View funding issue" %}
-            </a>
-          </section>
-        {% endif %}
+        {% include "pages/includes/funding_banner.html" with funding_banner=funding_banner funding_banner_classes="mt-3" only %}
       {% endblock %}
       {% if site_highlight %}
         <div

--- a/apps/sites/templates/pages/includes/funding_banner.html
+++ b/apps/sites/templates/pages/includes/funding_banner.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% if funding_banner %}
+  <section class="funding-banner{% if funding_banner_classes %} {{ funding_banner_classes }}{% endif %}" aria-labelledby="{{ funding_banner_title_id|default:'funding-banner-title' }}">
+    <span class="funding-banner__mark" aria-hidden="true">💖</span>
+    <div>
+      <strong id="{{ funding_banner_title_id|default:'funding-banner-title' }}">{{ funding_banner.title }}</strong>
+      <p class="mb-0">{{ funding_banner.message }}</p>
+    </div>
+    <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
+      {% trans "View funding issue" %}
+    </a>
+  </section>
+{% endif %}

--- a/apps/sites/tests/test_funding_banner_template.py
+++ b/apps/sites/tests/test_funding_banner_template.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from django.template.loader import render_to_string
+
+
+def test_funding_banner_include_renders_supplied_layout_classes():
+    html = render_to_string(
+        "pages/includes/funding_banner.html",
+        {
+            "funding_banner": {
+                "title": "Fund maintenance",
+                "message": "Keep the project maintained.",
+                "issue_url": "https://github.com/arthexis/arthexis/issues/1",
+            },
+            "funding_banner_classes": "funding-banner--sidebar mb-4",
+        },
+    )
+
+    assert 'class="funding-banner funding-banner--sidebar mb-4"' in html
+    assert 'href="https://github.com/arthexis/arthexis/issues/1"' in html
+    assert "View funding issue" in html
+
+
+def test_funding_banner_templates_share_single_include():
+    base_template = Path("apps/sites/templates/pages/base.html").read_text()
+    docs_template = Path("apps/docs/templates/docs/readme.html").read_text()
+
+    assert 'include "pages/includes/funding_banner.html"' in base_template
+    assert 'include "pages/includes/funding_banner.html"' in docs_template
+    assert "funding-banner__mark" not in base_template
+    assert "funding-banner__mark" not in docs_template
+
+
+def test_funding_banner_css_uses_defined_tokens():
+    css = Path("apps/sites/static/pages/css/base.css").read_text()
+    funding_banner_css = css[css.index(".funding-banner {") :]
+
+    assert "--bs-spacer-3" not in funding_banner_css
+    assert "#9ec5fe" not in funding_banner_css
+    assert "#cfe2ff" not in funding_banner_css
+    assert "var(--bs-link-color)" in funding_banner_css
+    assert "var(--bs-link-hover-color)" in funding_banner_css


### PR DESCRIPTION
### Motivation
- The global funding banner was visually dominant and clashed with the suite's sober colors, especially on wide/readme pages. The intent is to reduce its visual weight and restrict its footprint to the right-hand/document column where appropriate. 
- Make the banner theme-aware so it respects both light and dark modes and uses existing design tokens rather than hardcoded colors. 

### Description
- Render the funding banner through an overridable `{% block funding_banner %}` in `pages/base.html` so pages can place it where it best fits. (`apps/sites/templates/pages/base.html`).
- Move the README/docs placement to the content column and add a sticky sidebar variant by injecting a `funding-banner--sidebar` instance into `apps/docs/templates/docs/readme.html`. This prevents the banner from spanning the full page width. 
- Replace hardcoded banner colors and sizing with theme-aware CSS variables and Bootstrap tokens, reduce contrast, increase padding/spacing, and add a `.funding-banner--sidebar` sticky modifier; updates in `apps/sites/static/pages/css/base.css` implement light/dark variants and responsive fallbacks. 

### Testing
- Bootstrapped environment with `./env-refresh.sh --deps-only` which completed successfully. 
- Ran `./.venv/bin/python manage.py test run -- apps/sites/tests/test_site_highlight.py` and received `4 passed`. 
- Ran `./.venv/bin/python manage.py test run -- apps/docs/tests/test_rendering.py` and received `1 passed`. 
- All executed automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8725908c832682b806601df8cfe2)

### Related Issue
- No linked issue: follow-up maintenance refinement for the funding continuity banner behavior and styling; related historical context is #7433.