### PR TITLE
Add WhatsApp listener install CLI

### DIFF
--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -171,7 +171,20 @@ class Command(BaseCommand):
             "install-listener",
             help="Plan or write OS startup artifacts for WhatsApp listener mode.",
         )
-        self._add_browser_arguments(install, default_timeout=120.0)
+        self._add_browser_arguments(
+            install,
+            default_timeout=120.0,
+            default_browser=None,
+            default_channel=None,
+            browser_help=(
+                "Browser engine to place in the generated listener command. "
+                "Defaults from --platform."
+            ),
+            channel_help=(
+                "Optional Playwright Chromium channel. Defaults to msedge for "
+                "Windows Edge plans."
+            ),
+        )
         install.add_argument(
             "--from",
             dest="from_phone",
@@ -261,7 +274,16 @@ class Command(BaseCommand):
         )
         install.add_argument("--json", action="store_true", help="Emit JSON output.")
 
-    def _add_browser_arguments(self, parser, *, default_timeout: float) -> None:
+    def _add_browser_arguments(
+        self,
+        parser,
+        *,
+        default_timeout: float,
+        default_browser: str | None = DEFAULT_WHATSAPP_WEB_BROWSER,
+        default_channel: str | None = DEFAULT_WHATSAPP_WEB_CHANNEL,
+        browser_help: str | None = None,
+        channel_help: str | None = None,
+    ) -> None:
         parser.add_argument(
             "--profile-dir",
             default=str(DEFAULT_WHATSAPP_WEB_PROFILE_DIR),
@@ -272,17 +294,15 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--browser",
-            default=DEFAULT_WHATSAPP_WEB_BROWSER,
+            default=default_browser,
             choices=("edge", "firefox", "chromium"),
-            help=(
-                "Browser engine to use. Defaults to Edge on Windows and Firefox "
-                "elsewhere."
-            ),
+            help=browser_help
+            or "Browser engine to use. Defaults to Edge on Windows and Firefox elsewhere.",
         )
         parser.add_argument(
             "--channel",
-            default=DEFAULT_WHATSAPP_WEB_CHANNEL,
-            help="Optional Playwright Chromium channel, for example msedge.",
+            default=default_channel,
+            help=channel_help or "Optional Playwright Chromium channel, for example msedge.",
         )
         parser.add_argument(
             "--cdp-url",
@@ -339,9 +359,9 @@ class Command(BaseCommand):
             "timeout_seconds": options["timeout"],
             "poll_interval_seconds": options["poll_interval"],
             "headless": options["headless"],
-            "browser": options["browser"],
-            "channel": options["channel"].strip(),
-            "cdp_url": options["cdp_url"].strip(),
+            "browser": options.get("browser") or "",
+            "channel": (options.get("channel") or "").strip(),
+            "cdp_url": (options.get("cdp_url") or "").strip(),
         }
 
     def _handle_login(self, options):

