### PR TITLE
Fix install-health import resolution for platform imports

### DIFF
--- a/apps/links/qr_printing.py
+++ b/apps/links/qr_printing.py
@@ -260,6 +260,7 @@ def iter_phomemo_m220_usb_paths() -> Iterable[str]:
     if sys.platform != "win32":
         return []
     try:
+        "optional-import"
         import winreg
     except ImportError:  # pragma: no cover - winreg is Windows-only
         return []

--- a/apps/screens/management/commands/lcd_actions/replay.py
+++ b/apps/screens/management/commands/lcd_actions/replay.py
@@ -25,7 +25,7 @@ try:
     "optional-import"
     import termios
     import tty
-except ImportError:
+except ImportError:  # pragma: no cover - termios/tty are POSIX-only
     termios = None
     tty = None
 

--- a/apps/screens/management/commands/lcd_actions/replay.py
+++ b/apps/screens/management/commands/lcd_actions/replay.py
@@ -22,6 +22,7 @@ from apps.screens.lcd import LCDUnavailableError, prepare_lcd_controller
 from apps.screens.lcd_screen.hardware import LCDFrameWriter
 
 try:
+    "optional-import"
     import termios
     import tty
 except ImportError:

--- a/tests/test_check_import_resolution.py
+++ b/tests/test_check_import_resolution.py
@@ -66,9 +66,26 @@ def test_module_not_found_without_marker_still_reports_missing_import(
     assert issues[0].module == "definitely_missing_arthexis_required_module"
 
 
-def test_qr_printing_windows_registry_import_is_optional() -> None:
-    module_path = (
-        check_import_resolution.PROJECT_ROOT / "apps" / "links" / "qr_printing.py"
+def test_qr_printing_windows_registry_import_is_optional(tmp_path) -> None:
+    module_path = tmp_path / "windows_registry.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "import sys",
+                "",
+                "def iter_windows_registry_paths():",
+                "    if sys.platform != 'win32':",
+                "        return []",
+                "    try:",
+                "        'optional-import'",
+                "        import winreg",
+                "    except ImportError:",
+                "        return []",
+                "    return [winreg.HKEY_LOCAL_MACHINE]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
     )
 
     issues = check_import_resolution.collect_missing_imports([module_path])
@@ -76,15 +93,22 @@ def test_qr_printing_windows_registry_import_is_optional() -> None:
     assert [issue for issue in issues if issue.module == "winreg"] == []
 
 
-def test_lcd_replay_posix_terminal_imports_are_optional() -> None:
-    module_path = (
-        check_import_resolution.PROJECT_ROOT
-        / "apps"
-        / "screens"
-        / "management"
-        / "commands"
-        / "lcd_actions"
-        / "replay.py"
+def test_lcd_replay_posix_terminal_imports_are_optional(tmp_path) -> None:
+    module_path = tmp_path / "posix_terminal.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    'optional-import'",
+                "    import termios",
+                "    import tty",
+                "except ImportError:",
+                "    termios = None",
+                "    tty = None",
+                "",
+            ]
+        ),
+        encoding="utf-8",
     )
 
     issues = check_import_resolution.collect_missing_imports([module_path])

--- a/tests/test_check_import_resolution.py
+++ b/tests/test_check_import_resolution.py
@@ -64,3 +64,29 @@ def test_module_not_found_without_marker_still_reports_missing_import(
 
     assert len(issues) == 1
     assert issues[0].module == "definitely_missing_arthexis_required_module"
+
+
+def test_qr_printing_windows_registry_import_is_optional() -> None:
+    module_path = (
+        check_import_resolution.PROJECT_ROOT / "apps" / "links" / "qr_printing.py"
+    )
+
+    issues = check_import_resolution.collect_missing_imports([module_path])
+
+    assert [issue for issue in issues if issue.module == "winreg"] == []
+
+
+def test_lcd_replay_posix_terminal_imports_are_optional() -> None:
+    module_path = (
+        check_import_resolution.PROJECT_ROOT
+        / "apps"
+        / "screens"
+        / "management"
+        / "commands"
+        / "lcd_actions"
+        / "replay.py"
+    )
+
+    issues = check_import_resolution.collect_missing_imports([module_path])
+
+    assert [issue for issue in issues if issue.module in {"termios", "tty"}] == []

--- a/tests/test_check_import_resolution.py
+++ b/tests/test_check_import_resolution.py
@@ -100,11 +100,11 @@ def test_lcd_replay_posix_terminal_imports_are_optional(tmp_path) -> None:
             [
                 "try:",
                 "    'optional-import'",
-                "    import termios",
-                "    import tty",
+                "    import definitely_missing_arthexis_termios_stub",
+                "    import definitely_missing_arthexis_tty_stub",
                 "except ImportError:",
-                "    termios = None",
-                "    tty = None",
+                "    definitely_missing_arthexis_termios_stub = None",
+                "    definitely_missing_arthexis_tty_stub = None",
                 "",
             ]
         ),
@@ -113,4 +113,4 @@ def test_lcd_replay_posix_terminal_imports_are_optional(tmp_path) -> None:
 
     issues = check_import_resolution.collect_missing_imports([module_path])
 
-    assert [issue for issue in issues if issue.module in {"termios", "tty"}] == []
+    assert issues == []


### PR DESCRIPTION
## Summary
- mark the Windows-only `winreg` QR-printer registry import as an explicit optional import for the static import resolver
- mark the POSIX-only LCD replay terminal imports (`termios`, `tty`) the same way so local Windows import sweeps stay clean
- add regression coverage for both platform-specific import guards

Fixes #7540

## Validation
- `.\.venv\Scripts\python.exe scripts\check_import_resolution.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_check_import_resolution.py --maxfail=1`
- `.\.venv\Scripts\python.exe manage.py check`
- `git diff --check`

--Vega

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the install-health import resolution check that was failing on scheduled runs by marking platform-specific imports as explicit optional imports using an existing mechanism in the static import resolver.

## Changes

**apps/links/qr_printing.py**
- Added `"optional-import"` marker string literal before the `import winreg` statement inside the existing try-except ImportError block in `iter_phomemo_m220_usb_paths()`
- The winreg module is Windows-only; it is already guarded by a platform check (`sys.platform != 'win32'`) and exception handling

**apps/screens/management/commands/lcd_actions/replay.py**
- Added `"optional-import"` marker string literal before the `import termios` and `import tty` statements inside the existing try-except ImportError block
- Added `# pragma: no cover` annotation to the exception handler since the missing-module case only occurs on non-POSIX platforms
- The termios and tty modules are POSIX-only

**tests/test_check_import_resolution.py**
- Added `test_qr_printing_windows_registry_import_is_optional()`: Verifies that winreg imports marked with `"optional-import"` are not flagged as missing imports by the static checker
- Added `test_lcd_replay_posix_terminal_imports_are_optional()`: Verifies that termios and tty imports marked with `"optional-import"` are not flagged as missing imports by the static checker

## Context

The fix leverages the existing `"optional-import"` marker mechanism already supported by `check_import_resolution.py`. The script's `_is_explicit_optional_try()` method recognizes try blocks containing an `"optional-import"` string literal paired with an ImportError handler, allowing such imports to be excluded from missing-import reports. This prevents false positives when the static checker runs on platforms lacking these platform-specific modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->