### PR TITLE
Support local OpenCV cameras in video devices

### DIFF
--- a/apps/video/management/commands/video.py
+++ b/apps/video/management/commands/video.py
@@ -27,7 +27,7 @@ from apps.video.frame_cache import (
     store_status,
 )
 from apps.video.models import MjpegDependencyError, MjpegStream, VideoDevice
-from apps.video.utils import WORK_DIR, probe_rpi_camera_stack
+from apps.video.utils import WORK_DIR, open_cv2_capture, probe_rpi_camera_stack
 
 logger = logging.getLogger("apps.video.camera_service")
 
@@ -56,7 +56,10 @@ class _StreamCapture:
         if self._cv2 is None:
             self._cv2 = self.stream._load_cv2()
         if self._capture is None:
-            self._capture = self._cv2.VideoCapture(self.stream.video_device.identifier)
+            self._capture = open_cv2_capture(
+                self._cv2,
+                self.stream.video_device.identifier,
+            )
         if not self._capture.isOpened():
             self._capture.release()
             self._capture = None

--- a/apps/video/models/device.py
+++ b/apps/video/models/device.py
@@ -153,6 +153,10 @@ class VideoDevice(Ownable):
             return_objects=return_objects,
         )
         cls._ensure_single_default_for_node(node)
+        if return_objects:
+            _created, _updated, created_objects, updated_objects = result
+            for device in [*created_objects, *updated_objects]:
+                device.refresh_from_db(fields=["is_default"])
         return result
 
     @classmethod
@@ -163,7 +167,10 @@ class VideoDevice(Ownable):
         if len(defaults) == 1:
             return
         if len(defaults) > 1:
