### PR TITLE
Fix AP portal fallbacks and Soul registration templates

### DIFF
--- a/apps/souls/templates/souls/me.html
+++ b/apps/souls/templates/souls/me.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/base.html" %}
 {% block content %}
 <h1>Your Soul Seed</h1>
 <p>Soul Seed ID: {{ soul.soul_id }}</p>

--- a/apps/souls/templates/souls/register_complete.html
+++ b/apps/souls/templates/souls/register_complete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/base.html" %}
 {% block content %}
 <h1>Check your email</h1>
 <p>Verification was sent to {{ registration.email }}.</p>

--- a/apps/souls/templates/souls/register_landing.html
+++ b/apps/souls/templates/souls/register_landing.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/base.html" %}
 {% block content %}
 <h1>Soul Seed Registration</h1>
 <form method="post" action="{% url 'souls:register_start' %}">

--- a/apps/souls/templates/souls/register_offering.html
+++ b/apps/souls/templates/souls/register_offering.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/base.html" %}
 {% block content %}
 <h1>Upload Offering</h1>
 <p>Max upload 25MB. Recommended 10MB.</p>

--- a/apps/souls/templates/souls/register_survey.html
+++ b/apps/souls/templates/souls/register_survey.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/base.html" %}
 {% block content %}
 <h1>{{ survey.title }}</h1>
 <form method="post">

--- a/apps/souls/tests/test_registration_views.py
+++ b/apps/souls/tests/test_registration_views.py
@@ -19,6 +19,12 @@ SOUL_SEED_REGISTRATION_TITLE = "Soul Seed Registration"
 
 
 class SoulRegistrationViewsTests(TestCase):
