### PR TITLE
ci: skip require-pr-issue-link workflow for dependabot PRs

### DIFF
--- a/.github/workflows/require-pr-issue-link.yml
+++ b/.github/workflows/require-pr-issue-link.yml
@@ -32,6 +32,11 @@ jobs:
               return;
             }
 
+            if (context.actor === 'dependabot[bot]' || pullRequest.user?.login === 'dependabot[bot]') {
+              core.info('Dependabot PR; skipping issue-link requirement.');
+              return;
+            }
+
             const defaultBranch = context.payload.repository?.default_branch;
             if (defaultBranch && pullRequest.base.ref !== defaultBranch) {
               core.info(

--- a/.github/workflows/require-pr-issue-link.yml
+++ b/.github/workflows/require-pr-issue-link.yml
@@ -33,12 +33,24 @@ jobs:
             }
 
             const dependabotAccounts = new Set(['dependabot[bot]', 'app/dependabot']);
-            if (
-              dependabotAccounts.has(context.actor) ||
-              dependabotAccounts.has(pullRequest.user?.login || '')
-            ) {
+            const actorLogins = [
+              context.actor,
+              context.payload?.actor?.login,
+              pullRequest.user?.login,
+              context.payload?.sender?.login,
+              context.payload?.author?.login,
+            ].filter(Boolean);
+            const isDependabotActor = actorLogins.some((login) =>
+              dependabotAccounts.has((login || '').toLowerCase()),
+            );
+
+            if (isDependabotActor) {
               core.info('Dependabot PR; skipping issue-link requirement.');
               return;
+            }
+
+            if (actorLogins.length === 0) {
+              core.info('Actor metadata is unavailable; applying standard PR enforcement logic.');
             }
 
             const defaultBranch = context.payload.repository?.default_branch;

--- a/.github/workflows/require-pr-issue-link.yml
+++ b/.github/workflows/require-pr-issue-link.yml
@@ -32,7 +32,11 @@ jobs:
               return;
             }
 
-            if (context.actor === 'dependabot[bot]' || pullRequest.user?.login === 'dependabot[bot]') {
+            const dependabotAccounts = new Set(['dependabot[bot]', 'app/dependabot']);
+            if (
+              dependabotAccounts.has(context.actor) ||
+              dependabotAccounts.has(pullRequest.user?.login || '')
+            ) {
               core.info('Dependabot PR; skipping issue-link requirement.');
               return;
             }


### PR DESCRIPTION
### Motivation
- Dependabot-generated PRs normally do not reference a tracked issue and were causing the `require-issue-link` workflow to fail, so the workflow should skip enforcement for dependabot to avoid spurious CI failures.

### Description
- Added an early-return check to `.github/workflows/require-pr-issue-link.yml` that skips the issue-link enforcement when `context.actor === 'dependabot[bot]'` or `pullRequest.user?.login === 'dependabot[bot]'` and logs the skip.

### Testing
- Parsed the updated workflow YAML using `python - <<'PY' ... yaml.safe_load(...)` which succeeded.
- Ran `git status --short` to verify the change was staged and committed successfully.

No linked issue

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04e4fc0d083269d18bf1598cef825)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Modified `.github/workflows/require-pr-issue-link.yml` to skip the issue-link enforcement for Dependabot-authored pull requests.

Added an early-return conditional that detects Dependabot accounts by checking `context.actor` or `pullRequest.user?.login` against a set including `'dependabot[bot]'` and `'app/dependabot'`. When matched the workflow logs "Dependabot PR; skipping issue-link requirement." and exits before evaluating draft/default-branch and PR-body validations.

This prevents the workflow from failing Dependabot-generated PRs, which typically do not include references to tracked issues and would otherwise trigger enforcement failures.

## Lines Changed
+9 / -0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
