### PR TITLE
fix(terminals,turn-boundary): avoid destructive Windows PID liveness checks

### DIFF
--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -99,17 +99,26 @@ def _is_process_running(pid: int) -> bool:
         return True
 
     import ctypes
+    from ctypes import wintypes
 
     process_query_limited_information = 0x1000
     synchronize = 0x00100000
     access = process_query_limited_information | synchronize
-    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    kernel32 = ctypes.windll.kernel32
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.GetLastError.argtypes = []
+    kernel32.GetLastError.restype = wintypes.DWORD
+
+    handle = kernel32.OpenProcess(access, False, pid)
     if handle:
-        ctypes.windll.kernel32.CloseHandle(handle)
+        kernel32.CloseHandle(handle)
         return True
 
     error_access_denied = 5
-    return ctypes.GetLastError() == error_access_denied
+    return kernel32.GetLastError() == error_access_denied
 
 
 def _read_pid_file(pid_file: Path) -> tuple[int | None, str | None]:

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -89,11 +89,27 @@ def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
 
 
 def _is_process_running(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except (OSError, ValueError, SystemError):
+    if pid <= 0:
         return False
-    return True
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except (OSError, ValueError, SystemError):
+            return False
+        return True
+
+    import ctypes
+
+    process_query_limited_information = 0x1000
+    synchronize = 0x00100000
+    access = process_query_limited_information | synchronize
+    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    if handle:
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return True
+
+    error_access_denied = 5
+    return ctypes.GetLastError() == error_access_denied
 
 
 def _read_pid_file(pid_file: Path) -> tuple[int | None, str | None]:

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -137,6 +137,61 @@ def test_is_process_running_handles_windows_system_error(monkeypatch):
     assert tasks._is_process_running(1234) is False
 
 
+def test_is_process_running_uses_pointer_sized_windows_handle(monkeypatch):
+    import ctypes
+    from ctypes import wintypes
+
+    class FakeKernelFunction:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    class FakeKernel32:
+        def __init__(self):
+            self.OpenProcess = FakeKernelFunction(0x100000000)
+            self.CloseHandle = FakeKernelFunction(True)
+            self.GetLastError = FakeKernelFunction(0)
+
+    kernel32 = FakeKernel32()
+    monkeypatch.setattr(tasks.os, "name", "nt", raising=False)
+    monkeypatch.setattr(ctypes, "windll", type("FakeWindll", (), {"kernel32": kernel32})(), raising=False)
+
+    assert tasks._is_process_running(1234) is True
+    assert kernel32.OpenProcess.argtypes == [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    assert kernel32.OpenProcess.restype is wintypes.HANDLE
+    assert kernel32.CloseHandle.calls == [(0x100000000,)]
+
+
+def test_is_process_running_treats_windows_access_denied_as_running(monkeypatch):
+    import ctypes
+
+    class FakeKernelFunction:
+        def __init__(self, result):
+            self.result = result
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            return self.result
+
+    class FakeKernel32:
+        def __init__(self):
+            self.OpenProcess = FakeKernelFunction(0)
+            self.CloseHandle = FakeKernelFunction(True)
+            self.GetLastError = FakeKernelFunction(5)
+
+    monkeypatch.setattr(tasks.os, "name", "nt", raising=False)
+    monkeypatch.setattr(ctypes, "windll", type("FakeWindll", (), {"kernel32": FakeKernel32()})(), raising=False)
+
+    assert tasks._is_process_running(1234) is True
+
+
 def test_terminal_state_dir_falls_back_to_tmp_when_posix_state_home_is_unwritable(tmp_path, monkeypatch):
     monkeypatch.delenv("ARTHEXIS_TERMINAL_STATE_DIR", raising=False)
     monkeypatch.delenv("XDG_STATE_HOME", raising=False)

--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -176,11 +176,27 @@ def read_json(path: Path) -> dict[str, Any] | None:
 
 
 def _is_process_running(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except (OSError, ValueError, SystemError):
+    if pid <= 0:
         return False
-    return True
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except (OSError, ValueError, SystemError):
+            return False
+        return True
+
+    import ctypes
+
+    process_query_limited_information = 0x1000
+    synchronize = 0x00100000
+    access = process_query_limited_information | synchronize
+    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    if handle:
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return True
+
+    error_access_denied = 5
+    return ctypes.GetLastError() == error_access_denied
 
 
 def _use_path_based_state_io() -> bool:

--- a/skills/arthexis-cleanup-step/scripts/turn_boundary.py
+++ b/skills/arthexis-cleanup-step/scripts/turn_boundary.py
@@ -186,17 +186,26 @@ def _is_process_running(pid: int) -> bool:
         return True
 
     import ctypes
+    from ctypes import wintypes
 
     process_query_limited_information = 0x1000
     synchronize = 0x00100000
     access = process_query_limited_information | synchronize
-    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    kernel32 = ctypes.windll.kernel32
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.GetLastError.argtypes = []
+    kernel32.GetLastError.restype = wintypes.DWORD
+
+    handle = kernel32.OpenProcess(access, False, pid)
     if handle:
-        ctypes.windll.kernel32.CloseHandle(handle)
+        kernel32.CloseHandle(handle)
         return True
 
     error_access_denied = 5
-    return ctypes.GetLastError() == error_access_denied
+    return kernel32.GetLastError() == error_access_denied
 
 
 def _use_path_based_state_io() -> bool:


### PR DESCRIPTION
### Motivation
- Prevent unsafe Windows liveness probes that used `os.kill(pid, 0)` and could terminate arbitrary processes on Windows, creating a local DoS vector.
- Preserve existing behavior on POSIX while making Windows checks non-destructive and explicit about invalid PIDs.

### Description
- Replace the cross-platform `os.kill(pid, 0)` probe with a platform-specific implementation that keeps `os.kill(pid, 0)` for non-Windows and uses `OpenProcess`/`CloseHandle` via `ctypes` on Windows in both `apps/terminals/tasks.py` and `skills/arthexis-cleanup-step/scripts/turn_boundary.py`.
- Add a fast-fail guard `if pid <= 0: return False` to both helpers to handle invalid PIDs consistently.
- Treat Windows `ERROR_ACCESS_DENIED` as an indication the PID exists (matching prior semantics) by returning `True` when `OpenProcess` fails with access denied.

### Testing
- Ran `python3 -m py_compile apps/terminals/tasks.py skills/arthexis-cleanup-step/scripts/turn_boundary.py`, which completed successfully.
- Attempted `.venv/bin/python -m py_compile ...` but it could not run in this environment because `.venv` is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62cd85a0c83268439bb1718b9ff1c)