### PR TITLE
Add error report diagnostic package CLI

### DIFF
--- a/docs/development/install-lifecycle-scripts-manual.md
+++ b/docs/development/install-lifecycle-scripts-manual.md
@@ -2,7 +2,7 @@
 
 > **Single source of truth:** Keep operational flag and behavior details in this file. Update `apps/docs/cookbooks/install-start-stop-upgrade-uninstall.md` only with role-oriented guidance and a link back here.
 
-This is the canonical reference for Linux lifecycle scripts: `install.sh`, `start.sh`, `stop.sh`, `status.sh`, `command.sh`, `upgrade.sh`, `configure.sh`, and `uninstall.sh`.
+This is the canonical reference for Linux lifecycle scripts: `install.sh`, `start.sh`, `stop.sh`, `status.sh`, `command.sh`, `upgrade.sh`, `configure.sh`, `error-report.sh`, and `uninstall.sh`.
 
 
 ## Lifecycle map (operator contract)
@@ -25,11 +25,14 @@ Graceful shutdown]
 Pull/update/migrate]
     U --> S
     U --> T
+    T --> R[error-report.sh
+Collect diagnostics]
+    O --> R
     P --> X[uninstall.sh
 Retire node]
 
     classDef safety fill:#fff8e6,stroke:#b36b00,color:#3d2500;
-    class T,O safety;
+    class T,O,R safety;
 ```
 
 This map is a regression guardrail: lifecycle changes should preserve these operator touchpoints unless the manual and tests are updated together.
@@ -223,7 +226,34 @@ For non-ops/admin Django commands, use `.venv/bin/python manage.py ...` directly
 | `--no-warn` | Skip DB deletion warning prompt. |
 | `--rfid-service`, `--no-rfid-service` | Control whether RFID unit/lock is removed during uninstall. |
 
-## 8. Documentation maintenance check
+## 8. Error report (`error-report.sh`)
+
+`error-report.sh` builds a single diagnostic zip without invoking Django
+management commands. It is intended for startup, upgrade, migration, and
+environment failures where `command.sh` or `manage.py` may not work.
+
+### Supported flags
+
+| Flag | Notes |
+| --- | --- |
+| `--output-dir DIR` | Directory for generated zip files. Defaults to `work/error-reports`. |
+| `--since DURATION` | Include non-critical logs modified within a duration such as `12h` or `7d`. |
+| `--max-log-files COUNT` | Cap selected log files. Defaults to `30`. |
+| `--max-file-bytes BYTES` | Copy only the tail of large text files. Defaults to `262144`. |
+| `--upload-url URL` | Upload the generated zip to an explicit signed URL after writing it locally. |
+| `--upload-method METHOD` | Upload method, `PUT` or `POST`. Defaults to `PUT`. |
+| `--upload-timeout SECONDS` | Upload timeout. Defaults to `60`. |
+| `--allow-insecure-upload` | Permit `http://` upload URLs. HTTPS is required by default. |
+| `--dry-run` | Print planned report contents without writing a zip or uploading. |
+| `-h`, `--help` | Print usage and exit successfully. |
+
+The collector uses Python standard library modules only and passes copied text
+through secret redaction. It excludes environment files, databases, dumps,
+backups, media/static/cache trees, virtual environments, Git internals, and key
+material. See `docs/operations/error-report.md` for operator usage and package
+contents.
+
+## 9. Documentation maintenance check
 
 When lifecycle script docs are updated:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ In Arthexis terminology, the **suite** is the collection of applications, while 
 - [App Structure Policy](development/app-structure-policy.md)
 - [Endpoint Documentation Inventory](integrations/endpoint-inventory.md)
 - [Endpoint Documentation Completeness Checklist](integrations/documentation-completeness-checklist.md)
+- [Error Report Package](operations/error-report.md)
 - [Integration Onboarding Tracks](integrations/onboarding-tracks.md)
 - OCPP 1.6 coverage artifact: `apps/ocpp/coverage.json`
 - [Ops Command Wrapper](operations/operational-commands.md)

--- a/docs/operations/error-report.md
+++ b/docs/operations/error-report.md
@@ -1,0 +1,84 @@
+# Error Report Package
+
+`error-report.sh` builds a single diagnostic zip from the repository root without
+calling Django management commands. Use it when an Arthexis node cannot start,
+the virtual environment is broken, migrations fail before Django loads, or an
+operator needs one package to attach to a support request.
+
+## Usage
+
+```bash
+./error-report.sh
+./error-report.sh --since 24h
+./error-report.sh --output-dir work/error-reports
+./error-report.sh --upload-url "https://signed-upload-url"
+```
+
+The default output path is:
+
+```text
+work/error-reports/arthexis-error-report-<hostname>-<timestamp>.zip
+```
+
+Run a no-write preview with:
+
+```bash
+./error-report.sh --dry-run
+```
+
+## Contents
+
+The zip includes text diagnostics only:
+
+- `manifest.json` with report metadata, options, file hashes, warnings, and
+  collected entry names.
+- `summary.txt` with a concise human-readable overview.
+- `system/` metadata for platform, Python, and selected environment state.
+- `arthexis/` metadata for version, git state, and a side-effect-free status
+  snapshot.
+- `arthexis/locks/` text lock files when present.
+- selected recent `logs/` text files, capped by `--max-log-files` and
+  `--max-file-bytes`.
+
+`status.sh` is not invoked because it may update startup locks. The report
+instead writes its own read-only status snapshot.
+
+## Safety
+
+The collector excludes high-risk material by default:
+
+- environment files such as `.env` and `arthexis.env`
+- databases, dumps, backups, and broad data directories
+- private keys, certificate keys, and local key files
+- `media/`, `static/`, caches, virtual environments, and Git internals
+
+All copied text and command output pass through a redaction layer for common
+secret-bearing values such as tokens, passwords, authorization headers, private
+key blocks, AWS access keys, and credential-bearing URLs.
+
+Secrets must not be added manually to a report before sharing it.
+
+## Uploads
+
+Uploading is disabled unless an explicit URL is provided:
+
+```bash
+./error-report.sh --upload-url "https://signed-upload-url"
+```
+
+The default method is `PUT`; use `--upload-method POST` only when the receiver
+expects it. HTTPS is required unless `--allow-insecure-upload` is supplied for a
+local or otherwise controlled endpoint.
+
+The local zip is always created before upload. If upload fails, the command exits
+with a non-zero status and leaves the zip in place.
+
+## Useful Options
+
+| Option | Notes |
+| --- | --- |
+| `--since 24h` | Include non-critical logs modified within the last 24 hours. Standard error/startup logs are still preferred. |
+| `--max-log-files COUNT` | Cap the number of log files included. Defaults to `30`. |
+| `--max-file-bytes BYTES` | Copy only the tail of each text file when it is larger than this limit. Defaults to `262144`. |
+| `--output-dir DIR` | Write reports somewhere other than `work/error-reports`. |
+| `--dry-run` | Show planned zip entries without writing a report or uploading. |

