### PR TITLE
Restore AP portal registration recovery

### DIFF
--- a/config/data/ap_portal/app.js
+++ b/config/data/ap_portal/app.js
@@ -2,6 +2,15 @@ const form = document.querySelector("#consent-form");
 const statusEl = document.querySelector("#status");
 const sourceLink = document.querySelector("#source-link");
 
+function redirectAfterDelay(url, delayMs) {
+  if (!url) {
+    return;
+  }
+  window.setTimeout(() => {
+    window.location.href = url;
+  }, delayMs || 3000);
+}
+
 async function loadStatus() {
   const response = await fetch("/api/status", { cache: "no-store" });
   if (!response.ok) {
@@ -12,7 +21,9 @@ async function loadStatus() {
     sourceLink.href = payload.source_code_url;
   }
   if (payload.authorized) {
-    statusEl.textContent = "This device is already authorized. Internet access should be available.";
+    statusEl.textContent = "This device is already authorized. Opening suite login.";
+    form.hidden = true;
+    redirectAfterDelay(payload.authorized_redirect_url, payload.redirect_delay_ms);
   }
 }
 
@@ -36,10 +47,8 @@ form.addEventListener("submit", async (event) => {
     if (!response.ok) {
       throw new Error(result.error || "Unable to authorize this device.");
     }
-    statusEl.textContent = "Access recorded. Redirecting to a connectivity check.";
-    window.setTimeout(() => {
-      window.location.href = result.redirect_url || "/";
-    }, 700);
+    statusEl.textContent = "Access recorded. Opening suite login.";
+    redirectAfterDelay(result.redirect_url || "/", result.redirect_delay_ms);
   } catch (error) {
     statusEl.textContent = error.message;
     button.disabled = false;

--- a/config/data/ap_portal/app.js
+++ b/config/data/ap_portal/app.js
@@ -8,7 +8,7 @@ function redirectAfterDelay(url, delayMs) {
   }
   window.setTimeout(() => {
     window.location.href = url;
-  }, delayMs || 3000);
+  }, delayMs ?? 3000);
 }
 
 async function loadStatus() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ In Arthexis terminology, the **suite** is the collection of applications, while 
 - [Good Command](operations/good-command.md)
 - [Install & Lifecycle Scripts Manual](development/install-lifecycle-scripts-manual.md)
 - [Agent Card v1 RFID Layout](development/agent-card-v1.md)
+- [AP Portal Recovery](operations/ap-portal.md)
 - [Sigil Script Command](development/sigil-script-command.md)
 - [LCD Screen Hardware](lcd-screen-hardware.md)
 - [App Structure Policy](development/app-structure-policy.md)

--- a/docs/operations/ap-portal.md
+++ b/docs/operations/ap-portal.md
@@ -1,0 +1,64 @@
+# AP Portal Recovery
+
+The AP portal is the simple Python welcome and consent screen for the
+`arthexis-1` access point. It runs as `arthexis-ap-portal.service` on
+`127.0.0.1:9080` and nginx exposes it on port 80 and, when local certificates
+exist, port 443.
+
+Use this runbook when AP clients see the Django suite page instead of the AP
+portal, or when `http://10.42.0.1/health` does not return portal JSON.
+
+## Local Prototype
+
+From the repository root:
+
+```bash
+python scripts/ap_portal_server.py --bind 127.0.0.1 --port 9080 --skip-firewall-sync
+```
+
+Then open:
+
+```text
+http://127.0.0.1:9080/
+http://127.0.0.1:9080/health
+http://127.0.0.1:9080/api/status
+```
+
+`--skip-firewall-sync` is for development only. Production AP installs must let
+the portal synchronize nftables authorization rules. In this local-only mode,
+loopback clients use a deterministic development MAC (`02:00:00:00:00:01`) so
+the consent flow can be previewed from a browser without an AP neighbor table.
+Authorized clients wait three seconds on the portal status message, then redirect
+to the suite login at `http://10.42.0.1:8888/login/` by default. Override
+`--suite-login-host`, `--suite-login-port`, or `--suite-login-path` only for
+gateways that use a different AP-side suite address.
+
+## Gateway Recovery
+
+On the gateway device:
+
+```bash
+cd /path/to/arthexis
+sudo ./scripts/setup_ap_portal.sh
+systemctl status arthexis-ap-portal.service --no-pager
+curl -i http://127.0.0.1:9080/health
+curl -i http://127.0.0.1:9080/api/status
+curl -i http://10.42.0.1/health
+```
+
+Expected results:
+
+- `arthexis-ap-portal.service` is active.
+- Local port `9080` returns `{"ok": true}` from `/health`.
+- AP-facing port `80` returns the same portal health JSON through nginx.
+- `http://10.42.0.1/` shows the AP consent page headed `AP activity is monitored`.
+
+If nginx validation fails, `setup_ap_portal.sh` restores the most recent
+pre-portal nginx site backup before exiting.
+
+## Registration Template Packaging
+
+If `/soul/register/` returns a server error while other suite pages render, check
+that `apps.souls` is present under `[tool.setuptools.package-data]` in
+`pyproject.toml`. The registration flow renders templates from
+`apps/souls/templates/souls/`, so release wheels must include that tree.

