### PR TITLE
Suppress direct RFID GPIO reuse warnings

### DIFF
--- a/apps/cards/reader.py
+++ b/apps/cards/reader.py
@@ -4,13 +4,15 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
 from django.core.exceptions import ValidationError
 from django.utils import timezone
-from typing import Any
 
 from apps.cards.actions import dispatch_rfid_action
 from apps.cards.models import RFID
 from apps.core.notifications import notify_async
+from apps.video.rfid import queue_camera_snapshot
 
 from .constants import (
     DEFAULT_RST_PIN,
@@ -18,7 +20,6 @@ from .constants import (
     SPI_BUS,
     SPI_DEVICE,
 )
-from apps.video.rfid import queue_camera_snapshot
 from .utils import convert_endianness_value, normalize_endianness
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,24 @@ _HEX_RE = re.compile(r"^[0-9A-F]+$")
 _KEY_RE = re.compile(r"^[0-9A-F]{12}$")
 _SPI_DEVICE_PATTERN = re.compile(r"(?:/dev/)?spidev(?P<bus>\d+)\.(?P<device>\d+)$")
 _SPI_DEVICE_SHORT_PATTERN = re.compile(r"(?P<bus>\d+)\.(?P<device>\d+)$")
+
+
+def _suppress_gpio_warnings() -> None:
+    """Suppress expected GPIO reuse warnings before direct MFRC522 setup."""
+
+    try:
+        import RPi.GPIO as GPIO  # type: ignore
+    except Exception:  # pragma: no cover - hardware dependent
+        return
+
+    setwarnings = getattr(GPIO, "setwarnings", None)
+    if not callable(setwarnings):
+        return
+
+    try:
+        setwarnings(False)
+    except Exception:  # pragma: no cover - defensive hardware guard
+        logger.debug("Unable to suppress GPIO warnings before RFID setup", exc_info=True)
 
 
 def _normalize_command_text(value: object) -> str:
@@ -146,6 +165,7 @@ def _with_detected_rfid_card(timeout: float, handler) -> dict:
         from mfrc522 import MFRC522  # type: ignore
 
         spi_bus, spi_device = resolve_spi_bus_device()
+        _suppress_gpio_warnings()
         mfrc = MFRC522(
             bus=spi_bus,
             device=spi_device,
@@ -450,6 +470,7 @@ def _init_default_reader_strategy(
         from mfrc522 import MFRC522  # type: ignore
 
         spi_bus, spi_device = resolve_spi_bus_device()
+        _suppress_gpio_warnings()
         reader = MFRC522(
             bus=spi_bus,
             device=spi_device,

--- a/apps/cards/tests/test_reader.py
+++ b/apps/cards/tests/test_reader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -66,6 +67,48 @@ def test_initialize_reader_strategy_wraps_provided_reader():
         mfrc=fake_reader,
         cleanup_gpio=False,
         source="provided",
+    )
+
+
+def test_default_reader_strategy_suppresses_gpio_warnings(monkeypatch):
+    events: list[tuple[str, object]] = []
+
+    gpio_module = ModuleType("RPi.GPIO")
+
+    def _setwarnings(value):
+        events.append(("setwarnings", value))
+
+    gpio_module.setwarnings = _setwarnings
+
+    rpi_module = ModuleType("RPi")
+    rpi_module.GPIO = gpio_module
+
+    class _DefaultReader:
+        def __init__(self, **kwargs):
+            events.append(("reader", kwargs))
+
+    mfrc522_module = ModuleType("mfrc522")
+    mfrc522_module.MFRC522 = _DefaultReader
+
+    monkeypatch.setitem(sys.modules, "RPi", rpi_module)
+    monkeypatch.setitem(sys.modules, "RPi.GPIO", gpio_module)
+    monkeypatch.setitem(sys.modules, "mfrc522", mfrc522_module)
+    monkeypatch.setattr(reader, "resolve_spi_bus_device", lambda: (0, 0))
+
+    strategy, failure = reader._init_default_reader_strategy(cleanup=False)
+
+    assert failure is None
+    assert strategy is not None
+    assert strategy.source == "default"
+    assert events[0] == ("setwarnings", False)
+    assert events[1] == (
+        "reader",
+        {
+            "bus": 0,
+            "device": 0,
+            "pin_mode": reader.GPIO_PIN_MODE_BCM,
+            "pin_rst": reader.DEFAULT_RST_PIN,
+        },
     )
 
 


### PR DESCRIPTION
## Summary

- suppress expected GPIO reuse warnings before direct/default MFRC522 initialization
- keep missing GPIO libraries tolerated in non-hardware environments
- add reader coverage that verifies `GPIO.setwarnings(False)` runs before default reader construction

Closes #7582.

## Validation

- `..\arthexis\.venv\Scripts\python.exe -m pytest apps\cards\tests\test_reader.py -q`
- `..\arthexis\.venv\Scripts\python.exe -m ruff check apps\cards\reader.py apps\cards\tests\test_reader.py`
- `git diff --check`
- `..\arthexis\.venv\Scripts\python.exe manage.py check`