### PR TITLE
Add WhatsApp Secretary listener

### DIFF
--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -116,7 +116,10 @@ class Command(BaseCommand):
             "--idle-after",
             type=float,
             default=DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
-            help="Desktop idle seconds required before polling; 0 disables. Default: 300.",
+            help=(
+                "Desktop idle seconds required before polling (Windows only); "
+                "0 disables. Default: 300."
+            ),
         )
         listen.add_argument(
             "--poll-every",

--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -6,10 +6,15 @@ from pathlib import Path
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.meta.services import (
+    DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
+    DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS,
+    DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS,
+    DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
     DEFAULT_WHATSAPP_WEB_BROWSER,
     DEFAULT_WHATSAPP_WEB_CHANNEL,
     DEFAULT_WHATSAPP_WEB_PROFILE_DIR,
     dataclass_payload,
+    listen_for_whatsapp_secretary_requests,
     parse_cli_date,
     read_whatsapp_web_messages,
     send_whatsapp_web_message,
@@ -18,7 +23,7 @@ from apps.meta.services import (
 
 
 class Command(BaseCommand):
-    help = "On-demand WhatsApp Web login, send, and read commands."
+    help = "WhatsApp Web login, send, read, and local listener commands."
 
     def add_arguments(self, parser):
         subparsers = parser.add_subparsers(dest="action", required=True)
@@ -83,6 +88,81 @@ class Command(BaseCommand):
         )
         read.add_argument("--json", action="store_true", help="Emit JSON output.")
 
+        listen = subparsers.add_parser(
+            "listen",
+            help="Poll an operator self-chat and launch a Codex Secretary terminal.",
+        )
+        self._add_browser_arguments(listen, default_timeout=120.0)
+        listen.add_argument(
+            "--from",
+            dest="from_phone",
+            required=True,
+            help="Operator self-chat phone number.",
+        )
+        listen.add_argument(
+            "--country-code",
+            default="52",
+            help="Country code for 10-digit local numbers. Default: 52.",
+        )
+        listen.add_argument(
+            "--trigger-prefix",
+            default=DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+            help=(
+                "Message prefix required to launch Secretary. Use an empty value "
+                "to process every new message. Default: secretary:"
+            ),
+        )
+        listen.add_argument(
+            "--idle-after",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
+            help="Desktop idle seconds required before polling; 0 disables. Default: 300.",
+        )
+        listen.add_argument(
+            "--poll-every",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS,
+            help="Seconds between WhatsApp read polls. Default: 60.",
+        )
+        listen.add_argument(
+            "--quiet-window",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS,
+            help="Seconds without new messages required before processing. Default: 60.",
+        )
+        listen.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Maximum visible new messages to inspect per poll; 0 means all.",
+        )
+        listen.add_argument(
+            "--codex-command",
+            default="codex",
+            help="Codex executable command used in the launched terminal.",
+        )
+        listen.add_argument(
+            "--secretary-name",
+            default="Secretary",
+            help="Nickname used in the generated SECRETARY prompt.",
+        )
+        listen.add_argument(
+            "--terminal-title",
+            default="Arthexis Secretary",
+            help="Window/tab title for the launched terminal.",
+        )
+        listen.add_argument(
+            "--once",
+            action="store_true",
+            help="Exit after processing one quiet message batch.",
+        )
+        listen.add_argument(
+            "--no-launch",
+            action="store_true",
+            help="Match and advance the cursor without launching Codex.",
+        )
+        listen.add_argument("--json", action="store_true", help="Emit JSON output.")
+
     def _add_browser_arguments(self, parser, *, default_timeout: float) -> None:
         parser.add_argument(
             "--profile-dir",
@@ -140,6 +220,8 @@ class Command(BaseCommand):
                 result = self._handle_send(options)
             elif action == "read":
                 result = self._handle_read(options)
+            elif action == "listen":
+                return self._handle_listen(options)
             else:
                 raise CommandError(f"Unknown whatsapp action: {action}")
         except (RuntimeError, ValueError) as exc:
@@ -195,6 +277,42 @@ class Command(BaseCommand):
             limit=options["limit"],
             **self._browser_options(options),
         )
+
+    def _handle_listen(self, options):
+        if options["limit"] < 0:
+            raise CommandError("--limit must be >= 0. Use 0 to return all visible messages.")
+        if options["idle_after"] < 0:
+            raise CommandError("--idle-after must be >= 0.")
+        if options["poll_every"] < 1:
+            raise CommandError("--poll-every must be >= 1.")
+        if options["quiet_window"] < 1:
+            raise CommandError("--quiet-window must be >= 1.")
+
+        def write_event(result) -> None:
+            if options.get("json"):
+                self.stdout.write(json.dumps(dataclass_payload(result), indent=2))
+            else:
+                self._write_text_result(result)
+
+        results = listen_for_whatsapp_secretary_requests(
+            phone=options["from_phone"],
+            default_country_code=options["country_code"],
+            trigger_prefix=options["trigger_prefix"],
+            idle_after_seconds=options["idle_after"],
+            daemon_poll_seconds=options["poll_every"],
+            quiet_window_seconds=options["quiet_window"],
+            limit=options["limit"],
+            launch=not options["no_launch"],
+            codex_command=options["codex_command"],
+            secretary_name=options["secretary_name"],
+            terminal_title=options["terminal_title"],
+            max_batches=1 if options["once"] else None,
+            event_callback=None if options["once"] else write_event,
+            **self._browser_options(options),
+        )
+        if options["once"] and results:
+            write_event(results[-1])
+        return None
 
     def _write_text_result(self, result) -> None:
         payload = dataclass_payload(result)

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -801,6 +801,10 @@ def _merge_message_batches(
     return merged, changed
 
 
+def _split_windows_command_line(value: str) -> list[str]:
+    return [part.strip("\"") for part in shlex.split(value, posix=False)]
+
+
 def launch_codex_secretary_terminal(
     prompt: str,
     *,
@@ -812,7 +816,8 @@ def launch_codex_secretary_terminal(
     from apps.terminals.tasks import launch_command_in_terminal
 
     if sys.platform == "win32":
-        command = [codex_command.strip() or "codex", prompt]
+        command = _split_windows_command_line(codex_command.strip() or "codex")
+        command.append(prompt)
     else:
         command = [*shlex.split(codex_command or "codex"), prompt]
     launch_path = launch_command_in_terminal(

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -713,7 +713,7 @@ def operator_idle_seconds() -> float | None:
         if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
             return None
         tick_count = ctypes.windll.kernel32.GetTickCount()
-        return max((tick_count - info.dwTime) / 1000.0, 0.0)
+        return ((tick_count - info.dwTime) & 0xFFFFFFFF) / 1000.0
     except Exception:
         logger.debug("Could not read local operator idle time.", exc_info=True)
         return None
@@ -811,7 +811,10 @@ def launch_codex_secretary_terminal(
 
     from apps.terminals.tasks import launch_command_in_terminal
 
-    command = [*shlex.split(codex_command), prompt]
+    if sys.platform == "win32":
+        command = [codex_command.strip() or "codex", prompt]
+    else:
+        command = [*shlex.split(codex_command or "codex"), prompt]
     launch_path = launch_command_in_terminal(
         command,
         title=terminal_title,
@@ -861,6 +864,7 @@ def listen_for_whatsapp_secretary_requests(
     polls = 0
     processed_batches = 0
     reader = read_messages or read_whatsapp_web_messages
+    should_store_results = max_batches is not None or max_polls is not None
 
     while True:
         if max_polls is not None and polls >= max_polls:
@@ -891,7 +895,8 @@ def listen_for_whatsapp_secretary_requests(
             )
             if event_callback:
                 event_callback(result)
-            results.append(result)
+            if should_store_results:
+                results.append(result)
             if max_batches is None:
                 sleep(daemon_poll_seconds)
                 continue
@@ -910,7 +915,6 @@ def listen_for_whatsapp_secretary_requests(
             )
             cursor_file = cursor_file_for_profile(read_result.profile_dir)
             cursor_key = cursor_key_for_profile(normalized_phone, read_result.profile_dir)
-            _write_cursor(cursor_file, cursor_key, pending[-1].fingerprint)
             detail = "Batch ignored because no Secretary trigger prefix was present."
             launched = False
             status = "ignored"
@@ -928,6 +932,7 @@ def listen_for_whatsapp_secretary_requests(
                     detail = launcher(prompt)
                     launched = True
                     status = "launched"
+            _write_cursor(cursor_file, cursor_key, pending[-1].fingerprint)
             result = WhatsAppSecretaryListenResult(
                 status=status,
                 phone=normalized_phone,
@@ -941,7 +946,8 @@ def listen_for_whatsapp_secretary_requests(
             )
             if event_callback:
                 event_callback(result)
-            results.append(result)
+            if should_store_results:
+                results.append(result)
             processed_batches += 1
             pending = []
             pending_changed_at = 0.0

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -6,8 +6,10 @@ import json
 import logging
 import os
 import re
+import shlex
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -22,6 +24,10 @@ DEFAULT_WHATSAPP_WEB_PROFILE_DIR = (
 DEFAULT_WHATSAPP_WEB_BROWSER = "edge" if sys.platform == "win32" else "firefox"
 DEFAULT_WHATSAPP_WEB_CHANNEL = "msedge" if sys.platform == "win32" else ""
 WHATSAPP_WEB_CURSOR_FILENAME = "message-cursors.json"
+DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX = "secretary:"
+DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS = 300.0
+DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS = 60.0
+DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS = 60.0
 
 LOGGED_IN_SELECTORS = (
     "#pane-side",
@@ -110,6 +116,19 @@ class WhatsAppWebReadResult:
     messages: list[WhatsAppWebMessage]
     cursor_updated: bool = False
     cursor_file: Path | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class WhatsAppSecretaryListenResult:
+    status: str
+    phone: str
+    message_count: int
+    launched: bool = False
+    cursor_updated: bool = False
+    cursor_file: Path | None = None
+    batch_fingerprint: str = ""
+    elapsed_seconds: float = 0.0
     detail: str = ""
 
 
@@ -676,6 +695,260 @@ def _write_cursor(cursor_file: Path, key: str, value: str) -> None:
             json.dumps(next_payload, indent=2, sort_keys=True), encoding="utf-8"
         )
         os.replace(temp_file, cursor_file)
+
+
+def operator_idle_seconds() -> float | None:
+    """Return local desktop idle seconds when the platform exposes it."""
+
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        class LASTINPUTINFO(ctypes.Structure):
+            _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_uint)]
+
+        info = LASTINPUTINFO()
+        info.cbSize = ctypes.sizeof(info)
+        if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
+            return None
+        tick_count = ctypes.windll.kernel32.GetTickCount()
+        return max((tick_count - info.dwTime) / 1000.0, 0.0)
+    except Exception:
+        logger.debug("Could not read local operator idle time.", exc_info=True)
+        return None
+
+
+def _message_text_after_trigger(text: str, trigger_prefix: str) -> str | None:
+    stripped = text.strip()
+    prefix = trigger_prefix.strip()
+    if not prefix:
+        return stripped
+    if stripped.lower().startswith(prefix.lower()):
+        return stripped[len(prefix) :].strip()
+    return None
+
+
+def secretary_request_text_from_messages(
+    messages: list[WhatsAppWebMessage],
+    *,
+    trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+) -> str:
+    """Build a Secretary request from the first triggered message and continuations."""
+
+    request_parts: list[str] = []
+    collecting = not trigger_prefix.strip()
+    for message in messages:
+        text = message.text.strip()
+        if not text:
+            continue
+        triggered_text = _message_text_after_trigger(text, trigger_prefix)
+        if triggered_text is not None:
+            collecting = True
+            text = triggered_text
+        elif not collecting:
+            continue
+        if text:
+            request_parts.append(text)
+    return "\n\n".join(request_parts).strip()
+
+
+def build_whatsapp_secretary_prompt(
+    messages: list[WhatsAppWebMessage],
+    *,
+    trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+    secretary_name: str = "Secretary",
+) -> str:
+    request_text = secretary_request_text_from_messages(
+        messages,
+        trigger_prefix=trigger_prefix,
+    )
+    if not request_text:
+        return ""
+    return "\n".join(
+        [
+            f"[SECRETARY] {secretary_name}:",
+            "",
+            "You are a SECRETARY agent operating for the ARTHEXIS operator.",
+            "Read the operator manual before acting if this is a new console session.",
+            "Record your current goal and owned scope in the workgroup file before taking ownership.",
+            "Treat the WhatsApp request below as the current operator request.",
+            "",
+            "Operator request:",
+            request_text,
+        ]
+    )
+
+
+def _batch_fingerprint(messages: list[WhatsAppWebMessage]) -> str:
+    data = "\x1f".join(message.fingerprint for message in messages)
+    return hashlib.sha256(data.encode("utf-8")).hexdigest() if data else ""
+
+
+def _merge_message_batches(
+    current: list[WhatsAppWebMessage],
+    incoming: list[WhatsAppWebMessage],
+) -> tuple[list[WhatsAppWebMessage], bool]:
+    by_fingerprint = {message.fingerprint: message for message in current}
+    merged = list(current)
+    changed = False
+    for message in incoming:
+        if message.fingerprint in by_fingerprint:
+            continue
+        by_fingerprint[message.fingerprint] = message
+        merged.append(message)
+        changed = True
+    return merged, changed
+
+
+def launch_codex_secretary_terminal(
+    prompt: str,
+    *,
+    codex_command: str = "codex",
+    terminal_title: str = "Arthexis Secretary",
+) -> str:
+    from django.conf import settings
+
+    from apps.terminals.tasks import launch_command_in_terminal
+
+    command = [*shlex.split(codex_command), prompt]
+    launch_path = launch_command_in_terminal(
+        command,
+        title=terminal_title,
+        state_key="whatsapp-secretary",
+        working_directory=Path(settings.BASE_DIR),
+    )
+    return f"Codex Secretary terminal launch requested; pid file: {launch_path}"
+
+
+def listen_for_whatsapp_secretary_requests(
+    *,
+    phone: str,
+    default_country_code: str = "52",
+    trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+    idle_after_seconds: float = DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
+    daemon_poll_seconds: float = DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS,
+    quiet_window_seconds: float = DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS,
+    limit: int = 50,
+    launch: bool = True,
+    codex_command: str = "codex",
+    secretary_name: str = "Secretary",
+    terminal_title: str = "Arthexis Secretary",
+    max_batches: int | None = None,
+    max_polls: int | None = None,
+    read_messages: Callable[..., WhatsAppWebReadResult] | None = None,
+    launch_callback: Callable[[str], str] | None = None,
+    idle_seconds: Callable[[], float | None] = operator_idle_seconds,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    event_callback: Callable[[WhatsAppSecretaryListenResult], None] | None = None,
+    **browser_options,
+) -> list[WhatsAppSecretaryListenResult]:
+    """Poll WhatsApp self-chat, debounce quiet batches, and launch Secretary."""
+
+    if limit < 0:
+        raise ValueError("--limit must be >= 0. Use 0 to return all visible messages.")
+    idle_after_seconds = max(float(idle_after_seconds), 0.0)
+    daemon_poll_seconds = max(float(daemon_poll_seconds), 1.0)
+    quiet_window_seconds = max(float(quiet_window_seconds), 1.0)
+    started_at = monotonic()
+    normalized_phone = normalize_whatsapp_phone(
+        phone, default_country_code=default_country_code
+    )
+    pending: list[WhatsAppWebMessage] = []
+    pending_changed_at = 0.0
+    results: list[WhatsAppSecretaryListenResult] = []
+    polls = 0
+    processed_batches = 0
+    reader = read_messages or read_whatsapp_web_messages
+
+    while True:
+        if max_polls is not None and polls >= max_polls:
+            return results
+        idle_for = idle_seconds()
+        if idle_after_seconds and idle_for is not None and idle_for < idle_after_seconds:
+            sleep(min(daemon_poll_seconds, idle_after_seconds - idle_for))
+            polls += 1
+            continue
+
+        read_result = reader(
+            phone=normalized_phone,
+            default_country_code=default_country_code,
+            only_new=True,
+            update_cursor=False,
+            limit=limit,
+            **browser_options,
+        )
+        polls += 1
+        if read_result.status != "ok":
+            result = WhatsAppSecretaryListenResult(
+                status=read_result.status,
+                phone=normalized_phone,
+                message_count=0,
+                cursor_file=read_result.cursor_file,
+                elapsed_seconds=monotonic() - started_at,
+                detail=read_result.detail or "WhatsApp Web read did not return ok.",
+            )
+            if event_callback:
+                event_callback(result)
+            results.append(result)
+            if max_batches is None:
+                sleep(daemon_poll_seconds)
+                continue
+            return results
+
+        if read_result.messages:
+            pending, changed = _merge_message_batches(pending, read_result.messages)
+            if changed or not pending_changed_at:
+                pending_changed_at = monotonic()
+
+        if pending and monotonic() - pending_changed_at >= quiet_window_seconds:
+            prompt = build_whatsapp_secretary_prompt(
+                pending,
+                trigger_prefix=trigger_prefix,
+                secretary_name=secretary_name,
+            )
+            cursor_file = cursor_file_for_profile(read_result.profile_dir)
+            cursor_key = cursor_key_for_profile(normalized_phone, read_result.profile_dir)
+            _write_cursor(cursor_file, cursor_key, pending[-1].fingerprint)
+            detail = "Batch ignored because no Secretary trigger prefix was present."
+            launched = False
+            status = "ignored"
+            if prompt:
+                status = "matched"
+                detail = "Secretary request matched."
+                if launch:
+                    launcher = launch_callback or (
+                        lambda text: launch_codex_secretary_terminal(
+                            text,
+                            codex_command=codex_command,
+                            terminal_title=terminal_title,
+                        )
+                    )
+                    detail = launcher(prompt)
+                    launched = True
+                    status = "launched"
+            result = WhatsAppSecretaryListenResult(
+                status=status,
+                phone=normalized_phone,
+                message_count=len(pending),
+                launched=launched,
+                cursor_updated=True,
+                cursor_file=cursor_file,
+                batch_fingerprint=_batch_fingerprint(pending),
+                elapsed_seconds=monotonic() - started_at,
+                detail=detail,
+            )
+            if event_callback:
+                event_callback(result)
+            results.append(result)
+            processed_batches += 1
+            pending = []
+            pending_changed_at = 0.0
+            if max_batches is not None and processed_batches >= max_batches:
+                return results
+
+        sleep(daemon_poll_seconds)
 
 
 def read_whatsapp_web_messages(

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -11,6 +11,7 @@ from django.core.management.base import CommandError
 
 from apps.meta.management.commands import whatsapp as whatsapp_command
 from apps.meta.services import (
+    WhatsAppSecretaryListenResult,
     WhatsAppWebLoginResult,
     WhatsAppWebLoginStatus,
     WhatsAppWebMessage,
@@ -20,14 +21,17 @@ from apps.meta.services import (
     _read_cursor,
     _with_whatsapp_page,
     _write_cursor,
+    build_whatsapp_secretary_prompt,
     build_whatsapp_web_messages,
     cursor_file_for_profile,
     cursor_key_for_profile,
     detect_whatsapp_web_login_state,
     filter_whatsapp_web_messages,
+    listen_for_whatsapp_secretary_requests,
     normalize_whatsapp_phone,
     parse_cli_date,
     read_whatsapp_web_messages,
+    secretary_request_text_from_messages,
 )
 
 
@@ -227,6 +231,49 @@ def test_filter_messages_by_date_and_cursor():
     assert filtered == [second]
 
 
+def test_secretary_request_requires_trigger_and_keeps_continuations():
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="out",
+            sender="ARTHEXIS",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="ordinary self note",
+        ),
+        WhatsAppWebMessage(
+            fingerprint="b",
+            index=1,
+            message_id="b",
+            direction="out",
+            sender="ARTHEXIS",
+            timestamp_raw="14:31, 2026-05-01",
+            timestamp_iso="2026-05-01T14:31:00",
+            text="secretary: book the maintenance visit",
+        ),
+        WhatsAppWebMessage(
+            fingerprint="c",
+            index=2,
+            message_id="c",
+            direction="out",
+            sender="ARTHEXIS",
+            timestamp_raw="14:32, 2026-05-01",
+            timestamp_iso="2026-05-01T14:32:00",
+            text="include the charger photos",
+        ),
+    ]
+
+    request = secretary_request_text_from_messages(messages, trigger_prefix="secretary:")
+    prompt = build_whatsapp_secretary_prompt(messages, secretary_name="Mara")
+
+    assert request == "book the maintenance visit\n\ninclude the charger photos"
+    assert prompt.startswith("[SECRETARY] Mara:")
+    assert "ordinary self note" not in prompt
+    assert "book the maintenance visit" in prompt
+
+
 def test_cursor_file_round_trips_atomic_payload(tmp_path):
     cursor_file = tmp_path / "message-cursors.json"
 
@@ -286,6 +333,119 @@ def test_read_new_cursor_advances_to_returned_limited_batch(monkeypatch, tmp_pat
     assert result.cursor_updated is True
     assert _read_cursor(cursor_file, cursor_key) == result.messages[-1].fingerprint
     assert result.messages[-1].fingerprint != all_messages[-1].fingerprint
+
+
+def test_secretary_listener_waits_for_quiet_window_before_launch(tmp_path):
+    profile_dir = tmp_path / "profile-a"
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="out",
+            sender="ARTHEXIS",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="secretary: summarize the quote",
+        ),
+        WhatsAppWebMessage(
+            fingerprint="b",
+            index=1,
+            message_id="b",
+            direction="out",
+            sender="ARTHEXIS",
+            timestamp_raw="14:31, 2026-05-01",
+            timestamp_iso="2026-05-01T14:31:00",
+            text="focus on pending approvals",
+        ),
+    ]
+    reads = iter(
+        [
+            [messages[0]],
+            messages,
+            messages,
+        ]
+    )
+    now = {"value": 0.0}
+    launched_prompts = []
+
+    def fake_read_messages(**kwargs):
+        assert kwargs["only_new"] is True
+        assert kwargs["update_cursor"] is False
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="525551234567",
+            profile_dir=profile_dir,
+            messages=next(reads),
+            cursor_file=cursor_file_for_profile(profile_dir),
+        )
+
+    def fake_sleep(seconds):
+        now["value"] += seconds
+
+    results = listen_for_whatsapp_secretary_requests(
+        phone="5551234567",
+        idle_after_seconds=0,
+        daemon_poll_seconds=60,
+        quiet_window_seconds=60,
+        max_batches=1,
+        read_messages=fake_read_messages,
+        launch_callback=lambda prompt: launched_prompts.append(prompt) or "launched",
+        monotonic=lambda: now["value"],
+        sleep=fake_sleep,
+        idle_seconds=lambda: 999,
+    )
+    cursor_key = cursor_key_for_profile("525551234567", profile_dir)
+
+    assert results[-1].status == "launched"
+    assert results[-1].message_count == 2
+    assert len(launched_prompts) == 1
+    assert "summarize the quote" in launched_prompts[0]
+    assert "focus on pending approvals" in launched_prompts[0]
+    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "b"
+
+
+def test_secretary_listener_ignores_and_advances_untriggered_batch(tmp_path):
+    profile_dir = tmp_path / "profile-a"
+    message = WhatsAppWebMessage(
+        fingerprint="a",
+        index=0,
+        message_id="a",
+        direction="out",
+        sender="ARTHEXIS",
+        timestamp_raw="14:30, 2026-05-01",
+        timestamp_iso="2026-05-01T14:30:00",
+        text="ordinary self note",
+    )
+    now = {"value": 60.0}
+
+    def fake_read_messages(**kwargs):
+        del kwargs
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="525551234567",
+            profile_dir=profile_dir,
+            messages=[message],
+            cursor_file=cursor_file_for_profile(profile_dir),
+        )
+
+    results = listen_for_whatsapp_secretary_requests(
+        phone="5551234567",
+        idle_after_seconds=0,
+        daemon_poll_seconds=60,
+        quiet_window_seconds=60,
+        max_batches=1,
+        read_messages=fake_read_messages,
+        launch_callback=lambda prompt: f"unexpected {prompt}",
+        monotonic=lambda: now["value"],
+        sleep=lambda seconds: now.update(value=now["value"] + seconds),
+        idle_seconds=lambda: 999,
+    )
+    cursor_key = cursor_key_for_profile("525551234567", profile_dir)
+
+    assert results[-1].status == "ignored"
+    assert results[-1].launched is False
+    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "a"
 
 
 def test_whatsapp_login_command_outputs_json(monkeypatch, tmp_path):
@@ -486,3 +646,51 @@ def test_whatsapp_read_command_rejects_negative_limit():
             "--limit",
             "-1",
         )
+
+
+def test_whatsapp_listen_command_outputs_json(monkeypatch, tmp_path):
+    def fake_listen_for_whatsapp_secretary_requests(**kwargs):
+        assert kwargs["phone"] == "5551234567"
+        assert kwargs["trigger_prefix"] == "secretary:"
+        assert kwargs["idle_after_seconds"] == 300
+        assert kwargs["daemon_poll_seconds"] == 60
+        assert kwargs["quiet_window_seconds"] == 60
+        assert kwargs["launch"] is False
+        assert kwargs["max_batches"] == 1
+        assert kwargs["profile_dir"] == tmp_path
+        return [
+            WhatsAppSecretaryListenResult(
+                status="matched",
+                phone="525551234567",
+                message_count=1,
+                launched=False,
+                cursor_updated=True,
+                cursor_file=tmp_path / "message-cursors.json",
+                batch_fingerprint="abc",
+                detail="Secretary request matched.",
+            )
+        ]
+
+    monkeypatch.setattr(
+        whatsapp_command,
+        "listen_for_whatsapp_secretary_requests",
+        fake_listen_for_whatsapp_secretary_requests,
+    )
+    stdout = StringIO()
+
+    call_command(
+        "whatsapp",
+        "listen",
+        "--from",
+        "5551234567",
+        "--profile-dir",
+        str(tmp_path),
+        "--once",
+        "--no-launch",
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "matched"
+    assert payload["message_count"] == 1

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -510,10 +510,15 @@ def test_secretary_launcher_preserves_windows_codex_path(monkeypatch, tmp_path):
 
     detail = launch_codex_secretary_terminal(
         "prompt",
-        codex_command=r"C:\Program Files\Codex\codex.exe",
+        codex_command=r'"C:\Program Files\Codex\codex.exe" --model gpt-5',
     )
 
-    assert captured["command"] == [r"C:\Program Files\Codex\codex.exe", "prompt"]
+    assert captured["command"] == [
+        r"C:\Program Files\Codex\codex.exe",
+        "--model",
+        "gpt-5",
+        "prompt",
+    ]
     assert captured["kwargs"]["state_key"] == "whatsapp-secretary"
     assert "terminal.pid" in detail
 

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -27,6 +27,7 @@ from apps.meta.services import (
     cursor_key_for_profile,
     detect_whatsapp_web_login_state,
     filter_whatsapp_web_messages,
+    launch_codex_secretary_terminal,
     listen_for_whatsapp_secretary_requests,
     normalize_whatsapp_phone,
     parse_cli_date,
@@ -446,6 +447,75 @@ def test_secretary_listener_ignores_and_advances_untriggered_batch(tmp_path):
     assert results[-1].status == "ignored"
     assert results[-1].launched is False
     assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "a"
+
+
+def test_secretary_listener_keeps_cursor_when_launch_fails(tmp_path):
+    profile_dir = tmp_path / "profile-a"
+    message = WhatsAppWebMessage(
+        fingerprint="a",
+        index=0,
+        message_id="a",
+        direction="out",
+        sender="ARTHEXIS",
+        timestamp_raw="14:30, 2026-05-01",
+        timestamp_iso="2026-05-01T14:30:00",
+        text="secretary: open a terminal",
+    )
+    now = {"value": 60.0}
+
+    def fake_read_messages(**kwargs):
+        del kwargs
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="525551234567",
+            profile_dir=profile_dir,
+            messages=[message],
+            cursor_file=cursor_file_for_profile(profile_dir),
+        )
+
+    def fail_launch(prompt):
+        raise RuntimeError(f"launch failed for {prompt[:10]}")
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        listen_for_whatsapp_secretary_requests(
+            phone="5551234567",
+            idle_after_seconds=0,
+            daemon_poll_seconds=60,
+            quiet_window_seconds=60,
+            max_batches=1,
+            read_messages=fake_read_messages,
+            launch_callback=fail_launch,
+            monotonic=lambda: now["value"],
+            sleep=lambda seconds: now.update(value=now["value"] + seconds),
+            idle_seconds=lambda: 999,
+        )
+
+    cursor_key = cursor_key_for_profile("525551234567", profile_dir)
+    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == ""
+
+
+def test_secretary_launcher_preserves_windows_codex_path(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_launch_command_in_terminal(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return tmp_path / "terminal.pid"
+
+    monkeypatch.setattr("apps.meta.services.sys.platform", "win32")
+    monkeypatch.setattr(
+        "apps.terminals.tasks.launch_command_in_terminal",
+        fake_launch_command_in_terminal,
+    )
+
+    detail = launch_codex_secretary_terminal(
+        "prompt",
+        codex_command=r"C:\Program Files\Codex\codex.exe",
+    )
+
+    assert captured["command"] == [r"C:\Program Files\Codex\codex.exe", "prompt"]
+    assert captured["kwargs"]["state_key"] == "whatsapp-secretary"
+    assert "terminal.pid" in detail
 
 
 def test_whatsapp_login_command_outputs_json(monkeypatch, tmp_path):

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
-from pathlib import Path
+import shutil
 import subprocess
+from collections.abc import Sequence
+from pathlib import Path
 
 from celery import shared_task
 from django.conf import settings
@@ -43,6 +46,11 @@ def _can_create_state_dir(base: Path) -> bool:
 
 def _terminal_pid_file(terminal_pk: int) -> Path:
     return _terminal_state_dir() / f"{terminal_pk}.pid"
+
+
+def _named_terminal_pid_file(state_key: str) -> Path:
+    safe_key = re.sub(r"[^A-Za-z0-9_.-]+", "-", state_key).strip(".-")
+    return _terminal_state_dir() / f"{safe_key or 'terminal'}.pid"
 
 
 def _is_process_running(pid: int) -> bool:
@@ -116,22 +124,141 @@ def _build_startup_script(terminal: AgentTerminal) -> str:
     return "\n".join(script_lines)
 
 
-def _launch_terminal(terminal: AgentTerminal) -> None:
+def _powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _command_script(
+    command: Sequence[str],
+    *,
+    working_directory: Path | str | None,
+    shell: str,
+) -> str:
+    if not command:
+        raise ValueError("Terminal command cannot be empty.")
+    if shell == "powershell":
+        lines = []
+        if working_directory:
+            lines.append(f"Set-Location -LiteralPath {_powershell_quote(str(working_directory))}")
+        executable, *args = [str(part) for part in command]
+        joined_args = " ".join(_powershell_quote(arg) for arg in args)
+        suffix = f" {joined_args}" if joined_args else ""
+        lines.append(f"& {_powershell_quote(executable)}{suffix}")
+        return "\n".join(lines)
+    lines = []
+    if working_directory:
+        lines.append(f"cd {shlex.quote(str(working_directory))}")
+    lines.append(shlex.join(str(part) for part in command))
+    return "\n".join(lines)
+
+
+def _write_windows_startup_script(state_key: str, startup_script: str) -> Path:
+    script_dir = _terminal_state_dir() / "scripts"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script_path = script_dir / f"{re.sub(r'[^A-Za-z0-9_.-]+', '-', state_key).strip('.-') or 'terminal'}.ps1"
+    script_path.write_text(startup_script, encoding="utf-8")
+    return script_path
+
+
+def _windows_terminal_command(
+    *,
+    script_path: Path,
+    title: str,
+    executable: str = "",
+) -> list[str]:
+    terminal = executable.strip()
+    if not terminal or terminal == "x-terminal-emulator":
+        terminal = shutil.which("wt.exe") or shutil.which("wt") or ""
+    powershell = shutil.which("powershell.exe") or "powershell.exe"
+    if terminal:
+        return [
+            terminal,
+            "new-tab",
+            "--title",
+            title,
+            powershell,
+            "-NoExit",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+        ]
+    return [
+        powershell,
+        "-NoExit",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script_path),
+    ]
+
+
+def _launch_startup_script(
+    startup_script: str,
+    *,
+    executable: str = "",
+    title: str = "Arthexis Agent Terminal",
+    state_key: str = "terminal",
+) -> Path:
     pid_dir = _terminal_state_dir()
     pid_dir.mkdir(parents=True, exist_ok=True)
-    pid_file = _terminal_pid_file(terminal.pk)
+    pid_file = _named_terminal_pid_file(state_key)
+    if _is_windows():
+        script_path = _write_windows_startup_script(state_key, startup_script)
+        command = _windows_terminal_command(
+            script_path=script_path,
+            title=title,
+            executable=executable,
+        )
+    else:
+        command = [*shlex.split(executable or "x-terminal-emulator")]
+        if startup_script:
+            command.extend(["-e", "sh", "-lc", startup_script])
+    process = subprocess.Popen(command)
+    pid_file.write_text(f"{process.pid}\n{' '.join(command)}\n", encoding="utf-8")
+    return pid_file
+
+
+def launch_command_in_terminal(
+    command: Sequence[str],
+    *,
+    title: str = "Arthexis Agent Terminal",
+    state_key: str = "terminal",
+    working_directory: Path | str | None = None,
+    executable: str = "",
+) -> Path:
+    startup_script = _command_script(
+        command,
+        working_directory=working_directory,
+        shell="powershell" if _is_windows() else "sh",
+    )
+    return _launch_startup_script(
+        startup_script,
+        executable=executable,
+        title=title,
+        state_key=state_key,
+    )
+
+
+def _launch_terminal(terminal: AgentTerminal) -> None:
     executable = terminal.resolved_executable()
     startup_script = _build_startup_script(terminal)
     if _is_windows():
-        raise RuntimeError(
-            "_launch_terminal does not support Windows POSIX shell launch "
-            f"for terminal pk={terminal.pk!r}; startup-script-present={bool(startup_script)!r}"
+        _launch_startup_script(
+            startup_script,
+            executable=executable,
+            title=terminal.name or "Arthexis Agent Terminal",
+            state_key=str(terminal.pk),
         )
+        return
+    pid_dir = _terminal_state_dir()
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = _terminal_pid_file(terminal.pk)
     command = [*shlex.split(executable)]
     if startup_script:
         command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{' '.join(command)}\n")
+    pid_file.write_text(f"{process.pid}\n{' '.join(command)}\n", encoding="utf-8")
 
 
 def _matches_current_node_role(terminal: AgentTerminal) -> bool:

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -128,6 +128,10 @@ def _powershell_quote(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+def _split_windows_command(value: str) -> list[str]:
+    return [part.strip("\"") for part in shlex.split(value, posix=False)]
+
+
 def _command_script(
     command: Sequence[str],
     *,
@@ -168,11 +172,14 @@ def _windows_terminal_command(
 ) -> list[str]:
     terminal = executable.strip()
     if not terminal or terminal == "x-terminal-emulator":
-        terminal = shutil.which("wt.exe") or shutil.which("wt") or ""
+        terminal_path = shutil.which("wt.exe") or shutil.which("wt") or ""
+        terminal_parts = [terminal_path] if terminal_path else []
+    else:
+        terminal_parts = _split_windows_command(terminal)
     powershell = shutil.which("powershell.exe") or "powershell.exe"
-    if terminal:
+    if terminal_parts:
         return [
-            terminal,
+            *terminal_parts,
             "new-tab",
             "--title",
             title,
@@ -215,7 +222,7 @@ def _launch_startup_script(
         if startup_script:
             command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{' '.join(command)}\n", encoding="utf-8")
+    pid_file.write_text(f"{process.pid}\n{shlex.join(command)}\n", encoding="utf-8")
     return pid_file
 
 
@@ -258,7 +265,7 @@ def _launch_terminal(terminal: AgentTerminal) -> None:
     if startup_script:
         command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{' '.join(command)}\n", encoding="utf-8")
+    pid_file.write_text(f"{process.pid}\n{shlex.join(command)}\n", encoding="utf-8")
 
 
 def _matches_current_node_role(terminal: AgentTerminal) -> bool:

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -78,7 +78,9 @@ def _process_commandline(pid: int) -> str:
     if not proc_cmdline.exists():
         return ""
     try:
-        return proc_cmdline.read_bytes().decode(errors="ignore").replace("\x00", " ").strip()
+        return _command_metadata(
+            proc_cmdline.read_bytes().decode(errors="ignore").split("\x00")
+        )
     except OSError:
         return ""
 
@@ -122,6 +124,10 @@ def _build_startup_script(terminal: AgentTerminal) -> str:
             continue
         script_lines.append(text)
     return "\n".join(script_lines)
+
+
+def _command_metadata(command: Sequence[str]) -> str:
+    return " ".join(" ".join(str(part).split()) for part in command if str(part).strip())
 
 
 def _powershell_quote(value: str) -> str:
@@ -222,7 +228,7 @@ def _launch_startup_script(
         if startup_script:
             command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{shlex.join(command)}\n", encoding="utf-8")
+    pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
     return pid_file
 
 
@@ -265,7 +271,7 @@ def _launch_terminal(terminal: AgentTerminal) -> None:
     if startup_script:
         command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{shlex.join(command)}\n", encoding="utf-8")
+    pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
 
 
 def _matches_current_node_role(terminal: AgentTerminal) -> bool:

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -1,14 +1,13 @@
+import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
-import pytest
 
 from apps.core.admin import OwnableAdminForm
 from apps.groups.models import SecurityGroup
 from apps.terminals import tasks
 from apps.terminals.admin import AgentTerminalAdmin
 from apps.terminals.models import AgentTerminal
-
 
 User = get_user_model()
 
@@ -34,18 +33,66 @@ def test_admin_disables_add_permission(db):
     assert admin.has_add_permission(request) is False
 
 
-def test_launch_terminal_fails_fast_on_windows_before_posix_shell(tmp_path, monkeypatch):
+def test_launch_terminal_uses_powershell_script_on_windows(tmp_path, monkeypatch):
     monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
     monkeypatch.setattr(tasks, "_is_windows", lambda: True)
+    monkeypatch.setattr(tasks.shutil, "which", lambda name: None)
+    launched = {}
+
+    class FakeProcess:
+        pid = 1234
+
+    def fake_popen(command):
+        launched["command"] = command
+        return FakeProcess()
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", fake_popen)
     terminal = AgentTerminal(name="windows-terminal", launch_command="echo ready")
 
-    with pytest.raises(RuntimeError, match="_launch_terminal") as exc_info:
-        tasks._launch_terminal(terminal)
+    tasks._launch_terminal(terminal)
 
-    message = str(exc_info.value)
-    assert "echo ready" not in message
-    assert "startup_script=" not in message
-    assert "executable=" not in message
+    assert launched["command"][:4] == [
+        "powershell.exe",
+        "-NoExit",
+        "-ExecutionPolicy",
+        "Bypass",
+    ]
+    script_path = tmp_path / "scripts" / "None.ps1"
+    assert script_path.read_text(encoding="utf-8") == "echo ready"
+    assert (tmp_path / "None.pid").exists()
+
+
+def test_launch_command_in_terminal_builds_windows_codex_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(tasks, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        tasks.shutil,
+        "which",
+        lambda name: "wt.exe" if name == "wt.exe" else None,
+    )
+    launched = {}
+
+    class FakeProcess:
+        pid = 5678
+
+    def fake_popen(command):
+        launched["command"] = command
+        return FakeProcess()
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", fake_popen)
+
+    pid_file = tasks.launch_command_in_terminal(
+        ["codex", "[SECRETARY] Mara:\nOperator request"],
+        title="Arthexis Secretary",
+        state_key="whatsapp-secretary",
+        working_directory=tmp_path / "repo",
+    )
+
+    assert launched["command"][:4] == ["wt.exe", "new-tab", "--title", "Arthexis Secretary"]
+    assert pid_file == tmp_path / "whatsapp-secretary.pid"
+    script = (tmp_path / "scripts" / "whatsapp-secretary.ps1").read_text(encoding="utf-8")
+    assert "Set-Location -LiteralPath" in script
+    assert "& 'codex' '[SECRETARY] Mara:" in script
 
 
 def test_is_process_running_handles_windows_value_error(monkeypatch):

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -95,6 +95,30 @@ def test_launch_command_in_terminal_builds_windows_codex_command(tmp_path, monke
     assert "& 'codex' '[SECRETARY] Mara:" in script
 
 
+def test_windows_terminal_executable_supports_arguments(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(tasks, "_is_windows", lambda: True)
+    monkeypatch.setattr(tasks.shutil, "which", lambda name: None)
+    launched = {}
+
+    class FakeProcess:
+        pid = 9012
+
+    def fake_popen(command):
+        launched["command"] = command
+        return FakeProcess()
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", fake_popen)
+
+    tasks.launch_command_in_terminal(
+        ["codex", "prompt"],
+        executable="wt.exe -w 0",
+        state_key="custom-wt",
+    )
+
+    assert launched["command"][:5] == ["wt.exe", "-w", "0", "new-tab", "--title"]
+
+
 def test_is_process_running_handles_windows_value_error(monkeypatch):
     def raise_value_error(pid, signal_number):
         raise ValueError("invalid pid")

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -148,6 +148,16 @@ def test_terminal_state_dir_falls_back_to_tmp_when_posix_state_home_is_unwritabl
     assert tasks._terminal_state_dir() == tmp_path / "tmp" / "arthexis-agent-terminals"
 
 
+def test_command_metadata_is_unquoted_and_single_line():
+    metadata = tasks._command_metadata(
+        ["x-terminal-emulator", "-e", "sh", "-lc", "echo ready\nprintf done"]
+    )
+
+    assert metadata == "x-terminal-emulator -e sh -lc echo ready printf done"
+    assert "\n" not in metadata
+    assert "'" not in metadata
+
+
 def test_admin_owner_fields_remain_editable_for_ownable_validation(db):
     admin = AgentTerminalAdmin(AgentTerminal, AdminSite())
     request = RequestFactory().get("/admin/terminals/agentterminal/")

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -15,10 +15,11 @@ Supported in this version:
 - Read visible messages from one phone-number chat on demand.
 - Filter read output by `--date`, `--since`, `--until`, or a local `--new`
   cursor.
+- Poll an operator self-chat in listener mode and launch a Codex Secretary
+  terminal for triggered requests.
 
 Not supported in this version:
 
-- Polling or background message ingestion.
 - Group chat automation.
 - Bulk messaging.
 - Attachments or media download.
@@ -71,6 +72,24 @@ Read only messages after the local cursor and then advance that cursor:
 python manage.py whatsapp read --from 525551234567 --new --json
 ```
 
+Listen for Secretary requests in the operator self-chat:
+
+```powershell
+python manage.py whatsapp listen --from 525551234567
+```
+
+By default, listener mode waits until the desktop has been idle for 300 seconds,
+polls WhatsApp once every 60 seconds, and processes a batch only after 60 seconds
+pass without additional new messages. A message must start with `secretary:` to
+launch a terminal. Messages that arrive after the first triggered message during
+the same quiet batch are included as continuation text.
+
+Run one local dry pass after a quiet batch without launching Codex:
+
+```powershell
+python manage.py whatsapp listen --from 525551234567 --once --no-launch --json
+```
+
 Attach to an already-open Edge debugging session:
 
 ```powershell
@@ -89,4 +108,10 @@ the local Arthexis cursor, but WhatsApp's own read state may still change.
 
 The `--new` cursor is local to the browser profile path and phone number. It
 returns the next visible batch after the stored cursor and advances only after an
-explicit on-demand read. It is not a poller and does not run in the background.
+explicit on-demand read or after listener mode finishes processing or ignoring a
+quiet batch.
+
+Listener mode is intentionally conservative. The default `secretary:` trigger
+prevents ordinary self-chat notes from launching local terminals. Use
+`--trigger-prefix ""` only when every new self-chat message should become a
+Secretary request.


### PR DESCRIPTION
## Summary
- add `manage.py whatsapp listen` for operator self-chat Secretary requests
- gate listener polling behind 5 minutes of desktop inactivity, poll every minute, and debounce batches for a full quiet minute
- launch Codex Secretary prompts through cross-platform terminal helpers, including Windows Terminal/PowerShell support
- document listener safety defaults and add focused WhatsApp/terminal tests

Closes #7551

## Validation
- `python -m ruff check apps\meta\services.py apps\meta\management\commands\whatsapp.py apps\meta\tests\test_whatsapp.py apps\terminals\tasks.py apps\terminals\tests\test_terminals_smoke.py`
- `python -m pytest apps\meta\tests\test_whatsapp.py apps\terminals\tests\test_terminals_smoke.py -q`
- `python manage.py whatsapp listen --help`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `git diff --check`