--- a/docs/operations/ap-portal.md
+++ b/docs/operations/ap-portal.md
@@ -30,8 +30,11 @@ loopback clients use a deterministic development MAC (`02:00:00:00:00:01`) so
 the consent flow can be previewed from a browser without an AP neighbor table.
 Authorized clients wait three seconds on the portal status message, then redirect
 to the suite login at `http://10.42.0.1:8888/login/` by default. Override
-`--suite-login-host`, `--suite-login-port`, or `--suite-login-path` only for
-gateways that use a different AP-side suite address.
+`--suite-login-scheme`, `--suite-login-host`, `--suite-login-port`, or
+`--suite-login-path` only for gateways that use a different AP-side suite
+address. Override `--authorized-redirect-delay-ms` when authorized clients
+should wait for a different interval; the default is `3000` ms, and `0` redirects
+immediately.
 
 ## Gateway Recovery
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,6 +344,7 @@ include-package-data = true
 "apps.sites.templatetags" = [ "**/*",]
 "apps.sites.tests" = [ "**/*",]
 "apps.sites.views" = [ "**/*",]
+"apps.souls" = [ "**/*",]
 "apps.summary" = [ "**/*",]
 "apps.summary.migrations" = [ "**/*",]
 "apps.tasks" = [ "**/*",]

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -19,11 +19,14 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-
 BASE_DIR = Path(__file__).resolve().parents[1]
 ASSETS_DIR = BASE_DIR / "config" / "data" / "ap_portal"
 DEFAULT_STATE_DIR = BASE_DIR / ".state" / "ap_portal"
 DEFAULT_SOURCE_URL = "https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py"
+DEFAULT_SUITE_LOGIN_HOST = "10.42.0.1"
+DEFAULT_SUITE_LOGIN_PORT = 8888
+DEFAULT_SUITE_LOGIN_PATH = "/login/"
+DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS = 3000
 AUTHORIZED_MACS_PATH = DEFAULT_STATE_DIR / "authorized_macs.txt"
 CONSENTS_PATH = DEFAULT_STATE_DIR / "consents.jsonl"
 ACTIVITY_PATH = DEFAULT_STATE_DIR / "activity.jsonl"
@@ -33,6 +36,7 @@ TERMS_VERSION = "qol-recording-v2"
 MAX_PAYLOAD_BYTES = 1024 * 1024
 ARP_TABLE_PATH = Path("/proc/net/arp")
 NDISC_CACHE_PATH = Path("/proc/net/ndisc_cache")