--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -259,6 +259,14 @@ class Command(BaseCommand):
             help="Linux systemd user unit directory. Default: ~/.config/systemd/user.",
         )
         install.add_argument(
+            "--base-dir",
+            help=(
+                "Target suite checkout directory for the generated runner. "
+                "Defaults to this checkout, or to a target-platform convention "
+                "for cross-platform plans."
+            ),
+        )
+        install.add_argument(
             "--python",
             dest="python_executable",
             help="Python executable to place in the generated listener command.",
@@ -456,6 +464,7 @@ class Command(BaseCommand):
             secretary_name=options["secretary_name"],
             terminal_title=options["terminal_title"],
             platform=options["platform"],
+            base_dir=options["base_dir"],
             output_dir=options["output_dir"],
             systemd_user_dir=options["systemd_user_dir"],
             python_executable=options["python_executable"],

--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -13,6 +13,7 @@ from apps.meta.services import (
     DEFAULT_WHATSAPP_WEB_BROWSER,
     DEFAULT_WHATSAPP_WEB_CHANNEL,
     DEFAULT_WHATSAPP_WEB_PROFILE_DIR,
+    build_whatsapp_listener_install_plan,
     dataclass_payload,
     listen_for_whatsapp_secretary_requests,
     parse_cli_date,
@@ -166,6 +167,100 @@ class Command(BaseCommand):
         )
         listen.add_argument("--json", action="store_true", help="Emit JSON output.")
 
+        install = subparsers.add_parser(
+            "install-listener",
+            help="Plan or write OS startup artifacts for WhatsApp listener mode.",
+        )
+        self._add_browser_arguments(install, default_timeout=120.0)
+        install.add_argument(
+            "--from",
+            dest="from_phone",
+            required=True,
+            help="Operator self-chat phone number.",
+        )
+        install.add_argument(
+            "--country-code",
+            default="52",
+            help="Country code for 10-digit local numbers. Default: 52.",
+        )
+        install.add_argument(
+            "--trigger-prefix",
+            default=DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+            help="Message prefix required to launch Secretary. Default: secretary:",
+        )
+        install.add_argument(
+            "--idle-after",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
+            help="Desktop idle seconds required before polling. Default: 300.",
+        )
+        install.add_argument(
+            "--poll-every",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS,
+            help="Seconds between WhatsApp read polls. Default: 60.",
+        )
+        install.add_argument(
+            "--quiet-window",
+            type=float,
+            default=DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS,
+            help="Seconds without new messages required before processing. Default: 60.",
+        )
+        install.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Maximum visible new messages to inspect per poll; 0 means all.",
+        )
+        install.add_argument(
+            "--codex-command",
+            default="codex",
+            help="Codex executable command used in the launched terminal.",
+        )
+        install.add_argument(
+            "--secretary-name",
+            default="Secretary",
+            help="Nickname used in the generated SECRETARY prompt.",
+        )
+        install.add_argument(
+            "--terminal-title",
+            default="Arthexis Secretary",
+            help="Window/tab title for the launched terminal.",
+        )
+        install.add_argument(
+            "--platform",
+            choices=("windows", "win32", "linux"),
+            help="Override target platform for generated artifacts.",
+        )
+        install.add_argument(
+            "--service-name",
+            default="arthexis-whatsapp-listener",
+            help="Scheduled Task or systemd unit base name.",
+        )
+        install.add_argument(
+            "--output-dir",
+            help="Directory for generated listener runner files.",
+        )
+        install.add_argument(
+            "--systemd-user-dir",
+            help="Linux systemd user unit directory. Default: ~/.config/systemd/user.",
+        )
+        install.add_argument(
+            "--python",
+            dest="python_executable",
+            help="Python executable to place in the generated listener command.",
+        )
+        install.add_argument(
+            "--manage-py",
+            help="Path to manage.py. Defaults to this suite checkout.",
+        )
+        install.add_argument(
+            "--write",
+            action="store_true",
+            help="Write helper files. Without this, only print the install plan.",
+        )
+        install.add_argument("--json", action="store_true", help="Emit JSON output.")
+
     def _add_browser_arguments(self, parser, *, default_timeout: float) -> None:
         parser.add_argument(
             "--profile-dir",
@@ -225,6 +320,8 @@ class Command(BaseCommand):
                 result = self._handle_read(options)
             elif action == "listen":
                 return self._handle_listen(options)
+            elif action == "install-listener":
+                return self._handle_install_listener(options)
             else:
                 raise CommandError(f"Unknown whatsapp action: {action}")
         except (RuntimeError, ValueError) as exc:
@@ -316,6 +413,75 @@ class Command(BaseCommand):
         if options["once"] and results:
             write_event(results[-1])
         return None
+
+    def _handle_install_listener(self, options):
+        if options["limit"] < 0:
+            raise CommandError("--limit must be >= 0. Use 0 to return all visible messages.")
+        if options["idle_after"] < 0:
+            raise CommandError("--idle-after must be >= 0.")
+        if options["poll_every"] < 1:
+            raise CommandError("--poll-every must be >= 1.")
+        if options["quiet_window"] < 1:
+            raise CommandError("--quiet-window must be >= 1.")
+
+        plan = build_whatsapp_listener_install_plan(
+            phone=options["from_phone"],
+            default_country_code=options["country_code"],
+            trigger_prefix=options["trigger_prefix"],
+            idle_after_seconds=options["idle_after"],
+            daemon_poll_seconds=options["poll_every"],
+            quiet_window_seconds=options["quiet_window"],
+            limit=options["limit"],
+            codex_command=options["codex_command"],
+            secretary_name=options["secretary_name"],
+            terminal_title=options["terminal_title"],
+            platform=options["platform"],
+            output_dir=options["output_dir"],
+            systemd_user_dir=options["systemd_user_dir"],
+            python_executable=options["python_executable"],
+            manage_py=options["manage_py"],
+            service_name=options["service_name"],
+            write_files=options["write"],
+            **self._browser_options(options),
+        )
+        if options.get("json"):
+            self.stdout.write(json.dumps(dataclass_payload(plan), indent=2))
+        else:
+            self._write_install_plan(plan)
+        return None
+
+    def _write_install_plan(self, plan) -> None:
+        payload = dataclass_payload(plan)
+        for key in (
+            "status",
+            "platform",
+            "service_name",
+            "base_dir",
+            "profile_dir",
+            "output_dir",
+            "runner_path",
+            "service_path",
+            "wrote_files",
+            "detail",
+        ):
+            self.stdout.write(f"{key}={payload[key]}")
+        self.stdout.write("listen_command:")
+        self.stdout.write(str(payload["listen_command"]))
+        self.stdout.write("requirements:")
+        for requirement in payload["requirements"]:
+            self.stdout.write(f"- {requirement}")
+        self.stdout.write("manual_commands:")
+        for key in (
+            "install_command",
+            "start_command",
+            "status_command",
+            "stop_command",
+            "uninstall_command",
+        ):
+            self.stdout.write(f"{key}={payload[key]}")
+        self.stdout.write("instructions:")
+        for instruction in payload["instructions"]:
+            self.stdout.write(f"- {instruction}")
 
     def _write_text_result(self, result) -> None:
         payload = dataclass_payload(result)

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -132,6 +132,28 @@ class WhatsAppSecretaryListenResult:
     detail: str = ""
 
 
+@dataclass(frozen=True)
+class WhatsAppListenerInstallPlan:
+    status: str
+    platform: str
+    service_name: str
+    base_dir: Path
+    profile_dir: Path
+    output_dir: Path
+    runner_path: Path
+    service_path: Path
+    listen_command: str
+    install_command: str
+    start_command: str
+    status_command: str
+    stop_command: str
+    uninstall_command: str
+    wrote_files: bool
+    requirements: list[str]
+    instructions: list[str]
+    detail: str = ""
+
+
 def dataclass_payload(value) -> dict[str, object]:
     payload = asdict(value)
     for key, item in list(payload.items()):
@@ -827,6 +849,351 @@ def launch_codex_secretary_terminal(
         working_directory=Path(settings.BASE_DIR),
     )
     return f"Codex Secretary terminal launch requested; pid file: {launch_path}"
+
+
+def _listener_install_platform(platform: str | None = None) -> str:
+    raw = (platform or sys.platform).lower()
+    if raw.startswith("win"):
+        return "windows"
+    if raw.startswith("linux"):
+        return "linux"
+    raise ValueError("WhatsApp listener install provisioning supports Windows and Linux.")
+
+
+def _safe_service_name(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.@-]+", "-", (value or "").strip()).strip(".-")
+    return safe or "arthexis-whatsapp-listener"
+
+
+def _default_listener_install_output_dir(platform: str) -> Path:
+    if platform == "windows":
+        root = os.environ.get("LOCALAPPDATA")
+        base = Path(root) if root else Path.home() / "AppData" / "Local"
+        return base / "Arthexis" / "whatsapp-listener"
+    root = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(root) if root else Path.home() / ".config"
+    return base / "arthexis" / "whatsapp-listener"
+
+
+def _default_systemd_user_dir() -> Path:
+    root = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(root) if root else Path.home() / ".config"
+    return base / "systemd" / "user"
+
+
+def _option_value(value: float | int | str) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _powershell_quote(value: str | Path) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _powershell_command(command: list[str | Path]) -> str:
+    return "& " + " ".join(_powershell_quote(part) for part in command)
+
+
+def _shell_command(command: list[str | Path]) -> str:
+    return shlex.join(str(part) for part in command)
+
+
+def _systemd_quote(value: str | Path) -> str:
+    raw = str(value)
+    if not raw or re.search(r"\s", raw):
+        return '"' + raw.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return raw
+
+
+def _whatsapp_listener_command(
+    *,
+    phone: str,
+    default_country_code: str,
+    trigger_prefix: str,
+    idle_after_seconds: float,
+    daemon_poll_seconds: float,
+    quiet_window_seconds: float,
+    limit: int,
+    codex_command: str,
+    secretary_name: str,
+    terminal_title: str,
+    profile_dir: Path,
+    browser: str,
+    channel: str,
+    cdp_url: str,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+    headless: bool,
+    python_executable: str | Path,
+    manage_py: str | Path,
+) -> list[str | Path]:
+    command: list[str | Path] = [
+        python_executable,
+        manage_py,
+        "whatsapp",
+        "listen",
+        "--from",
+        phone,
+        "--country-code",
+        default_country_code,
+        "--profile-dir",
+        profile_dir,
+        "--browser",
+        browser,
+        "--timeout",
+        _option_value(timeout_seconds),
+        "--poll-interval",
+        _option_value(poll_interval_seconds),
+        "--trigger-prefix",
+        trigger_prefix,
+        "--idle-after",
+        _option_value(idle_after_seconds),
+        "--poll-every",
+        _option_value(daemon_poll_seconds),
+        "--quiet-window",
+        _option_value(quiet_window_seconds),
+        "--limit",
+        str(limit),
+        "--codex-command",
+        codex_command,
+        "--secretary-name",
+        secretary_name,
+        "--terminal-title",
+        terminal_title,
+    ]
+    if channel:
+        command.extend(["--channel", channel])
+    if cdp_url:
+        command.extend(["--cdp-url", cdp_url])
+    if headless:
+        command.append("--headless")
+    return command
+
+
+def _windows_listener_runner(base_dir: Path, command: list[str | Path]) -> str:
+    return "\n".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            f"Set-Location -LiteralPath {_powershell_quote(base_dir)}",
+            _powershell_command(command),
+            "",
+        ]
+    )
+
+
+def _windows_register_task_script(service_name: str, runner_path: Path) -> str:
+    task_arg = f'-NoProfile -ExecutionPolicy Bypass -File "{runner_path}"'
+    return "\n".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            f"$TaskName = {_powershell_quote(service_name)}",
+            f"$Action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument {_powershell_quote(task_arg)}",
+            "$Trigger = New-ScheduledTaskTrigger -AtLogOn",
+            (
+                "$Settings = New-ScheduledTaskSettingsSet -MultipleInstances IgnoreNew "
+                "-RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) "
+                "-AllowStartIfOnBatteries -DontStopIfGoingOnBatteries"
+            ),
+            (
+                "Register-ScheduledTask -TaskName $TaskName -Action $Action "
+                "-Trigger $Trigger -Settings $Settings "
+                "-Description 'Runs the Arthexis WhatsApp Secretary listener after interactive login.' "
+                "-Force"
+            ),
+            "",
+        ]
+    )
+
+
+def _linux_listener_runner(base_dir: Path, command: list[str | Path]) -> str:
+    return "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            f"cd {shlex.quote(str(base_dir))}",
+            f"exec {_shell_command(command)}",
+            "",
+        ]
+    )
+
+
+def _linux_systemd_unit(service_name: str, base_dir: Path, runner_path: Path) -> str:
+    return "\n".join(
+        [
+            "[Unit]",
+            f"Description=Arthexis WhatsApp Secretary Listener ({service_name})",
+            "After=graphical-session.target",
+            "Wants=graphical-session.target",
+            "",
+            "[Service]",
+            "Type=simple",
+            f"WorkingDirectory={_systemd_quote(base_dir)}",
+            f"ExecStart={_systemd_quote(runner_path)}",
+            "Restart=always",
+            "RestartSec=30",
+            "Environment=PYTHONUNBUFFERED=1",
+            "",
+            "[Install]",
+            "WantedBy=default.target",
+            "",
+        ]
+    )
+
+
+def build_whatsapp_listener_install_plan(
+    *,
+    phone: str,
+    default_country_code: str = "52",
+    trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+    idle_after_seconds: float = DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
+    daemon_poll_seconds: float = DEFAULT_WHATSAPP_SECRETARY_POLL_SECONDS,
+    quiet_window_seconds: float = DEFAULT_WHATSAPP_SECRETARY_QUIET_SECONDS,
+    limit: int = 50,
+    codex_command: str = "codex",
+    secretary_name: str = "Secretary",
+    terminal_title: str = "Arthexis Secretary",
+    profile_dir: Path | str | None = None,
+    browser: str = DEFAULT_WHATSAPP_WEB_BROWSER,
+    channel: str = DEFAULT_WHATSAPP_WEB_CHANNEL,
+    cdp_url: str = "",
+    timeout_seconds: float = 120.0,
+    poll_interval_seconds: float = 1.0,
+    headless: bool = False,
+    platform: str | None = None,
+    base_dir: Path | str | None = None,
+    python_executable: str | Path | None = None,
+    manage_py: Path | str | None = None,
+    service_name: str = "arthexis-whatsapp-listener",
+    output_dir: Path | str | None = None,
+    systemd_user_dir: Path | str | None = None,
+    write_files: bool = False,
+) -> WhatsAppListenerInstallPlan:
+    """Build and optionally write manual provisioning artifacts for listener startup."""
+
+    from django.conf import settings
+
+    resolved_platform = _listener_install_platform(platform)
+    safe_service = _safe_service_name(service_name)
+    resolved_base_dir = Path(base_dir or settings.BASE_DIR).resolve()
+    resolved_profile_dir = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
+    resolved_output_dir = Path(output_dir or _default_listener_install_output_dir(resolved_platform)).expanduser()
+    resolved_python = str(python_executable or sys.executable)
+    resolved_manage_py = Path(manage_py or (resolved_base_dir / "manage.py"))
+    command = _whatsapp_listener_command(
+        phone=phone,
+        default_country_code=default_country_code,
+        trigger_prefix=trigger_prefix,
+        idle_after_seconds=idle_after_seconds,
+        daemon_poll_seconds=daemon_poll_seconds,
+        quiet_window_seconds=quiet_window_seconds,
+        limit=limit,
+        codex_command=codex_command,
+        secretary_name=secretary_name,
+        terminal_title=terminal_title,
+        profile_dir=resolved_profile_dir,
+        browser=browser,
+        channel=channel,
+        cdp_url=cdp_url,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        headless=headless,
+        python_executable=resolved_python,
+        manage_py=resolved_manage_py,
+    )
+
+    wrote_files = False
+    if resolved_platform == "windows":
+        runner_path = resolved_output_dir / f"{safe_service}.ps1"
+        service_path = resolved_output_dir / f"Register-{safe_service}.ps1"
+        listen_command = _powershell_command(command)
+        install_command = (
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass -File "
+            f"{_powershell_quote(service_path)}"
+        )
+        start_command = f"Start-ScheduledTask -TaskName {_powershell_quote(safe_service)}"
+        status_command = f"Get-ScheduledTask -TaskName {_powershell_quote(safe_service)}"
+        stop_command = f"Stop-ScheduledTask -TaskName {_powershell_quote(safe_service)}"
+        uninstall_command = (
+            "Unregister-ScheduledTask -Confirm:$false -TaskName "
+            f"{_powershell_quote(safe_service)}"
+        )
+        requirements = [
+            "Windows interactive user session; do not provision as a non-interactive Windows service.",
+            "Microsoft Edge installed and available to Playwright through the msedge channel.",
+            "Run `python -m playwright install chromium` if Playwright browser assets are missing.",
+            "`whatsapp login` completed for the same persistent profile before unattended startup.",
+            "`codex` available on PATH, or pass --codex-command with its full executable path.",
+        ]
+        instructions = [
+            "Run `python manage.py whatsapp login --timeout 300` in a headed session first.",
+            "Run the install command to register the generated Scheduled Task.",
+            "Use the start command to launch the task immediately, or sign out and back in.",
+            "Use the status command to inspect task registration and the stop/uninstall commands for rollback.",
+        ]
+        if write_files:
+            resolved_output_dir.mkdir(parents=True, exist_ok=True)
+            runner_path.write_text(_windows_listener_runner(resolved_base_dir, command), encoding="utf-8")
+            service_path.write_text(_windows_register_task_script(safe_service, runner_path), encoding="utf-8")
+            wrote_files = True
+    else:
+        runner_path = resolved_output_dir / f"{safe_service}.sh"
+        unit_name = safe_service if safe_service.endswith(".service") else f"{safe_service}.service"
+        service_dir = Path(systemd_user_dir or _default_systemd_user_dir()).expanduser()
+        service_path = service_dir / unit_name
+        listen_command = _shell_command(command)
+        install_command = f"systemctl --user daemon-reload && systemctl --user enable {shlex.quote(unit_name)}"
+        start_command = f"systemctl --user start {shlex.quote(unit_name)}"
+        status_command = f"systemctl --user status {shlex.quote(unit_name)}"
+        stop_command = f"systemctl --user stop {shlex.quote(unit_name)}"
+        uninstall_command = f"systemctl --user disable --now {shlex.quote(unit_name)}"
+        requirements = [
+            "Linux graphical user session with systemd --user available.",
+            "Firefox installed through Playwright; run `python -m playwright install firefox` if needed.",
+            "`loginctl enable-linger <user>` if the listener must survive logout.",
+            "`whatsapp login` completed for the same persistent profile before unattended startup.",
+            "`codex` available on PATH, or pass --codex-command with its full executable path.",
+        ]
+        instructions = [
+            "Run `python manage.py whatsapp login --timeout 300` in a headed graphical session first.",
+            "Run the install command after writing files to enable the generated user unit.",
+            "Use the start command to launch the listener immediately.",
+            "Use the status command for logs and the stop/uninstall commands for rollback.",
+        ]
+        if write_files:
+            resolved_output_dir.mkdir(parents=True, exist_ok=True)
+            service_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.write_text(_linux_listener_runner(resolved_base_dir, command), encoding="utf-8")
+            runner_path.chmod(0o755)
+            service_path.write_text(_linux_systemd_unit(unit_name, resolved_base_dir, runner_path), encoding="utf-8")
+            wrote_files = True
+
+    status = "written" if wrote_files else "planned"
+    detail = (
+        "Provisioning files were written; run the install command manually."
+        if wrote_files
+        else "Dry run only; pass --write to create provisioning files."
+    )
+    return WhatsAppListenerInstallPlan(
+        status=status,
+        platform=resolved_platform,
+        service_name=safe_service,
+        base_dir=resolved_base_dir,
+        profile_dir=resolved_profile_dir,
+        output_dir=resolved_output_dir,
+        runner_path=runner_path,
+        service_path=service_path,
+        listen_command=listen_command,
+        install_command=install_command,
+        start_command=start_command,
+        status_command=status_command,
+        stop_command=stop_command,
+        uninstall_command=uninstall_command,
+        wrote_files=wrote_files,
+        requirements=requirements,
+        instructions=instructions,
+        detail=detail,
+    )
 
 
 def listen_for_whatsapp_secretary_requests(

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -1097,6 +1097,14 @@ def build_whatsapp_listener_install_plan(
     from django.conf import settings
 
     resolved_platform = _listener_install_platform(platform)
+    host_platform = _listener_install_platform()
+    if platform and resolved_platform != host_platform and (
+        not python_executable or not manage_py
+    ):
+        raise ValueError(
+            "Cross-platform WhatsApp listener provisioning requires --python and "
+            "--manage-py for paths that exist on the target machine."
+        )
     safe_service = _safe_service_name(service_name)
     resolved_base_dir = Path(base_dir or settings.BASE_DIR).resolve()
     resolved_profile_dir = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from urllib.parse import quote, urlparse
 
 from filelock import FileLock
@@ -875,6 +875,41 @@ def _default_listener_install_output_dir(platform: str) -> Path:
     return base / "arthexis" / "whatsapp-listener"
 
 
+def _target_path_join(platform: str, base: str | Path, *parts: str) -> str:
+    path_class = PureWindowsPath if platform == "windows" else PurePosixPath
+    return str(path_class(str(base), *parts))
+
+
+def _default_listener_target_base_dir(platform: str) -> str:
+    if platform == "windows":
+        return r"C:\Arthexis"
+    return "/opt/arthexis"
+
+
+def _default_listener_target_profile_dir(platform: str) -> str:
+    if platform == "windows":
+        return _target_path_join(
+            platform,
+            "~",
+            ".codex",
+            "whatsapp-web",
+            "playwright-profile",
+        )
+    return _target_path_join(
+        platform,
+        "~",
+        ".codex",
+        "whatsapp-web",
+        "playwright-profile",
+    )
+
+
+def _default_listener_target_python(platform: str, base_dir: str | Path) -> str:
+    if platform == "windows":
+        return _target_path_join(platform, base_dir, ".venv", "Scripts", "python.exe")
+    return _target_path_join(platform, base_dir, ".venv", "bin", "python")
+
+
 def _default_systemd_user_dir() -> Path:
     root = os.environ.get("XDG_CONFIG_HOME")
     base = Path(root) if root else Path.home() / ".config"
@@ -994,7 +1029,7 @@ def _whatsapp_listener_command(
     return command
 
 
-def _windows_listener_runner(base_dir: Path, command: list[str | Path]) -> str:
+def _windows_listener_runner(base_dir: str | Path, command: list[str | Path]) -> str:
     return "\n".join(
         [
             "$ErrorActionPreference = 'Stop'",
@@ -1029,7 +1064,7 @@ def _windows_register_task_script(service_name: str, runner_path: Path) -> str:
     )
 
 
-def _linux_listener_runner(base_dir: Path, command: list[str | Path]) -> str:
+def _linux_listener_runner(base_dir: str | Path, command: list[str | Path]) -> str:
     return "\n".join(
         [
             "#!/usr/bin/env bash",
@@ -1041,7 +1076,11 @@ def _linux_listener_runner(base_dir: Path, command: list[str | Path]) -> str:
     )
 
 
-def _linux_systemd_unit(service_name: str, base_dir: Path, runner_path: Path) -> str:
+def _linux_systemd_unit(
+    service_name: str,
+    base_dir: str | Path,
+    runner_path: Path,
+) -> str:
     return "\n".join(
         [
             "[Unit]",
@@ -1097,17 +1136,18 @@ def build_whatsapp_listener_install_plan(
     from django.conf import settings
 
     resolved_platform = _listener_install_platform(platform)
-    host_platform = _listener_install_platform()
-    if platform and resolved_platform != host_platform and (
-        not python_executable or not manage_py
-    ):
-        raise ValueError(
-            "Cross-platform WhatsApp listener provisioning requires --python and "
-            "--manage-py for paths that exist on the target machine."
-        )
+    cross_platform = bool(platform and resolved_platform != _listener_install_platform())
     safe_service = _safe_service_name(service_name)
-    resolved_base_dir = Path(base_dir or settings.BASE_DIR).resolve()
-    resolved_profile_dir = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
+    if cross_platform:
+        resolved_base_dir: str | Path = str(
+            base_dir or _default_listener_target_base_dir(resolved_platform)
+        )
+        resolved_profile_dir: str | Path = str(
+            profile_dir or _default_listener_target_profile_dir(resolved_platform)
+        )
+    else:
+        resolved_base_dir = Path(base_dir or settings.BASE_DIR).resolve()
+        resolved_profile_dir = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
     resolved_output_dir = Path(output_dir or _default_listener_install_output_dir(resolved_platform)).expanduser()
     default_browser, default_channel = _platform_browser_defaults(resolved_platform)
     explicit_browser = (browser or "").strip().lower()
@@ -1115,8 +1155,25 @@ def build_whatsapp_listener_install_plan(
     resolved_channel = (channel or "").strip()
     if not resolved_channel and not explicit_browser:
         resolved_channel = default_channel
-    resolved_python = str(python_executable or sys.executable)
-    resolved_manage_py = Path(manage_py or (resolved_base_dir / "manage.py"))
+    resolved_python = str(
+        python_executable
+        or (
+            _default_listener_target_python(resolved_platform, resolved_base_dir)
+            if cross_platform
+            else sys.executable
+        )
+    )
+    resolved_manage_py: str | Path
+    if manage_py:
+        resolved_manage_py = str(manage_py)
+    elif cross_platform:
+        resolved_manage_py = _target_path_join(
+            resolved_platform,
+            resolved_base_dir,
+            "manage.py",
+        )
+    else:
+        resolved_manage_py = Path(resolved_base_dir) / "manage.py"
     command = _whatsapp_listener_command(
         phone=phone,
         default_country_code=default_country_code,

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -901,9 +901,15 @@ def _shell_command(command: list[str | Path]) -> str:
 
 def _systemd_quote(value: str | Path) -> str:
     raw = str(value)
-    if not raw or re.search(r"\s", raw):
+    if not raw or re.search(r"[\s\\\"']", raw):
         return '"' + raw.replace("\\", "\\\\").replace('"', '\\"') + '"'
     return raw
+
+
+def _platform_browser_defaults(platform: str) -> tuple[str, str]:
+    if platform == "windows":
+        return "edge", "msedge"
+    return "firefox", ""
 
 
 def _whatsapp_listener_command(
@@ -1054,8 +1060,8 @@ def build_whatsapp_listener_install_plan(
     secretary_name: str = "Secretary",
     terminal_title: str = "Arthexis Secretary",
     profile_dir: Path | str | None = None,
-    browser: str = DEFAULT_WHATSAPP_WEB_BROWSER,
-    channel: str = DEFAULT_WHATSAPP_WEB_CHANNEL,
+    browser: str | None = None,
+    channel: str | None = None,
     cdp_url: str = "",
     timeout_seconds: float = 120.0,
     poll_interval_seconds: float = 1.0,
@@ -1078,6 +1084,12 @@ def build_whatsapp_listener_install_plan(
     resolved_base_dir = Path(base_dir or settings.BASE_DIR).resolve()
     resolved_profile_dir = Path(profile_dir or DEFAULT_WHATSAPP_WEB_PROFILE_DIR).expanduser()
     resolved_output_dir = Path(output_dir or _default_listener_install_output_dir(resolved_platform)).expanduser()
+    default_browser, default_channel = _platform_browser_defaults(resolved_platform)
+    explicit_browser = (browser or "").strip().lower()
+    resolved_browser = explicit_browser or default_browser
+    resolved_channel = (channel or "").strip()
+    if not resolved_channel and not explicit_browser:
+        resolved_channel = default_channel
     resolved_python = str(python_executable or sys.executable)
     resolved_manage_py = Path(manage_py or (resolved_base_dir / "manage.py"))
     command = _whatsapp_listener_command(
@@ -1092,8 +1104,8 @@ def build_whatsapp_listener_install_plan(
         secretary_name=secretary_name,
         terminal_title=terminal_title,
         profile_dir=resolved_profile_dir,
-        browser=browser,
-        channel=channel,
+        browser=resolved_browser,
+        channel=resolved_channel,
         cdp_url=cdp_url,
         timeout_seconds=timeout_seconds,
         poll_interval_seconds=poll_interval_seconds,

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -912,6 +912,23 @@ def _platform_browser_defaults(platform: str) -> tuple[str, str]:
     return "firefox", ""
 
 
+def _browser_install_requirement(browser: str, platform: str, channel: str) -> str:
+    if browser == "edge":
+        channel_text = f" through the {channel} channel" if channel else ""
+        return f"Microsoft Edge installed and available to Playwright{channel_text}."
+    if browser == "firefox":
+        return (
+            "Playwright Firefox installed; run `python -m playwright install firefox` "
+            "if needed."
+        )
+    if browser == "chromium":
+        return (
+            "Playwright Chromium installed; run `python -m playwright install chromium` "
+            "if needed."
+        )
+    return f"Playwright browser assets installed for {platform} browser {browser!r}."
+
+
 def _whatsapp_listener_command(
     *,
     phone: str,
@@ -1132,8 +1149,11 @@ def build_whatsapp_listener_install_plan(
         )
         requirements = [
             "Windows interactive user session; do not provision as a non-interactive Windows service.",
-            "Microsoft Edge installed and available to Playwright through the msedge channel.",
-            "Run `python -m playwright install chromium` if Playwright browser assets are missing.",
+            _browser_install_requirement(
+                resolved_browser,
+                resolved_platform,
+                resolved_channel,
+            ),
             "`whatsapp login` completed for the same persistent profile before unattended startup.",
             "`codex` available on PATH, or pass --codex-command with its full executable path.",
         ]
@@ -1161,7 +1181,11 @@ def build_whatsapp_listener_install_plan(
         uninstall_command = f"systemctl --user disable --now {shlex.quote(unit_name)}"
         requirements = [
             "Linux graphical user session with systemd --user available.",
-            "Firefox installed through Playwright; run `python -m playwright install firefox` if needed.",
+            _browser_install_requirement(
+                resolved_browser,
+                resolved_platform,
+                resolved_channel,
+            ),
             "`loginctl enable-linger <user>` if the listener must survive logout.",
             "`whatsapp login` completed for the same persistent profile before unattended startup.",
             "`codex` available on PATH, or pass --codex-command with its full executable path.",

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -1239,7 +1239,10 @@ def build_whatsapp_listener_install_plan(
         service_dir = Path(systemd_user_dir or _default_systemd_user_dir()).expanduser()
         service_path = service_dir / unit_name
         listen_command = _shell_command(command)
-        install_command = f"systemctl --user daemon-reload && systemctl --user enable {shlex.quote(unit_name)}"
+        install_command = (
+            "systemctl --user daemon-reload && systemctl --user enable "
+            f"{shlex.quote(str(service_path))}"
+        )
         start_command = f"systemctl --user start {shlex.quote(unit_name)}"
         status_command = f"systemctl --user status {shlex.quote(unit_name)}"
         stop_command = f"systemctl --user stop {shlex.quote(unit_name)}"

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -945,13 +945,11 @@ def test_install_listener_requirements_match_chromium_override(tmp_path):
     assert not any("Firefox" in item for item in payload["requirements"])
 
 
-def test_install_listener_cross_platform_requires_target_paths(tmp_path):
+def test_install_listener_cross_platform_uses_target_path_defaults(tmp_path):
     target = "linux" if sys.platform == "win32" else "windows"
+    stdout = StringIO()
 
-    with override_settings(BASE_DIR=tmp_path), pytest.raises(
-        CommandError,
-        match="Cross-platform WhatsApp listener provisioning requires --python",
-    ):
+    with override_settings(BASE_DIR=tmp_path):
         call_command(
             "whatsapp",
             "install-listener",
@@ -959,7 +957,50 @@ def test_install_listener_cross_platform_requires_target_paths(tmp_path):
             "5551234567",
             "--platform",
             target,
+            "--json",
+            stdout=stdout,
         )
+
+    payload = json.loads(stdout.getvalue())
+    assert sys.executable not in payload["listen_command"]
+    assert str(tmp_path) not in payload["listen_command"]
+    if target == "windows":
+        assert payload["base_dir"] == r"C:\Arthexis"
+        assert r"C:\Arthexis\.venv\Scripts\python.exe" in payload["listen_command"]
+        assert r"C:\Arthexis\manage.py" in payload["listen_command"]
+    else:
+        assert payload["base_dir"] == "/opt/arthexis"
+        assert "/opt/arthexis/.venv/bin/python" in payload["listen_command"]
+        assert "/opt/arthexis/manage.py" in payload["listen_command"]
+
+
+def test_install_listener_cross_platform_base_dir_controls_target_paths(tmp_path):
+    target = "linux" if sys.platform == "win32" else "windows"
+    base_dir = "/srv/arthexis" if target == "linux" else r"D:\Arthexis"
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            target,
+            "--base-dir",
+            base_dir,
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["base_dir"] == base_dir
+    if target == "windows":
+        assert r"D:\Arthexis\.venv\Scripts\python.exe" in payload["listen_command"]
+        assert r"D:\Arthexis\manage.py" in payload["listen_command"]
+    else:
+        assert "/srv/arthexis/.venv/bin/python" in payload["listen_command"]
+        assert "/srv/arthexis/manage.py" in payload["listen_command"]
 
 
 def test_systemd_quote_escapes_backslashes_without_spaces():

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -851,7 +851,8 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
     assert payload["platform"] == "linux"
     assert payload["wrote_files"] is False
     assert payload["service_path"] == str(systemd_dir / "arthexis-whatsapp-listener.service")
-    assert "systemctl --user enable arthexis-whatsapp-listener.service" in payload["install_command"]
+    assert "systemctl --user enable" in payload["install_command"]
+    assert str(systemd_dir / "arthexis-whatsapp-listener.service") in payload["install_command"]
     assert "--browser firefox" in payload["listen_command"]
     assert "--headless" in payload["listen_command"]
     assert not output_dir.exists()
@@ -1001,6 +1002,38 @@ def test_install_listener_cross_platform_base_dir_controls_target_paths(tmp_path
     else:
         assert "/srv/arthexis/.venv/bin/python" in payload["listen_command"]
         assert "/srv/arthexis/manage.py" in payload["listen_command"]
+
+
+def test_install_listener_cross_platform_written_runner_uses_target_base_dir(tmp_path):
+    target = "linux" if sys.platform == "win32" else "windows"
+    output_dir = tmp_path / "install"
+    stdout = StringIO()
+    args = [
+        "whatsapp",
+        "install-listener",
+        "--from",
+        "5551234567",
+        "--platform",
+        target,
+        "--output-dir",
+        str(output_dir),
+        "--write",
+        "--json",
+    ]
+    if target == "linux":
+        args.extend(["--systemd-user-dir", str(tmp_path / "systemd")])
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(*args, stdout=stdout)
+
+    payload = json.loads(stdout.getvalue())
+    runner_text = Path(payload["runner_path"]).read_text(encoding="utf-8")
+    assert str(tmp_path) not in payload["listen_command"]
+    assert str(tmp_path) not in runner_text
+    if target == "windows":
+        assert r"C:\Arthexis" in runner_text
+    else:
+        assert "/opt/arthexis" in runner_text
 
 
 def test_systemd_quote_escapes_backslashes_without_spaces():

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -20,6 +20,7 @@ from apps.meta.services import (
     WhatsAppWebSendResult,
     _is_whatsapp_web_url,
     _read_cursor,
+    _systemd_quote,
     _with_whatsapp_page,
     _write_cursor,
     build_whatsapp_secretary_prompt,
@@ -830,8 +831,6 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
             str(output_dir),
             "--systemd-user-dir",
             str(systemd_dir),
-            "--browser",
-            "firefox",
             "--headless",
             "--json",
             stdout=stdout,
@@ -848,6 +847,34 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
     assert "--headless" in payload["listen_command"]
     assert not output_dir.exists()
     assert not systemd_dir.exists()
+
+
+def test_install_listener_target_platform_controls_browser_defaults(tmp_path):
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "windows",
+            "--output-dir",
+            str(tmp_path / "install"),
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    assert "--browser" in payload["listen_command"]
+    assert "'edge'" in payload["listen_command"]
+    assert "--channel" in payload["listen_command"]
+    assert "'msedge'" in payload["listen_command"]
+
+
+def test_systemd_quote_escapes_backslashes_without_spaces():
+    assert _systemd_quote(r"/tmp/with\backslash") == r'"/tmp/with\\backslash"'
 
 
 def test_whatsapp_install_listener_rejects_bad_timing():

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -895,6 +895,33 @@ def test_install_listener_explicit_browser_skips_platform_channel_default(tmp_pa
     payload = json.loads(stdout.getvalue())
     assert "'firefox'" in payload["listen_command"]
     assert "--channel" not in payload["listen_command"]
+    assert any("Playwright Firefox" in item for item in payload["requirements"])
+    assert not any("Microsoft Edge" in item for item in payload["requirements"])
+
+
+def test_install_listener_requirements_match_chromium_override(tmp_path):
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "linux",
+            "--browser",
+            "chromium",
+            "--output-dir",
+            str(tmp_path / "install"),
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    assert "--browser chromium" in payload["listen_command"]
+    assert any("Playwright Chromium" in item for item in payload["requirements"])
+    assert not any("Firefox" in item for item in payload["requirements"])
 
 
 def test_systemd_quote_escapes_backslashes_without_spaces():

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from io import StringIO
 from pathlib import Path
 
@@ -792,6 +793,10 @@ def test_whatsapp_install_listener_windows_writes_manual_artifacts(tmp_path):
             str(profile_dir),
             "--codex-command",
             r"C:\Program Files\Codex\codex.exe",
+            "--python",
+            r"C:\Arthexis\.venv\Scripts\python.exe",
+            "--manage-py",
+            r"C:\Arthexis\manage.py",
             "--write",
             "--json",
             stdout=stdout,
@@ -831,6 +836,10 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
             str(output_dir),
             "--systemd-user-dir",
             str(systemd_dir),
+            "--python",
+            "/opt/arthexis/.venv/bin/python",
+            "--manage-py",
+            "/opt/arthexis/manage.py",
             "--headless",
             "--json",
             stdout=stdout,
@@ -862,6 +871,10 @@ def test_install_listener_target_platform_controls_browser_defaults(tmp_path):
             "windows",
             "--output-dir",
             str(tmp_path / "install"),
+            "--python",
+            r"C:\Arthexis\.venv\Scripts\python.exe",
+            "--manage-py",
+            r"C:\Arthexis\manage.py",
             "--json",
             stdout=stdout,
         )
@@ -888,6 +901,10 @@ def test_install_listener_explicit_browser_skips_platform_channel_default(tmp_pa
             "firefox",
             "--output-dir",
             str(tmp_path / "install"),
+            "--python",
+            r"C:\Arthexis\.venv\Scripts\python.exe",
+            "--manage-py",
+            r"C:\Arthexis\manage.py",
             "--json",
             stdout=stdout,
         )
@@ -914,6 +931,10 @@ def test_install_listener_requirements_match_chromium_override(tmp_path):
             "chromium",
             "--output-dir",
             str(tmp_path / "install"),
+            "--python",
+            "/opt/arthexis/.venv/bin/python",
+            "--manage-py",
+            "/opt/arthexis/manage.py",
             "--json",
             stdout=stdout,
         )
@@ -922,6 +943,23 @@ def test_install_listener_requirements_match_chromium_override(tmp_path):
     assert "--browser chromium" in payload["listen_command"]
     assert any("Playwright Chromium" in item for item in payload["requirements"])
     assert not any("Firefox" in item for item in payload["requirements"])
+
+
+def test_install_listener_cross_platform_requires_target_paths(tmp_path):
+    target = "linux" if sys.platform == "win32" else "windows"
+
+    with override_settings(BASE_DIR=tmp_path), pytest.raises(
+        CommandError,
+        match="Cross-platform WhatsApp listener provisioning requires --python",
+    ):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            target,
+        )
 
 
 def test_systemd_quote_escapes_backslashes_without_spaces():

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -873,6 +873,30 @@ def test_install_listener_target_platform_controls_browser_defaults(tmp_path):
     assert "'msedge'" in payload["listen_command"]
 
 
+def test_install_listener_explicit_browser_skips_platform_channel_default(tmp_path):
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "windows",
+            "--browser",
+            "firefox",
+            "--output-dir",
+            str(tmp_path / "install"),
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    assert "'firefox'" in payload["listen_command"]
+    assert "--channel" not in payload["listen_command"]
+
+
 def test_systemd_quote_escapes_backslashes_without_spaces():
     assert _systemd_quote(r"/tmp/with\backslash") == r'"/tmp/with\\backslash"'
 

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.test import override_settings
 
 from apps.meta.management.commands import whatsapp as whatsapp_command
 from apps.meta.services import (
@@ -769,3 +770,93 @@ def test_whatsapp_listen_command_outputs_json(monkeypatch, tmp_path):
     payload = json.loads(stdout.getvalue())
     assert payload["status"] == "matched"
     assert payload["message_count"] == 1
+
+
+def test_whatsapp_install_listener_windows_writes_manual_artifacts(tmp_path):
+    output_dir = tmp_path / "install"
+    profile_dir = tmp_path / "profile"
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "windows",
+            "--output-dir",
+            str(output_dir),
+            "--profile-dir",
+            str(profile_dir),
+            "--codex-command",
+            r"C:\Program Files\Codex\codex.exe",
+            "--write",
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    runner_path = Path(payload["runner_path"])
+    service_path = Path(payload["service_path"])
+
+    assert payload["status"] == "written"
+    assert payload["platform"] == "windows"
+    assert payload["wrote_files"] is True
+    assert runner_path.exists()
+    assert service_path.exists()
+    assert "--from" in payload["listen_command"]
+    assert "5551234567" in payload["listen_command"]
+    assert "C:\\Program Files\\Codex\\codex.exe" in payload["listen_command"]
+    assert "Register-ScheduledTask" in service_path.read_text(encoding="utf-8")
+    assert "whatsapp" in runner_path.read_text(encoding="utf-8")
+    assert "listen" in runner_path.read_text(encoding="utf-8")
+
+
+def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_path):
+    output_dir = tmp_path / "install"
+    systemd_dir = tmp_path / "systemd-user"
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "linux",
+            "--output-dir",
+            str(output_dir),
+            "--systemd-user-dir",
+            str(systemd_dir),
+            "--browser",
+            "firefox",
+            "--headless",
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+
+    assert payload["status"] == "planned"
+    assert payload["platform"] == "linux"
+    assert payload["wrote_files"] is False
+    assert payload["service_path"] == str(systemd_dir / "arthexis-whatsapp-listener.service")
+    assert "systemctl --user enable arthexis-whatsapp-listener.service" in payload["install_command"]
+    assert "--browser firefox" in payload["listen_command"]
+    assert "--headless" in payload["listen_command"]
+    assert not output_dir.exists()
+    assert not systemd_dir.exists()
+
+
+def test_whatsapp_install_listener_rejects_bad_timing():
+    with pytest.raises(CommandError, match="--quiet-window must be >= 1"):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--quiet-window",
+            "0",
+        )

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -115,6 +115,10 @@ python manage.py whatsapp send --to 525551234567 --message "Hello" --cdp-url htt
 manual registration commands. It only writes helper files when `--write` is
 passed. It does not silently register startup services.
 
+Run `install-listener` on the machine that will run the listener. When using
+`--platform` to generate files for a different operating system, also pass
+`--python` and `--manage-py` with paths that exist on that target machine.
+
 Shared requirements:
 
 - Run `python manage.py whatsapp login --timeout 300` first in a headed browser

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -90,10 +90,89 @@ Run one local dry pass after a quiet batch without launching Codex:
 python manage.py whatsapp listen --from 525551234567 --once --no-launch --json
 ```
 
+Plan listener startup provisioning without writing files:
+
+```powershell
+python manage.py whatsapp install-listener --from 525551234567
+```
+
+Write platform-specific helper files and print the manual install commands:
+
+```powershell
+python manage.py whatsapp install-listener --from 525551234567 --write
+```
+
 Attach to an already-open Edge debugging session:
 
 ```powershell
 python manage.py whatsapp send --to 525551234567 --message "Hello" --cdp-url http://127.0.0.1:9223
+```
+
+## Listener Startup Provisioning
+
+`install-listener` is a conservative provisioning helper. It builds the exact
+`whatsapp listen` command and prints the requirements, generated file paths, and
+manual registration commands. It only writes helper files when `--write` is
+passed. It does not silently register startup services.
+
+Shared requirements:
+
+- Run `python manage.py whatsapp login --timeout 300` first in a headed browser
+  and confirm `python manage.py whatsapp status --json` reports a logged-in
+  profile.
+- Keep the same `--profile-dir` for `login`, `status`, `listen`, and
+  `install-listener`.
+- Keep `codex` available on `PATH`, or pass `--codex-command` with the full
+  executable path and any fixed flags.
+- Use the default `secretary:` trigger unless every new self-chat message should
+  create a Secretary request.
+
+Windows provisioning uses an interactive Scheduled Task because Playwright and
+WhatsApp Web need the operator desktop session. The generated files are a
+PowerShell runner and a registration script. Typical flow:
+
+```powershell
+python manage.py whatsapp install-listener --from 525551234567 --write
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File '<printed Register-*.ps1 path>'
+Start-ScheduledTask -TaskName 'arthexis-whatsapp-listener'
+Get-ScheduledTask -TaskName 'arthexis-whatsapp-listener'
+```
+
+Windows requirements:
+
+- Microsoft Edge installed.
+- Playwright can launch Edge through the `msedge` channel.
+- The task runs as the current interactive user at logon, not as a Windows
+  service account.
+
+Rollback:
+
+```powershell
+Stop-ScheduledTask -TaskName 'arthexis-whatsapp-listener'
+Unregister-ScheduledTask -TaskName 'arthexis-whatsapp-listener' -Confirm:$false
+```
+
+Linux provisioning writes a shell runner and a systemd user unit. Typical flow:
+
+```bash
+python manage.py whatsapp install-listener --from 525551234567 --write
+systemctl --user daemon-reload
+systemctl --user enable arthexis-whatsapp-listener.service
+systemctl --user start arthexis-whatsapp-listener.service
+systemctl --user status arthexis-whatsapp-listener.service
+```
+
+Linux requirements:
+
+- A graphical user session with `systemd --user`.
+- Playwright Firefox installed with `python -m playwright install firefox` when
+  needed.
+- `loginctl enable-linger <user>` if the listener must survive logout.
+
+Rollback:
+
+```bash
+systemctl --user disable --now arthexis-whatsapp-listener.service
 ```
 
 ## Privacy And Side Effects

--- a/docs/integrations/whatsapp-web-cli.md
+++ b/docs/integrations/whatsapp-web-cli.md
@@ -115,9 +115,13 @@ python manage.py whatsapp send --to 525551234567 --message "Hello" --cdp-url htt
 manual registration commands. It only writes helper files when `--write` is
 passed. It does not silently register startup services.
 
-Run `install-listener` on the machine that will run the listener. When using
-`--platform` to generate files for a different operating system, also pass
-`--python` and `--manage-py` with paths that exist on that target machine.
+Run `install-listener` on the machine that will run the listener when possible.
+When using `--platform` to generate files for a different operating system, the
+generated listener command uses target-platform defaults:
+`C:\Arthexis\.venv\Scripts\python.exe` plus `C:\Arthexis\manage.py` for Windows,
+or `/opt/arthexis/.venv/bin/python` plus `/opt/arthexis/manage.py` for Linux.
+Pass `--base-dir`, `--python`, or `--manage-py` when the target machine uses a
+different checkout or virtualenv path.
 
 Shared requirements:
 


### PR DESCRIPTION
## Summary

- add `python manage.py whatsapp install-listener` as a safe provisioning planner for WhatsApp Secretary listener startup
- generate Windows Scheduled Task helper files and Linux systemd user-unit artifacts only when `--write` is passed
- document manual requirements, provisioning, verification, and rollback for Windows Edge and Linux Firefox setups

Closes #7558

## Validation

- `..\arthexis\.venv\Scripts\python.exe -m ruff check apps\meta\services.py apps\meta\management\commands\whatsapp.py apps\meta\tests\test_whatsapp.py`
- `..\arthexis\.venv\Scripts\python.exe -m pytest apps\meta\tests\test_whatsapp.py`
- `..\arthexis\.venv\Scripts\python.exe manage.py check`
- `..\arthexis\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `..\arthexis\.venv\Scripts\python.exe manage.py whatsapp install-listener --from 8119218587 --json`
- `git diff --check HEAD~1..HEAD`

Note: the repo `manage.py test run -- apps\meta\tests\test_whatsapp.py` wrapper refused this isolated worktree because it expects a local `.venv` under the worktree; the focused pytest command above used the shared main checkout venv successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces a new Django management subcommand `whatsapp install-listener` that generates a safe, platform-specific provisioning plan for starting the WhatsApp Secretary listener. The command defaults to printing a text-based installation plan without writing files, and optionally generates helper artifacts when the `--write` flag is supplied.

## Key Changes

### Management Command (`apps/meta/management/commands/whatsapp.py`)
- Added `install-listener` subcommand with support for listener-specific arguments (browser, profile directory, trigger prefix, timing parameters, codex command, etc.)
- Implemented `_handle_install_listener()` to validate shared numeric constraints and invoke the plan builder
- Implemented `_write_install_plan()` to format output as JSON or human-readable text plan including the listen command, platform-specific requirements, manual provisioning steps, and verification instructions

### Services Module (`apps/meta/services.py`)
- Introduced `WhatsAppListenerInstallPlan` dataclass encapsulating the plan state: platform detection, service naming, directory resolution, generated commands, file write status, and provisioning steps
- Implemented `build_whatsapp_listener_install_plan()` to:
  - Detect platform (Windows/Linux) and resolve base/profile/output directories (defaulting to Django `settings.BASE_DIR` and user config directories)
  - Build the exact `python manage.py whatsapp listen ...` command preserving all listener options
  - Generate platform-specific artifacts:
    - **Windows**: PowerShell Scheduled Task runner and registration script for Edge
    - **Linux**: bash runner and systemd user-unit file for Firefox
  - Support dry-run mode and conditional file writing with status tracking (`planned` or `written`)
  - Populate platform-specific start/stop/uninstall command references for manual execution

### Test Coverage (`apps/meta/tests/test_whatsapp.py`)
- Added `test_whatsapp_install_listener_windows_writes_manual_artifacts()` to verify Windows file generation (PowerShell runner, service file) and command content
- Added `test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit()` to verify Linux systemd unit planning without file writes
- Added `test_whatsapp_install_listener_rejects_bad_timing()` to validate rejection of invalid timing parameter values

### Documentation (`docs/integrations/whatsapp-web-cli.md`)
- Added usage examples for `python manage.py whatsapp install-listener` showing plan generation and `--write` mode
- Introduced "Listener Startup Provisioning" section documenting shared prerequisites, platform-specific manual provisioning steps for Windows Scheduled Task and Linux systemd user unit, verification procedures, and rollback instructions

## Design Highlights
- The command generates listener commands using identical options and validation as `whatsapp listen`, ensuring consistency
- Default behavior (print plan, no file writes) maintains operator control over provisioning—no implicit automated registration
- Generated artifacts include all necessary helper files (runners, systemd units) and manual command references for verification, starting, stopping, and uninstalling
- Supports both dry-run planning and actual file generation through a single `write_files` parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->