### PR TITLE
Prototype portable Codex skill packages

### DIFF
--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -1,6 +1,19 @@
 from django.contrib import admin
 
-from .models import AgentSkill
+from .models import AgentSkill, AgentSkillFile
+
+
+class AgentSkillFileInline(admin.TabularInline):
+    model = AgentSkillFile
+    extra = 0
+    fields = (
+        "relative_path",
+        "portability",
+        "included_by_default",
+        "exclusion_reason",
+        "size_bytes",
+    )
+    readonly_fields = ("size_bytes",)
 
 
 @admin.register(AgentSkill)
@@ -8,3 +21,17 @@ class AgentSkillAdmin(admin.ModelAdmin):
     list_display = ("slug", "title")
     search_fields = ("slug", "title", "markdown")
     filter_horizontal = ("node_roles",)
+    inlines = (AgentSkillFileInline,)
+
+
+@admin.register(AgentSkillFile)
+class AgentSkillFileAdmin(admin.ModelAdmin):
+    list_display = (
+        "skill",
+        "relative_path",
+        "portability",
+        "included_by_default",
+        "size_bytes",
+    )
+    list_filter = ("portability", "included_by_default")
+    search_fields = ("skill__slug", "relative_path", "exclusion_reason", "content")

--- a/apps/skills/management/commands/codex_skill_packages.py
+++ b/apps/skills/management/commands/codex_skill_packages.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.skills.package_services import (
+    export_codex_skill_package,
+    import_codex_skill_package,
+    scan_codex_skills_root,
+)
+
+
+class Command(BaseCommand):
+    help = "Scan, export, or import portable Codex skill packages."
+
+    def add_arguments(self, parser):
+        parser.add_argument("action", choices=["scan", "export", "import"])
+        parser.add_argument("--source", help="Codex skills root for scan.")
+        parser.add_argument("--output", help="ZIP package path for export.")
+        parser.add_argument("--package", help="ZIP package path for import.")
+        parser.add_argument("--slug", action="append", dest="slugs", default=[])
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument(
+            "--include-excluded",
+            action="store_true",
+            help="Export package records even when they are excluded by default.",
+        )
+
+    def handle(self, *args, **options):
+        action = options["action"]
+        if action == "scan":
+            source = options.get("source")
+            if not source:
+                raise CommandError("--source is required for scan")
+            summary = scan_codex_skills_root(Path(source), dry_run=options["dry_run"])
+        elif action == "export":
+            output = options.get("output")
+            if not output:
+                raise CommandError("--output is required for export")
+            summary = export_codex_skill_package(
+                Path(output),
+                skill_slugs=options["slugs"] or None,
+                portable_only=not options["include_excluded"],
+            )
+        else:
+            package = options.get("package")
+            if not package:
+                raise CommandError("--package is required for import")
+            summary = import_codex_skill_package(
+                Path(package),
+                dry_run=options["dry_run"],
+            )
+        self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))

--- a/apps/skills/migrations/0003_agentskillfile.py
+++ b/apps/skills/migrations/0003_agentskillfile.py
@@ -1,0 +1,59 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [("skills", "0002_seed_agent_skills")]
+
+    operations = [
+        migrations.CreateModel(
+            name="AgentSkillFile",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("relative_path", models.CharField(max_length=500)),
+                ("content", models.TextField(blank=True)),
+                ("content_sha256", models.CharField(blank=True, max_length=64)),
+                (
+                    "portability",
+                    models.CharField(
+                        choices=[
+                            ("portable", "Portable"),
+                            ("operator_scoped", "Operator scoped"),
+                            ("device_scoped", "Device scoped"),
+                            ("secret", "Secret"),
+                            ("cache", "Cache"),
+                            ("state", "State"),
+                            ("generated_reference", "Generated reference"),
+                        ],
+                        default="portable",
+                        max_length=32,
+                    ),
+                ),
+                ("included_by_default", models.BooleanField(default=True)),
+                ("exclusion_reason", models.CharField(blank=True, max_length=255)),
+                ("size_bytes", models.PositiveIntegerField(default=0)),
+                (
+                    "skill",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="package_files",
+                        to="skills.agentskill",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Agent Skill File",
+                "verbose_name_plural": "Agent Skill Files",
+                "ordering": ("skill__slug", "relative_path"),
+                "unique_together": {("skill", "relative_path")},
+            },
+        ),
+    ]

--- a/apps/skills/models.py
+++ b/apps/skills/models.py
@@ -15,7 +15,9 @@ class AgentSkill(Entity):
     slug = models.SlugField(max_length=100, unique=True)
     title = models.CharField(max_length=150)
     markdown = models.TextField()
-    node_roles = models.ManyToManyField("nodes.NodeRole", blank=True, related_name="agent_skills")
+    node_roles = models.ManyToManyField(
+        "nodes.NodeRole", blank=True, related_name="agent_skills"
+    )
 
     class Meta:
         ordering = ("slug",)
@@ -33,3 +35,42 @@ class AgentSkill(Entity):
         super().clean()
         if not self.slug:
             raise ValidationError({"slug": "Slug is required."})
+
+
+class AgentSkillFile(models.Model):
+    """One file captured from a multi-file Codex skill package."""
+
+    class Portability(models.TextChoices):
+        PORTABLE = "portable", "Portable"
+        OPERATOR_SCOPED = "operator_scoped", "Operator scoped"
+        DEVICE_SCOPED = "device_scoped", "Device scoped"
+        SECRET = "secret", "Secret"
+        CACHE = "cache", "Cache"
+        STATE = "state", "State"
+        GENERATED_REFERENCE = "generated_reference", "Generated reference"
+
+    skill = models.ForeignKey(
+        AgentSkill,
+        on_delete=models.CASCADE,
+        related_name="package_files",
+    )
+    relative_path = models.CharField(max_length=500)
+    content = models.TextField(blank=True)
+    content_sha256 = models.CharField(max_length=64, blank=True)
+    portability = models.CharField(
+        max_length=32,
+        choices=Portability.choices,
+        default=Portability.PORTABLE,
+    )
+    included_by_default = models.BooleanField(default=True)
+    exclusion_reason = models.CharField(max_length=255, blank=True)
+    size_bytes = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        ordering = ("skill__slug", "relative_path")
+        unique_together = (("skill", "relative_path"),)
+        verbose_name = "Agent Skill File"
+        verbose_name_plural = "Agent Skill Files"
+
+    def __str__(self) -> str:
+        return f"{self.skill.slug}:{self.relative_path}"

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -227,12 +227,15 @@ def _restore_or_create_skill(*, slug: str, title: str, markdown: str) -> AgentSk
             markdown=markdown,
             is_seed_data=False,
         )
+    was_deleted = skill.is_deleted
     skill.title = title
     skill.markdown = markdown
     skill.is_deleted = False
     skill.save(update_fields=["title", "markdown", "is_deleted"])
     AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=False)
     skill.is_seed_data = False
+    if was_deleted:
+        skill.node_roles.clear()
     return skill
 
 
@@ -308,6 +311,11 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
         for file_info in validated_files:
             if file_info["path"] in seen_paths:
                 raise ValueError(f"Duplicate package file path: {file_info['path']}")
