### PR TITLE
links: secure default temp output for QR preview command

### DIFF
--- a/apps/links/management/commands/qr.py
+++ b/apps/links/management/commands/qr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,8 +14,6 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
-
 from apps.links.models import QRRedirect, Reference
 from apps.links.qr_printing import (
     DEFAULT_CHUNK_BYTES,
@@ -408,8 +407,9 @@ class Command(BaseCommand):
     def _resolve_output_path(self, output: str | None) -> Path:
         if output:
             return Path(output).expanduser().resolve()
-        stamp = timezone.localtime().strftime("%Y%m%d-%H%M%S")
-        return Path(tempfile.gettempdir()) / f"arthexis-qr-{stamp}.png"
+        fd, path = tempfile.mkstemp(prefix="arthexis-qr-", suffix=".png")
+        os.close(fd)
+        return Path(path)
 
 
 def _extract_windows_wifi_profile_password(output: str) -> str:

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from io import StringIO
+from pathlib import Path
+import stat
 
 import pytest
 from django.core.management import call_command
@@ -35,6 +37,29 @@ def test_qr_print_text_writes_preview_png(tmp_path) -> None:
     assert output_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
     assert "SOURCE=text" in stdout.getvalue()
     assert "PAYLOAD_BYTES=" in stdout.getvalue()
+
+
+def test_qr_print_without_output_uses_secure_tempfile() -> None:
+    stdout = StringIO()
+
+    call_command(
+        "qr",
+        "print",
+        "--wifi-ssid",
+        "Office WiFi",
+        "--wifi-password",
+        "top-secret",
+        stdout=stdout,
+    )
+
+    preview_line = next(line for line in stdout.getvalue().splitlines() if line.startswith("PREVIEW="))
+    preview_path = preview_line.split("=", 1)[1]
+    mode = stat.S_IMODE(Path(preview_path).stat().st_mode)
+
+    assert Path(preview_path).exists()
+    assert Path(preview_path).read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert Path(preview_path).name.startswith("arthexis-qr-")
+    assert mode == 0o600
 
 
 def test_qr_print_wifi_does_not_echo_password(tmp_path) -> None:

--- a/apps/links/tests/test_qr_command.py
+++ b/apps/links/tests/test_qr_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from io import StringIO
 from pathlib import Path
 import stat
+import sys
 
 import pytest
 from django.core.management import call_command
@@ -53,13 +54,20 @@ def test_qr_print_without_output_uses_secure_tempfile() -> None:
     )
 
     preview_line = next(line for line in stdout.getvalue().splitlines() if line.startswith("PREVIEW="))
-    preview_path = preview_line.split("=", 1)[1]
-    mode = stat.S_IMODE(Path(preview_path).stat().st_mode)
+    preview_path = Path(preview_line.split("=", 1)[1])
 
-    assert Path(preview_path).exists()
-    assert Path(preview_path).read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
-    assert Path(preview_path).name.startswith("arthexis-qr-")
-    assert mode == 0o600
+    try:
+        assert preview_path.exists()
+        assert preview_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        assert preview_path.name.startswith("arthexis-qr-")
+        if sys.platform != "win32":
+            mode = stat.S_IMODE(preview_path.stat().st_mode)
+            assert mode == 0o600
+    finally:
+        try:
+            preview_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def test_qr_print_wifi_does_not_echo_password(tmp_path) -> None:


### PR DESCRIPTION
### Motivation

- The QR preview command previously wrote default previews to a predictable timestamped file in the system temp dir, which could expose embedded Wi‑Fi passwords or be abused via symlink clobbering.  
- The goal is to prevent local-attack disclosure and integrity issues while preserving explicit `--output` behavior.

### Description

- Replace timestamp-based default preview path with a securely-created temporary file using `tempfile.mkstemp(prefix="arthexis-qr-", suffix=".png")` and return its `Path` for image writing.  
- Keep the explicit `--output` path behavior unchanged (calling `Path(output).expanduser().resolve()`).  
- Add `os` import and close the file descriptor returned by `mkstemp` before calling `image.save`.  
- Add a regression test `test_qr_print_without_output_uses_secure_tempfile` that invokes `qr print` without `--output`, asserts the preview file exists, contains PNG magic bytes, uses the `arthexis-qr-` prefix, and checks restrictive file mode `0o600`.

### Testing

- Added and updated unit tests in `apps/links/tests/test_qr_command.py`, including the new secure-tempfile regression test; these tests are intended to verify the default-output flow.  
- Could not execute the repository test runner in this environment because `.venv/bin/python` is not available and `./install.sh` failed due to missing system dependency (Redis), so automated tests were not run here.  
- Recommend running the test target `.venv/bin/python manage.py test run -- apps.links.tests.test_qr_command` in CI or a local environment after provisioning `.venv` (run `./install.sh`) to validate the change end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56302a2cc8326bf593790c0bea5ab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Secure QR Preview Temporary File Handling

This PR addresses a security vulnerability in the QR preview command by replacing timestamp-based default output paths with securely-generated temporary files using the OS-level `mkstemp()` function.

### Changes

**apps/links/management/commands/qr.py:**
- Updated the `_resolve_output_path()` method (lines 407-412) to use `tempfile.mkstemp(prefix="arthexis-qr-", suffix=".png")` instead of timestamp-based path generation for default preview paths
- Added `os` module import (line 5) to support file descriptor closure
- Implemented proper cleanup by closing the file descriptor returned by `mkstemp()` before image writing via `os.close(fd)`
- Preserved explicit `--output` flag behavior by continuing to call `Path(output).expanduser().resolve()` when a user-specified output path is provided

**apps/links/tests/test_qr_command.py:**
- Added new test `test_qr_print_without_output_uses_secure_tempfile()` (lines 43-70) that validates secure tempfile creation when the `--output` flag is omitted
- Test verifies PNG file validity via magic byte detection (`b"\x89PNG\r\n\x1a\n"`)
- Confirms correct filename prefix (`arthexis-qr-`) matches the mkstemp pattern
- Validates restrictive file permissions (`0o600`) on non-Windows platforms
- Includes proper cleanup via `finally` block with `unlink(missing_ok=True)`
- Added supporting imports: `Path`, `stat`, `sys` (lines 6-8)

### Security Impact
The change eliminates predictable temporary file paths for QR previews, preventing potential symlink attacks or unauthorized file access by leveraging the cryptographically-secure file creation guarantees provided by the OS through `mkstemp()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->