### PR TITLE
ci: increase install-hourly pytest timeout to 300s

### DIFF
--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -210,7 +210,7 @@ jobs:
           ./scripts/preflight-env.sh --pytest
           source .venv/bin/activate
           read -r -a xdist_args <<< "${PYTEST_XDIST_ARGS:-}"
-          python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=180 --junitxml=pytest-junit.xml | tee pytest.log
+          python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=300 --junitxml=pytest-junit.xml | tee pytest.log
       - name: Upload pytest log
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
### Motivation
- The hourly Install Health Check showed repeated cross-matrix failures consistent with pytest timeout pressure, so increase the per-test timeout to reduce transient false negatives.

### Description
- Change `--timeout=180` to `--timeout=300` in `.github/workflows/install-hourly.yml` for the `Run install smoke tests` step.

### Testing
- Reviewed failing run metadata via the Actions API (`curl .../actions/runs/<id>`), inspected job steps, and verified the workflow diff and commit locally with `git diff`/`git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e4b28ee08326901870d8c768d390)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Increases the pytest timeout threshold in the hourly install health check workflow to address repeated cross-matrix test failures caused by timeout pressure.

## Changes

Modified `.github/workflows/install-hourly.yml` to increase the pytest timeout parameter from 180 seconds to 300 seconds in the "Run install smoke tests" step. All other pytest configuration options remain unchanged (max failures, warning disabling, quiet mode, junit output, and log piping).

## Verification

The change was verified through the Actions API review of failing run metadata, inspection of job steps, and local validation using `git diff` and `git commit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->