### PR TITLE
Fix PostgreSQL local node MAC conflict recovery

### DIFF
--- a/apps/nodes/models/node.py
+++ b/apps/nodes/models/node.py
@@ -450,7 +450,9 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
             if stored_mac != current_mac:
                 node.mac_address = mac
                 try:
-                    node.save(update_fields=["mac_address"])
+                    with transaction.atomic():
+                        cls.objects.filter(pk=node.pk).update(mac_address=mac)
+                    node.mac_address = mac
                 except IntegrityError:
                     node.mac_address = stored_mac
                     logger.warning(

--- a/apps/nodes/models/node.py
+++ b/apps/nodes/models/node.py
@@ -448,10 +448,15 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
             current_mac = mac.strip().lower()
             should_cache = True
             if stored_mac != current_mac:
-                node.mac_address = mac
                 try:
                     with transaction.atomic():
-                        cls.objects.filter(pk=node.pk).update(mac_address=mac)
+                        rows_updated = cls.objects.filter(pk=node.pk).update(
+                            mac_address=mac
+                        )
+                    if rows_updated != 1:
+                        raise DatabaseError(
+                            "stale self node disappeared before MAC refresh"
+                        )
                     node.mac_address = mac
                 except IntegrityError:
                     node.mac_address = stored_mac
@@ -476,6 +481,7 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
                     except DatabaseError:
                         should_cache = False
                 except DatabaseError:
+                    node_id = node.pk
                     node.mac_address = stored_mac
                     should_cache = False
                     logger.warning(
@@ -483,10 +489,11 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
                         extra={
                             "runtime_mac_redacted": _redact_mac_for_log(mac),
                             "stored_mac_redacted": _redact_mac_for_log(stored_mac),
-                            "node_id": node.pk,
+                            "node_id": node_id,
                         },
                         exc_info=True,
                     )
+                    node = None
                 else:
                     logger.warning(
                         "nodes.Node.get_local refreshed stale self-node MAC address",

--- a/apps/nodes/models/node.py
+++ b/apps/nodes/models/node.py
@@ -448,12 +448,14 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
             current_mac = mac.strip().lower()
             should_cache = True
             if stored_mac != current_mac:
+                self_node_missing = False
                 try:
                     with transaction.atomic():
                         rows_updated = cls.objects.filter(pk=node.pk).update(
                             mac_address=mac
                         )
                     if rows_updated != 1:
+                        self_node_missing = True
                         raise DatabaseError(
                             "stale self node disappeared before MAC refresh"
                         )
@@ -493,7 +495,8 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
                         },
                         exc_info=True,
                     )
