### PR TITLE
Hide nav and funding banner on login; auto-hide closed GitHub funding issue

### DIFF
--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -122,6 +122,9 @@ def _build_funding_banner(request):
 def _github_issue_api_url(issue_url: str) -> str | None:
     """Return the matching GitHub issue API URL for ``issue_url`` when parseable."""
 
+    if not isinstance(issue_url, str):
+        return None
+
     parsed = urlparse(issue_url)
     if parsed.netloc.lower() != "github.com":
         return None

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -83,8 +83,21 @@ def _is_arthexis_dot_com_request(request) -> bool:
     return host == ARTHEXIS_FUNDING_HOST
 
 
+def _request_hides_funding_banner(request) -> bool:
+    """Return whether the resolved page suppresses funding banner chrome."""
+
+    if getattr(request, "hide_funding_banner", False):
+        return True
+
+    resolver_match = getattr(request, "resolver_match", None)
+    return getattr(resolver_match, "view_name", "") == "pages:login"
+
+
 def _build_funding_banner(request):
     """Build the public funding banner, shown only on arthexis.com."""
+
+    if _request_hides_funding_banner(request):
+        return None
 
     if not _is_arthexis_dot_com_request(request):
         return None

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlparse
@@ -54,6 +55,8 @@ _ROLE_FAVICONS = {
 ARTHEXIS_FUNDING_HOST = "arthexis.com"
 DEFAULT_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/7433"
 FUNDING_ISSUE_STATE_CACHE_TTL_SECONDS = 900
+FUNDING_ISSUE_FAILURE_CACHE_TTL_SECONDS = 300
+FUNDING_ISSUE_STATE_UNKNOWN = "unknown"
 
 
 def _parse_user_story_attachment_limit() -> int:
@@ -136,18 +139,17 @@ def _read_github_issue_state(issue_url: str) -> str | None:
     try:
         with urlopen(request, timeout=2) as response:  # noqa: S310
             payload = response.read().decode("utf-8")
-    except (TimeoutError, URLError, ValueError):
+    except (TimeoutError, URLError, UnicodeDecodeError, ValueError):
         return None
 
-    state_marker = '"state":'
-    marker_index = payload.find(state_marker)
-    if marker_index == -1:
+    try:
+        data = json.loads(payload)
+    except (TypeError, json.JSONDecodeError):
         return None
-    state_fragment = payload[marker_index + len(state_marker) : marker_index + len(state_marker) + 24]
-    if '"open"' in state_fragment:
-        return "open"
-    if '"closed"' in state_fragment:
-        return "closed"
+
+    state = data.get("state") if isinstance(data, dict) else None
+    if state in {"open", "closed"}:
+        return state
     return None
 
 
@@ -158,11 +160,18 @@ def _is_github_issue_open(issue_url: str) -> bool:
     cached_state = cache.get(cache_key)
     if cached_state in {"open", "closed"}:
         return cached_state == "open"
+    if cached_state == FUNDING_ISSUE_STATE_UNKNOWN:
+        return True
 
     state = _read_github_issue_state(issue_url)
     if state in {"open", "closed"}:
         cache.set(cache_key, state, timeout=FUNDING_ISSUE_STATE_CACHE_TTL_SECONDS)
         return state == "open"
+    cache.set(
+        cache_key,
+        FUNDING_ISSUE_STATE_UNKNOWN,
+        timeout=FUNDING_ISSUE_FAILURE_CACHE_TTL_SECONDS,
+    )
     return True
 
 

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -1,5 +1,5 @@
 import json
-from http.client import IncompleteRead
+from http.client import HTTPException, IncompleteRead
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlparse
@@ -157,7 +157,9 @@ def _read_github_issue_state(issue_url: str) -> str | None:
         with urlopen(request, timeout=2) as response:  # noqa: S310
             payload = response.read().decode("utf-8")
     except (
+        HTTPException,
         IncompleteRead,
+        OSError,
         TimeoutError,
         URLError,
         UnicodeDecodeError,

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -1,4 +1,5 @@
 import json
+from http.client import IncompleteRead
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlparse
@@ -152,7 +153,13 @@ def _read_github_issue_state(issue_url: str) -> str | None:
     try:
         with urlopen(request, timeout=2) as response:  # noqa: S310
             payload = response.read().decode("utf-8")
-    except (TimeoutError, URLError, UnicodeDecodeError, ValueError):
+    except (
+        IncompleteRead,
+        TimeoutError,
+        URLError,
+        UnicodeDecodeError,
+        ValueError,
+    ):
         return None
 
     try:

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from django.apps import apps
 from django.conf import settings
@@ -50,6 +53,7 @@ _ROLE_FAVICONS = {
 }
 ARTHEXIS_FUNDING_HOST = "arthexis.com"
 DEFAULT_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/7433"
+FUNDING_ISSUE_STATE_CACHE_TTL_SECONDS = 900
 
 
 def _parse_user_story_attachment_limit() -> int:
@@ -83,6 +87,10 @@ def _build_funding_banner(request):
         return None
 
     issue_url = getattr(settings, "ARTHEXIS_FUNDING_ISSUE_URL", "")
+    resolved_issue_url = issue_url or DEFAULT_FUNDING_ISSUE_URL
+    if not _is_github_issue_open(resolved_issue_url):
+        return None
+
     return {
         "title": _("Arthexis needs funding to keep maintenance running"),
         "message": _(
@@ -90,8 +98,72 @@ def _build_funding_banner(request):
             "available operating credits. Funding helps keep reviews, fixes, "
             "and continuity work moving."
         ),
-        "issue_url": issue_url or DEFAULT_FUNDING_ISSUE_URL,
+        "issue_url": resolved_issue_url,
     }
+
+
+def _github_issue_api_url(issue_url: str) -> str | None:
+    """Return the matching GitHub issue API URL for ``issue_url`` when parseable."""
+
+    parsed = urlparse(issue_url)
+    if parsed.netloc.lower() != "github.com":
+        return None
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 4 or parts[2] != "issues":
+        return None
+
+    owner, repo, _issues, number = parts
+    if not number.isdigit():
+        return None
+    return f"https://api.github.com/repos/{owner}/{repo}/issues/{number}"
+
+
+def _read_github_issue_state(issue_url: str) -> str | None:
+    """Read and return the issue state for ``issue_url`` from GitHub when available."""
+
+    api_url = _github_issue_api_url(issue_url)
+    if not api_url:
+        return None
+
+    request = Request(
+        api_url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "arthexis-funding-banner",
+        },
+    )
+    try:
+        with urlopen(request, timeout=2) as response:  # noqa: S310
+            payload = response.read().decode("utf-8")
+    except (TimeoutError, URLError, ValueError):
+        return None
+
+    state_marker = '"state":'
+    marker_index = payload.find(state_marker)
+    if marker_index == -1:
+        return None
+    state_fragment = payload[marker_index + len(state_marker) : marker_index + len(state_marker) + 24]
+    if '"open"' in state_fragment:
+        return "open"
+    if '"closed"' in state_fragment:
+        return "closed"
+    return None
+
+
+def _is_github_issue_open(issue_url: str) -> bool:
+    """Return whether the configured GitHub funding issue is currently open."""
+
+    cache_key = f"sites:funding_issue_state:{issue_url}"
+    cached_state = cache.get(cache_key)
+    if cached_state in {"open", "closed"}:
+        return cached_state == "open"
+
+    state = _read_github_issue_state(issue_url)
+    if state in {"open", "closed"}:
+        cache.set(cache_key, state, timeout=FUNDING_ISSUE_STATE_CACHE_TTL_SECONDS)
+        return state == "open"
+    return True
 
 
 def _resolve_landing_visibility(

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -769,6 +769,11 @@ body.user-story-open {
   padding: var(--funding-banner-spacing, var(--bs-spacer, 1rem));
 }
 
+.funding-banner__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .funding-banner p {
   color: var(--bs-secondary-color);
 }
@@ -791,10 +796,8 @@ body.user-story-open {
   color: var(--funding-banner-link-hover, var(--bs-link-hover-color));
 }
 
-.funding-banner--sidebar {
-  position: sticky;
-  top: var(--funding-banner-spacing, var(--bs-spacer, 1rem));
-  z-index: 1;
+.funding-banner__close {
+  flex: 0 0 auto;
 }
 
 html[data-bs-theme='light'] .funding-banner {
@@ -819,7 +822,4 @@ html[data-bs-theme='dark'] .funding-banner {
     flex-direction: column;
   }
 
-  .funding-banner--sidebar {
-    position: static;
-  }
 }

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -358,6 +358,46 @@ const setupSiteHighlightDismissal = () => {
   });
 };
 
+/**
+ * Dismiss the funding banner in browser-local storage only.
+ */
+const setupFundingBannerDismissal = () => {
+  const banner = document.querySelector('[data-funding-banner-cache-key]');
+  if (!banner) {
+    return;
+  }
+  const cacheKey = banner.dataset.fundingBannerCacheKey;
+  if (!cacheKey) {
+    return;
+  }
+
+  let localStorageAvailable = true;
+  try {
+    if (window.localStorage.getItem(cacheKey) === '1') {
+      banner.remove();
+      return;
+    }
+  } catch (error) {
+    localStorageAvailable = false;
+  }
+
+  const closeButton = banner.querySelector('[data-funding-banner-close="true"]');
+  if (!closeButton) {
+    return;
+  }
+  closeButton.addEventListener('click', event => {
+    event.preventDefault();
+    if (localStorageAvailable) {
+      try {
+        window.localStorage.setItem(cacheKey, '1');
+      } catch (error) {
+        // Keep close behavior even if storage is unavailable.
+      }
+    }
+    banner.remove();
+  });
+};
+
 applySiteThemeVariables();
 setupThemeToggle();
 initThemeState();
@@ -366,4 +406,5 @@ setupUserInfoTooltip();
 setupLanguageSelect();
 setupShareModal();
 setupSiteHighlightDismissal();
+setupFundingBannerDismissal();
 window.addEventListener('load', syncDebugToolbarTheme);

--- a/apps/sites/templates/pages/base.html
+++ b/apps/sites/templates/pages/base.html
@@ -28,6 +28,7 @@
   <body class="p-3 pb-0 d-flex flex-column min-vh-100">
     <div class="container flex-grow-1 mb-5">
       {% if not operator_interface_mode %}
+      {% block page_nav %}
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark py-2 m-0">
         <div class="container-fluid">
           <a class="navbar-brand" href="/">{{ badge_site_name|default:"Arthexis" }}</a>
@@ -192,6 +193,7 @@
           </div>
         </div>
       </nav>
+      {% endblock %}
       {% endif %}
       {% block funding_banner %}
         {% include "pages/includes/funding_banner.html" with funding_banner=funding_banner funding_banner_classes="mt-3" only %}

--- a/apps/sites/templates/pages/includes/funding_banner.html
+++ b/apps/sites/templates/pages/includes/funding_banner.html
@@ -1,13 +1,20 @@
 {% load i18n %}
 {% if funding_banner %}
-  <section class="funding-banner{% if funding_banner_classes %} {{ funding_banner_classes }}{% endif %}" aria-labelledby="{{ funding_banner_title_id|default:'funding-banner-title' }}">
+  <section
+    class="funding-banner{% if funding_banner_classes %} {{ funding_banner_classes }}{% endif %}"
+    aria-labelledby="{{ funding_banner_title_id|default:'funding-banner-title' }}"
+    data-funding-banner-cache-key="funding-banner-dismissed-{{ funding_banner.issue_url|slugify }}"
+  >
     <span class="funding-banner__mark" aria-hidden="true">💖</span>
-    <div>
+    <div class="funding-banner__body">
       <strong id="{{ funding_banner_title_id|default:'funding-banner-title' }}">{{ funding_banner.title }}</strong>
       <p class="mb-0">{{ funding_banner.message }}</p>
     </div>
     <a class="funding-banner__link" href="{{ funding_banner.issue_url }}" target="_blank" rel="noopener noreferrer">
       {% trans "View funding issue" %}
     </a>
+    <button type="button" class="btn-close funding-banner__close" data-funding-banner-close="true">
+      <span class="visually-hidden">{% trans "Dismiss funding banner" %}</span>
+    </button>
   </section>
 {% endif %}

--- a/apps/sites/templates/pages/login.html
+++ b/apps/sites/templates/pages/login.html
@@ -3,6 +3,9 @@
 
 {% block title %}{% trans "Login" %}{% endblock %}
 
+{% block page_nav %}{% endblock %}
+{% block funding_banner %}{% endblock %}
+
 {% block content %}
 <div class="d-flex justify-content-center align-items-center py-5" style="min-height: 75vh;">
   <div class="card p-4" style="max-width: 400px; width: 100%;">

--- a/apps/sites/tests/test_funding_banner_template.py
+++ b/apps/sites/tests/test_funding_banner_template.py
@@ -17,6 +17,8 @@ def test_funding_banner_include_renders_supplied_layout_classes():
     )
 
     assert 'class="funding-banner funding-banner--sidebar mb-4"' in html
