### PR TITLE
Add on-demand WhatsApp Web CLI

### DIFF
--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -177,6 +177,8 @@ class Command(BaseCommand):
         )
 
     def _handle_read(self, options):
+        if options["limit"] < 0:
+            raise CommandError("--limit must be >= 0. Use 0 to return all visible messages.")
         since = parse_cli_date(options["since"])
         until = parse_cli_date(options["until"])
         exact_date = parse_cli_date(options["date"])

--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.meta.services import (
+    DEFAULT_WHATSAPP_WEB_BROWSER,
+    DEFAULT_WHATSAPP_WEB_CHANNEL,
+    DEFAULT_WHATSAPP_WEB_PROFILE_DIR,
+    dataclass_payload,
+    parse_cli_date,
+    read_whatsapp_web_messages,
+    send_whatsapp_web_message,
+    validate_whatsapp_web_login,
+)
+
+
+class Command(BaseCommand):
+    help = "On-demand WhatsApp Web login, send, and read commands."
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest="action", required=True)
+
+        login = subparsers.add_parser(
+            "login",
+            help="Open WhatsApp Web and wait for QR/profile login registration.",
+        )
+        self._add_browser_arguments(login, default_timeout=300.0)
+        login.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+        status = subparsers.add_parser(
+            "status",
+            help="Check whether the persistent WhatsApp Web profile is logged in.",
+        )
+        self._add_browser_arguments(status, default_timeout=30.0)
+        status.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+        send = subparsers.add_parser(
+            "send",
+            help="Send one WhatsApp Web message to a phone number.",
+        )
+        self._add_browser_arguments(send, default_timeout=120.0)
+        send.add_argument("--to", required=True, help="Recipient phone number.")
+        send.add_argument("--message", required=True, help="Message body to send.")
+        send.add_argument(
+            "--country-code",
+            default="52",
+            help="Country code for 10-digit local numbers. Default: 52.",
+        )
+        send.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+        read = subparsers.add_parser(
+            "read",
+            help="Read visible WhatsApp Web messages from a phone-number chat.",
+        )
+        self._add_browser_arguments(read, default_timeout=120.0)
+        read.add_argument("--from", dest="from_phone", required=True, help="Phone number.")
+        read.add_argument(
+            "--country-code",
+            default="52",
+            help="Country code for 10-digit local numbers. Default: 52.",
+        )
+        read.add_argument("--date", help="Read messages from one YYYY-MM-DD date.")
+        read.add_argument("--since", help="Read messages on or after YYYY-MM-DD.")
+        read.add_argument("--until", help="Read messages on or before YYYY-MM-DD.")
+        read.add_argument(
+            "--new",
+            action="store_true",
+            help="Return messages after the local cursor for this phone/profile.",
+        )
+        read.add_argument(
+            "--no-update-cursor",
+            action="store_true",
+            help="Do not advance the local --new cursor after reading.",
+        )
+        read.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Maximum visible messages to return after filtering; 0 means all.",
+        )
+        read.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+    def _add_browser_arguments(self, parser, *, default_timeout: float) -> None:
+        parser.add_argument(
+            "--profile-dir",
+            default=str(DEFAULT_WHATSAPP_WEB_PROFILE_DIR),
+            help=(
+                "Persistent browser profile directory. "
+                f"Default: {DEFAULT_WHATSAPP_WEB_PROFILE_DIR}"
+            ),
+        )
+        parser.add_argument(
+            "--browser",
+            default=DEFAULT_WHATSAPP_WEB_BROWSER,
+            choices=("edge", "firefox", "chromium"),
+            help=(
+                "Browser engine to use. Defaults to Edge on Windows and Firefox "
+                "elsewhere."
+            ),
+        )
+        parser.add_argument(
+            "--channel",
+            default=DEFAULT_WHATSAPP_WEB_CHANNEL,
+            help="Optional Playwright Chromium channel, for example msedge.",
+        )
+        parser.add_argument(
+            "--cdp-url",
+            default="",
+            help="Attach to an already-open Chromium/Edge debugging URL.",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=float,
+            default=default_timeout,
+            help="Seconds to wait for WhatsApp Web UI state.",
+        )
+        parser.add_argument(
+            "--poll-interval",
+            type=float,
+            default=1.0,
+            help="Seconds between UI-state checks.",
+        )
+        parser.add_argument(
+            "--headless",
+            action="store_true",
+            help="Run headless. Headed mode is required for first QR login.",
+        )
+
+    def handle(self, *args, **options):
+        action = options["action"]
+        try:
+            if action == "login":
+                result = self._handle_login(options)
+            elif action == "status":
+                result = self._handle_status(options)
+            elif action == "send":
+                result = self._handle_send(options)
+            elif action == "read":
+                result = self._handle_read(options)
+            else:
+                raise CommandError(f"Unknown whatsapp action: {action}")
+        except (RuntimeError, ValueError) as exc:
+            raise CommandError(str(exc)) from exc
+
+        if options.get("json"):
+            self.stdout.write(json.dumps(dataclass_payload(result), indent=2))
+            return None
+        self._write_text_result(result)
+        return None
+
+    def _browser_options(self, options) -> dict[str, object]:
+        return {
+            "profile_dir": Path(options["profile_dir"]),
+            "timeout_seconds": options["timeout"],
+            "poll_interval_seconds": options["poll_interval"],
+            "headless": options["headless"],
+            "browser": options["browser"],
+            "channel": options["channel"].strip(),
+            "cdp_url": options["cdp_url"].strip(),
+        }
+
+    def _handle_login(self, options):
+        return validate_whatsapp_web_login(**self._browser_options(options))
+
+    def _handle_status(self, options):
+        return validate_whatsapp_web_login(**self._browser_options(options))
+
+    def _handle_send(self, options):
+        return send_whatsapp_web_message(
+            phone=options["to"],
+            message=options["message"],
+            default_country_code=options["country_code"],
+            **self._browser_options(options),
+        )
+
+    def _handle_read(self, options):
+        since = parse_cli_date(options["since"])
+        until = parse_cli_date(options["until"])
+        exact_date = parse_cli_date(options["date"])
+        if exact_date:
+            since = exact_date
+            until = exact_date
+        return read_whatsapp_web_messages(
+            phone=options["from_phone"],
+            default_country_code=options["country_code"],
+            since=since,
+            until=until,
+            only_new=options["new"],
+            update_cursor=not options["no_update_cursor"],
+            limit=options["limit"],
+            **self._browser_options(options),
+        )
+
+    def _write_text_result(self, result) -> None:
+        payload = dataclass_payload(result)
+        messages = payload.pop("messages", None)
+        for key, value in payload.items():
+            if value is not None:
+                self.stdout.write(f"{key}={value}")
+        if messages is not None:
+            for message in messages:
+                self.stdout.write(json.dumps(message, ensure_ascii=False))

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -160,6 +160,14 @@ def cursor_file_for_profile(profile_dir: Path | str | None = None) -> Path:
     return resolved.parent / WHATSAPP_WEB_CURSOR_FILENAME
 
 