+    def test_register_landing_renders(self):
+        response = self.client.get(reverse("souls:register_landing"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Soul Seed Registration")
+
     def test_register_start_uses_same_redirect_for_existing_and_new_email(self):
         user_model = get_user_model()
         user = user_model.objects.create_user(username="existing-user", email="existing@example.com", password="x")

--- a/docs/operations/ap-portal.md
+++ b/docs/operations/ap-portal.md
@@ -55,6 +55,10 @@ Expected results:
 - Local port `9080` returns `{"ok": true}` from `/health`.
 - AP-facing port `80` returns the same portal health JSON through nginx.
 - `http://10.42.0.1/` shows the AP consent page headed `AP activity is monitored`.
+- Captive-portal probe paths such as `/connecttest.txt`, plus nested unknown
+  browser paths such as `/soul/register/`, return the AP portal page instead of
+  a bare 404. Hidden path probes and missing nested asset paths such as
+  `/css/missing.css` still return 404.
 
 If nginx validation fails, `setup_ap_portal.sh` restores the most recent
 pre-portal nginx site backup before exiting.

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -17,7 +17,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 ASSETS_DIR = BASE_DIR / "config" / "data" / "ap_portal"
@@ -38,6 +38,26 @@ MAX_PAYLOAD_BYTES = 1024 * 1024
 ARP_TABLE_PATH = Path("/proc/net/arp")
 NDISC_CACHE_PATH = Path("/proc/net/ndisc_cache")
 LOCAL_DEVELOPMENT_MAC = "02:00:00:00:00:01"
+CAPTIVE_PORTAL_PROBE_PATHS = {
+    "/canonical.html",
+    "/connecttest.txt",
+    "/gen_204",
+    "/generate_204",
+    "/hotspot-detect.html",
+    "/library/test/success.html",
+    "/ncsi.txt",
+    "/success.txt",
+}
+
+
+def _path_has_hidden_segment(path: str) -> bool:
+    return any(segment.startswith(".") for segment in path.split("/") if segment)
+
+
+def _path_looks_like_asset(path: str) -> bool:
+    return bool(Path(path).suffix)
+
+
 TERMS_STATEMENT = (
     "I accept that my internet experience may be altered and recorded "
     "for quality of life purposes while using this access point."
@@ -640,36 +660,52 @@ class PortalApplication:
 
             def do_GET(self) -> None:
                 parsed = urlparse(self.path)
-                if parsed.path == "/health":
+                request_path = unquote(parsed.path)
+                if request_path == "/health":
                     self._json({"ok": True})
                     return
-                if parsed.path == "/api/status":
+                if request_path == "/api/status":
                     self._json(
                         app.state.status_for_request(
                             ip_address=self._client_ip(),
                             user_agent=self.headers.get("User-Agent", ""),
-                            path=parsed.path,
+                            path=request_path,
                             host=self.headers.get("Host", ""),
                         )
                     )
                     return
-                if parsed.path == "/api/clients":
+                if request_path == "/api/clients":
                     if not self._is_direct_local_request():
                         self._json({"error": "local_only"}, status=HTTPStatus.FORBIDDEN)
                         return
                     self._json({"clients": app.state.activity.client_summary()})
                     return
 
-                if parsed.path in {"", "/"}:
-                    self._record_request(parsed.path or "/")
-                    self._serve_asset("index.html")
+                if request_path in {"", "/"}:
+                    self._serve_portal_page(request_path or "/")
                     return
-                asset_name = parsed.path.lstrip("/")
-                if "/" in asset_name or asset_name.startswith("."):
+                if request_path.startswith("/api/"):
+                    self._record_request(request_path)
                     self.send_error(HTTPStatus.NOT_FOUND)
                     return
-                self._record_request(parsed.path)
-                self._serve_asset(asset_name)
+                if request_path in CAPTIVE_PORTAL_PROBE_PATHS:
+                    self._serve_portal_page(request_path)
+                    return
+                asset_name = request_path.lstrip("/")
+                if _path_has_hidden_segment(asset_name):
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
+                if "/" in asset_name:
+                    if _path_looks_like_asset(asset_name):
+                        self._record_request(request_path)
+                        if not self._serve_asset(asset_name):
+                            self.send_error(HTTPStatus.NOT_FOUND)
+                        return
+                    self._serve_portal_page(request_path)
+                    return
+                self._record_request(request_path)
+                if not self._serve_asset(asset_name):
+                    self.send_error(HTTPStatus.NOT_FOUND)
 
             def do_POST(self) -> None:
                 parsed = urlparse(self.path)
@@ -723,11 +759,20 @@ class PortalApplication:
                     referer=self.headers.get("Referer", ""),
                 )
 
-            def _serve_asset(self, name: str) -> None:
-                path = app.config.assets_dir / name
-                if not path.exists() or not path.is_file():
+            def _serve_portal_page(self, path: str) -> None:
+                self._record_request(path)
+                if not self._serve_asset("index.html"):
                     self.send_error(HTTPStatus.NOT_FOUND)
-                    return
+
+            def _serve_asset(self, name: str) -> bool:
+                assets_dir = app.config.assets_dir.resolve()
+                path = (assets_dir / name).resolve()
+                try:
+                    path.relative_to(assets_dir)
+                except ValueError:
+                    return False
+                if not path.exists() or not path.is_file():
+                    return False
                 content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
                 body = _read_text(path)
                 self.send_response(HTTPStatus.OK)
@@ -736,6 +781,7 @@ class PortalApplication:
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 self.wfile.write(body)
+                return True
 
             def _read_payload(self) -> dict[str, Any]:
                 raw = _read_limited_request_body(self.headers, self.rfile)

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -721,6 +721,134 @@ def test_read_limited_request_body_rejects_negative_length_before_reading():
         module._read_limited_request_body(headers, io.BytesIO(b"email=guest@example.com"))
 
 
+def _exercise_get(handler_class, path: str, *, asset_exists: bool = True):
+    handler = object.__new__(handler_class)
+    handler.path = path
+    handler.command = "GET"
+    handler.headers = {}
+    handler.client_address = ("10.42.0.25", 12345)
+    recorded = []
+    served = []
+    errors = []
+    handler._record_request = recorded.append
+    handler._serve_asset = lambda name: served.append(name) or asset_exists
+    handler.send_error = errors.append
+
+    handler.do_GET()
+
+    return SimpleNamespace(recorded=recorded, served=served, errors=errors)
+
+
+def test_get_probe_path_returns_portal_page(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/connecttest.txt")
+
+    assert result.recorded == ["/connecttest.txt"]
+    assert result.served == ["index.html"]
+    assert result.errors == []
+
+
+def test_get_nested_unknown_path_returns_portal_page(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/soul/register/")
+
+    assert result.recorded == ["/soul/register/"]
+    assert result.served == ["index.html"]
+    assert result.errors == []
+
+
+def test_get_unknown_api_path_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/api/unknown")
+
+    assert result.recorded == ["/api/unknown"]
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_missing_literal_asset_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/missing.css", asset_exists=False)
+
+    assert result.recorded == ["/missing.css"]
+    assert result.served == ["missing.css"]
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_hidden_asset_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/.env")
+
+    assert result.recorded == []
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_nested_hidden_asset_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/foo/.env")
+
+    assert result.recorded == []
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_encoded_nested_hidden_asset_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/foo/%2eenv")
+
+    assert result.recorded == []
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_encoded_dot_segment_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/foo/%2e%2e/admin")
+
+    assert result.recorded == []
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
+def test_get_nested_asset_path_serves_asset(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/css/style.css")
+
+    assert result.recorded == ["/css/style.css"]
+    assert result.served == ["css/style.css"]
+    assert result.errors == []
+
+
+def test_get_missing_nested_asset_path_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/css/missing.css", asset_exists=False)
+
+    assert result.recorded == ["/css/missing.css"]
+    assert result.served == ["css/missing.css"]
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
 def test_subscribe_post_returns_json_error_when_request_logging_fails(tmp_path):
     module = load_portal_module()
     handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()


### PR DESCRIPTION
## Summary

- return the AP portal page for captive-portal probe paths and nested unknown browser paths while preserving 404s for unknown API and hidden/literal missing assets
- point Soul registration templates at the project public base template so `/soul/register/` renders instead of raising `TemplateDoesNotExist: base.html`
- document the AP portal fallback expectation and add focused regressions

Closes #7577

## Validation

- `..\arthexis\.venv\Scripts\python.exe -m pytest tests\test_ap_portal_server.py -q`
- `..\arthexis\.venv\Scripts\python.exe -m pytest apps\souls\tests\test_registration_views.py -q` with isolated `ARTHEXIS_SQLITE_PATH` / `ARTHEXIS_SQLITE_TEST_PATH`
- `..\arthexis\.venv\Scripts\python.exe -m ruff check scripts\ap_portal_server.py tests\test_ap_portal_server.py apps\souls\tests\test_registration_views.py`
- `..\arthexis\.venv\Scripts\python.exe manage.py check`
- `..\arthexis\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `git diff --check`

Note: a rerun of the Souls tests without isolated SQLite paths failed because another active lane held `\\dev\\shm\\arthexis\\test_db.sqlite3`; the isolated rerun passed.