+            if (
+                file_info["path"] == SKILL_MARKDOWN
+                and file_info.get("included_by_default") is False
+            ):
+                raise ValueError(f"{SKILL_MARKDOWN} must be included")
             seen_paths.add(file_info["path"])
             archive_path = f"skills/{slug}/{file_info['path']}"
             content_by_path[file_info["path"]] = _read_package_text(

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from django.db import transaction
+
+from apps.skills.models import AgentSkill, AgentSkillFile
+
+PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
+
+BLOCKED_STATE_FILENAMES = {
+    "pending-approval-alerts.lock.json",
+    "security-codes.json",
+    "standard-materials.db",
+    "todo.md",
+    "workgroup.md",
+}
+BLOCKED_CACHE_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "cache",
+    "logs",
+    "node_modules",
+    "sessions",
+}
+BLOCKED_SECRET_DIRS = {"credentials", "secrets", "tokens"}
+SECRET_NAME_FRAGMENTS = ("credential", "password", "secret", "token")
+GENERATED_REFERENCE_DIRS = {"mtg-rules"}
+PORTABLE_ROOTS = {"agents", "assets", "references", "scripts", "templates"}
+OPERATOR_PATH_MARKERS = (
+    "C:\\Users\\",
+    "C:/Users/",
+    "/home/",
+    "/Users/",
+    ".codex\\",
+    ".codex/",
+)
+
+
+@dataclass(frozen=True)
+class SkillFileClassification:
+    portability: str
+    included_by_default: bool
+    exclusion_reason: str = ""
+
+
+@dataclass(frozen=True)
+class SkillFileScan:
+    relative_path: str
+    portability: str
+    included_by_default: bool
+    exclusion_reason: str
+    size_bytes: int
+    content_sha256: str
+
+
+def normalize_package_path(path: Path) -> str:
+    return path.as_posix()
+
+
+def classify_codex_skill_file(
+    relative_path: str,
+    content: str | None,
+) -> SkillFileClassification:
+    parts = [part.lower() for part in relative_path.replace("\\", "/").split("/")]
+    filename = parts[-1]
+    suffix = Path(filename).suffix.lower()
+
+    if filename in BLOCKED_STATE_FILENAMES:
+        return SkillFileClassification(
+            AgentSkillFile.Portability.STATE,
+            False,
+            "runtime state is not portable",
+        )
+    if any(part in BLOCKED_SECRET_DIRS for part in parts):
+        return SkillFileClassification(
+            AgentSkillFile.Portability.SECRET,
+            False,
+            "credential directory is not portable",
+        )
+    if any(fragment in filename for fragment in SECRET_NAME_FRAGMENTS):
+        return SkillFileClassification(
+            AgentSkillFile.Portability.SECRET,
+            False,
+            "credential-like filename is not portable",
+        )
+    if any(part in BLOCKED_CACHE_DIRS for part in parts):
+        return SkillFileClassification(
+            AgentSkillFile.Portability.CACHE,
+            False,
+            "cache, log, or generated runtime directory is not portable",
+        )
+    if any(part in GENERATED_REFERENCE_DIRS for part in parts):
+        return SkillFileClassification(
+            AgentSkillFile.Portability.GENERATED_REFERENCE,
+            False,
+            "generated reference archive should be refreshed on the target",
+        )
+    if suffix in {".db", ".sqlite", ".sqlite3", ".pyc", ".pyo", ".log", ".tmp"}:
+        return SkillFileClassification(
+            AgentSkillFile.Portability.STATE,
+            False,
+            "runtime artifact file is not portable",
+        )
+    if content is None:
+        return SkillFileClassification(
+            AgentSkillFile.Portability.DEVICE_SCOPED,
+            False,
+            "binary files are not exported by this prototype",
+        )
+    if any(marker in content for marker in OPERATOR_PATH_MARKERS):
+        return SkillFileClassification(
+            AgentSkillFile.Portability.OPERATOR_SCOPED,
+            False,
+            "operator-local paths must be parameterized before export",
+        )
+    if relative_path == "SKILL.md" or parts[0] in PORTABLE_ROOTS:
+        return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
+    return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
+
+
+def _read_skill_file(path: Path) -> tuple[bytes, str | None]:
+    content_bytes = path.read_bytes()
+    try:
+        return content_bytes, content_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return content_bytes, None
+
+
+def _scan_file(skill_dir: Path, path: Path) -> tuple[SkillFileScan, str]:
+    relative_path = normalize_package_path(path.relative_to(skill_dir))
+    content_bytes, text = _read_skill_file(path)
+    classification = classify_codex_skill_file(relative_path, text)
+    digest = hashlib.sha256(content_bytes).hexdigest()
+    return (
+        SkillFileScan(
+            relative_path=relative_path,
+            portability=classification.portability,
+            included_by_default=classification.included_by_default,
+            exclusion_reason=classification.exclusion_reason,
+            size_bytes=len(content_bytes),
+            content_sha256=digest,
+        ),
+        text or "",
+    )
+
+
+def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict:
+    skill_dir = Path(skill_dir)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"{skill_dir} does not contain SKILL.md")
+
+    file_entries = []
+    file_content_by_path = {}
+    for path in sorted(skill_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        scan, text = _scan_file(skill_dir, path)
+        file_entries.append(scan)
+        file_content_by_path[scan.relative_path] = text
+
+    summary = {
+        "slug": skill_dir.name,
+        "dry_run": dry_run,
+        "files": [asdict(entry) for entry in file_entries],
+        "included": sum(1 for entry in file_entries if entry.included_by_default),
+        "excluded": sum(1 for entry in file_entries if not entry.included_by_default),
+    }
+    if dry_run:
+        return summary
+
+    with transaction.atomic():
+        skill, _ = AgentSkill.objects.update_or_create(
+            slug=skill_dir.name,
+            defaults={
+                "title": skill_dir.name.replace("-", " ").title(),
+                "markdown": file_content_by_path.get("SKILL.md", ""),
+            },
+        )
+        seen_paths = {entry.relative_path for entry in file_entries}
+        skill.package_files.exclude(relative_path__in=seen_paths).delete()
+        for entry in file_entries:
+            AgentSkillFile.objects.update_or_create(
+                skill=skill,
+                relative_path=entry.relative_path,
+                defaults={
+                    "content": (
+                        file_content_by_path[entry.relative_path]
+                        if entry.included_by_default
+                        else ""
+                    ),
+                    "content_sha256": entry.content_sha256,
+                    "portability": entry.portability,
+                    "included_by_default": entry.included_by_default,
+                    "exclusion_reason": entry.exclusion_reason,
+                    "size_bytes": entry.size_bytes,
+                },
+            )
+    return summary
+
+
+def scan_codex_skills_root(source: Path, *, dry_run: bool = True) -> dict:
+    source = Path(source)
+    summaries = []
+    for child in sorted(source.iterdir()):
+        if child.is_dir() and (child / "SKILL.md").exists():
+            summaries.append(scan_codex_skill_directory(child, dry_run=dry_run))
+    return {"source": str(source), "dry_run": dry_run, "skills": summaries}
+
+
+def export_codex_skill_package(
+    output_path: Path,
+    *,
+    skill_slugs: list[str] | None = None,
+    portable_only: bool = True,
+) -> dict:
+    output_path = Path(output_path)
+    queryset = AgentSkill.objects.prefetch_related("package_files")
+    if skill_slugs:
+        queryset = queryset.filter(slug__in=skill_slugs)
+
+    manifest = {"format": PACKAGE_FORMAT, "skills": []}
+    with ZipFile(output_path, "w", ZIP_DEFLATED) as package:
+        for skill in queryset.order_by("slug"):
+            skill_entry = {
+                "slug": skill.slug,
+                "title": skill.title,
+                "files": [],
+            }
+            for file_entry in skill.package_files.all():
+                if portable_only and not file_entry.included_by_default:
+                    continue
+                archive_path = f"skills/{skill.slug}/{file_entry.relative_path}"
+                package.writestr(archive_path, file_entry.content)
+                skill_entry["files"].append(
+                    {
+                        "path": file_entry.relative_path,
+                        "portability": file_entry.portability,
+                        "included_by_default": file_entry.included_by_default,
+                        "content_sha256": file_entry.content_sha256,
+                    }
+                )
+            if skill_entry["files"]:
+                manifest["skills"].append(skill_entry)
+        package.writestr("manifest.json", json.dumps(manifest, indent=2))
+    return manifest
+
+
+def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> dict:
+    package_path = Path(package_path)
+    with ZipFile(package_path) as package:
+        manifest = json.loads(package.read("manifest.json").decode("utf-8"))
+        if manifest.get("format") != PACKAGE_FORMAT:
+            raise ValueError("Unsupported Codex skill package format")
+        summary = {
+            "package": str(package_path),
+            "dry_run": dry_run,
+            "skills": [],
+        }
+        if dry_run:
+            for skill_entry in manifest.get("skills", []):
+                summary["skills"].append(
+                    {
+                        "slug": skill_entry["slug"],
+                        "files": len(skill_entry.get("files", [])),
+                    }
+                )
+            return summary
+
+        with transaction.atomic():
+            for skill_entry in manifest.get("skills", []):
+                slug = skill_entry["slug"]
+                files = skill_entry.get("files", [])
+                content_by_path = {
+                    file_info["path"]: package.read(
+                        f"skills/{slug}/{file_info['path']}"
+                    ).decode("utf-8")
+                    for file_info in files
+                }
+                skill, _ = AgentSkill.objects.update_or_create(
+                    slug=slug,
+                    defaults={
+                        "title": skill_entry.get(
+                            "title", slug.replace("-", " ").title()
+                        ),
+                        "markdown": content_by_path.get("SKILL.md", ""),
+                    },
+                )
+                seen_paths = {file_info["path"] for file_info in files}
+                skill.package_files.exclude(relative_path__in=seen_paths).delete()
+                for file_info in files:
+                    content = content_by_path[file_info["path"]]
+                    AgentSkillFile.objects.update_or_create(
+                        skill=skill,
+                        relative_path=file_info["path"],
+                        defaults={
+                            "content": content,
+                            "content_sha256": hashlib.sha256(
+                                content.encode("utf-8")
+                            ).hexdigest(),
+                            "portability": file_info.get(
+                                "portability", AgentSkillFile.Portability.PORTABLE
+                            ),
+                            "included_by_default": file_info.get(
+                                "included_by_default", True
+                            ),
+                            "exclusion_reason": "",
+                            "size_bytes": len(content.encode("utf-8")),
+                        },
+                    )
+                summary["skills"].append({"slug": slug, "files": len(files)})
+        return summary

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -267,8 +267,30 @@ def _import_file_spec(file_info: dict, content: str) -> dict:
     }
 
 
+def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[dict]:
+    validated_skills = []
+    for skill_entry in manifest.get("skills", []):
+        slug = validate_package_skill_slug(skill_entry["slug"])
+        validated_files = [
+            {
+                **file_info,
+                "path": validate_package_relative_path(file_info["path"]),
+            }
+            for file_info in skill_entry.get("files", [])
+        ]
+        for file_info in validated_files:
+            archive_path = f"skills/{slug}/{file_info['path']}"
+            try:
+                package.getinfo(archive_path)
+            except KeyError as error:
+                raise ValueError(f"Missing package file: {archive_path}") from error
+        validated_skills.append({**skill_entry, "slug": slug, "files": validated_files})
+    return validated_skills
+
+
 def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict:
     skill_dir = Path(skill_dir)
+    slug = validate_package_skill_slug(skill_dir.name)
     skill_md = skill_dir / SKILL_MARKDOWN
     if not skill_md.exists():
         raise ValueError(f"{skill_dir} does not contain {SKILL_MARKDOWN}")
