### PR TITLE
Fix install health ownable admin check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ Agents must run relevant tests after code changes.
 ### Test Execution
 
 * Execute tests and **fix errors introduced by changes**.
-* Prefer validated repository entrypoints over ad-hoc interpreter calls. Run `./env-refresh.sh --deps-only` before Django or pytest commands when the environment may be unbootstrapped.
+* Prefer validated repository entrypoints over ad-hoc interpreter calls. When `.venv` is missing, run the platform install entrypoint first (`./install.sh` on Linux/macOS, `install.bat` on Windows); the install scripts create `.venv`. Use `./env-refresh.sh --deps-only` or `env-refresh.bat` only after `.venv` already exists and dependencies need refreshing.
 * Use `.venv/bin/python` (or the repo's validated wrapper/management entrypoints) instead of bare `python` when invoking `manage.py` or `pytest` directly.
 * Use the canonical app-test command for this repository: `.venv/bin/python manage.py test run -- <target>`.
 * Use direct `pytest` only where this repository already requires it:

--- a/apps/terminals/admin.py
+++ b/apps/terminals/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
+from apps.core.admin import OwnableAdminMixin
+
 from .models import AgentTerminal
 
 
 @admin.register(AgentTerminal)
-class AgentTerminalAdmin(admin.ModelAdmin):
+class AgentTerminalAdmin(OwnableAdminMixin, admin.ModelAdmin):
     list_display = ("name", "owner_display", "effective_node_role", "auto_close_on_exit", "updated_at")
     list_filter = ("auto_close_on_exit", "prompt_block_mode", "node_role")
     search_fields = ("name", "executable", "launch_command", "launch_prompt")

--- a/apps/terminals/admin.py
+++ b/apps/terminals/admin.py
@@ -1,20 +1,26 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
-from apps.core.admin import OwnableAdminMixin
+from apps.core.admin import OwnableAdminForm, OwnableAdminMixin
 
 from .models import AgentTerminal
 
 
+class AgentTerminalAdminForm(OwnableAdminForm):
+    owner_field_names = ("user", "group", "avatar")
+    owner_conflict_message = _("Select only one owner between user, group, and avatar.")
+    owner_required_message = _("Profiles must be assigned to a user, security group, or avatar.")
+
+
 @admin.register(AgentTerminal)
 class AgentTerminalAdmin(OwnableAdminMixin, admin.ModelAdmin):
+    ownable_fieldset = ("Owner", {"fields": ("user", "group", "avatar")})
+    ownable_form_class = AgentTerminalAdminForm
     list_display = ("name", "owner_display", "effective_node_role", "auto_close_on_exit", "updated_at")
     list_filter = ("auto_close_on_exit", "prompt_block_mode", "node_role")
     search_fields = ("name", "executable", "launch_command", "launch_prompt")
     readonly_fields = (
         "name",
-        "user",
-        "group",
-        "avatar",
         "node_role",
         "executable",
         "launch_command",

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -2,6 +2,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 
+from apps.core.admin import OwnableAdminForm
 from apps.groups.models import SecurityGroup
 from apps.terminals.admin import AgentTerminalAdmin
 from apps.terminals.models import AgentTerminal
@@ -29,3 +30,16 @@ def test_admin_disables_add_permission(db):
     request.user = User.objects.create_superuser(username="root", password="secret")
 
     assert admin.has_add_permission(request) is False
+
+
+def test_admin_owner_fields_remain_editable_for_ownable_validation(db):
+    admin = AgentTerminalAdmin(AgentTerminal, AdminSite())
+    request = RequestFactory().get("/admin/terminals/agentterminal/")
+    request.user = User.objects.create_superuser(username="owner-admin", password="secret")
+
+    readonly_fields = set(admin.get_readonly_fields(request))
+    assert {"user", "group", "avatar"}.isdisjoint(readonly_fields)
+
+    form_class = admin.get_form(request)
+    assert issubclass(form_class, OwnableAdminForm)
+    assert {"user", "group", "avatar"}.issubset(form_class.base_fields)

--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -24,7 +24,8 @@ Maintain a **single canonical migrations graph only** under `apps/*/migrations/`
 | Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
 | Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
 | CI pipelines | `python -m pytest ...` inside workflow jobs | Valid in CI workflow implementation where jobs already manage interpreter/bootstrap lifecycle. |
-| Troubleshooting missing deps | `./env-refresh.sh --deps-only` | Run when environment may be unbootstrapped; then rerun the canonical command. |
+| Initial local bootstrap | `./install.sh` or `install.bat` | Run when `.venv` is missing. The install entrypoints create `.venv` before migrations and environment refresh. |
+| Troubleshooting missing deps | `./env-refresh.sh --deps-only` or `env-refresh.bat` | Run only after `.venv` already exists; then rerun the canonical command. |
 | Troubleshooting command behavior | `.venv/bin/python manage.py test run -- <target> -k <pattern>` | Troubleshoot through the same canonical entrypoint first. |
 | Direct local pytest | `.venv/bin/python -m pytest ...` | Allowed only for low-level debugging of pytest/plugin behavior or when developing pytest-backed helpers. Prefer recording reproductions with the canonical management command in PR notes. |
 


### PR DESCRIPTION
## Summary
- Add OwnableAdminMixin to AgentTerminalAdmin so the ownable admin coverage check passes.
- Clarify bootstrap guidance: use install.sh/install.bat when .venv is missing, and reserve env-refresh for existing environments that need dependency refresh.

Fixes #7497

## Validation
- .venv\\Scripts\\python.exe manage.py test run -- apps/core/tests/test_ownable.py -> 7 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `OwnableAdminMixin` to `AgentTerminalAdmin` to satisfy the ownable admin coverage check introduced by a regression test that validates all registered ownable admins include the mixin. Additionally clarifies bootstrap and troubleshooting guidance in documentation.

## Changes

### Code Changes

**apps/terminals/admin.py**
- Modified `AgentTerminalAdmin` class declaration to inherit from `OwnableAdminMixin` in addition to `admin.ModelAdmin`
- Import added: `from apps.core.admin import OwnableAdminMixin`
- The `OwnableAdminMixin` provides normalized owner fieldset and validation for ownable models

### Documentation Changes

**AGENTS.md**
- Updated bootstrap guidance to conditionally check for `.venv` existence
- If `.venv` is absent, agents must run the OS-appropriate install entrypoint (`install.sh` or `install.bat`) first
- Restricts `env-refresh` usage to cases where `.venv` already exists and dependencies need refresh

**docs/development/command-matrix.md**
- Added "Initial local bootstrap" context with guidance to use `./install.sh` or `install.bat` when `.venv` is missing (these entrypoints create `.venv` before migrations and environment refresh)
- Refined "Troubleshooting missing deps" context to include `env-refresh.bat` and clarify it should only run after `.venv` exists, followed by rerunning the canonical command

## Validation

Test suite validation: Running `apps/core/tests/test_ownable.py` yields 7 passed tests, including the regression test `test_ownable_admins_use_mixin` that enforces the mixin requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->