### PR TITLE
Fix Evergo customer export on Postgres

### DIFF
--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -7,7 +7,7 @@ from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import CharField, Prefetch, Q, Value
-from django.db.models.fields.json import KeyTextTransform
+from django.db.models.fields.json import KeyTextTransform, KeyTransform
 from django.db.models.functions import Coalesce, NullIf
 from django.http import HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
@@ -1068,7 +1068,7 @@ class EvergoCustomerAdmin(DjangoObjectActions, admin.ModelAdmin):
                 NullIf("latest_order__site_name", Value("")),
                 KeyTextTransform(
                     "marca_cargador",
-                    KeyTextTransform("orden_instalacion", "raw_payload"),
+                    KeyTransform("orden_instalacion", "raw_payload"),
                 ),
                 output_field=CharField(),
             )

--- a/apps/evergo/admin.py
+++ b/apps/evergo/admin.py
@@ -7,20 +7,26 @@ from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import CharField, Prefetch, Q, Value
+from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Coalesce, NullIf
-from django.utils.html import format_html, format_html_join
 from django.http import HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import path, reverse
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _, ngettext
+from django.utils.html import format_html, format_html_join
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from django_object_actions import DjangoObjectActions
 
 from apps.core.admin import OwnableAdminMixin, ProfileAdminMixin, SaveBeforeChangeAction
 from apps.core.admin.mixins import _build_credentials_actions
 
 from .exceptions import EvergoAPIError
-from .forms import EvergoContractorLoginWizardForm, EvergoLoadCustomersForm, EvergoUserAdminForm
+from .forms import (
+    EvergoContractorLoginWizardForm,
+    EvergoLoadCustomersForm,
+    EvergoUserAdminForm,
+)
 from .models import (
     EvergoArtifact,
     EvergoCustomer,
@@ -1060,7 +1066,10 @@ class EvergoCustomerAdmin(DjangoObjectActions, admin.ModelAdmin):
         queryset = super().get_queryset(request).annotate(
             brand_sort_value=Coalesce(
                 NullIf("latest_order__site_name", Value("")),
-                "raw_payload__orden_instalacion__marca_cargador__text",
+                KeyTextTransform(
+                    "marca_cargador",
+                    KeyTextTransform("orden_instalacion", "raw_payload"),
+                ),
                 output_field=CharField(),
             )
         )


### PR DESCRIPTION
## Summary
- extract the nested Evergo charger brand JSON value as text before using it in the customer admin Coalesce annotation
- keeps the export queryset compatible with Postgres jsonb while preserving SQLite behavior

Closes #7456

## Verification
- ARTHEXIS_DB_BACKEND=postgres POSTGRES_HOST=solstice-7456-postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_DB=arthexis python -m pytest apps/evergo/tests/test_admin_customers.py::test_evergo_customer_export_defaults_to_no_header_row -q
- python -m pytest apps/evergo/tests/test_admin_customers.py -q
- ruff check apps/evergo/admin.py
- git diff --check

--codename Solstice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Modified the Evergo customer admin queryset's `brand_sort_value` annotation to extract nested JSON values as text before passing to the Coalesce operation. The annotation now uses Django's `KeyTransform` and `KeyTextTransform` to navigate `raw_payload → orden_instalacion → marca_cargador` and explicitly convert the result to text, replacing the previous approach that relied on the string lookup `"raw_payload__...__text"`.

## Rationale

The previous implementation caused a type mismatch in Postgres: Coalesce was receiving a text field (`latest_order__site_name`) and a raw jsonb value from the JSON path. SQLite tolerated mixing types, but Postgres strictly enforces type compatibility in Coalesce expressions, causing the customer export to fail. By explicitly converting the JSON value to text before Coalesce, both operands are now text-compatible and the export works across both database backends.

## Verification

- Targeted export test passed on Postgres: `test_evergo_customer_export_defaults_to_no_header_row`
- Full Evergo admin customer test suite passed on Postgres
- Code quality checks passed: ruff and git diff --check
- Existing export behavior preserved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->