--- a/error-report.sh
+++ b/error-report.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Lifecycle CLI contract: keep help/options aligned with docs/development/install-lifecycle-scripts-manual.md.
+usage() {
+  cat <<'EOF'
+Usage: ./error-report.sh [options]
+
+Options:
+  --output-dir DIR          Directory for generated zip files. Defaults to work/error-reports.
+  --since DURATION          Only include non-critical logs modified within DURATION, such as 12h or 7d.
+  --max-log-files COUNT     Maximum number of log files to include. Defaults to 30.
+  --max-file-bytes BYTES    Maximum bytes copied from each text file. Defaults to 262144.
+  --upload-url URL          Upload the generated zip to an explicit signed URL.
+  --upload-method METHOD    Upload HTTP method, PUT or POST. Defaults to PUT.
+  --upload-timeout SECONDS  Upload timeout in seconds. Defaults to 60.
+  --allow-insecure-upload   Permit http:// upload URLs. HTTPS is required by default.
+  --dry-run                 Print the collection plan without writing a zip or uploading.
+  -h, --help                Show this help message and exit.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+else
+  echo "Python 3 is required to build an Arthexis error report." >&2
+  exit 1
+fi
+
+exec "$PYTHON_BIN" "$BASE_DIR/scripts/error_report.py" --base-dir "$BASE_DIR" "$@"

--- a/error-report.sh
+++ b/error-report.sh
@@ -29,11 +29,19 @@ case "${1:-}" in
     ;;
 esac
 
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON_BIN=python3
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_BIN=python
-else
+select_python() {
+  local candidate
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && \
+      "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! PYTHON_BIN="$(select_python)"; then
   echo "Python 3 is required to build an Arthexis error report." >&2
   exit 1
 fi

--- a/scripts/error_report.py
+++ b/scripts/error_report.py
@@ -64,7 +64,6 @@ SENSITIVE_PARTS = {
     "__pycache__",
     "backups",
     "cache",
-    "data",
     "media",
     "node_modules",
     "static",
@@ -392,6 +391,7 @@ def collect_logs(builder: ReportBuilder, cutoff: float | None) -> None:
 
 
 def status_snapshot(base_dir: Path, log_dirs: Iterable[Path]) -> str:
+    log_dir_list = list(log_dirs)
     lock_dir = base_dir / ".locks"
     service = read_optional_text(lock_dir / "service.lck")
     role = read_optional_text(lock_dir / "role.lck") or os.environ.get("NODE_ROLE", "")
@@ -416,9 +416,9 @@ def status_snapshot(base_dir: Path, log_dirs: Iterable[Path]) -> str:
         f"Upgrade in progress lock present: {upgrade_in_progress}",
         "Log directories:",
     ]
-    for log_dir in log_dirs:
+    for log_dir in log_dir_list:
         lines.append(f"- {log_dir}")
-    if not list(log_dirs):
+    if not log_dir_list:
         lines.append("- none found")
     lines.extend(
         [

--- a/scripts/error_report.py
+++ b/scripts/error_report.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+import time
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+SCHEMA_VERSION = 1
+DEFAULT_MAX_LOG_FILES = 30
+DEFAULT_MAX_FILE_BYTES = 256 * 1024
+DEFAULT_OUTPUT_DIR = Path("work") / "error-reports"
+TEXT_SUFFIXES = {".log", ".txt", ".json", ".ndjson", ".lck", ".md", ""}
+LOG_SUFFIXES = {".log", ".txt", ".json", ".ndjson"}
+STANDARD_LOG_NAMES = {
+    "error.log",
+    "tests-error.log",
+    "celery.log",
+    "command.log",
+    "install.log",
+    "service-start.log",
+    "start.log",
+    "status.log",
+    "upgrade.log",
+    "delegated-upgrade.log",
+    "watch-upgrade.log",
+}
+SENSITIVE_NAMES = {
+    ".env",
+    "arthexis.env",
+    "local_settings.py",
+    "db.sqlite3",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+}
+SENSITIVE_SUFFIXES = {
+    ".db",
+    ".dump",
+    ".key",
+    ".p12",
+    ".pem",
+    ".pfx",
+    ".sqlite",
+    ".sqlite3",
+}
+SENSITIVE_PARTS = {
+    ".git",
+    ".venv",
+    "__pycache__",
+    "backups",
+    "cache",
+    "data",
+    "media",
+    "node_modules",
+    "static",
+    "venv",
+}
+SECRET_KEY_RE = re.compile(
+    r"(?i)\b([A-Z0-9_.-]*(?:SECRET|TOKEN|PASSWORD|PASS|CREDENTIAL|PRIVATE|API_KEY|ACCESS_KEY|SECRET_KEY)[A-Z0-9_.-]*\b)"
+    r"(\s*[:=]\s*)"
+    r"([^\s,;]+)"
+)
+AUTH_HEADER_RE = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+AWS_ACCESS_KEY_RE = re.compile(r"\bA(?:KIA|SIA)[0-9A-Z]{16}\b")
+URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^/\s@]+)@",
+                             re.IGNORECASE)
+PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+SSO_KEY_RE = re.compile(r"(?i)\bsso-key\s+[^\s]+")
+
+
+@dataclass(frozen=True)
+class ReportConfig:
+    base_dir: Path
+    output_dir: Path
+    since: timedelta | None = None
+    max_log_files: int = DEFAULT_MAX_LOG_FILES
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    upload_url: str | None = None
+    upload_method: str = "PUT"
+    upload_timeout: int = 60
+    allow_insecure_upload: bool = False
+    dry_run: bool = False
+
+
+@dataclass
+class ReportEntry:
+    archive_path: str
+    content: bytes
+    source_path: str | None = None
+    truncated: bool = False
+
+
+@dataclass
+class ReportResult:
+    path: Path
+    entries: list[ReportEntry]
+    warnings: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def sanitize_filename(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+    return cleaned or "unknown"
+
+
+def parse_duration(value: str) -> timedelta:
+    match = re.fullmatch(r"\s*(\d+)\s*([smhdw])\s*", value)
+    if not match:
+        raise argparse.ArgumentTypeError(
+            "duration must use a suffix: s, m, h, d, or w; for example 12h or 7d"
+        )
+    amount = int(match.group(1))
+    unit = match.group(2)
+    if unit == "s":
+        return timedelta(seconds=amount)
+    if unit == "m":
+        return timedelta(minutes=amount)
+    if unit == "h":
+        return timedelta(hours=amount)
+    if unit == "d":
+        return timedelta(days=amount)
+    return timedelta(weeks=amount)
+
+
+def redact_text(text: str) -> str:
+    redacted = PRIVATE_KEY_BLOCK_RE.sub("<redacted:private-key>", text)
+    redacted = URL_USERINFO_RE.sub(r"\1<redacted>@", redacted)
+    redacted = AUTH_HEADER_RE.sub(lambda match: f"{match.group(1)} <redacted>", redacted)
+    redacted = AWS_ACCESS_KEY_RE.sub("<redacted:aws-access-key>", redacted)
+    redacted = SSO_KEY_RE.sub("sso-key <redacted>", redacted)
+    redacted = SECRET_KEY_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}<redacted>", redacted)
+    return redacted
+
+
+def is_sensitive_path(path: Path) -> bool:
+    name = path.name.lower()
+    suffix = path.suffix.lower()
+    if name in SENSITIVE_NAMES or suffix in SENSITIVE_SUFFIXES:
+        return True
+    parts = {part.lower() for part in path.parts}
+    return bool(parts & SENSITIVE_PARTS)
+
+
+def should_read_text(path: Path) -> bool:
+    return path.suffix.lower() in TEXT_SUFFIXES
+
+
+def read_text_tail(path: Path, max_bytes: int) -> tuple[str, bool]:
+    size = path.stat().st_size
+    truncated = size > max_bytes
+    with path.open("rb") as handle:
+        if truncated:
+            handle.seek(-max_bytes, os.SEEK_END)
+        payload = handle.read(max_bytes)
+    text = payload.decode("utf-8", errors="replace")
+    if truncated:
+        text = f"[truncated to last {max_bytes} bytes from {size} total bytes]\n{text}"
+    return redact_text(text), truncated
+
+
+def normalize_archive_path(path: str | Path) -> str:
+    raw = Path(path).as_posix().lstrip("/")
+    parts = [part for part in raw.split("/") if part not in {"", ".", ".."}]
+    return "/".join(parts)
+
+
+def path_relative_to(path: Path, base_dir: Path) -> Path | None:
+    try:
+        return path.resolve().relative_to(base_dir.resolve())
+    except ValueError:
+        return None
+
+
+class ReportBuilder:
+    def __init__(self, config: ReportConfig, created_at: datetime) -> None:
+        self.config = config
+        self.created_at = created_at
+        self.entries: list[ReportEntry] = []
+        self.warnings: list[str] = []
+        self._archive_paths: set[str] = set()
+
+    def add_text(self, archive_path: str, text: str, source_path: Path | None = None) -> None:
+        self.add_bytes(
+            archive_path,
+            redact_text(text).encode("utf-8"),
+            source_path=source_path,
+            truncated=False,
+        )
+
+    def add_json(self, archive_path: str, payload: object) -> None:
+        self.add_text(archive_path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    def add_file_tail(self, archive_path: str, path: Path) -> None:
+        if path.is_symlink():
+            self.warnings.append(f"Skipped symlink: {path}")
+            return
+        if not path.is_file():
+            return
+        if is_sensitive_path(path):
+            self.warnings.append(f"Skipped sensitive path: {path}")
+            return
+        if not should_read_text(path):
+            self.warnings.append(f"Skipped non-text file: {path}")
+            return
+        try:
+            text, truncated = read_text_tail(path, self.config.max_file_bytes)
+        except OSError as exc:
+            self.warnings.append(f"Could not read {path}: {exc}")
+            return
+        self.add_bytes(
+            archive_path,
+            text.encode("utf-8"),
+            source_path=path,
+            truncated=truncated,
+        )
+
+    def add_bytes(
+        self,
+        archive_path: str,
+        content: bytes,
+        *,
+        source_path: Path | None = None,
+        truncated: bool = False,
+    ) -> None:
+        safe_archive_path = self._dedupe_archive_path(normalize_archive_path(archive_path))
+        self.entries.append(
+            ReportEntry(
+                archive_path=safe_archive_path,
+                content=content,
+                source_path=str(source_path) if source_path else None,
+                truncated=truncated,
+            )
+        )
+
+    def _dedupe_archive_path(self, archive_path: str) -> str:
+        if archive_path not in self._archive_paths:
+            self._archive_paths.add(archive_path)
+            return archive_path
+        stem, suffix = os.path.splitext(archive_path)
+        counter = 2
+        while True:
+            candidate = f"{stem}-{counter}{suffix}"
+            if candidate not in self._archive_paths:
+                self._archive_paths.add(candidate)
+                return candidate
+            counter += 1
+
+
+def run_command(args: list[str], *, cwd: Path, timeout: int = 10) -> str:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return f"Command not available: {args[0]}\n"
+    except subprocess.TimeoutExpired:
+        return f"Command timed out after {timeout}s: {' '.join(args)}\n"
+
+    output = completed.stdout
+    if completed.stderr:
+        output += ("\n[stderr]\n" if output else "[stderr]\n") + completed.stderr
+    output += f"\n[exit_code] {completed.returncode}\n"
+    return redact_text(output)
+
+
+def read_optional_text(path: Path) -> str:
+    try:
+        return redact_text(path.read_text(encoding="utf-8", errors="replace").strip())
+    except OSError:
+        return ""
+
+
+def discover_log_dirs(base_dir: Path) -> list[Path]:
+    candidates: list[Path] = []
+    env_log_dir = os.environ.get("ARTHEXIS_LOG_DIR")
+    if env_log_dir:
+        candidates.append(Path(env_log_dir))
+    candidates.append(base_dir / "logs")
+
+    seen: set[Path] = set()
+    existing: list[Path] = []
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except OSError:
+            continue
+        if resolved in seen or not resolved.is_dir():
+            continue
+        seen.add(resolved)
+        existing.append(resolved)
+    return existing
+
+
+def collect_log_files(base_dir: Path, config: ReportConfig, cutoff: float | None) -> list[Path]:
+    files: list[Path] = []
+    for log_dir in discover_log_dirs(base_dir):
+        for path in log_dir.rglob("*"):
+            if not path.is_file() or path.is_symlink():
+                continue
+            if path.suffix.lower() not in LOG_SUFFIXES:
+                continue
+            if is_sensitive_path(path):
+                continue
+            if cutoff is not None and path.name not in STANDARD_LOG_NAMES:
+                try:
+                    if path.stat().st_mtime < cutoff:
+                        continue
+                except OSError:
+                    continue
+            files.append(path)
+
+    def sort_key(path: Path) -> tuple[int, float, str]:
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        standard_rank = 0 if path.name in STANDARD_LOG_NAMES else 1
+        return (standard_rank, -mtime, str(path))
+
+    unique: dict[Path, Path] = {}
+    for path in files:
+        try:
+            unique[path.resolve()] = path
+        except OSError:
+            continue
+    return sorted(unique.values(), key=sort_key)[: config.max_log_files]
+
+
+def archive_path_for_source(path: Path, base_dir: Path, prefix: str = "") -> str:
+    relative = path_relative_to(path, base_dir)
+    if relative is None:
+        relative = Path("external") / sanitize_filename(str(path.parent)) / path.name
+    if prefix:
+        relative = Path(prefix) / relative
+    return normalize_archive_path(relative)
+
+
+def collect_locks(builder: ReportBuilder) -> None:
+    lock_dir = builder.config.base_dir / ".locks"
+    if not lock_dir.is_dir():
+        builder.add_text("arthexis/locks.txt", "No .locks directory found.\n")
+        return
+    found = False
+    for path in sorted(lock_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".lck", ".json", ".txt", ".log", ""}:
+            continue
+        if is_sensitive_path(path):
+            continue
+        found = True
+        relative = path.relative_to(lock_dir)
+        builder.add_file_tail(Path("arthexis/locks") / relative, path)
+    if not found:
+        builder.add_text("arthexis/locks.txt", "No readable lock files found.\n")
+
+
+def collect_logs(builder: ReportBuilder, cutoff: float | None) -> None:
+    logs = collect_log_files(builder.config.base_dir, builder.config, cutoff)
+    if not logs:
+        builder.add_text("logs/README.txt", "No readable log files found.\n")
+        return
+    for path in logs:
+        builder.add_file_tail(archive_path_for_source(path, builder.config.base_dir), path)
+
+
+def status_snapshot(base_dir: Path, log_dirs: Iterable[Path]) -> str:
+    lock_dir = base_dir / ".locks"
+    service = read_optional_text(lock_dir / "service.lck")
+    role = read_optional_text(lock_dir / "role.lck") or os.environ.get("NODE_ROLE", "")
+    backend_port = read_optional_text(lock_dir / "backend_port.lck")
+    auto_upgrade = (lock_dir / "auto-upgrade.lck").exists() or (
+        lock_dir / "auto_upgrade.lck"
+    ).exists()
+    upgrade_in_progress = (lock_dir / "upgrade_in_progress.lck").exists()
+    installed = (base_dir / ".venv").is_dir()
+    version = read_optional_text(base_dir / "VERSION")
+    revision = read_optional_text(base_dir / ".revision")
+    lines = [
+        "Arthexis error-report status snapshot",
+        "",
+        f"Installed venv: {installed}",
+        f"Version: {version or 'unknown'}",
+        f"Revision marker: {revision or 'not present'}",
+        f"Service: {service or 'not configured'}",
+        f"Node role: {role or 'not configured'}",
+        f"Backend port: {backend_port or 'not configured'}",
+        f"Auto-upgrade lock present: {auto_upgrade}",
+        f"Upgrade in progress lock present: {upgrade_in_progress}",
+        "Log directories:",
+    ]
+    for log_dir in log_dirs:
+        lines.append(f"- {log_dir}")
+    if not list(log_dirs):
+        lines.append("- none found")
+    lines.extend(
+        [
+            "",
+            "Note: status.sh is not invoked by error-report because it can update startup locks.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def collect_report_entries(config: ReportConfig, created_at: datetime) -> ReportBuilder:
+    base_dir = config.base_dir
+    builder = ReportBuilder(config, created_at)
+    log_dirs = discover_log_dirs(base_dir)
+    cutoff = None
+    if config.since is not None:
+        cutoff = time.time() - config.since.total_seconds()
+
+    builder.add_text(
+        "system/platform.txt",
+        "\n".join(
+            [
+                f"Hostname: {socket.gethostname()}",
+                f"Platform: {platform.platform()}",
+                f"System: {platform.system()}",
+                f"Release: {platform.release()}",
+                f"Machine: {platform.machine()}",
+                f"Processor: {platform.processor()}",
+            ]
+        )
+        + "\n",
+    )
+    builder.add_text(
+        "system/python.txt",
+        "\n".join(
+            [
+                f"Executable: {sys.executable}",
+                f"Version: {sys.version}",
+                f"Prefix: {sys.prefix}",
+            ]
+        )
+        + "\n",
+    )
+    builder.add_text(
+        "system/environment.txt",
+        "\n".join(
+            [
+                f"ARTHEXIS_LOG_DIR set: {bool(os.environ.get('ARTHEXIS_LOG_DIR'))}",
+                f"NODE_ROLE set: {bool(os.environ.get('NODE_ROLE'))}",
+                f"PATH entries: {len(os.environ.get('PATH', '').split(os.pathsep)) if os.environ.get('PATH') else 0}",
+            ]
+        )
+        + "\n",
+    )
+    builder.add_text("arthexis/status.txt", status_snapshot(base_dir, log_dirs))
+    builder.add_text(
+        "arthexis/git.txt",
+        "\n".join(
+            [
+                "$ git rev-parse HEAD",
+                run_command(["git", "rev-parse", "HEAD"], cwd=base_dir),
+                "$ git status --short --branch",
+                run_command(["git", "status", "--short", "--branch"], cwd=base_dir),
+                "$ git remote -v",
+                run_command(["git", "remote", "-v"], cwd=base_dir),
+            ]
+        ),
+    )
+    version_path = base_dir / "VERSION"
+    if version_path.is_file():
+        builder.add_file_tail("arthexis/VERSION", version_path)
+
+    collect_locks(builder)
+    collect_logs(builder, cutoff)
+    return builder
+
+
+def build_manifest(
+    config: ReportConfig,
+    created_at: datetime,
+    report_path: Path,
+    entries: list[ReportEntry],
+    warnings: list[str],
+) -> dict[str, object]:
+    entry_records = []
+    for entry in entries:
+        digest = hashlib.sha256(entry.content).hexdigest()
+        entry_records.append(
+            {
+                "path": entry.archive_path,
+                "bytes": len(entry.content),
+                "sha256": digest,
+                "source": entry.source_path,
+                "truncated": entry.truncated,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": created_at.isoformat(),
+        "generated_by": "scripts/error_report.py",
+        "report_name": report_path.name,
+        "base_dir": str(config.base_dir),
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "python_version": sys.version,
+        "options": {
+            "since_seconds": int(config.since.total_seconds()) if config.since else None,
+            "max_log_files": config.max_log_files,
+            "max_file_bytes": config.max_file_bytes,
+            "upload_requested": bool(config.upload_url),
+            "upload_method": config.upload_method,
+        },
+        "exclusions": [
+            "environment files",
+            "databases and dumps",
+            "private keys and certificates",
+            "media/static/cache/venv trees",
+            "backups and broad data directories",
+        ],
+        "warnings": warnings,
+        "entries": entry_records,
+    }
+
+
+def build_summary(manifest: dict[str, object]) -> str:
+    entries = manifest.get("entries", [])
+    warnings = manifest.get("warnings", [])
+    return "\n".join(
+        [
+            "Arthexis Error Report",
+            "",
+            f"Created at: {manifest['created_at']}",
+            f"Hostname: {manifest['hostname']}",
+            f"Platform: {manifest['platform']}",
+            f"Entries: {len(entries) if isinstance(entries, list) else 0}",
+            f"Warnings: {len(warnings) if isinstance(warnings, list) else 0}",
+            "",
+            "This package excludes databases, env files, private keys, backups, media, static files, caches, and venvs.",
+            "Text content and command output are redacted for common secret-bearing values.",
+        ]
+    ) + "\n"
+
+
+def report_path_for(config: ReportConfig, created_at: datetime) -> Path:
+    stamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+    hostname = sanitize_filename(socket.gethostname())
+    return config.output_dir / f"arthexis-error-report-{hostname}-{stamp}.zip"
+
+
+def build_report(config: ReportConfig) -> ReportResult:
+    created_at = utc_now()
+    report_path = report_path_for(config, created_at)
+    builder = collect_report_entries(config, created_at)
+    manifest = build_manifest(config, created_at, report_path, builder.entries, builder.warnings)
+    manifest_entry = ReportEntry(
+        archive_path="manifest.json",
+        content=(json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+    )
+    summary_entry = ReportEntry(
+        archive_path="summary.txt",
+        content=build_summary(manifest).encode("utf-8"),
+    )
+    entries = [manifest_entry, summary_entry, *builder.entries]
+
+    if config.dry_run:
+        return ReportResult(path=report_path, entries=entries, warnings=builder.warnings, dry_run=True)
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(report_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for entry in entries:
+            archive.writestr(entry.archive_path, entry.content)
+    return ReportResult(path=report_path, entries=entries, warnings=builder.warnings)
+
+
+def validate_upload_url(url: str, allow_insecure: bool) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("upload URL must be an http(s) URL with a host")
+    if parsed.scheme != "https" and not allow_insecure:
+        raise ValueError("upload URL must use https unless --allow-insecure-upload is set")
+
+
+def upload_report(path: Path, url: str, *, method: str = "PUT", timeout: int = 60, allow_insecure: bool = False) -> int:
+    validate_upload_url(url, allow_insecure)
+    method = method.upper()
+    if method not in {"PUT", "POST"}:
+        raise ValueError("upload method must be PUT or POST")
+    data = path.read_bytes()
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Content-Type": "application/zip",
+            "Content-Length": str(len(data)),
+        },
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return int(getattr(response, "status", response.getcode()))
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build an Arthexis diagnostic error-report zip.")
+    parser.add_argument("--base-dir", default=Path.cwd(), type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--since", type=parse_duration)
+    parser.add_argument("--max-log-files", type=positive_int, default=DEFAULT_MAX_LOG_FILES)
+    parser.add_argument("--max-file-bytes", type=positive_int, default=DEFAULT_MAX_FILE_BYTES)
+    parser.add_argument("--upload-url")
+    parser.add_argument("--upload-method", default="PUT", choices=["PUT", "POST", "put", "post"])
+    parser.add_argument("--upload-timeout", type=positive_int, default=60)
+    parser.add_argument("--allow-insecure-upload", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    base_dir = args.base_dir.expanduser().resolve()
+    output_dir = args.output_dir
+    if output_dir is None:
+        output_dir = base_dir / DEFAULT_OUTPUT_DIR
+    elif not output_dir.is_absolute():
+        output_dir = base_dir / output_dir
+
+    config = ReportConfig(
+        base_dir=base_dir,
+        output_dir=output_dir,
+        since=args.since,
+        max_log_files=args.max_log_files,
+        max_file_bytes=args.max_file_bytes,
+        upload_url=args.upload_url,
+        upload_method=args.upload_method.upper(),
+        upload_timeout=args.upload_timeout,
+        allow_insecure_upload=args.allow_insecure_upload,
+        dry_run=args.dry_run,
+    )
+
+    try:
+        result = build_report(config)
+    except OSError as exc:
+        print(f"error-report failed: {exc}", file=sys.stderr)
+        return 1
+
+    if result.dry_run:
+        print(f"Would create: {result.path}")
+        for entry in result.entries:
+            source = f" <- {entry.source_path}" if entry.source_path else ""
+            print(f"- {entry.archive_path}{source}")
+        if config.upload_url:
+            print("Upload skipped during dry run.")
+        return 0
+
+    print(f"Created error report: {result.path}")
+    if result.warnings:
+        print(f"Warnings: {len(result.warnings)}")
+    if config.upload_url:
+        try:
+            status = upload_report(
+                result.path,
+                config.upload_url,
+                method=config.upload_method,
+                timeout=config.upload_timeout,
+                allow_insecure=config.allow_insecure_upload,
+            )
+        except (HTTPError, URLError, OSError, ValueError) as exc:
+            print(f"Upload failed; local zip remains at {result.path}: {exc}", file=sys.stderr)
+            return 2
+        print(f"Uploaded error report: HTTP {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/error_report.py
+++ b/scripts/error_report.py
@@ -14,6 +14,7 @@ import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from gettext import gettext as _
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
@@ -76,8 +77,14 @@ SECRET_KEY_RE = re.compile(
 )
 AUTH_HEADER_RE = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
 AWS_ACCESS_KEY_RE = re.compile(r"\bA(?:KIA|SIA)[0-9A-Z]{16}\b")
-URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^/\s@]+)@",
-                             re.IGNORECASE)
+URL_USERINFO_RE = re.compile(
+    r"([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^/\s@]+)@",
+    re.IGNORECASE,
+)
+URL_TOKEN_USERINFO_RE = re.compile(
+    r"([a-z][a-z0-9+.-]*://)([^/\s:@]+)@",
+    re.IGNORECASE,
+)
 PRIVATE_KEY_BLOCK_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
     re.DOTALL,
@@ -128,7 +135,7 @@ def parse_duration(value: str) -> timedelta:
     match = re.fullmatch(r"\s*(\d+)\s*([smhdw])\s*", value)
     if not match:
         raise argparse.ArgumentTypeError(
-            "duration must use a suffix: s, m, h, d, or w; for example 12h or 7d"
+            _("duration must use a suffix: s, m, h, d, or w; for example 12h or 7d")
         )
     amount = int(match.group(1))
     unit = match.group(2)
@@ -146,6 +153,7 @@ def parse_duration(value: str) -> timedelta:
 def redact_text(text: str) -> str:
     redacted = PRIVATE_KEY_BLOCK_RE.sub("<redacted:private-key>", text)
     redacted = URL_USERINFO_RE.sub(r"\1<redacted>@", redacted)
+    redacted = URL_TOKEN_USERINFO_RE.sub(r"\1<redacted>@", redacted)
     redacted = AUTH_HEADER_RE.sub(lambda match: f"{match.group(1)} <redacted>", redacted)
     redacted = AWS_ACCESS_KEY_RE.sub("<redacted:aws-access-key>", redacted)
     redacted = SSO_KEY_RE.sub("sso-key <redacted>", redacted)
@@ -153,12 +161,15 @@ def redact_text(text: str) -> str:
     return redacted
 
 
-def is_sensitive_path(path: Path) -> bool:
+def is_sensitive_path(path: Path, *, base_dir: Path | None = None) -> bool:
     name = path.name.lower()
     suffix = path.suffix.lower()
     if name in SENSITIVE_NAMES or suffix in SENSITIVE_SUFFIXES:
         return True
-    parts = {part.lower() for part in path.parts}
+    relative = path_relative_to(path, base_dir) if base_dir is not None else None
+    if relative is None:
+        return False
+    parts = {part.lower() for part in relative.parts}
     return bool(parts & SENSITIVE_PARTS)
 
 
@@ -217,7 +228,7 @@ class ReportBuilder:
             return
         if not path.is_file():
             return
-        if is_sensitive_path(path):
+        if is_sensitive_path(path, base_dir=self.config.base_dir):
             self.warnings.append(f"Skipped sensitive path: {path}")
             return
         if not should_read_text(path):
@@ -274,17 +285,24 @@ def run_command(args: list[str], *, cwd: Path, timeout: int = 10) -> str:
             cwd=str(cwd),
             check=False,
             capture_output=True,
-            text=True,
             timeout=timeout,
         )
     except FileNotFoundError:
-        return f"Command not available: {args[0]}\n"
+        return _("Command not available: {command}").format(command=args[0]) + "\n"
     except subprocess.TimeoutExpired:
-        return f"Command timed out after {timeout}s: {' '.join(args)}\n"
+        return (
+            _("Command timed out after {timeout}s: {command}").format(
+                timeout=timeout,
+                command=" ".join(args),
+            )
+            + "\n"
+        )
 
-    output = completed.stdout
-    if completed.stderr:
-        output += ("\n[stderr]\n" if output else "[stderr]\n") + completed.stderr
+    stdout = completed.stdout.decode("utf-8", errors="replace")
+    stderr = completed.stderr.decode("utf-8", errors="replace")
+    output = stdout
+    if stderr:
+        output += ("\n[stderr]\n" if output else "[stderr]\n") + stderr
     output += f"\n[exit_code] {completed.returncode}\n"
     return redact_text(output)
 
@@ -325,7 +343,7 @@ def collect_log_files(base_dir: Path, config: ReportConfig, cutoff: float | None
                 continue
             if path.suffix.lower() not in LOG_SUFFIXES:
                 continue
-            if is_sensitive_path(path):
+            if is_sensitive_path(path, base_dir=base_dir):
                 continue
             if cutoff is not None and path.name not in STANDARD_LOG_NAMES:
                 try:
@@ -372,7 +390,7 @@ def collect_locks(builder: ReportBuilder) -> None:
             continue
         if path.suffix.lower() not in {".lck", ".json", ".txt", ".log", ""}:
             continue
-        if is_sensitive_path(path):
+        if is_sensitive_path(path, base_dir=builder.config.base_dir):
             continue
         found = True
         relative = path.relative_to(lock_dir)
@@ -596,16 +614,16 @@ def build_report(config: ReportConfig) -> ReportResult:
 def validate_upload_url(url: str, allow_insecure: bool) -> None:
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise ValueError("upload URL must be an http(s) URL with a host")
+        raise ValueError(_("upload URL must be an http(s) URL with a host"))
     if parsed.scheme != "https" and not allow_insecure:
-        raise ValueError("upload URL must use https unless --allow-insecure-upload is set")
+        raise ValueError(_("upload URL must use https unless --allow-insecure-upload is set"))
 
 
 def upload_report(path: Path, url: str, *, method: str = "PUT", timeout: int = 60, allow_insecure: bool = False) -> int:
     validate_upload_url(url, allow_insecure)
     method = method.upper()
     if method not in {"PUT", "POST"}:
-        raise ValueError("upload method must be PUT or POST")
+        raise ValueError(_("upload method must be PUT or POST"))
     data = path.read_bytes()
     request = Request(
         url,
@@ -623,12 +641,12 @@ def upload_report(path: Path, url: str, *, method: str = "PUT", timeout: int = 6
 def positive_int(value: str) -> int:
     parsed = int(value)
     if parsed <= 0:
-        raise argparse.ArgumentTypeError("value must be greater than zero")
+        raise argparse.ArgumentTypeError(_("value must be greater than zero"))
     return parsed
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build an Arthexis diagnostic error-report zip.")
+    parser = argparse.ArgumentParser(description=_("Build an Arthexis diagnostic error-report zip."))
     parser.add_argument("--base-dir", default=Path.cwd(), type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--output-dir", type=Path, default=None)
     parser.add_argument("--since", type=parse_duration)
@@ -668,21 +686,21 @@ def main(argv: list[str] | None = None) -> int:
     try:
         result = build_report(config)
     except OSError as exc:
-        print(f"error-report failed: {exc}", file=sys.stderr)
+        print(_("error-report failed: {error}").format(error=exc), file=sys.stderr)
         return 1
 
     if result.dry_run:
-        print(f"Would create: {result.path}")
+        print(_("Would create: {path}").format(path=result.path))
         for entry in result.entries:
             source = f" <- {entry.source_path}" if entry.source_path else ""
             print(f"- {entry.archive_path}{source}")
         if config.upload_url:
-            print("Upload skipped during dry run.")
+            print(_("Upload skipped during dry run."))
         return 0
 
-    print(f"Created error report: {result.path}")
+    print(_("Created error report: {path}").format(path=result.path))
     if result.warnings:
-        print(f"Warnings: {len(result.warnings)}")
+        print(_("Warnings: {count}").format(count=len(result.warnings)))
     if config.upload_url:
         try:
             status = upload_report(
@@ -693,9 +711,15 @@ def main(argv: list[str] | None = None) -> int:
                 allow_insecure=config.allow_insecure_upload,
             )
         except (HTTPError, URLError, OSError, ValueError) as exc:
-            print(f"Upload failed; local zip remains at {result.path}: {exc}", file=sys.stderr)
+            print(
+                _("Upload failed; local zip remains at {path}: {error}").format(
+                    path=result.path,
+                    error=exc,
+                ),
+                file=sys.stderr,
+            )
             return 2
-        print(f"Uploaded error report: HTTP {status}")
+        print(_("Uploaded error report: HTTP {status}").format(status=status))
     return 0
 
 

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts import error_report
+
+
+def test_build_report_redacts_text_and_excludes_sensitive_files(tmp_path: Path) -> None:
+    base_dir = tmp_path
+    (base_dir / "logs").mkdir()
+    (base_dir / ".locks").mkdir()
+    (base_dir / "VERSION").write_text("1.2.3\n", encoding="utf-8")
+    (base_dir / "arthexis.env").write_text("SECRET_KEY=do-not-copy\n", encoding="utf-8")
+    (base_dir / "db.sqlite3").write_text("database", encoding="utf-8")
+    (base_dir / ".locks" / "service.lck").write_text("arthexis\n", encoding="utf-8")
+    (base_dir / "logs" / "error.log").write_text(
+        "SECRET_KEY=do-not-leak\nAuthorization: Bearer abc.def.ghi\n",
+        encoding="utf-8",
+    )
+
+    result = error_report.build_report(
+        error_report.ReportConfig(
+            base_dir=base_dir,
+            output_dir=base_dir / "work" / "error-reports",
+        )
+    )
+
+    assert result.path.exists()
+    with zipfile.ZipFile(result.path) as archive:
+        names = set(archive.namelist())
+        assert "manifest.json" in names
+        assert "summary.txt" in names
+        assert "logs/error.log" in names
+        assert "arthexis/locks/service.lck" in names
+        assert "arthexis.env" not in names
+        assert "db.sqlite3" not in names
+        payload = archive.read("logs/error.log").decode("utf-8")
+
+    assert "do-not-leak" not in payload
+    assert "abc.def.ghi" not in payload
+    assert "SECRET_KEY=<redacted>" in payload
+    assert "Bearer <redacted>" in payload
+
+
+def test_build_report_writes_manifest_with_entry_hashes(tmp_path: Path) -> None:
+    base_dir = tmp_path
+    (base_dir / "logs").mkdir()
+    (base_dir / "logs" / "error.log").write_text("boom\n", encoding="utf-8")
+
+    result = error_report.build_report(
+        error_report.ReportConfig(
+            base_dir=base_dir,
+            output_dir=base_dir / "reports",
+            max_log_files=1,
+            max_file_bytes=128,
+        )
+    )
+
+    with zipfile.ZipFile(result.path) as archive:
+        manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+
+    assert manifest["schema_version"] == error_report.SCHEMA_VERSION
+    assert manifest["options"]["max_log_files"] == 1
+    assert manifest["options"]["max_file_bytes"] == 128
+    assert any(entry["path"] == "logs/error.log" for entry in manifest["entries"])
+    assert all(entry["sha256"] for entry in manifest["entries"])
+
+
+def test_dry_run_returns_planned_entries_without_writing_zip(tmp_path: Path) -> None:
+    base_dir = tmp_path
+    (base_dir / "logs").mkdir()
+    (base_dir / "logs" / "error.log").write_text("boom\n", encoding="utf-8")
+    output_dir = base_dir / "reports"
+
+    result = error_report.build_report(
+        error_report.ReportConfig(
+            base_dir=base_dir,
+            output_dir=output_dir,
+            dry_run=True,
+        )
+    )
+
+    assert result.dry_run is True
+    assert not result.path.exists()
+    assert any(entry.archive_path == "logs/error.log" for entry in result.entries)
+
+
+def test_upload_report_requires_https_by_default(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.zip"
+    report_path.write_bytes(b"zip")
+
+    with pytest.raises(ValueError, match="https"):
+        error_report.upload_report(report_path, "http://example.test/upload")
+
+
+def test_upload_report_uses_explicit_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    report_path = tmp_path / "report.zip"
+    report_path.write_bytes(b"zip")
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status = 204
+
+        def getcode(self) -> int:
+            return 204
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            return None
+
+    def fake_urlopen(request: object, timeout: int) -> FakeResponse:
+        captured["method"] = request.get_method()
+        captured["data"] = request.data
+        captured["timeout"] = timeout
+        captured["content_type"] = request.headers["Content-type"]
+        return FakeResponse()
+
+    monkeypatch.setattr(error_report, "urlopen", fake_urlopen)
+
+    status = error_report.upload_report(
+        report_path,
+        "https://example.test/upload",
+        method="POST",
+        timeout=12,
+    )
+
+    assert status == 204
+    assert captured == {
+        "method": "POST",
+        "data": b"zip",
+        "timeout": 12,
+        "content_type": "application/zip",
+    }

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -97,6 +97,14 @@ def test_upload_report_requires_https_by_default(tmp_path: Path) -> None:
         error_report.upload_report(report_path, "http://example.test/upload")
 
 
+def test_data_parent_directory_does_not_make_log_file_sensitive(tmp_path: Path) -> None:
+    log_path = tmp_path / "data" / "arthexis" / "logs" / "error.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("safe diagnostic line\n", encoding="utf-8")
+
+    assert error_report.is_sensitive_path(log_path) is False
+
+
 def test_upload_report_uses_explicit_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     report_path = tmp_path / "report.zip"
     report_path.write_bytes(b"zip")

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -98,11 +98,22 @@ def test_upload_report_requires_https_by_default(tmp_path: Path) -> None:
 
 
 def test_data_parent_directory_does_not_make_log_file_sensitive(tmp_path: Path) -> None:
-    log_path = tmp_path / "data" / "arthexis" / "logs" / "error.log"
+    base_dir = tmp_path / "data" / "arthexis"
+    log_path = base_dir / "logs" / "error.log"
     log_path.parent.mkdir(parents=True)
     log_path.write_text("safe diagnostic line\n", encoding="utf-8")
 
-    assert error_report.is_sensitive_path(log_path) is False
+    assert error_report.is_sensitive_path(log_path, base_dir=base_dir) is False
+    assert error_report.is_sensitive_path(base_dir / "media" / "capture.log", base_dir=base_dir) is True
+
+
+def test_redact_text_removes_token_only_url_credentials() -> None:
+    payload = "origin https://ghp_do-not-leak@github.com/arthexis/arthexis.git (fetch)"
+
+    redacted = error_report.redact_text(payload)
+
+    assert "ghp_do-not-leak" not in redacted
+    assert "https://<redacted>@github.com/arthexis/arthexis.git" in redacted
 
 
 def test_upload_report_uses_explicit_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -9,6 +9,11 @@ import pytest
 from scripts import error_report
 
 
+@pytest.fixture(autouse=True)
+def clear_arthexis_log_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARTHEXIS_LOG_DIR", raising=False)
+
+
 def test_build_report_redacts_text_and_excludes_sensitive_files(tmp_path: Path) -> None:
     base_dir = tmp_path
     (base_dir / "logs").mkdir()

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -40,6 +40,7 @@ def test_lifecycle_manual_covers_operator_entrypoints() -> None:
         "## 5. Runtime status (`status.sh`)",
         "## 6. Operational command entrypoint (`command.sh`)",
         "## 7. Uninstall (`uninstall.sh`)",
+        "## 8. Error report (`error-report.sh`)",
     )
 
     for section in expected_sections:
@@ -89,6 +90,12 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
             "--stop",
             "--branch",
         ),
+        "error-report.sh": (
+            "Usage: ./error-report.sh",
+            "--output-dir DIR",
+            "--upload-url URL",
+            "--dry-run",
+        ),
         "uninstall.sh": ("--service NAME", "--no-warn", "--rfid-service", "--no-rfid-service"),
     }
 
@@ -108,3 +115,4 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
     manual = MANUAL.read_text(encoding="utf-8")
     assert "`./command.sh list`" in manual
     assert "`./command.sh <operational-command> [args...]`" in manual
+    assert "`error-report.sh` builds a single diagnostic zip" in manual

--- a/tests/test_lifecycle_script_contracts.py
+++ b/tests/test_lifecycle_script_contracts.py
@@ -95,6 +95,7 @@ def test_lifecycle_scripts_expose_documented_entrypoints() -> None:
             "--output-dir DIR",
             "--upload-url URL",
             "--dry-run",
+            "sys.version_info[0] == 3",
         ),
         "uninstall.sh": ("--service NAME", "--no-warn", "--rfid-service", "--no-rfid-service"),
     }


### PR DESCRIPTION
## Summary
- add root `error-report.sh` non-Django CLI for building a single diagnostic zip
- add stdlib-only `scripts/error_report.py` collector with manifest, summary, log/lock/git/system diagnostics, secret redaction, exclusions, dry-run, and explicit signed-URL upload support
- document operator usage and lifecycle contract, and add focused tests for package creation, redaction/exclusion, dry-run, upload URL safety, and lifecycle docs

Closes #7532

## Validation
- `.venv\Scripts\python.exe -m ruff check scripts/error_report.py tests/test_error_report.py`
- `.venv\Scripts\python.exe -m pytest tests/test_error_report.py tests/test_lifecycle_script_contracts.py`
- `.venv\Scripts\python.exe scripts\error_report.py --base-dir . --dry-run --max-log-files 2 --max-file-bytes 4096`
- `.venv\Scripts\python.exe scripts\error_report.py --base-dir . --output-dir work\error-reports --max-log-files 1 --max-file-bytes 2048`
- inspected generated zip for `manifest.json`, `summary.txt`, and `logs/` entries
- `git diff --cached --check`