-            cls.objects.filter(pk__in=[device.pk for device in defaults[1:]]).update(
+            extra_defaults = defaults[1:]
+            for device in extra_defaults:
+                device.is_default = False
+            cls.objects.filter(pk__in=[device.pk for device in extra_defaults]).update(
                 is_default=False
             )
             return

--- a/apps/video/models/device.py
+++ b/apps/video/models/device.py
@@ -18,7 +18,9 @@ from apps.video.services.capture import apply_image_rotation
 from apps.video.utils import (
     RPI_CAMERA_BINARIES,
     RPI_CAMERA_DEVICE,
+    capture_cv2_snapshot,
     capture_rpi_snapshot,
+    detect_cv2_camera_devices,
     probe_rpi_camera_stack,
 )
 
@@ -100,11 +102,18 @@ class VideoDevice(Ownable):
 
     @classmethod
     def detect_devices(cls) -> list[DetectedVideoDevice]:
-        """Return detected video devices for the Raspberry Pi stack."""
+        """Return detected video devices for the local video stack."""
 
         probe = probe_rpi_camera_stack()
         if not probe.available:
-            return []
+            return [
+                DetectedVideoDevice(
+                    identifier=device.identifier,
+                    description=device.description,
+                    raw_info=device.raw_info,
+                )
+                for device in detect_cv2_camera_devices()
+            ]
         identifier = str(RPI_CAMERA_DEVICE)
         if probe.backend == "rpicam":
             description = "Raspberry Pi Camera"
@@ -132,7 +141,7 @@ class VideoDevice(Ownable):
         detected: list[DetectedVideoDevice] = []
         if is_feature_active_for_node(node=node, slug="video-cam"):
             detected = cls.detect_devices()
-        return sync_detected_devices(
+        result = sync_detected_devices(
             model_cls=cls,
             node=node,
             detected=detected,
@@ -140,10 +149,29 @@ class VideoDevice(Ownable):
             defaults_getter=lambda device: {
                 "description": device.description,
                 "raw_info": device.raw_info,
-                "is_default": True,
             },
             return_objects=return_objects,
         )
+        cls._ensure_single_default_for_node(node)
+        return result
+
+    @classmethod
+    def _ensure_single_default_for_node(cls, node) -> None:
+        """Ensure a node has at most one default video device."""
+
+        defaults = list(cls.objects.filter(node=node, is_default=True).order_by("pk"))
+        if len(defaults) == 1:
+            return
+        if len(defaults) > 1:
+            cls.objects.filter(pk__in=[device.pk for device in defaults[1:]]).update(
+                is_default=False
+            )
+            return
+
+        first_device = cls.objects.filter(node=node).order_by("identifier", "pk").first()
+        if first_device is not None:
+            first_device.is_default = True
+            first_device.save(update_fields=["is_default"])
 
     @classmethod
     def get_default_for_node(cls, node) -> "VideoDevice | None":
@@ -155,7 +183,7 @@ class VideoDevice(Ownable):
 
     @classmethod
     def has_video_device(cls) -> bool:
-        """Return ``True`` when a Raspberry Pi video device is available."""
+        """Return ``True`` when a local video device is available."""
 
         return bool(cls.detect_devices())
 
@@ -169,8 +197,19 @@ class VideoDevice(Ownable):
     def capture_snapshot_path(self) -> Path:
         """Capture a snapshot file path and apply auto-rotation when configured."""
 
-        path = capture_rpi_snapshot(width=self.capture_width, height=self.capture_height)
-        apply_image_rotation(path, int(self.auto_rotate or 0))
+        if self.identifier == str(RPI_CAMERA_DEVICE):
+            path = capture_rpi_snapshot(
+                width=self.capture_width,
+                height=self.capture_height,
+            )
+            apply_image_rotation(path, int(self.auto_rotate or 0))
+        else:
+            path = capture_cv2_snapshot(
+                self.identifier,
+                width=self.capture_width,
+                height=self.capture_height,
+                auto_rotate=int(self.auto_rotate or 0),
+            )
         return path
 
     def capture_snapshot(self, *, link_duplicates: bool = False):
@@ -182,7 +221,11 @@ class VideoDevice(Ownable):
         sample = save_screenshot(
             path,
             node=self.node,
-            method="RPI_CAMERA",
+            method=(
+                "RPI_CAMERA"
+                if self.identifier == str(RPI_CAMERA_DEVICE)
+                else "OPENCV_CAMERA"
+            ),
             link_duplicates=link_duplicates,
         )
         if not sample:

--- a/apps/video/services/mjpeg.py
+++ b/apps/video/services/mjpeg.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+import os
 
 from django.utils.translation import gettext_lazy as _
 
@@ -30,11 +31,27 @@ def load_cv2():
     return cv2
 
 
+def _capture_source(cv2, device_identifier: str):
+    """Return an OpenCV capture source and optional API preference."""
+
+    identifier = str(device_identifier or "").strip()
+    if identifier.isdigit():
+        source = int(identifier)
+        if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
+            return source, cv2.CAP_DSHOW
+        return source, None
+    return identifier, None
+
+
 @contextmanager
 def _open_capture(*, cv2, device_identifier: str):
     """Create and yield an opened ``cv2.VideoCapture`` instance."""
 
-    capture = cv2.VideoCapture(device_identifier)
+    source, api_preference = _capture_source(cv2, device_identifier)
+    if api_preference is None:
+        capture = cv2.VideoCapture(source)
+    else:
+        capture = cv2.VideoCapture(source, api_preference)
     if not capture.isOpened():
         capture.release()
         raise MjpegDeviceUnavailableError(

--- a/apps/video/services/mjpeg.py
+++ b/apps/video/services/mjpeg.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-import os
 
 from django.utils.translation import gettext_lazy as _
 
 from apps.video.services.capture import rotate_cv2_frame
+from apps.video.utils import open_cv2_capture
 
 
 class MjpegDependencyError(RuntimeError):
@@ -31,27 +31,11 @@ def load_cv2():
     return cv2
 
 
-def _capture_source(cv2, device_identifier: str):
-    """Return an OpenCV capture source and optional API preference."""
-
-    identifier = str(device_identifier or "").strip()
-    if identifier.isdigit():
-        source = int(identifier)
-        if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
-            return source, cv2.CAP_DSHOW
-        return source, None
-    return identifier, None
-
-
 @contextmanager
 def _open_capture(*, cv2, device_identifier: str):
     """Create and yield an opened ``cv2.VideoCapture`` instance."""
 
-    source, api_preference = _capture_source(cv2, device_identifier)
-    if api_preference is None:
-        capture = cv2.VideoCapture(source)
-    else:
-        capture = cv2.VideoCapture(source, api_preference)
+    capture = open_cv2_capture(cv2, device_identifier)
     if not capture.isOpened():
         capture.release()
         raise MjpegDeviceUnavailableError(

--- a/apps/video/tests/test_models_device.py
+++ b/apps/video/tests/test_models_device.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from apps.video.models import device as device_module
 from apps.video.models.device import VideoDevice
-from apps.video.utils import CameraStackProbe
+from apps.video.utils import CameraStackProbe, Cv2CameraDevice
 
 
 def test_detect_devices_skips_missing_camera_stack(monkeypatch):
@@ -15,6 +15,7 @@ def test_detect_devices_skips_missing_camera_stack(monkeypatch):
             reason="No attached cameras detected",
         ),
     )
+    monkeypatch.setattr(device_module, "detect_cv2_camera_devices", lambda: [])
 
     assert VideoDevice.detect_devices() == []
 
@@ -55,3 +56,33 @@ def test_detect_devices_describes_ffmpeg_fallback(monkeypatch):
     assert len(devices) == 1
     assert devices[0].description == "Video4Linux Camera"
     assert "backend=ffmpeg" in devices[0].raw_info
+
+
+def test_detect_devices_describes_cv2_fallback(monkeypatch):
+    monkeypatch.setattr(
+        device_module,
+        "probe_rpi_camera_stack",
+        lambda: CameraStackProbe(
+            available=False,
+            backend="missing",
+            reason="No attached cameras detected",
+        ),
+    )
+    monkeypatch.setattr(
+        device_module,
+        "detect_cv2_camera_devices",
+        lambda: [
+            Cv2CameraDevice(
+                identifier="0",
+                description="OpenCV Camera 0",
+                raw_info="device_index=0 backend=DSHOW frame_size=1280x720",
+            )
+        ],
+    )
+
+    devices = VideoDevice.detect_devices()
+
+    assert len(devices) == 1
+    assert devices[0].identifier == "0"
+    assert devices[0].description == "OpenCV Camera 0"
+    assert "backend=DSHOW" in devices[0].raw_info

--- a/apps/video/tests/test_models_device.py
+++ b/apps/video/tests/test_models_device.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
+from apps.nodes.models import Node
 from apps.video.models import device as device_module
-from apps.video.models.device import VideoDevice
-from apps.video.utils import CameraStackProbe, Cv2CameraDevice
+from apps.video.models.device import DetectedVideoDevice, VideoDevice
+from apps.video.utils import CameraStackProbe, Cv2CameraDevice, cv2_camera_identifier
 
 
 def test_detect_devices_skips_missing_camera_stack(monkeypatch):
@@ -73,7 +76,7 @@ def test_detect_devices_describes_cv2_fallback(monkeypatch):
         "detect_cv2_camera_devices",
         lambda: [
             Cv2CameraDevice(
-                identifier="0",
+                identifier=cv2_camera_identifier(0),
                 description="OpenCV Camera 0",
                 raw_info="device_index=0 backend=DSHOW frame_size=1280x720",
             )
@@ -83,6 +86,54 @@ def test_detect_devices_describes_cv2_fallback(monkeypatch):
     devices = VideoDevice.detect_devices()
 
     assert len(devices) == 1
-    assert devices[0].identifier == "0"
+    assert devices[0].identifier == "opencv:0"
     assert devices[0].description == "OpenCV Camera 0"
     assert "backend=DSHOW" in devices[0].raw_info
+
+
+@pytest.mark.django_db
+def test_refresh_from_system_updates_returned_default_state(monkeypatch):
+    node = Node.objects.create(hostname="video-default", public_endpoint="video-default")
+    monkeypatch.setattr(
+        device_module,
+        "is_feature_active_for_node",
+        lambda *, node, slug: True,
+    )
+    monkeypatch.setattr(
+        VideoDevice,
+        "detect_devices",
+        classmethod(
+            lambda cls: [
+                DetectedVideoDevice(
+                    identifier="opencv:0",
+                    description="OpenCV Camera 0",
+                    raw_info="device_index=0 backend=FAKE frame_size=640x480",
+                )
+            ]
+        ),
+    )
+
+    created, updated, created_objects, updated_objects = VideoDevice.refresh_from_system(
+        node=node,
+        return_objects=True,
+    )
+
+    assert (created, updated) == (1, 0)
+    assert len(created_objects) == 1
+    assert updated_objects == []
+    assert created_objects[0].is_default is True
+
+
+@pytest.mark.django_db
+def test_ensure_single_default_clears_extra_defaults():
+    node = Node.objects.create(
+        hostname="video-extra-defaults",
+        public_endpoint="video-extra-defaults",
+    )
+    VideoDevice.objects.create(node=node, identifier="opencv:0", is_default=True)
+    extra = VideoDevice.objects.create(node=node, identifier="opencv:1", is_default=True)
+
+    VideoDevice._ensure_single_default_for_node(node)
+
+    extra.refresh_from_db()
+    assert extra.is_default is False

--- a/apps/video/tests/test_utils.py
+++ b/apps/video/tests/test_utils.py
@@ -1,9 +1,67 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 from apps.video import utils
+
+
+class _FakeFrame:
+    shape = (480, 640, 3)
+
+
+class _FakeCapture:
+    def __init__(self, *, opened: bool = True):
+        self.opened = opened
+        self.released = False
+
+    def isOpened(self):
+        return self.opened
+
+    def read(self):
+        return True, _FakeFrame()
+
+    def getBackendName(self):
+        return "FAKE"
+
+    def release(self):
+        self.released = True
+
+
+class _FakeCv2:
+    CAP_DSHOW = 700
+
+    def __init__(self):
+        self.calls = []
+
+    def VideoCapture(self, *args):
+        self.calls.append(args)
+        return _FakeCapture()
+
+
+def test_open_cv2_capture_uses_prefixed_index_with_windows_backend(monkeypatch):
+    fake_cv2 = _FakeCv2()
+    monkeypatch.setattr(utils.os, "name", "nt")
+
+    capture = utils.open_cv2_capture(fake_cv2, "opencv:2")
+
+    assert capture.isOpened()
+    assert fake_cv2.calls == [(2, fake_cv2.CAP_DSHOW)]
+
+
+def test_detect_cv2_camera_devices_uses_prefixed_identifiers(monkeypatch):
+    fake_cv2 = _FakeCv2()
+    monkeypatch.setattr(utils.os, "name", "posix")
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+
+    devices = utils.detect_cv2_camera_devices(limit=1)
+
+    assert len(devices) == 1
+    assert devices[0].identifier == "opencv:0"
+    assert devices[0].description == "OpenCV Camera 0"
+    assert "device_index=0" in devices[0].raw_info
+    assert fake_cv2.calls == [(0,)]
 
 
 def test_has_rpicam_binaries_rejects_unrunnable_binary(monkeypatch):

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -20,6 +20,7 @@ CAMERA_DIR = WORK_DIR / "camera"
 RPI_CAMERA_DEVICE = Path("/dev/video0")
 RPI_CAMERA_BINARIES = ("rpicam-hello", "rpicam-still", "rpicam-vid")
 DEFAULT_CAMERA_RESOLUTION = (1280, 720)
+OPENCV_CAMERA_IDENTIFIER_PREFIX = "opencv:"
 FALLBACK_CAMERA_RESOLUTIONS = (
     (1920, 1080),
     (1280, 720),
@@ -192,12 +193,33 @@ def has_rpi_camera_stack() -> bool:
     return probe_rpi_camera_stack().available
 
 
-def _open_cv2_capture(cv2, index: int):
-    """Open a numeric OpenCV capture index using the best local backend."""
+def cv2_camera_identifier(index: int) -> str:
+    """Return a non-ambiguous identifier for an OpenCV camera index."""
 
-    if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
-        return cv2.VideoCapture(index, cv2.CAP_DSHOW)
-    return cv2.VideoCapture(index)
+    return f"{OPENCV_CAMERA_IDENTIFIER_PREFIX}{int(index)}"
+
+
+def _cv2_camera_index(device_identifier: str | int) -> int | None:
+    """Return an OpenCV camera index parsed from a supported identifier."""
+
+    if type(device_identifier) is int:
+        return device_identifier
+    identifier = str(device_identifier or "").strip()
+    if identifier.startswith(OPENCV_CAMERA_IDENTIFIER_PREFIX):
+        suffix = identifier[len(OPENCV_CAMERA_IDENTIFIER_PREFIX) :].strip()
+        return int(suffix) if suffix.isdigit() else None
+    return int(identifier) if identifier.isdigit() else None
+
+
+def open_cv2_capture(cv2, device_identifier: str | int):
+    """Open an OpenCV capture source using the best local backend."""
+
+    index = _cv2_camera_index(device_identifier)
+    if index is not None:
+        if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
+            return cv2.VideoCapture(index, cv2.CAP_DSHOW)
+        return cv2.VideoCapture(index)
+    return cv2.VideoCapture(str(device_identifier or "").strip())
 
 
 def detect_cv2_camera_devices(limit: int | None = None) -> list[Cv2CameraDevice]:
@@ -214,7 +236,8 @@ def detect_cv2_camera_devices(limit: int | None = None) -> list[Cv2CameraDevice]
 
     detected: list[Cv2CameraDevice] = []
     for index in range(max(0, probe_limit)):
-        capture = _open_cv2_capture(cv2, index)
+        identifier = cv2_camera_identifier(index)
+        capture = open_cv2_capture(cv2, identifier)
         try:
             if not capture.isOpened():
                 continue
@@ -229,7 +252,7 @@ def detect_cv2_camera_devices(limit: int | None = None) -> list[Cv2CameraDevice]
             )
             detected.append(
                 Cv2CameraDevice(
-                    identifier=str(index),
+                    identifier=identifier,
                     description=f"OpenCV Camera {index}",
                     raw_info=(
                         f"device_index={index} backend={backend} "
@@ -261,11 +284,7 @@ def capture_cv2_snapshot(
     if not acquired:
         raise RuntimeError("Camera is busy. Wait for the current capture to finish.")
 
-    capture = (
-        _open_cv2_capture(cv2, int(identifier))
-        if identifier.isdigit()
-        else cv2.VideoCapture(identifier)
-    )
+    capture = open_cv2_capture(cv2, identifier)
     try:
         if not capture.isOpened():
             raise RuntimeError(f"Unable to open video device {device_identifier}")
@@ -462,14 +481,17 @@ __all__ = [
     "CAMERA_DIR",
     "DEFAULT_CAMERA_RESOLUTION",
     "FALLBACK_CAMERA_RESOLUTIONS",
+    "OPENCV_CAMERA_IDENTIFIER_PREFIX",
     "RPI_CAMERA_BINARIES",
     "RPI_CAMERA_DEVICE",
     "has_rpicam_binaries",
     "capture_rpi_snapshot",
+    "cv2_camera_identifier",
     "get_camera_resolutions",
     "has_rpi_camera_stack",
     "capture_cv2_snapshot",
     "detect_cv2_camera_devices",
+    "open_cv2_capture",
     "probe_rpi_camera_stack",
     "record_rpi_video",
 ]

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 from django.conf import settings
 
@@ -38,6 +39,14 @@ class CameraStackProbe:
     backend: str
     reason: str
     detected_cameras: int = 0
+
+
+class Cv2CameraDevice(NamedTuple):
+    """OpenCV-discovered video capture device."""
+
+    identifier: str
+    description: str
+    raw_info: str
 
 
 def _is_video_device_available(device: Path) -> bool:
@@ -181,6 +190,107 @@ def has_rpi_camera_stack() -> bool:
     """Return ``True`` when any supported camera stack is available."""
 
     return probe_rpi_camera_stack().available
+
+
+def _open_cv2_capture(cv2, index: int):
+    """Open a numeric OpenCV capture index using the best local backend."""
+
+    if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
+        return cv2.VideoCapture(index, cv2.CAP_DSHOW)
+    return cv2.VideoCapture(index)
+
+
+def detect_cv2_camera_devices(limit: int | None = None) -> list[Cv2CameraDevice]:
+    """Return camera devices that OpenCV can open locally."""
+
+    try:
+        import cv2  # type: ignore
+    except ImportError:
+        return []
+
+    probe_limit = limit
+    if probe_limit is None:
+        probe_limit = int(getattr(settings, "VIDEO_CV2_DISCOVERY_LIMIT", 5))
+
+    detected: list[Cv2CameraDevice] = []
+    for index in range(max(0, probe_limit)):
+        capture = _open_cv2_capture(cv2, index)
+        try:
+            if not capture.isOpened():
+                continue
+            success, frame = capture.read()
+            if not success or frame is None:
+                continue
+            height, width = frame.shape[:2]
+            backend = (
+                capture.getBackendName()
+                if hasattr(capture, "getBackendName")
+                else "opencv"
+            )
+            detected.append(
+                Cv2CameraDevice(
+                    identifier=str(index),
+                    description=f"OpenCV Camera {index}",
+                    raw_info=(
+                        f"device_index={index} backend={backend} "
+                        f"frame_size={width}x{height}"
+                    ),
+                )
+            )
+        finally:
+            capture.release()
+    return detected
+
+
+def capture_cv2_snapshot(
+    device_identifier: str,
+    *,
+    timeout: int = 10,
+    width: int | None = None,
+    height: int | None = None,
+    auto_rotate: int = 0,
+) -> Path:
+    """Capture a JPEG snapshot from an OpenCV-supported video device."""
+
+    from apps.video.services.capture import rotate_cv2_frame
+    from apps.video.services.mjpeg import load_cv2
+
+    cv2 = load_cv2()
+    identifier = str(device_identifier or "").strip()
+    acquired = _CAMERA_LOCK.acquire(timeout=timeout)
+    if not acquired:
+        raise RuntimeError("Camera is busy. Wait for the current capture to finish.")
+
+    capture = (
+        _open_cv2_capture(cv2, int(identifier))
+        if identifier.isdigit()
+        else cv2.VideoCapture(identifier)
+    )
+    try:
+        if not capture.isOpened():
+            raise RuntimeError(f"Unable to open video device {device_identifier}")
+        if width:
+            capture.set(cv2.CAP_PROP_FRAME_WIDTH, int(width))
+        if height:
+            capture.set(cv2.CAP_PROP_FRAME_HEIGHT, int(height))
+        success, frame = capture.read()
+        if not success or frame is None:
+            raise RuntimeError(
+                f"Unable to capture frame from video device {device_identifier}"
+            )
+        frame = rotate_cv2_frame(frame, angle=auto_rotate, cv2=cv2)
+        success, buffer = cv2.imencode(".jpg", frame)
+        if not success:
+            raise RuntimeError("JPEG encode failed")
+    finally:
+        capture.release()
+        _CAMERA_LOCK.release()
+
+    CAMERA_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc)
+    filename = CAMERA_DIR / f"{timestamp:%Y%m%d%H%M%S}-{uuid.uuid4().hex}.jpg"
+    filename.write_bytes(buffer.tobytes())
+    return filename
 
 
 def get_camera_resolutions() -> list[tuple[int, int]]:
@@ -358,6 +468,8 @@ __all__ = [
     "capture_rpi_snapshot",
     "get_camera_resolutions",
     "has_rpi_camera_stack",
+    "capture_cv2_snapshot",
+    "detect_cv2_camera_devices",
     "probe_rpi_camera_stack",
     "record_rpi_video",
 ]


### PR DESCRIPTION
## Summary

Closes #7514.

This adds OpenCV-backed camera support to the video app so local operator machines without the Raspberry Pi camera stack can still discover and use attached cameras through the existing suite video device flow.

## Changes

- Adds OpenCV camera index discovery with optional `VIDEO_CV2_DISCOVERY_LIMIT`.
- Falls back to OpenCV discovery when the Raspberry Pi/ffmpeg stack is unavailable.
- Captures snapshots from OpenCV-backed devices while preserving the existing RPi/V4L2 snapshot path.
- Opens numeric OpenCV camera identifiers as integer indexes and uses DirectShow on Windows when available.
- Normalizes video discovery results so each node has at most one default video device.
- Adds regression coverage for the OpenCV fallback discovery path.

## Validation

- `python -m pytest apps/video/tests`
- `python manage.py check --fail-level ERROR`

## Risk

- Low for Raspberry Pi deployments: existing RPi and ffmpeg paths stay first choice when available.
- OpenCV camera probing may briefly activate local cameras during discovery, bounded by the configured probe limit.