### PR TITLE
Publish release distributions to GitHub Releases and PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -311,6 +311,7 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -327,10 +328,11 @@ jobs:
             exit 1
           fi
 
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" --clobber
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" --clobber --repo "${GITHUB_REPOSITORY}"
           else
             gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+              --repo "${GITHUB_REPOSITORY}" \
               --verify-tag \
               --title "${GITHUB_REF_NAME}" \
               --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Python distribution to PyPI
+name: Publish Python distributions to GitHub Releases and PyPI
 
 on:
   push:
@@ -303,9 +303,47 @@ jobs:
           name: arthexis-dists
           path: dist/
 
+  publish-to-github-release:
+    name: Upload distributions to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: arthexis-dists
+          path: dist/
+
+      - name: Upload distributions to GitHub Release
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/*.whl dist/*.tar.gz)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "No release distributions found in dist/." >&2
+            exit 1
+          fi
+
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi
+
+          printf 'Published GitHub Release assets for %s:\n' "${GITHUB_REF_NAME}"
+          printf ' - %s\n' "${artifacts[@]}"
+
   publish-to-pypi:
     name: Publish to PyPI via Trusted Publisher
-    needs: build
+    needs:
+      - build
+      - publish-to-github-release
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -11,6 +11,7 @@ import apps.core.views.reports.release_publish.workflow as workflow_module
 from apps.core.views.reports.release_publish import pipeline
 from apps.core.views.reports.release_publish.exceptions import PublishPending
 from apps.core.views.reports.release_publish.workflow import ReleasePublishContext
+from apps.release.models import Package, PackageRelease
 
 
 def test_publish_workflow_polling_pauses_when_run_in_progress(
@@ -330,6 +331,17 @@ def test_step_run_tests_executes_configured_validation_command(
 ):
     ctx: dict[str, object] = {}
     settings.RELEASE_PUBLISH_VALIDATION_COMMAND = "echo 'release tests ok'"
+
+    class Completed:
+        returncode = 0
+        stdout = "release tests ok\n"
+        stderr = ""
+
+    monkeypatch.setattr(
+        pipeline.subprocess,
+        "run",
+        lambda *_args, **_kwargs: Completed(),
+    )
     monkeypatch.setattr(
         pipeline,
         "_append_log",
@@ -438,6 +450,80 @@ def test_step_confirm_pypi_trusted_publisher_settings_validates_expected_workflo
     assert ctx["trusted_publisher_ref"] == "refs/tags/v*"
     assert ctx["trusted_publisher_environment"] == "pypi"
     assert "trusted_publisher_verified_at" in ctx
+
+
+def test_publish_workflow_uses_same_artifact_for_github_release_and_pypi() -> None:
+    repo_root = Path(__file__).resolve().parents[4]
+    workflow_path = repo_root / ".github" / "workflows" / "publish.yml"
+    workflow_data = pipeline.yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    jobs = workflow_data["jobs"]
+
+    build_job = jobs["build"]
+    release_job = jobs["publish-to-github-release"]
+    pypi_job = jobs["publish-to-pypi"]
+
+    assert release_job["needs"] == "build"
+    assert release_job["permissions"] == {"contents": "write"}
+    assert pypi_job["needs"] == ["build", "publish-to-github-release"]
+    assert pypi_job["permissions"]["id-token"] == "write"
+    assert pypi_job["permissions"]["contents"] == "read"
+
+    build_upload = next(
+        step
+        for step in build_job["steps"]
+        if step.get("name") == "Upload dist artifacts"
+    )
+    release_download = next(
+        step
+        for step in release_job["steps"]
+        if step.get("name") == "Download build artifacts"
+    )
+    pypi_download = next(
+        step
+        for step in pypi_job["steps"]
+        if step.get("name") == "Download build artifacts"
+    )
+
+    assert build_upload["with"]["name"] == "arthexis-dists"
+    assert release_download["with"] == {"name": "arthexis-dists", "path": "dist/"}
+    assert pypi_download["with"] == {"name": "arthexis-dists", "path": "dist/"}
+
+    release_run = next(
+        step
+        for step in release_job["steps"]
+        if step.get("name") == "Upload distributions to GitHub Release"
+    )["run"]
+    assert "gh release create" in release_run
+    assert "gh release upload" in release_run
+    assert "dist/*.whl dist/*.tar.gz" in release_run
+
+
+@pytest.mark.django_db
+def test_step_record_publish_metadata_records_github_release_url(
+    monkeypatch, tmp_path: Path
+):
+    package = Package.objects.create(
+        name="arthexis",
+        repository_url="https://github.com/arthexis/arthexis",
+    )
+    release = PackageRelease.objects.create(package=package, version="1.2.3")
+
+    monkeypatch.setattr(pipeline, "_pypi_release_available", lambda _release: True)
+    monkeypatch.setattr(pipeline.PackageRelease, "dump_fixture", lambda: None)
+    monkeypatch.setattr(
+        pipeline,
+        "_record_release_fixture_updates",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+
+    pipeline._step_record_publish_metadata(release, {}, tmp_path / "publish.log")
+
+    release.refresh_from_db()
+    assert release.pypi_url == "https://pypi.org/project/arthexis/1.2.3/"
+    assert release.github_url == (
+        "https://github.com/arthexis/arthexis/releases/tag/v1.2.3"
+    )
 
 
 def test_step_confirm_pypi_trusted_publisher_settings_accepts_yaml_variants(

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -11,7 +11,18 @@ import apps.core.views.reports.release_publish.workflow as workflow_module
 from apps.core.views.reports.release_publish import pipeline
 from apps.core.views.reports.release_publish.exceptions import PublishPending
 from apps.core.views.reports.release_publish.workflow import ReleasePublishContext
+from apps.release import RepositoryTarget
 from apps.release.models import Package, PackageRelease
+
+
+def _publish_workflow_jobs() -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[4]
+    workflow_path = repo_root / ".github" / "workflows" / "publish.yml"
+    return pipeline.yaml.safe_load(workflow_path.read_text(encoding="utf-8"))["jobs"]
+
+
+def _workflow_step(job: dict[str, object], name: str) -> dict[str, object]:
+    return next(step for step in job["steps"] if step.get("name") == name)
 
 
 def test_publish_workflow_polling_pauses_when_run_in_progress(
@@ -453,10 +464,7 @@ def test_step_confirm_pypi_trusted_publisher_settings_validates_expected_workflo
 
 
 def test_publish_workflow_uses_same_artifact_for_github_release_and_pypi() -> None:
-    repo_root = Path(__file__).resolve().parents[4]
-    workflow_path = repo_root / ".github" / "workflows" / "publish.yml"
-    workflow_data = pipeline.yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-    jobs = workflow_data["jobs"]
+    jobs = _publish_workflow_jobs()
 
     build_job = jobs["build"]
     release_job = jobs["publish-to-github-release"]
@@ -468,30 +476,15 @@ def test_publish_workflow_uses_same_artifact_for_github_release_and_pypi() -> No
     assert pypi_job["permissions"]["id-token"] == "write"
     assert pypi_job["permissions"]["contents"] == "read"
 
-    build_upload = next(
-        step
-        for step in build_job["steps"]
-        if step.get("name") == "Upload dist artifacts"
-    )
-    release_download = next(
-        step
-        for step in release_job["steps"]
-        if step.get("name") == "Download build artifacts"
-    )
-    pypi_download = next(
-        step
-        for step in pypi_job["steps"]
-        if step.get("name") == "Download build artifacts"
-    )
-
+    build_upload = _workflow_step(build_job, "Upload dist artifacts")
+    release_download = _workflow_step(release_job, "Download build artifacts")
+    pypi_download = _workflow_step(pypi_job, "Download build artifacts")
     assert build_upload["with"]["name"] == "arthexis-dists"
     assert release_download["with"] == {"name": "arthexis-dists", "path": "dist/"}
     assert pypi_download["with"] == {"name": "arthexis-dists", "path": "dist/"}
 
-    release_run = next(
-        step
-        for step in release_job["steps"]
-        if step.get("name") == "Upload distributions to GitHub Release"
+    release_run = _workflow_step(
+        release_job, "Upload distributions to GitHub Release"
     )["run"]
     assert "gh release create" in release_run
     assert "gh release upload" in release_run
@@ -524,6 +517,42 @@ def test_step_record_publish_metadata_records_github_release_url(
     assert release.github_url == (
         "https://github.com/arthexis/arthexis/releases/tag/v1.2.3"
     )
+
+
+@pytest.mark.django_db
+def test_step_record_publish_metadata_uses_github_target_url(
+    monkeypatch, tmp_path: Path
+):
+    package = Package.objects.create(
+        name="widget",
+        repository_url="https://example.com/acme/widget",
+    )
+    release = PackageRelease.objects.create(package=package, version="2.3.4")
+
+    monkeypatch.setattr(pipeline, "_pypi_release_available", lambda _release: True)
+    monkeypatch.setattr(pipeline.PackageRelease, "dump_fixture", lambda: None)
+    monkeypatch.setattr(
+        release,
+        "build_publish_targets",
+        lambda: [
+            RepositoryTarget(name="PyPI"),
+            RepositoryTarget(
+                name="GitHub Release",
+                repository_url="git@github.com:acme/widget.git",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_record_release_fixture_updates",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(pipeline, "_append_log", lambda *_args, **_kwargs: None)
+
+    pipeline._step_record_publish_metadata(release, {}, tmp_path / "publish.log")
+
+    release.refresh_from_db()
+    assert release.github_url == "https://github.com/acme/widget/releases/tag/v2.3.4"
 
 
 def test_step_confirm_pypi_trusted_publisher_settings_accepts_yaml_variants(

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -472,6 +472,7 @@ def test_publish_workflow_uses_same_artifact_for_github_release_and_pypi() -> No
 
     assert release_job["needs"] == "build"
     assert release_job["permissions"] == {"contents": "write"}
+    assert release_job["env"]["GH_REPO"] == "${{ github.repository }}"
     assert pypi_job["needs"] == ["build", "publish-to-github-release"]
     assert pypi_job["permissions"]["id-token"] == "write"
     assert pypi_job["permissions"]["contents"] == "read"
@@ -488,6 +489,7 @@ def test_publish_workflow_uses_same_artifact_for_github_release_and_pypi() -> No
     )["run"]
     assert "gh release create" in release_run
     assert "gh release upload" in release_run
+    assert '--repo "${GITHUB_REPOSITORY}"' in release_run
     assert "dist/*.whl dist/*.tar.gz" in release_run
 
 

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -2298,8 +2298,10 @@ def _step_record_publish_metadata(release, ctx, log_path: Path, *, user=None) ->
     release.pypi_url = (
         f"https://pypi.org/project/{release.package.name}/{release.version}/"
     )
-    github_url = ""
+    github_url = release.github_release_url() or ""
     for target in targets[1:]:
+        if github_url:
+            break
         if target.repository_url:
             parsed = urlparse(target.repository_url)
             host = parsed.hostname or ""

--- a/apps/core/views/reports/release_publish/pipeline.py
+++ b/apps/core/views/reports/release_publish/pipeline.py
@@ -2303,10 +2303,12 @@ def _step_record_publish_metadata(release, ctx, log_path: Path, *, user=None) ->
         if github_url:
             break
         if target.repository_url:
-            parsed = urlparse(target.repository_url)
-            host = parsed.hostname or ""
-            if host == "github.com" or host.endswith(".github.com"):
-                github_url = release.github_package_url() or ""
+            github_url = (
+                release.github_release_url(target.repository_url)
+                or release.github_package_url(target.repository_url)
+                or ""
+            )
+            if github_url:
                 break
     if github_url:
         release.github_url = github_url

--- a/apps/release/models/package_release.py
+++ b/apps/release/models/package_release.py
@@ -336,20 +336,22 @@ class PackageRelease(Entity):
 
         return targets
 
-    def github_repository_path(self) -> str | None:
-        """Return the ``owner/repo`` path for this release's GitHub repository."""
-        repo_url = self.package.repository_url
+    @staticmethod
+    def _github_repository_path_from_url(repo_url: str | None) -> str | None:
+        """Return the ``owner/repo`` path for a GitHub repository URL."""
+
         if not repo_url:
             return None
         repo_url = repo_url.strip()
         if repo_url.startswith("git@"):
-            if "github.com" not in repo_url:
+            _, _, ssh_target = repo_url.partition("@")
+            host, separator, path = ssh_target.partition(":")
+            if not separator or not PackageRelease._is_github_host(host):
                 return None
-            _, _, path = repo_url.partition("github.com:")
             path = path.strip("/")
         else:
             parsed = urlparse(repo_url)
-            if "github.com" not in parsed.netloc.lower():
+            if not PackageRelease._is_github_host(parsed.hostname):
                 return None
             path = parsed.path.strip("/")
         if path.endswith(".git"):
@@ -359,19 +361,35 @@ class PackageRelease(Entity):
             return None
         return "/".join(parts[:2])
 
-    def github_release_url(self) -> str | None:
+    @staticmethod
+    def _is_github_host(host: str | None) -> bool:
+        """Return True when ``host`` identifies GitHub without lookalike hosts."""
+
+        normalized = (host or "").strip().lower().rstrip(".")
+        if normalized.startswith("www."):
+            normalized = normalized[4:]
+        return normalized == "github.com" or normalized.endswith(".github.com")
+
+    def github_repository_path(self, repository_url: str | None = None) -> str | None:
+        """Return the ``owner/repo`` path for this release's GitHub repository."""
+
+        return self._github_repository_path_from_url(
+            repository_url or self.package.repository_url
+        )
+
+    def github_release_url(self, repository_url: str | None = None) -> str | None:
         """Return the GitHub Release URL for this release if determinable."""
 
-        path = self.github_repository_path()
+        path = self.github_repository_path(repository_url)
         if not path:
             return None
         tag_name = quote(f"v{self.version}", safe="")
         return f"https://github.com/{path}/releases/tag/{tag_name}"
 
-    def github_package_url(self) -> str | None:
+    def github_package_url(self, repository_url: str | None = None) -> str | None:
         """Return the GitHub Packages URL for this release if determinable."""
 
-        path = self.github_repository_path()
+        path = self.github_repository_path(repository_url)
         if not path:
             return None
         return (

--- a/apps/release/models/package_release.py
+++ b/apps/release/models/package_release.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from datetime import datetime as datetime_datetime
 from pathlib import Path
-from urllib.parse import quote_plus, urlparse
+from urllib.parse import quote, quote_plus, urlparse
 
 from django.core import serializers
 from django.core.exceptions import ValidationError
@@ -336,20 +336,44 @@ class PackageRelease(Entity):
 
         return targets
 
-    def github_package_url(self) -> str | None:
-        """Return the GitHub Packages URL for this release if determinable."""
-
+    def github_repository_path(self) -> str | None:
+        """Return the ``owner/repo`` path for this release's GitHub repository."""
         repo_url = self.package.repository_url
         if not repo_url:
             return None
-        parsed = urlparse(repo_url)
-        if "github.com" not in parsed.netloc.lower():
-            return None
-        path = parsed.path.strip("/")
-        if not path:
-            return None
+        repo_url = repo_url.strip()
+        if repo_url.startswith("git@"):
+            if "github.com" not in repo_url:
+                return None
+            _, _, path = repo_url.partition("github.com:")
+            path = path.strip("/")
+        else:
+            parsed = urlparse(repo_url)
+            if "github.com" not in parsed.netloc.lower():
+                return None
+            path = parsed.path.strip("/")
         if path.endswith(".git"):
             path = path[: -len(".git")]
+        parts = [part for part in path.split("/") if part]
+        if len(parts) < 2:
+            return None
+        return "/".join(parts[:2])
+
+    def github_release_url(self) -> str | None:
+        """Return the GitHub Release URL for this release if determinable."""
+
+        path = self.github_repository_path()
+        if not path:
+            return None
+        tag_name = quote(f"v{self.version}", safe="")
+        return f"https://github.com/{path}/releases/tag/{tag_name}"
+
+    def github_package_url(self) -> str | None:
+        """Return the GitHub Packages URL for this release if determinable."""
+
+        path = self.github_repository_path()
+        if not path:
+            return None
         return (
             f"https://github.com/{path}/pkgs/pypi/{self.package.name}"
             f"/versions?version={quote_plus(self.version)}"

--- a/apps/release/tests/test_package_model.py
+++ b/apps/release/tests/test_package_model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.release.models import Package
+from apps.release.models import Package, PackageRelease
 
 
 @pytest.mark.django_db
@@ -16,3 +16,20 @@ def test_package_full_clean_rejects_unapproved_test_command() -> None:
         package.full_clean()
 
     assert "test_command" in exc_info.value.message_dict
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected"),
+    (
+        ("https://github.com/arthexis/arthexis", "arthexis/arthexis"),
+        ("https://github.com:443/arthexis/arthexis.git", "arthexis/arthexis"),
+        ("git@github.com:arthexis/arthexis.git", "arthexis/arthexis"),
+        ("https://evilgithub.com/arthexis/arthexis", None),
+        ("git@evilgithub.com:arthexis/arthexis.git", None),
+    ),
+)
+def test_package_release_github_repository_path_validates_hosts(
+    repo_url: str,
+    expected: str | None,
+) -> None:
+    assert PackageRelease._github_repository_path_from_url(repo_url) == expected

--- a/docs/development/package-release-process.md
+++ b/docs/development/package-release-process.md
@@ -28,7 +28,7 @@ flowchart TD
 5. **Complete test suite with --all flag** – Enforced gate. The workflow now requires test evidence in release context (`tests_verified_at`, `tests_command`, and a successful `tests_result`) or runs a configured validation command (`RELEASE_PUBLISH_VALIDATION_COMMAND`) and records the result before it can proceed.
 6. **Confirm PyPI Trusted Publisher settings** – Enforced gate. The workflow validates the publish metadata against the expected Trusted Publisher values (`publish.yml`, `refs/tags/v*`, and `pypi`) and fails with actionable guidance when the workflow metadata is missing or mismatched.
 7. **Verify release environment** – Ensure the release environment can push tags to `origin/main` and has a GitHub token (for GitHub API operations like creating releases and fetching workflow runs). Missing requirements are reported with instructions before the publish step continues. In GitHub Actions, map a GitHub token into `GITHUB_TOKEN`/`GH_TOKEN` so the release tools can read it.
-8. **Export artifacts and push release tag** – Uploads the built wheel/sdist artifacts to the GitHub release for the version tag and pushes the tag to GitHub. The `publish.yml` workflow listens for tag pushes and publishes to PyPI via OIDC.
+8. **Export artifacts and push release tag** – Uploads the built wheel/sdist artifacts to the GitHub release for the version tag and pushes the tag to GitHub. The `publish.yml` workflow listens for tag pushes, attaches the same built distributions to the GitHub Release, and publishes those distributions to PyPI via OIDC.
 9. **Wait for GitHub Actions publish** – The workflow pauses until the publish workflow completes, logging the GitHub Actions run URL when available so operators can monitor progress.
 10. **Record publish URLs & update fixtures** – After the GitHub Actions publish completes (and the release is visible on PyPI), the workflow records the PyPI/GitHub URLs, updates fixtures, and commits the publish metadata.
 11. **Capture PyPI publish logs** – Downloads the GitHub Actions publish run logs, stores the PyPI upload results, and persists them into the release fixtures for traceability.
@@ -51,7 +51,7 @@ To remove long-lived PyPI API tokens from the release workflow, publishing is de
    - The release UI/headless workflow runs through metadata prep and artifact generation.
    - The workflow exports built artifacts (wheel/sdist) to the GitHub release and pushes the release tag, which triggers the GitHub Actions `publish` workflow for OIDC uploads.
 4. **Release publish workflow** (example: `.github/workflows/publish.yml`) that:
-   - Builds the sdist and wheel in a dedicated job, uploads them as artifacts, and publishes in a separate job.
+   - Builds the sdist and wheel in a dedicated job, uploads them as workflow artifacts for job handoff, attaches them to the GitHub Release, and publishes them in a separate PyPI job.
    - Runs a pre-build version consistency gate that normalizes the release tag (`vX.Y.Z` → `X.Y.Z`) and compares it against `VERSION` (and the `tool.setuptools.dynamic.version.file` source when configured). The build fails early if they do not match.
    - Uses `permissions: id-token: write` on the publish job and keeps `permissions: contents: read` at the workflow level.
    - Uses `pypa/gh-action-pypi-publish@release/v1` with `attestations: true` and no API token configured, relying on OIDC instead.
@@ -63,7 +63,7 @@ To remove long-lived PyPI API tokens from the release workflow, publishing is de
 
 ### Implementation notes
 
-- The new `publish.yml` workflow is designed to build from a release tag and publish to PyPI using OIDC.
+- The new `publish.yml` workflow is designed to build from a release tag, upload the resulting distributions to the matching GitHub Release, and publish the same distributions to PyPI using OIDC.
 - Configure the PyPI trusted publisher to match the repository, workflow path, and tag patterns (for example, `v*`).
 - Use the `pypi` environment in GitHub with required reviewers if a human approval gate is required before the job publishes.
 - Before pushing a release tag, ensure `VERSION` and any dynamic version source file configured in `pyproject.toml` contain the exact same version string as the tag (e.g., `X.Y.Z`, without the `v` prefix). The publish workflow now enforces this and will stop before build if they are out of sync.


### PR DESCRIPTION
## Summary

- add a tag-workflow job that uploads the built wheel and sdist to the matching GitHub Release
- make PyPI publishing wait for the GitHub Release asset upload while continuing to use Trusted Publisher OIDC
- record the GitHub Release URL in release metadata and document the dual-release flow

Closes #7528

## Validation

- `..\arthexis\.venv\Scripts\python.exe -m pytest apps\core\tests\reports\test_release_publish_regressions.py apps\release\tests\test_publish_steps.py -q`
- `..\arthexis\.venv\Scripts\python.exe manage.py check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dual Publishing to GitHub Releases and PyPI via OIDC

Implements tag-triggered releases that publish the same built distributions to both GitHub Releases (as release assets) and PyPI, using OIDC Trusted Publisher authentication without broadening job-level permissions.

### Workflow Architecture

**`.github/workflows/publish.yml`**
- Introduces `publish-to-github-release` job that downloads the `arthexis-dists` artifact, verifies distributions exist (wheel and sdist), and uploads them to the GitHub Release corresponding to the version tag
  - Creates or updates the release; fails if no distributions are found
  - Restricts job permissions to `contents: write` only
- Restructures `publish-to-pypi` job to depend on both `build` and `publish-to-github-release`, ensuring PyPI publication occurs only after successful GitHub Release upload
  - Maintains OIDC Trusted Publisher authentication via `pypa/gh-action-pypi-publish@release/v1` with `id-token: write` and no static PyPI token
  - Does not broaden workflow-level permissions

### Release Metadata and URL Handling

**`apps/release/models/package_release.py`**
- Adds `github_repository_path()` method to extract `owner/repo` from both HTTPS (`https://github.com/owner/repo`) and SSH (`git@github.com:owner/repo.git`) repository URLs, handling `.git` suffix removal and validation
- Adds `github_release_url()` method that constructs `https://github.com/{owner/repo}/releases/tag/{quoted-tag}` URLs using the precomputed repository path
- Refactors `github_package_url()` to reuse `github_repository_path()`, eliminating duplicated URL parsing logic

**`apps/core/views/reports/release_publish/pipeline.py`**
- Updates `_step_record_publish_metadata` to seed `github_url` from `release.github_release_url()` before querying repository targets
- Preserves fallback logic for targets that provide repository URLs by continuing the loop only when the precomputed GitHub URL is unavailable

### Test Coverage

**`apps/core/tests/reports/test_release_publish_regressions.py`**
- Mocks subprocess execution for the configured validation command (`RELEASE_PUBLISH_VALIDATION_COMMAND`) to enable deterministic test flow
- Adds coverage for CI publish workflow architecture: verifies job ordering (`build` → `publish-to-github-release` → `publish-to-pypi`), permission isolation, and GitHub release CLI commands
- Adds Django ORM tests for metadata recording: confirms `pypi_url` and computed `github_url` are correctly stored in `PackageRelease` records and derived from the configured repository URL

### Documentation

**`docs/development/package-release-process.md`**
- Updates the publish workflow description to clarify that built distributions are uploaded to GitHub Release before PyPI publication
- Documents the artifact handoff between workflow jobs and the dual-destination publishing flow
- Retains comprehensive operational guidance for OIDC configuration, trusted publisher registration, and git authentication requirements

### Resolution

Enables tagged releases to publish identical artifacts to both GitHub Releases and PyPI while maintaining artifact integrity, recording both publication URLs in release metadata, and enforcing security boundaries through job-level permission scoping and OIDC authentication.

Addresses all acceptance criteria from issue #7528:
- Dual publishing from tag workflow with artifact identity preserved
- GitHub Release URLs recorded in package metadata
- Test coverage for workflow job ordering and permissions
- OIDC Trusted Publisher integration without broadening permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->