### PR TITLE
Harden skill materialization path replacement

### DIFF
--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -193,6 +193,20 @@ def _prepare_materialized_file_path(path: Path, skill_dir: Path) -> None:
         _remove_tree_best_effort(path)
 
 
+def _validate_materialized_package_paths(package_paths: list[str]) -> None:
+    unique_paths = set(package_paths)
+    if len(unique_paths) != len(package_paths):
+        raise ValueError("Duplicate package path")
+    for package_path in unique_paths:
+        parts = package_path.split("/")
+        for index in range(1, len(parts)):
+            prefix = "/".join(parts[:index])
+            if prefix in unique_paths:
+                raise ValueError(
+                    f"Package path collides with nested path: {package_path}"
+                )
+
+
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
     normalized = relative_path.replace("\\", "/")
     return normalized, [part.lower() for part in normalized.split("/")]
@@ -626,11 +640,18 @@ def materialize_codex_skill_files(
             raise ValueError(f"Unsafe skill directory: {skill_dir}") from error
         package_managed = bool(_included_package_files(skill))
         files = []
-        desired_paths = set()
+        entries = []
         for relative_path, content in _package_file_entries(skill):
             package_path = validate_package_relative_path(relative_path)
-            desired_paths.add(package_path)
+            entries.append((relative_path, package_path, content))
+        desired_paths = {package_path for _, package_path, _ in entries}
+        _validate_materialized_package_paths(
+            [package_path for _, package_path, _ in entries]
+        )
+
+        for relative_path, package_path, content in entries:
             target_path = skill_dir / package_path
+            _prepare_materialized_file_path(target_path, skill_dir)
             resolved_target_path = target_path.resolve(strict=False)
             try:
                 resolved_target_path.relative_to(resolved_skill_dir)
@@ -641,7 +662,6 @@ def materialize_codex_skill_files(
                 resolve_sigils_on_write=resolve_sigils_on_write,
                 allowed_roots=allowed_roots,
             )
-            _prepare_materialized_file_path(target_path, skill_dir)
             existing = (
                 target_path.read_text(encoding="utf-8")
                 if target_path.exists()

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -179,6 +179,20 @@ def _prune_stale_materialized_files(
             continue
 
 
+def _prepare_materialized_file_path(path: Path, skill_dir: Path) -> None:
+    current = skill_dir
+    for part in path.relative_to(skill_dir).parts[:-1]:
+        current = current / part
+        if current.is_symlink() or current.is_file():
+            current.unlink()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        path.unlink()
+    elif path.is_dir():
+        _remove_tree_best_effort(path)
+
+
 def _normalized_parts(relative_path: str) -> tuple[str, list[str]]:
     normalized = relative_path.replace("\\", "/")
     return normalized, [part.lower() for part in normalized.split("/")]
@@ -584,6 +598,7 @@ def materialize_codex_skill_files(
         queryset = queryset.filter(slug__in=skill_slugs)
 
     target_root.mkdir(parents=True, exist_ok=True)
+    resolved_target_root = target_root.resolve(strict=False)
     if skill_slugs is None:
         keep_slugs = set(queryset.values_list("slug", flat=True))
         for child in target_root.iterdir():
@@ -599,17 +614,26 @@ def materialize_codex_skill_files(
     for skill in queryset.order_by("slug"):
         slug = validate_package_skill_slug(skill.slug)
         skill_dir = target_root / slug
+        if skill_dir.is_symlink():
+            raise ValueError(f"Unsafe skill directory symlink: {skill_dir}")
+        if skill_dir.exists() and not skill_dir.is_dir():
+            skill_dir.unlink()
         skill_dir.mkdir(parents=True, exist_ok=True)
         resolved_skill_dir = skill_dir.resolve(strict=False)
+        try:
+            resolved_skill_dir.relative_to(resolved_target_root)
+        except ValueError as error:
+            raise ValueError(f"Unsafe skill directory: {skill_dir}") from error
         package_managed = bool(_included_package_files(skill))
         files = []
         desired_paths = set()
         for relative_path, content in _package_file_entries(skill):
             package_path = validate_package_relative_path(relative_path)
             desired_paths.add(package_path)
-            target_path = (skill_dir / package_path).resolve(strict=False)
+            target_path = skill_dir / package_path
+            resolved_target_path = target_path.resolve(strict=False)
             try:
-                target_path.relative_to(resolved_skill_dir)
+                resolved_target_path.relative_to(resolved_skill_dir)
             except ValueError as error:
                 raise ValueError(f"Unsafe package path: {relative_path}") from error
             resolved_content = _resolve_document_sigils(
@@ -617,7 +641,7 @@ def materialize_codex_skill_files(
                 resolve_sigils_on_write=resolve_sigils_on_write,
                 allowed_roots=allowed_roots,
             )
-            target_path.parent.mkdir(parents=True, exist_ok=True)
+            _prepare_materialized_file_path(target_path, skill_dir)
             existing = (
                 target_path.read_text(encoding="utf-8")
                 if target_path.exists()

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -194,14 +194,17 @@ def _prepare_materialized_file_path(path: Path, skill_dir: Path) -> None:
 
 
 def _validate_materialized_package_paths(package_paths: list[str]) -> None:
-    unique_paths = set(package_paths)
-    if len(unique_paths) != len(package_paths):
-        raise ValueError("Duplicate package path")
-    for package_path in unique_paths:
-        parts = package_path.split("/")
+    normalized_paths = {}
+    for package_path in package_paths:
+        normalized_path = package_path.casefold()
+        if normalized_path in normalized_paths:
+            raise ValueError(f"Duplicate package path: {package_path}")
+        normalized_paths[normalized_path] = package_path
+    for normalized_path, package_path in normalized_paths.items():
+        parts = normalized_path.split("/")
         for index in range(1, len(parts)):
             prefix = "/".join(parts[:index])
-            if prefix in unique_paths:
+            if prefix in normalized_paths:
                 raise ValueError(
                     f"Package path collides with nested path: {package_path}"
                 )

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -336,6 +336,32 @@ def test_materialize_rejects_package_path_prefix_collisions(tmp_path):
 
 
 @pytest.mark.django_db
+def test_materialize_rejects_case_insensitive_prefix_collisions(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    skill = AgentSkill.objects.create(
+        slug="portable-skill",
+        title="Portable Skill",
+        markdown="current markdown",
+    )
+    for relative_path, content in [
+        ("references/Topic", "parent file"),
+        ("references/topic/child.md", "child file"),
+    ]:
+        AgentSkillFile.objects.create(
+            skill=skill,
+            relative_path=relative_path,
+            content=content,
+            content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            portability=AgentSkillFile.Portability.PORTABLE,
+            included_by_default=True,
+            size_bytes=len(content.encode("utf-8")),
+        )
+
+    with pytest.raises(ValueError, match="collides with nested path"):
+        materialize_codex_skill_files(target_root)
+
+
+@pytest.mark.django_db
 def test_materialize_recovers_from_stale_parent_symlink(tmp_path):
     target_root = tmp_path / "codex-skills"
     skill_root = target_root / "portable-skill"

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -274,6 +274,65 @@ def test_materialize_legacy_skill_preserves_existing_portable_tree(tmp_path):
 
 
 @pytest.mark.django_db
+def test_materialize_replaces_file_directory_path_collisions(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    skill_root = target_root / "portable-skill"
+    _write(skill_root / "references" / "topic" / "old.md", "old directory")
+    _write(skill_root / "scripts" / "setup", "old file")
+    skill = AgentSkill.objects.create(
+        slug="portable-skill",
+        title="Portable Skill",
+        markdown="current markdown",
+    )
+    for relative_path, content in [
+        ("references/topic", "new file"),
+        ("scripts/setup/install.ps1", "Write-Output install"),
+    ]:
+        AgentSkillFile.objects.create(
+            skill=skill,
+            relative_path=relative_path,
+            content=content,
+            content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            portability=AgentSkillFile.Portability.PORTABLE,
+            included_by_default=True,
+            size_bytes=len(content.encode("utf-8")),
+        )
+
+    materialize_codex_skill_files(target_root)
+
+    assert (skill_root / "references" / "topic").read_text(encoding="utf-8") == (
+        "new file"
+    )
+    assert not (skill_root / "references" / "topic" / "old.md").exists()
+    assert (skill_root / "scripts" / "setup" / "install.ps1").read_text(
+        encoding="utf-8"
+    ) == "Write-Output install"
+
+
+@pytest.mark.django_db
+def test_materialize_rejects_symlinked_skill_directory(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    target_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    try:
+        (target_root / "portable-skill").symlink_to(
+            outside_root,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    AgentSkill.objects.create(
+        slug="portable-skill",
+        title="Portable Skill",
+        markdown="current markdown",
+    )
+
+    with pytest.raises(ValueError, match="Unsafe skill directory symlink"):
+        materialize_codex_skill_files(target_root)
+
+
+@pytest.mark.django_db
 def test_export_synthesizes_legacy_skill_markdown_file(tmp_path):
     AgentSkill.objects.create(
         slug="legacy-skill",

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -310,6 +310,71 @@ def test_materialize_replaces_file_directory_path_collisions(tmp_path):
 
 
 @pytest.mark.django_db
+def test_materialize_rejects_package_path_prefix_collisions(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    skill = AgentSkill.objects.create(
+        slug="portable-skill",
+        title="Portable Skill",
+        markdown="current markdown",
+    )
+    for relative_path, content in [
+        ("references/topic", "parent file"),
+        ("references/topic/child.md", "child file"),
+    ]:
+        AgentSkillFile.objects.create(
+            skill=skill,
+            relative_path=relative_path,
+            content=content,
+            content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            portability=AgentSkillFile.Portability.PORTABLE,
+            included_by_default=True,
+            size_bytes=len(content.encode("utf-8")),
+        )
+
+    with pytest.raises(ValueError, match="collides with nested path"):
+        materialize_codex_skill_files(target_root)
+
+
+@pytest.mark.django_db
+def test_materialize_recovers_from_stale_parent_symlink(tmp_path):
+    target_root = tmp_path / "codex-skills"
+    skill_root = target_root / "portable-skill"
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    skill_root.mkdir(parents=True)
+    try:
+        (skill_root / "references").symlink_to(
+            outside_root,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    skill = AgentSkill.objects.create(
+        slug="portable-skill",
+        title="Portable Skill",
+        markdown="current markdown",
+    )
+    content = "new file"
+    AgentSkillFile.objects.create(
+        skill=skill,
+        relative_path="references/topic.md",
+        content=content,
+        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        portability=AgentSkillFile.Portability.PORTABLE,
+        included_by_default=True,
+        size_bytes=len(content.encode("utf-8")),
+    )
+
+    materialize_codex_skill_files(target_root)
+
+    assert not (skill_root / "references").is_symlink()
+    assert (skill_root / "references" / "topic.md").read_text(
+        encoding="utf-8"
+    ) == content
+    assert not (outside_root / "topic.md").exists()
+
+
+@pytest.mark.django_db
 def test_materialize_rejects_symlinked_skill_directory(tmp_path):
     target_root = tmp_path / "codex-skills"
     target_root.mkdir()


### PR DESCRIPTION
## Summary
- replace stale file/directory path collisions before writing materialized skill package files
- reject symlinked skill directories before write/prune operations
- add regression coverage for both collision directions and symlinked skill dirs

## Validation
- .\\.venv\\Scripts\\python.exe -m ruff check apps/skills/package_services.py apps/skills/tests/test_package_services.py
- git diff --check
- .\\.venv\\Scripts\\python.exe -m pytest apps/skills -q
- .\\.venv\\Scripts\\python.exe manage.py check --fail-level ERROR
- .\\.venv\\Scripts\\python.exe manage.py makemigrations --check --dry-run
- .\\.venv\\Scripts\\python.exe scripts/check_import_resolution.py apps/skills

Follow-up to review feedback raised after #7526 was already merged.