### PR TITLE
Harden Linux WhatsApp listener runner permissions

### DIFF
--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -1313,7 +1313,7 @@ def build_whatsapp_listener_install_plan(
             resolved_output_dir.mkdir(parents=True, exist_ok=True)
             service_path.parent.mkdir(parents=True, exist_ok=True)
             runner_path.write_text(_linux_listener_runner(resolved_base_dir, command), encoding="utf-8")
-            runner_path.chmod(0o755)
+            runner_path.chmod(0o700)
             service_path.write_text(_linux_systemd_unit(unit_name, resolved_base_dir, runner_path), encoding="utf-8")
             wrote_files = True
 

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -964,6 +964,7 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
     assert not systemd_dir.exists()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Linux permission bits not supported on Windows")
 def test_whatsapp_install_listener_linux_write_restricts_runner_permissions(tmp_path):
     output_dir = tmp_path / "install"
     systemd_dir = tmp_path / "systemd-user"

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -964,6 +964,40 @@ def test_whatsapp_install_listener_linux_dry_run_plans_systemd_user_unit(tmp_pat
     assert not systemd_dir.exists()
 
 
+def test_whatsapp_install_listener_linux_write_restricts_runner_permissions(tmp_path):
+    output_dir = tmp_path / "install"
+    systemd_dir = tmp_path / "systemd-user"
+    stdout = StringIO()
+
+    with override_settings(BASE_DIR=tmp_path):
+        call_command(
+            "whatsapp",
+            "install-listener",
+            "--from",
+            "5551234567",
+            "--platform",
+            "linux",
+            "--output-dir",
+            str(output_dir),
+            "--systemd-user-dir",
+            str(systemd_dir),
+            "--python",
+            "/opt/arthexis/.venv/bin/python",
+            "--manage-py",
+            "/opt/arthexis/manage.py",
+            "--write",
+            "--json",
+            stdout=stdout,
+        )
+
+    payload = json.loads(stdout.getvalue())
+    runner_path = Path(payload["runner_path"])
+
+    assert payload["status"] == "written"
+    assert runner_path.exists()
+    assert runner_path.stat().st_mode & 0o777 == 0o700
+
+
 def test_install_listener_target_platform_controls_browser_defaults(tmp_path):
     stdout = StringIO()
 


### PR DESCRIPTION
### Motivation

- The Linux listener installer writes a shell runner that embeds operator-specific values and was being made world-readable by an unconditional `chmod(0o755)`, which can leak sensitive local configuration on multi-user systems.

### Description

- Change the generated Linux runner script file mode from `0o755` to `0o700` in `apps/meta/services.py` to restrict access to the owning user only.
- Add a regression test `test_whatsapp_install_listener_linux_write_restricts_runner_permissions` in `apps/meta/tests/test_whatsapp.py` that runs `whatsapp install-listener --write` and asserts the produced runner file has mode `0o700`.

### Testing

- Ran the targeted test with `python3 -m pytest apps/meta/tests/test_whatsapp.py -k install_listener_linux_write_restricts_runner_permissions`, and it passed.
- Attempted the repository bootstrap (`./install.sh`) and canonical test flow, but the environment lacks `redis-server` and a prebuilt `.venv`, so full suite execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f627d1d0d083268b98ca5f54bc4fe4)