### PR TITLE
Add tiered auto-upgrade channels

### DIFF
--- a/apps/core/auto_upgrade.py
+++ b/apps/core/auto_upgrade.py
@@ -10,6 +10,10 @@ from pathlib import Path
 from django.conf import settings
 from django.utils import timezone
 
+from apps.core.versioning import (
+    AUTO_UPGRADE_DAY_MINUTES,
+    AUTO_UPGRADE_WEEK_MINUTES,
+)
 
 AUTO_UPGRADE_LOG_NAME = "auto-upgrade.log"
 AUTO_UPGRADE_TASK_NAME = "auto-upgrade-check"
@@ -21,15 +25,24 @@ AUTO_UPGRADE_FAST_LANE_INTERVAL_MINUTES = 60
 DEFAULT_AUTO_UPGRADE_MODE = "stable"
 AUTO_UPGRADE_CADENCE_HOUR = 4
 AUTO_UPGRADE_INTERVAL_MINUTES = {
-    "latest": 1440,
-    "unstable": 15,
-    "stable": 10080,
-    "regular": 10080,
-    "normal": 10080,
+    "latest": AUTO_UPGRADE_DAY_MINUTES,
+    "unstable": AUTO_UPGRADE_DAY_MINUTES,
+    "stable": AUTO_UPGRADE_WEEK_MINUTES,
+    "lts": AUTO_UPGRADE_WEEK_MINUTES,
+    "regular": AUTO_UPGRADE_DAY_MINUTES,
+    "normal": AUTO_UPGRADE_DAY_MINUTES,
+    "version": AUTO_UPGRADE_DAY_MINUTES,
 }
 AUTO_UPGRADE_FALLBACK_INTERVAL = AUTO_UPGRADE_INTERVAL_MINUTES[DEFAULT_AUTO_UPGRADE_MODE]
 AUTO_UPGRADE_CRONTAB_SCHEDULES = {
     "latest": {
+        "minute": "0",
+        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
+        "day_of_week": "*",
+        "day_of_month": "*",
+        "month_of_year": "*",
+    },
+    "unstable": {
         "minute": "0",
         "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
         "day_of_week": "*",
@@ -43,17 +56,31 @@ AUTO_UPGRADE_CRONTAB_SCHEDULES = {
         "day_of_month": "*",
         "month_of_year": "*",
     },
-    "regular": {
+    "lts": {
         "minute": "0",
         "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
         "day_of_week": "4",
         "day_of_month": "*",
         "month_of_year": "*",
     },
+    "regular": {
+        "minute": "0",
+        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
+        "day_of_week": "*",
+        "day_of_month": "*",
+        "month_of_year": "*",
+    },
     "normal": {
         "minute": "0",
         "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "4",
+        "day_of_week": "*",
+        "day_of_month": "*",
+        "month_of_year": "*",
+    },
+    "version": {
+        "minute": "0",
+        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
+        "day_of_week": "*",
         "day_of_month": "*",
         "month_of_year": "*",
     },
@@ -268,8 +295,9 @@ def _resolve_policy_interval_minutes() -> int:
     """
 
     try:  # pragma: no cover - optional dependency failures
-        from apps.nodes.models import Node, UpgradePolicy
         from django.db import DatabaseError
+
+        from apps.nodes.models import Node, UpgradePolicy
     except Exception:
         return AUTO_UPGRADE_INTERVAL_MINUTES.get("unstable", AUTO_UPGRADE_FAST_LANE_INTERVAL_MINUTES)
 
@@ -359,11 +387,11 @@ def ensure_auto_upgrade_periodic_task(
     del sender, kwargs, base_dir  # Unused when invoked as a Django signal handler.
 
     try:  # pragma: no cover - optional dependency failures
+        from django.db.utils import OperationalError, ProgrammingError
         from django_celery_beat.models import (
             IntervalSchedule,
             PeriodicTask,
         )
-        from django.db.utils import OperationalError, ProgrammingError
     except Exception:
         return
 
@@ -380,7 +408,7 @@ def ensure_auto_upgrade_periodic_task(
                 interval_minutes = parsed_interval
 
     try:
-        description = "Upgrade policy checks run every %s minutes." % interval_minutes
+        description = f"Upgrade policy checks run every {interval_minutes} minutes."
         schedule = _get_or_create_interval_schedule(
             every=interval_minutes,
             period=IntervalSchedule.MINUTES,

--- a/apps/core/auto_upgrade.py
+++ b/apps/core/auto_upgrade.py
@@ -13,6 +13,10 @@ from django.utils import timezone
 from apps.core.versioning import (
     AUTO_UPGRADE_DAY_MINUTES,
     AUTO_UPGRADE_WEEK_MINUTES,
+    UPGRADE_CHANNEL_ALIASES,
+    UPGRADE_CHANNEL_REGULAR,
+    UPGRADE_CHANNEL_STABLE,
+    UPGRADE_CHANNEL_UNSTABLE,
 )
 
 AUTO_UPGRADE_LOG_NAME = "auto-upgrade.log"
@@ -24,66 +28,37 @@ AUTO_UPGRADE_FAST_LANE_INTERVAL_MINUTES = 60
 
 DEFAULT_AUTO_UPGRADE_MODE = "stable"
 AUTO_UPGRADE_CADENCE_HOUR = 4
+_CANONICAL_AUTO_UPGRADE_INTERVAL_MINUTES = {
+    UPGRADE_CHANNEL_UNSTABLE: AUTO_UPGRADE_DAY_MINUTES,
+    UPGRADE_CHANNEL_STABLE: AUTO_UPGRADE_WEEK_MINUTES,
+    UPGRADE_CHANNEL_REGULAR: AUTO_UPGRADE_DAY_MINUTES,
+}
 AUTO_UPGRADE_INTERVAL_MINUTES = {
-    "latest": AUTO_UPGRADE_DAY_MINUTES,
-    "unstable": AUTO_UPGRADE_DAY_MINUTES,
-    "stable": AUTO_UPGRADE_WEEK_MINUTES,
-    "lts": AUTO_UPGRADE_WEEK_MINUTES,
-    "regular": AUTO_UPGRADE_DAY_MINUTES,
-    "normal": AUTO_UPGRADE_DAY_MINUTES,
-    "version": AUTO_UPGRADE_DAY_MINUTES,
+    alias: _CANONICAL_AUTO_UPGRADE_INTERVAL_MINUTES[channel]
+    for alias, channel in UPGRADE_CHANNEL_ALIASES.items()
+    if channel in _CANONICAL_AUTO_UPGRADE_INTERVAL_MINUTES
 }
 AUTO_UPGRADE_FALLBACK_INTERVAL = AUTO_UPGRADE_INTERVAL_MINUTES[DEFAULT_AUTO_UPGRADE_MODE]
+_DAILY_AUTO_UPGRADE_CRONTAB = {
+    "minute": "0",
+    "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
+    "day_of_week": "*",
+    "day_of_month": "*",
+    "month_of_year": "*",
+}
+_WEEKLY_AUTO_UPGRADE_CRONTAB = {
+    **_DAILY_AUTO_UPGRADE_CRONTAB,
+    "day_of_week": "4",
+}
+_CANONICAL_AUTO_UPGRADE_CRONTABS = {
+    UPGRADE_CHANNEL_UNSTABLE: _DAILY_AUTO_UPGRADE_CRONTAB,
+    UPGRADE_CHANNEL_STABLE: _WEEKLY_AUTO_UPGRADE_CRONTAB,
+    UPGRADE_CHANNEL_REGULAR: _DAILY_AUTO_UPGRADE_CRONTAB,
+}
 AUTO_UPGRADE_CRONTAB_SCHEDULES = {
-    "latest": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "*",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "unstable": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "*",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "stable": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "4",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "lts": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "4",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "regular": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "*",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "normal": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "*",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
-    "version": {
-        "minute": "0",
-        "hour": str(AUTO_UPGRADE_CADENCE_HOUR),
-        "day_of_week": "*",
-        "day_of_month": "*",
-        "month_of_year": "*",
-    },
+    alias: dict(_CANONICAL_AUTO_UPGRADE_CRONTABS[channel])
+    for alias, channel in UPGRADE_CHANNEL_ALIASES.items()
+    if channel in _CANONICAL_AUTO_UPGRADE_CRONTABS
 }
 
 

--- a/apps/core/system/upgrade.py
+++ b/apps/core/system/upgrade.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 
+import logging
+import subprocess
 from collections import deque
 from datetime import datetime, timedelta
-import logging
 from pathlib import Path
-import subprocess
 
 from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady, FieldError, ImproperlyConfigured
 from django.db import DatabaseError
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _, ngettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from apps.celery.utils import enqueue_task, is_celery_enabled
 from apps.core.auto_upgrade import (
     AUTO_UPGRADE_TASK_NAME,
     AUTO_UPGRADE_TASK_PATH,
-    auto_upgrade_failure_guide,
     auto_upgrade_base_dir,
+    auto_upgrade_failure_guide,
     auto_upgrade_log_file,
     ensure_auto_upgrade_periodic_task,
 )
@@ -26,10 +27,15 @@ from apps.core.tasks.auto_upgrade import (
     _read_auto_upgrade_failure_count,
     check_github_updates,
 )
+from apps.core.versioning import (
+    UPGRADE_CHANNEL_REGULAR,
+    UPGRADE_CHANNEL_STABLE,
+    UPGRADE_CHANNEL_UNSTABLE,
+    normalize_upgrade_channel,
+)
 
 from .filesystem import _auto_upgrade_skip_file
 from .ui import _format_datetime, _format_timestamp, _suite_uptime_details
-
 
 AUTO_UPGRADE_LOG_LIMIT = 30
 AUTO_UPGRADE_RECENT_ACTIVITY_HOURS = 48
@@ -45,11 +51,14 @@ REVISION_STATE_ERROR = "error"
 
 
 UPGRADE_CHANNEL_CHOICES: dict[str, dict[str, object]] = {
-    "stable": {"override": "stable", "label": _("Stable")},
-    "unstable": {"override": "unstable", "label": _("Unstable")},
+    "stable": {"override": UPGRADE_CHANNEL_STABLE, "label": _("Stable / LTS")},
+    "regular": {"override": UPGRADE_CHANNEL_REGULAR, "label": _("Regular / Normal")},
+    "latest": {"override": UPGRADE_CHANNEL_UNSTABLE, "label": _("Latest / Unstable")},
     # Legacy aliases
-    "normal": {"override": "stable", "label": _("Stable")},
-    "latest": {"override": "latest", "label": _("Latest")},
+    "lts": {"override": UPGRADE_CHANNEL_STABLE, "label": _("Stable / LTS")},
+    "normal": {"override": UPGRADE_CHANNEL_REGULAR, "label": _("Regular / Normal")},
+    "version": {"override": UPGRADE_CHANNEL_REGULAR, "label": _("Regular / Normal")},
+    "unstable": {"override": UPGRADE_CHANNEL_UNSTABLE, "label": _("Latest / Unstable")},
 }
 
 
@@ -238,9 +247,9 @@ def _load_upgrade_policy_report() -> dict[str, object]:
         policy = assignment.policy
         if not policy:
             continue
-        channel = (policy.channel or "stable").lower()
+        channel = normalize_upgrade_channel(policy.channel or "stable") or "stable"
         channel_label = str(getattr(policy, "get_channel_display", lambda: policy.channel)())
-        channel_state = "ok" if channel == "stable" else "warning"
+        channel_state = "ok" if channel in {"stable", "regular"} else "warning"
         channels.add(channel)
         policies.append(
             {
@@ -257,10 +266,7 @@ def _load_upgrade_policy_report() -> dict[str, object]:
             }
         )
 
-    normalized_channels = {
-        "unstable" if channel in {"unstable", "latest"} else "stable"
-        for channel in channels
-    }
+    normalized_channels = {normalize_upgrade_channel(channel) or channel for channel in channels}
     return {
         "policies": policies,
         "manual": not policies,
@@ -288,9 +294,7 @@ def _set_upgrade_policy_channel(channel: str) -> dict[str, object]:
     if not isinstance(override, str):
         return _error_response(normalized, _("Unsupported upgrade channel."))
 
-    policy_channel = override
-    if policy_channel not in {"stable", "unstable", "latest"}:
-        policy_channel = "stable"
+    policy_channel = normalize_upgrade_channel(override) or UPGRADE_CHANNEL_STABLE
 
     try:  # pragma: no cover - optional dependency
         from apps.nodes.models import Node, NodeUpgradePolicyAssignment

--- a/apps/core/tasks/auto_upgrade/tasks.py
+++ b/apps/core/tasks/auto_upgrade/tasks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import shutil
 import socket
 import subprocess
@@ -22,13 +21,21 @@ from django.utils import timezone
 
 from apps.core.auto_upgrade import (
     AUTO_UPGRADE_FALLBACK_INTERVAL,
-    AUTO_UPGRADE_INTERVAL_MINUTES,
     DEFAULT_AUTO_UPGRADE_MODE,
     append_auto_upgrade_log,
     auto_upgrade_base_dir,
     shorten_auto_upgrade_failure,
 )
 from apps.core.notifications import LcdChannel
+from apps.core.versioning import (
+    UPGRADE_CHANNEL_REGULAR,
+    UPGRADE_CHANNEL_STABLE,
+    UPGRADE_CHANNEL_UNSTABLE,
+    auto_upgrade_bump_allowed,
+    auto_upgrade_bump_cadence_minutes,
+    classify_version_bump,
+    normalize_upgrade_channel,
+)
 from apps.release import release_workflow
 
 from ..system_ops import _ensure_runtime_services
@@ -90,16 +97,6 @@ def _project_base_dir() -> Path:
     return auto_upgrade_base_dir()
 
 
-def _normalize_channel_mode(value: str | None) -> str | None:
-    """Return a lowercased, whitespace-trimmed channel value."""
-
-    if value is None:
-        return None
-
-    normalized = value.strip().lower()
-    return normalized or None
-
-
 def _latest_release() -> tuple[str | None, str | None, str | None]:
     """Return the latest release version, revision, and PyPI URL when available."""
 
@@ -154,21 +151,6 @@ def _read_remote_version(base_dir: Path, branch: str) -> str | None:
         )
     except (subprocess.CalledProcessError, FileNotFoundError):  # pragma: no cover - git failure
         return None
-
-
-def _parse_major_minor(version: str) -> tuple[int, int] | None:
-    match = re.match(r"^\s*(\d+)\.(\d+)", version)
-    if not match:
-        return None
-    return int(match.group(1)), int(match.group(2))
-
-
-def _shares_stable_series(local: str, remote: str) -> bool:
-    local_parts = _parse_major_minor(local)
-    remote_parts = _parse_major_minor(remote)
-    if not local_parts or not remote_parts:
-        return False
-    return local_parts == remote_parts
 
 
 def _ci_status_for_revision(_base_dir: Path, _revision: str) -> str:
@@ -402,7 +384,9 @@ def _resolve_auto_upgrade_mode(
     skip_recency_check = False
 
     if policy is not None:
-        mode = (getattr(policy, "channel", "") or DEFAULT_AUTO_UPGRADE_MODE).lower()
+        mode = normalize_upgrade_channel(
+            getattr(policy, "channel", "") or DEFAULT_AUTO_UPGRADE_MODE
+        ) or DEFAULT_AUTO_UPGRADE_MODE
         interval_minutes = int(getattr(policy, "interval_minutes", 0) or 0)
         if interval_minutes <= 0:
             interval_minutes = AUTO_UPGRADE_FALLBACK_INTERVAL
@@ -412,14 +396,6 @@ def _resolve_auto_upgrade_mode(
         mode_file_exists = False
         mode_file_physical = False
         skip_recency_check = True
-
-        mode = {
-            "latest": "unstable",
-            "unstable": "unstable",
-            "stable": "stable",
-            "normal": "stable",
-            "regular": "stable",
-        }.get(mode, mode)
 
         return AutoUpgradeMode(
             mode=mode,
@@ -439,29 +415,21 @@ def _resolve_auto_upgrade_mode(
     except (OSError, UnicodeDecodeError):
         logger.warning("Failed to read auto-upgrade mode lockfile", exc_info=True)
     else:
-        cleaned_mode = _normalize_channel_mode(raw_mode)
+        cleaned_mode = normalize_upgrade_channel(raw_mode)
         if cleaned_mode:
             mode = cleaned_mode
 
     override_log: str | None = None
-    override_mode = _normalize_channel_mode(channel_override)
+    override_mode = normalize_upgrade_channel(channel_override)
     if override_mode:
-        if override_mode in {"latest", "unstable"}:
-            mode = "unstable"
+        if override_mode == UPGRADE_CHANNEL_UNSTABLE:
+            mode = UPGRADE_CHANNEL_UNSTABLE
             override_log = "latest"
-        elif override_mode in {"stable", "normal", "regular", "version"}:
-            mode = "stable"
-            if override_mode == "stable":
-                override_log = "stable"
+        elif override_mode in {UPGRADE_CHANNEL_STABLE, UPGRADE_CHANNEL_REGULAR}:
+            mode = override_mode
+            override_log = mode
 
-    mode = {
-        "latest": "unstable",
-        "unstable": "unstable",
-        "version": "stable",
-        "stable": "stable",
-        "normal": "stable",
-        "regular": "stable",
-    }.get(mode, mode)
+    mode = normalize_upgrade_channel(mode) or DEFAULT_AUTO_UPGRADE_MODE
 
     interval_minutes = _resolve_auto_upgrade_interval_minutes(mode)
 
@@ -698,16 +666,7 @@ def build_upgrade_decision(
                 notify=False,
             )
 
-    if mode.mode == "unstable":
-        if repo_state.severity == SEVERITY_LOW:
-            return AutoUpgradeDecision(
-                skip=True,
-                apply=False,
-                reason="low-severity-unstable-skip",
-                args=[],
-                notify=False,
-            )
-
+    if mode.mode == UPGRADE_CHANNEL_UNSTABLE:
         if (
             repo_state.local_revision == repo_state.remote_revision
             and repo_state.local_revision
@@ -741,6 +700,30 @@ def build_upgrade_decision(
                 notify=False,
             )
 
+        version_bump = classify_version_bump(repo_state.local_version, target_version)
+        if not auto_upgrade_bump_allowed(mode.mode, version_bump):
+            return AutoUpgradeDecision(
+                skip=True,
+                apply=False,
+                reason=f"{version_bump}-upgrade-disallowed",
+                args=[],
+                notify=False,
+            )
+
+        bump_cadence = auto_upgrade_bump_cadence_minutes(mode.mode, version_bump)
+        if (
+            bump_cadence
+            and not mode.admin_override
+            and _auto_upgrade_ran_recently(base_dir, bump_cadence)
+        ):
+            return AutoUpgradeDecision(
+                skip=True,
+                apply=False,
+                reason=f"{version_bump}-upgrade-not-due",
+                args=[],
+                notify=False,
+            )
+
         if repo_state.release_version and repo_state.release_revision:
             matches_revision = False
             model = _get_package_release_model()
@@ -763,7 +746,9 @@ def build_upgrade_decision(
                 skip=False,
                 apply=True,
                 reason=None,
-                args=_upgrade_command_args("stable"),
+                args=_upgrade_command_args(
+                    "regular" if mode.mode == UPGRADE_CHANNEL_REGULAR else "stable"
+                ),
                 notify=True,
             ),
             recency_throttled=recency_throttled,
@@ -795,10 +780,22 @@ def _normalize_upgrade_args_for_host(base_dir: Path, args: list[str]) -> list[st
 
 
 def _skip_reason_log_message(reason: str | None, mode: AutoUpgradeMode) -> str | None:
+    if reason and reason.endswith("-upgrade-disallowed"):
+        bump = reason.removesuffix("-upgrade-disallowed")
+        return (
+            f"Skipping {mode.mode} auto-upgrade; "
+            f"{bump} version upgrades are not allowed on this channel"
+        )
+    if reason and reason.endswith("-upgrade-not-due"):
+        bump = reason.removesuffix("-upgrade-not-due")
+        cadence = auto_upgrade_bump_cadence_minutes(mode.mode, bump)
+        if cadence:
+            return (
+                f"Skipping {mode.mode} auto-upgrade; last upgrade was less than "
+                f"{cadence} minutes ago for a {bump} version bump"
+            )
+
     reason_messages = {
-        "low-severity-unstable-skip": (
-            "Skipping auto-upgrade for low severity patch on latest channel"
-        ),
         "pypi-release-missing": (
             "Skipping auto-upgrade; PyPI release has not been published yet."
         ),
@@ -910,8 +907,8 @@ def _execute_upgrade_plan(
             append_auto_upgrade_log(
                 base_dir,
                 (
-                    "Scheduled post-upgrade health check in %s seconds"
-                    % AUTO_UPGRADE_HEALTH_DELAY_SECONDS
+                    "Scheduled post-upgrade health check in "
+                    f"{AUTO_UPGRADE_HEALTH_DELAY_SECONDS} seconds"
                 ),
             )
             _schedule_health_check(1)
@@ -931,8 +928,8 @@ def _execute_upgrade_plan(
             append_auto_upgrade_log(
                 base_dir,
                 (
-                    "Scheduled post-upgrade health check in %s seconds"
-                    % AUTO_UPGRADE_HEALTH_DELAY_SECONDS
+                    "Scheduled post-upgrade health check in "
+                    f"{AUTO_UPGRADE_HEALTH_DELAY_SECONDS} seconds"
                 ),
             )
             _schedule_health_check(1)
@@ -1084,7 +1081,7 @@ def _record_health_check_result(
     base_dir: Path, attempt: int, status: int | None, detail: str
 ) -> None:
     status_display = status if status is not None else "unreachable"
-    message = "Health check attempt %s %s (%s)" % (attempt, detail, status_display)
+    message = f"Health check attempt {attempt} {detail} ({status_display})"
     append_auto_upgrade_log(base_dir, message)
 
 

--- a/apps/core/tasks/auto_upgrade/tasks.py
+++ b/apps/core/tasks/auto_upgrade/tasks.py
@@ -779,14 +779,20 @@ def _normalize_upgrade_args_for_host(base_dir: Path, args: list[str]) -> list[st
     return args
 
 
-def _skip_reason_log_message(reason: str | None, mode: AutoUpgradeMode) -> str | None:
-    if reason and reason.endswith("-upgrade-disallowed"):
+def _version_bump_skip_reason_log_message(
+    reason: str | None, mode: AutoUpgradeMode
+) -> str | None:
+    if not reason:
+        return None
+
+    if reason.endswith("-upgrade-disallowed"):
         bump = reason.removesuffix("-upgrade-disallowed")
         return (
             f"Skipping {mode.mode} auto-upgrade; "
             f"{bump} version upgrades are not allowed on this channel"
         )
-    if reason and reason.endswith("-upgrade-not-due"):
+
+    if reason.endswith("-upgrade-not-due"):
         bump = reason.removesuffix("-upgrade-not-due")
         cadence = auto_upgrade_bump_cadence_minutes(mode.mode, bump)
         if cadence:
@@ -794,6 +800,14 @@ def _skip_reason_log_message(reason: str | None, mode: AutoUpgradeMode) -> str |
                 f"Skipping {mode.mode} auto-upgrade; last upgrade was less than "
                 f"{cadence} minutes ago for a {bump} version bump"
             )
+
+    return None
+
+
+def _skip_reason_log_message(reason: str | None, mode: AutoUpgradeMode) -> str | None:
+    version_message = _version_bump_skip_reason_log_message(reason, mode)
+    if version_message:
+        return version_message
 
     reason_messages = {
         "pypi-release-missing": (

--- a/apps/core/tests/test_auto_upgrade_decision.py
+++ b/apps/core/tests/test_auto_upgrade_decision.py
@@ -66,6 +66,103 @@ def test_build_upgrade_decision_applies_stable_and_unstable(monkeypatch):
     assert unstable_decision.args[1] == "--latest"
 
 
+def test_build_upgrade_decision_blocks_stable_major_upgrade(monkeypatch):
+    decision = tasks.build_upgrade_decision(
+        Path("/tmp/base"),
+        _mode(mode="stable"),
+        _repo_state(
+            release_version=None,
+            release_revision=None,
+            remote_version="2.0.0",
+            local_version="1.9.9",
+        ),
+    )
+
+    assert decision.skip is True
+    assert decision.apply is False
+    assert decision.reason == "major-upgrade-disallowed"
+
+
+def test_build_upgrade_decision_throttles_stable_minor_upgrade(monkeypatch):
+    checked_intervals: list[int] = []
+
+    def _ran_recently(_base_dir, interval_minutes):
+        checked_intervals.append(interval_minutes)
+        return interval_minutes == 43200
+
+    monkeypatch.setattr(tasks, "_auto_upgrade_ran_recently", _ran_recently)
+
+    decision = tasks.build_upgrade_decision(
+        Path("/tmp/base"),
+        _mode(mode="stable"),
+        _repo_state(
+            release_version=None,
+            release_revision=None,
+            remote_version="1.1.0",
+            local_version="1.0.9",
+        ),
+    )
+
+    assert decision.skip is True
+    assert decision.apply is False
+    assert decision.reason == "minor-upgrade-not-due"
+    assert 43200 in checked_intervals
+
+
+def test_build_upgrade_decision_regular_uses_regular_channel_for_minor(monkeypatch):
+    decision = tasks.build_upgrade_decision(
+        Path("/tmp/base"),
+        _mode(mode="regular"),
+        _repo_state(
+            release_version=None,
+            release_revision=None,
+            remote_version="1.1.0",
+            local_version="1.0.9",
+        ),
+    )
+
+    assert decision.apply is True
+    assert decision.args[1] == "--regular"
+
+
+def test_build_upgrade_decision_throttles_regular_major_upgrade(monkeypatch):
+    monkeypatch.setattr(tasks, "_auto_upgrade_ran_recently", lambda *_args: True)
+
+    decision = tasks.build_upgrade_decision(
+        Path("/tmp/base"),
+        _mode(mode="regular"),
+        _repo_state(
+            release_version=None,
+            release_revision=None,
+            remote_version="2.0.0",
+            local_version="1.9.9",
+        ),
+    )
+
+    assert decision.skip is True
+    assert decision.apply is False
+    assert decision.reason == "major-upgrade-not-due"
+
+
+def test_build_upgrade_decision_latest_ignores_release_severity(monkeypatch):
+    decision = tasks.build_upgrade_decision(
+        Path("/tmp/base"),
+        _mode(mode="unstable"),
+        _repo_state(
+            release_version=None,
+            release_revision=None,
+            remote_version="1.0.1",
+            local_version="1.0.1",
+            local_revision="local-rev",
+            remote_revision="remote-rev",
+            severity=tasks.SEVERITY_LOW,
+        ),
+    )
+
+    assert decision.apply is True
+    assert decision.args[1] == "--latest"
+
+
 def test_ci_status_for_revision_compatibility_shim_returns_empty_string(tmp_path):
     assert tasks._ci_status_for_revision(tmp_path, "abc123") == ""
 

--- a/apps/core/tests/test_versioning.py
+++ b/apps/core/tests/test_versioning.py
@@ -1,0 +1,56 @@
+from apps.core.versioning import (
+    AUTO_UPGRADE_DAY_MINUTES,
+    AUTO_UPGRADE_MONTH_MINUTES,
+    AUTO_UPGRADE_WEEK_MINUTES,
+    UPGRADE_CHANNEL_REGULAR,
+    UPGRADE_CHANNEL_STABLE,
+    UPGRADE_CHANNEL_UNSTABLE,
+    VERSION_BUMP_MAJOR,
+    VERSION_BUMP_MINOR,
+    VERSION_BUMP_NONE,
+    VERSION_BUMP_PATCH,
+    VERSION_BUMP_UNKNOWN,
+    auto_upgrade_bump_allowed,
+    auto_upgrade_bump_cadence_minutes,
+    classify_version_bump,
+    normalize_upgrade_channel,
+)
+
+
+def test_classify_version_bump_handles_semver_tiers():
+    assert classify_version_bump("1.2.3", "1.2.4") == VERSION_BUMP_PATCH
+    assert classify_version_bump("1.2.3", "1.3.0") == VERSION_BUMP_MINOR
+    assert classify_version_bump("1.2.3", "2.0.0") == VERSION_BUMP_MAJOR
+    assert classify_version_bump("1.2.3", "1.2.3") == VERSION_BUMP_NONE
+    assert classify_version_bump("1.2.3", "1.2.2") == VERSION_BUMP_UNKNOWN
+
+
+def test_normalize_upgrade_channel_aliases():
+    assert normalize_upgrade_channel("lts") == UPGRADE_CHANNEL_STABLE
+    assert normalize_upgrade_channel("normal") == UPGRADE_CHANNEL_REGULAR
+    assert normalize_upgrade_channel("version") == UPGRADE_CHANNEL_REGULAR
+    assert normalize_upgrade_channel("latest") == UPGRADE_CHANNEL_UNSTABLE
+
+
+def test_auto_upgrade_bump_rules_match_channel_tiers():
+    assert auto_upgrade_bump_allowed("stable", VERSION_BUMP_PATCH) is True
+    assert auto_upgrade_bump_allowed("stable", VERSION_BUMP_MINOR) is True
+    assert auto_upgrade_bump_allowed("stable", VERSION_BUMP_MAJOR) is False
+    assert auto_upgrade_bump_allowed("regular", VERSION_BUMP_MAJOR) is True
+
+    assert (
+        auto_upgrade_bump_cadence_minutes("stable", VERSION_BUMP_PATCH)
+        == AUTO_UPGRADE_WEEK_MINUTES
+    )
+    assert (
+        auto_upgrade_bump_cadence_minutes("stable", VERSION_BUMP_MINOR)
+        == AUTO_UPGRADE_MONTH_MINUTES
+    )
+    assert (
+        auto_upgrade_bump_cadence_minutes("regular", VERSION_BUMP_MINOR)
+        == AUTO_UPGRADE_DAY_MINUTES
+    )
+    assert (
+        auto_upgrade_bump_cadence_minutes("regular", VERSION_BUMP_MAJOR)
+        == AUTO_UPGRADE_WEEK_MINUTES
+    )

--- a/apps/core/versioning.py
+++ b/apps/core/versioning.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+VERSION_BUMP_NONE = "none"
+VERSION_BUMP_PATCH = "patch"
+VERSION_BUMP_MINOR = "minor"
+VERSION_BUMP_MAJOR = "major"
+VERSION_BUMP_UNKNOWN = "unknown"
+
+UPGRADE_CHANNEL_STABLE = "stable"
+UPGRADE_CHANNEL_REGULAR = "regular"
+UPGRADE_CHANNEL_UNSTABLE = "unstable"
+
+AUTO_UPGRADE_DAY_MINUTES = 1440
+AUTO_UPGRADE_WEEK_MINUTES = 10080
+AUTO_UPGRADE_MONTH_MINUTES = 43200
+
+UPGRADE_CHANNEL_ALIASES = {
+    "stable": UPGRADE_CHANNEL_STABLE,
+    "lts": UPGRADE_CHANNEL_STABLE,
+    "regular": UPGRADE_CHANNEL_REGULAR,
+    "normal": UPGRADE_CHANNEL_REGULAR,
+    "version": UPGRADE_CHANNEL_REGULAR,
+    "latest": UPGRADE_CHANNEL_UNSTABLE,
+    "unstable": UPGRADE_CHANNEL_UNSTABLE,
+}
+
+AUTO_UPGRADE_BUMP_CADENCES = {
+    UPGRADE_CHANNEL_STABLE: {
+        VERSION_BUMP_PATCH: AUTO_UPGRADE_WEEK_MINUTES,
+        VERSION_BUMP_MINOR: AUTO_UPGRADE_MONTH_MINUTES,
+    },
+    UPGRADE_CHANNEL_REGULAR: {
+        VERSION_BUMP_PATCH: AUTO_UPGRADE_DAY_MINUTES,
+        VERSION_BUMP_MINOR: AUTO_UPGRADE_DAY_MINUTES,
+        VERSION_BUMP_MAJOR: AUTO_UPGRADE_WEEK_MINUTES,
+    },
+}
+
+AUTO_UPGRADE_LIVE_CADENCE = AUTO_UPGRADE_DAY_MINUTES
+
+_VERSION_RE = re.compile(
+    r"^\s*v?(?P<major>\d+)"
+    r"(?:\.(?P<minor>\d+))?"
+    r"(?:\.(?P<patch>\d+))?"
+)
+
+
+@dataclass(frozen=True)
+class ParsedVersion:
+    major: int
+    minor: int = 0
+    patch: int = 0
+
+
+def normalize_upgrade_channel(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    return UPGRADE_CHANNEL_ALIASES.get(normalized, normalized)
+
+
+def parse_version(value: str | None) -> ParsedVersion | None:
+    if value is None:
+        return None
+
+    match = _VERSION_RE.match(value)
+    if not match:
+        return None
+
+    return ParsedVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor") or 0),
+        patch=int(match.group("patch") or 0),
+    )
+
+
+def classify_version_bump(
+    local_version: str | None,
+    target_version: str | None,
+) -> str:
+    local = parse_version(local_version)
+    target = parse_version(target_version)
+    if local is None or target is None:
+        return VERSION_BUMP_UNKNOWN
+
+    if (target.major, target.minor, target.patch) < (
+        local.major,
+        local.minor,
+        local.patch,
+    ):
+        return VERSION_BUMP_UNKNOWN
+
+    if target.major != local.major:
+        return VERSION_BUMP_MAJOR
+    if target.minor != local.minor:
+        return VERSION_BUMP_MINOR
+    if target.patch != local.patch:
+        return VERSION_BUMP_PATCH
+    return VERSION_BUMP_NONE
+
+
+def auto_upgrade_bump_cadence_minutes(channel: str, bump: str) -> int | None:
+    normalized_channel = normalize_upgrade_channel(channel)
+    if normalized_channel == UPGRADE_CHANNEL_UNSTABLE:
+        return AUTO_UPGRADE_LIVE_CADENCE
+    if normalized_channel is None:
+        return None
+    return AUTO_UPGRADE_BUMP_CADENCES.get(normalized_channel, {}).get(bump)
+
+
+def auto_upgrade_bump_allowed(channel: str, bump: str) -> bool:
+    normalized_channel = normalize_upgrade_channel(channel)
+    if normalized_channel == UPGRADE_CHANNEL_UNSTABLE:
+        return True
+    if bump == VERSION_BUMP_NONE:
+        return False
+    if normalized_channel is None:
+        return False
+    return bump in AUTO_UPGRADE_BUMP_CADENCES.get(normalized_channel, {})

--- a/apps/nodes/fixtures/upgrade_policies__fast_lane.json
+++ b/apps/nodes/fixtures/upgrade_policies__fast_lane.json
@@ -5,9 +5,9 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "Fast Lane",
-      "description": "Unstable channel with hourly checks.",
-      "channel": "unstable",
-      "interval_minutes": 60,
+      "description": "Latest/unstable channel with daily live-main checks.",
+      "channel": "latest",
+      "interval_minutes": 1440,
       "requires_pypi_packages": false
     }
   }

--- a/apps/nodes/fixtures/upgrade_policies__lts.json
+++ b/apps/nodes/fixtures/upgrade_policies__lts.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "LTS",
-      "description": "Stable long-term support with PyPI package requirements.",
+      "description": "Stable/LTS upgrades: patch weekly, minor monthly, no major upgrades.",
       "channel": "stable",
       "interval_minutes": 10080,
       "requires_pypi_packages": true

--- a/apps/nodes/fixtures/upgrade_policies__regular.json
+++ b/apps/nodes/fixtures/upgrade_policies__regular.json
@@ -1,0 +1,14 @@
+[
+  {
+    "model": "nodes.upgradepolicy",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "name": "Regular",
+      "description": "Regular/normal upgrades: patch and minor daily, major weekly.",
+      "channel": "regular",
+      "interval_minutes": 1440,
+      "requires_pypi_packages": true
+    }
+  }
+]

--- a/apps/nodes/fixtures/upgrade_policies__stable.json
+++ b/apps/nodes/fixtures/upgrade_policies__stable.json
@@ -5,7 +5,7 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "Stable",
-      "description": "Stable release upgrades on the standard cadence.",
+      "description": "Stable/LTS upgrades: patch weekly, minor monthly, no major upgrades.",
       "channel": "stable",
       "interval_minutes": 10080,
       "requires_pypi_packages": true

--- a/apps/nodes/fixtures/upgrade_policies__unstable.json
+++ b/apps/nodes/fixtures/upgrade_policies__unstable.json
@@ -5,9 +5,9 @@
       "is_seed_data": true,
       "is_deleted": false,
       "name": "Unstable",
-      "description": "Unstable channel for rapid rollout testing.",
-      "channel": "unstable",
-      "interval_minutes": 15,
+      "description": "Latest/unstable channel with daily live-main checks.",
+      "channel": "latest",
+      "interval_minutes": 1440,
       "requires_pypi_packages": false
     }
   }

--- a/apps/nodes/migrations/0011_upgrade_policy_tier_channels.py
+++ b/apps/nodes/migrations/0011_upgrade_policy_tier_channels.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0010_cleanup_retired_node_feature_slugs"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="upgradepolicy",
+            name="channel",
+            field=models.CharField(
+                choices=[
+                    ("stable", "Stable / LTS"),
+                    ("regular", "Regular / Normal"),
+                    ("latest", "Latest / Unstable"),
+                    ("lts", "LTS"),
+                    ("normal", "Normal"),
+                    ("unstable", "Unstable"),
+                ],
+                default="stable",
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="upgradepolicy",
+            name="interval_minutes",
+            field=models.PositiveIntegerField(
+                default=10080,
+                help_text=(
+                    "How often to check for upgrades, in minutes. Channel bump "
+                    "cadences still gate whether the upgrade is allowed to proceed."
+                ),
+            ),
+        ),
+    ]

--- a/apps/nodes/models/upgrade_policy.py
+++ b/apps/nodes/models/upgrade_policy.py
@@ -15,9 +15,12 @@ class UpgradePolicy(Entity):
     """Configurable policy governing automated upgrades."""
 
     class Channel(models.TextChoices):
-        STABLE = "stable", _("Stable")
+        STABLE = "stable", _("Stable / LTS")
+        REGULAR = "regular", _("Regular / Normal")
+        LATEST = "latest", _("Latest / Unstable")
+        LTS = "lts", _("LTS")
+        NORMAL = "normal", _("Normal")
         UNSTABLE = "unstable", _("Unstable")
-        LATEST = "latest", _("Latest")
 
     name = models.CharField(max_length=100, unique=True)
     description = models.CharField(max_length=200, blank=True)
@@ -28,7 +31,10 @@ class UpgradePolicy(Entity):
     )
     interval_minutes = models.PositiveIntegerField(
         default=10080,
-        help_text=_("How often to check for upgrades, in minutes."),
+        help_text=_(
+            "How often to check for upgrades, in minutes. Channel bump cadences "
+            "still gate whether the upgrade is allowed to proceed."
+        ),
     )
     requires_pypi_packages = models.BooleanField(
         default=False,

--- a/apps/ops/views.py
+++ b/apps/ops/views.py
@@ -6,8 +6,7 @@ from urllib.parse import urlencode
 
 import requests
 from django.conf import settings
-from django.contrib import admin
-from django.contrib import messages
+from django.contrib import admin, messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -208,13 +207,21 @@ def _build_node_role_validation_summary() -> dict[str, object]:
             {"label": "No restart", "flags": ["--no-restart"]},
         ]
     else:
+        from apps.core.versioning import (
+            UPGRADE_CHANNEL_REGULAR,
+            UPGRADE_CHANNEL_UNSTABLE,
+            normalize_upgrade_channel,
+        )
+
         upgrade_policy_options = []
         for policy in UpgradePolicy.objects.order_by("name"):
-            channel_flag = (
-                "--latest"
-                if policy.channel == UpgradePolicy.Channel.UNSTABLE
-                else "--stable"
-            )
+            policy_channel = normalize_upgrade_channel(policy.channel)
+            if policy_channel == UPGRADE_CHANNEL_UNSTABLE:
+                channel_flag = "--latest"
+            elif policy_channel == UPGRADE_CHANNEL_REGULAR:
+                channel_flag = "--regular"
+            else:
+                channel_flag = "--stable"
             option_label = f"Policy: {policy.name}"
             if not policy.is_active:
                 option_label = f"{option_label} (inactive)"

--- a/configure.sh
+++ b/configure.sh
@@ -51,7 +51,7 @@ LOCK_DIR="$BASE_DIR/.locks"
 
 # Lifecycle CLI contract: keep reconfiguration flags aligned with docs/development/install-lifecycle-scripts-manual.md and contract tests.
 usage() {
-    echo "Usage: $0 [--service NAME] [--port PORT] [--latest|--stable|--regular|--normal|--unstable] [--fixed] [--check] [--auto-upgrade|--no-auto-upgrade] [--debug|--no-debug] [--celery|--no-celery] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--feature SLUG [--kind suite|node] [--enabled|--disabled]] [--feature-param FEATURE:KEY=VALUE] [--email ADMIN_EMAIL] [--satellite|--terminal|--control|--watchtower] [--repair [--failover ROLE]]" >&2
+    echo "Usage: $0 [--service NAME] [--port PORT] [--latest|--unstable|--stable|--lts|--regular|--normal] [--fixed] [--check] [--auto-upgrade|--no-auto-upgrade] [--debug|--no-debug] [--celery|--no-celery] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--feature SLUG [--kind suite|node] [--enabled|--disabled]] [--feature-param FEATURE:KEY=VALUE] [--email ADMIN_EMAIL] [--satellite|--terminal|--control|--watchtower] [--repair [--failover ROLE]]" >&2
     exit 1
 }
 
@@ -443,7 +443,7 @@ set_upgrade_channel() {
     local new_channel="$1"
 
     if [ -n "$UPGRADE_CHANNEL" ] && [ "$UPGRADE_CHANNEL" != "$new_channel" ]; then
-        echo "Only one of --latest, --stable, or --regular may be specified" >&2
+        echo "Only one auto-upgrade channel flag may be specified" >&2
         usage
     fi
 
@@ -457,20 +457,16 @@ while [[ $# -gt 0 ]]; do
             SERVICE="$2"
             shift 2
             ;;
-        --latest)
+        --latest|--unstable)
             set_upgrade_channel "latest"
             shift
             ;;
-        --stable)
+        --stable|--lts)
             set_upgrade_channel "stable"
             shift
             ;;
         --regular|--normal)
-            set_upgrade_channel "version"
-            shift
-            ;;
-        --unstable)
-            set_upgrade_channel "latest"
+            set_upgrade_channel "regular"
             shift
             ;;
         --fixed)
@@ -757,11 +753,11 @@ if [ "$REPAIR" = true ]; then
     if [ -f "$LOCK_DIR/auto_upgrade.lck" ]; then
         stored_channel=$(tr -d '\r\n\t ' < "$LOCK_DIR/auto_upgrade.lck" | tr '[:upper:]' '[:lower:]')
         case "$stored_channel" in
-            latest|stable|version)
+            latest|unstable|stable|lts|regular|normal|version)
                 REPAIR_AUTO_UPGRADE_CHANNEL="$stored_channel"
                 ;;
             "")
-                REPAIR_AUTO_UPGRADE_CHANNEL="version"
+                REPAIR_AUTO_UPGRADE_CHANNEL="stable"
                 ;;
             *)
                 REPAIR_AUTO_UPGRADE_CHANNEL="version"
@@ -793,14 +789,14 @@ if [ "$CHECK" = true ]; then
 
     if [ -f "$LOCK_DIR/auto_upgrade.lck" ]; then
         case "$(cat "$LOCK_DIR/auto_upgrade.lck")" in
-            latest)
-                echo "Auto-upgrade: enabled (latest channel)"
+            latest|unstable)
+                echo "Auto-upgrade: enabled (latest/unstable channel)"
                 ;;
-            stable)
-                echo "Auto-upgrade: enabled (stable channel)"
+            stable|lts)
+                echo "Auto-upgrade: enabled (stable/LTS channel)"
                 ;;
-            version)
-                echo "Auto-upgrade: enabled (regular channel)"
+            regular|normal|version)
+                echo "Auto-upgrade: enabled (regular/normal channel)"
                 ;;
             *)
                 echo "Auto-upgrade: enabled (unknown channel)"
@@ -951,18 +947,18 @@ if [ -n "$AUTO_UPGRADE_MODE" ] && [ -z "$NODE_ROLE" ]; then
     ACTION_PERFORMED=true
     mkdir -p "$LOCK_DIR"
     if [ "$AUTO_UPGRADE_MODE" = "enable" ]; then
-        channel="${UPGRADE_CHANNEL:-version}"
+        channel="${UPGRADE_CHANNEL:-stable}"
         echo "$channel" > "$LOCK_DIR/auto_upgrade.lck"
         run_auto_upgrade_management enable
         case "$channel" in
-            latest)
-                echo "Auto-upgrade enabled on the latest channel."
+            latest|unstable)
+                echo "Auto-upgrade enabled on the latest/unstable channel."
                 ;;
-            stable)
-                echo "Auto-upgrade enabled on the stable channel."
+            stable|lts)
+                echo "Auto-upgrade enabled on the stable/LTS channel."
                 ;;
             *)
-                echo "Auto-upgrade enabled on the regular channel."
+                echo "Auto-upgrade enabled on the regular/normal channel."
                 ;;
         esac
     else
@@ -1119,18 +1115,18 @@ fi
 
 
 if [ "$AUTO_UPGRADE_MODE" = "enable" ]; then
-    channel="${UPGRADE_CHANNEL:-version}"
+    channel="${UPGRADE_CHANNEL:-stable}"
     echo "$channel" > "$LOCK_DIR/auto_upgrade.lck"
     run_auto_upgrade_management enable
     case "$channel" in
-        latest)
-            echo "Auto-upgrade enabled on the latest channel."
+        latest|unstable)
+            echo "Auto-upgrade enabled on the latest/unstable channel."
             ;;
-        stable)
-            echo "Auto-upgrade enabled on the stable channel."
+        stable|lts)
+            echo "Auto-upgrade enabled on the stable/LTS channel."
             ;;
         *)
-            echo "Auto-upgrade enabled on the regular channel."
+            echo "Auto-upgrade enabled on the regular/normal channel."
             ;;
     esac
 elif [ "$AUTO_UPGRADE_MODE" = "disable" ]; then

--- a/docs/auto-upgrade.md
+++ b/docs/auto-upgrade.md
@@ -15,9 +15,15 @@ delegated systemd unit is launched, and what to check if something fails.
   the lock is removed, the periodic task is removed as well, and any
   environment override set with `ARTHEXIS_UPGRADE_FREQ` is ignored unless it is
   a positive integer.
-- Stable auto-upgrades run once per week on Thursday mornings before 5:00 AM,
-  while latest runs daily at the same hour unless overridden with
-  `ARTHEXIS_UPGRADE_FREQ`.
+- Auto-upgrade channels are grouped into three tiers:
+  - `stable`/`lts`: patch upgrades can proceed weekly, minor upgrades can
+    proceed monthly, and major upgrades are blocked.
+  - `regular`/`normal`: patch and minor upgrades can proceed daily, and major
+    upgrades can proceed weekly.
+  - `latest`/`unstable`: tracks live `main` revisions daily instead of gating on
+    release version bumps.
+  `ARTHEXIS_UPGRADE_FREQ` still overrides the check interval, but channel bump
+  cadence gates whether a release upgrade may proceed.
 - Boot-time prestart checks (`scripts/boot-upgrade-prestart.sh`) keep a per-service
   recency lock at `.locks/<service>-boot-upgrade-last-check.lck` after a
   successful run. If the local revision is unchanged and the recency TTL has
@@ -35,7 +41,8 @@ delegated systemd unit is launched, and what to check if something fails.
      `logs/delegated-upgrade.log` for easy inspection.
 3. The transient unit runs `/usr/local/bin/watch-upgrade`, which:
    - Stops the managed service.
-   - Executes `upgrade.sh` (default `--stable`; Celery can pass `--latest`).
+   - Executes `upgrade.sh` (default `--stable`; Celery can pass `--regular` or
+     `--latest`).
    - Restarts the service and exits with the upgrade status.
 4. Celery schedules a post-upgrade health check after the run to confirm HTTP
    200 responses and records any failures.
@@ -46,6 +53,8 @@ Run one of the following from the project root:
 
 ```bash
 ./upgrade.sh --stable   # direct run, useful for local validation
+./upgrade.sh --regular  # release upgrade path with regular/normal channel semantics
+./upgrade.sh --latest   # live-main path used by latest/unstable
 ./upgrade.sh --detached # launches the delegated watcher so the upgrade continues if the console disconnects
 ./scripts/delegated-upgrade.sh  # matches the automated delegated path
 ```

--- a/docs/development/install-lifecycle-scripts-manual.md
+++ b/docs/development/install-lifecycle-scripts-manual.md
@@ -51,8 +51,9 @@ If this repository is provided without Git remotes configured, `configure.sh`, `
 | `--upgrade` | Allow install flow to run in upgrade mode (reuses existing DB state paths). |
 | `--auto-upgrade` | Enable auto-upgrade lock behavior. |
 | `--fixed` | Disable auto-upgrade lock behavior. |
-| `--latest`, `--unstable` | Enable auto-upgrade and set unstable channel. |
-| `--stable`, `--regular`, `--normal` | Enable auto-upgrade and set stable channel. |
+| `--latest`, `--unstable` | Enable auto-upgrade and set latest/unstable channel. |
+| `--stable`, `--lts` | Enable auto-upgrade and set stable/LTS channel. |
+| `--regular`, `--normal` | Enable auto-upgrade and set regular/normal channel. |
 | `--celery` | Enable Celery lock and related unit handling. |
 | `--embedded` | Force embedded service mode. |
 | `--systemd` | Force systemd service mode. |
@@ -105,8 +106,9 @@ Other arguments are passed through to `scripts/service-start.sh`.
 
 | Flag | Notes |
 | --- | --- |
-| `--latest`, `--unstable`, `-l`, `-t` | Use unstable channel behavior. |
-| `--stable`, `--normal`, `--regular` | Use stable channel behavior. |
+| `--latest`, `--unstable`, `-l`, `-t` | Use latest/unstable channel behavior. |
+| `--stable`, `--lts` | Use stable/LTS channel behavior. |
+| `--normal`, `--regular` | Use regular/normal channel behavior. |
 | `--force`, `-f` | Force stop/upgrade when needed. |
 | `--confirm` | Enable confirmation for stop operations. |
 | `--stash` | Force auto-stash of local changes before upgrade. |
@@ -158,9 +160,9 @@ Both supported backends emit a consistent reconciliation report that includes co
 | --- | --- |
 | `--service NAME` | Set service name lock. |
 | `--port PORT` | Set backend port lock. |
-| `--latest`, `--unstable` | Set latest channel for auto-upgrade. |
-| `--stable` | Set stable channel for auto-upgrade. |
-| `--regular`, `--normal` | Set version/regular channel for auto-upgrade. |
+| `--latest`, `--unstable` | Set latest/unstable channel for auto-upgrade. |
+| `--stable`, `--lts` | Set stable/LTS channel for auto-upgrade. |
+| `--regular`, `--normal` | Set regular/normal channel for auto-upgrade. |
 | `--fixed` | Disable auto-upgrade. |
 | `--auto-upgrade`, `--no-auto-upgrade` | Explicitly enable/disable auto-upgrade. |
 | `--debug`, `--no-debug` | Toggle debug env setting. |
@@ -178,6 +180,11 @@ Both supported backends emit a consistent reconciliation report that includes co
 | `--check` | Print current role/port/upgrade/debug/feature state. |
 | `--repair` | Restore lock state from existing role and lock files. |
 | `--failover ROLE` | Provide role fallback for repair when role lock cannot be resolved. |
+
+Auto-upgrade channel tiers gate release bumps after the scheduler fires:
+`stable`/`lts` allows patch upgrades weekly and minor upgrades monthly,
+`regular`/`normal` allows patch and minor upgrades daily and major upgrades
+weekly, and `latest`/`unstable` follows live `main` revisions daily.
 
 
 ## 5. Runtime status (`status.sh`)

--- a/docs/startup-sequence.md
+++ b/docs/startup-sequence.md
@@ -58,7 +58,7 @@ Systemd-managed service starts can run the boot upgrade prestart helper before
 3. If the last successful check is recent (within
    `ARTHEXIS_BOOT_UPGRADE_CHECK_TTL_SECONDS`, default `300`) and the revision is
    unchanged, skip invoking `upgrade.sh`.
-4. Otherwise invoke `upgrade.sh` (stable/latest channel rules unchanged). On
+4. Otherwise invoke `upgrade.sh` with the configured channel tier. On
    success, refresh the recency lock; on failure, preserve existing behavior by
    writing backoff to `.locks/<service>-boot-upgrade-backoff-until.lck`.
 

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ is_debian_host() {
 
 # Lifecycle CLI contract: keep this usage block aligned with docs/development/install-lifecycle-scripts-manual.md and lifecycle contract tests.
 usage() {
-    echo "Usage: $0 [--service NAME] [--port PORT] [--upgrade] [--fixed] [--stable|--regular|--normal|--unstable|--latest] [--satellite] [--terminal] [--control] [--watchtower] [--celery] [--embedded|--systemd] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--clean] [--start|--no-start] [--repair]" >&2
+    echo "Usage: $0 [--service NAME] [--port PORT] [--upgrade] [--fixed] [--stable|--lts|--regular|--normal|--unstable|--latest] [--satellite] [--terminal] [--control] [--watchtower] [--celery] [--embedded|--systemd] [--lcd-screen|--no-lcd-screen] [--rfid-service|--no-rfid-service] [--camera-service|--no-camera-service] [--boot-upgrade|--no-boot-upgrade] [--clean] [--start|--no-start] [--repair]" >&2
     exit 1
 }
 
@@ -282,12 +282,17 @@ while [[ $# -gt 0 ]]; do
             ;;
         --latest|--unstable)
             AUTO_UPGRADE=true
-            CHANNEL="unstable"
+            CHANNEL="latest"
             shift
             ;;
-        --stable|--regular|--normal)
+        --stable|--lts)
             AUTO_UPGRADE=true
             CHANNEL="stable"
+            shift
+            ;;
+        --regular|--normal)
+            AUTO_UPGRADE=true
+            CHANNEL="regular"
             shift
             ;;
         --celery)
@@ -761,7 +766,7 @@ fi
 
 arthexis_timing_start "requirements_install"
 env_refresh_args=(--force-refresh --install-and-refresh)
-if [ "$CHANNEL" = "unstable" ]; then
+if [ "$CHANNEL" = "unstable" ] || [ "$CHANNEL" = "latest" ]; then
     env_refresh_args+=(--latest)
 fi
 INSTALL_HARDWARE_DEPS=false
@@ -879,8 +884,10 @@ if [ "$AUTO_UPGRADE" = true ]; then
     rm -f AUTO_UPGRADE
     echo "$CHANNEL" > "$LOCK_DIR/auto_upgrade.lck"
     if [ "$UPGRADE" = true ]; then
-        if [ "$CHANNEL" = "unstable" ]; then
+        if [ "$CHANNEL" = "unstable" ] || [ "$CHANNEL" = "latest" ]; then
             ./upgrade.sh --latest
+        elif [ "$CHANNEL" = "regular" ] || [ "$CHANNEL" = "normal" ]; then
+            ./upgrade.sh --regular
         else
             ./upgrade.sh --stable
         fi
@@ -893,8 +900,10 @@ ensure_auto_upgrade_periodic_task()
 PYCODE
     deactivate
 elif [ "$UPGRADE" = true ]; then
-    if [ "$CHANNEL" = "unstable" ]; then
+    if [ "$CHANNEL" = "unstable" ] || [ "$CHANNEL" = "latest" ]; then
         ./upgrade.sh --latest
+    elif [ "$CHANNEL" = "regular" ] || [ "$CHANNEL" = "normal" ]; then
+        ./upgrade.sh --regular
     else
         ./upgrade.sh --stable
     fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -853,26 +853,6 @@ env_refresh_in_progress() {
   return 1
 }
 
-parse_major_minor() {
-  local version="$1"
-  if [[ "$version" =~ ^[[:space:]]*([0-9]+)\.([0-9]+) ]]; then
-    echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-  fi
-}
-
-shares_stable_series() {
-  local local_version
-  local remote_version
-  local_version=$(parse_major_minor "$1")
-  remote_version=$(parse_major_minor "$2")
-
-  if [ -z "$local_version" ] || [ -z "$remote_version" ]; then
-    return 1
-  fi
-
-  [[ "$local_version" == "$remote_version" ]]
-}
-
 cleanup_non_terminal_git_state() {
   local role="$1"
 
@@ -1116,8 +1096,13 @@ while [[ $# -gt 0 ]]; do
       FORWARDED_ARGS+=("$1")
       shift
       ;;
-    --stable|--normal|--regular)
+    --stable|--lts)
       CHANNEL="stable"
+      FORWARDED_ARGS+=("$1")
+      shift
+      ;;
+    --normal|--regular)
+      CHANNEL="regular"
       FORWARDED_ARGS+=("$1")
       shift
       ;;
@@ -1925,7 +1910,7 @@ if [[ "$LOCAL_VERSION" == "$REMOTE_VERSION" ]]; then
   elif [[ $RERUN_AFTER_SELF_UPDATE -eq 1 ]]; then
     echo "Detected prior upgrade.sh update; continuing upgrade for $REMOTE_VERSION despite matching versions."
   elif [[ "$CHANNEL" == "unstable" ]]; then
-    echo "Unstable channel requested; continuing upgrade despite matching version $REMOTE_VERSION."
+    echo "Latest/unstable channel requested; continuing upgrade despite matching version $REMOTE_VERSION."
   elif [[ $FORCE_UPGRADE -eq 1 ]]; then
     echo "Forcing upgrade despite matching version $LOCAL_VERSION."
   elif [[ -n "$REMOTE_REVISION" && -n "$LOCAL_REVISION" && "$LOCAL_REVISION" != "$REMOTE_REVISION" ]]; then


### PR DESCRIPTION
## Summary
- add consolidated semver/channel helpers for auto-upgrade bump classification and alias normalization
- implement three auto-upgrade tiers: stable/LTS patch weekly and minor monthly with major blocked, regular/normal patch+minor daily and major weekly, latest/unstable live-main daily
- update policy choices, seed fixtures, lifecycle scripts, docs, and focused tests for the new tier behavior

## Tests
- .\.venv\Scripts\python.exe -m pytest apps/core/tests/test_versioning.py apps/core/tests/test_auto_upgrade_decision.py tests/test_lifecycle_script_contracts.py
- .\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run
- .\.venv\Scripts\python.exe -m ruff check apps/core/versioning.py apps/core/auto_upgrade.py apps/core/system/upgrade.py apps/core/tasks/auto_upgrade/tasks.py apps/core/tests/test_auto_upgrade_decision.py apps/core/tests/test_versioning.py apps/nodes/models/upgrade_policy.py apps/ops/views.py