### PR TITLE
Add Evergo workspace view, contractor selection in tracking, and seed migration

### DIFF
--- a/apps/evergo/migrations/0006_seed_evergo_workspace.py
+++ b/apps/evergo/migrations/0006_seed_evergo_workspace.py
@@ -1,0 +1,68 @@
+from django.db import migrations
+
+
+EVERGO_GROUP_NAME = "Evergo Contractors"
+EVERGO_MODULE_MENU = "Evergo"
+EVERGO_MODULE_PATH = "/evergo/"
+EVERGO_WORKSPACE_PATH = "/evergo/workspace/"
+
+
+def seed_evergo_workspace(apps, schema_editor):
+    del schema_editor
+    SecurityGroup = apps.get_model("groups", "SecurityGroup")
+    Module = apps.get_model("modules", "Module")
+    Landing = apps.get_model("pages", "Landing")
+
+    group, _ = SecurityGroup.objects.get_or_create(name=EVERGO_GROUP_NAME)
+
+    module, _ = Module.objects.get_or_create(
+        path=EVERGO_MODULE_PATH,
+        defaults={
+            "menu": EVERGO_MODULE_MENU,
+            "security_group": group,
+            "security_mode": "exclusive",
+        },
+    )
+    changed = []
+    if module.menu != EVERGO_MODULE_MENU:
+        module.menu = EVERGO_MODULE_MENU
+        changed.append("menu")
+    if module.security_group_id != group.id:
+        module.security_group = group
+        changed.append("security_group")
+    if module.security_mode != "exclusive":
+        module.security_mode = "exclusive"
+        changed.append("security_mode")
+    if changed:
+        module.save(update_fields=changed)
+
+    Landing.objects.get_or_create(
+        module=module,
+        path=EVERGO_WORKSPACE_PATH,
+        defaults={"label": EVERGO_MODULE_MENU, "enabled": True},
+    )
+
+
+def unseed_evergo_workspace(apps, schema_editor):
+    del schema_editor
+    Module = apps.get_model("modules", "Module")
+    Landing = apps.get_model("pages", "Landing")
+
+    module = Module.objects.filter(path=EVERGO_MODULE_PATH).first()
+    if module is None:
+        return
+    Landing.objects.filter(module=module, path=EVERGO_WORKSPACE_PATH).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("evergo", "0005_evergocustomersharelink"),
+        ("groups", "0003_seed_ap_user_group"),
+        ("modules", "0003_rename_docs_module_pill"),
+        ("pages", "0007_seed_visitors_module"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_evergo_workspace, unseed_evergo_workspace),
+    ]

--- a/apps/evergo/templates/evergo/order_tracking_public.html
+++ b/apps/evergo/templates/evergo/order_tracking_public.html
@@ -110,6 +110,15 @@
     <form method="post" enctype="multipart/form-data" id="tracking-form">
         {% csrf_token %}
         <div class="card">
