### PR TITLE
terminals: avoid leaking resolved startup commands

### DIFF
--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -185,6 +185,10 @@ def _write_posix_startup_script(state_key: str, startup_script: str) -> Path:
     return script_path
 
 
+def _posix_startup_command(script_path: Path) -> list[str]:
+    return ["sh", "-lc", f". {shlex.quote(str(script_path))}"]
+
+
 def _windows_terminal_command(
     *,
     script_path: Path,
@@ -242,7 +246,7 @@ def _launch_startup_script(
         command = [*shlex.split(executable or "x-terminal-emulator")]
         if startup_script:
             script_path = _write_posix_startup_script(state_key, startup_script)
-            command.extend(["-e", "sh", str(script_path)])
+            command.extend(["-e", *_posix_startup_command(script_path)])
     process = subprocess.Popen(command)
     pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
     if os.name != "nt":
@@ -288,7 +292,7 @@ def _launch_terminal(terminal: AgentTerminal) -> None:
     command = [*shlex.split(executable)]
     if startup_script:
         script_path = _write_posix_startup_script(str(terminal.pk), startup_script)
-        command.extend(["-e", "sh", str(script_path)])
+        command.extend(["-e", *_posix_startup_command(script_path)])
     process = subprocess.Popen(command)
     pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
     os.chmod(pid_file, 0o600)

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -53,6 +53,12 @@ def _named_terminal_pid_file(state_key: str) -> Path:
     return _terminal_state_dir() / f"{safe_key or 'terminal'}.pid"
 
 
+def _ensure_private_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        os.chmod(path, 0o700)
+
+
 def _is_process_running(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -164,9 +170,18 @@ def _command_script(
 
 def _write_windows_startup_script(state_key: str, startup_script: str) -> Path:
     script_dir = _terminal_state_dir() / "scripts"
-    script_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_directory(script_dir)
     script_path = script_dir / f"{re.sub(r'[^A-Za-z0-9_.-]+', '-', state_key).strip('.-') or 'terminal'}.ps1"
     script_path.write_text(startup_script, encoding="utf-8")
+    return script_path
+
+
+def _write_posix_startup_script(state_key: str, startup_script: str) -> Path:
+    script_dir = _terminal_state_dir() / "scripts"
+    _ensure_private_directory(script_dir)
+    script_path = script_dir / f"{re.sub(r'[^A-Za-z0-9_.-]+', '-', state_key).strip('.-') or 'terminal'}.sh"
+    script_path.write_text(startup_script, encoding="utf-8")
+    os.chmod(script_path, 0o700)
     return script_path
 
 
@@ -214,7 +229,7 @@ def _launch_startup_script(
     state_key: str = "terminal",
 ) -> Path:
     pid_dir = _terminal_state_dir()
-    pid_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_directory(pid_dir)
     pid_file = _named_terminal_pid_file(state_key)
     if _is_windows():
         script_path = _write_windows_startup_script(state_key, startup_script)
@@ -226,9 +241,12 @@ def _launch_startup_script(
     else:
         command = [*shlex.split(executable or "x-terminal-emulator")]
         if startup_script:
-            command.extend(["-e", "sh", "-lc", startup_script])
+            script_path = _write_posix_startup_script(state_key, startup_script)
+            command.extend(["-e", "sh", str(script_path)])
     process = subprocess.Popen(command)
     pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
+    if os.name != "nt":
+        os.chmod(pid_file, 0o600)
     return pid_file
 
 
@@ -265,13 +283,15 @@ def _launch_terminal(terminal: AgentTerminal) -> None:
         )
         return
     pid_dir = _terminal_state_dir()
-    pid_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_directory(pid_dir)
     pid_file = _terminal_pid_file(terminal.pk)
     command = [*shlex.split(executable)]
     if startup_script:
-        command.extend(["-e", "sh", "-lc", startup_script])
+        script_path = _write_posix_startup_script(str(terminal.pk), startup_script)
+        command.extend(["-e", "sh", str(script_path)])
     process = subprocess.Popen(command)
     pid_file.write_text(f"{process.pid}\n{_command_metadata(command)}\n", encoding="utf-8")
+    os.chmod(pid_file, 0o600)
 
 
 def _matches_current_node_role(terminal: AgentTerminal) -> bool:

--- a/apps/terminals/tasks.py
+++ b/apps/terminals/tasks.py
@@ -75,15 +75,22 @@ def _ensure_private_state_dir(path: Path) -> None:
 
 def _write_pid_file(pid_file: Path, pid: int, command: Sequence[str]) -> None:
     content = f"{pid}\n{_command_metadata(command)}\n"
+    _write_private_file(pid_file, content, 0o600, "Terminal pid file")
+
+
+def _write_private_file(path: Path, content: str, mode: int, description: str) -> None:
     if _is_windows():
-        pid_file.write_text(content, encoding="utf-8")
+        path.write_text(content, encoding="utf-8")
         return
-    if pid_file.is_symlink():
-        raise PermissionError(f"Terminal pid file must not be a symlink: {pid_file}")
+    if path.is_symlink():
+        raise PermissionError(f"{description} must not be a symlink: {path}")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
-    fd = os.open(pid_file, flags, 0o600)
+    fd = os.open(path, flags, mode)
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is not None:
+        fchmod(fd, mode)
     with os.fdopen(fd, "w", encoding="utf-8") as output:
         output.write(content)
 
@@ -201,7 +208,7 @@ def _write_windows_startup_script(state_key: str, startup_script: str) -> Path:
     script_dir = _terminal_state_dir() / "scripts"
     _ensure_private_state_dir(script_dir)
     script_path = script_dir / f"{re.sub(r'[^A-Za-z0-9_.-]+', '-', state_key).strip('.-') or 'terminal'}.ps1"
-    script_path.write_text(startup_script, encoding="utf-8")
+    _write_private_file(script_path, startup_script, 0o700, "Terminal startup script")
     return script_path
 
 
@@ -209,8 +216,7 @@ def _write_posix_startup_script(state_key: str, startup_script: str) -> Path:
     script_dir = _terminal_state_dir() / "scripts"
     _ensure_private_state_dir(script_dir)
     script_path = script_dir / f"{re.sub(r'[^A-Za-z0-9_.-]+', '-', state_key).strip('.-') or 'terminal'}.sh"
-    script_path.write_text(startup_script, encoding="utf-8")
-    os.chmod(script_path, 0o700)
+    _write_private_file(script_path, startup_script, 0o700, "Terminal startup script")
     return script_path
 
 

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -116,7 +116,7 @@ def test_launch_command_in_terminal_uses_script_file_on_posix(tmp_path, monkeypa
 
     script_path = tmp_path / "scripts" / "linux-secret.sh"
     assert script_path.exists()
-    assert launched["command"][-2:] == ["sh", str(script_path)]
+    assert launched["command"][-3:] == ["sh", "-lc", f". {tasks.shlex.quote(str(script_path))}"]
     assert "super-secret-value" not in " ".join(launched["command"])
     assert pid_file.read_text(encoding="utf-8").splitlines()[1].endswith(str(script_path))
 

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -118,7 +118,9 @@ def test_launch_command_in_terminal_uses_script_file_on_posix(tmp_path, monkeypa
     assert script_path.exists()
     assert launched["command"][-3:] == ["sh", "-lc", f". {tasks.shlex.quote(str(script_path))}"]
     assert "super-secret-value" not in " ".join(launched["command"])
-    assert pid_file.read_text(encoding="utf-8").splitlines()[1].endswith(str(script_path))
+    metadata = pid_file.read_text(encoding="utf-8").splitlines()[1]
+    assert str(script_path) in metadata
+    assert "super-secret-value" not in metadata
 
 
 def test_windows_terminal_executable_supports_arguments(tmp_path, monkeypatch):

--- a/apps/terminals/tests/test_terminals_smoke.py
+++ b/apps/terminals/tests/test_terminals_smoke.py
@@ -95,6 +95,32 @@ def test_launch_command_in_terminal_builds_windows_codex_command(tmp_path, monke
     assert "& 'codex' '[SECRETARY] Mara:" in script
 
 
+def test_launch_command_in_terminal_uses_script_file_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(tasks, "_is_windows", lambda: False)
+    launched = {}
+
+    class FakeProcess:
+        pid = 9999
+
+    def fake_popen(command):
+        launched["command"] = command
+        return FakeProcess()
+
+    monkeypatch.setattr(tasks.subprocess, "Popen", fake_popen)
+
+    pid_file = tasks.launch_command_in_terminal(
+        ["echo", "super-secret-value"],
+        state_key="linux-secret",
+    )
+
+    script_path = tmp_path / "scripts" / "linux-secret.sh"
+    assert script_path.exists()
+    assert launched["command"][-2:] == ["sh", str(script_path)]
+    assert "super-secret-value" not in " ".join(launched["command"])
+    assert pid_file.read_text(encoding="utf-8").splitlines()[1].endswith(str(script_path))
+
+
 def test_windows_terminal_executable_supports_arguments(tmp_path, monkeypatch):
     monkeypatch.setenv("ARTHEXIS_TERMINAL_STATE_DIR", str(tmp_path))
     monkeypatch.setattr(tasks, "_is_windows", lambda: True)


### PR DESCRIPTION
### Motivation
- The terminals watchdog previously resolved sigils and embedded the full startup script into the process argv and a predictable PID file under `/tmp`, which can expose expanded ENV/CONF secrets to other local users.\
- The change aims to remove local information disclosure while preserving current terminal behavior and sigil resolution semantics.

### Description
- Stop embedding resolved startup content directly in process argv on POSIX and instead write the startup script to a per-state `scripts/` file and launch `sh <script_path>` so secrets do not appear on the command line.\
- Introduce `_ensure_private_directory` and apply restrictive POSIX permissions to terminal state directories and scripts (`0700`) and PID files (`0600`) to reduce exposure.\
- Add `_write_posix_startup_script` and update `_launch_startup_script` / `_launch_terminal` to use script files on POSIX systems.\
- Add a regression test `test_launch_command_in_terminal_uses_script_file_on_posix` validating that the launched argv and PID metadata reference the script path and do not contain inline secret content.

### Testing
- Attempted to run the app test suite with `.venv/bin/python manage.py test run -- apps.terminals.tests.test_terminals_smoke`, but the environment lacks the repository `.venv` so the command could not be executed.\
- Attempted to bootstrap the environment with `./install.sh`, but bootstrap failed in this environment due to missing `redis-server`, so automated test execution could not be completed here.\
- A targeted regression test was added to `apps/terminals/tests/test_terminals_smoke.py` to validate the fix at the unit level when running in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bc136308326a99a1baf4ed71c01)