### PR TITLE
skills: materialize portable package trees with sigils

### DIFF
--- a/apps/docs/cookbooks/sigils.md
+++ b/apps/docs/cookbooks/sigils.md
@@ -6,7 +6,8 @@ Sigils are bracketed tokens such as `[ENV.SMTP_PASSWORD]` that Arthexis expands 
 - [2. Syntax reference](#2-syntax-reference)
 - [3. Built-in prefixes](#3-built-in-prefixes)
 - [4. Managing Sigil Roots](#4-managing-sigil-roots)
-- [5. Troubleshooting and observability](#5-troubleshooting-and-observability)
+- [5. Portable documents](#5-portable-documents)
+- [6. Troubleshooting and observability](#6-troubleshooting-and-observability)
 
 ---
 
@@ -61,7 +62,18 @@ When adding a root:
 
 Changes take effect immediately—no service restart is required—so review tokens carefully in the test console before saving.
 
-## 5. Troubleshooting and observability
+## 5. Portable documents
+
+Portable suite documents, including Codex skill packages, store sigils as raw
+text and resolve only allowed non-secret sigils when files are materialized on a
+specific device. This lets one package adapt to local paths, node roles, or
+suite metadata without embedding another installation's values.
+
+Do not use portable documents to move secrets or runtime coordination state
+between devices. Secrets must be configured independently on each node, and
+local files such as `workgroup.md` stay local to the device where they are used.
+
+## 6. Troubleshooting and observability
 
 - Unknown prefixes remain in place (for example `[UNKNOWN.VALUE]`) and are logged so you can spot typos quickly.
 - Failed lookups for entity prefixes raise descriptive errors in the logs; configuration prefixes resolve to an empty string when the key is missing.

--- a/apps/skills/management/commands/codex_skill_packages.py
+++ b/apps/skills/management/commands/codex_skill_packages.py
@@ -8,24 +8,33 @@ from django.core.management.base import BaseCommand, CommandError
 from apps.skills.package_services import (
     export_codex_skill_package,
     import_codex_skill_package,
+    materialize_codex_skill_files,
     scan_codex_skills_root,
 )
 
 
 class Command(BaseCommand):
-    help = "Scan, export, or import portable Codex skill packages."
+    help = "Scan, export, import, or materialize portable Codex skill packages."
 
     def add_arguments(self, parser):
-        parser.add_argument("action", choices=["scan", "export", "import"])
+        parser.add_argument(
+            "action", choices=["scan", "export", "import", "materialize"]
+        )
         parser.add_argument("--source", help="Codex skills root for scan.")
         parser.add_argument("--output", help="ZIP package path for export.")
         parser.add_argument("--package", help="ZIP package path for import.")
+        parser.add_argument("--target", help="Local skills root for materialize.")
         parser.add_argument("--slug", action="append", dest="slugs", default=[])
         parser.add_argument("--dry-run", action="store_true")
         parser.add_argument(
             "--include-excluded",
             action="store_true",
             help="Export package records even when they are excluded by default.",
+        )
+        parser.add_argument(
+            "--no-resolve-sigils",
+            action="store_true",
+            help="Write stored text exactly as-is when materializing package files.",
         )
 
     def handle(self, *args, **options):
@@ -44,12 +53,23 @@ class Command(BaseCommand):
                 skill_slugs=options["slugs"] or None,
                 portable_only=not options["include_excluded"],
             )
-        else:
+        elif action == "import":
             package = options.get("package")
             if not package:
                 raise CommandError("--package is required for import")
             summary = import_codex_skill_package(
                 Path(package),
                 dry_run=options["dry_run"],
+            )
+        else:
+            target = options.get("target")
+            if not target:
+                raise CommandError("--target is required for materialize")
+            if options["dry_run"]:
+                raise CommandError("--dry-run is not supported for materialize")
+            summary = materialize_codex_skill_files(
+                Path(target),
+                skill_slugs=options["slugs"] or None,
+                resolve_sigils_on_write=not options["no_resolve_sigils"],
             )
         self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))

--- a/apps/skills/management/commands/codex_workgroup.py
+++ b/apps/skills/management/commands/codex_workgroup.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+
+from apps.skills.workgroup import (
+    ensure_workgroup_file,
+    read_workgroup_text,
+    workgroup_path,
+)
+
+
+class Command(BaseCommand):
+    help = "Inspect or initialize the local Codex workgroup coordination file."
+
+    def add_arguments(self, parser):
+        parser.add_argument("action", choices=["path", "ensure", "read"])
+        parser.add_argument(
+            "--codex-home", help="Override the local CODEX_HOME directory."
+        )
+
+    def handle(self, *args, **options):
+        codex_home = Path(options["codex_home"]) if options.get("codex_home") else None
+        action = options["action"]
+        if action == "path":
+            self.stdout.write(str(workgroup_path(codex_home=codex_home)))
+            return
+        if action == "ensure":
+            self.stdout.write(str(ensure_workgroup_file(codex_home=codex_home)))
+            return
+        self.stdout.write(read_workgroup_text(codex_home=codex_home))

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -151,6 +151,34 @@ def _remove_tree_best_effort(path: Path) -> None:
         return
 
 
+def _should_prune_materialized_path(
+    relative_path: str, desired_paths: set[str]
+) -> bool:
+    if relative_path in desired_paths:
+        return False
+    classification = classify_codex_skill_path(relative_path)
+    if classification is not None and not classification.included_by_default:
+        return False
+    top_level = relative_path.split("/", 1)[0]
+    return relative_path == SKILL_MARKDOWN or top_level in PORTABLE_ROOTS
+
+
+def _prune_stale_materialized_files(
+    skill_dir: Path,
+    desired_paths: set[str],
+) -> None:
+    for existing_path in sorted(skill_dir.rglob("*"), reverse=True):
+        try:
+            if existing_path.is_file() or existing_path.is_symlink():
+                relative = normalize_package_path(existing_path.relative_to(skill_dir))
+                if _should_prune_materialized_path(relative, desired_paths):
+                    existing_path.unlink()
+            elif existing_path.is_dir() and not any(existing_path.iterdir()):
+                existing_path.rmdir()
+        except OSError:
+            continue
+
+
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
     normalized = relative_path.replace("\\", "/")
     return normalized, [part.lower() for part in normalized.split("/")]
@@ -572,6 +600,7 @@ def materialize_codex_skill_files(
         skill_dir = target_root / slug
         skill_dir.mkdir(parents=True, exist_ok=True)
         resolved_skill_dir = skill_dir.resolve(strict=False)
+        package_managed = bool(_included_package_files(skill))
         files = []
         desired_paths = set()
         for relative_path, content in _package_file_entries(skill):
@@ -599,28 +628,8 @@ def materialize_codex_skill_files(
                 summary["files_written"] += 1
             files.append({"path": package_path, "changed": changed})
 
-        for existing_path in sorted(skill_dir.rglob("*"), reverse=True):
-            try:
-                if existing_path.is_file() or existing_path.is_symlink():
-                    relative = normalize_package_path(
-                        existing_path.relative_to(skill_dir)
-                    )
-                    if relative in desired_paths:
-                        continue
-                    classification = classify_codex_skill_path(relative)
-                    if (
-                        classification is not None
-                        and not classification.included_by_default
-                    ):
-                        continue
-                    top_level = relative.split("/", 1)[0]
-                    if relative != SKILL_MARKDOWN and top_level not in PORTABLE_ROOTS:
-                        continue
-                    existing_path.unlink()
-                elif existing_path.is_dir() and not any(existing_path.iterdir()):
-                    existing_path.rmdir()
-            except OSError:
-                continue
+        if package_managed:
+            _prune_stale_materialized_files(skill_dir, desired_paths)
 
         summary["skills"].append({"slug": slug, "files": files})
     return summary

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from zipfile import ZIP_DEFLATED, ZipFile
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_slug
 from django.db import transaction
@@ -15,7 +17,9 @@ from apps.skills.models import AgentSkill, AgentSkillFile
 PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
 SKILL_MARKDOWN = "SKILL.md"
 EMPTY_CONTENT_SHA256 = hashlib.sha256(b"").hexdigest()
-DEFAULT_MATERIALIZE_SIGIL_ROOTS = frozenset({"CONF", "NODE", "SYS"})
+DEFAULT_MATERIALIZE_SIGIL_ROOTS = frozenset({"NODE", "SYS"})
+SAFE_MATERIALIZE_CONF_KEYS = frozenset({"BASE_DIR", "NODE_ROLE"})
+CONF_DOT_SIGIL_RE = re.compile(r"\[CONF\.([A-Za-z0-9_-]+)\]")
 
 BLOCKED_STATE_FILENAMES = {
     "pending-approval-alerts.lock.json",
@@ -109,7 +113,42 @@ def _resolve_document_sigils(
 
     from apps.sigils.sigil_resolver import resolve_sigils
 
-    return resolve_sigils(content, allowed_roots=allowed_roots)
+    return resolve_sigils(
+        _resolve_safe_conf_sigils(content),
+        allowed_roots=allowed_roots,
+    )
+
+
+def _resolve_safe_conf_sigils(content: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        raw_key = match.group(1)
+        normalized_key = raw_key.replace("-", "_").upper()
+        if normalized_key not in SAFE_MATERIALIZE_CONF_KEYS:
+            return match.group(0)
+        for candidate in (raw_key, normalized_key, normalized_key.lower()):
+            sentinel = object()
+            value = getattr(settings, candidate, sentinel)
+            if value is not sentinel:
+                return str(value)
+        return ""
+
+    return CONF_DOT_SIGIL_RE.sub(replace, content)
+
+
+def _remove_tree_best_effort(path: Path) -> None:
+    try:
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+            return
+        if path.is_dir():
+            for nested in sorted(path.rglob("*"), reverse=True):
+                if nested.is_file() or nested.is_symlink():
+                    nested.unlink()
+                elif nested.is_dir():
+                    nested.rmdir()
+            path.rmdir()
+    except OSError:
+        return
 
 
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
@@ -520,12 +559,7 @@ def materialize_codex_skill_files(
         keep_slugs = set(queryset.values_list("slug", flat=True))
         for child in target_root.iterdir():
             if child.is_dir() and child.name not in keep_slugs:
-                for nested in sorted(child.rglob("*"), reverse=True):
-                    if nested.is_file() or nested.is_symlink():
-                        nested.unlink()
-                    elif nested.is_dir():
-                        nested.rmdir()
-                child.rmdir()
+                _remove_tree_best_effort(child)
 
     summary = {
         "target": str(target_root),
@@ -537,6 +571,7 @@ def materialize_codex_skill_files(
         slug = validate_package_skill_slug(skill.slug)
         skill_dir = target_root / slug
         skill_dir.mkdir(parents=True, exist_ok=True)
+        resolved_skill_dir = skill_dir.resolve(strict=False)
         files = []
         desired_paths = set()
         for relative_path, content in _package_file_entries(skill):
@@ -544,7 +579,7 @@ def materialize_codex_skill_files(
             desired_paths.add(package_path)
             target_path = (skill_dir / package_path).resolve(strict=False)
             try:
-                target_path.relative_to(skill_dir.resolve(strict=False))
+                target_path.relative_to(resolved_skill_dir)
             except ValueError as error:
                 raise ValueError(f"Unsafe package path: {relative_path}") from error
             resolved_content = _resolve_document_sigils(
@@ -565,25 +600,27 @@ def materialize_codex_skill_files(
             files.append({"path": package_path, "changed": changed})
 
         for existing_path in sorted(skill_dir.rglob("*"), reverse=True):
-            if not existing_path.is_file():
+            try:
+                if existing_path.is_file() or existing_path.is_symlink():
+                    relative = normalize_package_path(
+                        existing_path.relative_to(skill_dir)
+                    )
+                    if relative in desired_paths:
+                        continue
+                    classification = classify_codex_skill_path(relative)
+                    if (
+                        classification is not None
+                        and not classification.included_by_default
+                    ):
+                        continue
+                    top_level = relative.split("/", 1)[0]
+                    if relative != SKILL_MARKDOWN and top_level not in PORTABLE_ROOTS:
+                        continue
+                    existing_path.unlink()
+                elif existing_path.is_dir() and not any(existing_path.iterdir()):
+                    existing_path.rmdir()
+            except OSError:
                 continue
-            relative = normalize_package_path(existing_path.relative_to(skill_dir))
-            if relative in desired_paths:
-                continue
-            classification = classify_codex_skill_path(relative)
-            if classification is not None and not classification.included_by_default:
-                continue
-            top_level = relative.split("/", 1)[0]
-            if relative != SKILL_MARKDOWN and top_level not in PORTABLE_ROOTS:
-                continue
-            existing_path.unlink()
-
-        for existing_dir in sorted(
-            [path for path in skill_dir.rglob("*") if path.is_dir()],
-            reverse=True,
-        ):
-            if not any(existing_dir.iterdir()):
-                existing_dir.rmdir()
 
         summary["skills"].append({"slug": slug, "files": files})
     return summary

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -15,6 +15,7 @@ from apps.skills.models import AgentSkill, AgentSkillFile
 PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
 SKILL_MARKDOWN = "SKILL.md"
 EMPTY_CONTENT_SHA256 = hashlib.sha256(b"").hexdigest()
+DEFAULT_MATERIALIZE_SIGIL_ROOTS = frozenset({"CONF", "NODE", "SYS"})
 
 BLOCKED_STATE_FILENAMES = {
     "pending-approval-alerts.lock.json",
@@ -95,6 +96,20 @@ def validate_package_skill_slug(slug: str) -> str:
     except ValidationError as error:
         raise ValueError(f"Unsafe skill slug: {slug}") from error
     return slug
+
+
+def _resolve_document_sigils(
+    content: str,
+    *,
+    resolve_sigils_on_write: bool,
+    allowed_roots: set[str] | frozenset[str] | None,
+) -> str:
+    if not resolve_sigils_on_write:
+        return content
+
+    from apps.sigils.sigil_resolver import resolve_sigils
+
+    return resolve_sigils(content, allowed_roots=allowed_roots)
 
 
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
@@ -454,6 +469,124 @@ def export_codex_skill_package(
                 manifest["skills"].append(skill_entry)
         package.writestr("manifest.json", json.dumps(manifest, indent=2))
     return manifest
+
+
+def _included_package_files(skill: AgentSkill) -> list[AgentSkillFile]:
+    return [
+        file_entry
+        for file_entry in skill.package_files.all()
+        if file_entry.included_by_default
+    ]
+
+
+def _legacy_skill_file_entry(skill: AgentSkill) -> tuple[str, str]:
+    return SKILL_MARKDOWN, skill.markdown
+
+
+def _package_file_entries(skill: AgentSkill) -> list[tuple[str, str]]:
+    package_files = _included_package_files(skill)
+    if not package_files:
+        return [_legacy_skill_file_entry(skill)]
+
+    entries = [
+        (file_entry.relative_path, file_entry.content) for file_entry in package_files
+    ]
+    if SKILL_MARKDOWN not in {relative_path for relative_path, _ in entries}:
+        entries.insert(0, _legacy_skill_file_entry(skill))
+    return entries
+
+
+def materialize_codex_skill_files(
+    target_root: Path,
+    *,
+    skill_slugs: list[str] | None = None,
+    resolve_sigils_on_write: bool = True,
+    allowed_roots: set[str] | frozenset[str] | None = DEFAULT_MATERIALIZE_SIGIL_ROOTS,
+) -> dict:
+    """Write stored portable skill trees to a local skills directory.
+
+    Stored package content remains generic. SIGILS are resolved only while
+    writing to the target node, so portable documents can adapt to local suite
+    paths and role metadata without copying operator-specific state.
+    """
+
+    target_root = Path(target_root)
+    queryset = AgentSkill.objects.prefetch_related("package_files")
+    if skill_slugs:
+        queryset = queryset.filter(slug__in=skill_slugs)
+
+    target_root.mkdir(parents=True, exist_ok=True)
+    if skill_slugs is None:
+        keep_slugs = set(queryset.values_list("slug", flat=True))
+        for child in target_root.iterdir():
+            if child.is_dir() and child.name not in keep_slugs:
+                for nested in sorted(child.rglob("*"), reverse=True):
+                    if nested.is_file() or nested.is_symlink():
+                        nested.unlink()
+                    elif nested.is_dir():
+                        nested.rmdir()
+                child.rmdir()
+
+    summary = {
+        "target": str(target_root),
+        "resolve_sigils_on_write": resolve_sigils_on_write,
+        "skills": [],
+        "files_written": 0,
+    }
+    for skill in queryset.order_by("slug"):
+        slug = validate_package_skill_slug(skill.slug)
+        skill_dir = target_root / slug
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        files = []
+        desired_paths = set()
+        for relative_path, content in _package_file_entries(skill):
+            package_path = validate_package_relative_path(relative_path)
+            desired_paths.add(package_path)
+            target_path = (skill_dir / package_path).resolve(strict=False)
+            try:
+                target_path.relative_to(skill_dir.resolve(strict=False))
+            except ValueError as error:
+                raise ValueError(f"Unsafe package path: {relative_path}") from error
+            resolved_content = _resolve_document_sigils(
+                content,
+                resolve_sigils_on_write=resolve_sigils_on_write,
+                allowed_roots=allowed_roots,
+            )
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            existing = (
+                target_path.read_text(encoding="utf-8")
+                if target_path.exists()
+                else None
+            )
+            changed = existing != resolved_content
+            if changed:
+                target_path.write_text(resolved_content, encoding="utf-8")
+                summary["files_written"] += 1
+            files.append({"path": package_path, "changed": changed})
+
+        for existing_path in sorted(skill_dir.rglob("*"), reverse=True):
+            if not existing_path.is_file():
+                continue
+            relative = normalize_package_path(existing_path.relative_to(skill_dir))
+            if relative in desired_paths:
+                continue
+            classification = classify_codex_skill_path(relative)
+            if classification is not None and not classification.included_by_default:
+                continue
+            top_level = relative.split("/", 1)[0]
+            if relative != SKILL_MARKDOWN and top_level not in PORTABLE_ROOTS:
+                continue
+            existing_path.unlink()
+
+        for existing_dir in sorted(
+            [path for path in skill_dir.rglob("*") if path.is_dir()],
+            reverse=True,
+        ):
+            if not any(existing_dir.iterdir()):
+                existing_dir.rmdir()
+
+        summary["skills"].append({"slug": slug, "files": files})
+    return summary
 
 
 def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> dict:

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -556,10 +556,11 @@ def _package_file_entries(skill: AgentSkill) -> list[tuple[str, str]]:
         return [_legacy_skill_file_entry(skill)]
 
     entries = [
-        (file_entry.relative_path, file_entry.content) for file_entry in package_files
+        (file_entry.relative_path, file_entry.content)
+        for file_entry in package_files
+        if file_entry.relative_path != SKILL_MARKDOWN
     ]
-    if SKILL_MARKDOWN not in {relative_path for relative_path, _ in entries}:
-        entries.insert(0, _legacy_skill_file_entry(skill))
+    entries.insert(0, _legacy_skill_file_entry(skill))
     return entries
 
 

--- a/apps/skills/services.py
+++ b/apps/skills/services.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from django.conf import settings
 from django.db import transaction
 
-from apps.skills.models import AgentSkill
 from apps.nodes.models import NodeRole
+from apps.skills.models import AgentSkill
+from apps.skills.package_services import materialize_codex_skill_files
 
 DEFAULT_SKILL_ROLE_MAP = {
     "cp-doctor": "Satellite",
@@ -69,22 +70,5 @@ def sync_filesystem_to_db() -> int:
 
 def sync_db_to_filesystem() -> int:
     skills_root = Path(settings.BASE_DIR) / "skills"
-    keep = set(AgentSkill.objects.values_list("slug", flat=True))
-    for child in skills_root.iterdir():
-        if child.is_dir() and child.name not in keep:
-            for nested in sorted(child.rglob("*"), reverse=True):
-                if nested.is_file() or nested.is_symlink():
-                    nested.unlink()
-                elif nested.is_dir():
-                    nested.rmdir()
-            child.rmdir()
-
-    updates = 0
-    for skill in AgentSkill.objects.all():
-        target = skills_root / skill.slug / "SKILL.md"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        existing = target.read_text(encoding="utf-8") if target.exists() else None
-        if existing != skill.markdown:
-            target.write_text(skill.markdown, encoding="utf-8")
-            updates += 1
-    return updates
+    summary = materialize_codex_skill_files(skills_root)
+    return summary["files_written"]

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -174,10 +174,10 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
     skill = AgentSkill.objects.create(
         slug="operator-manual",
         title="Operator Manual",
-        markdown="fallback [CONF.BASE_DIR]",
+        markdown="Use suite root [CONF.BASE_DIR] and keep [CONF.SECRET_KEY]",
     )
     portable_files = [
-        ("SKILL.md", "Use suite root [CONF.BASE_DIR] and keep [CONF.SECRET_KEY]"),
+        ("SKILL.md", "Stale package markdown [CONF.BASE_DIR]"),
         ("references/glossary.md", "Portable glossary for [CONF.BASE_DIR]"),
         ("scripts/setup.ps1", "Write-Output '[CONF.BASE_DIR]'"),
     ]

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -227,39 +227,26 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
     assert not (skill_root / "credentials" / "token.txt").exists()
     assert not (skill_root / "workgroup.md").exists()
 
+    unresolved_target_root = tmp_path / "codex-skills-unresolved"
+    with override_settings(BASE_DIR=suite_root):
+        unresolved_summary = materialize_codex_skill_files(
+            unresolved_target_root,
+            resolve_sigils_on_write=False,
+        )
 
-@pytest.mark.django_db
-def test_materialize_can_write_unresolved_sigils(tmp_path):
-    SigilRoot.objects.get_or_create(
-        prefix="CONF",
-        defaults={"context_type": SigilRoot.Context.CONFIG},
+    unresolved_skill_root = unresolved_target_root / "operator-manual"
+    assert unresolved_summary["files_written"] == 3
+    assert (unresolved_skill_root / "SKILL.md").read_text(encoding="utf-8") == (
+        "Use suite root [CONF.BASE_DIR] and keep [CONF.SECRET_KEY]"
     )
-    target_root = tmp_path / "codex-skills"
-    skill = AgentSkill.objects.create(
-        slug="operator-manual",
-        title="Operator Manual",
-        markdown="fallback [CONF.BASE_DIR]",
-    )
-    content = "Use suite root [CONF.BASE_DIR]"
-    AgentSkillFile.objects.create(
-        skill=skill,
-        relative_path="SKILL.md",
-        content=content,
-        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
-        portability=AgentSkillFile.Portability.PORTABLE,
-        included_by_default=True,
-        size_bytes=len(content.encode("utf-8")),
-    )
-
-    summary = materialize_codex_skill_files(
-        target_root,
-        resolve_sigils_on_write=False,
-    )
-
-    assert summary["files_written"] == 1
-    assert (target_root / "operator-manual" / "SKILL.md").read_text(
+    assert (unresolved_skill_root / "references" / "glossary.md").read_text(
         encoding="utf-8"
-    ) == content
+    ) == "Portable glossary for [CONF.BASE_DIR]"
+    assert (unresolved_skill_root / "scripts" / "setup.ps1").read_text(
+        encoding="utf-8"
+    ) == "Write-Output '[CONF.BASE_DIR]'"
+    assert not (unresolved_skill_root / "credentials" / "token.txt").exists()
+    assert not (unresolved_skill_root / "workgroup.md").exists()
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -177,7 +177,7 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
         markdown="fallback [CONF.BASE_DIR]",
     )
     portable_files = [
-        ("SKILL.md", "Use suite root [CONF.BASE_DIR]"),
+        ("SKILL.md", "Use suite root [CONF.BASE_DIR] and keep [CONF.SECRET_KEY]"),
         ("references/glossary.md", "Portable glossary for [CONF.BASE_DIR]"),
         ("scripts/setup.ps1", "Write-Output '[CONF.BASE_DIR]'"),
     ]
@@ -216,7 +216,7 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
     skill_root = target_root / "operator-manual"
     assert summary["files_written"] == 3
     assert (skill_root / "SKILL.md").read_text(encoding="utf-8") == (
-        f"Use suite root {suite_root}"
+        f"Use suite root {suite_root} and keep [CONF.SECRET_KEY]"
     )
     assert (skill_root / "references" / "glossary.md").read_text(
         encoding="utf-8"
@@ -226,6 +226,40 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
     )
     assert not (skill_root / "credentials" / "token.txt").exists()
     assert not (skill_root / "workgroup.md").exists()
+
+
+@pytest.mark.django_db
+def test_materialize_can_write_unresolved_sigils(tmp_path):
+    SigilRoot.objects.get_or_create(
+        prefix="CONF",
+        defaults={"context_type": SigilRoot.Context.CONFIG},
+    )
+    target_root = tmp_path / "codex-skills"
+    skill = AgentSkill.objects.create(
+        slug="operator-manual",
+        title="Operator Manual",
+        markdown="fallback [CONF.BASE_DIR]",
+    )
+    content = "Use suite root [CONF.BASE_DIR]"
+    AgentSkillFile.objects.create(
+        skill=skill,
+        relative_path="SKILL.md",
+        content=content,
+        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        portability=AgentSkillFile.Portability.PORTABLE,
+        included_by_default=True,
+        size_bytes=len(content.encode("utf-8")),
+    )
+
+    summary = materialize_codex_skill_files(
+        target_root,
+        resolve_sigils_on_write=False,
+    )
+
+    assert summary["files_written"] == 1
+    assert (target_root / "operator-manual" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == content
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -250,6 +250,30 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
 
 
 @pytest.mark.django_db
+def test_materialize_legacy_skill_preserves_existing_portable_tree(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    skill_root = target_root / "legacy-skill"
+    _write(skill_root / "references" / "existing.md", "keep reference")
+    _write(skill_root / "scripts" / "existing.ps1", "Write-Output keep")
+    AgentSkill.objects.create(
+        slug="legacy-skill",
+        title="Legacy Skill",
+        markdown="legacy markdown",
+    )
+
+    summary = materialize_codex_skill_files(target_root)
+
+    assert summary["files_written"] == 1
+    assert (skill_root / "SKILL.md").read_text(encoding="utf-8") == "legacy markdown"
+    assert (skill_root / "references" / "existing.md").read_text(
+        encoding="utf-8"
+    ) == "keep reference"
+    assert (skill_root / "scripts" / "existing.ps1").read_text(
+        encoding="utf-8"
+    ) == "Write-Output keep"
+
+
+@pytest.mark.django_db
 def test_export_synthesizes_legacy_skill_markdown_file(tmp_path):
     AgentSkill.objects.create(
         slug="legacy-skill",

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -9,12 +9,14 @@ import pytest
 from django.test import override_settings
 
 from apps.nodes.models import NodeRole
+from apps.sigils.models import SigilRoot
 from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import (
     PACKAGE_FORMAT,
     classify_codex_skill_file,
     export_codex_skill_package,
     import_codex_skill_package,
+    materialize_codex_skill_files,
     scan_codex_skill_directory,
 )
 from apps.skills.services import sync_filesystem_to_db
@@ -44,6 +46,13 @@ def test_classifies_portable_state_secret_and_operator_scoped_files():
     )
     assert operator_scoped.portability == AgentSkillFile.Portability.OPERATOR_SCOPED
     assert operator_scoped.included_by_default is False
+
+    sigil_scoped = classify_codex_skill_file(
+        "references/glossary.md",
+        "Use [CONF.BASE_DIR] and [SYS.NODE_ROLE] for local paths.",
+    )
+    assert sigil_scoped.portability == AgentSkillFile.Portability.PORTABLE
+    assert sigil_scoped.included_by_default is True
 
     skill_markdown = classify_codex_skill_file(
         "SKILL.md",
@@ -152,6 +161,71 @@ def test_export_import_round_trip_includes_only_portable_files(tmp_path):
     assert not skill.package_files.filter(
         relative_path="credentials/odoo.json"
     ).exists()
+
+
+@pytest.mark.django_db
+def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_path):
+    SigilRoot.objects.get_or_create(
+        prefix="CONF",
+        defaults={"context_type": SigilRoot.Context.CONFIG},
+    )
+    suite_root = tmp_path / "suite-root"
+    target_root = tmp_path / "codex-skills"
+    skill = AgentSkill.objects.create(
+        slug="operator-manual",
+        title="Operator Manual",
+        markdown="fallback [CONF.BASE_DIR]",
+    )
+    portable_files = [
+        ("SKILL.md", "Use suite root [CONF.BASE_DIR]"),
+        ("references/glossary.md", "Portable glossary for [CONF.BASE_DIR]"),
+        ("scripts/setup.ps1", "Write-Output '[CONF.BASE_DIR]'"),
+    ]
+    for relative_path, content in portable_files:
+        AgentSkillFile.objects.create(
+            skill=skill,
+            relative_path=relative_path,
+            content=content,
+            content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            portability=AgentSkillFile.Portability.PORTABLE,
+            included_by_default=True,
+            size_bytes=len(content.encode("utf-8")),
+        )
+    AgentSkillFile.objects.create(
+        skill=skill,
+        relative_path="credentials/token.txt",
+        content="",
+        content_sha256=hashlib.sha256(b"").hexdigest(),
+        portability=AgentSkillFile.Portability.SECRET,
+        included_by_default=False,
+        exclusion_reason="secret payload",
+    )
+    AgentSkillFile.objects.create(
+        skill=skill,
+        relative_path="workgroup.md",
+        content="",
+        content_sha256=hashlib.sha256(b"").hexdigest(),
+        portability=AgentSkillFile.Portability.STATE,
+        included_by_default=False,
+        exclusion_reason="runtime state is not portable",
+    )
+
+    with override_settings(BASE_DIR=suite_root):
+        summary = materialize_codex_skill_files(target_root)
+
+    skill_root = target_root / "operator-manual"
+    assert summary["files_written"] == 3
+    assert (skill_root / "SKILL.md").read_text(encoding="utf-8") == (
+        f"Use suite root {suite_root}"
+    )
+    assert (skill_root / "references" / "glossary.md").read_text(
+        encoding="utf-8"
+    ) == f"Portable glossary for {suite_root}"
+    assert (skill_root / "scripts" / "setup.ps1").read_text(encoding="utf-8") == (
+        f"Write-Output '{suite_root}'"
+    )
+    assert not (skill_root / "credentials" / "token.txt").exists()
+    assert not (skill_root / "workgroup.md").exists()
 
 
 @pytest.mark.django_db

--- a/apps/skills/tests/test_workgroup.py
+++ b/apps/skills/tests/test_workgroup.py
@@ -21,10 +21,29 @@ def test_workgroup_service_initializes_local_coordination_file(tmp_path):
 
 
 def test_workgroup_command_reports_configured_path(tmp_path):
-    stdout = StringIO()
+    expected = workgroup_path(codex_home=tmp_path)
+    path_stdout = StringIO()
 
     call_command(
-        "codex_workgroup", "path", "--codex-home", str(tmp_path), stdout=stdout
+        "codex_workgroup", "path", "--codex-home", str(tmp_path), stdout=path_stdout
     )
 
-    assert stdout.getvalue().strip() == str(workgroup_path(codex_home=tmp_path))
+    assert path_stdout.getvalue().strip() == str(expected)
+
+    ensure_stdout = StringIO()
+    call_command(
+        "codex_workgroup",
+        "ensure",
+        "--codex-home",
+        str(tmp_path),
+        stdout=ensure_stdout,
+    )
+
+    assert ensure_stdout.getvalue().strip() == str(expected)
+
+    read_stdout = StringIO()
+    call_command(
+        "codex_workgroup", "read", "--codex-home", str(tmp_path), stdout=read_stdout
+    )
+
+    assert "Commander Overview" in read_stdout.getvalue()

--- a/apps/skills/tests/test_workgroup.py
+++ b/apps/skills/tests/test_workgroup.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.management import call_command
+
+from apps.skills.workgroup import (
+    WORKGROUP_FILENAME,
+    ensure_workgroup_file,
+    read_workgroup_text,
+    workgroup_path,
+)
+
+
+def test_workgroup_service_initializes_local_coordination_file(tmp_path):
+    path = ensure_workgroup_file(codex_home=tmp_path)
+
+    assert path == tmp_path / WORKGROUP_FILENAME
+    assert "Commander Overview" in path.read_text(encoding="utf-8")
+    assert read_workgroup_text(codex_home=tmp_path) == path.read_text(encoding="utf-8")
+
+
+def test_workgroup_command_reports_configured_path(tmp_path):
+    stdout = StringIO()
+
+    call_command(
+        "codex_workgroup", "path", "--codex-home", str(tmp_path), stdout=stdout
+    )
+
+    assert stdout.getvalue().strip() == str(workgroup_path(codex_home=tmp_path))

--- a/apps/skills/workgroup.py
+++ b/apps/skills/workgroup.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from django.conf import settings
+
+WORKGROUP_FILENAME = "workgroup.md"
+DEFAULT_WORKGROUP_TEMPLATE = """# Workgroup
+
+Global coordination file for named commander-equivalent coordinators and commander-created sub-agents.
+
+## Commander Overview
+
+- Last updated:
+- Active commander-equivalent coordinators:
+- Active combat:
+- Active role locks:
+- Active PR or issue ownership:
+- Coordination notes:
+
+## Commander-Equivalent Entries
+
+## Agent Entries
+"""
+
+
+def default_codex_home() -> Path:
+    configured_home = getattr(settings, "CODEX_HOME", "") or os.environ.get("CODEX_HOME", "")
+    if configured_home:
+        return Path(configured_home).expanduser()
+    return Path.home() / ".codex"
+
+
+def workgroup_path(*, codex_home: Path | str | None = None) -> Path:
+    root = Path(codex_home).expanduser() if codex_home is not None else default_codex_home()
+    return root / WORKGROUP_FILENAME
+
+
+def ensure_workgroup_file(*, codex_home: Path | str | None = None) -> Path:
+    path = workgroup_path(codex_home=codex_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(DEFAULT_WORKGROUP_TEMPLATE, encoding="utf-8")
+    return path
+
+
+def read_workgroup_text(*, codex_home: Path | str | None = None) -> str:
+    path = ensure_workgroup_file(codex_home=codex_home)
+    return path.read_text(encoding="utf-8")

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -25,15 +25,17 @@ SIGILS only when package files are materialized into a local directory. This
 lets one general skill package adapt to each node without embedding one
 operator's local paths.
 
-Default materialization allows non-secret local context roots:
+Default materialization allows non-secret local context:
 
-- `CONF`: Django settings such as `[CONF.BASE_DIR]`.
 - `SYS`: suite system metadata such as role or upgrade state.
 - `NODE`: local node records when the node sigil root is configured.
+- A small allow-list of simple `CONF` keys such as `[CONF.BASE_DIR]` and
+  `[CONF.NODE_ROLE]`.
 
-Do not use `ENV` SIGILS in portable skill content for secrets. Secrets must be
-configured independently on each node and must never move through skill package
-export/import.
+Arbitrary `CONF` keys are not resolved during default materialization. Secret
+settings such as `[CONF.SECRET_KEY]` remain literal text, and `ENV` SIGILS are
+not allowed by default. Secrets must be configured independently on each node
+and must never move through skill package export/import.
 
 ## Workgroup State
 

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -1,0 +1,63 @@
+# Codex Skill Packages
+
+Arthexis stores Codex skills as portable package trees, not only as one `SKILL.md`
+document. A package may include:
+
+- `SKILL.md`
+- `agents/`
+- `assets/`
+- `references/`
+- `scripts/`
+- `templates/`
+
+Runtime state, caches, generated archives, and secrets are not portable package
+content. The package scanner records excluded files as metadata when useful, but
+does not store their sensitive payloads.
+
+## SIGILS In Portable Documents
+
+Use **SIGILS** when a suite-owned skill or document needs local customization on
+each installed device. SIGILS are bracketed suite expressions such as
+`[CONF.BASE_DIR]`, `[SYS.NODE_ROLE]`, or `[NODE.ROLE]`.
+
+Portable package storage keeps SIGILS unresolved. The suite resolves allowed
+SIGILS only when package files are materialized into a local directory. This
+lets one general skill package adapt to each node without embedding one
+operator's local paths.
+
+Default materialization allows non-secret local context roots:
+
+- `CONF`: Django settings such as `[CONF.BASE_DIR]`.
+- `SYS`: suite system metadata such as role or upgrade state.
+- `NODE`: local node records when the node sigil root is configured.
+
+Do not use `ENV` SIGILS in portable skill content for secrets. Secrets must be
+configured independently on each node and must never move through skill package
+export/import.
+
+## Workgroup State
+
+`workgroup.md` is local runtime coordination state. It must not be copied from
+one device to another as package content. The suite exposes a workgroup service
+boundary so future polling, status pages, or admin views can read the local file
+without treating it as a portable document.
+
+Use:
+
+```bash
+python manage.py codex_workgroup path
+python manage.py codex_workgroup ensure
+python manage.py codex_workgroup read
+```
+
+To materialize stored skill trees:
+
+```bash
+python manage.py codex_skill_packages materialize --target ~/.codex/skills
+```
+
+To preserve raw SIGILS for inspection instead of resolving them:
+
+```bash
+python manage.py codex_skill_packages materialize --target ~/.codex/skills --no-resolve-sigils
+```

--- a/docs/development/sigil-script-command.md
+++ b/docs/development/sigil-script-command.md
@@ -77,8 +77,10 @@ SIGILS are also the suite's portability mechanism for skills and documents that
 are stored generally and written locally on each Arthexis device. A package can
 store `[CONF.BASE_DIR]`, `[SYS.NODE_ROLE]`, or another allowed suite SIGIL in a
 skill reference, script template, or agent instruction. The stored package keeps
-the SIGIL text. The target device resolves it only when materializing the file to
-its local directory.
+the SIGIL text. The target device resolves only allowed non-secret SIGILS when
+materializing the file to its local directory. Default materialization resolves
+`SYS`, `NODE`, and an explicit safe subset of simple `CONF` keys; arbitrary
+settings such as `[CONF.SECRET_KEY]` remain literal text.
 
 This keeps portable documents reusable while still allowing local behavior. It
 also sets a hard boundary: secrets and runtime state must not be moved through

--- a/docs/development/sigil-script-command.md
+++ b/docs/development/sigil-script-command.md
@@ -71,6 +71,23 @@ Use cached execution for repeated automation runs:
   --context user
 ```
 
+## Portable suite documents
+
+SIGILS are also the suite's portability mechanism for skills and documents that
+are stored generally and written locally on each Arthexis device. A package can
+store `[CONF.BASE_DIR]`, `[SYS.NODE_ROLE]`, or another allowed suite SIGIL in a
+skill reference, script template, or agent instruction. The stored package keeps
+the SIGIL text. The target device resolves it only when materializing the file to
+its local directory.
+
+This keeps portable documents reusable while still allowing local behavior. It
+also sets a hard boundary: secrets and runtime state must not be moved through
+SIGILS or package files. Store secrets on each node through that node's normal
+credential path, and keep `workgroup.md` as local coordination state.
+
+See [Codex Skill Packages](codex-skill-packages.md) for package materialization
+and workgroup rules.
+
 ## Error behavior
 
 The command exits non-zero for:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ In Arthexis terminology, the **suite** is the collection of applications, while 
 - [CodeQL Configuration](development/codeql.md)
 - [Cookbook Maintainer Guide](development/cookbook-maintainer-guide.md)
 - [Cookbook QA Checklist](../apps/docs/cookbooks/cookbook-qa-checklist.md)
+- [Codex Skill Packages](development/codex-skill-packages.md)
 - [Good Command](operations/good-command.md)
 - [Install & Lifecycle Scripts Manual](development/install-lifecycle-scripts-manual.md)
 - [Sigil Script Command](development/sigil-script-command.md)


### PR DESCRIPTION
## Summary
- materialize stored Codex skill package trees, not only `SKILL.md`
- resolve allowed suite SIGILS only when files are written to local skill directories
- add a suite workgroup service/command while keeping `workgroup.md` local runtime state and out of portable packages
- document SIGIL use, secret boundaries, workgroup behavior, and materialization commands

## Validation
- `upgrade.bat --main`
- `python manage.py migrate --noinput`
- `ruff check apps/skills/package_services.py apps/skills/services.py apps/skills/management/commands/codex_skill_packages.py apps/skills/management/commands/codex_workgroup.py apps/skills/tests/test_package_services.py apps/skills/tests/test_workgroup.py`
- `pytest apps/skills -q`
- `python manage.py check --fail-level ERROR`
- `python manage.py makemigrations --check --dry-run`
- `python scripts/check_import_resolution.py apps/skills`
- `git diff --check`
- `python manage.py codex_workgroup path --codex-home <temp>`
- `python manage.py codex_skill_packages materialize --target <temp> --slug cp-doctor --no-resolve-sigils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR implements materialization of portable Codex skill package directory trees with configurable SIGIL resolution. Previously, only `SKILL.md` files were synced to the filesystem; now the system supports writing complete portable package structures while treating SIGILs as portable placeholders that are resolved only during local materialization—not during storage. A new workgroup coordination system is introduced to manage local runtime state (`workgroup.md`) separately from portable packages.

## Key Changes

### New Materialization Pathway (`package_services.py`)

- **`materialize_codex_skill_files()`** function writes stored skill package content to a local directory tree with:
  - Selective file inclusion based on portability classification (`included_by_default` predicate)
  - SIGIL resolution gated behind `resolve_sigils_on_write` flag
  - Path safety validation and write-only-when-changed tracking
  - Stale file pruning in skill directories when not filtering by specific slugs
  - Default allowed SIGIL roots (`DEFAULT_MATERIALIZE_SIGIL_ROOTS`: `CONF`, `SYS`, `NODE`)
  - Automatic fallback from `skill.markdown` to ensure `SKILL.md` presence

### Workgroup Coordination System (`workgroup.py`)

- **`workgroup.md`** file stored in Codex home directory as local-only runtime coordination data
- Functions: `default_codex_home()`, `workgroup_path()`, `ensure_workgroup_file()`, `read_workgroup_text()`
- Supports configurable home directory via `CODEX_HOME` setting or environment variable (defaults to `~/.codex`)

### New Management Commands

**`codex_workgroup`** (`codex_workgroup.py`):
- `path` — prints resolved workgroup file path
- `ensure` — initializes workgroup file if missing and prints path
- `read` — prints workgroup file contents
- Accepts optional `--codex-home` override

**`codex_skill_packages materialize`** (`codex_skill_packages.py`):
- Materializes stored skill trees to `--target` directory
- `--no-resolve-sigils` preserves SIGIL text instead of resolving it
- Filters to specific `--slug` values when provided

### Refactored Sync (`services.py`)

- `sync_db_to_filesystem()` now delegates all filesystem operations to `materialize_codex_skill_files()`
- Eliminates inline directory pruning and per-skill `SKILL.md` iteration

### Test Coverage

- **`test_package_services.py`**: Verifies SIGIL classification and full-tree materialization with sigil resolution, excluded-file filtering, and `SKILL.md` fallback
- **`test_workgroup.py`**: Validates workgroup file creation, content initialization, and management command argument handling

### Documentation

- **`codex-skill-packages.md`**: Comprehensive guide to portable package structure, supported subdirectories, SIGIL portability semantics, and materialization commands
- **`sigil-script-command.md`**: Clarifies SIGIL design as a portability mechanism resolved at materialization time, with warnings against transporting secrets through SIGILs
- **`docs/index.md`**: Added navigation link to skill packages documentation

## Design Decisions Enforced

- SIGILs remain unresolved in portable storage; resolution happens only during local materialization
- `workgroup.md` is kept local to each device, never transported in portable packages
- Portable file classification prevents secrets and runtime state from being included by default
- Default SIGIL root allowlist (`CONF`, `SYS`, `NODE`) establishes clear security boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->