+    assert 'data-funding-banner-cache-key="funding-banner-dismissed-' in html
+    assert 'data-funding-banner-close="true"' in html
     assert 'href="https://github.com/arthexis/arthexis/issues/1"' in html
     assert "View funding issue" in html
 
@@ -40,3 +42,14 @@ def test_funding_banner_css_uses_defined_tokens():
     assert "#cfe2ff" not in funding_banner_css
     assert "var(--bs-link-color)" in funding_banner_css
     assert "var(--bs-link-hover-color)" in funding_banner_css
+
+
+def test_funding_banner_stays_in_page_flow_and_has_dismiss_script_hook():
+    css = Path("apps/sites/static/pages/css/base.css").read_text()
+    funding_banner_css = css[css.index(".funding-banner {") :]
+    script = Path("apps/sites/static/pages/js/base.js").read_text()
+
+    assert "position: fixed" not in funding_banner_css
+    assert "position: sticky" not in funding_banner_css
+    assert "setupFundingBannerDismissal();" in script
+    assert "data-funding-banner-close" in script

--- a/apps/sites/tests/test_login_view.py
+++ b/apps/sites/tests/test_login_view.py
@@ -16,3 +16,16 @@ def test_login_view_does_not_consume_registration_session_prefill_on_post(client
     session = client.session
     assert session.get(REGISTRATION_USERNAME_PREFILL_SESSION_KEY) == "session-registered-user"
 
+
+def test_login_view_hides_navigation_and_funding_banner(client, monkeypatch):
+    monkeypatch.setattr(
+        "apps.sites.context_processors._is_github_issue_open",
+        lambda *_args, **_kwargs: True,
+    )
+
+    response = client.get(reverse("pages:login"), HTTP_HOST="arthexis.com")
+    html = response.content.decode("utf-8")
+
+    assert response.status_code == 200
+    assert "navbar navbar-expand-lg" not in html
+    assert "View funding issue" not in html

--- a/apps/sites/tests/test_login_view.py
+++ b/apps/sites/tests/test_login_view.py
@@ -22,9 +22,12 @@ def test_login_view_does_not_consume_registration_session_prefill_on_post(client
 
 
 def test_login_view_hides_navigation_and_funding_banner(client, monkeypatch):
+    def fail_issue_lookup(*_args, **_kwargs):
+        raise AssertionError("login render must not check GitHub funding issue state")
+
     monkeypatch.setattr(
         "apps.sites.context_processors._is_github_issue_open",
-        lambda *_args, **_kwargs: True,
+        fail_issue_lookup,
     )
 
     response = client.get(reverse("pages:login"), HTTP_HOST="arthexis.com")

--- a/apps/sites/tests/test_login_view.py
+++ b/apps/sites/tests/test_login_view.py
@@ -6,6 +6,7 @@ from apps.sites.session_keys import REGISTRATION_USERNAME_PREFILL_SESSION_KEY
 
 pytestmark = [pytest.mark.django_db]
 
+
 def test_login_view_does_not_consume_registration_session_prefill_on_post(client):
     session = client.session
     session[REGISTRATION_USERNAME_PREFILL_SESSION_KEY] = "session-registered-user"
@@ -14,7 +15,10 @@ def test_login_view_does_not_consume_registration_session_prefill_on_post(client
     client.post(reverse("pages:login"), {"username": "", "password": ""})
 
     session = client.session
-    assert session.get(REGISTRATION_USERNAME_PREFILL_SESSION_KEY) == "session-registered-user"
+    assert (
+        session.get(REGISTRATION_USERNAME_PREFILL_SESSION_KEY)
+        == "session-registered-user"
+    )
 
 
 def test_login_view_hides_navigation_and_funding_banner(client, monkeypatch):

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from http.client import IncompleteRead
+from http.client import IncompleteRead, RemoteDisconnected
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -218,6 +218,46 @@ def test_github_issue_state_treats_incomplete_read_as_unknown(monkeypatch) -> No
 
         def read(self):
             raise IncompleteRead(b'{"state":')
+
+    monkeypatch.setattr(
+        context_processors, "urlopen", lambda *_args, **_kwargs: Response()
+    )
+
+    assert (
+        context_processors._read_github_issue_state(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        is None
+    )
+
+
+def test_github_issue_state_treats_remote_disconnect_as_unknown(monkeypatch) -> None:
+    monkeypatch.setattr(
+        context_processors,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RemoteDisconnected("remote closed connection")
+        ),
+    )
+
+    assert (
+        context_processors._read_github_issue_state(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        is None
+    )
+
+
+def test_github_issue_state_treats_socket_os_error_as_unknown(monkeypatch) -> None:
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            raise OSError("socket read failed")
 
     monkeypatch.setattr(
         context_processors, "urlopen", lambda *_args, **_kwargs: Response()

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -112,9 +112,13 @@ def test_funding_banner_only_shows_on_arthexis_dot_com(
     settings.ARTHEXIS_FUNDING_ISSUE_URL = (
         "https://github.com/arthexis/arthexis/issues/1"
     )
-    monkeypatch.setattr(
-        context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: True
-    )
+    issue_checks = []
+
+    def issue_is_open(issue_url):
+        issue_checks.append(issue_url)
+        return True
+
+    monkeypatch.setattr(context_processors, "_is_github_issue_open", issue_is_open)
 
     canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
     other_request = rf.get("/", HTTP_HOST="example.com")
@@ -123,6 +127,7 @@ def test_funding_banner_only_shows_on_arthexis_dot_com(
 
     assert banner is not None
     assert banner["issue_url"] == "https://github.com/arthexis/arthexis/issues/1"
+    assert issue_checks == ["https://github.com/arthexis/arthexis/issues/1"]
     assert context_processors._build_funding_banner(other_request) is None
 
 
@@ -192,3 +197,18 @@ def test_github_issue_open_caches_unknown_state_on_fetch_failure(monkeypatch) ->
         is True
     )
     assert calls == 1
+
+
+def test_funding_banner_skip_does_not_check_issue_state(
+    rf: RequestFactory, settings, monkeypatch
+) -> None:
+    settings.ALLOWED_HOSTS = ["arthexis.com"]
+    request = rf.get("/", HTTP_HOST="arthexis.com")
+    request.hide_funding_banner = True
+
+    def fail_issue_lookup(*_args, **_kwargs):
+        raise AssertionError("hidden funding banner must not check issue state")
+
+    monkeypatch.setattr(context_processors, "_is_github_issue_open", fail_issue_lookup)
+
+    assert context_processors._build_funding_banner(request) is None

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -103,9 +103,11 @@ def test_nav_links_includes_selected_site_highlight(
 def test_funding_banner_only_shows_on_arthexis_dot_com(
     rf: RequestFactory,
     settings,
+    monkeypatch,
 ) -> None:
     settings.ALLOWED_HOSTS = ["arthexis.com", "example.com"]
     settings.ARTHEXIS_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/1"
+    monkeypatch.setattr(context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: True)
 
     canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
     other_request = rf.get("/", HTTP_HOST="example.com")
@@ -115,3 +117,13 @@ def test_funding_banner_only_shows_on_arthexis_dot_com(
     assert banner is not None
     assert banner["issue_url"] == "https://github.com/arthexis/arthexis/issues/1"
     assert context_processors._build_funding_banner(other_request) is None
+
+
+def test_funding_banner_is_hidden_when_issue_is_closed(rf: RequestFactory, settings, monkeypatch) -> None:
+    settings.ALLOWED_HOSTS = ["arthexis.com"]
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/1"
+    monkeypatch.setattr(context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: False)
+
+    canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
+
+    assert context_processors._build_funding_banner(canonical_request) is None

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
-from datetime import timedelta
+from datetime import date, timedelta
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -89,8 +88,12 @@ def test_nav_links_includes_selected_site_highlight(
     )
     monkeypatch.setattr(context_processors, "_load_header_references", lambda *args: [])
     monkeypatch.setattr(context_processors, "_load_visible_modules", lambda *args: [])
-    monkeypatch.setattr(context_processors, "_parse_user_story_attachment_limit", lambda: 3)
-    monkeypatch.setattr(context_processors, "_select_current_module", lambda *args: None)
+    monkeypatch.setattr(
+        context_processors, "_parse_user_story_attachment_limit", lambda: 3
+    )
+    monkeypatch.setattr(
+        context_processors, "_select_current_module", lambda *args: None
+    )
     monkeypatch.setattr(context_processors, "_select_favicon_url", lambda *args: "")
     monkeypatch.setattr(context_processors, "_select_site_template", lambda *args: None)
 
@@ -106,8 +109,12 @@ def test_funding_banner_only_shows_on_arthexis_dot_com(
     monkeypatch,
 ) -> None:
     settings.ALLOWED_HOSTS = ["arthexis.com", "example.com"]
-    settings.ARTHEXIS_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/1"
-    monkeypatch.setattr(context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: True)
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = (
+        "https://github.com/arthexis/arthexis/issues/1"
+    )
+    monkeypatch.setattr(
+        context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: True
+    )
 
     canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
     other_request = rf.get("/", HTTP_HOST="example.com")
@@ -119,11 +126,69 @@ def test_funding_banner_only_shows_on_arthexis_dot_com(
     assert context_processors._build_funding_banner(other_request) is None
 
 
-def test_funding_banner_is_hidden_when_issue_is_closed(rf: RequestFactory, settings, monkeypatch) -> None:
+def test_funding_banner_is_hidden_when_issue_is_closed(
+    rf: RequestFactory, settings, monkeypatch
+) -> None:
     settings.ALLOWED_HOSTS = ["arthexis.com"]
-    settings.ARTHEXIS_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/1"
-    monkeypatch.setattr(context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: False)
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = (
+        "https://github.com/arthexis/arthexis/issues/1"
+    )
+    monkeypatch.setattr(
+        context_processors, "_is_github_issue_open", lambda *_args, **_kwargs: False
+    )
 
     canonical_request = rf.get("/", HTTP_HOST="arthexis.com")
 
     assert context_processors._build_funding_banner(canonical_request) is None
+
+
+def test_github_issue_state_uses_json_response(monkeypatch) -> None:
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"state": "closed"}'
+
+    monkeypatch.setattr(
+        context_processors, "urlopen", lambda *_args, **_kwargs: Response()
+    )
+
+    assert (
+        context_processors._read_github_issue_state(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        == "closed"
+    )
+
+
+def test_github_issue_open_caches_unknown_state_on_fetch_failure(monkeypatch) -> None:
+    calls = 0
+
+    def failing_reader(_issue_url):
+        nonlocal calls
+        calls += 1
+        return None
+
+    cache_key = (
+        "sites:funding_issue_state:" f"{context_processors.DEFAULT_FUNDING_ISSUE_URL}"
+    )
+    context_processors.cache.delete(cache_key)
+    monkeypatch.setattr(context_processors, "_read_github_issue_state", failing_reader)
+
+    assert (
+        context_processors._is_github_issue_open(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        is True
+    )
+    assert (
+        context_processors._is_github_issue_open(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        is True
+    )
+    assert calls == 1

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -148,6 +148,43 @@ def test_funding_banner_is_hidden_when_issue_is_closed(
     assert context_processors._build_funding_banner(canonical_request) is None
 
 
+def test_funding_banner_uses_default_issue_url_when_setting_is_blank(
+    rf: RequestFactory, settings, monkeypatch
+) -> None:
+    settings.ALLOWED_HOSTS = ["arthexis.com"]
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = ""
+    issue_checks = []
+
+    def issue_is_open(issue_url):
+        issue_checks.append(issue_url)
+        return True
+
+    monkeypatch.setattr(context_processors, "_is_github_issue_open", issue_is_open)
+
+    banner = context_processors._build_funding_banner(
+        rf.get("/", HTTP_HOST="arthexis.com")
+    )
+
+    assert banner is not None
+    assert banner["issue_url"] == context_processors.DEFAULT_FUNDING_ISSUE_URL
+    assert issue_checks == [context_processors.DEFAULT_FUNDING_ISSUE_URL]
+
+
+def test_mistyped_funding_issue_url_setting_does_not_break_rendering(
+    rf: RequestFactory, settings
+) -> None:
+    settings.ALLOWED_HOSTS = ["arthexis.com"]
+    settings.ARTHEXIS_FUNDING_ISSUE_URL = 7433
+
+    banner = context_processors._build_funding_banner(
+        rf.get("/", HTTP_HOST="arthexis.com")
+    )
+
+    assert banner is not None
+    assert banner["issue_url"] == 7433
+    assert context_processors._github_issue_api_url(True) is None
+
+
 def test_github_issue_state_uses_json_response(monkeypatch) -> None:
     class Response:
         def __enter__(self):

--- a/apps/sites/tests/test_site_highlight.py
+++ b/apps/sites/tests/test_site_highlight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from http.client import IncompleteRead
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -167,6 +168,29 @@ def test_github_issue_state_uses_json_response(monkeypatch) -> None:
             context_processors.DEFAULT_FUNDING_ISSUE_URL
         )
         == "closed"
+    )
+
+
+def test_github_issue_state_treats_incomplete_read_as_unknown(monkeypatch) -> None:
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            raise IncompleteRead(b'{"state":')
+
+    monkeypatch.setattr(
+        context_processors, "urlopen", lambda *_args, **_kwargs: Response()
+    )
+
+    assert (
+        context_processors._read_github_issue_state(
+            context_processors.DEFAULT_FUNDING_ISSUE_URL
+        )
+        is None
     )
 
 


### PR DESCRIPTION
### Motivation

- Remove distracting navigation chrome and the funding banner from the public login page so auth-focused pages are clean and focused.
- Ensure the funding banner reflects the current state of the upstream GitHub funding issue so the site doesn't continue advertising a closed issue.
- Avoid repeated API calls by caching the issue state to reduce load and transient network sensitivity.

### Description

- Added a reusable `page_nav` block to `apps/sites/templates/pages/base.html` so specific pages can opt out of the top navigation chrome without changing global layout behavior.
- Updated `apps/sites/templates/pages/login.html` to opt out of `page_nav` and `funding_banner`, removing navigation and banner from the login page.
- Enhanced `apps/sites/context_processors.py` with GitHub issue detection helpers: `_github_issue_api_url`, `_read_github_issue_state`, and `_is_github_issue_open`, plus a `FUNDING_ISSUE_STATE_CACHE_TTL_SECONDS` constant (900s) to cache the issue state and avoid frequent API calls.
- Modified `_build_funding_banner` to suppress the banner when the configured GitHub funding issue is determinable and closed, and to fall back to visible if the issue state cannot be fetched.
- Added and updated tests in `apps/sites/tests/test_login_view.py` and `apps/sites/tests/test_site_highlight.py` to cover the login page rendering (no nav or banner) and the closed-issue suppression behavior.

### Testing

- Bootstrapped the environment with `./env-refresh.sh --deps-only` and then ran the specific test targets with `.venv/bin/python manage.py test run -- apps/sites/tests/test_login_view.py apps/sites/tests/test_site_highlight.py`.
- Test run result: all tests passed (`7 passed`) for the modified targets.
- Network/API failures are safe: when GitHub issue state cannot be fetched the code conservatively leaves the banner visible to avoid false negatives from transient errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee15ba7a9883269fda880b579a6957)

No linked issue: release-interrupt maintainer-requested funding banner/login polish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enhances the public-facing login page and funding banner with improved visibility controls and GitHub funding issue state detection.

### Changes

**Login Page Visibility**
- Added a `{% block page_nav %}` wrapper around the navbar in `pages/base.html`, allowing child templates to override navigation rendering
- Updated `pages/login.html` to declare empty `page_nav` and `funding_banner` blocks, hiding both elements from the authentication page while keeping the HTML structure intact

**Funding Banner GitHub State Detection**
- Modified `_build_funding_banner()` in `context_processors.py` to:
  - Return `None` early when rendering the login page or when the request has `hide_funding_banner` set, avoiding synchronous GitHub API calls on auth routes
  - Resolve the configured funding issue URL (with fallback to `DEFAULT_FUNDING_ISSUE_URL = "https://github.com/arthexis/arthexis/issues/7433"`)
  - Check if the GitHub issue is open before showing the banner
- Added helper functions for safe GitHub API interaction:
  - `_github_issue_api_url()`: Parses GitHub issue URLs to construct API endpoints
  - `_read_github_issue_state()`: Fetches issue state from GitHub API with 2-second timeout and comprehensive exception handling (catches `IncompleteRead`, `TimeoutError`, `URLError`, `UnicodeDecodeError`, `ValueError`, and JSON parsing errors)
  - `_is_github_issue_open()`: Caches issue state with tiered TTLs—900 seconds for successful lookups, 300 seconds for failures (marked as "unknown" state)
- Conservative fallback behavior: banner displays when GitHub state cannot be determined

**Banner Presentation & Dismissal**
- Updated `funding_banner.html` to:
  - Add `data-funding-banner-cache-key` attribute for localStorage-based dismissal tracking
  - Wrap banner content in `.funding-banner__body` class
  - Include an accessible close button with `data-funding-banner-close="true"` and localized "Dismiss funding banner" label
- CSS refactoring in `base.css`:
  - Added `.funding-banner__body` (shrink-capable flex item) and `.funding-banner__close` (non-flexing close control)
  - Removed `.funding-banner--sidebar` sticky positioning rules to keep the banner in normal page flow
- JavaScript dismissal in `base.js`:
  - `setupFundingBannerDismissal()` checks localStorage on page load; removes banner if previously dismissed
  - Wires close button to remove the banner and set a persistent dismissal marker, with graceful handling of storage unavailability

### Testing

Comprehensive test coverage added across `test_login_view.py`, `test_site_highlight.py`, and `test_funding_banner_template.py`:
- Verifies login page does not invoke GitHub API checks
- Confirms nav and funding banner are absent from login HTML
- Tests banner hiding when GitHub issue is closed
- Validates fallback to `DEFAULT_FUNDING_ISSUE_URL` when setting is blank
- Handles malformed `ARTHEXIS_FUNDING_ISSUE_URL` settings without breaking rendering
- Tests JSON response parsing, `IncompleteRead` exception handling, and failure-state caching
- Validates dismissal button functionality and localStorage integration
- Verifies banner remains in normal document flow (non-fixed/non-sticky CSS)
- Confirms presence of dismissal setup hook in rendered HTML

**Test Results**: 15 tests passing; verification includes linting and checks.

### Impact

- **Login Page**: Streamlined for authentication focus; removes navigation chrome and funding messaging
- **Banner State Management**: Reduces GitHub API load via caching while maintaining visibility when state is unavailable
- **User Experience**: Local dismissal option with persistent memory; banner moves naturally with page content rather than overlaying

<!-- end of auto-generated comment: release notes by coderabbit.ai -->