### PR TITLE
Provision Soul Seed card payloads

### DIFF
--- a/apps/cards/agent_card.py
+++ b/apps/cards/agent_card.py
@@ -34,6 +34,7 @@ CREDENTIAL_RE = re.compile(
     re.IGNORECASE,
 )
 UNRESTRICTED_URL_RE = re.compile(r"https?://", re.IGNORECASE)
+EXTENSION_OVERFLOW_NOTE = "Additional skill sigils were omitted because the card has ten extension slots."
 
 
 class AgentCardError(ValueError):
@@ -261,7 +262,8 @@ def build_agent_card_sector_payloads(
     extension_index = 1
     for raw_slug in skill_slugs:
         if extension_index > len(EXTENSION_SECTORS):
-            compatibility_notes.append("Additional skill sigils were omitted because the card has ten extension slots.")
+            if EXTENSION_OVERFLOW_NOTE not in compatibility_notes:
+                compatibility_notes.append(EXTENSION_OVERFLOW_NOTE)
             omitted_skill_sigils.append(str(raw_slug))
             continue
         slug = str(raw_slug or "").strip()

--- a/apps/cards/agent_card.py
+++ b/apps/cards/agent_card.py
@@ -143,6 +143,29 @@ class ActivationPlan:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class AgentCardBuildResult:
+    sector_records: dict[int, str]
+    padded_sector_records: dict[int, str]
+    manifest: AgentCardManifest
+    compatibility_notes: list[str] = field(default_factory=list)
+    omitted_skill_sigils: list[str] = field(default_factory=list)
+
+    @property
+    def fingerprint(self) -> str:
+        return self.manifest.fingerprint
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fingerprint": self.fingerprint,
+            "sector_records": self.sector_records,
+            "padded_sector_records": self.padded_sector_records,
+            "manifest": self.manifest.to_dict(),
+            "compatibility_notes": self.compatibility_notes,
+            "omitted_skill_sigils": self.omitted_skill_sigils,
+        }
+
+
 def _sector_for_slot(slot_code: str) -> int | None:
     if slot_code == "M":
         return 1
@@ -155,6 +178,38 @@ def _sector_for_slot(slot_code: str) -> int | None:
         if 1 <= value <= 10:
             return value + 5
     return None
