### PR TITLE
Add QR console sticker printing command

### DIFF
--- a/apps/links/management/__init__.py
+++ b/apps/links/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for links."""

--- a/apps/links/management/commands/__init__.py
+++ b/apps/links/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Links management command package."""

--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -391,10 +391,8 @@ class Command(BaseCommand):
             output = subprocess.check_output(
                 ["netsh", "wlan", "show", "profile", f"name={profile}", "key=clear"],
                 text=True,
-                encoding="utf-8",
-                errors="replace",
             )
-        except (OSError, subprocess.CalledProcessError) as exc:
+        except (OSError, subprocess.CalledProcessError, UnicodeDecodeError) as exc:
             raise CommandError(f"Unable to read saved Wi-Fi profile '{profile}': {exc}") from exc
         password = _extract_windows_wifi_profile_password(output)
         if not password:

--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -1,0 +1,384 @@
+"""Console QR generation and printing commands."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.links.models import QRRedirect, Reference
+from apps.links.qr_printing import (
+    DEFAULT_CHUNK_BYTES,
+    DEFAULT_CHUNK_DELAY_SECONDS,
+    DEFAULT_LABEL_HEIGHT,
+    DEFAULT_LABEL_WIDTH,
+    DEFAULT_QR_SIZE,
+    PHOMEMO_M220_USB_PATH_ENV,
+    QRLabelSpec,
+    build_phomemo_m220_job,
+    build_qr_label_image,
+    build_wifi_payload,
+    iter_phomemo_m220_usb_paths,
+    resolve_phomemo_m220_usb_path,
+    write_windows_usb,
+)
+
+
+@dataclass(frozen=True)
+class QRSelection:
+    """Resolved QR payload and safe display metadata."""
+
+    source: str
+    payload: str
+    title: str = ""
+    subtitle: str = ""
+    footer: str = ""
+    detail: str = ""
+
+
+class Command(BaseCommand):
+    """QR command group."""
+
+    help = "QR command group. Use `qr print` to render or print labels."
+
+    def add_arguments(self, parser):
+        """Register QR subcommands."""
+
+        subparsers = parser.add_subparsers(dest="action")
+        subparsers.required = True
+
+        print_parser = subparsers.add_parser(
+            "print",
+            help="Render a QR label preview and optionally print it.",
+        )
+        self._add_print_arguments(print_parser)
+
+        devices_parser = subparsers.add_parser(
+            "devices",
+            help="List auto-discovered QR printer device paths.",
+        )
+        devices_parser.add_argument(
+            "--printer",
+            choices=["phomemo-m220"],
+            default="phomemo-m220",
+            help="Printer type to discover.",
+        )
+
+    def handle(self, *args, **options):
+        """Dispatch QR actions."""
+
+        action = options["action"]
+        if action == "print":
+            self._handle_print(options)
+            return
+        if action == "devices":
+            self._handle_devices(options)
+            return
+        raise CommandError(f"Unsupported QR action: {action}")
+
+    def _add_print_arguments(self, parser):
+        source = parser.add_mutually_exclusive_group(required=True)
+        source.add_argument("--text", help="Raw QR payload to encode.")
+        source.add_argument(
+            "--reference",
+            help="Reference id, transaction UUID, or exact title to print.",
+        )
+        source.add_argument("--redirect", help="QRRedirect slug to print.")
+        source.add_argument("--wifi-ssid", help="Build a Wi-Fi join QR for this SSID.")
+        source.add_argument(
+            "--wifi-profile",
+            help="Build a Wi-Fi join QR from a saved Windows WLAN profile.",
+        )
+
+        parser.add_argument(
+            "--wifi-password",
+            default="",
+            help="Wi-Fi password for --wifi-ssid. Prefer --wifi-password-file in scripts.",
+        )
+        parser.add_argument(
+            "--wifi-password-file",
+            help="Read the Wi-Fi password from a local file instead of argv.",
+        )
+        parser.add_argument(
+            "--wifi-auth",
+            default="WPA",
+            choices=["WPA", "WEP", "nopass"],
+            help="Wi-Fi authentication type.",
+        )
+        parser.add_argument(
+            "--wifi-hidden",
+            action="store_true",
+            help="Mark the Wi-Fi network as hidden in the QR payload.",
+        )
+        parser.add_argument(
+            "--base-url",
+            help="Base URL for QRRedirect payloads. Defaults to PUBLIC_BASE_URL when configured.",
+        )
+        parser.add_argument(
+            "--redirect-public-view",
+            action="store_true",
+            help="Encode the QRRedirect public view instead of the direct redirect path.",
+        )
+        parser.add_argument("--output", help="PNG preview path. Defaults to a temp file.")
+        parser.add_argument("--label-title", help="Override the printed label title.")
+        parser.add_argument("--label-subtitle", help="Override the printed label subtitle.")
+        parser.add_argument("--footer", help="Override the printed label footer.")
+        parser.add_argument("--width", type=int, default=DEFAULT_LABEL_WIDTH)
+        parser.add_argument("--height", type=int, default=DEFAULT_LABEL_HEIGHT)
+        parser.add_argument("--qr-size", type=int, default=DEFAULT_QR_SIZE)
+        parser.add_argument(
+            "--printer",
+            choices=["none", "phomemo-m220"],
+            default="none",
+            help="Printer backend. Use phomemo-m220 to write a USB print job.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Build the preview and printer job without writing to USB.",
+        )
+        parser.add_argument(
+            "--usb-path",
+            help=(
+                "Windows USB device path. Defaults to "
+                f"{PHOMEMO_M220_USB_PATH_ENV} or auto-discovery."
+            ),
+        )
+        parser.add_argument("--chunk-bytes", type=int, default=DEFAULT_CHUNK_BYTES)
+        parser.add_argument("--chunk-delay", type=float, default=DEFAULT_CHUNK_DELAY_SECONDS)
+        parser.add_argument("--speed", type=int, default=2)
+        parser.add_argument("--density", type=int, default=15)
+
+    def _handle_print(self, options):
+        selection = self._resolve_selection(options)
+        spec = QRLabelSpec(
+            width=options["width"],
+            height=options["height"],
+            qr_size=options["qr_size"],
+            title=options.get("label_title") or selection.title,
+            subtitle=options.get("label_subtitle") or selection.subtitle,
+            footer=options.get("footer") or selection.footer,
+        )
+        image = build_qr_label_image(selection.payload, spec=spec)
+        output_path = self._resolve_output_path(options.get("output"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        image.convert("RGB").save(output_path, format="PNG")
+
+        self.stdout.write(f"SOURCE={selection.source}")
+        if selection.detail:
+            self.stdout.write(selection.detail)
+        self.stdout.write(f"PREVIEW={output_path}")
+        self.stdout.write(f"PAYLOAD_BYTES={len(selection.payload.encode('utf-8'))}")
+
+        if options["printer"] == "none":
+            if options.get("dry_run"):
+                self.stdout.write("DRY_RUN=1")
+            return
+
+        if options["printer"] != "phomemo-m220":
+            raise CommandError(f"Unsupported printer: {options['printer']}")
+
+        job = build_phomemo_m220_job(
+            image,
+            speed=options["speed"],
+            density=options["density"],
+        )
+        self.stdout.write("PRINTER=phomemo-m220")
+        self.stdout.write(f"COMMAND_BYTES={len(job)}")
+        self.stdout.write(f"CHUNK_BYTES={options['chunk_bytes']}")
+        self.stdout.write(f"CHUNK_DELAY_SECONDS={options['chunk_delay']}")
+        if options.get("dry_run"):
+            self.stdout.write("DRY_RUN=1")
+            return
+
+        usb_path = resolve_phomemo_m220_usb_path(options.get("usb_path"))
+        if not usb_path:
+            raise CommandError(
+                "No Phomemo M220 USB path configured. Pass --usb-path, set "
+                f"{PHOMEMO_M220_USB_PATH_ENV}, or run `python manage.py qr devices`."
+            )
+        written = write_windows_usb(
+            usb_path,
+            job,
+            chunk_size=options["chunk_bytes"],
+            delay_seconds=options["chunk_delay"],
+        )
+        self.stdout.write(self.style.SUCCESS(f"PHOMEMO_M220_WRITE_OK bytes={written}"))
+
+    def _handle_devices(self, options):
+        if options["printer"] != "phomemo-m220":
+            raise CommandError(f"Unsupported printer: {options['printer']}")
+        env_path = resolve_phomemo_m220_usb_path("")
+        configured = bool(env_path)
+        if configured:
+            self.stdout.write(f"CONFIGURED_OR_DISCOVERED={env_path}")
+        paths = list(iter_phomemo_m220_usb_paths())
+        if not paths:
+            self.stdout.write("No Phomemo M220 USBPRINT candidates found.")
+            return
+        for path in paths:
+            self.stdout.write(path)
+
+    def _resolve_selection(self, options) -> QRSelection:
+        if options.get("text"):
+            return QRSelection(
+                source="text",
+                payload=options["text"],
+                title="QR CODE",
+            )
+        if options.get("reference"):
+            return self._resolve_reference(options["reference"])
+        if options.get("redirect"):
+            return self._resolve_redirect(options["redirect"], options)
+        if options.get("wifi_ssid"):
+            return self._resolve_wifi_ssid(options)
+        if options.get("wifi_profile"):
+            return self._resolve_wifi_profile(options)
+        raise CommandError("Choose one QR source.")
+
+    def _resolve_reference(self, value: str) -> QRSelection:
+        cleaned = value.strip()
+        if not cleaned:
+            raise CommandError("Reference lookup cannot be blank.")
+
+        reference = None
+        if cleaned.isdigit():
+            reference = Reference.objects.filter(pk=int(cleaned)).first()
+        if reference is None:
+            try:
+                reference_uuid = uuid.UUID(cleaned)
+            except ValueError:
+                reference_uuid = None
+            if reference_uuid is not None:
+                reference = Reference.objects.filter(transaction_uuid=reference_uuid).first()
+
+        if reference is None:
+            matches = list(Reference.objects.filter(alt_text__iexact=cleaned).order_by("pk")[:2])
+            if len(matches) > 1:
+                raise CommandError(
+                    f"Multiple references match '{cleaned}'. Use the numeric id instead."
+                )
+            reference = matches[0] if matches else None
+
+        if reference is None:
+            raise CommandError(f"No reference found for '{cleaned}'.")
+        if not reference.value:
+            raise CommandError(f"Reference #{reference.pk} has no value to encode.")
+        return QRSelection(
+            source="reference",
+            payload=reference.value,
+            title=reference.alt_text,
+            subtitle=f"Reference #{reference.pk}",
+            detail=f"REFERENCE_ID={reference.pk}",
+        )
+
+    def _resolve_redirect(self, value: str, options) -> QRSelection:
+        slug = value.strip()
+        if not slug:
+            raise CommandError("QRRedirect slug cannot be blank.")
+        redirect = QRRedirect.objects.filter(slug__iexact=slug).first()
+        if redirect is None:
+            raise CommandError(f"No QR redirect found for slug '{slug}'.")
+        path = redirect.public_path() if options.get("redirect_public_view") else redirect.redirect_path()
+        payload = self._build_absolute_url(path, options.get("base_url"))
+        detail = f"QR_REDIRECT_SLUG={redirect.slug}"
+        if payload.startswith("/"):
+            detail += "\nPAYLOAD_RELATIVE=1"
+        return QRSelection(
+            source="redirect",
+            payload=payload,
+            title=redirect.title or redirect.slug,
+            subtitle=f"QR redirect {redirect.slug}",
+            detail=detail,
+        )
+
+    def _resolve_wifi_ssid(self, options) -> QRSelection:
+        ssid = options["wifi_ssid"].strip()
+        password = self._wifi_password_from_options(options)
+        auth_type = options["wifi_auth"]
+        if auth_type != "nopass" and not password:
+            raise CommandError("--wifi-password or --wifi-password-file is required unless --wifi-auth=nopass.")
+        return QRSelection(
+            source="wifi",
+            payload=build_wifi_payload(
+                ssid,
+                password,
+                auth_type=auth_type,
+                hidden=options.get("wifi_hidden", False),
+            ),
+            title="WIFI",
+            subtitle=ssid,
+            footer="Scan to join",
+            detail=f"WIFI_SSID={ssid}",
+        )
+
+    def _resolve_wifi_profile(self, options) -> QRSelection:
+        profile = options["wifi_profile"].strip()
+        if not profile:
+            raise CommandError("Wi-Fi profile cannot be blank.")
+        password = self._read_windows_wifi_profile_password(profile)
+        return QRSelection(
+            source="wifi-profile",
+            payload=build_wifi_payload(
+                profile,
+                password,
+                auth_type=options["wifi_auth"],
+                hidden=options.get("wifi_hidden", False),
+            ),
+            title="WIFI",
+            subtitle=profile,
+            footer="Scan to join",
+            detail=f"WIFI_SSID={profile}",
+        )
+
+    def _wifi_password_from_options(self, options) -> str:
+        password_file = options.get("wifi_password_file")
+        if password_file:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise CommandError(f"Unable to read --wifi-password-file '{path}': {exc}") from exc
+        return options.get("wifi_password", "")
+
+    def _read_windows_wifi_profile_password(self, profile: str) -> str:
+        if sys.platform != "win32":
+            raise CommandError("--wifi-profile can only read saved profiles on Windows.")
+        try:
+            output = subprocess.check_output(
+                ["netsh", "wlan", "show", "profile", f"name={profile}", "key=clear"],
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise CommandError(f"Unable to read saved Wi-Fi profile '{profile}': {exc}") from exc
+        password = ""
+        for line in output.splitlines():
+            key, separator, value = line.partition(":")
+            if separator and key.strip().lower() == "key content":
+                password = value.strip()
+                break
+        if not password:
+            raise CommandError(f"Saved Wi-Fi password was not available for profile '{profile}'.")
+        return password
+
+    def _build_absolute_url(self, path: str, base_url: str | None) -> str:
+        base = (base_url or getattr(settings, "PUBLIC_BASE_URL", "") or "").strip()
+        if not base:
+            return path
+        return urljoin(base.rstrip("/") + "/", path.lstrip("/"))
+
+    def _resolve_output_path(self, output: str | None) -> Path:
+        if output:
+            return Path(output).expanduser().resolve()
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        return Path(tempfile.gettempdir()) / f"arthexis-qr-{stamp}.png"

--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -29,6 +30,19 @@ from apps.links.qr_printing import (
     iter_phomemo_m220_usb_paths,
     resolve_phomemo_m220_usb_path,
     write_windows_usb,
+)
+
+WINDOWS_WIFI_PASSWORD_LABELS = frozenset(
+    {
+        "key content",
+        "contenido de la clave",
+        "contenido clave",
+        "clave",
+        "contenu de cle",
+        "cle",
+        "contenuto chiave",
+        "chiave",
+    }
 )
 
 
@@ -167,10 +181,17 @@ class Command(BaseCommand):
             subtitle=options.get("label_subtitle") or selection.subtitle,
             footer=options.get("footer") or selection.footer,
         )
-        image = build_qr_label_image(selection.payload, spec=spec)
+        try:
+            image = build_qr_label_image(selection.payload, spec=spec)
+        except Exception as exc:
+            raise CommandError(f"Failed to render QR label: {exc}") from exc
+
         output_path = self._resolve_output_path(options.get("output"))
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        image.convert("RGB").save(output_path, format="PNG")
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            image.convert("RGB").save(output_path, format="PNG")
+        except OSError as exc:
+            raise CommandError(f"Failed to write QR preview '{output_path}': {exc}") from exc
 
         self.stdout.write(f"SOURCE={selection.source}")
         if selection.detail:
@@ -186,11 +207,15 @@ class Command(BaseCommand):
         if options["printer"] != "phomemo-m220":
             raise CommandError(f"Unsupported printer: {options['printer']}")
 
-        job = build_phomemo_m220_job(
-            image,
-            speed=options["speed"],
-            density=options["density"],
-        )
+        try:
+            job = build_phomemo_m220_job(
+                image,
+                speed=options["speed"],
+                density=options["density"],
+            )
+        except Exception as exc:
+            raise CommandError(f"Failed to build Phomemo M220 print job: {exc}") from exc
+
         self.stdout.write("PRINTER=phomemo-m220")
         self.stdout.write(f"COMMAND_BYTES={len(job)}")
         self.stdout.write(f"CHUNK_BYTES={options['chunk_bytes']}")
@@ -199,18 +224,24 @@ class Command(BaseCommand):
             self.stdout.write("DRY_RUN=1")
             return
 
-        usb_path = resolve_phomemo_m220_usb_path(options.get("usb_path"))
+        try:
+            usb_path = resolve_phomemo_m220_usb_path(options.get("usb_path"))
+        except Exception as exc:
+            raise CommandError(f"Failed to resolve Phomemo M220 USB path: {exc}") from exc
         if not usb_path:
             raise CommandError(
                 "No Phomemo M220 USB path configured. Pass --usb-path, set "
                 f"{PHOMEMO_M220_USB_PATH_ENV}, or run `python manage.py qr devices`."
             )
-        written = write_windows_usb(
-            usb_path,
-            job,
-            chunk_size=options["chunk_bytes"],
-            delay_seconds=options["chunk_delay"],
-        )
+        try:
+            written = write_windows_usb(
+                usb_path,
+                job,
+                chunk_size=options["chunk_bytes"],
+                delay_seconds=options["chunk_delay"],
+            )
+        except Exception as exc:
+            raise CommandError(f"Failed to write Phomemo M220 USB job: {exc}") from exc
         self.stdout.write(self.style.SUCCESS(f"PHOMEMO_M220_WRITE_OK bytes={written}"))
 
     def _handle_devices(self, options):
@@ -336,7 +367,7 @@ class Command(BaseCommand):
             title="WIFI",
             subtitle=profile,
             footer="Scan to join",
-            detail=f"WIFI_SSID={profile}",
+            detail=f"WIFI_PROFILE={profile}",
         )
 
     def _wifi_password_from_options(self, options) -> str:
@@ -344,7 +375,7 @@ class Command(BaseCommand):
         if password_file:
             path = Path(password_file).expanduser()
             try:
-                return path.read_text(encoding="utf-8").strip()
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
             except OSError as exc:
                 raise CommandError(f"Unable to read --wifi-password-file '{path}': {exc}") from exc
         return options.get("wifi_password", "")
@@ -361,12 +392,7 @@ class Command(BaseCommand):
             )
         except (OSError, subprocess.CalledProcessError) as exc:
             raise CommandError(f"Unable to read saved Wi-Fi profile '{profile}': {exc}") from exc
-        password = ""
-        for line in output.splitlines():
-            key, separator, value = line.partition(":")
-            if separator and key.strip().lower() == "key content":
-                password = value.strip()
-                break
+        password = _extract_windows_wifi_profile_password(output)
         if not password:
             raise CommandError(f"Saved Wi-Fi password was not available for profile '{profile}'.")
         return password
@@ -382,3 +408,21 @@ class Command(BaseCommand):
             return Path(output).expanduser().resolve()
         stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         return Path(tempfile.gettempdir()) / f"arthexis-qr-{stamp}.png"
+
+
+def _extract_windows_wifi_profile_password(output: str) -> str:
+    for line in output.splitlines():
+        key, separator, value = line.partition(":")
+        if not separator:
+            continue
+        if _normalize_windows_label(key) in WINDOWS_WIFI_PASSWORD_LABELS:
+            return value.strip()
+    return ""
+
+
+def _normalize_windows_label(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    without_accents = "".join(
+        character for character in normalized if not unicodedata.combining(character)
+    )
+    return " ".join(without_accents.casefold().split())

--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -418,7 +418,10 @@ def _extract_windows_wifi_profile_password(output: str) -> str:
         if not separator:
             continue
         if _normalize_windows_label(key) in WINDOWS_WIFI_PASSWORD_LABELS:
-            return value.strip()
+            password = value.rstrip("\r\n")
+            if password.startswith((" ", "\t")):
+                password = password[1:]
+            return password
     return ""
 
 

--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -8,12 +8,12 @@ import tempfile
 import unicodedata
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
 
 from apps.links.models import QRRedirect, Reference
 from apps.links.qr_printing import (
@@ -189,7 +189,7 @@ class Command(BaseCommand):
         output_path = self._resolve_output_path(options.get("output"))
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            image.convert("RGB").save(output_path, format="PNG")
+            image.save(output_path, format="PNG")
         except OSError as exc:
             raise CommandError(f"Failed to write QR preview '{output_path}': {exc}") from exc
 
@@ -355,7 +355,11 @@ class Command(BaseCommand):
         profile = options["wifi_profile"].strip()
         if not profile:
             raise CommandError("Wi-Fi profile cannot be blank.")
-        password = self._read_windows_wifi_profile_password(profile)
+        password = (
+            ""
+            if options["wifi_auth"] == "nopass"
+            else self._read_windows_wifi_profile_password(profile)
+        )
         return QRSelection(
             source="wifi-profile",
             payload=build_wifi_payload(
@@ -406,7 +410,7 @@ class Command(BaseCommand):
     def _resolve_output_path(self, output: str | None) -> Path:
         if output:
             return Path(output).expanduser().resolve()
-        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        stamp = timezone.localtime().strftime("%Y%m%d-%H%M%S")
         return Path(tempfile.gettempdir()) / f"arthexis-qr-{stamp}.png"
 
 

--- a/apps/links/qr_printing.py
+++ b/apps/links/qr_printing.py
@@ -142,11 +142,29 @@ def _make_qr_image(payload: str) -> Image.Image:
 
 
 def _load_font(size: int, *, bold: bool) -> ImageFont.ImageFont:
-    font_name = "arialbd.ttf" if bold else "arial.ttf"
-    try:
-        return ImageFont.truetype(font_name, size)
-    except OSError:
-        return ImageFont.load_default()
+    candidates = (
+        (
+            "arialbd.ttf",
+            "Arial Bold.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+            "/Library/Fonts/Arial Bold.ttf",
+        )
+        if bold
+        else (
+            "arial.ttf",
+            "Arial.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+            "/Library/Fonts/Arial.ttf",
+        )
+    )
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
 
 
 def _truncate_to_width(

--- a/apps/links/qr_printing.py
+++ b/apps/links/qr_printing.py
@@ -1,0 +1,362 @@
+"""QR label rendering and printer helpers for the links app."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+import time
+from collections.abc import Iterable
+from ctypes import wintypes
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from apps.links.qr_utils import _load_qrcode_module
+
+DEFAULT_LABEL_WIDTH = 320
+DEFAULT_LABEL_HEIGHT = 240
+DEFAULT_QR_SIZE = 160
+DEFAULT_CHUNK_BYTES = 16
+DEFAULT_CHUNK_DELAY_SECONDS = 0.04
+PHOMEMO_M220_USBPRINT_INTERFACE_GUID = "{28d78fad-5a12-11d1-ae5b-0000f803a8c2}"
+PHOMEMO_M220_USB_VID_PID = "VID_0483&PID_5740"
+PHOMEMO_M220_USB_PATH_ENV = "ARTHEXIS_QR_PRINTER_USB_PATH"
+
+
+@dataclass(frozen=True)
+class QRLabelSpec:
+    """Layout options for a compact QR sticker label."""
+
+    width: int = DEFAULT_LABEL_WIDTH
+    height: int = DEFAULT_LABEL_HEIGHT
+    qr_size: int = DEFAULT_QR_SIZE
+    title: str = ""
+    subtitle: str = ""
+    footer: str = ""
+    margin: int = 4
+
+
+def wifi_escape(value: str) -> str:
+    """Escape Wi-Fi QR payload fields."""
+
+    return (
+        value.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace(":", "\\:")
+        .replace('"', '\\"')
+    )
+
+
+def build_wifi_payload(
+    ssid: str,
+    password: str = "",
+    *,
+    auth_type: str = "WPA",
+    hidden: bool = False,
+) -> str:
+    """Return a standards-compatible Wi-Fi QR payload."""
+
+    cleaned_ssid = ssid.strip()
+    if not cleaned_ssid:
+        raise ValueError("Wi-Fi SSID is required")
+    cleaned_auth_type = (auth_type or "WPA").strip() or "WPA"
+    fields = [
+        f"T:{wifi_escape(cleaned_auth_type)}",
+        f"S:{wifi_escape(cleaned_ssid)}",
+    ]
+    if cleaned_auth_type.lower() != "nopass":
+        fields.append(f"P:{wifi_escape(password)}")
+    fields.append(f"H:{str(bool(hidden)).lower()}")
+    return "WIFI:" + ";".join(fields) + ";;"
+
+
+def render_qr_png_bytes(payload: str, spec: QRLabelSpec | None = None) -> bytes:
+    """Return a PNG preview for a QR label."""
+
+    image = build_qr_label_image(payload, spec=spec)
+    buffer = BytesIO()
+    image.convert("RGB").save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def build_qr_label_image(payload: str, spec: QRLabelSpec | None = None) -> Image.Image:
+    """Render a QR code on a compact monochrome label canvas."""
+
+    if not payload:
+        raise ValueError("QR payload is required")
+    spec = spec or QRLabelSpec()
+    if spec.width <= 0 or spec.height <= 0:
+        raise ValueError("Label dimensions must be positive")
+    if spec.width % 8:
+        raise ValueError("Label width must be divisible by 8 for raster printing")
+
+    canvas = Image.new("L", (spec.width, spec.height), 255)
+    qr_image = _make_qr_image(payload)
+    qr_size = max(24, min(spec.qr_size, spec.width - (spec.margin * 2), spec.height - 56))
+    qr_image = qr_image.resize((qr_size, qr_size), Image.Resampling.NEAREST)
+    canvas.paste(qr_image, ((spec.width - qr_size) // 2, spec.margin))
+
+    draw = ImageDraw.Draw(canvas)
+    title_font = _load_font(22, bold=True)
+    text_font = _load_font(16, bold=False)
+    small_font = _load_font(14, bold=False)
+    text_y = spec.margin + qr_size + 4
+    max_text_width = spec.width - (spec.margin * 2)
+
+    for text, font, gap in (
+        (spec.title, title_font, 4),
+        (spec.subtitle, text_font, 2),
+        (spec.footer, small_font, 0),
+    ):
+        if not text:
+            continue
+        display = _truncate_to_width(draw, text.strip(), font, max_text_width)
+        if not display:
+            continue
+        bbox = draw.textbbox((0, 0), display, font=font)
+        text_width = bbox[2] - bbox[0]
+        text_height = bbox[3] - bbox[1]
+        if text_y + text_height > spec.height:
+            break
+        draw.text(((spec.width - text_width) // 2, text_y), display, fill=0, font=font)
+        text_y += text_height + gap
+
+    return canvas
+
+
+def _make_qr_image(payload: str) -> Image.Image:
+    qrcode = _load_qrcode_module()
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=8,
+        border=3,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    return qr.make_image(fill_color="black", back_color="white").convert("L")
+
+
+def _load_font(size: int, *, bold: bool) -> ImageFont.ImageFont:
+    font_name = "arialbd.ttf" if bold else "arial.ttf"
+    try:
+        return ImageFont.truetype(font_name, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def _truncate_to_width(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font: ImageFont.ImageFont,
+    max_width: int,
+) -> str:
+    if not text:
+        return ""
+    if _text_width(draw, text, font) <= max_width:
+        return text
+    suffix = "..."
+    available = max_width - _text_width(draw, suffix, font)
+    if available <= 0:
+        return ""
+    low = 0
+    high = len(text)
+    while low < high:
+        midpoint = (low + high + 1) // 2
+        candidate = text[:midpoint].rstrip()
+        if _text_width(draw, candidate, font) <= available:
+            low = midpoint
+        else:
+            high = midpoint - 1
+    return text[:low].rstrip() + suffix if low else ""
+
+
+def _text_width(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font: ImageFont.ImageFont,
+) -> int:
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def pack_monochrome_raster(image: Image.Image, *, threshold: int = 180) -> tuple[int, int, bytes]:
+    """Pack a label image into the one-bit row raster used by Phomemo M220."""
+
+    width, height = image.size
+    if width % 8:
+        raise ValueError("Image width must be divisible by 8")
+    bytes_per_line = width // 8
+    black_white = image.convert("L").point(lambda pixel: 0 if pixel < threshold else 255, "1")
+    pixels = black_white.load()
+    raster = bytearray()
+    for y in range(height):
+        for x_byte in range(bytes_per_line):
+            value = 0
+            for bit in range(8):
+                if pixels[x_byte * 8 + bit, y] == 0:
+                    value |= 0x80 >> bit
+            raster.append(value)
+    return bytes_per_line, height, bytes(raster)
+
+
+def build_phomemo_m220_job(
+    image: Image.Image,
+    *,
+    speed: int = 2,
+    density: int = 15,
+    media_type: int = 0x0A,
+) -> bytes:
+    """Build a raw Phomemo M220 raster print job."""
+
+    for name, value in (("speed", speed), ("density", density), ("media_type", media_type)):
+        if value < 0 or value > 255:
+            raise ValueError(f"{name} must fit in one byte")
+    bytes_per_line, height, raster = pack_monochrome_raster(image)
+    command = bytearray()
+    command += b"\x1b\x4e\x0d" + bytes([speed])
+    command += b"\x1b\x4e\x04" + bytes([density])
+    command += b"\x1f\x11" + bytes([media_type])
+    command += b"\x1d\x76\x30\x00"
+    command += bytes(
+        [
+            bytes_per_line & 0xFF,
+            (bytes_per_line >> 8) & 0xFF,
+            height & 0xFF,
+            (height >> 8) & 0xFF,
+        ]
+    )
+    command += raster
+    command += b"\x1f\xf0\x05\x00"
+    command += b"\x1f\xf0\x03\x00"
+    return bytes(command)
+
+
+def iter_phomemo_m220_usb_paths() -> Iterable[str]:
+    """Yield Windows USBPRINT interface paths that look like a Phomemo M220."""
+
+    if sys.platform != "win32":
+        return []
+    try:
+        import winreg
+    except ImportError:  # pragma: no cover - winreg is Windows-only
+        return []
+
+    key_path = (
+        "SYSTEM\\CurrentControlSet\\Control\\DeviceClasses\\"
+        f"{PHOMEMO_M220_USBPRINT_INTERFACE_GUID}"
+    )
+    try:
+        root_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path)
+    except OSError:
+        return []
+
+    paths: list[str] = []
+    with root_key:
+        index = 0
+        while True:
+            try:
+                subkey_name = winreg.EnumKey(root_key, index)
+            except OSError:
+                break
+            index += 1
+            normalized = subkey_name.upper()
+            if PHOMEMO_M220_USB_VID_PID not in normalized:
+                continue
+            if not subkey_name.startswith("##?#"):
+                continue
+            paths.append("\\\\?\\" + subkey_name[4:])
+    return paths
+
+
+def resolve_phomemo_m220_usb_path(explicit_path: str | None = None) -> str:
+    """Return an explicit, environment, or auto-discovered M220 USB path."""
+
+    if explicit_path and explicit_path.strip():
+        return explicit_path.strip()
+    env_path = os.environ.get(PHOMEMO_M220_USB_PATH_ENV, "").strip()
+    if env_path:
+        return env_path
+    candidates = list(iter_phomemo_m220_usb_paths())
+    return candidates[0] if len(candidates) == 1 else ""
+
+
+def write_windows_usb(
+    usb_path: str,
+    data: bytes,
+    *,
+    chunk_size: int = DEFAULT_CHUNK_BYTES,
+    delay_seconds: float = DEFAULT_CHUNK_DELAY_SECONDS,
+) -> int:
+    """Write bytes to a Windows USB device path."""
+
+    if sys.platform != "win32":
+        raise OSError("Windows USB device writes are only supported on Windows")
+    if not usb_path:
+        raise ValueError("USB path is required")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.WriteFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPCVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    kernel32.WriteFile.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.CreateFileW(
+        usb_path,
+        0x40000000,
+        0x00000001 | 0x00000002,
+        None,
+        3,
+        0,
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise OSError(ctypes.get_last_error(), f"CreateFileW failed for {usb_path}")
+
+    total = 0
+    try:
+        for offset in range(0, len(data), chunk_size):
+            chunk = data[offset : offset + chunk_size]
+            written = wintypes.DWORD(0)
+            buffer = ctypes.create_string_buffer(chunk)
+            ok = kernel32.WriteFile(
+                handle,
+                buffer,
+                len(chunk),
+                ctypes.byref(written),
+                None,
+            )
+            if not ok:
+                raise OSError(ctypes.get_last_error(), f"WriteFile failed at offset {offset}")
+            total += written.value
+            if written.value != len(chunk):
+                raise RuntimeError(
+                    f"short write at offset {offset}: {written.value}/{len(chunk)}"
+                )
+            if delay_seconds:
+                time.sleep(delay_seconds)
+    finally:
+        kernel32.CloseHandle(handle)
+    return total

--- a/apps/links/qr_printing.py
+++ b/apps/links/qr_printing.py
@@ -352,8 +352,12 @@ def write_windows_usb(
                 raise OSError(ctypes.get_last_error(), f"WriteFile failed at offset {offset}")
             total += written.value
             if written.value != len(chunk):
-                raise RuntimeError(
-                    f"short write at offset {offset}: {written.value}/{len(chunk)}"
+                raise OSError(
+                    ctypes.get_last_error(),
+                    (
+                        f"short write at offset {offset}: "
+                        f"{written.value}/{len(chunk)}"
+                    ),
                 )
             if delay_seconds:
                 time.sleep(delay_seconds)

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -1,0 +1,148 @@
+"""Tests for the QR console command."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from apps.links.models import QRRedirect, Reference
+from apps.links.qr_printing import (
+    QRLabelSpec,
+    build_phomemo_m220_job,
+    build_qr_label_image,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_qr_print_text_writes_preview_png(tmp_path) -> None:
+    output_path = tmp_path / "text-qr.png"
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--text",
+        "https://example.test/path",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    assert output_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert "SOURCE=text" in stdout.getvalue()
+    assert "PAYLOAD_BYTES=" in stdout.getvalue()
+
+
+def test_qr_print_wifi_does_not_echo_password(tmp_path) -> None:
+    output_path = tmp_path / "wifi-qr.png"
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--wifi-ssid",
+        "Office WiFi",
+        "--wifi-password",
+        "do-not-print-this-secret",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "WIFI_SSID=Office WiFi" in output
+    assert "do-not-print-this-secret" not in output
+
+
+def test_qr_print_reference_uses_database_value(settings, tmp_path) -> None:
+    settings.MEDIA_ROOT = tmp_path / "media"
+    reference = Reference.objects.create(
+        alt_text="Support Portal",
+        value="https://example.test/support",
+    )
+    output_path = tmp_path / "reference-qr.png"
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--reference",
+        str(reference.pk),
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "SOURCE=reference" in output
+    assert f"REFERENCE_ID={reference.pk}" in output
+
+
+def test_qr_print_redirect_uses_base_url(tmp_path) -> None:
+    redirect = QRRedirect.objects.create(
+        slug="support",
+        target_url="https://example.test/support-target",
+        title="Support",
+    )
+    output_path = tmp_path / "redirect-qr.png"
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--redirect",
+        redirect.slug,
+        "--base-url",
+        "https://suite.example.test",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "SOURCE=redirect" in output
+    assert "QR_REDIRECT_SLUG=support" in output
+    assert "PAYLOAD_RELATIVE=1" not in output
+
+
+def test_qr_print_phomemo_dry_run_builds_job_without_usb(tmp_path) -> None:
+    output_path = tmp_path / "phomemo-qr.png"
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--text",
+        "https://example.test/phomemo",
+        "--printer",
+        "phomemo-m220",
+        "--dry-run",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "PRINTER=phomemo-m220" in output
+    assert "COMMAND_BYTES=" in output
+    assert "DRY_RUN=1" in output
+
+
+def test_phomemo_m220_job_contains_raster_payload() -> None:
+    image = build_qr_label_image(
+        "https://example.test",
+        QRLabelSpec(title="QR CODE", subtitle="Example"),
+    )
+
+    job = build_phomemo_m220_job(image)
+
+    assert job.startswith(b"\x1b\x4e\x0d\x02")
+    assert b"\x1d\x76\x30\x00" in job
+    assert job.endswith(b"\x1f\xf0\x05\x00\x1f\xf0\x03\x00")

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -176,6 +176,15 @@ def test_windows_wifi_profile_password_parser_accepts_localized_label() -> None:
     assert qr_command._extract_windows_wifi_profile_password(output) == "localized-secret"
 
 
+def test_windows_wifi_profile_password_parser_preserves_secret_spaces() -> None:
+    output = "Key Content     :  leading-and-trailing-secret "
+
+    assert (
+        qr_command._extract_windows_wifi_profile_password(output)
+        == " leading-and-trailing-secret "
+    )
+
+
 def test_qr_print_reference_uses_database_value(settings, tmp_path) -> None:
     settings.MEDIA_ROOT = tmp_path / "media"
     reference = Reference.objects.create(

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -121,6 +121,37 @@ def test_qr_print_wifi_profile_uses_profile_lookup(monkeypatch, tmp_path) -> Non
     assert "profile-secret" not in output
 
 
+def test_qr_print_wifi_profile_nopass_skips_password_lookup(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "wifi-profile-open-qr.png"
+    stdout = StringIO()
+
+    def fail_password_lookup(self, profile):
+        raise AssertionError("open profiles should not read saved keys")
+
+    monkeypatch.setattr(
+        qr_command.Command,
+        "_read_windows_wifi_profile_password",
+        fail_password_lookup,
+    )
+
+    call_command(
+        "qr",
+        "print",
+        "--wifi-profile",
+        "Guest Profile",
+        "--wifi-auth",
+        "nopass",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "SOURCE=wifi-profile" in output
+    assert "WIFI_PROFILE=Guest Profile" in output
+
+
 def test_qr_devices_lists_discovered_phomemo_paths(monkeypatch) -> None:
     stdout = StringIO()
     monkeypatch.setattr(qr_command, "resolve_phomemo_m220_usb_path", lambda path="": "USB-A")

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -7,6 +7,7 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 
+from apps.links.management.commands import qr as qr_command
 from apps.links.models import QRRedirect, Reference
 from apps.links.qr_printing import (
     QRLabelSpec,
@@ -56,6 +57,92 @@ def test_qr_print_wifi_does_not_echo_password(tmp_path) -> None:
     assert output_path.exists()
     assert "WIFI_SSID=Office WiFi" in output
     assert "do-not-print-this-secret" not in output
+
+
+def test_qr_print_wifi_password_file_preserves_secret_spaces(tmp_path) -> None:
+    password_file = tmp_path / "wifi-password.txt"
+    password_file.write_text(" leading-and-trailing-secret \r\n", encoding="utf-8")
+
+    password = qr_command.Command()._wifi_password_from_options(
+        {"wifi_password_file": str(password_file)}
+    )
+
+    assert password == " leading-and-trailing-secret "
+
+
+def test_qr_print_wifi_password_file_does_not_echo_secret(tmp_path) -> None:
+    output_path = tmp_path / "wifi-file-qr.png"
+    password_file = tmp_path / "wifi-password.txt"
+    password_file.write_text("secret from file\n", encoding="utf-8")
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--wifi-ssid",
+        "Office WiFi",
+        "--wifi-password-file",
+        str(password_file),
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "WIFI_SSID=Office WiFi" in output
+    assert "secret from file" not in output
+
+
+def test_qr_print_wifi_profile_uses_profile_lookup(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "wifi-profile-qr.png"
+    stdout = StringIO()
+
+    monkeypatch.setattr(
+        qr_command.Command,
+        "_read_windows_wifi_profile_password",
+        lambda self, profile: "profile-secret",
+    )
+
+    call_command(
+        "qr",
+        "print",
+        "--wifi-profile",
+        "Office Profile",
+        "--output",
+        str(output_path),
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert output_path.exists()
+    assert "SOURCE=wifi-profile" in output
+    assert "WIFI_PROFILE=Office Profile" in output
+    assert "profile-secret" not in output
+
+
+def test_qr_devices_lists_discovered_phomemo_paths(monkeypatch) -> None:
+    stdout = StringIO()
+    monkeypatch.setattr(qr_command, "resolve_phomemo_m220_usb_path", lambda path="": "USB-A")
+    monkeypatch.setattr(qr_command, "iter_phomemo_m220_usb_paths", lambda: ["USB-A", "USB-B"])
+
+    call_command("qr", "devices", stdout=stdout)
+
+    output = stdout.getvalue()
+    assert "CONFIGURED_OR_DISCOVERED=USB-A" in output
+    assert "USB-A" in output
+    assert "USB-B" in output
+
+
+def test_windows_wifi_profile_password_parser_accepts_localized_label() -> None:
+    output = "\n".join(
+        [
+            "Nombre de perfil     : Office WiFi",
+            "Contenido de la clave     : localized-secret",
+        ]
+    )
+
+    assert qr_command._extract_windows_wifi_profile_password(output) == "localized-secret"
 
 
 def test_qr_print_reference_uses_database_value(settings, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Add `python manage.py qr print` for QR label preview generation from text, Wi-Fi payloads, `Reference` rows, and `QRRedirect` slugs.
- Add a Phomemo M220 backend that builds the validated monochrome raster job and writes it in slow 16-byte USB chunks, with Windows USBPRINT auto-discovery and `ARTHEXIS_QR_PRINTER_USB_PATH` override support.
- Add focused coverage for text, Wi-Fi secret-safe output, database `Reference`, `QRRedirect`, Phomemo dry-run job generation, and raster command framing.

Closes #7535

## Validation

- `.\.venv\Scripts\python.exe -m pytest apps\links\tests\test_qr_command.py`
- `.\.venv\Scripts\python.exe -m pytest apps\links\tests`
- `.\.venv\Scripts\python.exe manage.py check`
- `.\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.\.venv\Scripts\python.exe -m ruff check apps\links\qr_printing.py apps\links\management\commands\qr.py apps\links\tests\test_qr_command.py`
- `git diff --cached --check`
- `.\.venv\Scripts\python.exe manage.py qr devices`
- `.\.venv\Scripts\python.exe manage.py qr print --wifi-profile IZZI-158E-5G --printer phomemo-m220 --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a Django management command `python manage.py qr` to generate QR label previews and optionally print them to a configured sticker printer, implementing the requirements from issue #7535.

## Key Changes

**Management Command (`apps/links/management/commands/qr.py`)**: 
- Adds a new `qr` management command with `print` and `devices` subcommands
- The `print` subcommand accepts QR payloads from mutually-exclusive sources: raw text via `--text`, existing `Reference` records (by numeric ID, transaction UUID, or case-insensitive alt text), `QRRedirect` records (by slug), or Wi-Fi payloads via `--wifi-ssid` with password from file or argument, or from Windows Wi-Fi profiles via `--wifi-profile`
- Generates a label spec with configurable width, height, QR size, and optional title/subtitle/footer overrides
- Renders QR payloads to PNG preview files (temporary location by default, or `--output` path if specified)
- Outputs structured metadata including source type, preview path, and payload byte length
- Supports printer backends with validation for `phomemo-m220`
- Implements optional `--dry-run` mode that generates the print job without writing to USB
- The `devices` subcommand enumerates and displays available printer USB paths

**QR Printing Utilities (`apps/links/qr_printing.py`)**:
- Implements `QRLabelSpec` dataclass for layout configuration (width, height, QR size, margins, text overlays)
- Provides `build_wifi_payload()` to construct standards-compliant Wi-Fi QR strings with proper escaping and validation
- Implements `build_qr_label_image()` and `render_qr_png_bytes()` for QR image generation with optional text overlays
- Adds Phomemo M220 backend support:
  - `pack_monochrome_raster()` converts images to 1-bit row format with configurable thresholding
  - `build_phomemo_m220_job()` constructs validated binary print jobs with speed/density/media parameters
  - `iter_phomemo_m220_usb_paths()` discovers Phomemo printers on Windows via registry enumeration
  - `resolve_phomemo_m220_usb_path()` resolves device paths with support for environment variable override (`ARTHEXIS_QR_PRINTER_USB_PATH`)
  - `write_windows_usb()` writes print jobs to USB in 16-byte chunks with configurable inter-chunk delay

**Security**: Ensures Wi-Fi passwords and full QR payloads are not echoed in command output.

**Test Coverage (`apps/links/tests/test_qr_command.py`)**:
- Verifies PNG preview generation with valid signatures
- Tests `SOURCE=` metadata output for different input types (text, reference, redirect, Wi-Fi)
- Confirms password fields are not displayed in console output while SSID is included
- Validates reference and redirect QR printing with proper database lookups and URL building
- Tests Phomemo dry-run mode with `--dry-run` flag
- Validates Phomemo M220 binary job protocol correctness including raster payload and command framing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->