### PR TITLE
Load Windows DPAPI secrets into suite environment variables

### DIFF
--- a/config/loadenv.py
+++ b/config/loadenv.py
@@ -1,11 +1,83 @@
+import logging
+import os
+import re
+import subprocess
 from pathlib import Path
 from dotenv import load_dotenv
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+logger = logging.getLogger(__name__)
+
+_DPAPI_ENV_PREFIX = "ARTHEXIS_DPAPI_ENV_"
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _read_windows_dpapi_secret(path: str) -> str:
+    script = r"""
+$ErrorActionPreference = 'Stop'
+$Path = $env:ARTHEXIS_DPAPI_CREDENTIAL_PATH
+$secure = Get-Content -LiteralPath $Path | ConvertTo-SecureString
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+try {
+    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+}
+finally {
+    if ($bstr -ne [IntPtr]::Zero) {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+"""
+    env = os.environ.copy()
+    env["ARTHEXIS_DPAPI_CREDENTIAL_PATH"] = path
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout.rstrip("\r\n")
+
+
+def _load_dpapi_env_secrets() -> None:
+    if os.name != "nt":
+        return
+
+    for source_key, credential_path in list(os.environ.items()):
+        if not source_key.startswith(_DPAPI_ENV_PREFIX):
+            continue
+        target_key = source_key.removeprefix(_DPAPI_ENV_PREFIX)
+        if not _ENV_NAME_RE.match(target_key):
+            logger.warning("Ignoring invalid DPAPI environment target %s", target_key)
+            continue
+        if os.environ.get(target_key):
+            continue
+        if not credential_path:
+            continue
+        try:
+            secret = _read_windows_dpapi_secret(credential_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load DPAPI environment secret for %s from %s: %s",
+                target_key,
+                credential_path,
+                exc,
+            )
+            continue
+        if secret:
+            os.environ[target_key] = secret
 
 
 def loadenv() -> None:
     """Load all .env files from the repository root."""
     for env_file in sorted(BASE_DIR.glob("*.env")):
         load_dotenv(env_file, override=False)
+    _load_dpapi_env_secrets()

--- a/config/loadenv.py
+++ b/config/loadenv.py
@@ -103,20 +103,12 @@ def _load_dpapi_env_secrets() -> None:
         )
         return
 
-    for target_key, error in errors.items():
-        logger.warning(
-            "Failed to load DPAPI environment secret for %s from %s: %s",
-            target_key,
-            pending.get(target_key, ""),
-            error,
-        )
+    for _ in errors:
+        logger.warning("Failed to load one configured DPAPI environment secret.")
 
     for target_key, secret in secrets.items():
         if target_key not in pending:
-            logger.warning(
-                "Ignoring DPAPI environment secret for unexpected target %s",
-                target_key,
-            )
+            logger.warning("Ignoring DPAPI environment secret for unexpected target.")
             continue
         if target_key in os.environ:
             continue

--- a/config/loadenv.py
+++ b/config/loadenv.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -13,23 +14,43 @@ _DPAPI_ENV_PREFIX = "ARTHEXIS_DPAPI_ENV_"
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-def _read_windows_dpapi_secret(path: str) -> str:
+def _called_process_error_detail(exc: Exception) -> str:
+    if isinstance(exc, subprocess.CalledProcessError) and exc.stderr:
+        return exc.stderr.strip()
+    return str(exc)
+
+
+def _read_windows_dpapi_secrets(
+    paths_by_target: dict[str, str],
+) -> tuple[dict[str, str], dict[str, str]]:
     script = r"""
 $ErrorActionPreference = 'Stop'
-$Path = $env:ARTHEXIS_DPAPI_CREDENTIAL_PATH
-$secure = Get-Content -LiteralPath $Path | ConvertTo-SecureString
-$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-try {
-    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-}
-finally {
-    if ($bstr -ne [IntPtr]::Zero) {
-        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+$items = $env:ARTHEXIS_DPAPI_CREDENTIAL_PATHS | ConvertFrom-Json
+$secrets = [ordered]@{}
+$errors = [ordered]@{}
+foreach ($property in $items.PSObject.Properties) {
+    $target = $property.Name
+    $Path = [string]$property.Value
+    try {
+        $secure = Get-Content -LiteralPath $Path | ConvertTo-SecureString
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+        try {
+            $secrets[$target] = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+        }
+        finally {
+            if ($bstr -ne [IntPtr]::Zero) {
+                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+            }
+        }
+    }
+    catch {
+        $errors[$target] = $_.Exception.Message
     }
 }
+[ordered]@{ secrets = $secrets; errors = $errors } | ConvertTo-Json -Compress -Depth 4
 """
     env = os.environ.copy()