+
+
+def _compact_digest(value: object, *, length: int = 12) -> str:
+    text = str(value or "")
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:length].upper()
+
+
+def _pad_record(record: str) -> str:
+    encoded = record.encode("ascii", errors="strict")
+    if len(encoded) > SLOT_PAYLOAD_BYTES:
+        raise AgentCardError(f"Agent Card record exceeds {SLOT_PAYLOAD_BYTES} bytes.")
+    return record.ljust(SLOT_PAYLOAD_BYTES)
+
+
+def _identity_record(slot_index: int, source_value: object) -> str:
+    if not source_value:
+        return f"AC1|I{slot_index}|VOID=1"
+    source_text = str(source_value)
+    return (
+        f"AC1|I{slot_index}|NS=SOUL|"
+        f"ID={_compact_digest(f'id:{source_text}', length=8)}|"
+        f"H={_compact_digest(f'hash:{source_text}', length=12)}"
+    )
+
+
+def _empty_extension_record(slot_index: int, source_value: object = "") -> str:
+    digest_source = source_value or f"empty-extension-{slot_index}"
+    return f"AC1|F{slot_index:02d}|T=EMPTY|H={_compact_digest(digest_source, length=6)}"
+
+
+def _skill_sigil_for_slug(skill_slug: str) -> str:
+    return f"[AGENT.SKILL:{skill_slug}]"
 
 
 def _coerce_sector_payloads(
@@ -180,6 +235,70 @@ def _coerce_sector_payloads(
     if len(values) != len(APPLICATION_SECTORS):
         raise AgentCardError("Agent Card v1 requires exactly 15 application sectors.")
     return {sector: values[index] for index, sector in enumerate(APPLICATION_SECTORS)}
+
+
+def build_agent_card_sector_payloads(
+    *,
+    identity_sources: Mapping[str, object],
+    skill_slugs: Iterable[str],
+) -> AgentCardBuildResult:
+    """Build a complete Agent Card v1 sector map and validate it with the parser."""
+
+    ordered_identity_sources = [
+        identity_sources.get("intent"),
+        identity_sources.get("bundle"),
+        identity_sources.get("interface"),
+        identity_sources.get("card"),
+    ]
+    sector_records: dict[int, str] = {
+        1: "AC1|M|S=4|X=10|ALG=SHA8|POL=RDRSIG",
+    }
+    for index, source_value in enumerate(ordered_identity_sources, start=1):
+        sector_records[index + 1] = _identity_record(index, source_value)
+
+    compatibility_notes: list[str] = []
+    omitted_skill_sigils: list[str] = []
+    extension_index = 1
+    for raw_slug in skill_slugs:
+        if extension_index > len(EXTENSION_SECTORS):
+            compatibility_notes.append("Additional skill sigils were omitted because the card has ten extension slots.")
+            omitted_skill_sigils.append(str(raw_slug))
+            continue
+        slug = str(raw_slug or "").strip()
+        if not slug:
+            continue
+        sigil = _skill_sigil_for_slug(slug)
+        record = (
+            f"AC1|K{extension_index:02d}|SIG={sigil}|"
+            f"H={_compact_digest(f'skill:{slug}', length=6)}"
+        )
+        try:
+            _parse_record(extension_index + 5, record)
+        except AgentCardError:
+            compatibility_notes.append(
+                f"Skill sigil for '{slug}' does not fit Agent Card v1 sector limits."
+            )
+            omitted_skill_sigils.append(sigil)
+            continue
+        sector_records[extension_index + 5] = record
+        extension_index += 1
+
+    while extension_index <= len(EXTENSION_SECTORS):
+        sector_records[extension_index + 5] = _empty_extension_record(
+            extension_index,
+            identity_sources.get("card"),
+        )
+        extension_index += 1
+
+    manifest = parse_agent_card(sector_records)
+    padded_records = {sector: _pad_record(record) for sector, record in sector_records.items()}
+    return AgentCardBuildResult(
+        sector_records=sector_records,
+        padded_sector_records=padded_records,
+        manifest=manifest,
+        compatibility_notes=compatibility_notes,
+        omitted_skill_sigils=omitted_skill_sigils,
+    )
 
 
 def _trim_and_validate_payload(sector: int, payload: str | bytes) -> str:

--- a/apps/cards/agent_card.py
+++ b/apps/cards/agent_card.py
@@ -261,15 +261,15 @@ def build_agent_card_sector_payloads(
     omitted_skill_sigils: list[str] = []
     extension_index = 1
     for raw_slug in skill_slugs:
-        if extension_index > len(EXTENSION_SECTORS):
-            if EXTENSION_OVERFLOW_NOTE not in compatibility_notes:
-                compatibility_notes.append(EXTENSION_OVERFLOW_NOTE)
-            omitted_skill_sigils.append(str(raw_slug))
-            continue
         slug = str(raw_slug or "").strip()
         if not slug:
             continue
         sigil = _skill_sigil_for_slug(slug)
+        if extension_index > len(EXTENSION_SECTORS):
+            if EXTENSION_OVERFLOW_NOTE not in compatibility_notes:
+                compatibility_notes.append(EXTENSION_OVERFLOW_NOTE)
+            omitted_skill_sigils.append(sigil)
+            continue
         record = (
             f"AC1|K{extension_index:02d}|SIG={sigil}|"
             f"H={_compact_digest(f'skill:{slug}', length=6)}"

--- a/apps/cards/tests/test_agent_card.py
+++ b/apps/cards/tests/test_agent_card.py
@@ -125,7 +125,7 @@ def test_build_agent_card_sector_payloads_reports_overflow_once():
     )
 
     assert len(build.compatibility_notes) == 1
-    assert len(build.omitted_skill_sigils) == 2
+    assert build.omitted_skill_sigils == ["[AGENT.SKILL:s10]", "[AGENT.SKILL:s11]"]
 
 
 def test_score_soul_identity_returns_best_candidate():

--- a/apps/cards/tests/test_agent_card.py
+++ b/apps/cards/tests/test_agent_card.py
@@ -118,6 +118,16 @@ def test_build_agent_card_sector_payloads_omits_oversized_skill_sigils():
     ]
 
 
+def test_build_agent_card_sector_payloads_reports_overflow_once():
+    build = build_agent_card_sector_payloads(
+        identity_sources={"intent": "intent", "bundle": "bundle", "interface": "interface", "card": "AABB"},
+        skill_slugs=[f"s{index}" for index in range(12)],
+    )
+
+    assert len(build.compatibility_notes) == 1
+    assert len(build.omitted_skill_sigils) == 2
+
+
 def test_score_soul_identity_returns_best_candidate():
     card = parse_agent_card(valid_agent_card_records())
 

--- a/apps/cards/tests/test_agent_card.py
+++ b/apps/cards/tests/test_agent_card.py
@@ -6,6 +6,7 @@ import pytest
 
 from apps.cards.agent_card import (
     AgentCardError,
+    build_agent_card_sector_payloads,
     parse_agent_card,
     plan_agent_activation,
     score_soul_identity,
@@ -83,6 +84,38 @@ def test_parse_agent_card_rejects_non_ascii_string_payloads():
 def test_parse_agent_card_rejects_non_iterable_or_scalar_payloads(sector_payloads):
     with pytest.raises(AgentCardError, match="mapping or iterable"):
         parse_agent_card(sector_payloads)
+
+
+def test_build_agent_card_sector_payloads_returns_valid_complete_payload():
+    build = build_agent_card_sector_payloads(
+        identity_sources={
+            "intent": "intent:1",
+            "bundle": "bundle:2",
+            "interface": "interface:3",
+            "card": "AABBCCDD",
+        },
+        skill_slugs=["rfid-triage"],
+    )
+
+    assert sorted(build.sector_records) == list(range(1, 16))
+    assert all(len(record.encode("ascii")) <= 48 for record in build.sector_records.values())
+    assert all(len(record.encode("ascii")) == 48 for record in build.padded_sector_records.values())
+    parsed = parse_agent_card(build.sector_records)
+    assert parsed.fingerprint == build.fingerprint
+    assert parsed.capability_sigils() == ["[AGENT.SKILL:rfid-triage]"]
+
+
+def test_build_agent_card_sector_payloads_omits_oversized_skill_sigils():
+    build = build_agent_card_sector_payloads(
+        identity_sources={"intent": "intent", "bundle": "bundle", "interface": "interface", "card": "AABB"},
+        skill_slugs=["skill-" + "x" * 80, "rfid-triage"],
+    )
+
+    assert build.omitted_skill_sigils
+    assert build.compatibility_notes
+    assert parse_agent_card(build.sector_records).capability_sigils() == [
+        "[AGENT.SKILL:rfid-triage]"
+    ]
 
 
 def test_score_soul_identity_returns_best_candidate():

--- a/apps/souls/management/commands/soul_seed.py
+++ b/apps/souls/management/commands/soul_seed.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
 
-from apps.souls.services import compose_skill_bundle
+from apps.souls.services import compose_skill_bundle, provision_soul_seed_card
 
 
 class Command(BaseCommand):
@@ -21,8 +22,31 @@ class Command(BaseCommand):
             action="store_true",
             help="Persist the intent, bundle, and interface spec. Defaults to dry-run.",
         )
+        provision_parser = subparsers.add_parser(
+            "provision",
+            help="Provision Agent Card v1 payloads from an operator prompt and card UID.",
+        )
+        provision_parser.add_argument("--prompt", required=True, help="Problem or job description for this card.")
+        provision_parser.add_argument("--card-uid", required=True, help="RFID card UID to bind to the payload.")
+        provision_parser.add_argument("--limit", type=int, default=5, help="Maximum skill matches to include.")
+        provision_parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Persist the intent, bundle, interface spec, RFID, and Soul Seed card.",
+        )
+        provision_parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit the full provisioning payload as JSON.",
+        )
+        provision_parser.add_argument(
+            "--sectors-json-out",
+            help="Write generated raw sector records to this JSON file for a future card writer.",
+        )
 
     def handle(self, *args, **options):
