### PR TITLE
Harden Agent Card activation reader-event validation

### DIFF
--- a/apps/cards/agent_card.py
+++ b/apps/cards/agent_card.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
+import json
 import re
 from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+from django.conf import settings
 
 AGENT_CARD_PREFIX = "AC1"
 APPLICATION_SECTORS = range(1, 16)
@@ -16,6 +20,7 @@ PRINTABLE_ASCII_MIN = 32
 PRINTABLE_ASCII_MAX = 126
 FRESH_READER_EVENT_SECONDS = 300
 FUTURE_READER_EVENT_SKEW_SECONDS = 30
+READER_PROOF_SECRET_SETTING = "AGENT_CARD_READER_PROOF_SECRET"
 
 TRUST_TIERS = {
     "unknown",
@@ -422,11 +427,38 @@ def _expected_reader_proof(
     trust_tier: str,
     reader_id: str,
     node_id: str,
-    observed_at: str,
+    observed_at: str | datetime,
     manifest_fingerprint: str,
+    secret: str | bytes | None = None,
 ) -> str:
-    payload = "|".join((trust_tier, reader_id, node_id, observed_at, manifest_fingerprint))
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    payload = {
+        "manifest_fingerprint": str(manifest_fingerprint),
+        "node_id": str(node_id),
+        "observed_at": _reader_observed_at_value(observed_at),
+        "reader_id": str(reader_id),
+        "trust_tier": str(trust_tier),
+    }
+    canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(_reader_proof_secret(secret), canonical_payload, hashlib.sha256).hexdigest()
+
+
+def _reader_proof_secret(secret: str | bytes | None = None) -> bytes:
+    raw_secret = secret
+    if raw_secret is None:
+        raw_secret = getattr(
+            settings,
+            READER_PROOF_SECRET_SETTING,
+            getattr(settings, "SECRET_KEY", ""),
+        )
+    if isinstance(raw_secret, bytes):
+        return raw_secret
+    return str(raw_secret).encode("utf-8")
+
+
+def _reader_observed_at_value(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value or "").strip()
 
 
 def _confidence_for_count(count: int) -> str:
@@ -479,7 +511,7 @@ def validate_reader_event(
         return ReaderTrustResult(False, "unknown", "unknown reader trust tier")
     if trust_tier not in ACTIVATING_TRUST_TIERS:
         return ReaderTrustResult(False, trust_tier, "reader is not trusted for activation")
-    observed_at = str(reader_event.get("observed_at") or "").strip()
+    observed_at = _reader_observed_at_value(reader_event.get("observed_at"))
     if not observed_at:
         return ReaderTrustResult(False, trust_tier, "reader event timestamp is required")
     try:
@@ -495,21 +527,23 @@ def validate_reader_event(
     age = now - observed
     if age > timedelta(seconds=FRESH_READER_EVENT_SECONDS):
         return ReaderTrustResult(False, trust_tier, "reader event is stale")
-    if not reader_event.get("reader_id"):
+    reader_id = str(reader_event.get("reader_id") or "").strip()
+    node_id = str(reader_event.get("node_id") or "").strip()
+    if not reader_id:
         return ReaderTrustResult(False, trust_tier, "reader_id is required")
-    if not reader_event.get("node_id"):
+    if not node_id:
         return ReaderTrustResult(False, trust_tier, "node_id is required")
     proof = str(reader_event.get("proof") or "").strip()
     if not proof:
         return ReaderTrustResult(False, trust_tier, "reader proof is required")
     expected_proof = _expected_reader_proof(
         trust_tier=trust_tier,
-        reader_id=str(reader_event.get("reader_id")),
-        node_id=str(reader_event.get("node_id")),
+        reader_id=reader_id,
+        node_id=node_id,
         observed_at=observed_at,
         manifest_fingerprint=manifest_fingerprint,
     )
-    if proof != expected_proof:
+    if not hmac.compare_digest(proof, expected_proof):
         return ReaderTrustResult(False, trust_tier, "reader proof is invalid")
     return ReaderTrustResult(True, trust_tier)
 

--- a/apps/cards/agent_card.py
+++ b/apps/cards/agent_card.py
@@ -417,6 +417,18 @@ def _candidate_id(candidate: Mapping[str, Any] | object) -> str:
     return str(getattr(candidate, "id", None) or getattr(candidate, "soul_id", "") or getattr(candidate, "name", ""))
 
 
+def _expected_reader_proof(
+    *,
+    trust_tier: str,
+    reader_id: str,
+    node_id: str,
+    observed_at: str,
+    manifest_fingerprint: str,
+) -> str:
+    payload = "|".join((trust_tier, reader_id, node_id, observed_at, manifest_fingerprint))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def _confidence_for_count(count: int) -> str:
     if count <= 0:
         return "no_match"
@@ -457,33 +469,48 @@ def score_soul_identity(
     return best
 
 
-def validate_reader_event(reader_event: Mapping[str, Any]) -> ReaderTrustResult:
+def validate_reader_event(
+    reader_event: Mapping[str, Any],
+    *,
+    manifest_fingerprint: str,
+) -> ReaderTrustResult:
     trust_tier = str(reader_event.get("trust_tier") or "unknown").strip()
     if trust_tier not in TRUST_TIERS:
         return ReaderTrustResult(False, "unknown", "unknown reader trust tier")
     if trust_tier not in ACTIVATING_TRUST_TIERS:
         return ReaderTrustResult(False, trust_tier, "reader is not trusted for activation")
-    observed_at = reader_event.get("observed_at")
-    if observed_at:
-        try:
-            observed = datetime.fromisoformat(str(observed_at).replace("Z", "+00:00"))
-        except ValueError:
-            return ReaderTrustResult(False, trust_tier, "reader event timestamp is invalid")
-        if observed.tzinfo is None:
-            observed = observed.replace(tzinfo=timezone.utc)
-        now = datetime.now(timezone.utc)
-        observed = observed.astimezone(timezone.utc)
-        if observed - now > timedelta(seconds=FUTURE_READER_EVENT_SKEW_SECONDS):
-            return ReaderTrustResult(False, trust_tier, "reader event timestamp is in the future")
-        age = now - observed
-        if age > timedelta(seconds=FRESH_READER_EVENT_SECONDS):
-            return ReaderTrustResult(False, trust_tier, "reader event is stale")
+    observed_at = str(reader_event.get("observed_at") or "").strip()
+    if not observed_at:
+        return ReaderTrustResult(False, trust_tier, "reader event timestamp is required")
+    try:
+        observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return ReaderTrustResult(False, trust_tier, "reader event timestamp is invalid")
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    observed = observed.astimezone(timezone.utc)
+    if observed - now > timedelta(seconds=FUTURE_READER_EVENT_SKEW_SECONDS):
+        return ReaderTrustResult(False, trust_tier, "reader event timestamp is in the future")
+    age = now - observed
+    if age > timedelta(seconds=FRESH_READER_EVENT_SECONDS):
+        return ReaderTrustResult(False, trust_tier, "reader event is stale")
     if not reader_event.get("reader_id"):
         return ReaderTrustResult(False, trust_tier, "reader_id is required")
     if not reader_event.get("node_id"):
         return ReaderTrustResult(False, trust_tier, "node_id is required")
-    if not reader_event.get("proof"):
+    proof = str(reader_event.get("proof") or "").strip()
+    if not proof:
         return ReaderTrustResult(False, trust_tier, "reader proof is required")
+    expected_proof = _expected_reader_proof(
+        trust_tier=trust_tier,
+        reader_id=str(reader_event.get("reader_id")),
+        node_id=str(reader_event.get("node_id")),
+        observed_at=observed_at,
+        manifest_fingerprint=manifest_fingerprint,
+    )
+    if proof != expected_proof:
+        return ReaderTrustResult(False, trust_tier, "reader proof is invalid")
     return ReaderTrustResult(True, trust_tier)
 
 
@@ -494,7 +521,7 @@ def plan_agent_activation(
     skill_bundle_id: str | int | None = None,
     interface_spec_id: str | int | None = None,
 ) -> ActivationPlan:
-    trust = validate_reader_event(reader_event)
+    trust = validate_reader_event(reader_event, manifest_fingerprint=card.fingerprint)
     if not trust.trusted:
         return ActivationPlan(
             status="rejected",

--- a/apps/cards/tests/test_agent_card.py
+++ b/apps/cards/tests/test_agent_card.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from apps.cards.agent_card import (
+    _expected_reader_proof,
     AgentCardError,
     build_agent_card_sector_payloads,
     parse_agent_card,
@@ -167,6 +168,7 @@ def test_plan_agent_activation_rejects_unknown_reader_trust():
 
 def test_plan_agent_activation_accepts_trusted_reader_with_bundle_and_interface():
     card = parse_agent_card(valid_agent_card_records())
+    observed_at = datetime.now(timezone.utc).isoformat()
 
     plan = plan_agent_activation(
         card,
@@ -174,8 +176,14 @@ def test_plan_agent_activation_accepts_trusted_reader_with_bundle_and_interface(
             "reader_id": "reader-1",
             "node_id": "node-1",
             "trust_tier": "trusted_operator_console",
-            "observed_at": datetime.now(timezone.utc).isoformat(),
-            "proof": "signed",
+            "observed_at": observed_at,
+            "proof": _expected_reader_proof(
+                trust_tier="trusted_operator_console",
+                reader_id="reader-1",
+                node_id="node-1",
+                observed_at=observed_at,
+                manifest_fingerprint=card.fingerprint,
+            ),
         },
         skill_bundle_id=1,
         interface_spec_id=2,
@@ -188,6 +196,7 @@ def test_plan_agent_activation_accepts_trusted_reader_with_bundle_and_interface(
 
 def test_plan_agent_activation_rejects_future_reader_timestamp():
     card = parse_agent_card(valid_agent_card_records())
+    observed_at = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
 
     plan = plan_agent_activation(
         card,
@@ -195,8 +204,14 @@ def test_plan_agent_activation_rejects_future_reader_timestamp():
             "reader_id": "reader-1",
             "node_id": "node-1",
             "trust_tier": "trusted_operator_console",
-            "observed_at": (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat(),
-            "proof": "signed",
+            "observed_at": observed_at,
+            "proof": _expected_reader_proof(
+                trust_tier="trusted_operator_console",
+                reader_id="reader-1",
+                node_id="node-1",
+                observed_at=observed_at,
+                manifest_fingerprint=card.fingerprint,
+            ),
         },
         skill_bundle_id=1,
         interface_spec_id=2,
@@ -205,3 +220,24 @@ def test_plan_agent_activation_rejects_future_reader_timestamp():
     assert plan.accepted is False
     assert plan.status == "rejected"
     assert "future" in plan.reason
+
+
+def test_plan_agent_activation_rejects_unbound_reader_proof():
+    card = parse_agent_card(valid_agent_card_records())
+
+    plan = plan_agent_activation(
+        card,
+        {
+            "reader_id": "reader-1",
+            "node_id": "node-1",
+            "trust_tier": "trusted_operator_console",
+            "observed_at": datetime.now(timezone.utc).isoformat(),
+            "proof": "not-a-signature",
+        },
+        skill_bundle_id=1,
+        interface_spec_id=2,
+    )
+
+    assert plan.accepted is False
+    assert plan.status == "rejected"
+    assert "invalid" in plan.reason

--- a/apps/cards/tests/test_agent_card.py
+++ b/apps/cards/tests/test_agent_card.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -194,6 +195,33 @@ def test_plan_agent_activation_accepts_trusted_reader_with_bundle_and_interface(
     assert plan.capability_sigils
 
 
+def test_plan_agent_activation_accepts_datetime_reader_timestamp():
+    card = parse_agent_card(valid_agent_card_records())
+    observed_at = datetime.now(timezone.utc)
+
+    plan = plan_agent_activation(
+        card,
+        {
+            "reader_id": "reader-1",
+            "node_id": "node-1",
+            "trust_tier": "trusted_operator_console",
+            "observed_at": observed_at,
+            "proof": _expected_reader_proof(
+                trust_tier="trusted_operator_console",
+                reader_id="reader-1",
+                node_id="node-1",
+                observed_at=observed_at,
+                manifest_fingerprint=card.fingerprint,
+            ),
+        },
+        skill_bundle_id=1,
+        interface_spec_id=2,
+    )
+
+    assert plan.accepted is True
+    assert plan.status == "ready"
+
+
 def test_plan_agent_activation_rejects_future_reader_timestamp():
     card = parse_agent_card(valid_agent_card_records())
     observed_at = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
@@ -233,6 +261,37 @@ def test_plan_agent_activation_rejects_unbound_reader_proof():
             "trust_tier": "trusted_operator_console",
             "observed_at": datetime.now(timezone.utc).isoformat(),
             "proof": "not-a-signature",
+        },
+        skill_bundle_id=1,
+        interface_spec_id=2,
+    )
+
+    assert plan.accepted is False
+    assert plan.status == "rejected"
+    assert "invalid" in plan.reason
+
+
+def test_plan_agent_activation_rejects_plain_hash_reader_proof():
+    card = parse_agent_card(valid_agent_card_records())
+    observed_at = datetime.now(timezone.utc).isoformat()
+    payload = "|".join(
+        (
+            "trusted_operator_console",
+            "reader-1",
+            "node-1",
+            observed_at,
+            card.fingerprint,
+        )
+    )
+
+    plan = plan_agent_activation(
+        card,
+        {
+            "reader_id": "reader-1",
+            "node_id": "node-1",
+            "trust_tier": "trusted_operator_console",
+            "observed_at": observed_at,
+            "proof": hashlib.sha256(payload.encode("utf-8")).hexdigest(),
         },
         skill_bundle_id=1,
         interface_spec_id=2,


### PR DESCRIPTION
### Motivation

- The prior activation helper accepted a caller-provided `trust_tier` and any non-empty `proof`, allowing untrusted callers to obtain `ready` activation plans by spoofing the event.
- The change prevents bypass of freshness and proof binding so activation decisions cannot be made from unbound reader payloads.

### Description

- Added `_expected_reader_proof()` which derives a proof digest from `trust_tier`, `reader_id`, `node_id`, `observed_at`, and the card `manifest_fingerprint`.
- Changed `validate_reader_event()` to require `observed_at`, enforce timestamp freshness, accept `manifest_fingerprint` as an argument, and reject events whose `proof` does not match the computed digest.
- Updated `plan_agent_activation()` to pass the card fingerprint into `validate_reader_event()` so the proof is bound to the manifest.
- Updated tests in `apps/cards/tests/test_agent_card.py` to generate bound proofs for the valid case and added `test_plan_agent_activation_rejects_unbound_reader_proof()` to prevent regressions.

### Testing

- Updated unit tests: modified `test_plan_agent_activation_accepts_trusted_reader_with_bundle_and_interface`, modified `test_plan_agent_activation_rejects_future_reader_timestamp`, and added `test_plan_agent_activation_rejects_unbound_reader_proof` in `apps/cards/tests/test_agent_card.py`.
- Attempted to run the test subset with `.venv/bin/python manage.py test run -- apps/cards/tests/test_agent_card.py` but `.venv` is not present in the environment so the command could not be executed.
- Attempted repository bootstrap via `./install.sh` but it failed due to missing system dependency `redis-server`, so automated tests were not executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62cd83f1083268f0ab6f1aff1d380)