-                    node = None
+                    if self_node_missing:
+                        node = None
                 else:
                     logger.warning(
                         "nodes.Node.get_local refreshed stale self-node MAC address",

--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -199,6 +199,43 @@ def test_get_local_does_not_cache_stale_self_after_mac_conflict(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_get_local_does_not_return_deleted_self_after_zero_row_mac_update(monkeypatch):
+    self_node = Node.objects.create(
+        hostname="deleted-self-node",
+        mac_address="00:11:22:33:44:56",
+        current_relation=Node.Relation.SELF,
+    )
+    Node._local_cache.clear()
+    monkeypatch.setattr(
+        Node, "get_current_mac", staticmethod(lambda: "aa:bb:cc:dd:ee:01")
+    )
+
+    original_filter = Node.objects.filter
+    deleted_during_update = False
+
+    class DeletingUpdate:
+        def update(self, **kwargs):
+            nonlocal deleted_during_update
+            deleted_during_update = True
+            original_filter(pk=self_node.pk).delete()
+            return 0
+
+    def deleting_filter(*args, **kwargs):
+        if kwargs == {"pk": self_node.pk}:
+            return DeletingUpdate()
+        return original_filter(*args, **kwargs)
+
+    monkeypatch.setattr(Node.objects, "filter", deleting_filter)
+
+    local = Node.get_local()
+
+    assert deleted_during_update is True
+    assert local is None
+    assert "aa:bb:cc:dd:ee:01" not in Node._local_cache
+    assert not original_filter(pk=self_node.pk).exists()
+
+
+@pytest.mark.django_db
 def test_get_local_logs_redacted_mac_values(monkeypatch, caplog):
     self_node = Node.objects.create(
         hostname="self-node",

--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -20,12 +20,14 @@ from apps.nodes.views import node_info, register_node
 from apps.nodes.views.registration import handlers
 from apps.sites.models import SiteProfile
 
+
 @pytest.fixture
 def admin_user(db):
     User = get_user_model()
     return User.objects.create_superuser(
         username="admin", email="admin@example.com", password="password"
     )
+
 
 def _build_request(factory, payload):
     request = factory.post(
@@ -34,6 +36,7 @@ def _build_request(factory, payload):
         content_type="application/json",
     )
     return request
+
 
 @pytest.mark.django_db
 def test_register_node_rejects_invalid_enrollment_token_without_creating_node(
@@ -57,6 +60,7 @@ def test_register_node_rejects_invalid_enrollment_token_without_creating_node(
 
     assert response.status_code == 400
     assert not Node.objects.filter(mac_address=payload["mac_address"]).exists()
+
 
 @pytest.mark.django_db
 def test_register_node_accepts_valid_enrollment_token_for_existing_node(admin_user):
@@ -87,6 +91,7 @@ def test_register_node_accepts_valid_enrollment_token_for_existing_node(admin_us
     node.refresh_from_db()
     assert response.status_code == 200
     assert node.public_key == payload["public_key"]
+
 
 @pytest.mark.django_db
 def test_register_node_updates_mesh_identity_fields(admin_user):
@@ -127,6 +132,7 @@ def test_register_node_updates_mesh_identity_fields(admin_user):
     assert node.last_mesh_heartbeat is not None
     assert node.mesh_capability_flags == sorted(payload["mesh_capability_flags"])
 
+
 @pytest.mark.django_db
 def test_node_info_omits_sensitive_identity_fields():
     node = Node.objects.create(
@@ -153,6 +159,7 @@ def test_node_info_omits_sensitive_identity_fields():
     assert "host_instance_id" not in data
     assert "uuid" not in data
 
+
 @pytest.mark.django_db
 def test_get_local_does_not_cache_stale_self_after_mac_conflict(monkeypatch):
     self_node = Node.objects.create(
@@ -165,18 +172,22 @@ def test_get_local_does_not_cache_stale_self_after_mac_conflict(monkeypatch):
         Node, "get_current_mac", staticmethod(lambda: "aa:bb:cc:dd:ee:ff")
     )
 
-    original_save = Node.save
+    original_filter = Node.objects.filter
+    race_inserted = False
 
-    def conflicting_save(self, *args, **kwargs):
-        if self.pk == self_node.pk and kwargs.get("update_fields") == ["mac_address"]:
+    def racing_filter(*args, **kwargs):
+        nonlocal race_inserted
+        if kwargs == {"mac_address__iexact": "aa:bb:cc:dd:ee:ff"} and not race_inserted:
+            race_inserted = True
             Node.objects.create(
                 hostname="racer",
                 mac_address="aa:bb:cc:dd:ee:ff",
                 current_relation=Node.Relation.PEER,
             )
-        return original_save(self, *args, **kwargs)
+            return Node.objects.none()
+        return original_filter(*args, **kwargs)
 
-    monkeypatch.setattr(Node, "save", conflicting_save)
+    monkeypatch.setattr(Node.objects, "filter", racing_filter)
 
     local = Node.get_local()
 
@@ -185,6 +196,7 @@ def test_get_local_does_not_cache_stale_self_after_mac_conflict(monkeypatch):
     self_node.refresh_from_db()
     assert self_node.mac_address == "00:11:22:33:44:55"
     assert Node._local_cache["aa:bb:cc:dd:ee:ff"][0].hostname == "racer"
+
 
 @pytest.mark.django_db
 def test_get_local_logs_redacted_mac_values(monkeypatch, caplog):
@@ -198,10 +210,18 @@ def test_get_local_logs_redacted_mac_values(monkeypatch, caplog):
         Node, "get_current_mac", staticmethod(lambda: "aa:bb:cc:dd:ee:ff")
     )
 
-    def raise_conflict(*args, **kwargs):
-        raise IntegrityError("simulated uniqueness conflict")
+    original_filter = Node.objects.filter
 
-    monkeypatch.setattr(Node, "save", raise_conflict)
+    class ConflictingUpdate:
+        def update(self, **kwargs):
+            raise IntegrityError("simulated uniqueness conflict")
+
+    def conflicting_filter(*args, **kwargs):
+        if kwargs == {"pk": self_node.pk}:
+            return ConflictingUpdate()
+        return original_filter(*args, **kwargs)
+
+    monkeypatch.setattr(Node.objects, "filter", conflicting_filter)
 
     caplog.set_level(logging.WARNING, logger="apps.nodes.models.node")
     Node.get_local()

--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -8,7 +8,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from django.db import IntegrityError
+from django.db import DatabaseError, IntegrityError
 from django.http import HttpResponse, JsonResponse
 from django.test import RequestFactory
 
@@ -233,6 +233,46 @@ def test_get_local_does_not_return_deleted_self_after_zero_row_mac_update(monkey
     assert local is None
     assert "aa:bb:cc:dd:ee:01" not in Node._local_cache
     assert not original_filter(pk=self_node.pk).exists()
+
+
+@pytest.mark.django_db
+def test_get_local_returns_self_after_transient_mac_update_error(monkeypatch):
+    self_node = Node.objects.create(
+        hostname="transient-self-node",
+        mac_address="00:11:22:33:44:57",
+        current_relation=Node.Relation.SELF,
+    )
+    other_node = Node.objects.create(
+        hostname="other-node",
+        mac_address="00:11:22:33:44:58",
+        current_relation=Node.Relation.PEER,
+    )
+    Node._local_cache.clear()
+    monkeypatch.setattr(
+        Node, "get_current_mac", staticmethod(lambda: "aa:bb:cc:dd:ee:02")
+    )
+
+    original_filter = Node.objects.filter
+
+    class FailingUpdate:
+        def update(self, **kwargs):
+            raise DatabaseError("simulated transient write failure")
+
+    def failing_filter(*args, **kwargs):
+        if kwargs == {"pk": self_node.pk}:
+            return FailingUpdate()
+        return original_filter(*args, **kwargs)
+
+    monkeypatch.setattr(Node.objects, "filter", failing_filter)
+
+    local = Node.get_local()
+
+    assert local is not None
+    assert local.pk == self_node.pk
+    assert local.pk != other_node.pk
+    self_node.refresh_from_db()
+    assert self_node.mac_address == "00:11:22:33:44:57"
+    assert "aa:bb:cc:dd:ee:02" not in Node._local_cache
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Closes #7442.

This fixes the PostgreSQL-only install smoke failure where `Node.get_local()` could return and cache a stale `SELF` node after a runtime MAC update collided with another node row. The MAC refresh now runs the direct database update inside a savepoint-backed atomic block, so PostgreSQL can recover from the uniqueness violation and then look up the row that owns the runtime MAC.

## Verification

- `ARTHEXIS_DB_BACKEND=postgres POSTGRES_HOST=sedge-7442-postgres POSTGRES_PORT=5432 POSTGRES_DB=arthexis POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres python -m pytest apps/nodes/tests/test_register_node.py::test_get_local_does_not_cache_stale_self_after_mac_conflict -q --disable-warnings --maxfail=1` - passed, `1 passed in 103.04s`
- `ARTHEXIS_DB_BACKEND=postgres POSTGRES_HOST=sedge-7442-postgres POSTGRES_PORT=5432 POSTGRES_DB=arthexis POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres python -m pytest apps/nodes/tests/test_register_node.py -q --disable-warnings --maxfail=1` - passed, `8 passed in 118.03s`
- `python -m black --fast --check apps/nodes/models/node.py apps/nodes/tests/test_register_node.py` - passed
- `python -m compileall -q apps/nodes/models/node.py apps/nodes/tests/test_register_node.py` - passed
- `git diff --check` - passed

## Notes

I did not chase the earlier `features_feature` PostgreSQL log noise because the failing install jobs both failed on `apps/nodes/tests/test_register_node.py::test_get_local_does_not_cache_stale_self_after_mac_conflict`, while the SQLite matrix passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a PostgreSQL-only install smoke test failure where `Node.get_local()` could cache a stale SELF node after a runtime MAC update collided with an existing node row in the database.

## Changes

### apps/nodes/models/node.py
Modified the `get_local()` classmethod to use a queryset `update()` operation wrapped in `transaction.atomic()` instead of calling `node.save(update_fields=["mac_address"])` when refreshing a stale self-node MAC address. After the atomic database update succeeds, the in-memory `node.mac_address` is explicitly synchronized to the new runtime MAC. When an `IntegrityError` occurs during the update (indicating another node owns the runtime MAC), the existing exception handler now calls `transaction.set_rollback(False)` to allow recovery within the savepoint and then looks up the node that actually owns the new MAC. This enables PostgreSQL to recover from uniqueness violations and find the correct node without caching stale data.

### apps/nodes/tests/test_register_node.py
Updated both MAC conflict tests to monkeypatch `Node.objects.filter()` instead of `Node.save()`:

- **test_get_local_does_not_cache_stale_self_after_mac_conflict**: The new `racing_filter` function intercepts the filter call for the runtime MAC lookup, inserts a conflicting node on the first call, then returns an empty queryset. This simulates the race condition where another node claims the MAC between the self-node lookup and the MAC update attempt.

- **test_get_local_logs_redacted_mac_values**: Replaces `Node.save()` mocking with a `ConflictingUpdate` class whose `.update()` method raises `IntegrityError`, allowing the method to exercise the conflict recovery path and verify that MAC values are redacted in warning logs.

Minor formatting adjustments (blank lines) were added around fixtures and test functions for readability.

## Testing
The changes were verified with:
- Targeted pytest for the failing test under PostgreSQL: `test_get_local_does_not_cache_stale_self_after_mac_conflict` — passed
- Full nodes register test suite under PostgreSQL: `apps/nodes/tests/test_register_node.py` — all 8 tests passed
- Code formatting (Black) and bytecode compilation checks passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->