+LOCAL_DEVELOPMENT_MAC = "02:00:00:00:00:01"
 TERMS_STATEMENT = (
     "I accept that my internet experience may be altered and recorded "
     "for quality of life purposes while using this access point."
@@ -58,7 +62,12 @@ class PortalConfig:
     consents_path: Path
     activity_path: Path
     source_url: str
+    suite_login_host: str = DEFAULT_SUITE_LOGIN_HOST
+    suite_login_port: int = DEFAULT_SUITE_LOGIN_PORT
+    suite_login_path: str = DEFAULT_SUITE_LOGIN_PATH
+    authorized_redirect_delay_ms: int = DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS
     sync_firewall: bool = True
+    local_development_mac: str | None = None
 
 
 class FirewallSyncError(RuntimeError):
@@ -109,6 +118,38 @@ def _ip_addresses_match(left: str, right: str) -> bool:
         return ipaddress.ip_address(left) == ipaddress.ip_address(right)
     except ValueError:
         return left == right
+
+
+def _is_loopback_ip(value: str) -> bool:
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return value in {"localhost"}
+
+
+def _normalize_url_path(value: str) -> str:
+    path = str(value or DEFAULT_SUITE_LOGIN_PATH).strip() or DEFAULT_SUITE_LOGIN_PATH
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+def _host_for_suite_redirect(host: str, configured_host: str = "") -> str:
+    if configured_host:
+        host = configured_host
+    parsed = urlparse(host if "://" in host else f"//{host}")
+    hostname = parsed.hostname or "arthexis.net"
+    try:
+        parsed_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return hostname
+    if parsed_ip.version == 6:
+        return f"[{hostname}]"
+    return hostname
+
+
+def _suite_login_url(host: str, *, configured_host: str = "", port: int, path: str) -> str:
+    return f"http://{_host_for_suite_redirect(host, configured_host)}:{port}{_normalize_url_path(path)}"
 
 
 class FirewallManager:
@@ -320,6 +361,9 @@ class PortalState:
         mac_address = self.resolve_mac(ip_address)
         with self._lock:
             authorized = bool(mac_address and mac_address in self._authorized)
+        authorized_redirect_url = (
+            self.suite_login_url(host) if authorized else ""
+        )
         self.activity.record(
             "status_check",
             ip_address=ip_address,
@@ -332,6 +376,8 @@ class PortalState:
         return {
             "authorized": authorized,
             "mac_address": mac_address,
+            "authorized_redirect_url": authorized_redirect_url,
+            "redirect_delay_ms": self.config.authorized_redirect_delay_ms,
             "terms_version": TERMS_VERSION,
             "terms_statement": TERMS_STATEMENT,
             "monitoring_notice": MONITORING_NOTICE,
@@ -365,6 +411,14 @@ class PortalState:
             path=path,
             host=host,
             referer=referer,
+        )
+
+    def suite_login_url(self, host: str) -> str:
+        return _suite_login_url(
+            host,
+            configured_host=self.config.suite_login_host,
+            port=self.config.suite_login_port,
+            path=self.config.suite_login_path,
         )
 
     def subscribe(
@@ -426,7 +480,7 @@ class PortalState:
                         user_agent=user_agent,
                         host=host,
                     )
-                except OSError:
+                except OSError as consent_error:
                     rollback_error = None
                     try:
                         self._restore_consent_log(consent_rollback_position)
@@ -447,7 +501,7 @@ class PortalState:
                             exc.add_note(f"file rollback failed: {rollback_error}")
                         raise
                     if rollback_error is not None:
-                        raise rollback_error
+                        raise rollback_error from consent_error
                     raise
                 self._authorized = next_authorized
             else:
@@ -473,12 +527,15 @@ class PortalState:
             "mac_address": mac_address,
             "monitoring_notice": MONITORING_NOTICE,
             "source_code_url": self.config.source_url,
-            "redirect_url": "http://neverssl.com/",
+            "redirect_url": self.suite_login_url(host),
+            "redirect_delay_ms": self.config.authorized_redirect_delay_ms,
         }
 
     def resolve_mac(self, ip_address: str | None) -> str | None:
         if not ip_address:
             return None
+        if self.config.local_development_mac and _is_loopback_ip(ip_address):
+            return self.config.local_development_mac
 
         mac_address = self._resolve_mac_from_arp(ip_address)
         if mac_address:
@@ -681,6 +738,15 @@ def build_config(args: argparse.Namespace) -> PortalConfig:
     state_dir = Path(args.state_dir).expanduser().resolve()
     assets_dir = Path(args.assets_dir).expanduser().resolve()
     source_url = args.source_url or os.environ.get("ARTHEXIS_AP_SOURCE_URL") or DEFAULT_SOURCE_URL
+    local_development_mac = (
+        args.local_development_mac
+        or os.environ.get("ARTHEXIS_AP_LOCAL_DEVELOPMENT_MAC")
+        or (LOCAL_DEVELOPMENT_MAC if args.skip_firewall_sync else "")
+    )
+    if local_development_mac:
+        local_development_mac = _normalize_mac(local_development_mac)
+        if not MAC_RE.fullmatch(local_development_mac):
+            raise ValueError(f"Invalid local development MAC: {local_development_mac}")
     return PortalConfig(
         bind=args.bind,
         port=args.port,
@@ -690,7 +756,12 @@ def build_config(args: argparse.Namespace) -> PortalConfig:
         consents_path=state_dir / "consents.jsonl",
         activity_path=state_dir / "activity.jsonl",
         source_url=source_url,
+        suite_login_host=args.suite_login_host,
+        suite_login_port=args.suite_login_port,
+        suite_login_path=_normalize_url_path(args.suite_login_path),
+        authorized_redirect_delay_ms=args.authorized_redirect_delay_ms,
         sync_firewall=not args.skip_firewall_sync,
+        local_development_mac=local_development_mac or None,
     )
 
 
@@ -701,6 +772,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assets-dir", default=str(ASSETS_DIR))
     parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
     parser.add_argument("--source-url", default="")
+    parser.add_argument("--suite-login-host", default=DEFAULT_SUITE_LOGIN_HOST)
+    parser.add_argument("--suite-login-port", type=int, default=DEFAULT_SUITE_LOGIN_PORT)
+    parser.add_argument("--suite-login-path", default=DEFAULT_SUITE_LOGIN_PATH)
+    parser.add_argument(
+        "--authorized-redirect-delay-ms",
+        type=int,
+        default=DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS,
+    )
+    parser.add_argument(
+        "--local-development-mac",
+        default="",
+        help=(
+            "Loopback MAC used only for local preview clients. When omitted, "
+            f"{LOCAL_DEVELOPMENT_MAC} is used with --skip-firewall-sync."
+        ),
+    )
     parser.add_argument(
         "--skip-firewall-sync",
         action="store_true",

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -135,10 +135,14 @@ def _normalize_url_path(value: str) -> str:
 
 
 def _host_for_suite_redirect(host: str, configured_host: str = "") -> str:
-    if configured_host:
-        host = configured_host
-    parsed = urlparse(host if "://" in host else f"//{host}")
-    hostname = parsed.hostname or "arthexis.net"
+    raw_host = (configured_host or host or "").strip()
+    if not raw_host:
+        return "arthexis.net"
+    if "://" in raw_host or raw_host.startswith("[") or raw_host.count(":") < 2:
+        parsed = urlparse(raw_host if "://" in raw_host else f"//{raw_host}")
+        hostname = parsed.hostname or "arthexis.net"
+    else:
+        hostname = raw_host
     try:
         parsed_ip = ipaddress.ip_address(hostname)
     except ValueError:

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -23,6 +23,7 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 ASSETS_DIR = BASE_DIR / "config" / "data" / "ap_portal"
 DEFAULT_STATE_DIR = BASE_DIR / ".state" / "ap_portal"
 DEFAULT_SOURCE_URL = "https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py"
+DEFAULT_SUITE_LOGIN_SCHEME = "http"
 DEFAULT_SUITE_LOGIN_HOST = "10.42.0.1"
 DEFAULT_SUITE_LOGIN_PORT = 8888
 DEFAULT_SUITE_LOGIN_PATH = "/login/"
@@ -62,6 +63,7 @@ class PortalConfig:
     consents_path: Path
     activity_path: Path
     source_url: str
+    suite_login_scheme: str = DEFAULT_SUITE_LOGIN_SCHEME
     suite_login_host: str = DEFAULT_SUITE_LOGIN_HOST
     suite_login_port: int = DEFAULT_SUITE_LOGIN_PORT
     suite_login_path: str = DEFAULT_SUITE_LOGIN_PATH
@@ -134,6 +136,13 @@ def _normalize_url_path(value: str) -> str:
     return path
 
 
+def _normalize_url_scheme(value: str) -> str:
+    scheme = str(value or DEFAULT_SUITE_LOGIN_SCHEME).strip().lower().removesuffix("://")
+    if scheme not in {"http", "https"}:
+        raise ValueError("--suite-login-scheme must be http or https.")
+    return scheme
+
+
 def _host_for_suite_redirect(host: str, configured_host: str = "") -> str:
     raw_host = (configured_host or host or "").strip()
     if not raw_host:
@@ -152,8 +161,19 @@ def _host_for_suite_redirect(host: str, configured_host: str = "") -> str:
     return hostname
 
 
-def _suite_login_url(host: str, *, configured_host: str = "", port: int, path: str) -> str:
-    return f"http://{_host_for_suite_redirect(host, configured_host)}:{port}{_normalize_url_path(path)}"
+def _suite_login_url(
+    host: str,
+    *,
+    configured_host: str = "",
+    scheme: str,
+    port: int,
+    path: str,
+) -> str:
+    return (
+        f"{_normalize_url_scheme(scheme)}://"
+        f"{_host_for_suite_redirect(host, configured_host)}:{port}"
+        f"{_normalize_url_path(path)}"
+    )
 
 
 class FirewallManager:
@@ -421,6 +441,7 @@ class PortalState:
         return _suite_login_url(
             host,
             configured_host=self.config.suite_login_host,
+            scheme=self.config.suite_login_scheme,
             port=self.config.suite_login_port,
             path=self.config.suite_login_path,
         )
@@ -760,6 +781,7 @@ def build_config(args: argparse.Namespace) -> PortalConfig:
         consents_path=state_dir / "consents.jsonl",
         activity_path=state_dir / "activity.jsonl",
         source_url=source_url,
+        suite_login_scheme=_normalize_url_scheme(args.suite_login_scheme),
         suite_login_host=args.suite_login_host,
         suite_login_port=args.suite_login_port,
         suite_login_path=_normalize_url_path(args.suite_login_path),
@@ -776,6 +798,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--assets-dir", default=str(ASSETS_DIR))
     parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
     parser.add_argument("--source-url", default="")
+    parser.add_argument("--suite-login-scheme", default=DEFAULT_SUITE_LOGIN_SCHEME)
     parser.add_argument("--suite-login-host", default=DEFAULT_SUITE_LOGIN_HOST)
     parser.add_argument("--suite-login-port", type=int, default=DEFAULT_SUITE_LOGIN_PORT)
     parser.add_argument("--suite-login-path", default=DEFAULT_SUITE_LOGIN_PATH)

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -5,9 +5,9 @@ import io
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ap_portal_server.py"
 
@@ -59,6 +59,7 @@ def test_subscribe_records_consent_activity_and_authorizes_client(tmp_path):
 
     assert result["authorized"] is True
     assert result["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert result["redirect_url"] == "http://10.42.0.1:8888/login/"
     assert "ARE being monitored" in result["monitoring_notice"]
     assert state.config.authorized_macs_path.read_text(encoding="utf-8") == "aa:bb:cc:dd:ee:ff\n"
 
@@ -380,6 +381,53 @@ def test_status_records_activity_and_exposes_monitoring_paths(tmp_path):
     assert activity["monitoring_notice"] == module.MONITORING_NOTICE
 
 
+def test_status_redirects_authorized_client_to_suite_login_port(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+
+    payload = state.status_for_request(
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        path="/api/status",
+        host="arthexis.net",
+    )
+
+    assert payload["authorized"] is True
+    assert payload["authorized_redirect_url"] == "http://10.42.0.1:8888/login/"
+    assert payload["redirect_delay_ms"] == module.DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS
+
+
+def test_suite_login_redirect_defaults_to_gateway_host():
+    module = load_portal_module()
+
+    assert (
+        module._suite_login_url(
+            "arthexis.net",
+            configured_host=module.DEFAULT_SUITE_LOGIN_HOST,
+            port=8888,
+            path="login/",
+        )
+        == "http://10.42.0.1:8888/login/"
+    )
+
+
+def test_suite_login_redirect_can_reuse_current_host_without_existing_port():
+    module = load_portal_module()
+
+    assert (
+        module._suite_login_url("127.0.0.1:9080", configured_host="", port=8888, path="login/")
+        == "http://127.0.0.1:8888/login/"
+    )
+
+
 def test_read_events_uses_bounded_tail_without_reading_whole_file(tmp_path, monkeypatch):
     module = load_portal_module()
     state = module.PortalState(make_config(module, tmp_path))
@@ -549,6 +597,37 @@ def test_resolve_mac_reads_ipv6_neighbor_cache(tmp_path, monkeypatch):
 
     assert state.resolve_mac("fd42:0:0:42::25") == "aa:bb:cc:dd:ee:ff"
     assert state.resolve_mac("fd42:0:0:42::26") is None
+
+
+def test_loopback_client_requires_explicit_local_development_mac(tmp_path):
+    module = load_portal_module()
+    state = module.PortalState(make_config(module, tmp_path))
+
+    assert state.resolve_mac("127.0.0.1") is None
+
+
+def test_skip_firewall_sync_defaults_loopback_to_development_mac(tmp_path):
+    module = load_portal_module()
+    args = SimpleNamespace(
+        bind="127.0.0.1",
+        port=9080,
+        assets_dir=str(tmp_path),
+        state_dir=str(tmp_path / "state"),
+        source_url="",
+        suite_login_host=module.DEFAULT_SUITE_LOGIN_HOST,
+        suite_login_port=module.DEFAULT_SUITE_LOGIN_PORT,
+        suite_login_path=module.DEFAULT_SUITE_LOGIN_PATH,
+        authorized_redirect_delay_ms=module.DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS,
+        skip_firewall_sync=True,
+        local_development_mac="",
+    )
+
+    config = module.build_config(args)
+    state = module.PortalState(config)
+
+    assert config.sync_firewall is False
+    assert config.local_development_mac == module.LOCAL_DEVELOPMENT_MAC
+    assert state.resolve_mac("127.0.0.1") == module.LOCAL_DEVELOPMENT_MAC
 
 
 def test_read_limited_request_body_rejects_large_payload():

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -436,6 +436,7 @@ def test_suite_login_redirect_defaults_to_gateway_host():
         module._suite_login_url(
             "arthexis.net",
             configured_host=module.DEFAULT_SUITE_LOGIN_HOST,
+            scheme=module.DEFAULT_SUITE_LOGIN_SCHEME,
             port=8888,
             path="login/",
         )
@@ -450,6 +451,7 @@ def test_suite_login_redirect_brackets_raw_ipv6_gateway_host():
         module._suite_login_url(
             "arthexis.net",
             configured_host="fd42:0:0:42::1",
+            scheme=module.DEFAULT_SUITE_LOGIN_SCHEME,
             port=8888,
             path="/login/",
         )
@@ -461,9 +463,43 @@ def test_suite_login_redirect_can_reuse_current_host_without_existing_port():
     module = load_portal_module()
 
     assert (
-        module._suite_login_url("127.0.0.1:9080", configured_host="", port=8888, path="login/")
+        module._suite_login_url(
+            "127.0.0.1:9080",
+            configured_host="",
+            scheme=module.DEFAULT_SUITE_LOGIN_SCHEME,
+            port=8888,
+            path="login/",
+        )
         == "http://127.0.0.1:8888/login/"
     )
+
+
+def test_suite_login_redirect_scheme_is_configurable():
+    module = load_portal_module()
+
+    assert (
+        module._suite_login_url(
+            "arthexis.net",
+            configured_host="10.42.0.1",
+            scheme="https",
+            port=443,
+            path="/login/",
+        )
+        == "https://10.42.0.1:443/login/"
+    )
+
+
+def test_suite_login_redirect_rejects_invalid_scheme():
+    module = load_portal_module()
+
+    with pytest.raises(ValueError, match="--suite-login-scheme"):
+        module._suite_login_url(
+            "arthexis.net",
+            configured_host="10.42.0.1",
+            scheme="ftp",
+            port=8888,
+            path="/login/",
+        )
 
 
 def test_read_events_uses_bounded_tail_without_reading_whole_file(tmp_path, monkeypatch):
@@ -652,6 +688,7 @@ def test_skip_firewall_sync_defaults_loopback_to_development_mac(tmp_path):
         assets_dir=str(tmp_path),
         state_dir=str(tmp_path / "state"),
         source_url="",
+        suite_login_scheme=module.DEFAULT_SUITE_LOGIN_SCHEME,
         suite_login_host=module.DEFAULT_SUITE_LOGIN_HOST,
         suite_login_port=module.DEFAULT_SUITE_LOGIN_PORT,
         suite_login_path=module.DEFAULT_SUITE_LOGIN_PATH,

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -405,6 +406,29 @@ def test_status_redirects_authorized_client_to_suite_login_port(tmp_path):
     assert payload["redirect_delay_ms"] == module.DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS
 
 
+def test_status_preserves_zero_redirect_delay(tmp_path):
+    module = load_portal_module()
+    config = replace(make_config(module, tmp_path), authorized_redirect_delay_ms=0)
+    state = module.PortalState(config)
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        host="arthexis.net",
+    )
+
+    payload = state.status_for_request(
+        ip_address="10.42.0.25",
+        user_agent="client-test",
+        path="/api/status",
+        host="arthexis.net",
+    )
+
+    assert payload["redirect_delay_ms"] == 0
+
+
 def test_suite_login_redirect_defaults_to_gateway_host():
     module = load_portal_module()
 
@@ -416,6 +440,20 @@ def test_suite_login_redirect_defaults_to_gateway_host():
             path="login/",
         )
         == "http://10.42.0.1:8888/login/"
+    )
+
+
+def test_suite_login_redirect_brackets_raw_ipv6_gateway_host():
+    module = load_portal_module()
+
+    assert (
+        module._suite_login_url(
+            "arthexis.net",
+            configured_host="fd42:0:0:42::1",
+            port=8888,
+            path="/login/",
+        )
+        == "http://[fd42:0:0:42::1]:8888/login/"
     )
 
 

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_package_data() -> dict[str, list[str]]:
+    pyproject = ROOT / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return data["tool"]["setuptools"]["package-data"]
+
+
+def _covered_by_package_data(package_root: Path, file_path: Path, patterns: list[str]) -> bool:
+    return any(file_path in package_root.glob(pattern) for pattern in patterns)
+
+
+def test_souls_registration_templates_are_in_package_data():
+    package_name = "apps.souls"
+    package_root = ROOT / Path(*package_name.split("."))
+    package_data = _load_package_data()
+    patterns = package_data.get(package_name, [])
+
+    assert "**/*" in patterns
+
+    templates = sorted((package_root / "templates" / "souls").glob("*.html"))
+    assert templates
+    assert all(_covered_by_package_data(package_root, template, patterns) for template in templates)


### PR DESCRIPTION
## Summary\n- redirect authorized AP portal clients to the gateway suite login with a configurable delay\n- support deterministic loopback consent previews when firewall sync is skipped\n- package apps.souls templates and document AP portal recovery steps\n\nFixes #7561\n\n## Validation\n- python -m pytest tests/test_ap_portal_server.py tests/test_package_data.py\n- ruff check scripts/ap_portal_server.py tests/test_ap_portal_server.py tests/test_package_data.py\n- manage.py check --fail-level ERROR\n- manage.py makemigrations --check --dry-run\n- scripts/check_import_resolution.py apps\\souls scripts\n- local smoke: ap_portal_server.py on 127.0.0.1:19081 with --skip-firewall-sync; /health ok; subscribe/status redirect to http://10.42.0.1:8888/login/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR restores AP portal registration recovery by implementing configurable redirect behavior for authorized clients, supporting deterministic local testing with firewall sync disabled, ensuring apps.souls templates are included in distributions, and documenting the recovery process.

## Changes

### Client-Side Redirect Behavior (`config/data/ap_portal/app.js`)
Added a `redirectAfterDelay(url, delayMs)` helper function to centralize delayed redirects. Updated the authorization flow to redirect authorized clients using a configurable redirect URL and delay from the server response (`payload.authorized_redirect_url` and `payload.redirect_delay_ms`), and updated the consent-recorded flow to use the same pattern (`result.redirect_url` and `result.redirect_delay_ms`).

### Server-Side Configuration and Routing (`scripts/ap_portal_server.py`)
Extended `PortalConfig` with new configurable fields:
- Suite login host, port, and path (with sensible defaults: `10.42.0.1:8888/login/`)
- Authorized redirect delay in milliseconds (default 1000ms)
- Optional local development MAC for loopback testing

Added `PortalState.suite_login_url()` method to construct the redirect URL. The `/api/status` and `/api/subscribe` endpoints now return `authorized_redirect_url` and `redirect_delay_ms` so clients receive server-specified redirect behavior.

### Local Development Support
Enhanced local preview device identification with a `local_development_mac` field that is used when the client IP is loopback (127.0.0.1). When `--skip-firewall-sync` is enabled, loopback clients automatically resolve to `LOCAL_DEVELOPMENT_MAC`, allowing deterministic consent flow testing without requiring AP neighbor tables. Added CLI arguments and environment variable support for configuring the local development MAC.

### Template Packaging (`pyproject.toml`)
Added `[tool.setuptools.package-data]` configuration to include all files from `apps.souls` in distributions via the `"**/*"` pattern, ensuring registration templates are available at runtime.

### Test Coverage
Added comprehensive test coverage for the new redirect behavior:
- `test_status_redirects_authorized_client_to_suite_login_port`: Verifies authorized clients receive the correct redirect URL in status responses
- `test_suite_login_redirect_defaults_to_gateway_host`: Validates the default gateway address behavior
- `test_suite_login_redirect_can_reuse_current_host_without_existing_port`: Confirms host reuse when no specific port is configured
- `test_loopback_client_requires_explicit_local_development_mac`: Ensures loopback clients return `None` by default
- `test_skip_firewall_sync_defaults_loopback_to_development_mac`: Verifies deterministic loopback behavior when firewall sync is disabled
- Updated `test_subscribe_records_consent_activity_and_authorizes_client` to assert the returned redirect URL

Added `tests/test_package_data.py` to verify that apps.souls templates are correctly included in the configured package data, preventing regression where templates could be missing from distributions.

### Documentation
Created `docs/operations/ap-portal.md` as a new operations runbook covering:
- When to use the runbook (Django suite page appears instead of portal, or missing portal JSON on `/health`)
- Local portal server prototype with `--skip-firewall-sync` mode for deterministic testing
- Gateway-side recovery via `setup_ap_portal.sh` with curl/systemctl validation checks
- Packaging checklist requiring `apps.souls` templates in `pyproject.toml`
- Nginx behavior expectations and rollback procedures

Added link to the new runbook in `docs/index.md` under "Quick links".

## Validation
Changes were validated with:
- Pytest on affected test modules
- Ruff linting on modified scripts and tests
- Django system checks and migration validation
- Import resolution checks for apps.souls and scripts
- Local smoke test: Portal server on loopback with `--skip-firewall-sync` returned `/health` OK and confirmed redirect behavior to gateway suite login at `http://10.42.0.1:8888/login/`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->