### PR TITLE
souls: document and test UID-only Soul Seed activation path

### DIFF
--- a/apps/souls/management/commands/soul_seed.py
+++ b/apps/souls/management/commands/soul_seed.py
@@ -63,12 +63,12 @@ class Command(BaseCommand):
             required=True,
             help="Stable console identity for session isolation.",
         )
-        activate_parser.add_argument("--reader-id", default="", help="Reader identity, when known.")
+        activate_parser.add_argument("--reader-id", default="", help="Reader identity, when known. Optional for UID-only local activation.")
         activate_parser.add_argument(
             "--trust-tier",
             default=CardSession.TrustTier.UNKNOWN,
             choices=CardSession.TrustTier.values,
-            help="Trust tier assigned to this activation source.",
+            help="Trust tier assigned to this activation source; defaults to unknown for UID-only scans.",
         )
         activate_parser.add_argument(
             "--timeout-seconds",

--- a/apps/souls/management/commands/soul_seed.py
+++ b/apps/souls/management/commands/soul_seed.py
@@ -63,12 +63,12 @@ class Command(BaseCommand):
             required=True,
             help="Stable console identity for session isolation.",
         )
-        activate_parser.add_argument("--reader-id", default="", help="Reader identity, when known. Optional for UID-only local activation.")
+        activate_parser.add_argument("--reader-id", default="", help="Reader identity, when known. Optional for UID-only activation.")
         activate_parser.add_argument(
             "--trust-tier",
             default=CardSession.TrustTier.UNKNOWN,
             choices=CardSession.TrustTier.values,
-            help="Trust tier assigned to this activation source; defaults to unknown for UID-only scans.",
+            help="Trust tier assigned to this activation source. Defaults to unknown for UID-only activation.",
         )
         activate_parser.add_argument(
             "--timeout-seconds",

--- a/apps/souls/tests/test_soul_seed_foundation.py
+++ b/apps/souls/tests/test_soul_seed_foundation.py
@@ -439,8 +439,6 @@ def test_soul_seed_activate_command_outputs_json_from_scan_payload(skill, tmp_pa
         str(scan_path),
         "--console-id",
         "console-a",
-        "--reader-id",
-        "reader-1",
         "--json",
         stdout=stdout,
     )
@@ -449,6 +447,8 @@ def test_soul_seed_activate_command_outputs_json_from_scan_payload(skill, tmp_pa
     assert summary["action"] == "activated"
     assert summary["card"]["card_uid"] == "AABBCCDD"
     assert summary["session"]["console_id"] == "console-a"
+    assert summary["session"]["reader_id"] == ""
+    assert summary["session"]["trust_tier"] == CardSession.TrustTier.UNKNOWN
     assert summary["interface"]["visible_fields"] == ["intent", "matches", "commands", "suggestions"]
 
 

--- a/docs/development/agent-card-v1.md
+++ b/docs/development/agent-card-v1.md
@@ -277,6 +277,12 @@ python manage.py soul_seed activate --card-uid AABBCCDD --console-id terminal-1 
 Reader adapters can pass scan output as JSON instead of extracting a UID
 themselves. The payload must contain `card_uid`, `uid`, or `rfid`:
 
+UID-only activation is intentionally enabled for local console flows. When a
+reader proof is unavailable, activation still proceeds with trust tier
+`unknown` so operators can bootstrap or recover a console session. Deployments
+that require stronger assurance should run this boundary behind a trusted local
+adapter that injects `reader_id` and an explicit trusted tier.
+
 ```powershell
 python manage.py soul_seed activate --scan-json scan.json --console-id terminal-1 --reader-id desk-reader --json
 ```

--- a/docs/development/agent-card-v1.md
+++ b/docs/development/agent-card-v1.md
@@ -281,7 +281,7 @@ UID-only activation is intentionally enabled for local console flows. When a
 reader proof is unavailable, activation still proceeds with trust tier
 `unknown` so operators can bootstrap or recover a console session. Deployments
 that require stronger assurance should run this boundary behind a trusted local
-adapter that injects `reader_id` and an explicit trusted tier.
+adapter that injects `reader_id` and an explicit trust tier.
 
 ```powershell
 python manage.py soul_seed activate --scan-json scan.json --console-id terminal-1 --reader-id desk-reader --json


### PR DESCRIPTION
### Motivation

- Clarify and document the intended/observed behavior of the `soul_seed activate` console boundary for UID-only scanner payloads so operators and developers understand that UID-only activation yields an empty `reader_id` and `unknown` trust tier for local/bootstrapping flows.
- Provide a targeted test that asserts the JSON activation output for UID-only scans so the behavior is explicit in the test-suite contract.

### Description

- Updated the `soul_seed activate` CLI help text in `apps/souls/management/commands/soul_seed.py` to note that `--reader-id` is optional for UID-only local activation and that the `--trust-tier` defaults to `unknown` for UID-only scans.
- Added a clarifying paragraph to `docs/development/agent-card-v1.md` documenting that UID-only activation is intentionally enabled for local console bootstrap/recovery and recommending using a trusted local adapter for stronger assurance.
- Tightened the existing activation command test in `apps/souls/tests/test_soul_seed_foundation.py` (`test_soul_seed_activate_command_outputs_json_from_scan_payload`) to assert that a UID-only scan returns an empty `reader_id` and `trust_tier == CardSession.TrustTier.UNKNOWN` in the session payload, without changing runtime activation logic.

### Testing

- Attempted to run the suite tests with `.venv/bin/python manage.py test run -- apps.souls.tests.test_soul_seed_foundation`, but execution was blocked because `.venv` is not present in this environment so the test runner could not be invoked.
- Attempted to bootstrap the environment via `./install.sh`, but the install script failed due to a missing system dependency (`redis-server`), preventing automated test execution here.
- The change set includes the updated unit test described above, but automated test execution could not be completed in this environment due to the blockers listed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f562b1f52083268b2bc1c45e928118)