+            <h2>Evergo account</h2>
+            <label for="id_tracking_contractor">Contractor account</label>
+            <select id="id_tracking_contractor" name="contractor" onchange="window.location='?contractor='+this.value">
+                {% for contractor in contractor_options %}
+                    <option value="{{ contractor.pk }}" {% if selected_contractor_id == contractor.pk|stringformat:'s' %}selected{% endif %}>{{ contractor }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="card">
             <h2>Datos principales</h2>
             {{ form.non_field_errors }}
             <div class="grid">

--- a/apps/evergo/templates/evergo/workspace.html
+++ b/apps/evergo/templates/evergo/workspace.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Evergo Workspace</title>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 1rem; }
+        .tabs { display: flex; gap: .5rem; margin-bottom: 1rem; }
+        .tab-link { padding: .5rem .75rem; text-decoration: none; border: 1px solid #cbd5e1; border-radius: .5rem; color: inherit; }
+        .tab-link.active { background: #e2e8f0; font-weight: 600; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border-bottom: 1px solid #e2e8f0; padding: .5rem; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Evergo</h1>
+    <nav class="tabs" aria-label="Evergo views">
+        <a class="tab-link {% if active_tab == 'customers' %}active{% endif %}" href="?tab=customers{% if selected_contractor_id %}&contractor={{ selected_contractor_id }}{% endif %}">Customers</a>
+        <a class="tab-link {% if active_tab == 'orders' %}active{% endif %}" href="?tab=orders{% if selected_contractor_id %}&contractor={{ selected_contractor_id }}{% endif %}">Orders</a>
+    </nav>
+    <form method="get" style="margin-bottom:1rem;">
+        <input type="hidden" name="tab" value="{{ active_tab }}">
+        <label for="id_workspace_contractor">Contractor account</label>
+        <select id="id_workspace_contractor" name="contractor" onchange="this.form.submit()">
+            <option value="">All contractors</option>
+            {% for contractor in contractors %}
+                <option value="{{ contractor.pk }}" {% if selected_contractor_id == contractor.pk|stringformat:'s' %}selected{% endif %}>{{ contractor }}</option>
+            {% endfor %}
+        </select>
+    </form>
+
+    {% if active_tab == "customers" %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Last SO</th>
+                    <th>Name</th>
+                    <th>Address</th>
+                    <th>Brand</th>
+                    <th>Phone number</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for customer in customers %}
+                <tr>
+                    <td><a href="{% url 'evergo:customer-public-detail' public_id=customer.public_id %}">{{ customer.latest_so|default:"-" }}</a></td>
+                    <td>{{ customer.name|default:"-" }}</td>
+                    <td>{{ customer.address|default:"-" }}</td>
+                    <td>{{ customer.latest_order.site_name|default:"-" }}</td>
+                    <td>{{ customer.phone_number|default:"-" }}</td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="5">No customers found.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Order Number</th>
+                    <th>Customer</th>
+                    <th>Status Name</th>
+                    <th>Address</th>
+                    <th>Phone</th>
+                    <th>Brand</th>
+                    <th>Municipio</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for order in orders %}
+                <tr>
+                    <td><a href="{% url 'evergo:order-tracking-public' order_id=order.remote_id %}{% if selected_contractor_id %}?contractor={{ selected_contractor_id }}{% endif %}">{{ order.order_number|default:order.remote_id }}</a></td>
+                    <td>{{ order.client_name|default:"-" }}</td>
+                    <td>{{ order.status_name|default:"-" }}</td>
+                    <td>{{ order.address_street|default:"-" }}</td>
+                    <td>{{ order.phone_primary|default:order.phone_secondary|default:"-" }}</td>
+                    <td>{{ order.site_name|default:"-" }}</td>
+                    <td>{{ order.address_municipality|default:"-" }}</td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="7">No orders found.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+</body>
+</html>

--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from apps.evergo.models import EvergoArtifact, EvergoCustomer, EvergoCustomerShareLink, EvergoUser
+from apps.groups.models import SecurityGroup
 
 
 def _create_customer(*, username: str = "evergo-owner") -> EvergoCustomer:
@@ -86,6 +87,100 @@ def test_my_evergo_dashboard_renders_and_generates_table_from_local_orders(clien
     assert "Monterrey" in content
     assert "https://portal-mex.evergo.com/ordenes/28690" in content
     assert "Copy / Paste table" in content
+
+
+@pytest.mark.django_db
+def test_evergo_workspace_requires_contractors_security_group(client):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="workspace-user", email="workspace@example.com")
+    client.force_login(user)
+
+    response = client.get(reverse("evergo:workspace"))
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_evergo_workspace_renders_customers_and_orders_tabs(client):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="workspace-member", email="member@example.com")
+    group = SecurityGroup.objects.create(name="Evergo Contractors")
+    user.groups.add(group)
+    profile = EvergoUser.objects.create(user=user, evergo_email="member@example.com", evergo_password="secret")
+    customer = EvergoCustomer.objects.create(user=profile, name="Customer One", latest_so="SO-1")
+    from apps.evergo.models import EvergoOrder
+
+    order = EvergoOrder.objects.create(
+        user=profile,
+        remote_id=5001,
+        order_number="SO-1",
+        client_name=customer.name,
+        status_name="Assigned",
+    )
+    customer.latest_order = order
+    customer.save(update_fields=["latest_order"])
+    client.force_login(user)
+
+    customers_response = client.get(reverse("evergo:workspace"))
+    orders_response = client.get(reverse("evergo:workspace"), {"tab": "orders"})
+
+    assert customers_response.status_code == 200
+    assert "Customers" in customers_response.content.decode()
+    assert "Customer One" in customers_response.content.decode()
+    assert orders_response.status_code == 200
+    assert "Orders" in orders_response.content.decode()
+    assert "SO-1" in orders_response.content.decode()
+
+
+@pytest.mark.django_db
+def test_workspace_filters_rows_by_selected_contractor(client):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="workspace-filter", email="workspace-filter@example.com")
+    group = SecurityGroup.objects.create(name="Evergo Contractors")
+    user.groups.add(group)
+    profile_a = EvergoUser.objects.create(user=user, evergo_email="a@example.com", evergo_password="secret")
+    owner_b = user_model.objects.create_user(username="workspace-b", email="workspace-b@example.com")
+    profile_b = EvergoUser.objects.create(user=owner_b, evergo_email="b@example.com", evergo_password="secret")
+    EvergoCustomer.objects.create(user=profile_a, name="Customer A", latest_so="SO-A")
+    EvergoCustomer.objects.create(user=profile_b, name="Customer B", latest_so="SO-B")
+    client.force_login(user)
+
+    response = client.get(reverse("evergo:workspace"), {"tab": "customers", "contractor": str(profile_a.pk)})
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Customer A" in content
+    assert "Customer B" not in content
+
+
+@pytest.mark.django_db
+def test_order_tracking_uses_selected_contractor_account(client, monkeypatch):
+    user_model = get_user_model()
+    staff = user_model.objects.create_user(username="tracking-staff", email="staff@example.com", is_staff=True)
+    owner_a = user_model.objects.create_user(username="owner-a", email="owner-a@example.com")
+    owner_b = user_model.objects.create_user(username="owner-b", email="owner-b@example.com")
+    profile_a = EvergoUser.objects.create(user=owner_a, evergo_email="a@example.com", evergo_password="secret")
+    profile_b = EvergoUser.objects.create(user=owner_b, evergo_email="b@example.com", evergo_password="secret")
+    from apps.evergo.models import EvergoOrder
+
+    order = EvergoOrder.objects.create(user=profile_a, remote_id=8022, order_number="SO-8022")
+
+    monkeypatch.setattr(
+        EvergoUser,
+        "fetch_charger_brand_options",
+        lambda self: ["Brand A"] if self.pk == profile_a.pk else ["Brand B"],
+    )
+    monkeypatch.setattr(
+        EvergoUser,
+        "fetch_order_detail",
+        lambda self, order_id: {},
+    )
+    client.force_login(staff)
+
+    response = client.get(reverse("evergo:order-tracking-public", args=[order.remote_id]), {"contractor": str(profile_b.pk)})
+
+    assert response.status_code == 200
+    assert "Brand B" in response.content.decode()
 
 
 def test_to_tsv_sanitizes_formula_and_line_break_characters():

