### PR TITLE
Add CI install smoke lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,16 @@ on:
       - "tests/**"
       - "manage.py"
       - "configure.sh"
+      - "env-refresh.bat"
       - "env-refresh.sh"
+      - "install.bat"
       - "install.sh"
+      - "service.bat"
+      - "start.bat"
       - "start.sh"
+      - "stop.bat"
       - "stop.sh"
+      - "upgrade.bat"
       - "upgrade.sh"
   push:
     branches:
@@ -56,14 +62,99 @@ on:
       - 'tests/**'
       - 'manage.py'
       - 'configure.sh'
+      - 'env-refresh.bat'
       - 'env-refresh.sh'
+      - 'install.bat'
       - 'install.sh'
+      - 'service.bat'
+      - 'start.bat'
       - 'start.sh'
+      - 'stop.bat'
       - 'stop.sh'
+      - 'upgrade.bat'
       - 'upgrade.sh'
   workflow_dispatch:
 
 jobs:
+  cold_install_smoke:
+    name: Cold Linux install smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      OCPP_STATE_REDIS_URL: redis://localhost:6379
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install base system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates curl git python3-venv \
+            libcairo2 libgdk-pixbuf-2.0-0 libpango-1.0-0 \
+            libpangocairo-1.0-0 shared-mime-info
+
+      - name: Run cold install smoke
+        run: |
+          ./scripts/ci/install-linux-smoke.sh --cold
+
+  windows_install_smoke:
+    name: Windows install.bat smoke
+    runs-on: windows-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    env:
+      ARTHEXIS_DB_BACKEND: sqlite
+      PYTHONDONTWRITEBYTECODE: '1'
+      NODE_OPTIONS: '--no-deprecation'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install GTK runtime for WeasyPrint
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-cairo
+            mingw-w64-x86_64-gdk-pixbuf2
+            mingw-w64-x86_64-libffi
+            mingw-w64-x86_64-pango
+
+      - name: Add GTK runtime to PATH
+        shell: pwsh
+        run: |
+          "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run Windows install smoke
+        shell: pwsh
+        run: |
+          .\scripts\ci\install-windows-smoke.ps1
+
   upgrade:
     name: Upgrade safety gate
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,13 @@ jobs:
             mingw-w64-x86_64-libffi
             mingw-w64-x86_64-pango
 
-      - name: Add GTK runtime to PATH
+      - name: Expose GTK runtime to WeasyPrint
         shell: pwsh
         run: |
           $gtkBin = Join-Path '${{ steps.setup_msys2.outputs.msys2-location }}' 'mingw64\bin'
           if (-not (Test-Path $gtkBin)) {
             throw "Expected MSYS2 GTK bin directory at $gtkBin"
           }
-          $gtkBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           "WEASYPRINT_DLL_DIRECTORIES=$gtkBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run Windows install smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run Windows install smoke
         shell: pwsh
         run: |
-          .\scripts\ci\install-windows-smoke.ps1
+          .\scripts\ci\install-windows-smoke.ps1 --cold
 
   upgrade:
     name: Upgrade safety gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install GTK runtime for WeasyPrint
+        id: setup_msys2
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -148,7 +149,12 @@ jobs:
       - name: Add GTK runtime to PATH
         shell: pwsh
         run: |
-          "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $gtkBin = Join-Path '${{ steps.setup_msys2.outputs.msys2-location }}' 'mingw64\bin'
+          if (-not (Test-Path $gtkBin)) {
+            throw "Expected MSYS2 GTK bin directory at $gtkBin"
+          }
+          $gtkBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "WEASYPRINT_DLL_DIRECTORIES=$gtkBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run Windows install smoke
         shell: pwsh

--- a/scripts/ci/install-linux-smoke.sh
+++ b/scripts/ci/install-linux-smoke.sh
@@ -32,6 +32,7 @@ python "$REPO_ROOT/scripts/generate_requirements.py" --check
 
 source .venv/bin/activate
 python scripts/check_editable_install_import.py
+python manage.py check --fail-level ERROR
 python scripts/check_migration_conflicts.py
 python manage.py migrations check
 python manage.py migrate --noinput --database default