-    env["ARTHEXIS_DPAPI_CREDENTIAL_PATH"] = path
+    env["ARTHEXIS_DPAPI_CREDENTIAL_PATHS"] = json.dumps(paths_by_target)
     result = subprocess.run(
         [
             "powershell",
@@ -44,13 +65,18 @@ finally {
         text=True,
         timeout=10,
     )
-    return result.stdout.rstrip("\r\n")
+    payload = json.loads(result.stdout or "{}")
+    return (
+        dict(payload.get("secrets") or {}),
+        dict(payload.get("errors") or {}),
+    )
 
 
 def _load_dpapi_env_secrets() -> None:
     if os.name != "nt":
         return
 
+    pending: dict[str, str] = {}
     for source_key, credential_path in list(os.environ.items()):
         if not source_key.startswith(_DPAPI_ENV_PREFIX):
             continue
@@ -58,19 +84,41 @@ def _load_dpapi_env_secrets() -> None:
         if not _ENV_NAME_RE.match(target_key):
             logger.warning("Ignoring invalid DPAPI environment target %s", target_key)
             continue
-        if os.environ.get(target_key):
+        if target_key in os.environ:
             continue
         if not credential_path:
             continue
-        try:
-            secret = _read_windows_dpapi_secret(credential_path)
-        except Exception as exc:
+        pending[target_key] = credential_path
+
+    if not pending:
+        return
+
+    try:
+        secrets, errors = _read_windows_dpapi_secrets(pending)
+    except Exception as exc:
+        logger.warning(
+            "Failed to load DPAPI environment secrets for %s: %s",
+            ", ".join(sorted(pending)),
+            _called_process_error_detail(exc),
+        )
+        return
+
+    for target_key, error in errors.items():
+        logger.warning(
+            "Failed to load DPAPI environment secret for %s from %s: %s",
+            target_key,
+            pending.get(target_key, ""),
+            error,
+        )
+
+    for target_key, secret in secrets.items():
+        if target_key not in pending:
             logger.warning(
-                "Failed to load DPAPI environment secret for %s from %s: %s",
+                "Ignoring DPAPI environment secret for unexpected target %s",
                 target_key,
-                credential_path,
-                exc,
             )
+            continue
+        if target_key in os.environ:
             continue
         if secret:
             os.environ[target_key] = secret

--- a/tests/test_loadenv.py
+++ b/tests/test_loadenv.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from config import loadenv as loadenv_module
+
+
+def test_load_dpapi_env_secret_hydrates_target(monkeypatch, tmp_path: Path):
+    credential_path = tmp_path / "credential.dpapi"
+    credential_path.write_text("encrypted", encoding="utf-8")
+
+    monkeypatch.setattr(loadenv_module.os, "name", "nt")
+    monkeypatch.setenv(
+        "ARTHEXIS_DPAPI_ENV_TECNOLOGIA_MAIL_PASSWORD", str(credential_path)
+    )
+    monkeypatch.delenv("TECNOLOGIA_MAIL_PASSWORD", raising=False)
+    monkeypatch.setattr(
+        loadenv_module, "_read_windows_dpapi_secret", lambda path: f"secret:{path}"
+    )
+
+    loadenv_module._load_dpapi_env_secrets()
+
+    assert loadenv_module.os.environ["TECNOLOGIA_MAIL_PASSWORD"] == (
+        f"secret:{credential_path}"
+    )
+
+
+def test_load_dpapi_env_secret_preserves_existing_target(monkeypatch, tmp_path: Path):
+    credential_path = tmp_path / "credential.dpapi"
+    credential_path.write_text("encrypted", encoding="utf-8")
+
+    monkeypatch.setattr(loadenv_module.os, "name", "nt")
+    monkeypatch.setenv(
+        "ARTHEXIS_DPAPI_ENV_TECNOLOGIA_MAIL_PASSWORD", str(credential_path)
+    )
+    monkeypatch.setenv("TECNOLOGIA_MAIL_PASSWORD", "already-set")
+    monkeypatch.setattr(
+        loadenv_module, "_read_windows_dpapi_secret", lambda path: "new-secret"
+    )
+
+    loadenv_module._load_dpapi_env_secrets()
+
+    assert loadenv_module.os.environ["TECNOLOGIA_MAIL_PASSWORD"] == "already-set"

--- a/tests/test_loadenv.py
+++ b/tests/test_loadenv.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 from config import loadenv as loadenv_module
@@ -12,15 +13,21 @@ def test_load_dpapi_env_secret_hydrates_target(monkeypatch, tmp_path: Path):
         "ARTHEXIS_DPAPI_ENV_TECNOLOGIA_MAIL_PASSWORD", str(credential_path)
     )
     monkeypatch.delenv("TECNOLOGIA_MAIL_PASSWORD", raising=False)
-    monkeypatch.setattr(
-        loadenv_module, "_read_windows_dpapi_secret", lambda path: f"secret:{path}"
-    )
+
+    calls = []
+
+    def _read_secrets(paths_by_target):
+        calls.append(paths_by_target)
+        return ({"TECNOLOGIA_MAIL_PASSWORD": f"secret:{credential_path}"}, {})
+
+    monkeypatch.setattr(loadenv_module, "_read_windows_dpapi_secrets", _read_secrets)
 
     loadenv_module._load_dpapi_env_secrets()
 
     assert loadenv_module.os.environ["TECNOLOGIA_MAIL_PASSWORD"] == (
         f"secret:{credential_path}"
     )
+    assert calls == [{"TECNOLOGIA_MAIL_PASSWORD": str(credential_path)}]
 
 
 def test_load_dpapi_env_secret_preserves_existing_target(monkeypatch, tmp_path: Path):
@@ -32,10 +39,96 @@ def test_load_dpapi_env_secret_preserves_existing_target(monkeypatch, tmp_path: 
         "ARTHEXIS_DPAPI_ENV_TECNOLOGIA_MAIL_PASSWORD", str(credential_path)
     )
     monkeypatch.setenv("TECNOLOGIA_MAIL_PASSWORD", "already-set")
+    calls = []
+
+    def _read_secrets(paths_by_target):
+        calls.append(paths_by_target)
+        return ({"TECNOLOGIA_MAIL_PASSWORD": "new-secret"}, {})
+
     monkeypatch.setattr(
-        loadenv_module, "_read_windows_dpapi_secret", lambda path: "new-secret"
+        loadenv_module,
+        "_read_windows_dpapi_secrets",
+        _read_secrets,
     )
 
     loadenv_module._load_dpapi_env_secrets()
 
     assert loadenv_module.os.environ["TECNOLOGIA_MAIL_PASSWORD"] == "already-set"
+    assert calls == []
+
+
+def test_load_dpapi_env_secret_preserves_empty_existing_target(
+    monkeypatch,
+    tmp_path: Path,
+):
+    credential_path = tmp_path / "credential.dpapi"
+    credential_path.write_text("encrypted", encoding="utf-8")
+
+    monkeypatch.setattr(loadenv_module.os, "name", "nt")
+    monkeypatch.setenv(
+        "ARTHEXIS_DPAPI_ENV_TECNOLOGIA_MAIL_PASSWORD", str(credential_path)
+    )
+    monkeypatch.setenv("TECNOLOGIA_MAIL_PASSWORD", "")
+    calls = []
+
+    def _read_secrets(paths_by_target):
+        calls.append(paths_by_target)
+        return ({"TECNOLOGIA_MAIL_PASSWORD": "new-secret"}, {})
+
+    monkeypatch.setattr(
+        loadenv_module,
+        "_read_windows_dpapi_secrets",
+        _read_secrets,
+    )
+
+    loadenv_module._load_dpapi_env_secrets()
+
+    assert loadenv_module.os.environ["TECNOLOGIA_MAIL_PASSWORD"] == ""
+    assert calls == []
+
+
+def test_load_dpapi_env_secret_batches_pending_targets(monkeypatch, tmp_path: Path):
+    first_path = tmp_path / "first.dpapi"
+    second_path = tmp_path / "second.dpapi"
+    first_path.write_text("encrypted", encoding="utf-8")
+    second_path.write_text("encrypted", encoding="utf-8")
+
+    monkeypatch.setattr(loadenv_module.os, "name", "nt")
+    monkeypatch.setenv("ARTHEXIS_DPAPI_ENV_FIRST_SECRET", str(first_path))
+    monkeypatch.setenv("ARTHEXIS_DPAPI_ENV_SECOND_SECRET", str(second_path))
+    monkeypatch.delenv("FIRST_SECRET", raising=False)
+    monkeypatch.delenv("SECOND_SECRET", raising=False)
+    calls = []
+
+    def _read_secrets(paths_by_target):
+        calls.append(paths_by_target)
+        return (
+            {
+                "FIRST_SECRET": "first-secret",
+                "SECOND_SECRET": "second-secret",
+            },
+            {},
+        )
+
+    monkeypatch.setattr(loadenv_module, "_read_windows_dpapi_secrets", _read_secrets)
+
+    loadenv_module._load_dpapi_env_secrets()
+
+    assert calls == [
+        {
+            "FIRST_SECRET": str(first_path),
+            "SECOND_SECRET": str(second_path),
+        }
+    ]
+    assert loadenv_module.os.environ["FIRST_SECRET"] == "first-secret"
+    assert loadenv_module.os.environ["SECOND_SECRET"] == "second-secret"
+
+
+def test_called_process_error_detail_prefers_stderr():
+    error = subprocess.CalledProcessError(
+        1,
+        ["powershell"],
+        stderr="invalid dpapi payload\n",
+    )
+
+    assert loadenv_module._called_process_error_detail(error) == "invalid dpapi payload"


### PR DESCRIPTION
## Summary

Closes #7516.

This adds a small Windows-only runtime bridge so `arthexis.env` can map a target environment variable to a DPAPI-encrypted credential file. It preserves sigil-backed secret references such as `[ENV.TECNOLOGIA_MAIL_PASSWORD]` without copying the underlying password into the suite database or repository files.

## Changes

- Loads `ARTHEXIS_DPAPI_ENV_<TARGET>` mappings after dotenv files are read.
- Decrypts Windows DPAPI credential files via PowerShell using an environment variable for the credential path.
- Preserves already-defined target environment variables.
- Ignores DPAPI mappings on non-Windows runtimes.
- Adds focused unit tests for hydration and existing-value precedence.

## Validation

- `python -m pytest tests/test_loadenv.py`
- `python manage.py check --fail-level ERROR`

## Risk

- Low on non-Windows hosts because the loader returns without action.
- On Windows, a bad credential file logs a warning and leaves the target variable unset rather than stopping startup.
- Secret values are not printed by the loader or stored in committed files.