### PR TITLE
Fix Postgres Soul Seed session row locks

### DIFF
--- a/apps/souls/services/card_sessions.py
+++ b/apps/souls/services/card_sessions.py
@@ -75,7 +75,7 @@ def close_card_session(session: CardSession, *, reason: str = "") -> CardSession
 
 def _active_console_sessions(console_id: str):
     return (
-        CardSession.objects.select_for_update()
+        CardSession.objects.select_for_update(of=("self",))
         .filter(node_id=console_id, state__in=ACTIVE_SESSION_STATES)
         .select_related(
             "card",

--- a/apps/souls/tests/test_soul_seed_foundation.py
+++ b/apps/souls/tests/test_soul_seed_foundation.py
@@ -29,6 +29,7 @@ from apps.souls.services import (
     provision_soul_seed_card,
     search_agent_skills,
 )
+from apps.souls.services.card_sessions import _active_console_sessions
 
 
 def _valid_agent_card_records() -> list[str]:
@@ -120,6 +121,13 @@ def test_evict_card_session_clears_runtime_fields():
     assert session.runtime_namespace == ""
     assert session.eviction_reason == "card switch"
     assert session.ended_at is not None
+
+
+def test_active_console_sessions_locks_only_session_rows():
+    queryset = _active_console_sessions("console-a")
+
+    assert queryset.query.select_for_update is True
+    assert queryset.query.select_for_update_of == ("self",)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- lock only CardSession rows when loading active Soul Seed sessions
- keep nullable card/RFID select_related joins out of the FOR UPDATE target list
- add a focused regression assertion for the select_for_update target

Fixes #7560.

## Validation
- python -m pytest apps/souls/tests/test_soul_seed_foundation.py::test_active_console_sessions_locks_only_session_rows apps/souls/tests/test_soul_seed_foundation.py::test_activate_soul_seed_card_starts_bounded_console_session -q
- python -m pytest apps/souls/tests/test_soul_seed_foundation.py -q
- python manage.py check
- python manage.py makemigrations --check --dry-run
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the Install Health Check workflow failures on debian/postgres and ubuntu/postgres matrix targets by limiting the row-locking scope when loading active Soul Seed sessions.

## Changes

**apps/souls/services/card_sessions.py**
- Modified `_active_console_sessions(console_id)` to use `select_for_update(of=("self",))` instead of an unconstrained `select_for_update()`
- This restricts the FOR UPDATE lock scope to CardSession rows only, excluding nullable card/RFID select_related joins from the lock target list

**apps/souls/tests/test_soul_seed_foundation.py**
- Added test `test_active_console_sessions_locks_only_session_rows` to verify the lock scope is correctly limited to session rows via SELECT ... FOR UPDATE with `of=('self',)`
- The test provides regression protection for the specific locking behavior fix

## Related Issue
Fixes #7560 (Install Health Check failing on postgres matrix targets)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->