--- a/apps/evergo/urls.py
+++ b/apps/evergo/urls.py
@@ -7,6 +7,7 @@ from . import views
 app_name = "evergo"
 
 urlpatterns = [
+    path("workspace/", views.evergo_workspace, name="workspace"),
     path("dashboard/<uuid:token>/", views.my_evergo_dashboard, name="my-dashboard"),
     path("orders/<int:order_id>/tracking/", views.order_tracking_public, name="order-tracking-public"),
     path("customers/<uuid:public_id>/", views.customer_public_detail, name="customer-public-detail"),

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -59,6 +59,7 @@ TRACKING_PREFILL_SOURCE_KEYS = (
     "tracking",
     "data",
 )
+EVERGO_CONTRACTORS_GROUP_NAME = "Evergo Contractors"
 
 
 def _parse_user_story_attachment_limit() -> int:
@@ -94,12 +95,68 @@ def _build_public_widget_context(*, user) -> dict[str, object]:
     }
 
 
+def _has_evergo_workspace_access(*, user) -> bool:
+    if not user.is_authenticated:
+        return False
+    return user.groups.filter(name=EVERGO_CONTRACTORS_GROUP_NAME).exists() or user.is_superuser
+
+
 def _normalize_display_text(value: str | None, *, default: str = "-") -> str:
     """Normalize common encoding artifacts in user-facing Evergo text."""
     normalized = str(value or "").strip()
     if not normalized:
         return default
     return DISPLAY_TEXT_FIXUPS.get(normalized, normalized)
