### PR TITLE
Guard AP portal decoded NUL paths

### DIFF
--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -58,6 +58,10 @@ def _path_looks_like_asset(path: str) -> bool:
     return bool(Path(path).suffix)
 
 
+def _path_has_nul_byte(path: str) -> bool:
+    return "\x00" in path
+
+
 TERMS_STATEMENT = (
     "I accept that my internet experience may be altered and recorded "
     "for quality of life purposes while using this access point."
@@ -661,6 +665,9 @@ class PortalApplication:
             def do_GET(self) -> None:
                 parsed = urlparse(self.path)
                 request_path = unquote(parsed.path)
+                if _path_has_nul_byte(request_path):
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
                 if request_path == "/health":
                     self._json({"ok": True})
                     return
@@ -765,8 +772,11 @@ class PortalApplication:
                     self.send_error(HTTPStatus.NOT_FOUND)
 
             def _serve_asset(self, name: str) -> bool:
-                assets_dir = app.config.assets_dir.resolve()
-                path = (assets_dir / name).resolve()
+                try:
+                    assets_dir = app.config.assets_dir.resolve()
+                    path = (assets_dir / name).resolve()
+                except (OSError, ValueError):
+                    return False
                 try:
                     path.relative_to(assets_dir)
                 except ValueError:

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -827,6 +827,17 @@ def test_get_encoded_dot_segment_still_404s(tmp_path):
     assert result.errors == [module.HTTPStatus.NOT_FOUND]
 
 
+def test_get_encoded_nul_path_still_404s(tmp_path):
+    module = load_portal_module()
+    handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()
+
+    result = _exercise_get(handler_class, "/foo%00bar.css")
+
+    assert result.recorded == []
+    assert result.served == []
+    assert result.errors == [module.HTTPStatus.NOT_FOUND]
+
+
 def test_get_nested_asset_path_serves_asset(tmp_path):
     module = load_portal_module()
     handler_class = module.PortalApplication(make_config(module, tmp_path)).handler_class()


### PR DESCRIPTION
## Summary

- reject decoded NUL-byte AP portal paths before asset routing
- make AP portal asset path resolution fail closed on invalid path values
- add a regression test for `/foo%00bar.css`

Closes #7580

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_ap_portal_server.py -q`
- `.\.venv\Scripts\python.exe -m ruff check scripts\ap_portal_server.py tests\test_ap_portal_server.py`
- `git diff --check` (CRLF warnings only)
- `.\.venv\Scripts\python.exe manage.py check`
- `.\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR hardens the AP portal server against NUL-byte path injection attacks and makes asset path resolution fail closed.

### Changes

**scripts/ap_portal_server.py**
- Added `_path_has_nul_byte()` helper to detect NUL bytes in decoded URL paths
- Added validation in `do_GET()` to reject requests with NUL bytes by returning 404 before asset routing
- Enhanced `_serve_asset()` error handling to catch both `OSError` and `ValueError` during path resolution, returning `False` instead of propagating exceptions

**tests/test_ap_portal_server.py**
- Added `test_get_encoded_nul_path_still_404s()` regression test verifying that `/foo%00bar.css` returns 404 without attempting asset serving

### Impact

Prevents crashes when decoded request paths contain embedded NUL bytes (e.g., `/foo%00bar.css`). Asset path resolution now fails safely by returning False rather than raising exceptions on invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->