+        if options["action"] == "provision":
+            return self._handle_provision(options)
         if options["action"] != "compose":
             raise CommandError(f"Unsupported soul_seed action: {options['action']}")
         prompt = (options.get("prompt") or "").strip()
@@ -38,3 +62,37 @@ class Command(BaseCommand):
         except ValueError as error:
             raise CommandError(str(error)) from error
         self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))
+
+    def _handle_provision(self, options):
+        prompt = (options.get("prompt") or "").strip()
+        if not prompt:
+            raise CommandError("--prompt is required")
+        try:
+            summary = provision_soul_seed_card(
+                prompt,
+                card_uid=options.get("card_uid") or "",
+                created_by=getattr(self, "user", None),
+                limit=options["limit"],
+                dry_run=not options["write"],
+            )
+        except ValueError as error:
+            raise CommandError(str(error)) from error
+        sectors_json_out = options.get("sectors_json_out")
+        if sectors_json_out:
+            try:
+                Path(sectors_json_out).write_text(
+                    json.dumps(summary["sector_records"], indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+            except OSError as error:
+                raise CommandError(str(error)) from error
+        if options.get("json"):
+            self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))
+            return
+        write_state = "persisted" if options["write"] else "planned"
+        self.stdout.write(f"Soul Seed card {write_state}: {summary['card']['card_uid']}")
+        self.stdout.write(f"Fingerprint: {summary['card']['manifest_fingerprint']}")
+        if summary["compatibility_notes"]:
+            self.stdout.write("Compatibility notes:")
+            for note in summary["compatibility_notes"]:
+                self.stdout.write(f"- {note}")

--- a/apps/souls/services/__init__.py
+++ b/apps/souls/services/__init__.py
@@ -1,3 +1,4 @@
+from .card_provisioning import plan_soul_seed_card, provision_soul_seed_card
 from .card_sessions import evict_card_session
 from .checkout import attach_soul_to_order_items
 from .package import build_soul_package
@@ -11,5 +12,7 @@ __all__ = [
     "digest_normalized_answers",
     "evict_card_session",
     "normalize_survey_response",
+    "plan_soul_seed_card",
+    "provision_soul_seed_card",
     "search_agent_skills",
 ]

--- a/apps/souls/services/card_provisioning.py
+++ b/apps/souls/services/card_provisioning.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.utils import timezone
 
 from apps.cards.agent_card import build_agent_card_sector_payloads
 from apps.cards.models import RFID
@@ -32,24 +34,31 @@ def _validated_created_by(created_by):
     return None
 
 
