### PR TITLE
fix(terminals): harden terminal PID state directory and file writes

### DIFF
--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -62,7 +62,9 @@ def _ensure_private_state_dir(path: Path) -> None:
         return
     if path.is_symlink():
         raise PermissionError(f"Terminal state dir must not be a symlink: {path}")
-    stats = path.stat()
+    stats = path.lstat()
+    if stat.S_ISLNK(stats.st_mode):
+        raise PermissionError(f"Terminal state dir must not be a symlink: {path}")
     getuid = getattr(os, "getuid", None)
     if getuid is not None and stats.st_uid != getuid():
         raise PermissionError(f"Terminal state dir must be owned by current user: {path}")
@@ -82,10 +84,8 @@ def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     fd = os.open(pid_file, flags, 0o600)
-    try:
-        os.write(fd, content.encode("utf-8"))
-    finally:
-        os.close(fd)
+    with os.fdopen(fd, "w", encoding="utf-8") as output:
+        output.write(content)
 
 
 def _is_process_running(pid: int) -> bool:

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -55,11 +55,16 @@ def _named_terminal_pid_file(state_key: str) -> Path:
 
 
 def _ensure_private_state_dir(path: Path) -> None:
+    if path.is_symlink():
+        raise PermissionError(f"Terminal state dir must not be a symlink: {path}")
     path.mkdir(parents=True, exist_ok=True)
     if _is_windows():
         return
+    if path.is_symlink():
+        raise PermissionError(f"Terminal state dir must not be a symlink: {path}")
     stats = path.stat()
-    if stats.st_uid != os.getuid():
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and stats.st_uid != getuid():
         raise PermissionError(f"Terminal state dir must be owned by current user: {path}")
     current_mode = stat.S_IMODE(stats.st_mode)
     if current_mode != 0o700:
@@ -71,6 +76,8 @@ def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
     if _is_windows():
         pid_file.write_text(content, encoding="utf-8")
         return
+    if pid_file.is_symlink():
+        raise PermissionError(f"Terminal pid file must not be a symlink: {pid_file}")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import re
 import shlex
 import shutil
@@ -51,6 +52,33 @@ def _terminal_pid_file(terminal_pk: int) -> Path:
 def _named_terminal_pid_file(state_key: str) -> Path:
     safe_key = re.sub(r"[^A-Za-z0-9_.-]+", "-", state_key).strip(".-")
     return _terminal_state_dir() / f"{safe_key or 'terminal'}.pid"
+
+
+def _ensure_private_state_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if _is_windows():
+        return
+    stats = path.stat()
+    if stats.st_uid != os.getuid():
+        raise PermissionError(f"Terminal state dir must be owned by current user: {path}")
+    current_mode = stat.S_IMODE(stats.st_mode)
+    if current_mode != 0o700:
+        path.chmod(0o700)
+
+
+def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
+    content = f"{pid}\n{_command_metadata(command)}\n"
+    if _is_windows():
+        pid_file.write_text(content, encoding="utf-8")
+        return
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(pid_file, flags, 0o600)
+    try:
+        os.write(fd, content.encode("utf-8"))
+    finally:
+        os.close(fd)
 
 
 def _is_process_running(pid: int) -> bool:
@@ -214,7 +242,7 @@ def _launch_startup_script(
     state_key: str = "terminal",
 ) -> Path:
     pid_dir = _terminal_state_dir()
-    pid_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_state_dir(pid_dir)
     pid_file = _named_terminal_pid_file(state_key)
     if _is_windows():
         script_path = _write_windows_startup_script(state_key, startup_script)
@@ -228,7 +256,7 @@ def _launch_startup_script(
         if startup_script:
             command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
+    _write_pid_file(pid_file, process.pid, command)
     return pid_file
 
 
@@ -265,13 +293,13 @@ def _launch_terminal(terminal: AgentTerminal) -> None:
         )
         return
     pid_dir = _terminal_state_dir()
-    pid_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_state_dir(pid_dir)
     pid_file = _terminal_pid_file(terminal.pk)
     command = [*shlex.split(executable)]
     if startup_script:
         command.extend(["-e", "sh", "-lc", startup_script])
     process = subprocess.Popen(command)
