### PR TITLE
meta: restrict WhatsApp Secretary listener to registered suite-user phone numbers

### DIFF
--- a/apps/meta/admin.py
+++ b/apps/meta/admin.py
@@ -4,7 +4,12 @@ from django.utils.translation import gettext_lazy as _
 
 from apps.features.utils import is_suite_feature_enabled
 from apps.locals.user_data import EntityModelAdmin
-from apps.meta.models import Attention, WhatsAppWebhook, WhatsAppWebhookMessage
+from apps.meta.models import (
+    Attention,
+    WhatsAppSecretaryAuthorizedPhone,
+    WhatsAppWebhook,
+    WhatsAppWebhookMessage,
+)
 
 
 @admin.register(Attention)
@@ -176,3 +181,10 @@ class WhatsAppWebhookMessageAdmin(EntityModelAdmin):
 
 
 __all__ = ["admin"]
+
+
+@admin.register(WhatsAppSecretaryAuthorizedPhone)
+class WhatsAppSecretaryAuthorizedPhoneAdmin(EntityModelAdmin):
+    list_display = ("phone", "user", "is_active", "label")
+    list_filter = ("is_active",)
+    search_fields = ("phone", "label", "user__username", "user__email")

--- a/apps/meta/management/commands/whatsapp.py
+++ b/apps/meta/management/commands/whatsapp.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from apps.meta.models import WhatsAppSecretaryAuthorizedPhone
 
 from apps.meta.services import (
     DEFAULT_WHATSAPP_SECRETARY_IDLE_AFTER_SECONDS,
@@ -16,7 +20,9 @@ from apps.meta.services import (
     build_whatsapp_listener_install_plan,
     dataclass_payload,
     listen_for_whatsapp_secretary_requests,
+    normalize_whatsapp_phone,
     parse_cli_date,
+    registered_whatsapp_secretary_phones,
     read_whatsapp_web_messages,
     send_whatsapp_web_message,
     validate_whatsapp_web_login,
@@ -282,6 +288,24 @@ class Command(BaseCommand):
         )
         install.add_argument("--json", action="store_true", help="Emit JSON output.")
 
+        register_phone = subparsers.add_parser(
+            "register-phone",
+            help="Register an authorized phone for Secretary listener.",
+        )
+        register_phone.add_argument("--user", required=True, help="Username or email.")
+        register_phone.add_argument(
+            "--phone",
+            required=True,
+            help="Authorized sender phone number.",
+        )
+        register_phone.add_argument("--label", default="", help="Optional label for this authorization.")
+        register_phone.add_argument(
+            "--country-code",
+            default="52",
+            help="Country code for 10-digit local numbers. Default: 52.",
+        )
+        register_phone.add_argument("--json", action="store_true", help="Emit JSON output.")
+
     def _add_browser_arguments(
         self,
         parser,
@@ -350,6 +374,8 @@ class Command(BaseCommand):
                 return self._handle_listen(options)
             elif action == "install-listener":
                 return self._handle_install_listener(options)
+            elif action == "register-phone":
+                return self._handle_register_phone(options)
             else:
                 raise CommandError(f"Unknown whatsapp action: {action}")
         except (RuntimeError, ValueError) as exc:
@@ -436,6 +462,9 @@ class Command(BaseCommand):
             terminal_title=options["terminal_title"],
             max_batches=1 if options["once"] else None,
             event_callback=None if options["once"] else write_event,
+            authorized_phones=lambda: registered_whatsapp_secretary_phones(
+                raise_on_error=True
+            ),
             **self._browser_options(options),
         )
         if options["once"] and results:
@@ -511,6 +540,51 @@ class Command(BaseCommand):
         self.stdout.write("instructions:")
         for instruction in payload["instructions"]:
             self.stdout.write(f"- {instruction}")
+
+    def _handle_register_phone(self, options):
+        User = get_user_model()
+        user_value = (options["user"] or "").strip()
+        user = User.objects.filter(Q(username=user_value) | Q(email=user_value)).first()
+        if user is None:
+            raise CommandError(f"No suite user found for {user_value!r}.")
+
+        raw_phone = (options["phone"] or "").strip()
+        try:
+            phone = normalize_whatsapp_phone(
+                raw_phone, default_country_code=options["country_code"]
+            )
+        except ValueError as exc:
+            raise CommandError("--phone must be a valid WhatsApp phone number.") from exc
+        if not phone:
+            raise CommandError("--phone cannot be blank.")
+
+        phone_manager = getattr(
+            WhatsAppSecretaryAuthorizedPhone,
+            "all_objects",
+            WhatsAppSecretaryAuthorizedPhone.objects,
+        )
+        authorization, created = phone_manager.update_or_create(
+            phone=phone,
+            defaults={
+                "user": user,
+                "label": (options["label"] or "").strip(),
+                "is_active": True,
+                "is_deleted": False,
+            },
+        )
+        payload = {
+            "status": "created" if created else "updated",
+            "phone": authorization.phone,
+            "user": str(user),
+            "label": authorization.label,
+        }
+        if options.get("json"):
+            self.stdout.write(json.dumps(payload, indent=2))
+            return None
+        self.stdout.write(
+            f"{payload['status'].capitalize()} authorized phone {authorization.phone} for user {user}."
+        )
+        return None
 
     def _write_text_result(self, result) -> None:
         payload = dataclass_payload(result)

--- a/apps/meta/migrations/0005_whatsappsecretaryauthorizedphone.py
+++ b/apps/meta/migrations/0005_whatsappsecretaryauthorizedphone.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("meta", "0004_alter_attention_options"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WhatsAppSecretaryAuthorizedPhone",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("is_seed_data", models.BooleanField(default=False, editable=False)),
+                ("is_user_data", models.BooleanField(default=False, editable=False)),
+                ("is_deleted", models.BooleanField(default=False, editable=False)),
+                ("phone", models.CharField(max_length=32, unique=True)),
+                ("label", models.CharField(blank=True, max_length=120)),
+                ("is_active", models.BooleanField(default=True)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="whatsapp_secretary_phones",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "WhatsApp Secretary Authorized Phone",
+                "verbose_name_plural": "WhatsApp Secretary Authorized Phones",
+                "ordering": ["phone", "pk"],
+            },
+        ),
+    ]

