### PR TITLE
ci: gate release simulator to only run when a new release is needed

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -113,22 +113,22 @@ jobs:
               });
 
               const releaseCompletedAt = latestRelease.published_at || latestRelease.created_at;
-              if (releaseCompletedAt) {
-                const ageMillis = Date.now() - Date.parse(releaseCompletedAt);
-                if (ageMillis >= releaseCutoffMillis) {
-                  shouldRun = false;
-                  skipReason = `Latest release ${latestRelease.tag_name} completed at ${releaseCompletedAt}, which is at least three full days old.`;
-                }
-              }
+              const { data: comparison } = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: latestRelease.tag_name,
+                head: defaultBranch,
+              });
 
-              if (shouldRun) {
-                const { data: comparison } = await github.rest.repos.compareCommits({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  base: latestRelease.tag_name,
-                  head: defaultBranch,
-                });
-                if (!comparison.ahead_by) {
+              if (!comparison.ahead_by) {
+                const ageMillis = releaseCompletedAt
+                  ? Date.now() - Date.parse(releaseCompletedAt)
+                  : 0;
+
+                if (releaseCompletedAt && ageMillis >= releaseCutoffMillis) {
+                  shouldRun = false;
+                  skipReason = `Latest release ${latestRelease.tag_name} is at least three full days old and there are no new commits on ${defaultBranch}.`;
+                } else {
                   shouldRun = false;
                   skipReason = `No new commits on ${defaultBranch} since ${latestRelease.tag_name}; a new release is not currently needed.`;
                 }

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -86,6 +86,8 @@ jobs:
       contents: read
       issues: read
     outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+      skip_reason: ${{ steps.evaluate.outputs.skip_reason }}
       can_simulate: ${{ steps.evaluate.outputs.can_simulate }}
       blockers_json: ${{ steps.evaluate.outputs.blockers_json }}
       default_branch: ${{ steps.evaluate.outputs.default_branch }}
@@ -99,56 +101,101 @@ jobs:
             const installMarker = '<!-- install-health-check-failure -->';
             const defaultBranch = context.payload.repository.default_branch;
             const blockers = [];
+            const fullDayMillis = 24 * 60 * 60 * 1000;
+            const releaseCutoffMillis = 3 * fullDayMillis;
+            let shouldRun = true;
+            let skipReason = '';
 
-            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
+            try {
+              const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
 
-            const installFailureIssue = openIssues.find((issue) => issue.title === installIssueTitle && issue.body?.includes(installMarker));
-            if (installFailureIssue) {
-              blockers.push(`Open install failure issue: #${installFailureIssue.number}`);
-            }
+              const releaseCompletedAt = latestRelease.published_at || latestRelease.created_at;
+              if (releaseCompletedAt) {
+                const ageMillis = Date.now() - Date.parse(releaseCompletedAt);
+                if (ageMillis >= releaseCutoffMillis) {
+                  shouldRun = false;
+                  skipReason = `Latest release ${latestRelease.tag_name} completed at ${releaseCompletedAt}, which is at least three full days old.`;
+                }
+              }
 
-            const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: defaultBranch,
-              per_page: 100,
-            });
-
-            const latestCiRun = ciRuns
-              .filter((run) => run.name === 'Upgrade Gate')
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
-
-            if (latestCiRun && latestCiRun.conclusion === 'failure') {
-              let upgradeFailed = false;
-              try {
-                const { data: jobsData } = await github.rest.actions.listJobsForWorkflowRun({
+              if (shouldRun) {
+                const { data: comparison } = await github.rest.repos.compareCommits({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  run_id: latestCiRun.id,
-                  per_page: 100,
+                  base: latestRelease.tag_name,
+                  head: defaultBranch,
                 });
-                upgradeFailed = jobsData.jobs.some((job) => (job.name || '').toLowerCase().includes('upgrade') && job.conclusion === 'failure');
-              } catch (error) {
-                core.warning(`Unable to inspect CI jobs for run ${latestCiRun.id}: ${error.message}`);
+                if (!comparison.ahead_by) {
+                  shouldRun = false;
+                  skipReason = `No new commits on ${defaultBranch} since ${latestRelease.tag_name}; a new release is not currently needed.`;
+                }
               }
-
-              if (upgradeFailed) {
-                blockers.push(`Latest CI upgrade gate failed: ${latestCiRun.html_url}`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('No releases exist yet; continuing with release readiness checks.');
+              } else {
+                throw error;
               }
             }
 
-            const canSimulate = blockers.length === 0;
+            if (shouldRun) {
+              const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              const installFailureIssue = openIssues.find((issue) => issue.title === installIssueTitle && issue.body?.includes(installMarker));
+              if (installFailureIssue) {
+                blockers.push(`Open install failure issue: #${installFailureIssue.number}`);
+              }
+
+              const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: defaultBranch,
+                per_page: 100,
+              });
+
+              const latestCiRun = ciRuns
+                .filter((run) => run.name === 'Upgrade Gate')
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+              if (latestCiRun && latestCiRun.conclusion === 'failure') {
+                let upgradeFailed = false;
+                try {
+                  const { data: jobsData } = await github.rest.actions.listJobsForWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: latestCiRun.id,
+                    per_page: 100,
+                  });
+                  upgradeFailed = jobsData.jobs.some((job) => (job.name || '').toLowerCase().includes('upgrade') && job.conclusion === 'failure');
+                } catch (error) {
+                  core.warning(`Unable to inspect CI jobs for run ${latestCiRun.id}: ${error.message}`);
+                }
+
+                if (upgradeFailed) {
+                  blockers.push(`Latest CI upgrade gate failed: ${latestCiRun.html_url}`);
+                }
+              }
+            } else {
+              core.info(`Skipping release readiness check: ${skipReason}`);
+            }
+
+            const canSimulate = shouldRun && blockers.length === 0;
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('skip_reason', skipReason);
             core.setOutput('can_simulate', canSimulate ? 'true' : 'false');
             core.setOutput('blockers_json', JSON.stringify(blockers));
             core.setOutput('default_branch', defaultBranch);
 
   simulate_release:
-    if: ${{ github.event_name != 'push' }}
+    if: ${{ github.event_name != 'push' && needs.evaluate.outputs.should_run == 'true' }}
     needs:
       - evaluate
     runs-on: ubuntu-latest
@@ -178,7 +225,7 @@ jobs:
             --run-url "$RUN_URL"
 
   report:
-    if: ${{ always() && github.event_name != 'push' }}
+    if: ${{ always() && github.event_name != 'push' && needs.evaluate.outputs.should_run == 'true' }}
     needs:
       - evaluate
       - simulate_release
@@ -275,3 +322,55 @@ jobs:
               body,
             });
             core.info(`Created issue #${created.data.number}.`);
