### PR TITLE
Fix publish workflow ref integrity for manual releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+  RELEASE_REF: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+
 jobs:
   test:
     name: Run full test suite
@@ -34,7 +38,6 @@ jobs:
           --health-retries 5
     env:
       OCPP_STATE_REDIS_URL: redis://localhost:6379
-      RELEASE_REF: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,8 +95,6 @@ jobs:
     name: Build distributions
     needs: test
     runs-on: ubuntu-latest
-    env:
-      RELEASE_REF: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,7 +105,7 @@ jobs:
       - name: Resolve publish version against PyPI
         id: resolve_publish_version
         env:
-          RELEASE_TAG: ${{ env.RELEASE_REF }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -347,17 +348,17 @@ jobs:
             exit 1
           fi
 
-          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" --clobber --repo "${GITHUB_REPOSITORY}"
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" "${artifacts[@]}" --clobber --repo "${GITHUB_REPOSITORY}"
           else
-            gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+            gh release create "${RELEASE_TAG}" "${artifacts[@]}" \
               --repo "${GITHUB_REPOSITORY}" \
               --verify-tag \
-              --title "${GITHUB_REF_NAME}" \
+              --title "${RELEASE_TAG}" \
               --generate-notes
           fi
 
-          printf 'Published GitHub Release assets for %s:\n' "${GITHUB_REF_NAME}"
+          printf 'Published GitHub Release assets for %s:\n' "${RELEASE_TAG}"
           printf ' - %s\n' "${artifacts[@]}"
 
   publish-to-pypi:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,11 @@ jobs:
           --health-retries 5
     env:
       OCPP_STATE_REDIS_URL: redis://localhost:6379
+      RELEASE_REF: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ env.RELEASE_REF }}
           clean: false
       - uses: actions/setup-python@v6
         with:
@@ -90,17 +92,19 @@ jobs:
     name: Build distributions
     needs: test
     runs-on: ubuntu-latest
+    env:
+      RELEASE_REF: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
           persist-credentials: false
 
       - name: Resolve publish version against PyPI
         id: resolve_publish_version
         env:
-          RELEASE_TAG: ${{ inputs.release_tag || '' }}
+          RELEASE_TAG: ${{ env.RELEASE_REF }}
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -119,9 +123,12 @@ jobs:
           version_path = root / "VERSION"
           version_seed = version_path.read_text(encoding="utf-8").strip()
           ref_name = os.environ.get("RELEASE_TAG") or os.environ["GITHUB_REF_NAME"].strip()
-          tag_version = ref_name[1:] if ref_name.startswith("v") else ""
-
-          if ref_name.startswith("v") and not tag_version:
+          if not ref_name.startswith("v"):
+              raise SystemExit(
+                  "Release publish blocked: release ref must be a version tag like 'v1.2.3'."
+              )
+          tag_version = ref_name[1:]
+          if not tag_version:
               raise SystemExit(
                   "Release publish blocked: tag 'v' does not include a version."
               )
@@ -133,7 +140,7 @@ jobs:
                   "Release publish blocked: VERSION file is empty."
               )
 
-          if tag_version and tag_version != expected_version:
+          if tag_version != expected_version:
               raise SystemExit(
                   "Release publish blocked: tag and VERSION mismatch "
                   f"(tag={tag_version!r}, VERSION={expected_version!r}). "


### PR DESCRIPTION
### Motivation
- Close a release supply-chain integrity gap where a manually supplied `release_tag` could be a branch or raw SHA and be checked out for publishing while tests ran against a different ref.

### Description
- Normalize the release ref by introducing `RELEASE_REF = inputs.release_tag || github.ref_name` and use it for both `test` and `build` checkouts so tested and published sources match in `.github/workflows/publish.yml`.
- Replace direct `ref: ${{ inputs.release_tag || github.ref }}` with `ref: ${{ env.RELEASE_REF }}` in both jobs to prevent divergence between tested and built code.
- Harden version gating by requiring the release ref to start with `v` and enforcing `tag_version == VERSION`, blocking branch or SHA refs from bypassing the gate.

### Testing
- Parsed the edited workflow with PyYAML using `python - <<'PY' ... yaml.safe_load(...) ... PY` and the file loaded successfully.
- Committed the change successfully with `git commit` and created the PR titled `Fix publish workflow ref integrity for manual releases`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61bc077348326aeee38aa95e9e869)