+
+
+@login_required
+def evergo_workspace(request) -> HttpResponse:
+    """Render a tabbed Evergo workspace with customer/order snapshots."""
+    if not _has_evergo_workspace_access(user=request.user):
+        raise Http404("Evergo workspace not found.")
+
+    tab = request.GET.get("tab", "customers")
+    selected_contractor_id = request.GET.get("contractor", "")
+    if tab not in {"customers", "orders"}:
+        tab = "customers"
+
+    customers = (
+        EvergoCustomer.objects.select_related("latest_order")
+        .order_by("latest_so", "pk")
+        .only("public_id", "latest_so", "name", "address", "phone_number", "latest_order__site_name")
+    )
+    orders = (
+        EvergoOrder.objects.order_by("order_number", "pk")
+        .only(
+            "remote_id",
+            "order_number",
+            "client_name",
+            "status_name",
+            "address_street",
+            "phone_primary",
+            "phone_secondary",
+            "site_name",
+            "address_municipality",
+        )
+    )
+    contractors = EvergoUser.objects.order_by("name", "email", "pk").only("pk", "name", "email", "evergo_email")
+    if selected_contractor_id.isdigit():
+        contractor_pk = int(selected_contractor_id)
+        customers = customers.filter(user_id=contractor_pk)
+        orders = orders.filter(user_id=contractor_pk)
+    else:
+        selected_contractor_id = ""
+    return render(
+        request,
+        "evergo/workspace.html",
+        {
+            "active_tab": tab,
+            "customers": customers,
+            "orders": orders,
+            "contractors": contractors,
+            "selected_contractor_id": selected_contractor_id,
+        },
+    )
 
 
 def _get_evergo_public_image_limit() -> int:
@@ -646,7 +703,14 @@ def order_tracking_public(request, order_id: int) -> HttpResponse:
     if not request.user.is_staff:
         order_lookup["user__user"] = request.user
     order = get_object_or_404(EvergoOrder.objects.select_related("user"), **order_lookup)
+    contractor_options = EvergoUser.objects.order_by("name", "email", "pk").only("pk", "name", "email", "evergo_email")
+    requested_contractor_id = request.POST.get("contractor") or request.GET.get("contractor") or ""
     profile = order.user
+    if requested_contractor_id.isdigit():
+        selected_profile = contractor_options.filter(pk=int(requested_contractor_id)).first()
+        if selected_profile is not None:
+            profile = selected_profile
+    selected_contractor_id = str(profile.pk)
     brands = profile.fetch_charger_brand_options()
     remote_image_urls: dict[str, str] = {}
 
@@ -702,7 +766,9 @@ def order_tracking_public(request, order_id: int) -> HttpResponse:
                         request,
                         f"Orden enviada correctamente. {completed_steps}/4 pasos completados.",
                     )
-                    return redirect("evergo:order-tracking-public", order_id=order_id)
+                    return redirect(
+                        f"{reverse('evergo:order-tracking-public', kwargs={'order_id': order_id})}?contractor={selected_contractor_id}"
+                    )
     else:
         remote_initial_data, remote_prefill_errors, remote_image_urls = _load_remote_phase_one_initial_data(
             profile=profile,
@@ -741,6 +807,8 @@ def order_tracking_public(request, order_id: int) -> HttpResponse:
                 if order.remote_id is not None
                 else ""
             ),
+            "contractor_options": contractor_options,
+            "selected_contractor_id": selected_contractor_id,
             **_build_public_widget_context(user=request.user),
         },
     )


### PR DESCRIPTION
### Motivation

- Provide a simple tabbed workspace for Evergo contractors to browse customers and orders within the app.  
- Allow selecting which contractor account to use when viewing/submitting public order tracking so staff can act on behalf of another contractor.  
- Ensure the Evergo module/landing and contractor security group exist by seeding them in a migration.

### Description

- Add `evergo_workspace` view with access guarded by a new `_has_evergo_workspace_access` helper and the `Evergo Contractors` group constant `EVERGO_CONTRACTORS_GROUP_NAME`.  
- Add `workspace/` URL route and new template `apps/evergo/templates/evergo/workspace.html` to render tabbed Customers/Orders lists with a contractor filter.  
- Extend the public order tracking view/template to include a contractor selector (`contractor_options`/`selected_contractor_id`) and preserve the selected contractor across form submissions by appending `?contractor=...` to redirects.  
- Add a data migration `0006_seed_evergo_workspace.py` to create/get the `Evergo Contractors` security group, ensure the `Evergo` module exists with exclusive security, and create a workspace landing page.  
- Add tests in `apps/evergo/tests/test_public_views.py` covering workspace access control, rendering of customers/orders tabs, filtering by selected contractor, and that order tracking uses the selected contractor account.

### Testing

- Ran the updated Evergo public view tests via `pytest -q apps/evergo/tests/test_public_views.py`, which executed the newly added workspace and contractor-selection tests and succeeded.  
- Existing Evergo public-view regression tests in the same file were run together with the new tests and also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f281d01c9483269aa3097eb7f67547)