+def cursor_key_for_profile(phone: str, profile_dir: Path | str | None = None) -> str:
+    resolved = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
+    profile_id = hashlib.sha256(
+        str(resolved.resolve(strict=False)).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{phone}:{profile_id}"
+
+
 def _is_whatsapp_web_url(value: str) -> bool:
     try:
         parsed = urlparse(value)
@@ -722,8 +730,10 @@ def read_whatsapp_web_messages(
         )
         all_messages = build_whatsapp_web_messages(rows, phone=normalized_phone)
         cursor_file = cursor_file_for_profile(resolved_profile_dir)
-        cursor_key = f"{normalized_phone}:default"
+        cursor_key = cursor_key_for_profile(normalized_phone, resolved_profile_dir)
         after_fingerprint = _read_cursor(cursor_file, cursor_key) if only_new else ""
+        if only_new and not after_fingerprint:
+            after_fingerprint = _read_cursor(cursor_file, f"{normalized_phone}:default")
         messages = filter_whatsapp_web_messages(
             all_messages,
             since=since,
@@ -731,10 +741,10 @@ def read_whatsapp_web_messages(
             after_fingerprint=after_fingerprint,
         )
         if limit > 0:
-            messages = messages[-limit:]
+            messages = messages[:limit] if only_new else messages[-limit:]
         cursor_updated = False
-        if only_new and update_cursor and all_messages:
-            _write_cursor(cursor_file, cursor_key, all_messages[-1].fingerprint)
+        if only_new and update_cursor and messages:
+            _write_cursor(cursor_file, cursor_key, messages[-1].fingerprint)
             cursor_updated = True
         return WhatsAppWebReadResult(
             status="ok",

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
+import os
 import re
 import sys
 import time
 from dataclasses import asdict, dataclass
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 WHATSAPP_WEB_URL = "https://web.whatsapp.com/"
 DEFAULT_WHATSAPP_WEB_PROFILE_DIR = (
@@ -52,6 +54,7 @@ MESSAGE_COMPOSER_SELECTOR = (
 )
 SEND_BUTTON_SELECTOR = "button[aria-label*='Enviar'], button[aria-label*='Send']"
 SEND_ICON_SELECTOR = "[data-icon='send']"
+logger = logging.getLogger(__name__)
 
 
 class WhatsAppWebLoginStatus:
@@ -89,6 +92,7 @@ class WhatsAppWebSendResult:
 class WhatsAppWebMessage:
     fingerprint: str
     index: int
+    message_id: str
     direction: str
     sender: str
     timestamp_raw: str
@@ -154,6 +158,14 @@ def parse_cli_date(value: str | None) -> date | None:
 def cursor_file_for_profile(profile_dir: Path | str | None = None) -> Path:
     resolved = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
     return resolved.parent / WHATSAPP_WEB_CURSOR_FILENAME
+
+
+def _is_whatsapp_web_url(value: str) -> bool:
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and parsed.hostname == "web.whatsapp.com"
 
 
 def _first_visible_locator(page, selectors: tuple[str, ...], *, timeout_ms: int) -> str:
@@ -322,16 +334,19 @@ def _with_whatsapp_page(
         with sync_playwright() as playwright:
             if cdp_url:
                 connected_browser = playwright.chromium.connect_over_cdp(cdp_url)
-                context = connected_browser.contexts[0]
-                page = next(
-                    (
-                        candidate
-                        for candidate in context.pages
-                        if "web.whatsapp.com" in candidate.url
-                    ),
-                    context.pages[0] if context.pages else context.new_page(),
-                )
-                return callback(page, resolved_profile_dir, timeout_seconds)
+                try:
+                    context = connected_browser.contexts[0]
+                    page = next(
+                        (
+                            candidate
+                            for candidate in context.pages
+                            if _is_whatsapp_web_url(candidate.url)
+                        ),
+                        context.pages[0] if context.pages else context.new_page(),
+                    )
+                    return callback(page, resolved_profile_dir, timeout_seconds)
+                finally:
+                    connected_browser.close()
 
             context = _launch_persistent_context(
                 playwright,
@@ -527,13 +542,13 @@ def _parse_whatsapp_timestamp(value: str) -> datetime | None:
 def _message_fingerprint(
     *,
     phone: str,
+    message_id: str,
     direction: str,
     sender: str,
     timestamp_raw: str,
     text: str,
-    index: int,
 ) -> str:
-    data = "\x1f".join([phone, direction, sender, timestamp_raw, text, str(index)])
+    data = "\x1f".join([phone, message_id, direction, sender, timestamp_raw, text])
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
@@ -549,20 +564,24 @@ def build_whatsapp_web_messages(
             continue
         timestamp_raw, sender = _parse_pre_plain_text(str(row.get("pre") or ""))
         parsed = _parse_whatsapp_timestamp(timestamp_raw)
+        if timestamp_raw and parsed is None:
+            logger.warning("Could not parse WhatsApp Web timestamp: %s", timestamp_raw)
         timestamp_iso = parsed.isoformat() if parsed is not None else ""
         direction = str(row.get("direction") or "unknown")
+        message_id = str(row.get("message_id") or "")
         fingerprint = _message_fingerprint(
             phone=phone,
+            message_id=message_id,
             direction=direction,
             sender=sender,
             timestamp_raw=timestamp_raw,
             text=text,
-            index=index,
         )
         messages.append(
             WhatsAppWebMessage(
                 fingerprint=fingerprint,
                 index=index,
+                message_id=message_id,
                 direction=direction,
                 sender=sender,
                 timestamp_raw=timestamp_raw,
@@ -606,6 +625,8 @@ def _read_cursor(cursor_file: Path, key: str) -> str:
         payload = json.loads(cursor_file.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return ""
+    if isinstance(payload.get("cursors"), dict):
+        return str(payload["cursors"].get(key) or "")
     return str(payload.get(key) or "")
 
 
@@ -615,8 +636,27 @@ def _write_cursor(cursor_file: Path, key: str, value: str) -> None:
         payload = json.loads(cursor_file.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         payload = {}
-    payload[key] = value
-    cursor_file.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    if isinstance(payload.get("cursors"), dict):
+        cursors = dict(payload["cursors"])
+    else:
+        cursors = {
+            existing_key: existing_value
+            for existing_key, existing_value in payload.items()
+            if isinstance(existing_value, str)
+        }
+    cursors[key] = value
+    next_payload = {
+        "updated_at": datetime.now(UTC).isoformat(),
+        "expires_at": None,
+        "cursors": cursors,
+    }
+    temp_file = cursor_file.with_name(
+        f".{cursor_file.name}.{os.getpid()}.{time.monotonic_ns()}.tmp"
+    )
+    temp_file.write_text(
+        json.dumps(next_payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    os.replace(temp_file, cursor_file)
 
 
 def read_whatsapp_web_messages(
@@ -672,6 +712,7 @@ def read_whatsapp_web_messages(
                         ? spans.map((span) => span.innerText || span.textContent || '').join('\\n')
                         : (node.innerText || node.textContent || '');
                     return {
+                        message_id: container.getAttribute('data-id') || node.getAttribute('data-id') || '',
                         pre: node.getAttribute('data-pre-plain-text') || '',
                         direction,
                         text,

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -1,0 +1,716 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+from pathlib import Path
+from urllib.parse import quote
+
+WHATSAPP_WEB_URL = "https://web.whatsapp.com/"
+DEFAULT_WHATSAPP_WEB_PROFILE_DIR = (
+    Path.home() / ".codex" / "whatsapp-web" / "playwright-profile"
+)
+DEFAULT_WHATSAPP_WEB_BROWSER = "edge" if sys.platform == "win32" else "firefox"
+DEFAULT_WHATSAPP_WEB_CHANNEL = "msedge" if sys.platform == "win32" else ""
+WHATSAPP_WEB_CURSOR_FILENAME = "message-cursors.json"
+
+LOGGED_IN_SELECTORS = (
+    "#pane-side",
+    "#side",
+    "[aria-label='Chat list']",
+    "[aria-label='Lista de chats']",
+    "[aria-label='Chats']",
+    "[aria-label='Nuevo chat']",
+    "[aria-label='New chat']",
+    "[data-testid='chat-list']",
+    "[data-icon='new-chat-outline']",
+)
+LOGIN_REQUIRED_SELECTORS = (
+    "[data-testid='qrcode']",
+    "canvas[aria-label*='Scan']",
+    "canvas[aria-label*='Escanea']",
+    "div[data-ref] canvas",
+)
+LOGIN_REQUIRED_TEXT = (
+    "Use WhatsApp on your computer",
+    "Usa WhatsApp en tu computadora",
+    "Link with phone number",
+    "Vincular con el numero de telefono",
+    "Vincular con el número de teléfono",
+)
+USE_HERE_TEXT = ("Use here", "Usar aqui", "Usar aquí")
+MESSAGE_COMPOSER_SELECTOR = (
+    "footer [contenteditable='true'], "
+    "div[aria-label='Escribe un mensaje'], "
+    "div[aria-label='Type a message'], "
+    "[contenteditable='true'][role='textbox']"
+)
+SEND_BUTTON_SELECTOR = "button[aria-label*='Enviar'], button[aria-label*='Send']"
+SEND_ICON_SELECTOR = "[data-icon='send']"
+
+
+class WhatsAppWebLoginStatus:
+    """Known WhatsApp Web login validation states."""
+
+    LOGGED_IN = "logged_in"
+    LOGIN_REQUIRED = "login_required"
+    TIMEOUT = "timeout"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class WhatsAppWebLoginResult:
+    """Result from a local WhatsApp Web login validation probe."""
+
+    status: str
+    profile_dir: Path
+    elapsed_seconds: float
+    url: str = ""
+    marker: str = ""
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class WhatsAppWebSendResult:
+    status: str
+    phone: str
+    profile_dir: Path
+    elapsed_seconds: float
+    url: str = ""
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class WhatsAppWebMessage:
+    fingerprint: str
+    index: int
+    direction: str
+    sender: str
+    timestamp_raw: str
+    timestamp_iso: str
+    text: str
+
+
+@dataclass(frozen=True)
+class WhatsAppWebReadResult:
+    status: str
+    phone: str
+    profile_dir: Path
+    messages: list[WhatsAppWebMessage]
+    cursor_updated: bool = False
+    cursor_file: Path | None = None
+    detail: str = ""
+
+
+def dataclass_payload(value) -> dict[str, object]:
+    payload = asdict(value)
+    for key, item in list(payload.items()):
+        if isinstance(item, Path):
+            payload[key] = str(item)
+        elif isinstance(item, list):
+            payload[key] = [
+                asdict(child) if hasattr(child, "__dataclass_fields__") else child
+                for child in item
+            ]
+        elif item is None:
+            payload[key] = None
+    return payload
+
+
+def normalize_whatsapp_phone(value: str, *, default_country_code: str = "52") -> str:
+    """Return a WhatsApp Web URL phone identifier.
+
+    A 10-digit local number is interpreted using the default country code.
+    """
+
+    raw = (value or "").strip()
+    if raw.startswith("+"):
+        digits = re.sub(r"\D+", "", raw)
+    else:
+        digits = re.sub(r"\D+", "", raw)
+        if digits.startswith("00"):
+            digits = digits[2:]
+    if len(digits) == 10 and default_country_code:
+        digits = f"{default_country_code}{digits}"
+    if len(digits) < 8:
+        raise ValueError("WhatsApp phone number is too short.")
+    return digits
+
+
+def parse_cli_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"Expected YYYY-MM-DD date, got {value!r}.") from exc
+
+
+def cursor_file_for_profile(profile_dir: Path | str | None = None) -> Path:
+    resolved = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
+    return resolved.parent / WHATSAPP_WEB_CURSOR_FILENAME
+
+
+def _first_visible_locator(page, selectors: tuple[str, ...], *, timeout_ms: int) -> str:
+    for selector in selectors:
+        try:
+            if page.locator(selector).first.is_visible(timeout=timeout_ms):
+                return selector
+        except Exception:
+            continue
+    return ""
+
+
+def _first_visible_text(page, texts: tuple[str, ...], *, timeout_ms: int) -> str:
+    for text in texts:
+        try:
+            if page.get_by_text(text, exact=False).first.is_visible(timeout=timeout_ms):
+                return text
+        except Exception:
+            continue
+    return ""
+
+
+def detect_whatsapp_web_login_state(page, *, timeout_ms: int = 250) -> tuple[str, str]:
+    """Return the visible WhatsApp Web login state for the current page."""
+
+    marker = _first_visible_locator(
+        page, LOGGED_IN_SELECTORS, timeout_ms=timeout_ms
+    )
+    if marker:
+        return WhatsAppWebLoginStatus.LOGGED_IN, marker
+
+    marker = _first_visible_locator(
+        page, LOGIN_REQUIRED_SELECTORS, timeout_ms=timeout_ms
+    )
+    if marker:
+        return WhatsAppWebLoginStatus.LOGIN_REQUIRED, marker
+
+    marker = _first_visible_text(page, LOGIN_REQUIRED_TEXT, timeout_ms=timeout_ms)
+    if marker:
+        return WhatsAppWebLoginStatus.LOGIN_REQUIRED, marker
+
+    return WhatsAppWebLoginStatus.UNKNOWN, ""
+
+
+def accept_use_here_prompt(page) -> bool:
+    """Click WhatsApp's one-window takeover prompt when it is visible."""
+
+    for text in USE_HERE_TEXT:
+        try:
+            locator = page.get_by_text(text, exact=True).first
+            if locator.is_visible(timeout=300):
+                locator.click(timeout=2_000)
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _playwright_runtime_help(exc: Exception, *, browser: str) -> str:
+    base_message = str(exc)
+    lower_message = base_message.lower()
+
+    if "executable doesn't exist" in lower_message or "browser has been closed" in lower_message:
+        install_browser = "firefox" if browser == "firefox" else "chromium"
+        return (
+            f"{base_message}\n"
+            "The Playwright browser runtime is incomplete for this interpreter. "
+            f"Run `{sys.executable} -m playwright install {install_browser}`."
+        )
+
+    if "host system is missing dependencies" in lower_message:
+        return (
+            f"{base_message}\n"
+            "Playwright browser binaries exist, but OS dependencies are missing. "
+            "Install the missing dependencies for this machine."
+        )
+
+    return base_message
+
+
+def _ensure_windows_subprocess_event_loop_policy() -> None:
+    """Use a Windows asyncio policy that supports Playwright subprocesses."""
+
+    if sys.platform != "win32":
+        return
+
+    policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+    if policy_cls is None:
+        return
+    if isinstance(asyncio.get_event_loop_policy(), policy_cls):
+        return
+    asyncio.set_event_loop_policy(policy_cls())
+
+
+def _resolve_profile_dir(profile_dir: Path | str | None) -> Path:
+    resolved = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def _resolve_browser(browser: str) -> str:
+    resolved = (browser or DEFAULT_WHATSAPP_WEB_BROWSER).strip().lower()
+    aliases = {
+        "msedge": "edge",
+        "edge": "edge",
+        "firefox": "firefox",
+        "chromium": "chromium",
+        "chrome": "chromium",
+    }
+    if resolved not in aliases:
+        raise ValueError("Browser must be one of: edge, firefox, chromium.")
+    return aliases[resolved]
+
+
+def _launch_persistent_context(
+    playwright,
+    *,
+    profile_dir: Path,
+    browser: str,
+    channel: str,
+    headless: bool,
+):
+    launch_kwargs = {
+        "headless": headless,
+        "viewport": {"width": 1280, "height": 900},
+    }
+    if browser == "firefox":
+        return playwright.firefox.launch_persistent_context(
+            str(profile_dir), **launch_kwargs
+        )
+    if browser == "edge":
+        launch_kwargs["channel"] = channel or "msedge"
+    elif channel:
+        launch_kwargs["channel"] = channel
+    return playwright.chromium.launch_persistent_context(
+        str(profile_dir), **launch_kwargs
+    )
+
+
+def _with_whatsapp_page(
+    callback,
+    *,
+    profile_dir: Path | str | None = None,
+    browser: str = "",
+    channel: str = "",
+    headless: bool = False,
+    timeout_seconds: float = 120.0,
+    cdp_url: str = "",
+):
+    try:
+        from playwright.sync_api import Error as PlaywrightError
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Playwright is required for WhatsApp Web automation. "
+            f"Install it for this interpreter ({sys.executable})."
+        ) from exc
+
+    resolved_browser = _resolve_browser(browser)
+    resolved_profile_dir = _resolve_profile_dir(profile_dir)
+    timeout_seconds = max(float(timeout_seconds), 1.0)
+
+    try:
+        _ensure_windows_subprocess_event_loop_policy()
+        with sync_playwright() as playwright:
+            if cdp_url:
+                connected_browser = playwright.chromium.connect_over_cdp(cdp_url)
+                context = connected_browser.contexts[0]
+                page = next(
+                    (
+                        candidate
+                        for candidate in context.pages
+                        if "web.whatsapp.com" in candidate.url
+                    ),
+                    context.pages[0] if context.pages else context.new_page(),
+                )
+                return callback(page, resolved_profile_dir, timeout_seconds)
+
+            context = _launch_persistent_context(
+                playwright,
+                profile_dir=resolved_profile_dir,
+                browser=resolved_browser,
+                channel=channel.strip(),
+                headless=headless,
+            )
+            try:
+                page = context.pages[0] if context.pages else context.new_page()
+                return callback(page, resolved_profile_dir, timeout_seconds)
+            finally:
+                context.close()
+    except (PlaywrightError, PlaywrightTimeoutError) as exc:
+        raise RuntimeError(_playwright_runtime_help(exc, browser=resolved_browser)) from exc
+    except Exception as exc:
+        raise RuntimeError(_playwright_runtime_help(exc, browser=resolved_browser)) from exc
+
+
+def _wait_for_login_state(
+    page,
+    *,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> tuple[str, str, float]:
+    started_at = time.monotonic()
+    deadline = started_at + max(float(timeout_seconds), 1.0)
+    poll_interval_seconds = max(float(poll_interval_seconds), 0.2)
+    last_login_required_marker = ""
+
+    while time.monotonic() < deadline:
+        accept_use_here_prompt(page)
+        status, marker = detect_whatsapp_web_login_state(page)
+        if status == WhatsAppWebLoginStatus.LOGGED_IN:
+            return status, marker, time.monotonic() - started_at
+        if status == WhatsAppWebLoginStatus.LOGIN_REQUIRED:
+            last_login_required_marker = marker
+        page.wait_for_timeout(int(poll_interval_seconds * 1000))
+
+    elapsed = time.monotonic() - started_at
+    if last_login_required_marker:
+        return WhatsAppWebLoginStatus.LOGIN_REQUIRED, last_login_required_marker, elapsed
+    return WhatsAppWebLoginStatus.TIMEOUT, "", elapsed
+
+
+def validate_whatsapp_web_login(
+    *,
+    profile_dir: Path | str | None = None,
+    timeout_seconds: float = 120.0,
+    poll_interval_seconds: float = 1.0,
+    headless: bool = False,
+    browser: str = "",
+    channel: str = "",
+    cdp_url: str = "",
+) -> WhatsAppWebLoginResult:
+    """Open WhatsApp Web with a persistent profile and validate login state."""
+
+    def run(page, resolved_profile_dir: Path, resolved_timeout: float):
+        page.goto(
+            WHATSAPP_WEB_URL,
+            wait_until="domcontentloaded",
+            timeout=int(resolved_timeout * 1000),
+        )
+        status, marker, elapsed = _wait_for_login_state(
+            page,
+            timeout_seconds=resolved_timeout,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+        if status == WhatsAppWebLoginStatus.LOGGED_IN:
+            detail = "WhatsApp Web logged-in UI detected."
+        elif status == WhatsAppWebLoginStatus.LOGIN_REQUIRED:
+            detail = "WhatsApp Web login screen was visible until timeout."
+        else:
+            detail = "Timed out before detecting logged-in or login-required UI."
+        return WhatsAppWebLoginResult(
+            status=status,
+            profile_dir=resolved_profile_dir,
+            elapsed_seconds=elapsed,
+            url=page.url,
+            marker=marker,
+            detail=detail,
+        )
+
+    return _with_whatsapp_page(
+        run,
+        profile_dir=profile_dir,
+        browser=browser,
+        channel=channel,
+        headless=headless,
+        timeout_seconds=timeout_seconds,
+        cdp_url=cdp_url,
+    )
+
+
+def send_whatsapp_web_message(
+    *,
+    phone: str,
+    message: str,
+    default_country_code: str = "52",
+    profile_dir: Path | str | None = None,
+    timeout_seconds: float = 120.0,
+    poll_interval_seconds: float = 1.0,
+    headless: bool = False,
+    browser: str = "",
+    channel: str = "",
+    cdp_url: str = "",
+) -> WhatsAppWebSendResult:
+    normalized_phone = normalize_whatsapp_phone(
+        phone, default_country_code=default_country_code
+    )
+    message = (message or "").strip()
+    if not message:
+        raise ValueError("Message cannot be blank.")
+    target_url = f"{WHATSAPP_WEB_URL}send?phone={normalized_phone}&text={quote(message)}"
+
+    def run(page, resolved_profile_dir: Path, resolved_timeout: float):
+        started_at = time.monotonic()
+        page.goto(target_url, wait_until="domcontentloaded", timeout=int(resolved_timeout * 1000))
+        status, _marker, _elapsed = _wait_for_login_state(
+            page,
+            timeout_seconds=resolved_timeout,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+        if status != WhatsAppWebLoginStatus.LOGGED_IN:
+            return WhatsAppWebSendResult(
+                status=status,
+                phone=normalized_phone,
+                profile_dir=resolved_profile_dir,
+                elapsed_seconds=time.monotonic() - started_at,
+                url=page.url,
+                detail="WhatsApp Web is not logged in.",
+            )
+
+        page.locator(MESSAGE_COMPOSER_SELECTOR).last.click(timeout=15_000)
+        page.locator(MESSAGE_COMPOSER_SELECTOR).last.fill(message, timeout=15_000)
+        page.wait_for_timeout(500)
+        if page.locator(SEND_ICON_SELECTOR).count() > 0:
+            page.locator(SEND_ICON_SELECTOR).first.click(timeout=15_000)
+        elif page.locator(SEND_BUTTON_SELECTOR).count() > 0:
+            page.locator(SEND_BUTTON_SELECTOR).first.click(timeout=15_000)
+        else:
+            page.locator(MESSAGE_COMPOSER_SELECTOR).last.press("Enter", timeout=15_000)
+        page.wait_for_timeout(1_000)
+        return WhatsAppWebSendResult(
+            status="sent",
+            phone=normalized_phone,
+            profile_dir=resolved_profile_dir,
+            elapsed_seconds=time.monotonic() - started_at,
+            url=page.url,
+            detail="Message submitted through WhatsApp Web.",
+        )
+
+    return _with_whatsapp_page(
+        run,
+        profile_dir=profile_dir,
+        browser=browser,
+        channel=channel,
+        headless=headless,
+        timeout_seconds=timeout_seconds,
+        cdp_url=cdp_url,
+    )
+
+
+def _parse_pre_plain_text(value: str) -> tuple[str, str]:
+    match = re.match(r"^\[(?P<stamp>[^\]]+)\]\s*(?P<sender>.*?):\s*$", value or "")
+    if not match:
+        return "", ""
+    return match.group("stamp").strip(), match.group("sender").strip()
+
+
+def _parse_whatsapp_timestamp(value: str) -> datetime | None:
+    value = (value or "").strip()
+    if not value:
+        return None
+    for fmt in (
+        "%H:%M, %Y-%m-%d",
+        "%I:%M %p, %Y-%m-%d",
+        "%H:%M, %d/%m/%Y",
+        "%H:%M, %m/%d/%Y",
+        "%I:%M %p, %d/%m/%Y",
+        "%I:%M %p, %m/%d/%Y",
+        "%d/%m/%Y, %H:%M",
+        "%m/%d/%Y, %H:%M",
+        "%Y-%m-%d %H:%M",
+    ):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _message_fingerprint(
+    *,
+    phone: str,
+    direction: str,
+    sender: str,
+    timestamp_raw: str,
+    text: str,
+    index: int,
+) -> str:
+    data = "\x1f".join([phone, direction, sender, timestamp_raw, text, str(index)])
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def build_whatsapp_web_messages(
+    rows: list[dict[str, object]],
+    *,
+    phone: str,
+) -> list[WhatsAppWebMessage]:
+    messages: list[WhatsAppWebMessage] = []
+    for index, row in enumerate(rows):
+        text = str(row.get("text") or "").strip()
+        if not text:
+            continue
+        timestamp_raw, sender = _parse_pre_plain_text(str(row.get("pre") or ""))
+        parsed = _parse_whatsapp_timestamp(timestamp_raw)
+        timestamp_iso = parsed.isoformat() if parsed is not None else ""
+        direction = str(row.get("direction") or "unknown")
+        fingerprint = _message_fingerprint(
+            phone=phone,
+            direction=direction,
+            sender=sender,
+            timestamp_raw=timestamp_raw,
+            text=text,
+            index=index,
+        )
+        messages.append(
+            WhatsAppWebMessage(
+                fingerprint=fingerprint,
+                index=index,
+                direction=direction,
+                sender=sender,
+                timestamp_raw=timestamp_raw,
+                timestamp_iso=timestamp_iso,
+                text=text,
+            )
+        )
+    return messages
+
+
+def filter_whatsapp_web_messages(
+    messages: list[WhatsAppWebMessage],
+    *,
+    since: date | None = None,
+    until: date | None = None,
+    after_fingerprint: str = "",
+) -> list[WhatsAppWebMessage]:
+    filtered = messages
+    if after_fingerprint:
+        for index, message in enumerate(filtered):
+            if message.fingerprint == after_fingerprint:
+                filtered = filtered[index + 1 :]
+                break
+    if since or until:
+        dated_messages: list[WhatsAppWebMessage] = []
+        for message in filtered:
+            if not message.timestamp_iso:
+                continue
+            message_date = datetime.fromisoformat(message.timestamp_iso).date()
+            if since and message_date < since:
+                continue
+            if until and message_date > until:
+                continue
+            dated_messages.append(message)
+        filtered = dated_messages
+    return filtered
+
+
+def _read_cursor(cursor_file: Path, key: str) -> str:
+    try:
+        payload = json.loads(cursor_file.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return ""
+    return str(payload.get(key) or "")
+
+
+def _write_cursor(cursor_file: Path, key: str, value: str) -> None:
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        payload = json.loads(cursor_file.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        payload = {}
+    payload[key] = value
+    cursor_file.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def read_whatsapp_web_messages(
+    *,
+    phone: str,
+    default_country_code: str = "52",
+    since: date | None = None,
+    until: date | None = None,
+    only_new: bool = False,
+    update_cursor: bool = True,
+    limit: int = 50,
+    profile_dir: Path | str | None = None,
+    timeout_seconds: float = 120.0,
+    poll_interval_seconds: float = 1.0,
+    headless: bool = False,
+    browser: str = "",
+    channel: str = "",
+    cdp_url: str = "",
+) -> WhatsAppWebReadResult:
+    normalized_phone = normalize_whatsapp_phone(
+        phone, default_country_code=default_country_code
+    )
+    target_url = f"{WHATSAPP_WEB_URL}send?phone={normalized_phone}"
+
+    def run(page, resolved_profile_dir: Path, resolved_timeout: float):
+        page.goto(target_url, wait_until="domcontentloaded", timeout=int(resolved_timeout * 1000))
+        status, _marker, _elapsed = _wait_for_login_state(
+            page,
+            timeout_seconds=resolved_timeout,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+        if status != WhatsAppWebLoginStatus.LOGGED_IN:
+            return WhatsAppWebReadResult(
+                status=status,
+                phone=normalized_phone,
+                profile_dir=resolved_profile_dir,
+                messages=[],
+                detail="WhatsApp Web is not logged in.",
+            )
+        page.locator(MESSAGE_COMPOSER_SELECTOR).last.wait_for(timeout=15_000)
+        rows = page.evaluate(
+            """
+            () => Array.from(document.querySelectorAll('div[data-pre-plain-text]'))
+                .map((node) => {
+                    const container = node.closest('.message-in, .message-out') || node;
+                    const direction = container.classList.contains('message-out')
+                        ? 'out'
+                        : (container.classList.contains('message-in') ? 'in' : 'unknown');
+                    const spans = Array.from(node.querySelectorAll(
+                        'span.selectable-text, span[dir="auto"], span[dir="ltr"]'
+                    ));
+                    const text = spans.length
+                        ? spans.map((span) => span.innerText || span.textContent || '').join('\\n')
+                        : (node.innerText || node.textContent || '');
+                    return {
+                        pre: node.getAttribute('data-pre-plain-text') || '',
+                        direction,
+                        text,
+                    };
+                })
+            """
+        )
+        all_messages = build_whatsapp_web_messages(rows, phone=normalized_phone)
+        cursor_file = cursor_file_for_profile(resolved_profile_dir)
+        cursor_key = f"{normalized_phone}:default"
+        after_fingerprint = _read_cursor(cursor_file, cursor_key) if only_new else ""
+        messages = filter_whatsapp_web_messages(
+            all_messages,
+            since=since,
+            until=until,
+            after_fingerprint=after_fingerprint,
+        )
+        if limit > 0:
+            messages = messages[-limit:]
+        cursor_updated = False
+        if only_new and update_cursor and all_messages:
+            _write_cursor(cursor_file, cursor_key, all_messages[-1].fingerprint)
+            cursor_updated = True
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone=normalized_phone,
+            profile_dir=resolved_profile_dir,
+            messages=messages,
+            cursor_updated=cursor_updated,
+            cursor_file=cursor_file,
+            detail=f"Read {len(messages)} visible messages from WhatsApp Web.",
+        )
+
+    return _with_whatsapp_page(
+        run,
+        profile_dir=profile_dir,
+        browser=browser,
+        channel=channel,
+        headless=headless,
+        timeout_seconds=timeout_seconds,
+        cdp_url=cdp_url,
+    )

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -13,6 +13,8 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
+from filelock import FileLock
+
 WHATSAPP_WEB_URL = "https://web.whatsapp.com/"
 DEFAULT_WHATSAPP_WEB_PROFILE_DIR = (
     Path.home() / ".codex" / "whatsapp-web" / "playwright-profile"
@@ -139,8 +141,9 @@ def normalize_whatsapp_phone(value: str, *, default_country_code: str = "52") ->
         digits = re.sub(r"\D+", "", raw)
         if digits.startswith("00"):
             digits = digits[2:]
-    if len(digits) == 10 and default_country_code:
-        digits = f"{default_country_code}{digits}"
+    country_code = re.sub(r"\D+", "", default_country_code or "")
+    if len(digits) == 10 and country_code:
+        digits = f"{country_code}{digits}"
     if len(digits) < 8:
         raise ValueError("WhatsApp phone number is too short.")
     return digits
@@ -323,6 +326,12 @@ def _with_whatsapp_page(
     timeout_seconds: float = 120.0,
     cdp_url: str = "",
 ):
+    resolved_browser = _resolve_browser(browser)
+    resolved_profile_dir = _resolve_profile_dir(profile_dir)
+    timeout_seconds = max(float(timeout_seconds), 1.0)
+    if cdp_url and resolved_browser == "firefox":
+        raise ValueError("--cdp-url only supports Chromium/Edge sessions.")
+
     try:
         from playwright.sync_api import Error as PlaywrightError
         from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -332,10 +341,6 @@ def _with_whatsapp_page(
             "Playwright is required for WhatsApp Web automation. "
             f"Install it for this interpreter ({sys.executable})."
         ) from exc
-
-    resolved_browser = _resolve_browser(browser)
-    resolved_profile_dir = _resolve_profile_dir(profile_dir)
-    timeout_seconds = max(float(timeout_seconds), 1.0)
 
     try:
         _ensure_windows_subprocess_event_loop_policy()
@@ -638,33 +643,39 @@ def _read_cursor(cursor_file: Path, key: str) -> str:
     return str(payload.get(key) or "")
 
 
+def _cursor_lock_for_file(cursor_file: Path) -> FileLock:
+    lock_file = cursor_file.with_name(f".{cursor_file.name}.lock")
+    return FileLock(str(lock_file), timeout=10)
+
+
 def _write_cursor(cursor_file: Path, key: str, value: str) -> None:
     cursor_file.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        payload = json.loads(cursor_file.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError):
-        payload = {}
-    if isinstance(payload.get("cursors"), dict):
-        cursors = dict(payload["cursors"])
-    else:
-        cursors = {
-            existing_key: existing_value
-            for existing_key, existing_value in payload.items()
-            if isinstance(existing_value, str)
+    with _cursor_lock_for_file(cursor_file):
+        try:
+            payload = json.loads(cursor_file.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            payload = {}
+        if isinstance(payload.get("cursors"), dict):
+            cursors = dict(payload["cursors"])
+        else:
+            cursors = {
+                existing_key: existing_value
+                for existing_key, existing_value in payload.items()
+                if isinstance(existing_value, str)
+            }
+        cursors[key] = value
+        next_payload = {
+            "updated_at": datetime.now(UTC).isoformat(),
+            "expires_at": None,
+            "cursors": cursors,
         }
-    cursors[key] = value
-    next_payload = {
-        "updated_at": datetime.now(UTC).isoformat(),
-        "expires_at": None,
-        "cursors": cursors,
-    }
-    temp_file = cursor_file.with_name(
-        f".{cursor_file.name}.{os.getpid()}.{time.monotonic_ns()}.tmp"
-    )
-    temp_file.write_text(
-        json.dumps(next_payload, indent=2, sort_keys=True), encoding="utf-8"
-    )
-    os.replace(temp_file, cursor_file)
+        temp_file = cursor_file.with_name(
+            f".{cursor_file.name}.{os.getpid()}.{time.monotonic_ns()}.tmp"
+        )
+        temp_file.write_text(
+            json.dumps(next_payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        os.replace(temp_file, cursor_file)
 
 
 def read_whatsapp_web_messages(

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from apps.meta.management.commands import whatsapp as whatsapp_command
 from apps.meta.services import (
@@ -17,6 +18,7 @@ from apps.meta.services import (
     WhatsAppWebSendResult,
     _is_whatsapp_web_url,
     _read_cursor,
+    _with_whatsapp_page,
     _write_cursor,
     build_whatsapp_web_messages,
     cursor_file_for_profile,
@@ -96,6 +98,7 @@ def test_detect_whatsapp_web_login_state_detects_login_required_text():
 
 def test_normalize_whatsapp_phone_adds_default_country_code():
     assert normalize_whatsapp_phone("555 123 4567") == "525551234567"
+    assert normalize_whatsapp_phone("555 123 4567", default_country_code="+52") == "525551234567"
     assert normalize_whatsapp_phone("+1 (555) 123-4567") == "15551234567"
 
 
@@ -105,6 +108,16 @@ def test_is_whatsapp_web_url_requires_exact_whatsapp_host():
     assert not _is_whatsapp_web_url("https://example.com/?next=https://web.whatsapp.com/")
     assert not _is_whatsapp_web_url("https://web.whatsapp.com.example.com/")
     assert not _is_whatsapp_web_url("notaurl")
+
+
+def test_cdp_url_rejects_firefox_browser():
+    with pytest.raises(ValueError, match="Chromium/Edge"):
+        _with_whatsapp_page(
+            lambda *_args: None,
+            browser="firefox",
+            cdp_url="http://127.0.0.1:9223",
+            timeout_seconds=1,
+        )
 
 
 def test_parse_cli_date_requires_iso_format():
@@ -218,10 +231,12 @@ def test_cursor_file_round_trips_atomic_payload(tmp_path):
     cursor_file = tmp_path / "message-cursors.json"
 
     _write_cursor(cursor_file, "525551234567:default", "fingerprint-a")
+    _write_cursor(cursor_file, "525551234568:default", "fingerprint-b")
 
     payload = json.loads(cursor_file.read_text(encoding="utf-8"))
     assert payload["expires_at"] is None
     assert payload["cursors"]["525551234567:default"] == "fingerprint-a"
+    assert payload["cursors"]["525551234568:default"] == "fingerprint-b"
     assert _read_cursor(cursor_file, "525551234567:default") == "fingerprint-a"
 
 
@@ -271,6 +286,54 @@ def test_read_new_cursor_advances_to_returned_limited_batch(monkeypatch, tmp_pat
     assert result.cursor_updated is True
     assert _read_cursor(cursor_file, cursor_key) == result.messages[-1].fingerprint
     assert result.messages[-1].fingerprint != all_messages[-1].fingerprint
+
+
+def test_whatsapp_login_command_outputs_json(monkeypatch, tmp_path):
+    def fake_validate_whatsapp_web_login(**kwargs):
+        assert kwargs["profile_dir"] == tmp_path
+        assert kwargs["timeout_seconds"] == 3
+        assert kwargs["poll_interval_seconds"] == 0.5
+        assert kwargs["headless"] is True
+        assert kwargs["browser"] == "edge"
+        assert kwargs["channel"] == "msedge"
+        return WhatsAppWebLoginResult(
+            status=WhatsAppWebLoginStatus.LOGIN_REQUIRED,
+            profile_dir=Path(tmp_path),
+            elapsed_seconds=3.01,
+            url="https://web.whatsapp.com/",
+            marker="[data-testid='qrcode']",
+            detail="WhatsApp Web login screen was visible until timeout.",
+        )
+
+    monkeypatch.setattr(
+        whatsapp_command,
+        "validate_whatsapp_web_login",
+        fake_validate_whatsapp_web_login,
+    )
+    stdout = StringIO()
+
+    call_command(
+        "whatsapp",
+        "login",
+        "--profile-dir",
+        str(tmp_path),
+        "--timeout",
+        "3",
+        "--poll-interval",
+        "0.5",
+        "--headless",
+        "--browser",
+        "edge",
+        "--channel",
+        "msedge",
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == WhatsAppWebLoginStatus.LOGIN_REQUIRED
+    assert payload["profile_dir"] == str(tmp_path)
+    assert payload["marker"] == "[data-testid='qrcode']"
 
 
 def test_whatsapp_status_command_outputs_json(monkeypatch, tmp_path):
@@ -411,3 +474,15 @@ def test_whatsapp_read_command_outputs_messages(monkeypatch, tmp_path):
     assert payload["status"] == "ok"
     assert payload["messages"][0]["text"] == "hello"
     assert payload["cursor_updated"] is True
+
+
+def test_whatsapp_read_command_rejects_negative_limit():
+    with pytest.raises(CommandError, match="--limit must be >= 0"):
+        call_command(
+            "whatsapp",
+            "read",
+            "--from",
+            "5551234567",
+            "--limit",
+            "-1",
+        )

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+
+from apps.meta.management.commands import whatsapp as whatsapp_command
+from apps.meta.services import (
+    WhatsAppWebLoginResult,
+    WhatsAppWebLoginStatus,
+    WhatsAppWebMessage,
+    WhatsAppWebReadResult,
+    WhatsAppWebSendResult,
+    build_whatsapp_web_messages,
+    cursor_file_for_profile,
+    detect_whatsapp_web_login_state,
+    filter_whatsapp_web_messages,
+    normalize_whatsapp_phone,
+    parse_cli_date,
+)
+
+
+class FakeLocator:
+    def __init__(self, visible: bool):
+        self._visible = visible
+        self.first = self
+
+    def is_visible(self, *, timeout: int):
+        del timeout
+        return self._visible
+
+
+class FakePage:
+    def __init__(self, *, visible_selectors=None, visible_texts=None):
+        self.visible_selectors = set(visible_selectors or [])
+        self.visible_texts = set(visible_texts or [])
+
+    def locator(self, selector: str):
+        return FakeLocator(selector in self.visible_selectors)
+
+    def get_by_text(self, text: str, *, exact: bool):
+        del exact
+        return FakeLocator(text in self.visible_texts)
+
+
+def test_detect_whatsapp_web_login_state_detects_logged_in_chat_list():
+    page = FakePage(visible_selectors={"#pane-side", "[data-testid='qrcode']"})
+
+    status, marker = detect_whatsapp_web_login_state(page)
+
+    assert status == WhatsAppWebLoginStatus.LOGGED_IN
+    assert marker == "#pane-side"
+
+
+def test_detect_whatsapp_web_login_state_detects_login_required_qr():
+    page = FakePage(visible_selectors={"[data-testid='qrcode']"})
+
+    status, marker = detect_whatsapp_web_login_state(page)
+
+    assert status == WhatsAppWebLoginStatus.LOGIN_REQUIRED
+    assert marker == "[data-testid='qrcode']"
+
+
+def test_detect_whatsapp_web_login_state_detects_login_required_text():
+    page = FakePage(visible_texts={"Use WhatsApp on your computer"})
+
+    status, marker = detect_whatsapp_web_login_state(page)
+
+    assert status == WhatsAppWebLoginStatus.LOGIN_REQUIRED
+    assert marker == "Use WhatsApp on your computer"
+
+
+def test_normalize_whatsapp_phone_adds_default_country_code():
+    assert normalize_whatsapp_phone("811 921 8587") == "528119218587"
+    assert normalize_whatsapp_phone("+1 (555) 123-4567") == "15551234567"
+
+
+def test_parse_cli_date_requires_iso_format():
+    assert parse_cli_date("2026-05-01").isoformat() == "2026-05-01"
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        parse_cli_date("01/05/2026")
+
+
+def test_cursor_file_for_profile_uses_profile_parent(tmp_path):
+    profile = tmp_path / "profile"
+
+    assert cursor_file_for_profile(profile) == tmp_path / "message-cursors.json"
+
+
+def test_build_messages_from_whatsapp_rows():
+    rows = [
+        {
+            "pre": "[14:30, 2026-05-01] ARTHEXIS: ",
+            "direction": "in",
+            "text": "hello",
+        },
+        {
+            "pre": "[14:31, 2026-05-01] You: ",
+            "direction": "out",
+            "text": "reply",
+        },
+    ]
+
+    messages = build_whatsapp_web_messages(rows, phone="528119218587")
+
+    assert [message.text for message in messages] == ["hello", "reply"]
+    assert messages[0].timestamp_iso == "2026-05-01T14:30:00"
+    assert messages[0].sender == "ARTHEXIS"
+    assert messages[0].fingerprint
+
+
+def test_filter_messages_by_date_and_cursor():
+    first = WhatsAppWebMessage(
+        fingerprint="a",
+        index=0,
+        direction="in",
+        sender="A",
+        timestamp_raw="14:30, 2026-05-01",
+        timestamp_iso="2026-05-01T14:30:00",
+        text="old",
+    )
+    second = WhatsAppWebMessage(
+        fingerprint="b",
+        index=1,
+        direction="in",
+        sender="A",
+        timestamp_raw="14:30, 2026-05-02",
+        timestamp_iso="2026-05-02T14:30:00",
+        text="new",
+    )
+
+    filtered = filter_whatsapp_web_messages(
+        [first, second],
+        since=parse_cli_date("2026-05-02"),
+        until=parse_cli_date("2026-05-02"),
+        after_fingerprint="a",
+    )
+
+    assert filtered == [second]
+
+
+def test_whatsapp_status_command_outputs_json(monkeypatch, tmp_path):
+    def fake_validate_whatsapp_web_login(**kwargs):
+        assert kwargs["profile_dir"] == tmp_path
+        assert kwargs["timeout_seconds"] == 3
+        assert kwargs["poll_interval_seconds"] == 0.5
+        assert kwargs["headless"] is True
+        assert kwargs["browser"] == "edge"
+        assert kwargs["channel"] == "msedge"
+        return WhatsAppWebLoginResult(
+            status=WhatsAppWebLoginStatus.LOGIN_REQUIRED,
+            profile_dir=Path(tmp_path),
+            elapsed_seconds=3.01,
+            url="https://web.whatsapp.com/",
+            marker="[data-testid='qrcode']",
+            detail="WhatsApp Web login screen was visible until timeout.",
+        )
+
+    monkeypatch.setattr(
+        whatsapp_command,
+        "validate_whatsapp_web_login",
+        fake_validate_whatsapp_web_login,
+    )
+    stdout = StringIO()
+
+    call_command(
+        "whatsapp",
+        "status",
+        "--profile-dir",
+        str(tmp_path),
+        "--timeout",
+        "3",
+        "--poll-interval",
+        "0.5",
+        "--headless",
+        "--browser",
+        "edge",
+        "--channel",
+        "msedge",
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == WhatsAppWebLoginStatus.LOGIN_REQUIRED
+    assert payload["profile_dir"] == str(tmp_path)
+    assert payload["marker"] == "[data-testid='qrcode']"
+
+
+def test_whatsapp_send_command_outputs_json(monkeypatch, tmp_path):
+    def fake_send_whatsapp_web_message(**kwargs):
+        assert kwargs["phone"] == "8119218587"
+        assert kwargs["message"] == "hello"
+        assert kwargs["default_country_code"] == "52"
+        return WhatsAppWebSendResult(
+            status="sent",
+            phone="528119218587",
+            profile_dir=tmp_path,
+            elapsed_seconds=1.2,
+            url="https://web.whatsapp.com/",
+            detail="Message submitted through WhatsApp Web.",
+        )
+
+    monkeypatch.setattr(
+        whatsapp_command,
+        "send_whatsapp_web_message",
+        fake_send_whatsapp_web_message,
+    )
+    stdout = StringIO()
+
+    call_command(
+        "whatsapp",
+        "send",
+        "--to",
+        "8119218587",
+        "--message",
+        "hello",
+        "--profile-dir",
+        str(tmp_path),
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "sent"
+    assert payload["phone"] == "528119218587"
+
+
+def test_whatsapp_read_command_outputs_messages(monkeypatch, tmp_path):
+    def fake_read_whatsapp_web_messages(**kwargs):
+        assert kwargs["phone"] == "8119218587"
+        assert kwargs["since"].isoformat() == "2026-05-01"
+        assert kwargs["until"].isoformat() == "2026-05-01"
+        assert kwargs["only_new"] is True
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="528119218587",
+            profile_dir=tmp_path,
+            messages=[
+                WhatsAppWebMessage(
+                    fingerprint="abc",
+                    index=1,
+                    direction="in",
+                    sender="ARTHEXIS",
+                    timestamp_raw="14:30, 2026-05-01",
+                    timestamp_iso="2026-05-01T14:30:00",
+                    text="hello",
+                )
+            ],
+            cursor_updated=True,
+            cursor_file=tmp_path / "message-cursors.json",
+        )
+
+    monkeypatch.setattr(
+        whatsapp_command,
+        "read_whatsapp_web_messages",
+        fake_read_whatsapp_web_messages,
+    )
+    stdout = StringIO()
+
+    call_command(
+        "whatsapp",
+        "read",
+        "--from",
+        "8119218587",
+        "--date",
+        "2026-05-01",
+        "--new",
+        "--profile-dir",
+        str(tmp_path),
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "ok"
+    assert payload["messages"][0]["text"] == "hello"
+    assert payload["cursor_updated"] is True

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from io import StringIO
 from pathlib import Path
 
@@ -14,6 +15,9 @@ from apps.meta.services import (
     WhatsAppWebMessage,
     WhatsAppWebReadResult,
     WhatsAppWebSendResult,
+    _is_whatsapp_web_url,
+    _read_cursor,
+    _write_cursor,
     build_whatsapp_web_messages,
     cursor_file_for_profile,
     detect_whatsapp_web_login_state,
@@ -74,8 +78,16 @@ def test_detect_whatsapp_web_login_state_detects_login_required_text():
 
 
 def test_normalize_whatsapp_phone_adds_default_country_code():
-    assert normalize_whatsapp_phone("811 921 8587") == "528119218587"
+    assert normalize_whatsapp_phone("555 123 4567") == "525551234567"
     assert normalize_whatsapp_phone("+1 (555) 123-4567") == "15551234567"
+
+
+def test_is_whatsapp_web_url_requires_exact_whatsapp_host():
+    assert _is_whatsapp_web_url("https://web.whatsapp.com/")
+    assert _is_whatsapp_web_url("http://web.whatsapp.com/send?phone=525551234567")
+    assert not _is_whatsapp_web_url("https://example.com/?next=https://web.whatsapp.com/")
+    assert not _is_whatsapp_web_url("https://web.whatsapp.com.example.com/")
+    assert not _is_whatsapp_web_url("notaurl")
 
 
 def test_parse_cli_date_requires_iso_format():
@@ -95,27 +107,69 @@ def test_build_messages_from_whatsapp_rows():
         {
             "pre": "[14:30, 2026-05-01] ARTHEXIS: ",
             "direction": "in",
+            "message_id": "message-a",
             "text": "hello",
         },
         {
             "pre": "[14:31, 2026-05-01] You: ",
             "direction": "out",
+            "message_id": "message-b",
             "text": "reply",
         },
     ]
 
-    messages = build_whatsapp_web_messages(rows, phone="528119218587")
+    messages = build_whatsapp_web_messages(rows, phone="525551234567")
 
     assert [message.text for message in messages] == ["hello", "reply"]
     assert messages[0].timestamp_iso == "2026-05-01T14:30:00"
     assert messages[0].sender == "ARTHEXIS"
+    assert messages[0].message_id == "message-a"
     assert messages[0].fingerprint
+
+
+def test_build_messages_fingerprint_is_stable_across_dom_positions():
+    row = {
+        "pre": "[14:30, 2026-05-01] ARTHEXIS: ",
+        "direction": "in",
+        "message_id": "stable-message-id",
+        "text": "hello",
+    }
+    first = build_whatsapp_web_messages([row], phone="525551234567")[0]
+    second = build_whatsapp_web_messages(
+        [
+            {"pre": "", "direction": "in", "text": ""},
+            row,
+        ],
+        phone="525551234567",
+    )[0]
+
+    assert first.index == 0
+    assert second.index == 1
+    assert first.fingerprint == second.fingerprint
+
+
+def test_build_messages_logs_unparseable_timestamp(caplog):
+    rows = [
+        {
+            "pre": "[not a supported timestamp] ARTHEXIS: ",
+            "direction": "in",
+            "message_id": "message-a",
+            "text": "hello",
+        }
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="apps.meta.services"):
+        messages = build_whatsapp_web_messages(rows, phone="525551234567")
+
+    assert messages[0].timestamp_iso == ""
+    assert "Could not parse WhatsApp Web timestamp" in caplog.text
 
 
 def test_filter_messages_by_date_and_cursor():
     first = WhatsAppWebMessage(
         fingerprint="a",
         index=0,
+        message_id="a",
         direction="in",
         sender="A",
         timestamp_raw="14:30, 2026-05-01",
@@ -125,6 +179,7 @@ def test_filter_messages_by_date_and_cursor():
     second = WhatsAppWebMessage(
         fingerprint="b",
         index=1,
+        message_id="b",
         direction="in",
         sender="A",
         timestamp_raw="14:30, 2026-05-02",
@@ -140,6 +195,17 @@ def test_filter_messages_by_date_and_cursor():
     )
 
     assert filtered == [second]
+
+
+def test_cursor_file_round_trips_atomic_payload(tmp_path):
+    cursor_file = tmp_path / "message-cursors.json"
+
+    _write_cursor(cursor_file, "525551234567:default", "fingerprint-a")
+
+    payload = json.loads(cursor_file.read_text(encoding="utf-8"))
+    assert payload["expires_at"] is None
+    assert payload["cursors"]["525551234567:default"] == "fingerprint-a"
+    assert _read_cursor(cursor_file, "525551234567:default") == "fingerprint-a"
 
 
 def test_whatsapp_status_command_outputs_json(monkeypatch, tmp_path):
@@ -192,12 +258,12 @@ def test_whatsapp_status_command_outputs_json(monkeypatch, tmp_path):
 
 def test_whatsapp_send_command_outputs_json(monkeypatch, tmp_path):
     def fake_send_whatsapp_web_message(**kwargs):
-        assert kwargs["phone"] == "8119218587"
+        assert kwargs["phone"] == "5551234567"
         assert kwargs["message"] == "hello"
         assert kwargs["default_country_code"] == "52"
         return WhatsAppWebSendResult(
             status="sent",
-            phone="528119218587",
+            phone="525551234567",
             profile_dir=tmp_path,
             elapsed_seconds=1.2,
             url="https://web.whatsapp.com/",
@@ -215,7 +281,7 @@ def test_whatsapp_send_command_outputs_json(monkeypatch, tmp_path):
         "whatsapp",
         "send",
         "--to",
-        "8119218587",
+        "5551234567",
         "--message",
         "hello",
         "--profile-dir",
@@ -226,23 +292,24 @@ def test_whatsapp_send_command_outputs_json(monkeypatch, tmp_path):
 
     payload = json.loads(stdout.getvalue())
     assert payload["status"] == "sent"
-    assert payload["phone"] == "528119218587"
+    assert payload["phone"] == "525551234567"
 
 
 def test_whatsapp_read_command_outputs_messages(monkeypatch, tmp_path):
     def fake_read_whatsapp_web_messages(**kwargs):
-        assert kwargs["phone"] == "8119218587"
+        assert kwargs["phone"] == "5551234567"
         assert kwargs["since"].isoformat() == "2026-05-01"
         assert kwargs["until"].isoformat() == "2026-05-01"
         assert kwargs["only_new"] is True
         return WhatsAppWebReadResult(
             status="ok",
-            phone="528119218587",
+            phone="525551234567",
             profile_dir=tmp_path,
             messages=[
                 WhatsAppWebMessage(
                     fingerprint="abc",
                     index=1,
+                    message_id="abc",
                     direction="in",
                     sender="ARTHEXIS",
                     timestamp_raw="14:30, 2026-05-01",
@@ -265,7 +332,7 @@ def test_whatsapp_read_command_outputs_messages(monkeypatch, tmp_path):
         "whatsapp",
         "read",
         "--from",
-        "8119218587",
+        "5551234567",
         "--date",
         "2026-05-01",
         "--new",

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -20,10 +20,12 @@ from apps.meta.services import (
     _write_cursor,
     build_whatsapp_web_messages,
     cursor_file_for_profile,
+    cursor_key_for_profile,
     detect_whatsapp_web_login_state,
     filter_whatsapp_web_messages,
     normalize_whatsapp_phone,
     parse_cli_date,
+    read_whatsapp_web_messages,
 )
 
 
@@ -31,16 +33,23 @@ class FakeLocator:
     def __init__(self, visible: bool):
         self._visible = visible
         self.first = self
+        self.last = self
 
     def is_visible(self, *, timeout: int):
         del timeout
         return self._visible
 
+    def wait_for(self, *, timeout: int):
+        del timeout
+        return None
+
 
 class FakePage:
-    def __init__(self, *, visible_selectors=None, visible_texts=None):
+    def __init__(self, *, visible_selectors=None, visible_texts=None, rows=None):
         self.visible_selectors = set(visible_selectors or [])
         self.visible_texts = set(visible_texts or [])
+        self.rows = list(rows or [])
+        self.url = ""
 
     def locator(self, selector: str):
         return FakeLocator(selector in self.visible_selectors)
@@ -48,6 +57,14 @@ class FakePage:
     def get_by_text(self, text: str, *, exact: bool):
         del exact
         return FakeLocator(text in self.visible_texts)
+
+    def goto(self, url: str, *, wait_until: str, timeout: int):
+        del wait_until, timeout
+        self.url = url
+
+    def evaluate(self, script: str):
+        del script
+        return self.rows
 
 
 def test_detect_whatsapp_web_login_state_detects_logged_in_chat_list():
@@ -206,6 +223,54 @@ def test_cursor_file_round_trips_atomic_payload(tmp_path):
     assert payload["expires_at"] is None
     assert payload["cursors"]["525551234567:default"] == "fingerprint-a"
     assert _read_cursor(cursor_file, "525551234567:default") == "fingerprint-a"
+
+
+def test_cursor_key_is_scoped_to_profile_path(tmp_path):
+    first = cursor_key_for_profile("525551234567", tmp_path / "profile-a")
+    second = cursor_key_for_profile("525551234567", tmp_path / "profile-b")
+
+    assert first.startswith("525551234567:")
+    assert second.startswith("525551234567:")
+    assert first != second
+
+
+def test_read_new_cursor_advances_to_returned_limited_batch(monkeypatch, tmp_path):
+    rows = [
+        {
+            "pre": f"[14:{minute:02d}, 2026-05-01] ARTHEXIS: ",
+            "direction": "in",
+            "message_id": f"message-{index}",
+            "text": f"message {index}",
+        }
+        for index, minute in enumerate(range(30, 34))
+    ]
+    profile_dir = tmp_path / "profile-a"
+
+    def fake_with_whatsapp_page(callback, **kwargs):
+        del kwargs
+        page = FakePage(visible_selectors={"#pane-side"}, rows=rows)
+        return callback(page, profile_dir, 1.0)
+
+    monkeypatch.setattr(
+        "apps.meta.services._with_whatsapp_page",
+        fake_with_whatsapp_page,
+    )
+
+    result = read_whatsapp_web_messages(
+        phone="5551234567",
+        only_new=True,
+        limit=2,
+        profile_dir=profile_dir,
+        timeout_seconds=1.0,
+    )
+    all_messages = build_whatsapp_web_messages(rows, phone=result.phone)
+    cursor_file = cursor_file_for_profile(profile_dir)
+    cursor_key = cursor_key_for_profile(result.phone, profile_dir)
+
+    assert [message.text for message in result.messages] == ["message 0", "message 1"]
+    assert result.cursor_updated is True
+    assert _read_cursor(cursor_file, cursor_key) == result.messages[-1].fingerprint
+    assert result.messages[-1].fingerprint != all_messages[-1].fingerprint
 
 
 def test_whatsapp_status_command_outputs_json(monkeypatch, tmp_path):

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -50,31 +50,31 @@ python manage.py whatsapp status --json
 Send one message:
 
 ```powershell
-python manage.py whatsapp send --to 528119218587 --message "Hello from Arthexis"
+python manage.py whatsapp send --to 525551234567 --message "Hello from Arthexis"
 ```
 
 Read messages visible in a phone-number chat:
 
 ```powershell
-python manage.py whatsapp read --from 528119218587 --json
+python manage.py whatsapp read --from 525551234567 --json
 ```
 
 Read messages from one date:
 
 ```powershell
-python manage.py whatsapp read --from 528119218587 --date 2026-05-01 --json
+python manage.py whatsapp read --from 525551234567 --date 2026-05-01 --json
 ```
 
 Read only messages after the local cursor and then advance that cursor:
 
 ```powershell
-python manage.py whatsapp read --from 528119218587 --new --json
+python manage.py whatsapp read --from 525551234567 --new --json
 ```
 
 Attach to an already-open Edge debugging session:
 
 ```powershell
-python manage.py whatsapp send --to 528119218587 --message "Hello" --cdp-url http://127.0.0.1:9223
+python manage.py whatsapp send --to 525551234567 --message "Hello" --cdp-url http://127.0.0.1:9223
 ```
 
 ## Privacy And Side Effects

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -87,5 +87,6 @@ Opening a chat in WhatsApp Web can mark messages as read in the WhatsApp
 account. Use `read --new --no-update-cursor` to inspect output without advancing
 the local Arthexis cursor, but WhatsApp's own read state may still change.
 
-The `--new` cursor is local to the browser profile and phone number. It is not a
-poller and does not run in the background.
+The `--new` cursor is local to the browser profile path and phone number. It
+returns the next visible batch after the stored cursor and advances only after an
+explicit on-demand read. It is not a poller and does not run in the background.

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -1,0 +1,91 @@
+# WhatsApp Web CLI
+
+The `whatsapp` management command provides local, on-demand WhatsApp Web
+automation for operator workflows.
+
+This command uses a persistent browser profile. First-time setup requires a
+headed browser so the operator can complete WhatsApp Web QR registration.
+
+## Scope
+
+Supported in this version:
+
+- Register or validate a persistent WhatsApp Web login.
+- Send one message to one phone number on demand.
+- Read visible messages from one phone-number chat on demand.
+- Filter read output by `--date`, `--since`, `--until`, or a local `--new`
+  cursor.
+
+Not supported in this version:
+
+- Polling or background message ingestion.
+- Group chat automation.
+- Bulk messaging.
+- Attachments or media download.
+- Replacing the existing WhatsApp Business API bridge.
+
+## Browser Defaults
+
+- Windows defaults to Microsoft Edge through Playwright's `msedge` channel.
+- Linux defaults to Playwright Firefox.
+
+Use `--browser edge`, `--browser firefox`, or `--browser chromium` to override
+the default. Use `--channel msedge` when explicitly selecting Edge through
+Chromium on Windows.
+
+## Examples
+
+Register or refresh the local WhatsApp Web profile:
+
+```powershell
+python manage.py whatsapp login --timeout 300
+```
+
+Check the current profile status:
+
+```powershell
+python manage.py whatsapp status --json
+```
+
+Send one message:
+
+```powershell
+python manage.py whatsapp send --to 528119218587 --message "Hello from Arthexis"
+```
+
+Read messages visible in a phone-number chat:
+
+```powershell
+python manage.py whatsapp read --from 528119218587 --json
+```
+
+Read messages from one date:
+
+```powershell
+python manage.py whatsapp read --from 528119218587 --date 2026-05-01 --json
+```
+
+Read only messages after the local cursor and then advance that cursor:
+
+```powershell
+python manage.py whatsapp read --from 528119218587 --new --json
+```
+
+Attach to an already-open Edge debugging session:
+
+```powershell
+python manage.py whatsapp send --to 528119218587 --message "Hello" --cdp-url http://127.0.0.1:9223
+```
+
+## Privacy And Side Effects
+
+The command targets one requested phone-number chat. It does not scan unrelated
+chat lists for content. The `read` action extracts visible message text from
+the opened chat only.
+
+Opening a chat in WhatsApp Web can mark messages as read in the WhatsApp
+account. Use `read --new --no-update-cursor` to inspect output without advancing
+the local Arthexis cursor, but WhatsApp's own read state may still change.
+
+The `--new` cursor is local to the browser profile and phone number. It is not a
+poller and does not run in the background.


### PR DESCRIPTION
## Summary
- add `manage.py whatsapp` with `login`, `status`, `send`, and `read` subcommands
- default browser selection to Edge on Windows and Firefox on Linux, with optional CDP attach support for an already-open Edge/Chromium window
- add local `read --new` cursor handling plus date filters and operator docs
- address review feedback for exact WhatsApp URL matching, CDP connection cleanup, stable message fingerprints, profile-scoped locked cursor writes, bounded cursor advancement, and CLI guardrails

## Validation
- `python -m ruff check apps\\meta\\management\\commands\\whatsapp.py apps\\meta\\services.py apps\\meta\\tests\\test_whatsapp.py`
- `python -m pytest apps\\meta\\tests\\test_whatsapp.py -vv`
- `ARTHEXIS_SQLITE_TEST_PATH=<temp-unique-sqlite> python -m pytest apps\\meta\\tests -vv --durations=20`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py whatsapp --help`
- `git diff --check`
- live smoke: `manage.py whatsapp status --cdp-url http://127.0.0.1:9223 --timeout 30 --json`
- live smoke before redaction: `manage.py whatsapp send` to the operator's own number succeeded through Edge CDP
- live smoke before redaction: `manage.py whatsapp read` from the operator's own number returned the visible self-chat message

Closes #7544