+def _stable_identity_value(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
 def _identity_sources(
     *,
     card_uid: str,
     bundle_result: dict[str, Any],
-    bundle: SkillBundle | None = None,
-    interface_spec: AgentInterfaceSpec | None = None,
 ) -> dict[str, object]:
-    intent_id = bundle.intent_id if bundle else bundle_result["intent"].get("id")
-    bundle_id = bundle.pk if bundle else bundle_result["bundle"].get("id")
-    interface_id = (
-        interface_spec.pk
-        if interface_spec
-        else bundle_result["interface_spec"].get("id")
-    )
+    bundle_identity = {
+        "match_score": bundle_result["bundle"].get("match_score"),
+        "match_strategy": bundle_result["bundle"].get("match_strategy"),
+        "primary_skill": bundle_result["bundle"].get("primary_skill"),
+        "skill_slugs": bundle_result["bundle"].get("skill_slugs", []),
+        "summary": bundle_result["bundle"].get("summary"),
+    }
+    interface_identity = {
+        "commands": bundle_result["interface_spec"].get("commands", []),
+        "schema": bundle_result["interface_spec"].get("schema", {}),
+        "visible_fields": bundle_result["interface_spec"].get("visible_fields", []),
+    }
     return {
-        "intent": intent_id or bundle_result["intent"].get("normalized_intent"),
-        "bundle": bundle_id or bundle_result["bundle"].get("slug"),
-        "interface": interface_id or bundle_result["interface_spec"]["schema"],
+        "intent": bundle_result["intent"].get("normalized_intent"),
+        "bundle": _stable_identity_value(bundle_identity),
+        "interface": _stable_identity_value(interface_identity),
         "card": card_uid,
     }
 
@@ -58,16 +67,12 @@ def _build_payload(
     *,
     card_uid: str,
     bundle_result: dict[str, Any],
-    bundle: SkillBundle | None = None,
-    interface_spec: AgentInterfaceSpec | None = None,
 ) -> dict[str, Any]:
     skill_slugs = bundle_result["bundle"].get("skill_slugs", [])
     build_result = build_agent_card_sector_payloads(
         identity_sources=_identity_sources(
             card_uid=card_uid,
             bundle_result=bundle_result,
-            bundle=bundle,
-            interface_spec=interface_spec,
         ),
         skill_slugs=skill_slugs,
     )
@@ -165,20 +170,21 @@ def provision_soul_seed_card(
             .get(pk=bundle_result["bundle"]["id"])
         )
         interface_spec = AgentInterfaceSpec.objects.get(pk=bundle_result["interface_spec"]["id"])
-        agent_card = _build_payload(
-            card_uid=normalized_card_uid,
-            bundle_result=bundle_result,
-            bundle=bundle,
-            interface_spec=interface_spec,
-        )
+        agent_card = _build_payload(card_uid=normalized_card_uid, bundle_result=bundle_result)
         _update_bundle_compatibility_notes(bundle, agent_card["compatibility_notes"])
         rfid, _rfid_created = RFID.update_or_create_from_code(normalized_card_uid)
-        card = (
+        active_cards = list(
             SoulSeedCard.objects.exclude(status=SoulSeedCard.Status.REVOKED)
             .filter(card_uid=normalized_card_uid)
             .order_by("-id")
-            .first()
         )
+        card = active_cards[0] if active_cards else None
+        stale_card_ids = [existing_card.pk for existing_card in active_cards[1:]]
+        if stale_card_ids:
+            SoulSeedCard.objects.filter(pk__in=stale_card_ids).update(
+                status=SoulSeedCard.Status.REVOKED,
+                revoked_at=timezone.now(),
+            )
         created = card is None
         if card is None:
             card = SoulSeedCard(card_uid=normalized_card_uid)
@@ -186,7 +192,8 @@ def provision_soul_seed_card(
         card.intent = bundle.intent
         card.skill_bundle = bundle
         card.interface_spec = interface_spec
-        card.owner = created_by
+        if created_by is not None or card.owner_id is None:
+            card.owner = created_by
         card.status = SoulSeedCard.Status.ACTIVE
         card.manifest_fingerprint = agent_card["fingerprint"]
         card.card_payload = {

--- a/apps/souls/services/card_provisioning.py
+++ b/apps/souls/services/card_provisioning.py
@@ -5,7 +5,7 @@ import re
 from typing import Any
 
 from django.contrib.auth import get_user_model
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from apps.cards.agent_card import build_agent_card_sector_payloads
@@ -96,6 +96,18 @@ def _update_bundle_compatibility_notes(
     bundle.save(update_fields=["compatibility_notes", "updated_at"])
 
 
+def _locked_rfid_for_uid(card_uid: str) -> RFID:
+    try:
+        with transaction.atomic():
+            rfid, _created = RFID.update_or_create_from_code(card_uid)
+    except IntegrityError:
+        rfid = RFID.find_match(card_uid)
+        if rfid is None:
+            raise
+    # The RFID row is the per-card UID mutex, including the no-SoulSeedCard-yet case.
+    return RFID.objects.select_for_update().get(pk=rfid.pk)
+
+
 def _card_payload_summary(
     *,
     dry_run: bool,
@@ -172,9 +184,10 @@ def provision_soul_seed_card(
         interface_spec = AgentInterfaceSpec.objects.get(pk=bundle_result["interface_spec"]["id"])
         agent_card = _build_payload(card_uid=normalized_card_uid, bundle_result=bundle_result)
         _update_bundle_compatibility_notes(bundle, agent_card["compatibility_notes"])
-        rfid, _rfid_created = RFID.update_or_create_from_code(normalized_card_uid)
+        rfid = _locked_rfid_for_uid(normalized_card_uid)
         active_cards = list(
-            SoulSeedCard.objects.exclude(status=SoulSeedCard.Status.REVOKED)
+            SoulSeedCard.objects.select_for_update()
+            .exclude(status=SoulSeedCard.Status.REVOKED)
             .filter(card_uid=normalized_card_uid)
             .order_by("-id")
         )

--- a/apps/souls/services/card_provisioning.py
+++ b/apps/souls/services/card_provisioning.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from apps.cards.agent_card import build_agent_card_sector_payloads
+from apps.cards.models import RFID
+from apps.souls.models import AgentInterfaceSpec, SkillBundle, SoulSeedCard
+from apps.souls.services.skill_matching import compose_skill_bundle
+
+CARD_UID_RE = re.compile(r"^[0-9A-F]+$")
+
+
+def normalize_card_uid(card_uid: str) -> str:
+    normalized = RFID.normalize_code(card_uid)
+    if not normalized:
+        raise ValueError("card_uid is required.")
+    if not CARD_UID_RE.fullmatch(normalized):
+        raise ValueError("card_uid must contain hexadecimal digits only.")
+    return normalized
+
+
+def _validated_created_by(created_by):
+    if created_by is None:
+        return None
+    user_model = get_user_model()
+    if isinstance(created_by, user_model):
+        return created_by
+    return None
+
+
+def _identity_sources(
+    *,
+    card_uid: str,
+    bundle_result: dict[str, Any],
+    bundle: SkillBundle | None = None,
+    interface_spec: AgentInterfaceSpec | None = None,
+) -> dict[str, object]:
+    intent_id = bundle.intent_id if bundle else bundle_result["intent"].get("id")
+    bundle_id = bundle.pk if bundle else bundle_result["bundle"].get("id")
+    interface_id = (
+        interface_spec.pk
+        if interface_spec
+        else bundle_result["interface_spec"].get("id")
+    )
+    return {
+        "intent": intent_id or bundle_result["intent"].get("normalized_intent"),
+        "bundle": bundle_id or bundle_result["bundle"].get("slug"),
+        "interface": interface_id or bundle_result["interface_spec"]["schema"],
+        "card": card_uid,
+    }
+
+
+def _build_payload(
+    *,
+    card_uid: str,
+    bundle_result: dict[str, Any],
+    bundle: SkillBundle | None = None,
+    interface_spec: AgentInterfaceSpec | None = None,
+) -> dict[str, Any]:
+    skill_slugs = bundle_result["bundle"].get("skill_slugs", [])
+    build_result = build_agent_card_sector_payloads(
+        identity_sources=_identity_sources(
+            card_uid=card_uid,
+            bundle_result=bundle_result,
+            bundle=bundle,
+            interface_spec=interface_spec,
+        ),
+        skill_slugs=skill_slugs,
+    )
+    return build_result.to_dict()
+
+
+def _update_bundle_compatibility_notes(
+    bundle: SkillBundle,
+    notes: list[str],
+) -> None:
+    if not notes:
+        return
+    existing_notes = list(bundle.compatibility_notes or [])
+    merged_notes = [*existing_notes]
+    for note in notes:
+        if note not in merged_notes:
+            merged_notes.append(note)
+    if merged_notes == existing_notes:
+        return
+    bundle.compatibility_notes = merged_notes
+    bundle.save(update_fields=["compatibility_notes", "updated_at"])
+
+
+def _card_payload_summary(
+    *,
+    dry_run: bool,
+    card_uid: str,
+    bundle_result: dict[str, Any],
+    agent_card: dict[str, Any],
+    card: SoulSeedCard | None = None,
+    created: bool | None = None,
+) -> dict[str, Any]:
+    result = {
+        "dry_run": dry_run,
+        "card": {
+            "id": card.pk if card else None,
+            "card_uid": card_uid,
+            "status": card.status if card else SoulSeedCard.Status.ACTIVE,
+            "created": created,
+            "manifest_fingerprint": agent_card["fingerprint"],
+        },
+        "intent": bundle_result["intent"],
+        "bundle": bundle_result["bundle"],
+        "interface_spec": bundle_result["interface_spec"],
+        "matches": bundle_result.get("matches", []),
+        "agent_card": agent_card,
+        "sector_records": agent_card["sector_records"],
+        "padded_sector_records": agent_card["padded_sector_records"],
+        "compatibility_notes": agent_card["compatibility_notes"],
+        "omitted_skill_sigils": agent_card["omitted_skill_sigils"],
+    }
+    if card and card.rfid_id:
+        result["card"]["rfid_label_id"] = card.rfid_id
+    return result
+
+
+def provision_soul_seed_card(
+    prompt: str,
+    *,
+    card_uid: str,
+    created_by=None,
+    limit: int = 5,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    normalized_card_uid = normalize_card_uid(card_uid)
+    created_by = _validated_created_by(created_by)
+    if dry_run:
+        bundle_result = compose_skill_bundle(
+            prompt,
+            created_by=created_by,
+            limit=limit,
+            dry_run=True,
+        )
+        agent_card = _build_payload(
+            card_uid=normalized_card_uid,
+            bundle_result=bundle_result,
+        )
+        return _card_payload_summary(
+            dry_run=True,
+            card_uid=normalized_card_uid,
+            bundle_result=bundle_result,
+            agent_card=agent_card,
+        )
+
+    with transaction.atomic():
+        bundle_result = compose_skill_bundle(
+            prompt,
+            created_by=created_by,
+            limit=limit,
+            dry_run=False,
+        )
+        bundle = (
+            SkillBundle.objects.prefetch_related("skills")
+            .select_related("intent", "primary_skill")
+            .get(pk=bundle_result["bundle"]["id"])
+        )
+        interface_spec = AgentInterfaceSpec.objects.get(pk=bundle_result["interface_spec"]["id"])
+        agent_card = _build_payload(
+            card_uid=normalized_card_uid,
+            bundle_result=bundle_result,
+            bundle=bundle,
+            interface_spec=interface_spec,
+        )
+        _update_bundle_compatibility_notes(bundle, agent_card["compatibility_notes"])
+        rfid, _rfid_created = RFID.update_or_create_from_code(normalized_card_uid)
+        card = (
+            SoulSeedCard.objects.exclude(status=SoulSeedCard.Status.REVOKED)
+            .filter(card_uid=normalized_card_uid)
+            .order_by("-id")
+            .first()
+        )
+        created = card is None
+        if card is None:
+            card = SoulSeedCard(card_uid=normalized_card_uid)
+        card.rfid = rfid
+        card.intent = bundle.intent
+        card.skill_bundle = bundle
+        card.interface_spec = interface_spec
+        card.owner = created_by
+        card.status = SoulSeedCard.Status.ACTIVE
+        card.manifest_fingerprint = agent_card["fingerprint"]
+        card.card_payload = {
+            "agent_card": agent_card,
+            "prompt": prompt,
+            "bundle": bundle_result["bundle"],
+            "interface_spec": bundle_result["interface_spec"],
+        }
+        card.save()
+    return _card_payload_summary(
+        dry_run=False,
+        card_uid=normalized_card_uid,
+        bundle_result=bundle_result,
+        agent_card=agent_card,
+        card=card,
+        created=created,
+    )
+
+
+def plan_soul_seed_card(
+    prompt: str,
+    *,
+    card_uid: str,
+    created_by=None,
+    limit: int = 5,
+) -> dict[str, Any]:
+    return provision_soul_seed_card(
+        prompt,
+        card_uid=card_uid,
+        created_by=created_by,
+        limit=limit,
+        dry_run=True,
+    )

--- a/apps/souls/tests/test_soul_seed_foundation.py
+++ b/apps/souls/tests/test_soul_seed_foundation.py
@@ -4,6 +4,7 @@ import json
 from io import StringIO
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -171,6 +172,23 @@ def test_provision_soul_seed_card_write_persists_registry_records(skill):
 
 
 @pytest.mark.django_db
+def test_provision_soul_seed_card_write_matches_dry_run_fingerprint(skill):
+    dry_run = provision_soul_seed_card(
+        "rfid reader problem",
+        card_uid="AABBCCDD",
+        dry_run=True,
+    )
+    written = provision_soul_seed_card(
+        "rfid reader problem",
+        card_uid="AABBCCDD",
+        dry_run=False,
+    )
+
+    assert written["sector_records"] == dry_run["sector_records"]
+    assert written["card"]["manifest_fingerprint"] == dry_run["card"]["manifest_fingerprint"]
+
+
+@pytest.mark.django_db
 def test_provision_soul_seed_card_write_updates_active_card_for_duplicate_uid(skill):
     first = provision_soul_seed_card("rfid reader problem", card_uid="AABBCCDD", dry_run=False)
     second = provision_soul_seed_card("rfid-triage", card_uid="AABBCCDD", dry_run=False)
@@ -178,6 +196,36 @@ def test_provision_soul_seed_card_write_updates_active_card_for_duplicate_uid(sk
     assert second["card"]["created"] is False
     assert second["card"]["id"] == first["card"]["id"]
     assert SoulSeedCard.objects.filter(card_uid="AABBCCDD").count() == 1
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_preserves_owner_when_creator_missing(skill):
+    user = get_user_model().objects.create_user(username="seed-owner")
+    first = provision_soul_seed_card(
+        "rfid reader problem",
+        card_uid="AABBCCDD",
+        created_by=user,
+        dry_run=False,
+    )
+    second = provision_soul_seed_card("rfid-triage", card_uid="AABBCCDD", dry_run=False)
+
+    assert second["card"]["id"] == first["card"]["id"]
+    assert SoulSeedCard.objects.get(pk=second["card"]["id"]).owner == user
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_revokes_stale_duplicate_active_cards(skill):
+    older = SoulSeedCard.objects.create(card_uid="AABBCCDD", status=SoulSeedCard.Status.ACTIVE)
+    newer = SoulSeedCard.objects.create(card_uid="AABBCCDD", status=SoulSeedCard.Status.PREVIEW_ONLY)
+
+    summary = provision_soul_seed_card("rfid reader problem", card_uid="AABBCCDD", dry_run=False)
+    older.refresh_from_db()
+    newer.refresh_from_db()
+
+    assert summary["card"]["id"] == newer.pk
+    assert newer.status == SoulSeedCard.Status.ACTIVE
+    assert older.status == SoulSeedCard.Status.REVOKED
+    assert older.revoked_at is not None
 
 
 @pytest.mark.django_db

--- a/apps/souls/tests/test_soul_seed_foundation.py
+++ b/apps/souls/tests/test_soul_seed_foundation.py
@@ -7,11 +7,20 @@ import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
+from apps.cards.agent_card import parse_agent_card
+from apps.cards.models import RFID
 from apps.skills.models import AgentSkill, AgentSkillFile
-from apps.souls.models import AgentInterfaceSpec, CardSession, SkillBundle, SoulIntent
+from apps.souls.models import (
+    AgentInterfaceSpec,
+    CardSession,
+    SkillBundle,
+    SoulIntent,
+    SoulSeedCard,
+)
 from apps.souls.services import (
     compose_skill_bundle,
     evict_card_session,
+    provision_soul_seed_card,
     search_agent_skills,
 )
 
@@ -122,6 +131,95 @@ def test_soul_seed_compose_command_outputs_json(skill):
 def test_soul_seed_compose_command_rejects_negative_limit(skill):
     with pytest.raises(CommandError, match="non-negative"):
         call_command("soul_seed", "compose", "--prompt", "rfid reader problem", "--limit", "-1")
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_dry_run_returns_valid_agent_card(skill):
+    summary = provision_soul_seed_card(
+        "rfid reader problem",
+        card_uid="aa bb cc dd",
+        dry_run=True,
+    )
+
+    assert summary["dry_run"] is True
+    assert summary["card"]["card_uid"] == "AABBCCDD"
+    assert SoulSeedCard.objects.count() == 0
+    card = parse_agent_card(summary["sector_records"])
+    assert card.fingerprint == summary["card"]["manifest_fingerprint"]
+    assert card.capability_sigils() == ["[AGENT.SKILL:rfid-triage]"]
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_write_persists_registry_records(skill):
+    summary = provision_soul_seed_card(
+        "rfid reader problem",
+        card_uid="AABBCCDD",
+        dry_run=False,
+    )
+
+    soul_seed_card = SoulSeedCard.objects.get(pk=summary["card"]["id"])
+    assert summary["dry_run"] is False
+    assert summary["card"]["created"] is True
+    assert soul_seed_card.card_uid == "AABBCCDD"
+    assert soul_seed_card.rfid == RFID.objects.get(rfid="AABBCCDD")
+    assert soul_seed_card.intent_id == summary["intent"]["id"]
+    assert soul_seed_card.skill_bundle_id == summary["bundle"]["id"]
+    assert soul_seed_card.interface_spec_id == summary["interface_spec"]["id"]
+    assert soul_seed_card.manifest_fingerprint == parse_agent_card(
+        summary["sector_records"]
+    ).fingerprint
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_write_updates_active_card_for_duplicate_uid(skill):
+    first = provision_soul_seed_card("rfid reader problem", card_uid="AABBCCDD", dry_run=False)
+    second = provision_soul_seed_card("rfid-triage", card_uid="AABBCCDD", dry_run=False)
+
+    assert second["card"]["created"] is False
+    assert second["card"]["id"] == first["card"]["id"]
+    assert SoulSeedCard.objects.filter(card_uid="AABBCCDD").count() == 1
+
+
+@pytest.mark.django_db
+def test_provision_soul_seed_card_records_oversized_skill_note():
+    long_skill = AgentSkill.objects.create(
+        slug="skill-" + "x" * 80,
+        title="Oversized Skill",
+        markdown="oversized card payload test",
+    )
+
+    summary = provision_soul_seed_card(long_skill.slug, card_uid="AABBCCDD", dry_run=False)
+    bundle = SkillBundle.objects.get(pk=summary["bundle"]["id"])
+
+    assert summary["omitted_skill_sigils"]
+    assert summary["compatibility_notes"]
+    assert bundle.compatibility_notes == summary["compatibility_notes"]
+    assert parse_agent_card(summary["sector_records"]).capability_sigils() == []
+
+
+@pytest.mark.django_db
+def test_soul_seed_provision_command_outputs_json_and_sector_file(skill, tmp_path):
+    stdout = StringIO()
+    sectors_path = tmp_path / "sectors.json"
+
+    call_command(
+        "soul_seed",
+        "provision",
+        "--prompt",
+        "rfid reader problem",
+        "--card-uid",
+        "AABBCCDD",
+        "--json",
+        "--sectors-json-out",
+        str(sectors_path),
+        stdout=stdout,
+    )
+    summary = json.loads(stdout.getvalue())
+    sector_records = json.loads(sectors_path.read_text(encoding="utf-8"))
+
+    assert summary["dry_run"] is True
+    assert sector_records == summary["sector_records"]
+    assert parse_agent_card(sector_records).fingerprint == summary["card"]["manifest_fingerprint"]
 
 
 def test_agent_card_inspect_command_outputs_json(tmp_path):

--- a/docs/development/agent-card-v1.md
+++ b/docs/development/agent-card-v1.md
@@ -219,6 +219,50 @@ Because MIFARE Classic is cloneable and has known weaknesses, high-trust actions
 must rely on suite registry state, reader-event proof, freshness checks, and
 operator identity. The card alone is never enough for privileged activation.
 
+## Provisioning command contract
+
+The suite provisioning boundary is the `soul_seed provision` command. It turns
+an operator prompt and a card UID into a deterministic Agent Card v1 sector map.
+By default it is a dry run and does not write database records or physical card
+sectors:
+
+```powershell
+python manage.py soul_seed provision --prompt "rfid reader problem" --card-uid AABBCCDD --json
+```
+
+Use `--write` to persist the suite registry side of the card:
+
+```powershell
+python manage.py soul_seed provision --prompt "rfid reader problem" --card-uid AABBCCDD --write --json
+```
+
+Persisted provisioning creates or updates:
+
+- The composed `SoulIntent`, `SkillBundle`, and `AgentInterfaceSpec`.
+- The matching `RFID` registry record for the card UID.
+- One active `SoulSeedCard` for the card UID, unless the previous card record
+  was revoked.
+- The card manifest fingerprint and generated sector payload under
+  `SoulSeedCard.card_payload`.
+
+The command can write the raw unpadded sector records to a JSON file for a
+future hardware writer adapter:
+
+```powershell
+python manage.py soul_seed provision --prompt "rfid reader problem" --card-uid AABBCCDD --sectors-json-out sectors.json
+```
+
+The JSON response also includes `padded_sector_records`, where every value is
+exactly 48 bytes when encoded as ASCII. A physical writer should write those
+padded payloads, read sectors 1-15 back, and pass the read-back data through
+`parse_agent_card()` before declaring success.
+
+Skill SIGILS that do not fit in one 48 byte sector, or that fail parser safety
+checks, are omitted from the card payload and reported in compatibility notes.
+They still remain in the suite-side bundle, so the operator can revise the skill
+alias or handle them through a future registry indirection instead of storing
+unsafe or oversized text on the card.
+
 ## Parser and writer contract
 
 Future implementation should expose a small service boundary rather than ad hoc


### PR DESCRIPTION
## Summary\n- add deterministic Agent Card v1 sector payload builder with padded writer-ready records\n- add Soul Seed provisioning service for prompt + card UID dry-runs and persisted SoulSeedCard registry records\n- add soul_seed provision CLI, sector JSON output, tests, and provisioning docs\n\n## Validation\n- 28 passed: pytest apps/cards/tests/test_agent_card.py apps/souls/tests/test_soul_seed_foundation.py -q\n- ruff check on touched files\n- manage.py check --fail-level ERROR\n- manage.py makemigrations --check --dry-run\n- scripts/check_import_resolution.py apps/cards apps/souls\n- git diff --check\n\nCloses #7550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Provision Soul Seed card payloads

This PR implements a complete Soul Seed card provisioning pipeline, enabling deterministic Agent Card v1 sector payload generation from operator prompts. It closes issue #7550.

### Core Components

**Agent Card Builder** (`apps/cards/agent_card.py`):
- Introduces `AgentCardBuildResult` dataclass to represent fully-built Agent Card v1 sector maps, including unpadded/padded sector records, parsed manifest, compatibility notes, and omitted skills.
- Implements `build_agent_card_sector_payloads()` to assemble sector payloads from identity sources and skill slugs, enforce extension-slot limits, fill remaining slots with empty records, validate via `parse_agent_card`, pad records to fixed payload size, and track omitted/oversized skills.

**Provisioning Service** (`apps/souls/services/card_provisioning.py`):
- `normalize_card_uid()`: Validates and normalizes card UIDs using hexadecimal-only validation.
- `provision_soul_seed_card()`: Orchestrates provisioning in dry-run and write modes. In dry-run mode, generates payloads without persistence. In write mode, wraps operations in a transaction to create/update `SoulSeedCard`, `RFID`, and related registry records, tracking manifest fingerprints and compatibility notes.
- `plan_soul_seed_card()`: Convenience wrapper that delegates to provision with `dry_run=True`.

**CLI Extension** (`apps/souls/management/commands/soul_seed.py`):
- Adds `provision` subcommand alongside existing `compose` action with arguments: `--prompt`, `--card-uid`, `--limit`, `--write`, `--json`, and `--sectors-json-out`.
- Outputs either full JSON payload or card UID/fingerprint plus compatibility notes; optionally writes sector records to file.

### Test Coverage

- `test_build_agent_card_sector_payloads_returns_valid_complete_payload()`: Verifies correctly-sized sector records and payload parsing consistency.
- `test_build_agent_card_sector_payloads_omits_oversized_skill_sigils()`: Confirms invalid/oversized skills are omitted and tracked.
- Five integration tests in `test_soul_seed_foundation.py` covering dry-run validation, persistence with registry relationships, duplicate UID handling, oversized skill omission, and command JSON/file output.

### Documentation

Updated `docs/development/agent-card-v1.md` with "Provisioning command contract" section defining the `soul_seed provision` command boundary, dry-run vs persisted behavior, affected suite-side artifacts, and optional sector JSON export for future writer integration.

### Validation

- 28 pytest tests passed
- ruff check completed
- Django system checks passed
- Import resolution verified
- No formatting issues detected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->