### PR TITLE
Require AgentSkillFile permissions for skill package import

### DIFF
--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -73,7 +73,16 @@ class AgentSkillAdmin(admin.ModelAdmin):
         return super().changelist_view(request, extra_context=extra_context)
 
     def has_import_package_permission(self, request: HttpRequest) -> bool:
-        return self.has_add_permission(request) and self.has_change_permission(request)
+        file_opts = AgentSkillFile._meta
+        required_file_perms = [
+            f"{file_opts.app_label}.{action}_{file_opts.model_name}"
+            for action in ("add", "change", "delete")
+        ]
+        return (
+            self.has_add_permission(request)
+            and self.has_change_permission(request)
+            and request.user.has_perms(required_file_perms)
+        )
 
     def import_package_view(self, request: HttpRequest):
         if not self.has_import_package_permission(request):

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
+from django.contrib.auth.models import Permission
 from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -387,3 +388,27 @@ def test_import_package_blocks_staff_without_add_and_change_permissions(
 
     assert response.status_code == 403
     assert not AgentSkill.objects.filter(slug="blocked-import").exists()
+
+
+def test_import_package_blocks_staff_without_agent_skill_file_permissions(
+    client,
+    django_user_model,
+):
+    user = django_user_model.objects.create_user(
+        username="skill-import-missing-file-perms",
+        password="pw",
+        is_staff=True,
+    )
+    skill_perms = Permission.objects.filter(
+        codename__in=("add_agentskill", "change_agentskill"),
+    )
+    user.user_permissions.add(*skill_perms)
+    client.force_login(user)
+
+    response = client.post(
+        reverse("admin:skills_agentskill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("blocked-file-perms")},
+    )
+
+    assert response.status_code == 403
+    assert not AgentSkill.objects.filter(slug="blocked-file-perms").exists()


### PR DESCRIPTION
### Motivation
- The Codex skill package admin import endpoint performed create/update/delete of `AgentSkillFile` rows while only checking `AgentSkill` add/change permissions, which bypassed Django's model-level permission boundary for `AgentSkillFile`.
- Fix the authorisation gap so staff users cannot mutate package files unless they also have explicit `AgentSkillFile` permissions.

### Description
- Tighten `AgentSkillAdmin.has_import_package_permission` to require `add`, `change`, and `delete` permissions for the `AgentSkillFile` model in addition to the existing `AgentSkill` `add`/`change` checks (changed in `apps/skills/admin.py`).
- Add a regression test `test_import_package_blocks_staff_without_agent_skill_file_permissions` that grants a staff user only `AgentSkill` add/change permissions and asserts access to the import preview endpoint is denied (`apps/skills/tests/test_admin.py`).
- Add the required `Permission` import used by the new test (`apps/skills/tests/test_admin.py`).

### Testing
- Added unit test `apps.skills.tests.test_admin::test_import_package_blocks_staff_without_agent_skill_file_permissions` which asserts a 403 for staff users missing `AgentSkillFile` perms and it is included in the repository test suite.
- Attempted to run the test suite with `.venv/bin/python manage.py test run -- apps.skills.tests.test_admin` but `.venv/bin/python` is not present in this environment so the run could not be executed.
- Attempted `./install.sh` to create the environment but the installer failed due to missing system `redis-server`, and `python3 manage.py test run -- apps.skills.tests.test_admin` was not accepted by the repository's validated runtime guard (`missing_venv_python`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584f1ddc883269b34aa76509f5934)