### PR TITLE
Add admin Codex skill package import

### DIFF
--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -248,6 +248,16 @@ class AgentSkillAdmin(admin.ModelAdmin):
             return str(entry.get("name") or "")
         return str(entry or "")
 
+    def _import_package_entry_expired(self, entry, *, now=None) -> bool:
+        if not isinstance(entry, dict):
+            return True
+        try:
+            previewed_at = float(entry.get("ts"))
+        except (TypeError, ValueError):
+            return True
+        now = now or timezone.now()
+        return previewed_at < now.timestamp() - _IMPORT_PREVIEW_TTL_SECONDS
+
     def _consume_import_package(
         self,
         request: HttpRequest,
@@ -259,6 +269,9 @@ class AgentSkillAdmin(admin.ModelAdmin):
         request.session.modified = True
         storage_name = self._import_package_entry_name(entry)
         if not storage_name:
+            return None
+        if self._import_package_entry_expired(entry):
+            self._delete_import_upload(storage_name)
             return None
         try:
             exists = default_storage.exists(storage_name)

--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import json
-import time
-from pathlib import Path
-from tempfile import NamedTemporaryFile, gettempdir
+from datetime import timedelta
 from uuid import uuid4
 from zipfile import BadZipFile
 
 from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
+from django.core.files.storage import default_storage
 from django.http import HttpRequest, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
 
 from .forms import CodexSkillPackageImportForm
@@ -22,6 +22,7 @@ from .package_services import (
 )
 
 _SESSION_IMPORT_PACKAGES_KEY = "skills_agentskill_import_packages"
+_IMPORT_UPLOAD_STORAGE_DIR = "skills/imports"
 _IMPORT_UPLOAD_PREFIX = "agentskill-package-"
 _IMPORT_PREVIEW_TTL_SECONDS = 60 * 60
 _PACKAGE_IMPORT_ERRORS = (
@@ -88,11 +89,12 @@ class AgentSkillAdmin(admin.ModelAdmin):
         if request.method == "POST":
             form = CodexSkillPackageImportForm(request.POST, request.FILES)
             if form.is_valid():
-                upload_path = self._store_import_upload(form.cleaned_data["package"])
+                upload_name = self._store_import_upload(form.cleaned_data["package"])
                 try:
-                    preview = import_codex_skill_package(upload_path, dry_run=True)
+                    with default_storage.open(upload_name, "rb") as upload_file:
+                        preview = import_codex_skill_package(upload_file, dry_run=True)
                 except _PACKAGE_IMPORT_ERRORS as error:
-                    upload_path.unlink(missing_ok=True)
+                    self._delete_import_upload(upload_name)
                     self.message_user(
                         request,
                         _("Could not preview Codex skill package: %(error)s")
@@ -102,7 +104,7 @@ class AgentSkillAdmin(admin.ModelAdmin):
                 else:
                     preview_token = self._remember_import_package(
                         request,
-                        upload_path,
+                        upload_name,
                     )
                     self.message_user(
                         request,
@@ -148,8 +150,17 @@ class AgentSkillAdmin(admin.ModelAdmin):
             return HttpResponseRedirect(import_url)
 
         try:
-            import_codex_skill_package(package_path, dry_run=True)
-            summary = import_codex_skill_package(package_path, dry_run=False)
+            with default_storage.open(package_path, "rb") as upload_file:
+                import_codex_skill_package(upload_file, dry_run=True)
+            with default_storage.open(package_path, "rb") as upload_file:
+                summary = import_codex_skill_package(upload_file, dry_run=False)
+        except FileNotFoundError:
+            self.message_user(
+                request,
+                _("The package preview expired. Upload the package again."),
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(import_url)
         except _PACKAGE_IMPORT_ERRORS as error:
             self.message_user(
                 request,
@@ -158,7 +169,7 @@ class AgentSkillAdmin(admin.ModelAdmin):
             )
             return HttpResponseRedirect(import_url)
         finally:
-            package_path.unlink(missing_ok=True)
+            self._delete_import_upload(package_path)
 
         self.message_user(
             request,
@@ -171,67 +182,91 @@ class AgentSkillAdmin(admin.ModelAdmin):
         )
         return HttpResponseRedirect(reverse("admin:skills_agentskill_changelist"))
 
-    def _store_import_upload(self, uploaded_file) -> Path:
-        with NamedTemporaryFile(
-            delete=False,
-            dir=gettempdir(),
-            prefix=_IMPORT_UPLOAD_PREFIX,
-            suffix=".zip",
-        ) as temp_file:
-            for chunk in uploaded_file.chunks():
-                temp_file.write(chunk)
-            return Path(temp_file.name)
+    def _store_import_upload(self, uploaded_file) -> str:
+        if hasattr(uploaded_file, "seek"):
+            uploaded_file.seek(0)
+        storage_name = (
+            f"{_IMPORT_UPLOAD_STORAGE_DIR}/{_IMPORT_UPLOAD_PREFIX}{uuid4().hex}.zip"
+        )
+        return default_storage.save(storage_name, uploaded_file)
 
-    def _cleanup_expired_import_uploads(self, now: float | None = None) -> None:
-        now = now or time.time()
-        cutoff = now - _IMPORT_PREVIEW_TTL_SECONDS
-        for package_path in Path(gettempdir()).glob(f"{_IMPORT_UPLOAD_PREFIX}*.zip"):
+    def _cleanup_expired_import_uploads(self, now=None) -> None:
+        now = now or timezone.now()
+        cutoff = now - timedelta(seconds=_IMPORT_PREVIEW_TTL_SECONDS)
+        for storage_name in self._iter_import_upload_names():
             try:
-                if package_path.stat().st_mtime < cutoff:
-                    package_path.unlink(missing_ok=True)
-            except OSError:
+                modified_at = default_storage.get_modified_time(storage_name)
+            except (AttributeError, FileNotFoundError, NotImplementedError, OSError):
                 continue
+            if timezone.is_naive(modified_at):
+                modified_at = timezone.make_aware(
+                    modified_at,
+                    timezone.get_current_timezone(),
+                )
+            if modified_at < cutoff:
+                self._delete_import_upload(storage_name)
+
+    def _iter_import_upload_names(self) -> list[str]:
+        try:
+            _, filenames = default_storage.listdir(_IMPORT_UPLOAD_STORAGE_DIR)
+        except (FileNotFoundError, NotImplementedError, OSError):
+            return []
+        return [
+            f"{_IMPORT_UPLOAD_STORAGE_DIR}/{filename}"
+            for filename in filenames
+            if filename.startswith(_IMPORT_UPLOAD_PREFIX) and filename.endswith(".zip")
+        ]
+
+    def _delete_import_upload(self, storage_name: str) -> None:
+        if not storage_name:
+            return
+        try:
+            default_storage.delete(storage_name)
+        except (FileNotFoundError, NotImplementedError, OSError):
+            return
 
     def _remember_import_package(
         self,
         request: HttpRequest,
-        package_path: Path,
+        storage_name: str,
     ) -> str:
-        now = time.time()
+        now = timezone.now()
         self._cleanup_expired_import_uploads(now=now)
         packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
         for existing_entry in packages.values():
-            existing_path = self._import_package_entry_path(existing_entry)
-            if existing_path:
-                Path(existing_path).unlink(missing_ok=True)
+            existing_name = self._import_package_entry_name(existing_entry)
+            self._delete_import_upload(existing_name)
         packages = {}
         token = uuid4().hex
-        packages[token] = {"path": str(package_path), "ts": now}
+        packages[token] = {"name": storage_name, "ts": now.timestamp()}
         request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
         request.session.modified = True
         return token
 
-    def _import_package_entry_path(self, entry) -> str:
+    def _import_package_entry_name(self, entry) -> str:
         if isinstance(entry, dict):
-            return str(entry.get("path") or "")
+            return str(entry.get("name") or "")
         return str(entry or "")
 
     def _consume_import_package(
         self,
         request: HttpRequest,
         token: str,
-    ) -> Path | None:
+    ) -> str | None:
         packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
         entry = packages.pop(token, None)
         request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
         request.session.modified = True
-        raw_path = self._import_package_entry_path(entry)
-        if not raw_path:
+        storage_name = self._import_package_entry_name(entry)
+        if not storage_name:
             return None
-        package_path = Path(raw_path)
-        if not package_path.exists():
+        try:
+            exists = default_storage.exists(storage_name)
+        except (NotImplementedError, OSError):
+            exists = False
+        if not exists:
             return None
-        return package_path
+        return storage_name
 
     def _summary_message(self, summary: dict, *, singular, plural) -> str:
         skills = summary.get("skills", [])

--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
 from uuid import uuid4
 from zipfile import BadZipFile
 
@@ -15,15 +16,19 @@ from django.utils.translation import gettext_lazy as _, ngettext
 
 from .forms import CodexSkillPackageImportForm
 from .models import AgentSkill, AgentSkillFile
-from .package_services import import_codex_skill_package
+from .package_services import (
+    CodexSkillPackageImportError,
+    import_codex_skill_package,
+)
 
 _SESSION_IMPORT_PACKAGES_KEY = "skills_agentskill_import_packages"
+_IMPORT_UPLOAD_PREFIX = "agentskill-package-"
+_IMPORT_PREVIEW_TTL_SECONDS = 60 * 60
 _PACKAGE_IMPORT_ERRORS = (
     BadZipFile,
-    KeyError,
-    UnicodeDecodeError,
-    ValueError,
     json.JSONDecodeError,
+    UnicodeDecodeError,
+    CodexSkillPackageImportError,
 )
 
 
@@ -76,6 +81,7 @@ class AgentSkillAdmin(admin.ModelAdmin):
         if request.method == "POST" and request.POST.get("action") == "apply":
             return self._apply_import_package(request)
 
+        self._cleanup_expired_import_uploads()
         form = CodexSkillPackageImportForm()
         preview = None
         preview_token = ""
@@ -168,27 +174,47 @@ class AgentSkillAdmin(admin.ModelAdmin):
     def _store_import_upload(self, uploaded_file) -> Path:
         with NamedTemporaryFile(
             delete=False,
-            prefix="agentskill-package-",
+            dir=gettempdir(),
+            prefix=_IMPORT_UPLOAD_PREFIX,
             suffix=".zip",
         ) as temp_file:
             for chunk in uploaded_file.chunks():
                 temp_file.write(chunk)
             return Path(temp_file.name)
 
+    def _cleanup_expired_import_uploads(self, now: float | None = None) -> None:
+        now = now or time.time()
+        cutoff = now - _IMPORT_PREVIEW_TTL_SECONDS
+        for package_path in Path(gettempdir()).glob(f"{_IMPORT_UPLOAD_PREFIX}*.zip"):
+            try:
+                if package_path.stat().st_mtime < cutoff:
+                    package_path.unlink(missing_ok=True)
+            except OSError:
+                continue
+
     def _remember_import_package(
         self,
         request: HttpRequest,
         package_path: Path,
     ) -> str:
+        now = time.time()
+        self._cleanup_expired_import_uploads(now=now)
         packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
-        for existing_path in packages.values():
-            Path(existing_path).unlink(missing_ok=True)
+        for existing_entry in packages.values():
+            existing_path = self._import_package_entry_path(existing_entry)
+            if existing_path:
+                Path(existing_path).unlink(missing_ok=True)
         packages = {}
         token = uuid4().hex
-        packages[token] = str(package_path)
+        packages[token] = {"path": str(package_path), "ts": now}
         request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
         request.session.modified = True
         return token
+
+    def _import_package_entry_path(self, entry) -> str:
+        if isinstance(entry, dict):
+            return str(entry.get("path") or "")
+        return str(entry or "")
 
     def _consume_import_package(
         self,
@@ -196,9 +222,10 @@ class AgentSkillAdmin(admin.ModelAdmin):
         token: str,
     ) -> Path | None:
         packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
-        raw_path = packages.pop(token, None)
+        entry = packages.pop(token, None)
         request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
         request.session.modified = True
+        raw_path = self._import_package_entry_path(entry)
         if not raw_path:
             return None
         package_path = Path(raw_path)

--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -1,6 +1,30 @@
-from django.contrib import admin
+from __future__ import annotations
 
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from uuid import uuid4
+from zipfile import BadZipFile
+
+from django.contrib import admin, messages
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy as _, ngettext
+
+from .forms import CodexSkillPackageImportForm
 from .models import AgentSkill, AgentSkillFile
+from .package_services import import_codex_skill_package
+
+_SESSION_IMPORT_PACKAGES_KEY = "skills_agentskill_import_packages"
+_PACKAGE_IMPORT_ERRORS = (
+    BadZipFile,
+    KeyError,
+    UnicodeDecodeError,
+    ValueError,
+    json.JSONDecodeError,
+)
 
 
 class AgentSkillFileInline(admin.TabularInline):
@@ -22,6 +46,174 @@ class AgentSkillAdmin(admin.ModelAdmin):
     search_fields = ("slug", "title", "markdown")
     filter_horizontal = ("node_roles",)
     inlines = (AgentSkillFileInline,)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "import-package/",
+                self.admin_site.admin_view(self.import_package_view),
+                name="skills_agentskill_import_package",
+            ),
+        ]
+        return custom + urls
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = dict(extra_context or {})
+        if self.has_import_package_permission(request):
+            extra_context["model_import_url"] = reverse(
+                "admin:skills_agentskill_import_package",
+            )
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def has_import_package_permission(self, request: HttpRequest) -> bool:
+        return self.has_add_permission(request) and self.has_change_permission(request)
+
+    def import_package_view(self, request: HttpRequest):
+        if not self.has_import_package_permission(request):
+            raise PermissionDenied
+
+        if request.method == "POST" and request.POST.get("action") == "apply":
+            return self._apply_import_package(request)
+
+        form = CodexSkillPackageImportForm()
+        preview = None
+        preview_token = ""
+        if request.method == "POST":
+            form = CodexSkillPackageImportForm(request.POST, request.FILES)
+            if form.is_valid():
+                upload_path = self._store_import_upload(form.cleaned_data["package"])
+                try:
+                    preview = import_codex_skill_package(upload_path, dry_run=True)
+                except _PACKAGE_IMPORT_ERRORS as error:
+                    upload_path.unlink(missing_ok=True)
+                    self.message_user(
+                        request,
+                        _("Could not preview Codex skill package: %(error)s")
+                        % {"error": error},
+                        level=messages.ERROR,
+                    )
+                else:
+                    preview_token = self._remember_import_package(
+                        request,
+                        upload_path,
+                    )
+                    self.message_user(
+                        request,
+                        self._summary_message(
+                            preview,
+                            singular=_(
+                                "Previewed %(skill_count)d skill with %(file_count)d file."
+                            ),
+                            plural=_(
+                                "Previewed %(skill_count)d skills with %(file_count)d files."
+                            ),
+                        ),
+                        level=messages.SUCCESS,
+                    )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "title": _("Import Codex skill package"),
+            "form": form,
+            "preview": preview,
+            "preview_token": preview_token,
+            "changelist_url": reverse("admin:skills_agentskill_changelist"),
+        }
+        return TemplateResponse(
+            request,
+            "admin/skills/agentskill/import_package.html",
+            context,
+        )
+
+    def _apply_import_package(self, request: HttpRequest) -> HttpResponseRedirect:
+        package_path = self._consume_import_package(
+            request,
+            request.POST.get("token", ""),
+        )
+        import_url = reverse("admin:skills_agentskill_import_package")
+        if package_path is None:
+            self.message_user(
+                request,
+                _("The package preview expired. Upload the package again."),
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(import_url)
+
+        try:
+            import_codex_skill_package(package_path, dry_run=True)
+            summary = import_codex_skill_package(package_path, dry_run=False)
+        except _PACKAGE_IMPORT_ERRORS as error:
+            self.message_user(
+                request,
+                _("Could not import Codex skill package: %(error)s") % {"error": error},
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(import_url)
+        finally:
+            package_path.unlink(missing_ok=True)
+
+        self.message_user(
+            request,
+            self._summary_message(
+                summary,
+                singular=_("Imported %(skill_count)d skill with %(file_count)d file."),
+                plural=_("Imported %(skill_count)d skills with %(file_count)d files."),
+            ),
+            level=messages.SUCCESS,
+        )
+        return HttpResponseRedirect(reverse("admin:skills_agentskill_changelist"))
+
+    def _store_import_upload(self, uploaded_file) -> Path:
+        with NamedTemporaryFile(
+            delete=False,
+            prefix="agentskill-package-",
+            suffix=".zip",
+        ) as temp_file:
+            for chunk in uploaded_file.chunks():
+                temp_file.write(chunk)
+            return Path(temp_file.name)
+
+    def _remember_import_package(
+        self,
+        request: HttpRequest,
+        package_path: Path,
+    ) -> str:
+        packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
+        for existing_path in packages.values():
+            Path(existing_path).unlink(missing_ok=True)
+        packages = {}
+        token = uuid4().hex
+        packages[token] = str(package_path)
+        request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
+        request.session.modified = True
+        return token
+
+    def _consume_import_package(
+        self,
+        request: HttpRequest,
+        token: str,
+    ) -> Path | None:
+        packages = dict(request.session.get(_SESSION_IMPORT_PACKAGES_KEY, {}))
+        raw_path = packages.pop(token, None)
+        request.session[_SESSION_IMPORT_PACKAGES_KEY] = packages
+        request.session.modified = True
+        if not raw_path:
+            return None
+        package_path = Path(raw_path)
+        if not package_path.exists():
+            return None
+        return package_path
+
+    def _summary_message(self, summary: dict, *, singular, plural) -> str:
+        skills = summary.get("skills", [])
+        skill_count = len(skills)
+        file_count = sum(int(skill.get("files", 0)) for skill in skills)
+        return ngettext(singular, plural, skill_count) % {
+            "skill_count": skill_count,
+            "file_count": file_count,
+        }
 
 
 @admin.register(AgentSkillFile)

--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -198,7 +198,12 @@ class AgentSkillAdmin(admin.ModelAdmin):
                 modified_at = default_storage.get_modified_time(storage_name)
             except (AttributeError, FileNotFoundError, NotImplementedError, OSError):
                 continue
-            if timezone.is_naive(modified_at):
+            if timezone.is_naive(cutoff) and timezone.is_aware(modified_at):
+                modified_at = timezone.make_naive(
+                    modified_at,
+                    timezone.get_current_timezone(),
+                )
+            elif timezone.is_aware(cutoff) and timezone.is_naive(modified_at):
                 modified_at = timezone.make_aware(
                     modified_at,
                     timezone.get_current_timezone(),

--- a/apps/skills/forms.py
+++ b/apps/skills/forms.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+
+class CodexSkillPackageImportForm(forms.Form):
+    package = forms.FileField(
+        label=_("Codex skill package"),
+        help_text=_("Upload a .zip package exported from Codex skill packages."),
+        widget=forms.ClearableFileInput(
+            attrs={"accept": ".zip,application/zip,application/x-zip-compressed"},
+        ),
+    )
+
+    def clean_package(self):
+        package = self.cleaned_data["package"]
+        if not package.name.lower().endswith(".zip"):
+            raise forms.ValidationError(_("Upload a .zip Codex skill package."))
+        return package

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -54,6 +54,10 @@ OPERATOR_PATH_MARKERS = (
 )
 
 
+class CodexSkillPackageImportError(ValueError):
+    """Raised when an uploaded Codex skill package fails validation."""
+
+
 @dataclass(frozen=True)
 class SkillFileClassification:
     portability: str
@@ -400,38 +404,62 @@ def _read_package_text(package: ZipFile, archive_path: str) -> str:
     try:
         content = package.read(archive_path)
     except KeyError as error:
-        raise ValueError(f"Missing package file: {archive_path}") from error
+        raise CodexSkillPackageImportError(
+            f"Missing package file: {archive_path}"
+        ) from error
     try:
         return content.decode("utf-8")
     except UnicodeDecodeError as error:
-        raise ValueError(f"Invalid UTF-8 package file: {archive_path}") from error
+        raise CodexSkillPackageImportError(
+            f"Invalid UTF-8 package file: {archive_path}"
+        ) from error
 
 
 def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[dict]:
     validated_skills = []
     seen_slugs = set()
     for skill_entry in manifest.get("skills", []):
-        slug = validate_package_skill_slug(skill_entry["slug"])
+        try:
+            slug = validate_package_skill_slug(skill_entry["slug"])
+        except KeyError as error:
+            raise CodexSkillPackageImportError(
+                "Missing required package skill slug"
+            ) from error
+        except ValueError as error:
+            raise CodexSkillPackageImportError(str(error)) from error
         if slug in seen_slugs:
-            raise ValueError(f"Duplicate package skill slug: {slug}")
+            raise CodexSkillPackageImportError(
+                f"Duplicate package skill slug: {slug}"
+            )
         seen_slugs.add(slug)
         seen_paths = set()
         content_by_path = {}
-        validated_files = [
-            {
-                **file_info,
-                "path": validate_package_relative_path(file_info["path"]),
-            }
-            for file_info in skill_entry.get("files", [])
-        ]
+        try:
+            validated_files = [
+                {
+                    **file_info,
+                    "path": validate_package_relative_path(file_info["path"]),
+                }
+                for file_info in skill_entry.get("files", [])
+            ]
+        except KeyError as error:
+            raise CodexSkillPackageImportError(
+                "Missing required package file path"
+            ) from error
+        except ValueError as error:
+            raise CodexSkillPackageImportError(str(error)) from error
         for file_info in validated_files:
             if file_info["path"] in seen_paths:
-                raise ValueError(f"Duplicate package file path: {file_info['path']}")
+                raise CodexSkillPackageImportError(
+                    f"Duplicate package file path: {file_info['path']}"
+                )
             if (
                 file_info["path"] == SKILL_MARKDOWN
                 and file_info.get("included_by_default") is False
             ):
-                raise ValueError(f"{SKILL_MARKDOWN} must be included")
+                raise CodexSkillPackageImportError(
+                    f"{SKILL_MARKDOWN} must be included"
+                )
             seen_paths.add(file_info["path"])
             archive_path = f"skills/{slug}/{file_info['path']}"
             content_by_path[file_info["path"]] = _read_package_text(
@@ -439,7 +467,9 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
                 archive_path,
             )
         if SKILL_MARKDOWN not in content_by_path:
-            raise ValueError(f"Missing required {SKILL_MARKDOWN} for skill: {slug}")
+            raise CodexSkillPackageImportError(
+                f"Missing required {SKILL_MARKDOWN} for skill: {slug}"
+            )
         validated_skills.append(
             {
                 **skill_entry,
@@ -688,7 +718,9 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
     with ZipFile(package_path) as package:
         manifest = json.loads(package.read("manifest.json").decode("utf-8"))
         if manifest.get("format") != PACKAGE_FORMAT:
-            raise ValueError("Unsupported Codex skill package format")
+            raise CodexSkillPackageImportError(
+                "Unsupported Codex skill package format"
+            )
         validated_skills = _validate_manifest_skill_entries(package, manifest)
         summary = {
             "package": str(package_path),

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -416,9 +416,16 @@ def _read_package_text(package: ZipFile, archive_path: str) -> str:
 
 
 def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[dict]:
+    if not isinstance(manifest, dict):
+        raise CodexSkillPackageImportError("Package manifest must be an object")
+    skills = manifest.get("skills", [])
+    if not isinstance(skills, list):
+        raise CodexSkillPackageImportError("Package manifest skills must be a list")
     validated_skills = []
     seen_slugs = set()
-    for skill_entry in manifest.get("skills", []):
+    for skill_entry in skills:
+        if not isinstance(skill_entry, dict):
+            raise CodexSkillPackageImportError("Package skill entries must be objects")
         try:
             slug = validate_package_skill_slug(skill_entry["slug"])
         except KeyError as error:
@@ -434,14 +441,21 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
         seen_slugs.add(slug)
         seen_paths = set()
         content_by_path = {}
+        files = skill_entry.get("files", [])
+        if not isinstance(files, list):
+            raise CodexSkillPackageImportError("Package files must be a list")
         try:
             validated_files = [
                 {
                     **file_info,
                     "path": validate_package_relative_path(file_info["path"]),
                 }
-                for file_info in skill_entry.get("files", [])
+                for file_info in files
             ]
+        except TypeError as error:
+            raise CodexSkillPackageImportError(
+                "Package file entries must be objects"
+            ) from error
         except KeyError as error:
             raise CodexSkillPackageImportError(
                 "Missing required package file path"
@@ -716,7 +730,15 @@ def materialize_codex_skill_files(
 def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> dict:
     package_path = Path(package_path)
     with ZipFile(package_path) as package:
-        manifest = json.loads(package.read("manifest.json").decode("utf-8"))
+        try:
+            manifest_bytes = package.read("manifest.json")
+        except KeyError as error:
+            raise CodexSkillPackageImportError(
+                "Missing required manifest.json"
+            ) from error
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+        if not isinstance(manifest, dict):
+            raise CodexSkillPackageImportError("Package manifest must be an object")
         if manifest.get("format") != PACKAGE_FORMAT:
             raise CodexSkillPackageImportError(
                 "Unsupported Codex skill package format"

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -4,7 +4,9 @@ import hashlib
 import json
 import re
 from dataclasses import asdict, dataclass
+from os import PathLike
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import BinaryIO
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.conf import settings
@@ -729,9 +731,19 @@ def materialize_codex_skill_files(
     return summary
 
 
-def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> dict:
-    package_path = Path(package_path)
-    with ZipFile(package_path) as package:
+def import_codex_skill_package(
+    package_path: str | PathLike[str] | BinaryIO,
+    *,
+    dry_run: bool = True,
+) -> dict:
+    if isinstance(package_path, (str, PathLike)):
+        package_source = Path(package_path)
+        package_label = str(package_source)
+    else:
+        package_source = package_path
+        package_label = str(getattr(package_path, "name", "<uploaded package>"))
+
+    with ZipFile(package_source) as package:
         try:
             manifest_bytes = package.read("manifest.json")
         except KeyError as error:
@@ -747,7 +759,7 @@ def import_codex_skill_package(package_path: Path, *, dry_run: bool = True) -> d
             )
         validated_skills = _validate_manifest_skill_entries(package, manifest)
         summary = {
-            "package": str(package_path),
+            "package": package_label,
             "dry_run": dry_run,
             "skills": [],
         }

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -80,6 +80,8 @@ def normalize_package_path(path: Path) -> str:
 
 
 def validate_package_relative_path(relative_path: str) -> str:
+    if not isinstance(relative_path, str):
+        raise ValueError(f"Unsafe package path: {relative_path}")
     normalized = relative_path.replace("\\", "/")
     path = PurePosixPath(normalized)
     windows_path = PureWindowsPath(relative_path)

--- a/apps/skills/templates/admin/skills/agentskill/import_package.html
+++ b/apps/skills/templates/admin/skills/agentskill/import_package.html
@@ -1,0 +1,72 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{{ changelist_url }}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% translate "Import package" %}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    {% if preview %}
+      <div class="module">
+        <h2>{% trans "Package preview" %}</h2>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">{% trans "Skill slug" %}</th>
+              <th scope="col">{% trans "Files" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for skill in preview.skills %}
+              <tr>
+                <td>{{ skill.slug }}</td>
+                <td>{{ skill.files }}</td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="2">{% trans "The package does not contain any skills." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <form method="post">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="apply" />
+        <input type="hidden" name="token" value="{{ preview_token }}" />
+        <div class="submit-row">
+          <input type="submit" value="{% trans 'Import package' %}" class="default" />
+          <a href="{{ changelist_url }}" class="button cancel-link">{% trans 'Cancel' %}</a>
+        </div>
+      </form>
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data" class="module aligned">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="preview" />
+      <fieldset class="module aligned">
+        {% if form.non_field_errors %}
+          <div class="form-row errors">{{ form.non_field_errors }}</div>
+        {% endif %}
+        <div class="form-row{% if form.package.errors %} errors{% endif %}">
+          {{ form.package.errors }}
+          {{ form.package.label_tag }}
+          {{ form.package }}
+          {% if form.package.help_text %}
+            <div class="help">{{ form.package.help_text }}</div>
+          {% endif %}
+        </div>
+      </fieldset>
+      <div class="submit-row">
+        <input type="submit" value="{% trans 'Preview package' %}" class="default" />
+        <a href="{{ changelist_url }}" class="button cancel-link">{% trans 'Cancel' %}</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -286,6 +286,32 @@ def test_invalid_package_filename_shows_form_error_and_writes_nothing(admin_clie
     assert AgentSkillFile.objects.count() == file_count
 
 
+def test_expired_preview_token_cannot_import_package(
+    admin_client,
+    isolated_import_storage,
+):
+    url = reverse("admin:skills_agentskill_import_package")
+    preview_response = admin_client.post(
+        url,
+        {"action": "preview", "package": _valid_package_upload("admin-expired")},
+    )
+    token = preview_response.context["preview_token"]
+    session = admin_client.session
+    packages = session[skills_admin._SESSION_IMPORT_PACKAGES_KEY]
+    storage_name = packages[token]["name"]
+    packages[token]["ts"] = time.time() - skills_admin._IMPORT_PREVIEW_TTL_SECONDS - 5
+    session[skills_admin._SESSION_IMPORT_PACKAGES_KEY] = packages
+    session.save()
+
+    response = admin_client.post(url, {"action": "apply", "token": token}, follow=True)
+
+    assert response.status_code == 200
+    assert not AgentSkill.objects.filter(slug="admin-expired").exists()
+    assert not AgentSkillFile.objects.filter(skill__slug="admin-expired").exists()
+    assert not isolated_import_storage.exists(storage_name)
+    assert not admin_client.session[skills_admin._SESSION_IMPORT_PACKAGES_KEY]
+
+
 def test_preview_cleans_expired_storage_uploads(
     admin_client,
     isolated_import_storage,

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 from io import BytesIO
+from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
+from apps.skills import admin as skills_admin
 from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import PACKAGE_FORMAT
 
@@ -165,6 +169,58 @@ def test_invalid_package_preview_shows_error_and_writes_nothing(admin_client):
         assert AgentSkillFile.objects.count() == file_count
         if slug:
             assert not AgentSkill.objects.filter(slug=slug).exists()
+
+
+def test_invalid_package_filename_shows_form_error_and_writes_nothing(admin_client):
+    url = reverse("admin:skills_agentskill_import_package")
+    skill_count = AgentSkill.objects.count()
+    file_count = AgentSkillFile.objects.count()
+
+    response = admin_client.post(
+        url,
+        {
+            "action": "preview",
+            "package": SimpleUploadedFile(
+                "notazip.txt",
+                b"not a zip",
+                content_type="application/zip",
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "package" in response.context["form"].errors
+    assert "zip" in str(response.context["form"].errors["package"]).lower()
+    assert AgentSkill.objects.count() == skill_count
+    assert AgentSkillFile.objects.count() == file_count
+
+
+def test_preview_cleans_expired_temp_uploads(
+    admin_client,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(skills_admin, "gettempdir", lambda: str(tmp_path))
+    old_upload = tmp_path / f"{skills_admin._IMPORT_UPLOAD_PREFIX}old.zip"
+    old_upload.write_bytes(b"stale")
+    expired_at = time.time() - skills_admin._IMPORT_PREVIEW_TTL_SECONDS - 5
+    os.utime(old_upload, (expired_at, expired_at))
+
+    response = admin_client.post(
+        reverse("admin:skills_agentskill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("admin-cleanup")},
+    )
+
+    assert response.status_code == 200
+    assert not old_upload.exists()
+    token = response.context["preview_token"]
+    session_entry = admin_client.session[skills_admin._SESSION_IMPORT_PACKAGES_KEY][
+        token
+    ]
+    preview_upload = Path(session_entry["path"])
+    assert preview_upload.exists()
+    assert preview_upload.parent == tmp_path
+    preview_upload.unlink(missing_ok=True)
 
 
 def test_import_package_blocks_staff_without_add_and_change_permissions(

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import FileSystemStorage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -16,6 +18,13 @@ from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import PACKAGE_FORMAT
 
 pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture(autouse=True)
+def isolated_import_storage(monkeypatch, tmp_path):
+    storage = FileSystemStorage(location=tmp_path / "media")
+    monkeypatch.setattr(skills_admin, "default_storage", storage)
+    return storage
 
 
 def _zip_upload(
@@ -87,7 +96,10 @@ def test_agent_skill_changelist_links_import_package(admin_client):
     )
 
 
-def test_superuser_can_preview_valid_package_without_db_writes(admin_client):
+def test_superuser_can_preview_valid_package_without_db_writes(
+    admin_client,
+    isolated_import_storage,
+):
     response = admin_client.post(
         reverse("admin:skills_agentskill_import_package"),
         {"action": "preview", "package": _valid_package_upload("admin-preview")},
@@ -99,17 +111,27 @@ def test_superuser_can_preview_valid_package_without_db_writes(admin_client):
     ]
     assert response.context["preview_token"]
     assert "admin-preview" in response.rendered_content
+    session_entry = admin_client.session[skills_admin._SESSION_IMPORT_PACKAGES_KEY][
+        response.context["preview_token"]
+    ]
+    assert "name" in session_entry
+    assert isolated_import_storage.exists(session_entry["name"])
     assert not AgentSkill.objects.filter(slug="admin-preview").exists()
     assert not AgentSkillFile.objects.filter(skill__slug="admin-preview").exists()
 
 
-def test_superuser_can_import_valid_package(admin_client):
+def test_superuser_can_import_valid_package(admin_client, isolated_import_storage):
     url = reverse("admin:skills_agentskill_import_package")
     preview_response = admin_client.post(
         url,
         {"action": "preview", "package": _valid_package_upload("admin-import")},
     )
     token = preview_response.context["preview_token"]
+    session_entry = admin_client.session[skills_admin._SESSION_IMPORT_PACKAGES_KEY][
+        token
+    ]
+    storage_name = session_entry["name"]
+    assert isolated_import_storage.exists(storage_name)
 
     response = admin_client.post(url, {"action": "apply", "token": token}, follow=True)
 
@@ -129,6 +151,7 @@ def test_superuser_can_import_valid_package(admin_client):
         ("SKILL.md", "---\nname: admin-upload\n---\n"),
         ("references/rules.md", "portable rules"),
     ]
+    assert not isolated_import_storage.exists(storage_name)
 
 
 def test_invalid_package_preview_shows_error_and_writes_nothing(admin_client):
@@ -263,14 +286,16 @@ def test_invalid_package_filename_shows_form_error_and_writes_nothing(admin_clie
     assert AgentSkillFile.objects.count() == file_count
 
 
-def test_preview_cleans_expired_temp_uploads(
+def test_preview_cleans_expired_storage_uploads(
     admin_client,
-    monkeypatch,
-    tmp_path,
+    isolated_import_storage,
 ):
-    monkeypatch.setattr(skills_admin, "gettempdir", lambda: str(tmp_path))
-    old_upload = tmp_path / f"{skills_admin._IMPORT_UPLOAD_PREFIX}old.zip"
-    old_upload.write_bytes(b"stale")
+    old_upload_name = (
+        f"{skills_admin._IMPORT_UPLOAD_STORAGE_DIR}/"
+        f"{skills_admin._IMPORT_UPLOAD_PREFIX}old.zip"
+    )
+    isolated_import_storage.save(old_upload_name, ContentFile(b"stale"))
+    old_upload = Path(isolated_import_storage.path(old_upload_name))
     expired_at = time.time() - skills_admin._IMPORT_PREVIEW_TTL_SECONDS - 5
     os.utime(old_upload, (expired_at, expired_at))
 
@@ -280,15 +305,18 @@ def test_preview_cleans_expired_temp_uploads(
     )
 
     assert response.status_code == 200
-    assert not old_upload.exists()
+    assert not isolated_import_storage.exists(old_upload_name)
     token = response.context["preview_token"]
     session_entry = admin_client.session[skills_admin._SESSION_IMPORT_PACKAGES_KEY][
         token
     ]
-    preview_upload = Path(session_entry["path"])
-    assert preview_upload.exists()
-    assert preview_upload.parent == tmp_path
-    preview_upload.unlink(missing_ok=True)
+    preview_upload_name = session_entry["name"]
+    assert preview_upload_name.startswith(
+        f"{skills_admin._IMPORT_UPLOAD_STORAGE_DIR}/"
+        f"{skills_admin._IMPORT_UPLOAD_PREFIX}"
+    )
+    assert isolated_import_storage.exists(preview_upload_name)
+    isolated_import_storage.delete(preview_upload_name)
 
 
 def test_import_package_blocks_staff_without_add_and_change_permissions(

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -200,6 +200,27 @@ def test_invalid_package_preview_shows_error_and_writes_nothing(admin_client):
             "Unsafe package path",
             "unsafe-path",
         ),
+        (
+            _zip_upload(
+                {
+                    "format": PACKAGE_FORMAT,
+                    "skills": [
+                        {
+                            "slug": "non-string-path",
+                            "title": "Non String Path",
+                            "files": [
+                                {
+                                    "path": None,
+                                    "included_by_default": True,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ),
+            "Unsafe package path: None",
+            "non-string-path",
+        ),
     ]
 
     for upload, error_fragment, slug in invalid_cases:

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from zipfile import ZipFile
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from apps.skills.models import AgentSkill, AgentSkillFile
+from apps.skills.package_services import PACKAGE_FORMAT
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _zip_upload(
+    manifest: dict,
+    files: dict[str, str | bytes] | None = None,
+    *,
+    name: str = "codex-skills.zip",
+) -> SimpleUploadedFile:
+    buffer = BytesIO()
+    with ZipFile(buffer, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        for archive_path, content in (files or {}).items():
+            package.writestr(archive_path, content)
+    return SimpleUploadedFile(
+        name,
+        buffer.getvalue(),
+        content_type="application/zip",
+    )
+
+
+def _valid_package_upload(slug: str = "admin-upload") -> SimpleUploadedFile:
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": slug,
+                "title": "Admin Upload",
+                "files": [
+                    {"path": "SKILL.md", "included_by_default": True},
+                    {
+                        "path": "references/rules.md",
+                        "included_by_default": True,
+                    },
+                ],
+            }
+        ],
+    }
+    return _zip_upload(
+        manifest,
+        {
+            f"skills/{slug}/SKILL.md": "---\nname: admin-upload\n---\n",
+            f"skills/{slug}/references/rules.md": "portable rules",
+        },
+    )
+
+
+def test_agent_skill_changelist_links_import_package(admin_client):
+    response = admin_client.get(reverse("admin:skills_agentskill_changelist"))
+
+    assert response.status_code == 200
+    assert (
+        reverse("admin:skills_agentskill_import_package") in response.rendered_content
+    )
+
+
+def test_superuser_can_preview_valid_package_without_db_writes(admin_client):
+    response = admin_client.post(
+        reverse("admin:skills_agentskill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("admin-preview")},
+    )
+
+    assert response.status_code == 200
+    assert response.context["preview"]["skills"] == [
+        {"slug": "admin-preview", "files": 2}
+    ]
+    assert response.context["preview_token"]
+    assert "admin-preview" in response.rendered_content
+    assert not AgentSkill.objects.filter(slug="admin-preview").exists()
+    assert not AgentSkillFile.objects.filter(skill__slug="admin-preview").exists()
+
+
+def test_superuser_can_import_valid_package(admin_client):
+    url = reverse("admin:skills_agentskill_import_package")
+    preview_response = admin_client.post(
+        url,
+        {"action": "preview", "package": _valid_package_upload("admin-import")},
+    )
+    token = preview_response.context["preview_token"]
+
+    response = admin_client.post(url, {"action": "apply", "token": token}, follow=True)
+
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == reverse(
+        "admin:skills_agentskill_changelist"
+    )
+    skill = AgentSkill.objects.get(slug="admin-import")
+    assert skill.title == "Admin Upload"
+    assert skill.markdown == "---\nname: admin-upload\n---\n"
+    assert list(
+        skill.package_files.order_by("relative_path").values_list(
+            "relative_path",
+            "content",
+        )
+    ) == [
+        ("SKILL.md", "---\nname: admin-upload\n---\n"),
+        ("references/rules.md", "portable rules"),
+    ]
+
+
+def test_invalid_package_preview_shows_error_and_writes_nothing(admin_client):
+    url = reverse("admin:skills_agentskill_import_package")
+    invalid_cases = [
+        (
+            SimpleUploadedFile(
+                "broken.zip",
+                b"not a zip",
+                content_type="application/zip",
+            ),
+            "File is not a zip file",
+            None,
+        ),
+        (
+            _zip_upload({"format": "wrong", "skills": []}),
+            "Unsupported Codex skill package format",
+            None,
+        ),
+        (
+            _zip_upload(
+                {
+                    "format": PACKAGE_FORMAT,
+                    "skills": [
+                        {
+                            "slug": "unsafe-path",
+                            "title": "Unsafe",
+                            "files": [
+                                {
+                                    "path": "../secret.txt",
+                                    "included_by_default": True,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ),
+            "Unsafe package path",
+            "unsafe-path",
+        ),
+    ]
+
+    for upload, error_fragment, slug in invalid_cases:
+        skill_count = AgentSkill.objects.count()
+        file_count = AgentSkillFile.objects.count()
+
+        response = admin_client.post(url, {"action": "preview", "package": upload})
+
+        assert response.status_code == 200
+        assert any(
+            error_fragment in str(message) for message in response.context["messages"]
+        )
+        assert AgentSkill.objects.count() == skill_count
+        assert AgentSkillFile.objects.count() == file_count
+        if slug:
+            assert not AgentSkill.objects.filter(slug=slug).exists()
+
+
+def test_import_package_blocks_staff_without_add_and_change_permissions(
+    client,
+    django_user_model,
+):
+    user = django_user_model.objects.create_user(
+        username="skill-import-limited",
+        password="pw",
+        is_staff=True,
+    )
+    client.force_login(user)
+
+    response = client.post(
+        reverse("admin:skills_agentskill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("blocked-import")},
+    )
+
+    assert response.status_code == 403
+    assert not AgentSkill.objects.filter(slug="blocked-import").exists()

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -36,6 +36,22 @@ def _zip_upload(
     )
 
 
+def _raw_zip_upload(
+    files: dict[str, str | bytes],
+    *,
+    name: str = "codex-skills.zip",
+) -> SimpleUploadedFile:
+    buffer = BytesIO()
+    with ZipFile(buffer, "w") as package:
+        for archive_path, content in files.items():
+            package.writestr(archive_path, content)
+    return SimpleUploadedFile(
+        name,
+        buffer.getvalue(),
+        content_type="application/zip",
+    )
+
+
 def _valid_package_upload(slug: str = "admin-upload") -> SimpleUploadedFile:
     manifest = {
         "format": PACKAGE_FORMAT,
@@ -131,6 +147,37 @@ def test_invalid_package_preview_shows_error_and_writes_nothing(admin_client):
             _zip_upload({"format": "wrong", "skills": []}),
             "Unsupported Codex skill package format",
             None,
+        ),
+        (
+            _raw_zip_upload({"skills/missing-manifest/SKILL.md": "demo"}),
+            "Missing required manifest.json",
+            None,
+        ),
+        (
+            _zip_upload({"format": PACKAGE_FORMAT, "skills": "not a list"}),
+            "Package manifest skills must be a list",
+            None,
+        ),
+        (
+            _zip_upload({"format": PACKAGE_FORMAT, "skills": ["not an object"]}),
+            "Package skill entries must be objects",
+            None,
+        ),
+        (
+            _zip_upload(
+                {
+                    "format": PACKAGE_FORMAT,
+                    "skills": [
+                        {
+                            "slug": "invalid-files",
+                            "title": "Invalid Files",
+                            "files": "not a list",
+                        }
+                    ],
+                },
+            ),
+            "Package files must be a list",
+            "invalid-files",
         ),
         (
             _zip_upload(

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -345,6 +345,30 @@ def test_preview_cleans_expired_storage_uploads(
     isolated_import_storage.delete(preview_upload_name)
 
 
+def test_preview_cleanup_handles_use_tz_false(
+    admin_client,
+    isolated_import_storage,
+    settings,
+):
+    settings.USE_TZ = False
+    old_upload_name = (
+        f"{skills_admin._IMPORT_UPLOAD_STORAGE_DIR}/"
+        f"{skills_admin._IMPORT_UPLOAD_PREFIX}old.zip"
+    )
+    isolated_import_storage.save(old_upload_name, ContentFile(b"stale"))
+    old_upload = Path(isolated_import_storage.path(old_upload_name))
+    expired_at = time.time() - skills_admin._IMPORT_PREVIEW_TTL_SECONDS - 5
+    os.utime(old_upload, (expired_at, expired_at))
+
+    response = admin_client.post(
+        reverse("admin:skills_agentskill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("admin-naive")},
+    )
+
+    assert response.status_code == 200
+    assert not isolated_import_storage.exists(old_upload_name)
+
+
 def test_import_package_blocks_staff_without_add_and_change_permissions(
     client,
     django_user_model,

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -63,3 +63,18 @@ To preserve raw SIGILS for inspection instead of resolving them:
 ```bash
 python manage.py codex_skill_packages materialize --target ~/.codex/skills --no-resolve-sigils
 ```
+
+## Admin Package Import
+
+Staff users with both add and change permission for Agent Skills can import a
+Codex skill package from **Admin > Agent Skills > Import**.
+
+The admin upload first previews the package with the same dry-run validation as
+the command-line importer. The preview shows each skill slug and the number of
+manifest files that will be processed. No `AgentSkill` or `AgentSkillFile` rows
+are written until the operator confirms the preview.
+
+The apply step calls the same package importer without dry-run mode. Package
+service validation still owns the safety boundary: unsafe paths, invalid UTF-8,
+unsupported manifests, blocked secrets, portability reclassification, and
+soft-deleted slug restoration all follow the command-line import behavior.

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -74,6 +74,10 @@ the command-line importer. The preview shows each skill slug and the number of
 manifest files that will be processed. No `AgentSkill` or `AgentSkillFile` rows
 are written until the operator confirms the preview.
 
+Preview uploads are stored under the configured Django default storage backend
+with a one-hour expiry, so the follow-up apply request can run on another web
+worker as long as the deployment's default storage is shared by those workers.
+
 The apply step calls the same package importer without dry-run mode. Package
 service validation still owns the safety boundary: unsafe paths, invalid UTF-8,
 unsupported manifests, blocked secrets, portability reclassification, and


### PR DESCRIPTION
## Summary
- add an Agent Skill admin import-package flow for uploaded Codex skill package zips
- preview packages with the existing dry-run importer before writing database rows
- apply confirmed uploads through the existing package importer and document the admin flow

## Validation
- `.\.venv\Scripts\python.exe manage.py test run -- apps\skills\tests\test_admin.py`
- `.\.venv\Scripts\python.exe manage.py test run -- apps\skills`
- `.\.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.\.venv\Scripts\python.exe scripts\check_import_resolution.py apps\skills`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a Django admin interface for importing Codex skill packages, enabling staff users to upload ZIP files with a preview-before-commit workflow.

## Changes

**Admin interface (`apps/skills/admin.py`)**
- Extended `AgentSkillAdmin` with custom URL routing (`get_urls`) and changelist context to expose import functionality
- Added `import_package_view` to handle both GET (render form) and POST preview requests
  - Preview flow: validates uploaded ZIP, runs dry-run importer, displays preview or errors
  - Uses session storage to temporarily hold package data between preview and apply steps
- Added `_apply_import_package` to consume preview tokens and execute the final import
- Implemented permission check (`has_import_package_permission`) requiring add/change permissions
- Helper methods manage upload storage, session token lifecycle, and localized summary messages

**Form validation (`apps/skills/forms.py`)**
- New `CodexSkillPackageImportForm` validates that uploaded files are `.zip` packages

**Admin template (`apps/skills/templates/admin/skills/agentskill/import_package.html`)**
- Two-step form UI: file upload → preview summary → apply confirmation
- Displays preview package contents (skill slugs and files) before final import
- Standard admin styling and navigation

**Tests (`apps/skills/tests/test_admin.py`)**
- Verifies changelist links to import page
- Tests preview flow (no database writes, returns preview context)
- Tests apply flow (persists `AgentSkill` records and files to database)
- Validates error handling (invalid ZIP, malformed packages, path traversal attempts)
- Confirms authorization (denies staff without add/change permissions)

**Documentation (`docs/development/codex-skill-packages.md`)**
- Describes admin import workflow and note that it uses the same validation logic as the command-line importer

## Validation

The PR uses the existing dry-run importer (`dry_run`) to preview packages and the existing package importer to apply changes, reusing established safety validations across both CLI and admin paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->