### PR TITLE
Limit Codex skill package import decompression and entry sizes

### DIFF
--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -434,10 +434,12 @@ def _read_package_text(
     archive_path: str,
     *,
     max_size_bytes: int = MAX_PACKAGE_FILE_BYTES,
+    info=None,
 ) -> str:
-    info = _package_entry_info(package, archive_path)
+    if info is None:
+        info = _package_entry_info(package, archive_path)
     _validate_package_entry_size(info, archive_path, max_size_bytes=max_size_bytes)
-    content = package.read(archive_path)
+    content = package.read(info)
     try:
         return content.decode("utf-8")
     except UnicodeDecodeError as error:
@@ -522,6 +524,7 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
             content_by_path[file_info["path"]] = _read_package_text(
                 package,
                 archive_path,
+                info=info,
             )
         if SKILL_MARKDOWN not in content_by_path:
             raise CodexSkillPackageImportError(
@@ -783,10 +786,17 @@ def import_codex_skill_package(
         package_label = str(getattr(package_path, "name", "<uploaded package>"))
 
     with ZipFile(package_source) as package:
+        try:
+            manifest_info = _package_entry_info(package, "manifest.json")
+        except CodexSkillPackageImportError as error:
+            raise CodexSkillPackageImportError(
+                "Missing required manifest.json"
+            ) from error
         manifest_text = _read_package_text(
             package,
             "manifest.json",
             max_size_bytes=MAX_PACKAGE_MANIFEST_BYTES,
+            info=manifest_info,
         )
         manifest = json.loads(manifest_text)
         if not isinstance(manifest, dict):

--- a/apps/skills/package_services.py
+++ b/apps/skills/package_services.py
@@ -54,6 +54,11 @@ OPERATOR_PATH_MARKERS = (
     ".codex\\",
     ".codex/",
 )
+MAX_PACKAGE_FILES = 256
+MAX_PACKAGE_MANIFEST_BYTES = 1024 * 1024
+MAX_PACKAGE_FILE_BYTES = 2 * 1024 * 1024
+MAX_PACKAGE_TOTAL_BYTES = 16 * 1024 * 1024
+MAX_PACKAGE_COMPRESSION_RATIO = 200
 
 
 class CodexSkillPackageImportError(ValueError):
@@ -404,13 +409,35 @@ def _import_file_spec(file_info: dict, content: str) -> dict:
     }
 
 
-def _read_package_text(package: ZipFile, archive_path: str) -> str:
+def _package_entry_info(package: ZipFile, archive_path: str):
     try:
-        content = package.read(archive_path)
+        return package.getinfo(archive_path)
     except KeyError as error:
         raise CodexSkillPackageImportError(
             f"Missing package file: {archive_path}"
         ) from error
+
+
+def _validate_package_entry_size(info, archive_path: str, *, max_size_bytes: int) -> None:
+    if info.file_size > max_size_bytes:
+        raise CodexSkillPackageImportError(f"Package file too large: {archive_path}")
+    if info.compress_size > 0:
+        ratio = info.file_size / info.compress_size
+        if ratio > MAX_PACKAGE_COMPRESSION_RATIO:
+            raise CodexSkillPackageImportError(
+                f"Suspicious package compression ratio: {archive_path}"
+            )
+
+
+def _read_package_text(
+    package: ZipFile,
+    archive_path: str,
+    *,
+    max_size_bytes: int = MAX_PACKAGE_FILE_BYTES,
+) -> str:
+    info = _package_entry_info(package, archive_path)
+    _validate_package_entry_size(info, archive_path, max_size_bytes=max_size_bytes)
+    content = package.read(archive_path)
     try:
         return content.decode("utf-8")
     except UnicodeDecodeError as error:
@@ -427,6 +454,8 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
         raise CodexSkillPackageImportError("Package manifest skills must be a list")
     validated_skills = []
     seen_slugs = set()
+    total_file_bytes = 0
+    file_count = 0
     for skill_entry in skills:
         if not isinstance(skill_entry, dict):
             raise CodexSkillPackageImportError("Package skill entries must be objects")
@@ -480,6 +509,16 @@ def _validate_manifest_skill_entries(package: ZipFile, manifest: dict) -> list[d
                 )
             seen_paths.add(file_info["path"])
             archive_path = f"skills/{slug}/{file_info['path']}"
+            info = _package_entry_info(package, archive_path)
+            _validate_package_entry_size(
+                info, archive_path, max_size_bytes=MAX_PACKAGE_FILE_BYTES
+            )
+            total_file_bytes += info.file_size
+            file_count += 1
+            if file_count > MAX_PACKAGE_FILES:
+                raise CodexSkillPackageImportError("Package contains too many files")
+            if total_file_bytes > MAX_PACKAGE_TOTAL_BYTES:
+                raise CodexSkillPackageImportError("Package content exceeds size limit")
             content_by_path[file_info["path"]] = _read_package_text(
                 package,
                 archive_path,
@@ -744,13 +783,12 @@ def import_codex_skill_package(
         package_label = str(getattr(package_path, "name", "<uploaded package>"))
 
     with ZipFile(package_source) as package:
-        try:
-            manifest_bytes = package.read("manifest.json")
-        except KeyError as error:
-            raise CodexSkillPackageImportError(
-                "Missing required manifest.json"
-            ) from error
-        manifest = json.loads(manifest_bytes.decode("utf-8"))
+        manifest_text = _read_package_text(
+            package,
+            "manifest.json",
+            max_size_bytes=MAX_PACKAGE_MANIFEST_BYTES,
+        )
+        manifest = json.loads(manifest_text)
         if not isinstance(manifest, dict):
             raise CodexSkillPackageImportError("Package manifest must be an object")
         if manifest.get("format") != PACKAGE_FORMAT:

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -565,6 +565,16 @@ def test_import_rejects_windows_absolute_manifest_paths(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_dry_run_rejects_missing_manifest_with_legacy_message(tmp_path):
+    package_path = tmp_path / "missing-manifest.zip"
+    with ZipFile(package_path, "w") as package:
+        package.writestr("skills/missing-manifest/SKILL.md", "demo")
+
+    with pytest.raises(ValueError, match="Missing required manifest.json"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
 def test_import_dry_run_rejects_missing_manifest_files(tmp_path):
     package_path = tmp_path / "missing-file.zip"
     manifest = {

--- a/apps/skills/tests/test_package_services.py
+++ b/apps/skills/tests/test_package_services.py
@@ -606,6 +606,38 @@ def test_import_dry_run_rejects_non_utf8_package_files(tmp_path):
 
 
 @pytest.mark.django_db
+def test_import_dry_run_rejects_oversized_manifest(tmp_path):
+    package_path = tmp_path / "oversized-manifest.zip"
+    huge_manifest = "{" + ('"x":' + '"' + ("a" * (1024 * 1024)) + '"') + "}"
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", huge_manifest)
+
+    with pytest.raises(ValueError, match="Package file too large: manifest.json"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
+def test_import_dry_run_rejects_oversized_package_file(tmp_path):
+    package_path = tmp_path / "oversized-file.zip"
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "skills": [
+            {
+                "slug": "large-file",
+                "title": "Large File",
+                "files": [{"path": "SKILL.md", "included_by_default": True}],
+            }
+        ],
+    }
+    with ZipFile(package_path, "w") as package:
+        package.writestr("manifest.json", json.dumps(manifest))
+        package.writestr("skills/large-file/SKILL.md", "a" * ((2 * 1024 * 1024) + 1))
+
+    with pytest.raises(ValueError, match="Package file too large"):
+        import_codex_skill_package(package_path, dry_run=True)
+
+
+@pytest.mark.django_db
 def test_import_rejects_duplicate_manifest_paths(tmp_path):
     package_path = tmp_path / "duplicate-path.zip"
     manifest = {


### PR DESCRIPTION
### Motivation

- The ZIP-based Codex skill importer read `manifest.json` and every manifest-listed member via `ZipFile.read()` with no size, count, or compression-ratio limits, allowing crafted archives to exhaust memory/CPU during dry-run or real imports. 
- The change hardens the importer to enforce conservative bounds before any full-member decompression to prevent resource exhaustion while preserving existing behavior for valid packages.

### Description

- Add import safety constants `MAX_PACKAGE_FILES`, `MAX_PACKAGE_MANIFEST_BYTES`, `MAX_PACKAGE_FILE_BYTES`, `MAX_PACKAGE_TOTAL_BYTES`, and `MAX_PACKAGE_COMPRESSION_RATIO` to `apps/skills/package_services.py`.
- Introduce `_package_entry_info()` and `_validate_package_entry_size()` to inspect `ZipInfo` metadata and reject entries that exceed per-file size limits or have suspicious compression ratios before decompression.
- Change `_read_package_text()` to validate entry metadata via `_package_entry_info()` and `_validate_package_entry_size()` prior to calling `ZipFile.read()` so members are not fully materialized until they pass checks.
- Update `_validate_manifest_skill_entries()` to accumulate `file_count` and `total_file_bytes` across manifest-listed entries and to fail early when totals exceed configured limits.
- Read `manifest.json` through the bounded `_read_package_text()` path in `import_codex_skill_package()` so the manifest itself is size-limited.
- Add regression tests in `apps/skills/tests/test_package_services.py` that assert oversized `manifest.json` and oversized package file entries are rejected during dry-run import.

### Testing

- Added unit tests `test_import_dry_run_rejects_oversized_manifest` and `test_import_dry_run_rejects_oversized_package_file` under `apps/skills/tests/test_package_services.py` to cover the new failure modes.
- Attempted to run the repository test entrypoint (`.venv/bin/python manage.py test run -- apps.skills.tests.test_package_services`) but could not execute tests because `.venv` has not been created in this environment; `./install.sh` failed due to a missing Redis dependency, so automated tests were not executed here.
- Changes were committed locally and a PR description was prepared; CI is expected to run the test suite in the project's normal environment where the new tests will be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60d10fe508326821a08f6177ec68e)