@@ -283,7 +305,7 @@ def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict
         file_content_by_path[scan.relative_path] = text
 
     summary = {
-        "slug": skill_dir.name,
+        "slug": slug,
         "dry_run": dry_run,
         "files": [asdict(entry) for entry in file_entries],
         "included": sum(1 for entry in file_entries if entry.included_by_default),
@@ -294,8 +316,8 @@ def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict
 
     with transaction.atomic():
         skill = _restore_or_create_skill(
-            slug=skill_dir.name,
-            title=skill_dir.name.replace("-", " ").title(),
+            slug=slug,
+            title=slug.replace("-", " ").title(),
             markdown=file_content_by_path.get(SKILL_MARKDOWN, ""),
         )
         _sync_package_files(
@@ -375,13 +397,14 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
         manifest = json.loads(package.read("manifest.json").decode("utf-8"))
         if manifest.get("format") != PACKAGE_FORMAT:
             raise ValueError("Unsupported Codex skill package format")
+        validated_skills = _validate_manifest_skill_entries(package, manifest)
         summary = {
             "package": str(package_path),
             "dry_run": dry_run,
             "skills": [],
         }
         if dry_run:
-            for skill_entry in manifest.get("skills", []):
+            for skill_entry in validated_skills:
                 summary["skills"].append(
                     {
                         "slug": skill_entry["slug"],
@@ -391,18 +414,11 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
             return summary
 
         with transaction.atomic():
-            for skill_entry in manifest.get("skills", []):
-                slug = validate_package_skill_slug(skill_entry["slug"])
+            for skill_entry in validated_skills:
+                slug = skill_entry["slug"]
                 files = skill_entry.get("files", [])
-                validated_files = [
-                    {
-                        **file_info,
-                        "path": validate_package_relative_path(file_info["path"]),
-                    }
-                    for file_info in files
-                ]
                 content_by_path = {}
-                for file_info in validated_files:
+                for file_info in files:
                     content_by_path[file_info["path"]] = package.read(
                         f"skills/{slug}/{file_info['path']}"
                     ).decode("utf-8")
@@ -415,7 +431,7 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
                     skill,
                     [
                         _import_file_spec(file_info, content_by_path[file_info["path"]])
-                        for file_info in validated_files
+                        for file_info in files
                     ],
                 )
                 summary["skills"].append({"slug": slug, "files": len(files)})

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -280,8 +280,12 @@ def _read_package_text(package: ZipFile, archive_path: str) -> str:
 
 def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[dict]:
     validated_skills = []
+    seen_slugs = set()
     for skill_entry in manifest.get("skills", []):
         slug = validate_package_skill_slug(skill_entry["slug"])
+        if slug in seen_slugs:
+            raise ValueError(f"Duplicate package skill slug: {slug}")
+        seen_slugs.add(slug)
         seen_paths = set()
         content_by_path = {}
         validated_files = [
@@ -300,6 +304,8 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
                 package,
                 archive_path,
             )
+        if SKILL_MARKDOWN not in content_by_path:
+            raise ValueError(f"Missing required {SKILL_MARKDOWN} for skill: {slug}")
         validated_skills.append(
             {
                 **skill_entry,

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -221,11 +221,18 @@ def _scan_file(skill_dir: Path, path: Path) -> tuple[SkillFileScan, str]:
 def _restore_or_create_skill(*, slug: str, title: str, markdown: str) -> AgentSkill:
     skill = AgentSkill.all_objects.filter(slug=slug).first()
     if skill is None:
-        return AgentSkill.objects.create(slug=slug, title=title, markdown=markdown)
+        return AgentSkill.objects.create(
+            slug=slug,
+            title=title,
+            markdown=markdown,
+            is_seed_data=False,
+        )
     skill.title = title
     skill.markdown = markdown
     skill.is_deleted = False
     skill.save(update_fields=["title", "markdown", "is_deleted"])
+    AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=False)
+    skill.is_seed_data = False
     return skill
 
 
@@ -248,21 +255,24 @@ def _sync_package_files(skill: AgentSkill, file_specs: list[dict]) -> None:
 
 
 def _import_file_spec(file_info: dict, content: str) -> dict:
-    included_by_default = file_info.get("included_by_default", True)
+    classification = classify_codex_skill_file(file_info["path"], content)
+    manifest_included = file_info.get("included_by_default", True)
+    included_by_default = manifest_included and classification.included_by_default
     stored_content = content if included_by_default else ""
+    exclusion_reason = ""
+    if not included_by_default:
+        exclusion_reason = (
+            file_info.get("exclusion_reason")
+            or classification.exclusion_reason
+            or "excluded by package manifest"
+        )
     return {
         "relative_path": file_info["path"],
         "content": stored_content,
         "content_sha256": hashlib.sha256(stored_content.encode("utf-8")).hexdigest(),
-        "portability": file_info.get(
-            "portability", AgentSkillFile.Portability.PORTABLE
-        ),
+        "portability": classification.portability,
         "included_by_default": included_by_default,
-        "exclusion_reason": (
-            ""
-            if included_by_default
-            else file_info.get("exclusion_reason") or "excluded by package manifest"
-        ),
+        "exclusion_reason": exclusion_reason,
         "size_bytes": len(stored_content.encode("utf-8")),
     }
 
@@ -400,7 +410,22 @@ def export_codex_skill_package(
                 "title": skill.title,
                 "files": [],
             }
-            for file_entry in skill.package_files.all():
+            package_files = list(skill.package_files.all())
+            if not package_files:
+                archive_path = f"skills/{skill.slug}/{SKILL_MARKDOWN}"
+                package.writestr(archive_path, skill.markdown)
+                skill_entry["files"].append(
+                    {
+                        "path": SKILL_MARKDOWN,
+                        "portability": AgentSkillFile.Portability.PORTABLE,
+                        "included_by_default": True,
+                        "exclusion_reason": "",
+                        "content_sha256": hashlib.sha256(
+                            skill.markdown.encode("utf-8")
+                        ).hexdigest(),
+                    }
+                )
+            for file_entry in package_files:
                 if portable_only and not file_entry.included_by_default:
                     continue
                 archive_path = f"skills/{skill.slug}/{file_entry.relative_path}"

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -122,8 +122,6 @@ def classify_codex_skill_file(
             False,
             "operator-local paths must be parameterized before export",
         )
-    if relative_path == "SKILL.md" or parts[0] in PORTABLE_ROOTS:
-        return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
     return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
 
 
@@ -153,6 +151,35 @@ def _scan_file(skill_dir: Path, path: Path) -> tuple[SkillFileScan, str]:
     )
 
 
+def _restore_or_create_skill(*, slug: str, title: str, markdown: str) -> AgentSkill:
+    skill = AgentSkill.all_objects.filter(slug=slug).first()
+    if skill is None:
+        return AgentSkill.objects.create(slug=slug, title=title, markdown=markdown)
+    skill.title = title
+    skill.markdown = markdown
+    skill.is_deleted = False
+    skill.save(update_fields=["title", "markdown", "is_deleted"])
+    return skill
+
+
+def _sync_package_files(skill: AgentSkill, file_specs: list[dict]) -> None:
+    seen_paths = {file_spec["relative_path"] for file_spec in file_specs}
+    skill.package_files.exclude(relative_path__in=seen_paths).delete()
+    AgentSkillFile.objects.bulk_create(
+        [AgentSkillFile(skill=skill, **file_spec) for file_spec in file_specs],
+        update_conflicts=True,
+        update_fields=[
+            "content",
+            "content_sha256",
+            "portability",
+            "included_by_default",
+            "exclusion_reason",
+            "size_bytes",
+        ],
+        unique_fields=["skill", "relative_path"],
+    )
+
+
 def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict:
     skill_dir = Path(skill_dir)
     skill_md = skill_dir / "SKILL.md"
@@ -179,20 +206,16 @@ def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict
         return summary
 
     with transaction.atomic():
-        skill, _ = AgentSkill.objects.update_or_create(
+        skill = _restore_or_create_skill(
             slug=skill_dir.name,
-            defaults={
-                "title": skill_dir.name.replace("-", " ").title(),
-                "markdown": file_content_by_path.get("SKILL.md", ""),
-            },
+            title=skill_dir.name.replace("-", " ").title(),
+            markdown=file_content_by_path.get("SKILL.md", ""),
         )
-        seen_paths = {entry.relative_path for entry in file_entries}
-        skill.package_files.exclude(relative_path__in=seen_paths).delete()
-        for entry in file_entries:
-            AgentSkillFile.objects.update_or_create(
-                skill=skill,
-                relative_path=entry.relative_path,
-                defaults={
+        _sync_package_files(
+            skill,
+            [
+                {
+                    "relative_path": entry.relative_path,
                     "content": (
                         file_content_by_path[entry.relative_path]
                         if entry.included_by_default
@@ -203,8 +226,10 @@ def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict
                     "included_by_default": entry.included_by_default,
                     "exclusion_reason": entry.exclusion_reason,
                     "size_bytes": entry.size_bytes,
-                },
-            )
+                }
+                for entry in file_entries
+            ],
+        )
     return summary
 
 
@@ -229,6 +254,7 @@ def export_codex_skill_package(
         queryset = queryset.filter(slug__in=skill_slugs)
 
     manifest = {"format": PACKAGE_FORMAT, "skills": []}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     with ZipFile(output_path, "w", ZIP_DEFLATED) as package:
         for skill in queryset.order_by("slug"):
             skill_entry = {
@@ -286,23 +312,16 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
                     ).decode("utf-8")
                     for file_info in files
                 }
-                skill, _ = AgentSkill.objects.update_or_create(
+                skill = _restore_or_create_skill(
                     slug=slug,
-                    defaults={
-                        "title": skill_entry.get(
-                            "title", slug.replace("-", " ").title()
-                        ),
-                        "markdown": content_by_path.get("SKILL.md", ""),
-                    },
+                    title=skill_entry.get("title", slug.replace("-", " ").title()),
+                    markdown=content_by_path.get("SKILL.md", ""),
                 )
-                seen_paths = {file_info["path"] for file_info in files}
-                skill.package_files.exclude(relative_path__in=seen_paths).delete()
-                for file_info in files:
-                    content = content_by_path[file_info["path"]]
-                    AgentSkillFile.objects.update_or_create(
-                        skill=skill,
-                        relative_path=file_info["path"],
-                        defaults={
+                _sync_package_files(
+                    skill,
+                    [
+                        {
+                            "relative_path": file_info["path"],
                             "content": content,
                             "content_sha256": hashlib.sha256(
                                 content.encode("utf-8")
@@ -315,7 +334,10 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
                             ),
                             "exclusion_reason": "",
                             "size_bytes": len(content.encode("utf-8")),
-                        },
-                    )
+                        }
+                        for file_info in files
+                        for content in [content_by_path[file_info["path"]]]
+                    ],
+                )
                 summary["skills"].append({"slug": slug, "files": len(files)})
         return summary

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.db import transaction
@@ -11,6 +11,7 @@ from django.db import transaction
 from apps.skills.models import AgentSkill, AgentSkillFile
 
 PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
+SKILL_MARKDOWN = "SKILL.md"
 
 BLOCKED_STATE_FILENAMES = {
     "pending-approval-alerts.lock.json",
@@ -63,6 +64,20 @@ class SkillFileScan:
 
 
 def normalize_package_path(path: Path) -> str:
+    return path.as_posix()
+
+
+def validate_package_relative_path(relative_path: str) -> str:
+    normalized = relative_path.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if (
+        not normalized
+        or normalized == "."
+        or path.is_absolute()
+        or Path(relative_path).is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError(f"Unsafe package path: {relative_path}")
     return path.as_posix()
 
 
@@ -122,7 +137,13 @@ def classify_codex_skill_file(
             False,
             "operator-local paths must be parameterized before export",
         )
-    return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
+    if relative_path == SKILL_MARKDOWN or parts[0] in PORTABLE_ROOTS:
+        return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
+    return SkillFileClassification(
+        AgentSkillFile.Portability.DEVICE_SCOPED,
+        False,
+        "file is outside portable skill package roots",
+    )
 
 
 def _read_skill_file(path: Path) -> tuple[bytes, str | None]:
@@ -180,16 +201,36 @@ def _sync_package_files(skill: AgentSkill, file_specs: list[dict]) -> None:
     )
 
 
+def _import_file_spec(file_info: dict, content: str) -> dict:
+    included_by_default = file_info.get("included_by_default", True)
+    stored_content = content if included_by_default else ""
+    return {
+        "relative_path": file_info["path"],
+        "content": stored_content,
+        "content_sha256": hashlib.sha256(stored_content.encode("utf-8")).hexdigest(),
+        "portability": file_info.get(
+            "portability", AgentSkillFile.Portability.PORTABLE
+        ),
+        "included_by_default": included_by_default,
+        "exclusion_reason": (
+            ""
+            if included_by_default
+            else file_info.get("exclusion_reason") or "excluded by package manifest"
+        ),
+        "size_bytes": len(stored_content.encode("utf-8")),
+    }
+
+
 def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict:
     skill_dir = Path(skill_dir)
-    skill_md = skill_dir / "SKILL.md"
+    skill_md = skill_dir / SKILL_MARKDOWN
     if not skill_md.exists():
-        raise ValueError(f"{skill_dir} does not contain SKILL.md")
+        raise ValueError(f"{skill_dir} does not contain {SKILL_MARKDOWN}")
 
     file_entries = []
     file_content_by_path = {}
     for path in sorted(skill_dir.rglob("*")):
-        if not path.is_file():
+        if path.is_symlink() or not path.is_file():
             continue
         scan, text = _scan_file(skill_dir, path)
         file_entries.append(scan)
@@ -209,7 +250,7 @@ def scan_codex_skill_directory(skill_dir: Path, *, dry_run: bool = True) -> dict
         skill = _restore_or_create_skill(
             slug=skill_dir.name,
             title=skill_dir.name.replace("-", " ").title(),
-            markdown=file_content_by_path.get("SKILL.md", ""),
+            markdown=file_content_by_path.get(SKILL_MARKDOWN, ""),
         )
         _sync_package_files(
             skill,
@@ -237,7 +278,7 @@ def scan_codex_skills_root(source: Path, *, dry_run: bool = True) -> dict:
     source = Path(source)
     summaries = []
     for child in sorted(source.iterdir()):
-        if child.is_dir() and (child / "SKILL.md").exists():
+        if child.is_dir() and (child / SKILL_MARKDOWN).exists():
             summaries.append(scan_codex_skill_directory(child, dry_run=dry_run))
     return {"source": str(source), "dry_run": dry_run, "skills": summaries}
 
@@ -272,6 +313,7 @@ def export_codex_skill_package(
                         "path": file_entry.relative_path,
                         "portability": file_entry.portability,
                         "included_by_default": file_entry.included_by_default,
+                        "exclusion_reason": file_entry.exclusion_reason,
                         "content_sha256": file_entry.content_sha256,
                     }
                 )
@@ -306,37 +348,28 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
             for skill_entry in manifest.get("skills", []):
                 slug = skill_entry["slug"]
                 files = skill_entry.get("files", [])
-                content_by_path = {
-                    file_info["path"]: package.read(
+                validated_files = [
+                    {
+                        **file_info,
+                        "path": validate_package_relative_path(file_info["path"]),
+                    }
+                    for file_info in files
+                ]
+                content_by_path = {}
+                for file_info in validated_files:
+                    content_by_path[file_info["path"]] = package.read(
                         f"skills/{slug}/{file_info['path']}"
                     ).decode("utf-8")
-                    for file_info in files
-                }
                 skill = _restore_or_create_skill(
                     slug=slug,
                     title=skill_entry.get("title", slug.replace("-", " ").title()),
-                    markdown=content_by_path.get("SKILL.md", ""),
+                    markdown=content_by_path.get(SKILL_MARKDOWN, ""),
                 )
                 _sync_package_files(
                     skill,
                     [
-                        {
-                            "relative_path": file_info["path"],
-                            "content": content,
-                            "content_sha256": hashlib.sha256(
-                                content.encode("utf-8")
-                            ).hexdigest(),
-                            "portability": file_info.get(
-                                "portability", AgentSkillFile.Portability.PORTABLE
-                            ),
-                            "included_by_default": file_info.get(
-                                "included_by_default", True
-                            ),
-                            "exclusion_reason": "",
-                            "size_bytes": len(content.encode("utf-8")),
-                        }
-                        for file_info in files
-                        for content in [content_by_path[file_info["path"]]]
+                        _import_file_spec(file_info, content_by_path[file_info["path"]])
+                        for file_info in validated_files
                     ],
                 )
                 summary["skills"].append({"slug": slug, "files": len(files)})

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -267,10 +267,23 @@ def _import_file_spec(file_info: dict, content: str) -> dict:
     }
 
 
+def _read_package_text(package: ZipFile, archive_path: str) -> str:
+    try:
+        content = package.read(archive_path)
+    except KeyError as error:
+        raise ValueError(f"Missing package file: {archive_path}") from error
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"Invalid UTF-8 package file: {archive_path}") from error
+
+
 def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[dict]:
     validated_skills = []
     for skill_entry in manifest.get("skills", []):
         slug = validate_package_skill_slug(skill_entry["slug"])
+        seen_paths = set()
+        content_by_path = {}
         validated_files = [
             {
                 **file_info,
@@ -279,12 +292,22 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
             for file_info in skill_entry.get("files", [])
         ]
         for file_info in validated_files:
+            if file_info["path"] in seen_paths:
+                raise ValueError(f"Duplicate package file path: {file_info['path']}")
+            seen_paths.add(file_info["path"])
             archive_path = f"skills/{slug}/{file_info['path']}"
-            try:
-                package.getinfo(archive_path)
-            except KeyError as error:
-                raise ValueError(f"Missing package file: {archive_path}") from error
-        validated_skills.append({**skill_entry, "slug": slug, "files": validated_files})
+            content_by_path[file_info["path"]] = _read_package_text(
+                package,
+                archive_path,
+            )
+        validated_skills.append(
+            {
+                **skill_entry,
+                "slug": slug,
+                "files": validated_files,
+                "content_by_path": content_by_path,
+            }
+        )
     return validated_skills
 
 
@@ -417,11 +440,7 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
             for skill_entry in validated_skills:
                 slug = skill_entry["slug"]
                 files = skill_entry.get("files", [])
-                content_by_path = {}
-                for file_info in files:
-                    content_by_path[file_info["path"]] = package.read(
-                        f"skills/{slug}/{file_info['path']}"
-                    ).decode("utf-8")
+                content_by_path = skill_entry["content_by_path"]
                 skill = _restore_or_create_skill(
                     slug=slug,
                     title=skill_entry.get("title", slug.replace("-", " ").title()),

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.core.exceptions import ValidationError
@@ -73,11 +73,14 @@ def normalize_package_path(path: Path) -> str:
 def validate_package_relative_path(relative_path: str) -> str:
     normalized = relative_path.replace("\\", "/")
     path = PurePosixPath(normalized)
+    windows_path = PureWindowsPath(relative_path)
     if (
         not normalized
         or normalized == "."
         or path.is_absolute()
         or Path(relative_path).is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
         or any(part in {"", ".", ".."} for part in path.parts)
     ):
         raise ValueError(f"Unsafe package path: {relative_path}")

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -12,6 +12,7 @@ from apps.skills.models import AgentSkill, AgentSkillFile
 
 PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
 SKILL_MARKDOWN = "SKILL.md"
+EMPTY_CONTENT_SHA256 = hashlib.sha256(b"").hexdigest()
 
 BLOCKED_STATE_FILENAMES = {
     "pending-approval-alerts.lock.json",
@@ -81,11 +82,13 @@ def validate_package_relative_path(relative_path: str) -> str:
     return path.as_posix()
 
 
-def classify_codex_skill_file(
-    relative_path: str,
-    content: str | None,
-) -> SkillFileClassification:
-    parts = [part.lower() for part in relative_path.replace("\\", "/").split("/")]
+def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
+    normalized = relative_path.replace("\\", "/")
+    return normalized, [part.lower() for part in normalized.split("/")]
+
+
+def classify_codex_skill_path(relative_path: str) -> SkillFileClassification | None:
+    _, parts = _normalized_parts(relative_path)
     filename = parts[-1]
     suffix = Path(filename).suffix.lower()
 
@@ -125,6 +128,17 @@ def classify_codex_skill_file(
             False,
             "runtime artifact file is not portable",
         )
+    return None
+
+
+def classify_codex_skill_file(
+    relative_path: str,
+    content: str | None,
+) -> SkillFileClassification:
+    normalized, parts = _normalized_parts(relative_path)
+    path_classification = classify_codex_skill_path(relative_path)
+    if path_classification is not None:
+        return path_classification
     if content is None:
         return SkillFileClassification(
             AgentSkillFile.Portability.DEVICE_SCOPED,
@@ -137,7 +151,7 @@ def classify_codex_skill_file(
             False,
             "operator-local paths must be parameterized before export",
         )
-    if relative_path == SKILL_MARKDOWN or parts[0] in PORTABLE_ROOTS:
+    if normalized == SKILL_MARKDOWN or parts[0] in PORTABLE_ROOTS:
         return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
     return SkillFileClassification(
         AgentSkillFile.Portability.DEVICE_SCOPED,
@@ -156,19 +170,37 @@ def _read_skill_file(path: Path) -> tuple[bytes, str | None]:
 
 def _scan_file(skill_dir: Path, path: Path) -> tuple[SkillFileScan, str]:
     relative_path = normalize_package_path(path.relative_to(skill_dir))
+    path_classification = classify_codex_skill_path(relative_path)
+    if path_classification is not None:
+        return (
+            SkillFileScan(
+                relative_path=relative_path,
+                portability=path_classification.portability,
+                included_by_default=path_classification.included_by_default,
+                exclusion_reason=path_classification.exclusion_reason,
+                size_bytes=0,
+                content_sha256=EMPTY_CONTENT_SHA256,
+            ),
+            "",
+        )
+
     content_bytes, text = _read_skill_file(path)
     classification = classify_codex_skill_file(relative_path, text)
-    digest = hashlib.sha256(content_bytes).hexdigest()
+    stored_text = (
+        text if classification.included_by_default and text is not None else ""
+    )
+    stored_bytes = stored_text.encode("utf-8")
+    digest = hashlib.sha256(stored_bytes).hexdigest()
     return (
         SkillFileScan(
             relative_path=relative_path,
             portability=classification.portability,
             included_by_default=classification.included_by_default,
             exclusion_reason=classification.exclusion_reason,
-            size_bytes=len(content_bytes),
+            size_bytes=len(stored_bytes),
             content_sha256=digest,
         ),
-        text or "",
+        stored_text,
     )
 
 

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -6,6 +6,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from zipfile import ZIP_DEFLATED, ZipFile
 
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_slug
 from django.db import transaction
 
 from apps.skills.models import AgentSkill, AgentSkillFile
@@ -82,6 +84,16 @@ def validate_package_relative_path(relative_path: str) -> str:
     return path.as_posix()
 
 
+def validate_package_skill_slug(slug: str) -> str:
+    if not isinstance(slug, str) or not slug:
+        raise ValueError(f"Unsafe skill slug: {slug}")
+    try:
+        validate_slug(slug)
+    except ValidationError as error:
+        raise ValueError(f"Unsafe skill slug: {slug}") from error
+    return slug
+
+
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
     normalized = relative_path.replace("\\", "/")
     return normalized, [part.lower() for part in normalized.split("/")]
@@ -145,13 +157,15 @@ def classify_codex_skill_file(
             False,
             "binary files are not exported by this prototype",
         )
+    if normalized == SKILL_MARKDOWN:
+        return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
     if any(marker in content for marker in OPERATOR_PATH_MARKERS):
         return SkillFileClassification(
             AgentSkillFile.Portability.OPERATOR_SCOPED,
             False,
             "operator-local paths must be parameterized before export",
         )
-    if normalized == SKILL_MARKDOWN or parts[0] in PORTABLE_ROOTS:
+    if parts[0] in PORTABLE_ROOTS:
         return SkillFileClassification(AgentSkillFile.Portability.PORTABLE, True)
     return SkillFileClassification(
         AgentSkillFile.Portability.DEVICE_SCOPED,
@@ -378,7 +392,7 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
 
         with transaction.atomic():
             for skill_entry in manifest.get("skills", []):
-                slug = skill_entry["slug"]
+                slug = validate_package_skill_slug(skill_entry["slug"])
                 files = skill_entry.get("files", [])
                 validated_files = [
                     {

--- a/apps/skills/services.py
+++ b/apps/skills/services.py
@@ -8,7 +8,6 @@ from django.db import transaction
 from apps.skills.models import AgentSkill
 from apps.nodes.models import NodeRole
 
-
 DEFAULT_SKILL_ROLE_MAP = {
     "cp-doctor": "Satellite",
     "arthexis-cleanup-step": "Control",
@@ -24,7 +23,9 @@ def sync_filesystem_to_db() -> int:
     changed = 0
     with transaction.atomic():
         keep_slugs = set(DEFAULT_SKILL_ROLE_MAP)
-        AgentSkill.objects.exclude(slug__in=keep_slugs).delete()
+        AgentSkill.objects.filter(is_seed_data=True).exclude(
+            slug__in=keep_slugs
+        ).delete()
         for slug, role_name in DEFAULT_SKILL_ROLE_MAP.items():
             path = skills_root / slug / "SKILL.md"
             if not path.exists():
@@ -35,6 +36,8 @@ def sync_filesystem_to_db() -> int:
                 slug=slug,
                 defaults={"title": title, "markdown": content},
             )
+            AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
+            skill.is_seed_data = True
             role = NodeRole.objects.filter(name=role_name).first()
             if role:
                 skill.node_roles.set([role])

--- a/apps/skills/services.py
+++ b/apps/skills/services.py
@@ -18,6 +18,25 @@ DEFAULT_SKILL_ROLE_MAP = {
 }
 
 
+def _restore_or_create_seed_skill(
+    *,
+    slug: str,
+    title: str,
+    markdown: str,
+) -> tuple[AgentSkill, bool]:
+    skill = AgentSkill.all_objects.filter(slug=slug).first()
+    if skill is None:
+        return (
+            AgentSkill.objects.create(slug=slug, title=title, markdown=markdown),
+            True,
+        )
+    skill.title = title
+    skill.markdown = markdown
+    skill.is_deleted = False
+    skill.save(update_fields=["title", "markdown", "is_deleted"])
+    return skill, False
+
+
 def sync_filesystem_to_db() -> int:
     skills_root = Path(settings.BASE_DIR) / "skills"
     changed = 0
@@ -32,9 +51,10 @@ def sync_filesystem_to_db() -> int:
                 continue
             content = path.read_text(encoding="utf-8")
             title = slug.replace("-", " ").title()
-            skill, created = AgentSkill.objects.update_or_create(
+            skill, created = _restore_or_create_seed_skill(
                 slug=slug,
-                defaults={"title": title, "markdown": content},
+                title=title,
+                markdown=content,
             )
             AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
             skill.is_seed_data = True

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -303,6 +303,58 @@ def test_import_rejects_duplicate_manifest_paths(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_rejects_entries_missing_skill_markdown(tmp_path):
+    package_path = tmp_path / "missing-skill-markdown.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "missing-skill-markdown",
+                "title": "Missing Skill Markdown",
+                "files": [
+                    {"path": "references/rules.md", "included_by_default": True},
+                ],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr(
+            "skills/missing-skill-markdown/references/rules.md",
+            "portable rules",
+        )
+
+    with pytest.raises(ValueError, match="Missing required SKILL.md"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_import_rejects_duplicate_skill_slugs(tmp_path):
+    package_path = tmp_path / "duplicate-slug.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "duplicate-slug",
+                "title": "Duplicate Slug",
+                "files": [{"path": "SKILL.md", "included_by_default": True}],
+            },
+            {
+                "slug": "duplicate-slug",
+                "title": "Duplicate Slug Again",
+                "files": [{"path": "SKILL.md", "included_by_default": True}],
+            },
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/duplicate-slug/SKILL.md", "demo")
+
+    with pytest.raises(ValueError, match="Duplicate package skill slug"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
 def test_import_rejects_unsafe_skill_slugs(tmp_path):
     package_path = tmp_path / "unsafe-slug.zip"
     manifest = {
@@ -333,17 +385,23 @@ def test_import_redacts_excluded_manifest_entries(tmp_path):
                 "title": "Excluded",
                 "files": [
                     {
+                        "path": "SKILL.md",
+                        "portability": AgentSkillFile.Portability.PORTABLE,
+                        "included_by_default": True,
+                    },
+                    {
                         "path": "credentials/token.txt",
                         "portability": AgentSkillFile.Portability.SECRET,
                         "included_by_default": False,
                         "exclusion_reason": "secret payload",
-                    }
+                    },
                 ],
             }
         ],
     }
     with ZipFile(package_path, "w") as package:
         package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/excluded/SKILL.md", "---\nname: excluded\n---\n")
         package.writestr("skills/excluded/credentials/token.txt", "secret")
 
     import_codex_skill_package(package_path, dry_run=False)

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from zipfile import ZipFile
 
 import pytest
 from django.test import override_settings
 
 from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import (
+    PACKAGE_FORMAT,
     classify_codex_skill_file,
     export_codex_skill_package,
     import_codex_skill_package,
@@ -39,6 +42,10 @@ def test_classifies_portable_state_secret_and_operator_scoped_files():
     )
     assert operator_scoped.portability == AgentSkillFile.Portability.OPERATOR_SCOPED
     assert operator_scoped.included_by_default is False
+
+    unknown = classify_codex_skill_file("local-state.txt", "unknown root")
+    assert unknown.portability == AgentSkillFile.Portability.DEVICE_SCOPED
+    assert unknown.included_by_default is False
 
 
 @pytest.mark.django_db
@@ -144,6 +151,62 @@ def test_import_restores_soft_deleted_skill_slug(tmp_path):
     restored = AgentSkill.objects.get(slug="security-codes")
     assert restored.pk == skill.pk
     assert restored.is_deleted is False
+
+
+@pytest.mark.django_db
+def test_import_rejects_unsafe_manifest_paths(tmp_path):
+    package_path = tmp_path / "unsafe.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "unsafe",
+                "title": "Unsafe",
+                "files": [{"path": "../secret.txt", "included_by_default": True}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/unsafe/../secret.txt", "secret")
+
+    with pytest.raises(ValueError, match="Unsafe package path"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_import_redacts_excluded_manifest_entries(tmp_path):
+    package_path = tmp_path / "excluded.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "excluded",
+                "title": "Excluded",
+                "files": [
+                    {
+                        "path": "credentials/token.txt",
+                        "portability": AgentSkillFile.Portability.SECRET,
+                        "included_by_default": False,
+                        "exclusion_reason": "secret payload",
+                    }
+                ],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/excluded/credentials/token.txt", "secret")
+
+    import_codex_skill_package(package_path, dry_run=False)
+
+    file_entry = AgentSkillFile.objects.get(
+        skill__slug="excluded",
+        relative_path="credentials/token.txt",
+    )
+    assert file_entry.content == ""
+    assert file_entry.size_bytes == 0
+    assert file_entry.exclusion_reason == "secret payload"
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 import pytest
 from django.test import override_settings
 
+from apps.nodes.models import NodeRole
 from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import (
     PACKAGE_FORMAT,
@@ -181,11 +182,13 @@ def test_export_synthesizes_legacy_skill_markdown_file(tmp_path):
 
 @pytest.mark.django_db
 def test_scan_restores_soft_deleted_skill_slug(tmp_path):
+    role = NodeRole.objects.create(name="Old Role", acronym="OLD")
     skill = AgentSkill.objects.create(
         slug="operator-manual",
         title="Deleted",
         markdown="old",
     )
+    skill.node_roles.add(role)
     AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
     skill.refresh_from_db()
     skill.delete()
@@ -199,6 +202,7 @@ def test_scan_restores_soft_deleted_skill_slug(tmp_path):
     assert restored.pk == skill.pk
     assert restored.is_deleted is False
     assert restored.is_seed_data is False
+    assert not restored.node_roles.exists()
     assert (
         restored.markdown.replace("\r\n", "\n") == "---\nname: operator-manual\n---\n"
     )
@@ -354,6 +358,27 @@ def test_import_rejects_entries_missing_skill_markdown(tmp_path):
         )
 
     with pytest.raises(ValueError, match="Missing required SKILL.md"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_import_rejects_excluded_skill_markdown(tmp_path):
+    package_path = tmp_path / "excluded-skill-markdown.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "excluded-skill-markdown",
+                "title": "Excluded Skill Markdown",
+                "files": [{"path": "SKILL.md", "included_by_default": False}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/excluded-skill-markdown/SKILL.md", "demo")
+
+    with pytest.raises(ValueError, match="SKILL.md must be included"):
         import_codex_skill_package(package_path, dry_run=False)
 
 

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -271,6 +271,31 @@ def test_import_dry_run_validates_manifest_paths(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_rejects_windows_absolute_manifest_paths(tmp_path):
+    package_path = tmp_path / "windows-absolute.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "windows-absolute",
+                "title": "Windows Absolute",
+                "files": [
+                    {
+                        "path": "C:/Users/alice/secret.txt",
+                        "included_by_default": True,
+                    }
+                ],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="Unsafe package path"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
 def test_import_dry_run_rejects_missing_manifest_files(tmp_path):
     package_path = tmp_path / "missing-file.zip"
     manifest = {

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -70,6 +70,14 @@ def test_scan_dry_run_reports_without_writing(tmp_path):
     assert not AgentSkill.objects.filter(slug="operator-manual").exists()
 
 
+def test_scan_rejects_invalid_skill_directory_slug(tmp_path):
+    skill_dir = tmp_path / "Operator Manual"
+    _write(skill_dir / "SKILL.md", "---\nname: operator-manual\n---\n")
+
+    with pytest.raises(ValueError, match="Unsafe skill slug"):
+        scan_codex_skill_directory(skill_dir, dry_run=True)
+
+
 @pytest.mark.django_db
 def test_scan_redacts_path_blocked_files_without_reading(tmp_path, monkeypatch):
     skill_dir = tmp_path / "operator-manual"
@@ -207,6 +215,46 @@ def test_import_rejects_unsafe_manifest_paths(tmp_path):
 
     with pytest.raises(ValueError, match="Unsafe package path"):
         import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_import_dry_run_validates_manifest_paths(tmp_path):
+    package_path = tmp_path / "unsafe-dry-run.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "unsafe",
+                "title": "Unsafe",
+                "files": [{"path": "../secret.txt", "included_by_default": True}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="Unsafe package path"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
+def test_import_dry_run_rejects_missing_manifest_files(tmp_path):
+    package_path = tmp_path / "missing-file.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "missing-file",
+                "title": "Missing File",
+                "files": [{"path": "SKILL.md", "included_by_default": True}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="Missing package file"):
+        import_codex_skill_package(package_path, dry_run=True)
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -82,7 +82,7 @@ def test_export_import_round_trip_includes_only_portable_files(tmp_path):
     _write(skill_dir / "credentials" / "odoo.json", "{}")
     scan_codex_skill_directory(skill_dir, dry_run=False)
 
-    package_path = tmp_path / "portable-skills.zip"
+    package_path = tmp_path / "nested" / "portable-skills.zip"
     manifest = export_codex_skill_package(package_path, skill_slugs=["quotation"])
     AgentSkill.objects.filter(slug="quotation").delete()
 
@@ -100,6 +100,50 @@ def test_export_import_round_trip_includes_only_portable_files(tmp_path):
     assert not skill.package_files.filter(
         relative_path="credentials/odoo.json"
     ).exists()
+
+
+@pytest.mark.django_db
+def test_scan_restores_soft_deleted_skill_slug(tmp_path):
+    skill = AgentSkill.objects.create(
+        slug="operator-manual",
+        title="Deleted",
+        markdown="old",
+    )
+    AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
+    skill.refresh_from_db()
+    skill.delete()
+
+    skill_dir = tmp_path / "operator-manual"
+    _write(skill_dir / "SKILL.md", "---\nname: operator-manual\n---\n")
+
+    scan_codex_skill_directory(skill_dir, dry_run=False)
+
+    restored = AgentSkill.objects.get(slug="operator-manual")
+    assert restored.pk == skill.pk
+    assert restored.is_deleted is False
+    assert (
+        restored.markdown.replace("\r\n", "\n") == "---\nname: operator-manual\n---\n"
+    )
+
+
+@pytest.mark.django_db
+def test_import_restores_soft_deleted_skill_slug(tmp_path):
+    skill_dir = tmp_path / "security-codes"
+    _write(skill_dir / "SKILL.md", "---\nname: security-codes\n---\n")
+    scan_codex_skill_directory(skill_dir, dry_run=False)
+    package_path = tmp_path / "portable-skills.zip"
+    export_codex_skill_package(package_path, skill_slugs=["security-codes"])
+
+    skill = AgentSkill.objects.get(slug="security-codes")
+    AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
+    skill.refresh_from_db()
+    skill.delete()
+
+    import_codex_skill_package(package_path, dry_run=False)
+
+    restored = AgentSkill.objects.get(slug="security-codes")
+    assert restored.pk == skill.pk
+    assert restored.is_deleted is False
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -43,6 +43,13 @@ def test_classifies_portable_state_secret_and_operator_scoped_files():
     assert operator_scoped.portability == AgentSkillFile.Portability.OPERATOR_SCOPED
     assert operator_scoped.included_by_default is False
 
+    skill_markdown = classify_codex_skill_file(
+        "SKILL.md",
+        "Example path: C:\\Users\\arthexis\\.codex\\skills\\demo",
+    )
+    assert skill_markdown.portability == AgentSkillFile.Portability.PORTABLE
+    assert skill_markdown.included_by_default is True
+
     unknown = classify_codex_skill_file("local-state.txt", "unknown root")
     assert unknown.portability == AgentSkillFile.Portability.DEVICE_SCOPED
     assert unknown.included_by_default is False
@@ -199,6 +206,26 @@ def test_import_rejects_unsafe_manifest_paths(tmp_path):
         package.writestr("skills/unsafe/../secret.txt", "secret")
 
     with pytest.raises(ValueError, match="Unsafe package path"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_import_rejects_unsafe_skill_slugs(tmp_path):
+    package_path = tmp_path / "unsafe-slug.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "../ops",
+                "title": "Unsafe Slug",
+                "files": [],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="Unsafe skill slug"):
         import_codex_skill_package(package_path, dry_run=False)
 
 

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -258,6 +258,51 @@ def test_import_dry_run_rejects_missing_manifest_files(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_dry_run_rejects_non_utf8_package_files(tmp_path):
+    package_path = tmp_path / "invalid-encoding.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "invalid-encoding",
+                "title": "Invalid Encoding",
+                "files": [{"path": "SKILL.md", "included_by_default": True}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/invalid-encoding/SKILL.md", b"\xff")
+
+    with pytest.raises(ValueError, match="Invalid UTF-8 package file"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
+def test_import_rejects_duplicate_manifest_paths(tmp_path):
+    package_path = tmp_path / "duplicate-path.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "duplicate-path",
+                "title": "Duplicate Path",
+                "files": [
+                    {"path": "SKILL.md", "included_by_default": True},
+                    {"path": "SKILL.md", "included_by_default": True},
+                ],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/duplicate-path/SKILL.md", "demo")
+
+    with pytest.raises(ValueError, match="Duplicate package file path"):
+        import_codex_skill_package(package_path, dry_run=False)
+
+
+@pytest.mark.django_db
 def test_import_rejects_unsafe_skill_slugs(tmp_path):
     package_path = tmp_path / "unsafe-slug.zip"
     manifest = {

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -64,6 +64,34 @@ def test_scan_dry_run_reports_without_writing(tmp_path):
 
 
 @pytest.mark.django_db
+def test_scan_redacts_path_blocked_files_without_reading(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "operator-manual"
+    blocked_file = skill_dir / "logs" / "debug.log"
+    _write(skill_dir / "SKILL.md", "---\nname: operator-manual\n---\n")
+    _write(blocked_file, "blocked runtime log")
+
+    original_read_bytes = Path.read_bytes
+
+    def read_bytes(path: Path) -> bytes:
+        if path == blocked_file:
+            raise AssertionError("path-blocked files should not be read")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+
+    summary = scan_codex_skill_directory(skill_dir, dry_run=True)
+
+    blocked_entry = next(
+        entry
+        for entry in summary["files"]
+        if entry["relative_path"] == "logs/debug.log"
+    )
+    assert blocked_entry["portability"] == AgentSkillFile.Portability.CACHE
+    assert blocked_entry["included_by_default"] is False
+    assert blocked_entry["size_bytes"] == 0
+
+
+@pytest.mark.django_db
 def test_scan_preserves_custom_skills_and_redacts_excluded_content(tmp_path):
     AgentSkill.objects.create(slug="custom-existing", title="Custom", markdown="keep")
     skill_dir = tmp_path / "security-codes"
@@ -232,3 +260,25 @@ def test_seed_skill_sync_preserves_custom_skills(tmp_path):
     assert not AgentSkill.objects.filter(pk=stale.pk).exists()
     synced = AgentSkill.objects.get(slug="cp-doctor")
     assert synced.is_seed_data is True
+
+
+@pytest.mark.django_db
+def test_seed_skill_sync_restores_soft_deleted_default_skill(tmp_path):
+    skills_root = tmp_path / "skills"
+    _write(skills_root / "cp-doctor" / "SKILL.md", "restored diagnostic skill")
+    skill = AgentSkill.objects.create(
+        slug="cp-doctor",
+        title="Deleted",
+        markdown="old",
+    )
+    AgentSkill.all_objects.filter(pk=skill.pk).update(is_seed_data=True)
+    skill.refresh_from_db()
+    skill.delete()
+
+    with override_settings(BASE_DIR=tmp_path):
+        sync_filesystem_to_db()
+
+    restored = AgentSkill.objects.get(slug="cp-doctor")
+    assert restored.pk == skill.pk
+    assert restored.markdown == "restored diagnostic skill"
+    assert restored.is_seed_data is True

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from django.test import override_settings
+
+from apps.skills.models import AgentSkill, AgentSkillFile
+from apps.skills.package_services import (
+    classify_codex_skill_file,
+    export_codex_skill_package,
+    import_codex_skill_package,
+    scan_codex_skill_directory,
+)
+from apps.skills.services import sync_filesystem_to_db
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_classifies_portable_state_secret_and_operator_scoped_files():
+    assert classify_codex_skill_file(
+        "SKILL.md", "---\nname: demo\n"
+    ).included_by_default
+
+    state = classify_codex_skill_file("workgroup.md", "local state")
+    assert state.portability == AgentSkillFile.Portability.STATE
+    assert state.included_by_default is False
+
+    secret = classify_codex_skill_file("credentials/smtp.json", "{}")
+    assert secret.portability == AgentSkillFile.Portability.SECRET
+    assert secret.included_by_default is False
+
+    operator_scoped = classify_codex_skill_file(
+        "references/glossary.md",
+        "Use C:\\Users\\arthexis\\.codex\\skills locally.",
+    )
+    assert operator_scoped.portability == AgentSkillFile.Portability.OPERATOR_SCOPED
+    assert operator_scoped.included_by_default is False
+
+
+@pytest.mark.django_db
+def test_scan_dry_run_reports_without_writing(tmp_path):
+    skill_dir = tmp_path / "operator-manual"
+    _write(skill_dir / "SKILL.md", "---\nname: operator-manual\n---\n")
+    _write(skill_dir / "references" / "glossary.md", "portable reference")
+    _write(skill_dir / "credentials" / "smtp.json", "{}")
+
+    summary = scan_codex_skill_directory(skill_dir, dry_run=True)
+
+    assert summary["slug"] == "operator-manual"
+    assert summary["included"] == 2
+    assert summary["excluded"] == 1
+    assert not AgentSkill.objects.filter(slug="operator-manual").exists()
+
+
+@pytest.mark.django_db
+def test_scan_preserves_custom_skills_and_redacts_excluded_content(tmp_path):
+    AgentSkill.objects.create(slug="custom-existing", title="Custom", markdown="keep")
+    skill_dir = tmp_path / "security-codes"
+    _write(skill_dir / "SKILL.md", "---\nname: security-codes\n---\n")
+    _write(skill_dir / "scripts" / "New-Code.ps1", "Write-Output ok")
+    _write(skill_dir / "security-codes.json", '{"hash": "local"}')
+
+    scan_codex_skill_directory(skill_dir, dry_run=False)
+
+    assert AgentSkill.objects.filter(slug="custom-existing").exists()
+    skill = AgentSkill.objects.get(slug="security-codes")
+    assert skill.package_files.count() == 3
+    state_file = skill.package_files.get(relative_path="security-codes.json")
+    assert state_file.included_by_default is False
+    assert state_file.content == ""
+
+
+@pytest.mark.django_db
+def test_export_import_round_trip_includes_only_portable_files(tmp_path):
+    skill_dir = tmp_path / "quotation"
+    _write(skill_dir / "SKILL.md", "---\nname: quotation\n---\n")
+    _write(skill_dir / "references" / "quotation-rules.md", "portable rules")
+    _write(skill_dir / "credentials" / "odoo.json", "{}")
+    scan_codex_skill_directory(skill_dir, dry_run=False)
+
+    package_path = tmp_path / "portable-skills.zip"
+    manifest = export_codex_skill_package(package_path, skill_slugs=["quotation"])
+    AgentSkill.objects.filter(slug="quotation").delete()
+
+    assert manifest["skills"][0]["slug"] == "quotation"
+    assert {file["path"] for file in manifest["skills"][0]["files"]} == {
+        "SKILL.md",
+        "references/quotation-rules.md",
+    }
+
+    summary = import_codex_skill_package(package_path, dry_run=False)
+
+    assert summary["skills"] == [{"slug": "quotation", "files": 2}]
+    skill = AgentSkill.objects.get(slug="quotation")
+    assert skill.package_files.count() == 2
+    assert not skill.package_files.filter(
+        relative_path="credentials/odoo.json"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_seed_skill_sync_preserves_custom_skills(tmp_path):
+    skills_root = tmp_path / "skills"
+    _write(skills_root / "cp-doctor" / "SKILL.md", "diagnostic skill")
+    custom = AgentSkill.objects.create(
+        slug="operator-manual",
+        title="Operator Manual",
+        markdown="custom local skill",
+    )
+    stale = AgentSkill.objects.create(
+        slug="stale-seed",
+        title="Stale Seed",
+        markdown="remove",
+    )
+    AgentSkill.all_objects.filter(pk=stale.pk).update(is_seed_data=True)
+
+    with override_settings(BASE_DIR=tmp_path):
+        sync_filesystem_to_db()
+
+    assert AgentSkill.objects.filter(pk=custom.pk).exists()
+    assert not AgentSkill.objects.filter(pk=stale.pk).exists()
+    synced = AgentSkill.objects.get(slug="cp-doctor")
+    assert synced.is_seed_data is True

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from zipfile import ZipFile
@@ -153,6 +154,32 @@ def test_export_import_round_trip_includes_only_portable_files(tmp_path):
 
 
 @pytest.mark.django_db
+def test_export_synthesizes_legacy_skill_markdown_file(tmp_path):
+    AgentSkill.objects.create(
+        slug="legacy-skill",
+        title="Legacy Skill",
+        markdown="legacy markdown",
+    )
+    package_path = tmp_path / "legacy.zip"
+
+    manifest = export_codex_skill_package(package_path, skill_slugs=["legacy-skill"])
+
+    assert manifest["skills"][0]["files"] == [
+        {
+            "path": "SKILL.md",
+            "portability": AgentSkillFile.Portability.PORTABLE,
+            "included_by_default": True,
+            "exclusion_reason": "",
+            "content_sha256": hashlib.sha256(b"legacy markdown").hexdigest(),
+        }
+    ]
+    with ZipFile(package_path) as package:
+        assert package.read("skills/legacy-skill/SKILL.md").decode("utf-8") == (
+            "legacy markdown"
+        )
+
+
+@pytest.mark.django_db
 def test_scan_restores_soft_deleted_skill_slug(tmp_path):
     skill = AgentSkill.objects.create(
         slug="operator-manual",
@@ -171,6 +198,7 @@ def test_scan_restores_soft_deleted_skill_slug(tmp_path):
     restored = AgentSkill.objects.get(slug="operator-manual")
     assert restored.pk == skill.pk
     assert restored.is_deleted is False
+    assert restored.is_seed_data is False
     assert (
         restored.markdown.replace("\r\n", "\n") == "---\nname: operator-manual\n---\n"
     )
@@ -194,6 +222,7 @@ def test_import_restores_soft_deleted_skill_slug(tmp_path):
     restored = AgentSkill.objects.get(slug="security-codes")
     assert restored.pk == skill.pk
     assert restored.is_deleted is False
+    assert restored.is_seed_data is False
 
 
 @pytest.mark.django_db
@@ -413,6 +442,46 @@ def test_import_redacts_excluded_manifest_entries(tmp_path):
     assert file_entry.content == ""
     assert file_entry.size_bytes == 0
     assert file_entry.exclusion_reason == "secret payload"
+
+
+@pytest.mark.django_db
+def test_import_reclassifies_manifest_portability_flags(tmp_path):
+    package_path = tmp_path / "misclassified.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "misclassified",
+                "title": "Misclassified",
+                "files": [
+                    {
+                        "path": "SKILL.md",
+                        "portability": AgentSkillFile.Portability.PORTABLE,
+                        "included_by_default": True,
+                    },
+                    {
+                        "path": "credentials/token.txt",
+                        "portability": AgentSkillFile.Portability.PORTABLE,
+                        "included_by_default": True,
+                    },
+                ],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/misclassified/SKILL.md", "---\nname: demo\n---\n")
+        package.writestr("skills/misclassified/credentials/token.txt", "secret")
+
+    import_codex_skill_package(package_path, dry_run=False)
+
+    file_entry = AgentSkillFile.objects.get(
+        skill__slug="misclassified",
+        relative_path="credentials/token.txt",
+    )
+    assert file_entry.content == ""
+    assert file_entry.portability == AgentSkillFile.Portability.SECRET
+    assert file_entry.included_by_default is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #7519.

## Summary
- adds `AgentSkillFile` records for multi-file Codex skill packages
- adds `codex_skill_packages` scan/export/import management command prototype
- classifies package files as portable, operator-scoped, device-scoped, secret, cache, state, or generated reference
- preserves custom skills during the existing repo seed skill sync by deleting only stale seed-data rows
- adds focused package scan/export/import and preservation tests

## Validation
- `.\.venv\Scripts\python.exe manage.py test run -- apps\skills`
- `.\.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.\.venv\Scripts\python.exe scripts\check_import_resolution.py apps\skills`
- `.\.venv\Scripts\python.exe manage.py codex_skill_packages scan --source C:\Users\arthexis\.codex\skills --dry-run`

## Prototype notes
The local Codex dry-run correctly excludes operator-local paths, generated MTG reference archives, caches, and state files rather than importing them as portable package content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds prototype support for portable, multi-file Codex skill packages, including DB model, admin UI, package services (scan/export/import), a management command, seed-sync preservation, and focused tests.

Database & Admin
- New AgentSkillFile model capturing per-skill file metadata:
  - Fields: skill FK, relative_path, content, content_sha256, size_bytes, portability enum (portable, operator_scoped, device_scoped, secret, cache, state, generated_reference), included_by_default, exclusion_reason
  - Unique constraint per (skill, relative_path), ordering by skill slug then path
- Admin:
  - AgentSkillFileInline added to AgentSkillAdmin
  - AgentSkillFileAdmin registered with list/search/filter configured (portability, included_by_default, skill__slug, relative_path, exclusion_reason, content)

Packaging pipeline (apps/skills/package_services.py)
- Package format: arthexis.codex_skill_package.v1 with SKILL.md entry and manifest.json
- Classification:
  - Path-only classification for blocked files (state, cache, secret, generated_reference) to allow redaction without reading content
  - Content-aware classification for operator-scoped paths, portable roots (agents, assets, references, scripts, templates), and device-scoped fallback
  - Uses EMPTY_CONTENT_SHA256 for redacted entries and zero stored size
- Scanning:
  - scan_codex_skill_directory and scan_codex_skills_root produce per-skill summaries; dry-run reports without persisting
  - Full scan persists AgentSkill and AgentSkillFile rows transactionally; skips symlinked files
  - Soft-deleted AgentSkill rows matching scanned slugs are restored rather than creating slug collisions
- Export:
  - export_codex_skill_package writes ZIP with skills/<slug>/<relative_path> entries and manifest.json
  - Creates parent directories before ZIP creation; portable-only export excludes default-excluded files unless --include-excluded used
  - Preserves exclusion reasons in manifest so round-trip retains context
- Import:
  - import_codex_skill_package validates manifest/package format, safe relative paths, safe slugs, duplicate paths, SKILL.md presence, and member existence; dry-run shares same validations
  - Rejects unsafe slugs/paths and non-UTF-8 payloads during dry-run validation
  - Transactionally upserts skills and bulk-upserts package files, redacting excluded entries (empty content, zero size, empty-content hash) and removing stale package rows not in manifest
  - Validates and rejects unsafe/duplicate manifest entries prior to DB writes

Seed sync behavior (apps/skills/services.py)
- sync_filesystem_to_db now:
  - Only deletes AgentSkill rows marked is_seed_data=True and not in DEFAULT_SKILL_ROLE_MAP (preserves custom skills)
  - Restores matching soft-deleted seed skills and marks persisted rows as seed data after creation/restoration

Management command
- New command codex_skill_packages with actions: scan, export, import
  - Options: --source (scan), --output (export), --package (import), --slug (multiple), --dry-run, --include-excluded
  - Outputs sorted, pretty-printed JSON summaries

Tests (apps/skills/tests/test_package_services.py)
- Extensive tests added covering:
  - classify_codex_skill_file behavior for portable, state, secret, cache, operator-scoped, and device-scoped files
  - scan dry-run (no DB writes) and dry-run validations rejecting unsafe slugs
  - redaction of blocked files via path-only classification without reading file bytes
  - persistence mode: preserves existing custom skills, restores soft-deleted seed skills, and redacts excluded content (empty content stored)
  - export/import round-trip: only portable files exported/imported, nested export paths handled, manifest-driven import and upsert behavior
  - import validation tests: unsafe paths/slugs, missing archive members, non-UTF8 payloads, duplicate manifest paths, missing SKILL.md, and preservation of exclusion_reason for redacted entries

Other notable implementation details
- Bulk upserts for package file records used during import
- Skips symlinked files during scans
- Unknown/unrecognized files default to device-scoped and are excluded by default
- Preserves exclusion reasons in manifest to aid round-trip context

Validation & status
- Focused tests exercise classification, scanning, export/import, and seed-sync preservation
- Prototype intended to satisfy Issue #7519 acceptance criteria: multi-file package model, scan/dry-run reporting, safe export/import with redaction of secrets/state/cache and operator-local paths, and preservation of custom skills

Files touched (key)
- Added/modified: apps/skills/models.py, migrations/0003_agentskillfile.py, apps/skills/admin.py, apps/skills/package_services.py, apps/skills/management/commands/codex_skill_packages.py, apps/skills/services.py, apps/skills/tests/test_package_services.py
<!-- end of auto-generated comment: release notes by coderabbit.ai -->