+
+  close_report_when_not_needed:
+    if: ${{ github.event_name != 'push' && needs.evaluate.outputs.should_run != 'true' }}
+    needs:
+      - evaluate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close open release readiness report when checks are not needed
+        uses: actions/github-script@v9
+        env:
+          SKIP_REASON: ${{ needs.evaluate.outputs.skip_reason }}
+        with:
+          script: |
+            const title = 'Release Readiness Report';
+            const marker = '<!-- release-readiness-report -->';
+            const skipReason = process.env.SKIP_REASON || 'Release readiness check skipped by policy.';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = openIssues.find((issue) => issue.title === title && issue.body?.includes(marker));
+            if (!existing) {
+              core.info('No open release readiness report issue found to close.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              body: [
+                'Closing this report because release readiness checks are currently not needed.',
+                '',
+                `- Reason: ${skipReason}`,
+                `- Workflow run: ${runUrl}`,
+              ].join('\n'),
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              state: 'closed',
+            });


### PR DESCRIPTION
### Motivation

- Prevent unnecessary hourly release-readiness work when a release has already completed recently and no new changes exist. 
- Ensure the release readiness simulator only runs when a new release could be required, reducing noise and CI/API usage. 
- Keep the repository's release report issue state consistent by closing the report when checks are skipped by policy.

### Description

- Added a policy gate to `evaluate` in `.github/workflows/release-simulator.yml` that computes `should_run` and `skip_reason` outputs. 
- The gate fetches the latest GitHub release and skips checks when the latest release is at least three full days old, and also skips when there are no commits on the default branch since that release tag. 
- Gated `simulate_release` and `report` jobs to run only when `should_run == 'true'`, and added a `close_report_when_not_needed` job to close any open "Release Readiness Report" issue with the skip reason when checks are skipped. 
- All workflow changes live in ` .github/workflows/release-simulator.yml` and emit `should_run`, `skip_reason`, and existing outputs for downstream jobs.

### Testing

- Performed a YAML parse/load validation by running a short `python` snippet that `yaml.safe_load`-ed ` .github/workflows/release-simulator.yml`, which succeeded and confirmed the modified workflow is syntactically valid. 
- Committed the workflow update and created the PR; CI will run the updated workflow and its standard checks on merge to verify runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01f654404832692d1fdf697db3bdb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Simulator Workflow Enhancement

### Changes Summary
Modified `.github/workflows/release-simulator.yml` to gate the release simulator and reporting jobs based on policy conditions that determine whether a new release is needed.

### Key Additions

**New evaluate job outputs:**
- `should_run`: Boolean indicating whether release readiness checks should proceed
- `skip_reason`: Human-readable explanation when checks are skipped

**Policy gate logic in evaluate step:**
The evaluate step now fetches the latest GitHub release and computes `should_run` by checking:
- If the latest release is at least three full days old → skip
- If no commits exist on the default branch since the latest release tag → skip
- If either condition is true, `skip_reason` is set with the specific reason and blocker checking is skipped

**Conditional job execution:**
- `simulate_release` and `report` jobs are now gated to run only when `needs.evaluate.outputs.should_run == 'true'`
- `can_simulate` output is now additionally dependent on `should_run` (returns true only when `should_run` is true AND no blockers exist)

**New close_report_when_not_needed job:**
When `should_run` is false, this job:
- Locates any open "Release Readiness Report" issue
- Adds a comment with the `skip_reason` and workflow run URL
- Closes the issue to prevent stale reports

### Impact
Release readiness checks now only run when a new release is actually needed, reducing unnecessary workflow execution while maintaining the ability to document why checks were skipped through issue comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

No linked issue