--- a/apps/meta/models.py
+++ b/apps/meta/models.py
@@ -285,6 +285,27 @@ class WhatsAppWebhookMessage(Entity):
         }
 
 
+class WhatsAppSecretaryAuthorizedPhone(Entity):
+    """Allowlisted WhatsApp sender that can trigger Secretary listener actions."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="whatsapp_secretary_phones",
+    )
+    phone = models.CharField(max_length=32, unique=True)
+    label = models.CharField(max_length=120, blank=True)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ["phone", "pk"]
+        verbose_name = _("WhatsApp Secretary Authorized Phone")
+        verbose_name_plural = _("WhatsApp Secretary Authorized Phones")
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.phone} ({self.user})"
+
+
 class Attention(Entity):
     """Urgent attention request sent through the suite WhatsApp bridge."""
 

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -132,6 +132,10 @@ class WhatsAppSecretaryListenResult:
     detail: str = ""
 
 
+class WhatsAppSecretaryAuthorizationUnavailable(RuntimeError):
+    """Raised when the Secretary phone allowlist cannot be loaded."""
+
+
 @dataclass(frozen=True)
 class WhatsAppListenerInstallPlan:
     status: str
@@ -188,6 +192,18 @@ def normalize_whatsapp_phone(value: str, *, default_country_code: str = "52") ->
     if len(digits) < 8:
         raise ValueError("WhatsApp phone number is too short.")
     return digits
+
+
+def canonical_whatsapp_sender(value: str, *, default_country_code: str = "52") -> str:
+    """Return a stable allowlist key for a WhatsApp sender label."""
+
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    try:
+        return normalize_whatsapp_phone(raw, default_country_code=default_country_code)
+    except ValueError:
+        return ""
 
 
 def parse_cli_date(value: str | None) -> date | None:
@@ -755,12 +771,35 @@ def secretary_request_text_from_messages(
     messages: list[WhatsAppWebMessage],
     *,
     trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
+    authorized_phones: set[str] | None = None,
+    default_country_code: str = "52",
+    fallback_sender_phone: str = "",
 ) -> str:
     """Build a Secretary request from the first triggered message and continuations."""
 
     request_parts: list[str] = []
     collecting = not trigger_prefix.strip()
+    authorized_senders: set[str] | None = None
+    if authorized_phones is not None:
+        authorized_senders = {
+            sender
+            for phone in authorized_phones
+            if (sender := canonical_whatsapp_sender(phone, default_country_code=default_country_code))
+        }
     for message in messages:
+        sender_key = canonical_whatsapp_sender(
+            message.sender,
+            default_country_code=default_country_code,
+        )
+        if not sender_key and message.direction == "out":
+            sender_key = canonical_whatsapp_sender(
+                fallback_sender_phone,
+                default_country_code=default_country_code,
+            )
+        if authorized_senders is not None and (
+            not sender_key or sender_key not in authorized_senders
+        ):
+            continue
         text = message.text.strip()
         if not text:
             continue
@@ -780,10 +819,16 @@ def build_whatsapp_secretary_prompt(
     *,
     trigger_prefix: str = DEFAULT_WHATSAPP_SECRETARY_TRIGGER_PREFIX,
     secretary_name: str = "Secretary",
+    authorized_phones: set[str] | None = None,
+    default_country_code: str = "52",
+    fallback_sender_phone: str = "",
 ) -> str:
     request_text = secretary_request_text_from_messages(
         messages,
         trigger_prefix=trigger_prefix,
+        authorized_phones=authorized_phones,
+        default_country_code=default_country_code,
+        fallback_sender_phone=fallback_sender_phone,
     )
     if not request_text:
         return ""
@@ -1300,6 +1345,31 @@ def build_whatsapp_listener_install_plan(
     )
 
 
+def registered_whatsapp_secretary_phones(*, raise_on_error: bool = False) -> set[str]:
+    from django.db.utils import OperationalError, ProgrammingError
+
+    from apps.meta.models import WhatsAppSecretaryAuthorizedPhone
+
+    try:
+        authorizations = list(
+            WhatsAppSecretaryAuthorizedPhone.objects.filter(
+                is_active=True,
+                is_deleted=False,
+            )
+        )
+    except (OperationalError, ProgrammingError):
+        if raise_on_error:
+            raise WhatsAppSecretaryAuthorizationUnavailable(
+                "WhatsApp Secretary authorization lookup is unavailable."
+            )
+        return set()
+    return {
+        str(authorization.phone).strip()
+        for authorization in authorizations
+        if str(authorization.phone).strip()
+    }
+
+
 def listen_for_whatsapp_secretary_requests(
     *,
     phone: str,
@@ -1321,6 +1391,7 @@ def listen_for_whatsapp_secretary_requests(
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
     event_callback: Callable[[WhatsAppSecretaryListenResult], None] | None = None,
+    authorized_phones: set[str] | Callable[[], set[str]] | None = None,
     **browser_options,
 ) -> list[WhatsAppSecretaryListenResult]:
     """Poll WhatsApp self-chat, debounce quiet batches, and launch Secretary."""
@@ -1384,13 +1455,40 @@ def listen_for_whatsapp_secretary_requests(
                 pending_changed_at = monotonic()
 
         if pending and monotonic() - pending_changed_at >= quiet_window_seconds:
+            cursor_file = cursor_file_for_profile(read_result.profile_dir)
+            cursor_key = cursor_key_for_profile(normalized_phone, read_result.profile_dir)
+            try:
+                current_authorized_phones = (
+                    authorized_phones() if callable(authorized_phones) else authorized_phones
+                )
+            except WhatsAppSecretaryAuthorizationUnavailable as exc:
+                result = WhatsAppSecretaryListenResult(
+                    status="authorization_unavailable",
+                    phone=normalized_phone,
+                    message_count=len(pending),
+                    launched=False,
+                    cursor_updated=False,
+                    cursor_file=cursor_file,
+                    batch_fingerprint=_batch_fingerprint(pending),
+                    elapsed_seconds=monotonic() - started_at,
+                    detail=str(exc),
+                )
+                if event_callback:
+                    event_callback(result)
+                if should_store_results:
+                    results.append(result)
+                if max_batches is not None:
+                    return results
+                sleep(daemon_poll_seconds)
+                continue
             prompt = build_whatsapp_secretary_prompt(
                 pending,
                 trigger_prefix=trigger_prefix,
                 secretary_name=secretary_name,
+                authorized_phones=current_authorized_phones,
+                default_country_code=default_country_code,
+                fallback_sender_phone=normalized_phone,
             )
-            cursor_file = cursor_file_for_profile(read_result.profile_dir)
-            cursor_key = cursor_key_for_profile(normalized_phone, read_result.profile_dir)
             detail = "Batch ignored because no Secretary trigger prefix was present."
             launched = False
             status = "ignored"

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -9,9 +9,12 @@ from pathlib import Path
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db.utils import OperationalError
 from django.test import override_settings
 
+from apps.meta import models as meta_models
 from apps.meta.management.commands import whatsapp as whatsapp_command
+from apps.meta.models import WhatsAppSecretaryAuthorizedPhone
 from apps.meta.services import (
     WhatsAppSecretaryListenResult,
     WhatsAppWebLoginResult,
@@ -19,6 +22,7 @@ from apps.meta.services import (
     WhatsAppWebMessage,
     WhatsAppWebReadResult,
     WhatsAppWebSendResult,
+    WhatsAppSecretaryAuthorizationUnavailable,
     _is_whatsapp_web_url,
     _read_cursor,
     _systemd_quote,
@@ -35,6 +39,7 @@ from apps.meta.services import (
     normalize_whatsapp_phone,
     parse_cli_date,
     read_whatsapp_web_messages,
+    registered_whatsapp_secretary_phones,
     secretary_request_text_from_messages,
 )
 
@@ -398,6 +403,7 @@ def test_secretary_listener_waits_for_quiet_window_before_launch(tmp_path):
         monotonic=lambda: now["value"],
         sleep=fake_sleep,
         idle_seconds=lambda: 999,
+        authorized_phones={"525551234567"},
     )
     cursor_key = cursor_key_for_profile("525551234567", profile_dir)
 
@@ -407,6 +413,100 @@ def test_secretary_listener_waits_for_quiet_window_before_launch(tmp_path):
     assert "summarize the quote" in launched_prompts[0]
     assert "focus on pending approvals" in launched_prompts[0]
     assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "b"
+
+
+def test_secretary_listener_refreshes_authorized_phones_during_poll(tmp_path):
+    profile_dir = tmp_path / "profile-a"
+    message = WhatsAppWebMessage(
+        fingerprint="a",
+        index=0,
+        message_id="a",
+        direction="out",
+        sender="You",
+        timestamp_raw="14:30, 2026-05-01",
+        timestamp_iso="2026-05-01T14:30:00",
+        text="secretary: open a terminal",
+    )
+    calls = []
+    now = {"value": 60.0}
+
+    def fake_read_messages(**kwargs):
+        del kwargs
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="525551234567",
+            profile_dir=profile_dir,
+            messages=[message],
+            cursor_file=cursor_file_for_profile(profile_dir),
+        )
+
+    def authorized_phones():
+        calls.append("refresh")
+        return {"525551234567"}
+
+    results = listen_for_whatsapp_secretary_requests(
+        phone="5551234567",
+        idle_after_seconds=0,
+        daemon_poll_seconds=60,
+        quiet_window_seconds=60,
+        max_batches=1,
+        read_messages=fake_read_messages,
+        launch=False,
+        monotonic=lambda: now["value"],
+        sleep=lambda seconds: now.update(value=now["value"] + seconds),
+        idle_seconds=lambda: 999,
+        authorized_phones=authorized_phones,
+    )
+
+    assert calls == ["refresh"]
+    assert results[-1].status == "matched"
+
+
+def test_secretary_listener_keeps_cursor_when_authorization_lookup_fails(tmp_path):
+    profile_dir = tmp_path / "profile-a"
+    message = WhatsAppWebMessage(
+        fingerprint="a",
+        index=0,
+        message_id="a",
+        direction="out",
+        sender="You",
+        timestamp_raw="14:30, 2026-05-01",
+        timestamp_iso="2026-05-01T14:30:00",
+        text="secretary: open a terminal",
+    )
+    now = {"value": 60.0}
+
+    def fake_read_messages(**kwargs):
+        del kwargs
+        return WhatsAppWebReadResult(
+            status="ok",
+            phone="525551234567",
+            profile_dir=profile_dir,
+            messages=[message],
+            cursor_file=cursor_file_for_profile(profile_dir),
+        )
+
+    def broken_authorized_phones():
+        raise WhatsAppSecretaryAuthorizationUnavailable("lookup unavailable")
+
+    results = listen_for_whatsapp_secretary_requests(
+        phone="5551234567",
+        idle_after_seconds=0,
+        daemon_poll_seconds=60,
+        quiet_window_seconds=60,
+        max_batches=1,
+        read_messages=fake_read_messages,
+        launch=False,
+        monotonic=lambda: now["value"],
+        sleep=lambda seconds: now.update(value=now["value"] + seconds),
+        idle_seconds=lambda: 999,
+        authorized_phones=broken_authorized_phones,
+    )
+    cursor_key = cursor_key_for_profile("525551234567", profile_dir)
+
+    assert results[-1].status == "authorization_unavailable"
+    assert results[-1].cursor_updated is False
+    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == ""
 
 
 def test_secretary_listener_ignores_and_advances_untriggered_batch(tmp_path):
@@ -444,6 +544,7 @@ def test_secretary_listener_ignores_and_advances_untriggered_batch(tmp_path):
         monotonic=lambda: now["value"],
         sleep=lambda seconds: now.update(value=now["value"] + seconds),
         idle_seconds=lambda: 999,
+        authorized_phones={"525551234567"},
     )
     cursor_key = cursor_key_for_profile("525551234567", profile_dir)
 
@@ -491,6 +592,7 @@ def test_secretary_listener_keeps_cursor_when_launch_fails(tmp_path):
             monotonic=lambda: now["value"],
             sleep=lambda seconds: now.update(value=now["value"] + seconds),
             idle_seconds=lambda: 999,
+            authorized_phones={"525551234567"},
         )
 
     cursor_key = cursor_key_for_profile("525551234567", profile_dir)
@@ -736,6 +838,8 @@ def test_whatsapp_listen_command_outputs_json(monkeypatch, tmp_path):
         assert kwargs["launch"] is False
         assert kwargs["max_batches"] == 1
         assert kwargs["profile_dir"] == tmp_path
+        assert callable(kwargs["authorized_phones"])
+        assert kwargs["authorized_phones"]() == {"525551234567"}
         return [
             WhatsAppSecretaryListenResult(
                 status="matched",
@@ -754,6 +858,7 @@ def test_whatsapp_listen_command_outputs_json(monkeypatch, tmp_path):
         "listen_for_whatsapp_secretary_requests",
         fake_listen_for_whatsapp_secretary_requests,
     )
+    monkeypatch.setattr(whatsapp_command, "registered_whatsapp_secretary_phones", lambda **kwargs: {"525551234567"})
     stdout = StringIO()
 
     call_command(
@@ -1050,3 +1155,252 @@ def test_whatsapp_install_listener_rejects_bad_timing():
             "--quiet-window",
             "0",
         )
+
+
+def test_secretary_request_ignores_non_authorized_senders():
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="in",
+            sender="15551234567",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="secretary: do not run",
+        ),
+        WhatsAppWebMessage(
+            fingerprint="b",
+            index=1,
+            message_id="b",
+            direction="out",
+            sender="+52 55 5123 4567",
+            timestamp_raw="14:31, 2026-05-01",
+            timestamp_iso="2026-05-01T14:31:00",
+            text="secretary: run this",
+        ),
+    ]
+
+    request = secretary_request_text_from_messages(
+        messages,
+        trigger_prefix="secretary:",
+        authorized_phones={"525551234567"},
+    )
+
+    assert request == "run this"
+
+
+def test_secretary_request_uses_fallback_phone_for_display_sender():
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="out",
+            sender="You",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="secretary: run alias",
+        ),
+    ]
+
+    request = secretary_request_text_from_messages(
+        messages,
+        trigger_prefix="secretary:",
+        authorized_phones={"525551234567"},
+        fallback_sender_phone="5551234567",
+    )
+
+    assert request == "run alias"
+
+
+def test_secretary_request_rejects_display_sender_without_fallback_phone():
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="out",
+            sender="You",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="secretary: run alias",
+        ),
+    ]
+
+    request = secretary_request_text_from_messages(
+        messages,
+        trigger_prefix="secretary:",
+        authorized_phones={"525551234567"},
+    )
+
+    assert request == ""
+
+
+def test_secretary_request_rejects_inbound_display_sender_with_fallback_phone():
+    messages = [
+        WhatsAppWebMessage(
+            fingerprint="a",
+            index=0,
+            message_id="a",
+            direction="in",
+            sender="Alice",
+            timestamp_raw="14:30, 2026-05-01",
+            timestamp_iso="2026-05-01T14:30:00",
+            text="secretary: run alias",
+        ),
+    ]
+
+    request = secretary_request_text_from_messages(
+        messages,
+        trigger_prefix="secretary:",
+        authorized_phones={"525551234567"},
+        fallback_sender_phone="5551234567",
+    )
+
+    assert request == ""
+
+
+def test_whatsapp_register_phone_command_creates_authorization(monkeypatch):
+    class User:
+        def __str__(self):
+            return "ops"
+
+    class Query:
+        def __init__(self, user):
+            self.user = user
+
+        def first(self):
+            return self.user
+
+    class UserManager:
+        def filter(self, *args, **kwargs):
+            del args, kwargs
+            return Query(User())
+
+    class PhoneManager:
+        def __init__(self):
+            self.kwargs = {}
+
+        def update_or_create(self, **kwargs):
+            self.kwargs = kwargs
+            auth = type("Auth", (), {"phone": kwargs["phone"], "label": kwargs["defaults"]["label"]})()
+            return auth, True
+
+    manager = PhoneManager()
+    monkeypatch.setattr(whatsapp_command, "get_user_model", lambda: type("U", (), {"objects": UserManager()})())
+    monkeypatch.setattr(whatsapp_command, "WhatsAppSecretaryAuthorizedPhone", type("P", (), {"objects": manager}))
+
+    stdout = StringIO()
+    call_command("whatsapp", "register-phone", "--user", "ops", "--phone", "5551234567", "--json", stdout=stdout)
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["status"] == "created"
+    assert manager.kwargs["phone"] == "525551234567"
+    assert manager.kwargs["defaults"]["is_deleted"] is False
+
+
+def test_whatsapp_register_phone_command_rejects_sender_alias(monkeypatch):
+    class User:
+        def __str__(self):
+            return "ops"
+
+    class Query:
+        def first(self):
+            return User()
+
+    class UserManager:
+        def filter(self, *args, **kwargs):
+            del args, kwargs
+            return Query()
+
+    class PhoneManager:
+        def __init__(self):
+            self.kwargs = {}
+
+        def update_or_create(self, **kwargs):
+            self.kwargs = kwargs
+            auth = type("Auth", (), {"phone": kwargs["phone"], "label": kwargs["defaults"]["label"]})()
+            return auth, False
+
+    manager = PhoneManager()
+    monkeypatch.setattr(whatsapp_command, "get_user_model", lambda: type("U", (), {"objects": UserManager()})())
+    monkeypatch.setattr(whatsapp_command, "WhatsAppSecretaryAuthorizedPhone", type("P", (), {"objects": manager}))
+
+    stdout = StringIO()
+    with pytest.raises(CommandError, match="valid WhatsApp phone number"):
+        call_command(
+            "whatsapp",
+            "register-phone",
+            "--user",
+            "ops",
+            "--phone",
+            "You",
+            "--label",
+            "self-chat",
+            "--json",
+            stdout=stdout,
+        )
+    assert manager.kwargs == {}
+
+
+@pytest.mark.django_db
+def test_registered_whatsapp_secretary_phones_excludes_soft_deleted(django_user_model):
+    user = django_user_model.objects.create_user(username="ops")
+    WhatsAppSecretaryAuthorizedPhone.all_objects.create(
+        user=user,
+        phone="525551234567",
+        is_active=True,
+    )
+    WhatsAppSecretaryAuthorizedPhone.all_objects.create(
+        user=user,
+        phone="525551234568",
+        is_active=True,
+        is_deleted=True,
+    )
+    WhatsAppSecretaryAuthorizedPhone.all_objects.create(
+        user=user,
+        phone="525551234569",
+        is_active=False,
+    )
+
+    assert registered_whatsapp_secretary_phones() == {"525551234567"}
+
+
+def test_registered_whatsapp_secretary_phones_handles_lazy_queryset_errors(monkeypatch):
+    class BrokenQuerySet:
+        def __iter__(self):
+            raise OperationalError("missing authorization table")
+
+    class Manager:
+        def filter(self, **kwargs):
+            del kwargs
+            return BrokenQuerySet()
+
+    monkeypatch.setattr(
+        meta_models,
+        "WhatsAppSecretaryAuthorizedPhone",
+        type("P", (), {"objects": Manager()}),
+    )
+
+    assert registered_whatsapp_secretary_phones() == set()
+
+
+def test_registered_whatsapp_secretary_phones_can_raise_lazy_queryset_errors(monkeypatch):
+    class BrokenQuerySet:
+        def __iter__(self):
+            raise OperationalError("missing authorization table")
+
+    class Manager:
+        def filter(self, **kwargs):
+            del kwargs
+            return BrokenQuerySet()
+
+    monkeypatch.setattr(
+        meta_models,
+        "WhatsAppSecretaryAuthorizedPhone",
+        type("P", (), {"objects": Manager()}),
+    )
+
+    with pytest.raises(WhatsAppSecretaryAuthorizationUnavailable):
+        registered_whatsapp_secretary_phones(raise_on_error=True)


### PR DESCRIPTION
### Motivation

- The WhatsApp `listen` flow trusted a text prefix alone (`secretary:`) which allowed inbound messages from arbitrary senders to trigger a local Codex Secretary launch, creating a trust-boundary security issue. 
- Enforce an operator-backed allowlist so only phone numbers registered to suite users can produce Secretary prompts, and provide an easy CLI to register those phones.

### Description

- Added a new model `WhatsAppSecretaryAuthorizedPhone` to persist allowlisted sender phones tied to a suite user, plus a migration `0005_whatsappsecretaryauthorizedphone.py` to create the table.
- Gate Secretary request extraction and prompt building to only include messages from `authorized_phones` by extending `secretary_request_text_from_messages`, `build_whatsapp_secretary_prompt`, and passing an `authorized_phones` set through `listen_for_whatsapp_secretary_requests` and its call sites.
- Introduced the helper `registered_whatsapp_secretary_phones()` that loads active authorizations and wired the management command `whatsapp listen` to call it and pass the allowlist into the listener.
- Added a new `whatsapp register-phone` CLI subcommand to register/update an authorized phone for a suite user (`--user`, `--phone`, optional `--label`) and registered the new model in the Django admin; updated and added tests to cover the allowlist behavior and the CLI.

### Testing

- Ran the WhatsApp unit test module with `python3 -m pytest apps/meta/tests/test_whatsapp.py -q` and observed `28 passed, 0 failed` (final run succeeded).
- An attempt to run `./install.sh` in the container failed due to a missing system Redis dependency in the environment, which is an environment/setup limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f562efff5c8326bd7c2497ad291c6d)