-    pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
+    _write_pid_file(pid_file, process.pid, command)
 
 
 def _matches_current_node_role(terminal: AgentTerminal) -> bool:

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -148,6 +148,25 @@ def test_terminal_state_dir_falls_back_to_tmp_when_posix_state_home_is_unwritabl
     assert tasks._terminal_state_dir() == tmp_path / "tmp" / "arthexis-agent-terminals"
 
 
+def test_launch_terminal_rejects_symlinked_pid_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(tasks, "_is_windows", lambda: False)
+    victim = tmp_path / "victim.txt"
+    victim.write_text("ORIGINAL", encoding="utf-8")
+    (tmp_path / "None.pid").symlink_to(victim)
+    terminal = AgentTerminal(name="symlink-test", launch_command="echo ready")
+
+    class FakeProcess:
+        pid = 1234
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", lambda command: FakeProcess())
+
+    with pytest.raises(OSError):
+        tasks._launch_terminal(terminal)
+
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"
+
+
 def test_command_metadata_is_unquoted_and_single_line():
     metadata = tasks._command_metadata(
         ["x-terminal-emulator", "-e", "sh", "-lc", "echo ready\nprintf done"]

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -167,6 +167,27 @@ def test_launch_terminal_rejects_symlinked_pid_file(tmp_path, monkeypatch):
     assert victim.read_text(encoding="utf-8") == "ORIGINAL"
 
 
+def test_launch_terminal_rejects_symlinked_state_dir(tmp_path, monkeypatch):
+    target = tmp_path / "target"
+    target.mkdir()
+    state_dir = tmp_path / "state-link"
+    try:
+        state_dir.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("directory symlinks are unavailable")
+    monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(state_dir))
+    monkeypatch.setattr(tasks, "_is_windows", lambda: False)
+    terminal = AgentTerminal(name="symlink-state", launch_command="echo ready")
+
+    class FakeProcess:
+        pid = 1234
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", lambda command: FakeProcess())
+
+    with pytest.raises(PermissionError, match="state dir must not be a symlink"):
+        tasks._launch_terminal(terminal)
+
+
 def test_command_metadata_is_unquoted_and_single_line():
     metadata = tasks._command_metadata(
         ["x-terminal-emulator", "-e", "sh", "-lc", "echo ready\nprintf done"]


### PR DESCRIPTION
### Motivation

- The fallback POSIX state directory under a shared temporary location allowed predictable PID paths that a local attacker could pre-populate with symlinks to cause PID-file tampering or clobber service-writable files.
- The change hardens PID file handling to prevent symlink-following, enforce private ownership/permissions on the state directory, and keep Windows behaviour unchanged.

### Description

- Added `_ensure_private_state_dir(path: Path)` to create the state directory and on POSIX require it be owned by the current user and set its mode to `0700` when needed.
- Added `_write_pid_file(pid_file: Path, pid: int, command: Sequence[str])` which writes PID file content using `os.open` with `O_NOFOLLOW` when available and restrictive mode `0600`, and falls back to `Path.write_text()` on Windows.
- Replaced direct `mkdir(..., exist_ok=True)` and `Path.write_text()` calls in `_launch_startup_script` and `_launch_terminal` with the hardened helpers so both startup-script and direct-launch flows are protected. 
- Minor import added (`stat`) and a regression unit test `test_launch_terminal_rejects_symlinked_pid_file` was added to validate symlinked PID files are rejected and not overwritten.

### Testing

- Attempted the canonical test entrypoint `.venv/bin/python manage.py test run -- apps.terminals.tests.test_terminals_smoke` but it could not be run because the repository `.venv` is not present in this environment. (failed / not run)
- Attempted running the project install script `./install.sh` to prepare the environment but it failed due to a missing system dependency (`redis-server`), so the full test environment could not be provisioned. (failed / not run)
- Attempted `python3 -m pytest apps/terminals/tests/test_terminals_smoke.py -q` but `pytest-django` and other test dependencies are not installed in this environment, so the new regression test could not be executed here. (failed / not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60e68faac8326847ae2b8f73542fc)