### PR TITLE
Slow release readiness cadence

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -2,7 +2,7 @@ name: Release Simulator
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */3 * * *'
   workflow_dispatch:
   push:
     branches:
@@ -514,7 +514,7 @@ jobs:
             const body = [
               marker,
               '',
-              'Automated hourly release readiness report.',
+              'Automated release readiness report. Scheduled every 3 hours for 8 release windows per day.',
               '',
               `- Workflow run: ${runUrl}`,
               `- Ref: ${context.ref}`,


### PR DESCRIPTION
## Summary
- slow Release Simulator / Release Readiness from hourly to every 3 hours
- update the generated readiness report text to state the 8 release windows per day cadence

## Validation
- git diff --check