### PR TITLE
Restrict Evergo order tracking to contractors workspace access

### DIFF
--- a/apps/evergo/tests/test_public_views.py
+++ b/apps/evergo/tests/test_public_views.py
@@ -183,6 +183,21 @@ def test_order_tracking_uses_selected_contractor_account(client, monkeypatch):
     assert "Brand B" in response.content.decode()
 
 
+@pytest.mark.django_db
+def test_order_tracking_requires_staff_or_workspace_access(client):
+    user_model = get_user_model()
+    owner = user_model.objects.create_user(username="tracking-owner-blocked", email="blocked@example.com")
+    profile = EvergoUser.objects.create(user=owner, evergo_email="blocked@example.com", evergo_password="secret")
+    from apps.evergo.models import EvergoOrder
+
+    order = EvergoOrder.objects.create(user=profile, remote_id=9912, order_number="SO-9912")
+    client.force_login(owner)
+
+    response = client.get(reverse("evergo:order-tracking-public", args=[order.remote_id]))
+
+    assert response.status_code == 404
+
+
 def test_to_tsv_sanitizes_formula_and_line_break_characters():
     """Security: TSV export must neutralize formulas and sanitize control characters."""
 

--- a/apps/evergo/views.py
+++ b/apps/evergo/views.py
@@ -697,11 +697,13 @@ def _to_tsv(rows: list[dict[str, str]]) -> str:
 @login_required
 def order_tracking_public(request, order_id: int) -> HttpResponse:
     """Render and submit the order tracking phase-one helper form for authorized owners only."""
+    has_workspace_access = _has_evergo_workspace_access(user=request.user)
+    if not (request.user.is_staff or has_workspace_access):
+        raise Http404("Evergo order tracking not found.")
+
     order_lookup = {
         "remote_id": order_id,
     }
-    if not request.user.is_staff:
-        order_lookup["user__user"] = request.user
     order = get_object_or_404(EvergoOrder.objects.select_related("user"), **order_lookup)
     contractor_options = EvergoUser.objects.order_by("name", "email", "pk").only("pk", "name", "email", "evergo_email")
     requested_contractor_id = request.POST.get("contractor") or request.GET.get("contractor") or ""


### PR DESCRIPTION
### Motivation
- Close an authorization gap where a request `contractor` override could let a non-privileged owner make the server act as another contractor and use their Evergo credentials. 
- Enforce the intended policy that only staff or members of the Evergo Contractors security group may access the order-tracking helper endpoint while allowing contractor-group members to view across contractors.

### Description
- Gate `order_tracking_public` with an explicit check for `request.user.is_staff` or `_has_evergo_workspace_access(user=request.user)` and return `404` for authenticated users that lack both. 
- Allow workspace users (contractors group) and staff to access orders without forcing the order lookup to the current request user so that contractor-group users may view orders across contractors as intended. 
- Add a regression test `test_order_tracking_requires_staff_or_workspace_access` to assert non-staff users who are not in the Evergo Contractors group receive `404` when requesting the tracking page.

### Testing
- Bootstrapped the environment with `./env-refresh.sh --deps-only` and executed the app-level tests with `.venv/bin/python manage.py test run -- apps/evergo/tests/test_public_views.py`. 
- The test run passed: `28 passed` for `apps/evergo/tests/test_public_views.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d0389ef483268011d45295fa9b68)