### PR TITLE
skills: disable NODE sigils during default package materialization

### DIFF
--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -19,7 +19,7 @@ from apps.skills.models import AgentSkill, AgentSkillFile
 PACKAGE_FORMAT = "arthexis.codex_skill_package.v1"
 SKILL_MARKDOWN = "SKILL.md"
 EMPTY_CONTENT_SHA256 = hashlib.sha256(b"").hexdigest()
-DEFAULT_MATERIALIZE_SIGIL_ROOTS = frozenset({"NODE", "SYS"})
+DEFAULT_MATERIALIZE_SIGIL_ROOTS = frozenset({"SYS"})
 SAFE_MATERIALIZE_CONF_KEYS = frozenset({"BASE_DIR", "NODE_ROLE"})
 CONF_DOT_SIGIL_RE = re.compile(r"\[CONF\.([A-Za-z0-9_-]+)\]")
 

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import pytest
 from django.test import override_settings
 
-from apps.nodes.models import NodeRole
+from apps.nodes.models import Node, NodeRole
 from apps.sigils.models import SigilRoot
 from apps.skills.models import AgentSkill, AgentSkillFile
 from apps.skills.package_services import (
@@ -250,6 +250,35 @@ def test_materialize_writes_full_tree_resolves_sigils_and_skips_excluded(tmp_pat
 
 
 @pytest.mark.django_db
+def test_materialize_does_not_resolve_node_sigils_by_default(tmp_path):
+    SigilRoot.objects.get_or_create(
+        prefix="NODE",
+        defaults={"context_type": SigilRoot.Context.ENTITY},
+    )
+    Node.objects.create(hostname="materialize-safe-node")
+    skill = AgentSkill.objects.create(
+        slug="node-sigil-safety",
+        title="Node Sigil Safety",
+        markdown="Node sigil [NODE.hostname] should stay literal by default.",
+    )
+    AgentSkillFile.objects.create(
+        skill=skill,
+        relative_path="SKILL.md",
+        content=skill.markdown,
+        content_sha256=hashlib.sha256(skill.markdown.encode("utf-8")).hexdigest(),
+        portability=AgentSkillFile.Portability.PORTABLE,
+        included_by_default=True,
+        size_bytes=len(skill.markdown.encode("utf-8")),
+    )
+
+    target_root = tmp_path / "codex-skills"
+    materialize_codex_skill_files(target_root)
+
+    assert (target_root / "node-sigil-safety" / "SKILL.md").read_text(encoding="utf-8") == (
+        "Node sigil [NODE.hostname] should stay literal by default."
+    )
+
+
 def test_materialize_legacy_skill_preserves_existing_portable_tree(tmp_path):
     target_root = tmp_path / "codex-skills"
     skill_root = target_root / "legacy-skill"

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -279,6 +279,7 @@ def test_materialize_does_not_resolve_node_sigils_by_default(tmp_path):
     )
 
 
+@pytest.mark.django_db
 def test_materialize_legacy_skill_preserves_existing_portable_tree(tmp_path):
     target_root = tmp_path / "codex-skills"
     skill_root = target_root / "legacy-skill"

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -18,7 +18,7 @@ does not store their sensitive payloads.
 
 Use **SIGILS** when a suite-owned skill or document needs local customization on
 each installed device. SIGILS are bracketed suite expressions such as
-`[CONF.BASE_DIR]`, `[SYS.NODE_ROLE]`, or `[NODE.ROLE]`.
+`[CONF.BASE_DIR]` or `[SYS.NODE_ROLE]`.
 
 Portable package storage keeps SIGILS unresolved. The suite resolves allowed
 SIGILS only when package files are materialized into a local directory. This
@@ -28,7 +28,6 @@ operator's local paths.
 Default materialization allows non-secret local context:
 
 - `SYS`: suite system metadata such as role or upgrade state.
-- `NODE`: local node records when the node sigil root is configured.
 - A small allow-list of simple `CONF` keys such as `[CONF.BASE_DIR]` and
   `[CONF.NODE_ROLE]`.
 


### PR DESCRIPTION
### Motivation
- Materializing stored skill/package content previously resolved entity sigils by default which allowed `NODE` sigils to trigger callable model attributes with side effects. 
- Allowing `NODE` by default created an unsafe execution path during package materialization that could invoke methods like `Node.delete`.
- The intent is to preserve safe `SYS` and limited `CONF` resolution while preventing accidental execution of node-level callables during materialization.

### Description
- Removed `NODE` from the default sigil root allow-list by updating `DEFAULT_MATERIALIZE_SIGIL_ROOTS` to only include `SYS` in `apps/skills/package_services.py` so materialization no longer evaluates `NODE` entity sigils by default. 
- Added a regression test `test_materialize_does_not_resolve_node_sigils_by_default` in `apps/skills/tests/test_package_services.py` that verifies `[NODE.hostname]` remains literal when materializing with default settings. 
- Updated documentation in `docs/development/codex-skill-packages.md` to reflect the safer default materialization behavior (no default `NODE` resolution).

### Testing
- Added the regression test `apps.skills.tests.test_package_services::test_materialize_does_not_resolve_node_sigils_by_default` to prevent regressions. 
- Attempted to run the package service test suite with `.venv/bin/python manage.py test run -- apps.skills.tests.test_package_services`, but the test environment could not be provisioned because `.venv` is not present in this execution environment. 
- Attempted to run `./install.sh` to create the test environment, but it failed due to a missing `redis-server` prerequisite, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f564ae946083268cf12d842f2b5fd7)