### PR TITLE
Fix install health import resolution for turn boundary locks

### DIFF
--- a/scripts/check_import_resolution.py
+++ b/scripts/check_import_resolution.py
@@ -447,11 +447,12 @@ class ImportCollector(ast.NodeVisitor):
 
         if not isinstance(handler, ast.ExceptHandler):
             return False
+        import_error_names = {"ImportError", "ModuleNotFoundError"}
         if isinstance(handler.type, ast.Name):
-            return handler.type.id == "ImportError"
+            return handler.type.id in import_error_names
         if isinstance(handler.type, ast.Tuple):
             return any(
-                isinstance(elt, ast.Name) and elt.id == "ImportError"
+                isinstance(elt, ast.Name) and elt.id in import_error_names
                 for elt in handler.type.elts
             )
         return False

--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -22,16 +22,18 @@ import os as _os
 
 
 try:
+    "optional-import"
     import fcntl  # type: ignore[import-not-found]
     _HAS_FCNTL = True
-except Exception:  # pragma: no cover - exercised through platform fallback tests
+except ImportError:  # pragma: no cover - exercised through platform fallback tests
     fcntl = None  # type: ignore[assignment]
     _HAS_FCNTL = False
 
 try:
+    "optional-import"
     import msvcrt  # type: ignore[import-not-found]
     _HAS_MSVCRT = True
-except Exception:  # pragma: no cover - exercised through platform fallback tests
+except ImportError:  # pragma: no cover - exercised through platform fallback tests
     msvcrt = None  # type: ignore[assignment]
     _HAS_MSVCRT = False
 

--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -25,7 +25,7 @@ try:
     "optional-import"
     import fcntl  # type: ignore[import-not-found]
     _HAS_FCNTL = True
-except ImportError:  # pragma: no cover - exercised through platform fallback tests
+except ModuleNotFoundError:  # pragma: no cover - exercised through platform fallback tests
     fcntl = None  # type: ignore[assignment]
     _HAS_FCNTL = False
 
@@ -33,7 +33,7 @@ try:
     "optional-import"
     import msvcrt  # type: ignore[import-not-found]
     _HAS_MSVCRT = True
-except ImportError:  # pragma: no cover - exercised through platform fallback tests
+except ModuleNotFoundError:  # pragma: no cover - exercised through platform fallback tests
     msvcrt = None  # type: ignore[assignment]
     _HAS_MSVCRT = False
 

--- a/tests/test_check_import_resolution.py
+++ b/tests/test_check_import_resolution.py
@@ -22,6 +22,27 @@ def test_module_not_found_optional_marker_skips_missing_import(tmp_path) -> None
     assert check_import_resolution.collect_missing_imports([module_path]) == []
 
 
+def test_module_not_found_optional_marker_skips_missing_import_tuple_exception(
+    tmp_path,
+) -> None:
+    module_path = tmp_path / "optional_tuple_module.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    'optional-import'",
+                "    import definitely_missing_arthexis_optional_tuple_module",
+                "except (ModuleNotFoundError, ImportError):",
+                "    definitely_missing_arthexis_optional_tuple_module = None",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert check_import_resolution.collect_missing_imports([module_path]) == []
+
+
 def test_module_not_found_without_marker_still_reports_missing_import(
     tmp_path,
 ) -> None:

--- a/tests/test_check_import_resolution.py
+++ b/tests/test_check_import_resolution.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from scripts import check_import_resolution
+
+
+def test_module_not_found_optional_marker_skips_missing_import(tmp_path) -> None:
+    module_path = tmp_path / "optional_module.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    'optional-import'",
+                "    import definitely_missing_arthexis_optional_module",
+                "except ModuleNotFoundError:",
+                "    definitely_missing_arthexis_optional_module = None",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert check_import_resolution.collect_missing_imports([module_path]) == []
+
+
+def test_module_not_found_without_marker_still_reports_missing_import(
+    tmp_path,
+) -> None:
+    module_path = tmp_path / "missing_module.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    import definitely_missing_arthexis_required_module",
+                "except ModuleNotFoundError:",
+                "    definitely_missing_arthexis_required_module = None",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    issues = check_import_resolution.collect_missing_imports([module_path])
+
+    assert len(issues) == 1
+    assert issues[0].module == "definitely_missing_arthexis_required_module"


### PR DESCRIPTION
### Motivation
- Fix #7512 install-health failures where Linux import resolution flags the Windows-only `msvcrt` fallback import in `turn_boundary.py`.

### Description
- Mark `fcntl` and `msvcrt` guarded imports as optional import blocks for the static import checker.
- Narrow the fallback guards to `ImportError` so real import-time errors are not hidden.

### Testing
- `C:\Users\arthexis\Repos\arthexis\.venv\Scripts\python.exe scripts\check_import_resolution.py skills\arthexis-cleanup-step\scripts\turn_boundary.py`
- `C:\Users\arthexis\Repos\arthexis\.venv\Scripts\python.exe -m pytest tests\test_turn_boundary_cadence.py -q`
- `C:\Users\arthexis\Repos\arthexis\.venv\Scripts\python.exe manage.py check`

Note: the full local Windows import-resolution scan now gets past `msvcrt` and stops on existing Linux-only `termios`; the failed install-health matrix is Linux where `termios` resolves.

Fixes #7512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR resolves install-health CI failures in the import resolution check by improving how the static import checker handles platform-specific optional imports. The changes address failures on Linux where the Windows-only `msvcrt` module import was incorrectly flagged as unresolved.

## Changes

**scripts/check_import_resolution.py**
- Extended the optional import guard detection logic to recognize both `ImportError` and `ModuleNotFoundError` as valid caught exception types
- Previously only matched `ImportError`; now properly handles both exception types whether specified as `ast.Name` or within `ast.Tuple`

**skills/arthexis-cleanup-step/scripts/turn_boundary.py**
- Marked `fcntl` and `msvcrt` imports as optional using the `"optional-import"` marker to signal the static checker to skip these platform-specific imports
- Narrowed the fallback exception handling from generic `Exception` to `ModuleNotFoundError`, preventing unrelated import-time or runtime errors from being silently suppressed while preserving existing boolean behavior for `_HAS_FCNTL` and `_HAS_MSVCRT` detection

**tests/test_check_import_resolution.py** (new file)
- Adds test coverage for optional import behavior when using `try/except ModuleNotFoundError`
- One test verifies optional imports marked with the optional marker are not reported as issues
- One test verifies unmarked imports are correctly flagged as missing

## Impact
The static import checker can now proceed correctly on Linux systems by recognizing Windows-only fallback imports as optional, fixing the scheduled install-health workflow failures across the CI matrix (debian, ubuntu, etc.). The narrowed exception handling reduces the risk of masking legitimate import-time errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->