### PR TITLE
docs: import timezone to fix NameError in document library

### DIFF
--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -15,6 +15,7 @@ from django.http import FileResponse, Http404, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch, reverse
 from django.utils.cache import patch_cache_control, patch_vary_headers
+from django.utils import timezone
 from django.views.decorators.cache import never_cache
 
 from apps.gallery.models import GalleryImage


### PR DESCRIPTION
### Motivation
- Fix a runtime `NameError` raised in `_latest_gallery_images_for_user` when `timezone.now()` is used without `timezone` being imported, which caused the docs library to 500 for authorized non-gallery-manager users.

### Description
- Add `from django.utils import timezone` to `apps/docs/views.py` so the `Q(public_release_at__lte=timezone.now())` visibility filter works for all user paths.

### Testing
- Attempted canonical test command `.venv/bin/python manage.py test run -- apps.docs` could not be executed because `.venv` is not present and `./install.sh` failed due to a missing system dependency (`redis-server`), but `python3 -m py_compile apps/docs/views.py` succeeded, confirming the file compiles after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62f5571dc83269767dfd8c4a7dfd3)