--- a/scripts/ci/install-linux-smoke.sh
+++ b/scripts/ci/install-linux-smoke.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MODE="${1:-}"
+INSTALL_ARGS=(--no-start)
+
+cd "$REPO_ROOT"
+
+if [[ "$MODE" == "--cold" ]]; then
+  rm -rf .venv
+  rm -f .locks/requirements.bundle.sha256 \
+        .locks/requirements.hashes \
+        .locks/requirements.install-ts \
+        .locks/pip.version
+  INSTALL_ARGS=(--clean --no-start)
+elif [[ -n "$MODE" ]]; then
+  echo "Unknown option: $MODE" >&2
+  exit 1
+fi
+
+export ARTHEXIS_DB_BACKEND="${ARTHEXIS_DB_BACKEND:-sqlite}"
+export NODE_OPTIONS="${NODE_OPTIONS:---no-deprecation}"
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
+
+python "$REPO_ROOT/scripts/sort_pyproject_deps.py" --check
+python "$REPO_ROOT/scripts/generate_requirements.py" --check
+
+./install.sh "${INSTALL_ARGS[@]}"
+./scripts/preflight-env.sh
+
+source .venv/bin/activate
+python scripts/check_editable_install_import.py
+python scripts/check_migration_conflicts.py
+python manage.py migrations check
+python manage.py migrate --noinput --database default

--- a/scripts/ci/install-windows-smoke.ps1
+++ b/scripts/ci/install-windows-smoke.ps1
@@ -1,3 +1,7 @@
+param(
+    [string] $Mode = ""
+)
+
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
@@ -5,9 +9,9 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
 Set-Location $repoRoot
 
-$env:PYTHONDONTWRITEBYTECODE = "1"
-$env:NODE_OPTIONS = "--no-deprecation"
-$env:ARTHEXIS_DB_BACKEND = "sqlite"
+if (-not $env:PYTHONDONTWRITEBYTECODE) { $env:PYTHONDONTWRITEBYTECODE = "1" }
+if (-not $env:NODE_OPTIONS) { $env:NODE_OPTIONS = "--no-deprecation" }
+if (-not $env:ARTHEXIS_DB_BACKEND) { $env:ARTHEXIS_DB_BACKEND = "sqlite" }
 if ($env:pythonLocation) {
     $env:Path = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:Path"
 }
@@ -32,6 +36,28 @@ if ($gtkDllDirs.Count -eq 0) {
 }
 $env:WEASYPRINT_DLL_DIRECTORIES = $gtkDllDirs -join ";"
 
+if ($Mode -eq "--cold") {
+    Remove-Item -LiteralPath ".venv" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath ".locks\requirements.bundle.sha256" -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath ".locks\requirements.hashes" -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath ".locks\requirements.install-ts" -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath ".locks\pip.version" -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "db*.sqlite3" -Force -ErrorAction SilentlyContinue
+} elseif ($Mode) {
+    throw "Unknown option: $Mode"
+}
+
+$bootstrapPython = (Get-Command python -ErrorAction Stop).Source
+& $bootstrapPython scripts\sort_pyproject_deps.py --check
+if ($LASTEXITCODE -ne 0) {
+    throw "pyproject dependency ordering check failed with exit code $LASTEXITCODE"
+}
+
+& $bootstrapPython scripts\generate_requirements.py --check
+if ($LASTEXITCODE -ne 0) {
+    throw "generated requirements check failed with exit code $LASTEXITCODE"
+}
+
 cmd.exe /c install.bat
 if ($LASTEXITCODE -ne 0) {
     throw "install.bat failed with exit code $LASTEXITCODE"
@@ -45,6 +71,21 @@ if (-not (Test-Path $python)) {
 & $python scripts\check_editable_install_import.py
 if ($LASTEXITCODE -ne 0) {
     throw "Editable install import check failed with exit code $LASTEXITCODE"
+}
+
+& $python scripts\check_migration_conflicts.py
+if ($LASTEXITCODE -ne 0) {
+    throw "Migration conflict check failed with exit code $LASTEXITCODE"
+}
+
+& $python manage.py migrations check
+if ($LASTEXITCODE -ne 0) {
+    throw "Django migrations check failed with exit code $LASTEXITCODE"
+}
+
+& $python manage.py migrate --noinput --database default
+if ($LASTEXITCODE -ne 0) {
+    throw "Django migrate failed with exit code $LASTEXITCODE"
 }
 
 & $python manage.py check --fail-level ERROR

--- a/scripts/ci/install-windows-smoke.ps1
+++ b/scripts/ci/install-windows-smoke.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+Set-Location $repoRoot
+
+$env:PYTHONDONTWRITEBYTECODE = "1"
+$env:NODE_OPTIONS = "--no-deprecation"
+$env:ARTHEXIS_DB_BACKEND = "sqlite"
+
+$gtkCandidates = @(
+    "C:\Program Files\GTK3-Runtime Win64\bin",
+    "C:\msys64\mingw64\bin"
+)
+foreach ($candidate in $gtkCandidates) {
+    if (Test-Path $candidate) {
+        $env:Path = "$candidate;$env:Path"
+    }
+}
+
+cmd.exe /c install.bat
+if ($LASTEXITCODE -ne 0) {
+    throw "install.bat failed with exit code $LASTEXITCODE"
+}
+
+$python = Join-Path $repoRoot ".venv\Scripts\python.exe"
+if (-not (Test-Path $python)) {
+    throw "Expected virtual environment Python at $python"
+}
+
+& $python scripts\check_editable_install_import.py
+if ($LASTEXITCODE -ne 0) {
+    throw "Editable install import check failed with exit code $LASTEXITCODE"
+}
+
+& $python manage.py check --fail-level ERROR
+if ($LASTEXITCODE -ne 0) {
+    throw "Django system check failed with exit code $LASTEXITCODE"
+}

--- a/scripts/ci/install-windows-smoke.ps1
+++ b/scripts/ci/install-windows-smoke.ps1
@@ -9,15 +9,26 @@ $env:PYTHONDONTWRITEBYTECODE = "1"
 $env:NODE_OPTIONS = "--no-deprecation"
 $env:ARTHEXIS_DB_BACKEND = "sqlite"
 
-$gtkCandidates = @(
+$gtkCandidates = @()
+if ($env:WEASYPRINT_DLL_DIRECTORIES) {
+    $gtkCandidates += $env:WEASYPRINT_DLL_DIRECTORIES -split ";" | Where-Object { $_ }
+}
+$gtkCandidates += @(
     "C:\Program Files\GTK3-Runtime Win64\bin",
     "C:\msys64\mingw64\bin"
 )
+$gtkCandidates = $gtkCandidates | Select-Object -Unique
+$gtkDllDirs = @()
 foreach ($candidate in $gtkCandidates) {
     if (Test-Path $candidate) {
+        $gtkDllDirs += $candidate
         $env:Path = "$candidate;$env:Path"
     }
 }
+if ($gtkDllDirs.Count -eq 0) {
+    throw "No GTK runtime bin directory found for WeasyPrint."
+}
+$env:WEASYPRINT_DLL_DIRECTORIES = $gtkDllDirs -join ";"
 
 cmd.exe /c install.bat
 if ($LASTEXITCODE -ne 0) {

--- a/scripts/ci/install-windows-smoke.ps1
+++ b/scripts/ci/install-windows-smoke.ps1
@@ -8,6 +8,9 @@ Set-Location $repoRoot
 $env:PYTHONDONTWRITEBYTECODE = "1"
 $env:NODE_OPTIONS = "--no-deprecation"
 $env:ARTHEXIS_DB_BACKEND = "sqlite"
+if ($env:pythonLocation) {
+    $env:Path = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:Path"
+}
 
 $gtkCandidates = @()
 if ($env:WEASYPRINT_DLL_DIRECTORIES) {
@@ -22,7 +25,6 @@ $gtkDllDirs = @()
 foreach ($candidate in $gtkCandidates) {
     if (Test-Path $candidate) {
         $gtkDllDirs += $candidate
-        $env:Path = "$candidate;$env:Path"
     }
 }
 if ($gtkDllDirs.Count -eq 0) {


### PR DESCRIPTION
## Summary
- add reusable CI install smoke helpers for Linux and Windows bootstrap paths
- add cold Linux install and Windows install.bat smoke jobs to the upgrade gate workflow
- include Windows lifecycle .bat files in workflow path triggers

## Validation
- parsed .github/workflows/ci.yml with PyYAML
- parsed scripts/ci/install-windows-smoke.ps1 with PowerShell parser
- checked scripts/ci/install-linux-smoke.sh with Git Bash bash -n
- ran git diff --cached --check