### PR TITLE
Bundle static suite into RPi image artifacts

### DIFF
--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -149,6 +149,20 @@ class RaspberryPiImageBuildForm(forms.Form):
         required=False,
         help_text=_("Copy the base image without injecting Arthexis bootstrap scripts."),
     )
+    recovery_ssh_user = forms.CharField(
+        max_length=64,
+        required=False,
+        help_text=_("Recovery SSH username used when public keys are provided; defaults to arthe."),
+    )
+    recovery_authorized_keys = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 4}),
+        help_text=_("OpenSSH public keys to authorize for first-boot recovery access, one per line."),
+    )
+    skip_recovery_ssh = forms.BooleanField(
+        required=False,
+        help_text=_("Explicitly opt out of recovery SSH for this customized image."),
+    )
 
     def clean_name(self) -> str:
         """Keep artifact names safe to embed into output filenames."""
@@ -157,6 +171,37 @@ class RaspberryPiImageBuildForm(forms.Form):
         if not name or name in {".", ".."} or "/" in name or "\\" in name:
             raise ValidationError(_("Artifact name must not contain path separators or traversal segments."))
         return name
+
+    def clean_recovery_authorized_keys(self) -> list[str]:
+        """Normalize admin-entered recovery authorized keys."""
+
+        raw_value = self.cleaned_data.get("recovery_authorized_keys", "")
+        if not raw_value:
+            return []
+        return [
+            line.strip()
+            for line in raw_value.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+    def clean(self) -> dict[str, object]:
+        cleaned = super().clean()
+        skip_customize = bool(cleaned.get("skip_customize"))
+        skip_recovery_ssh = bool(cleaned.get("skip_recovery_ssh"))
+        recovery_authorized_keys = cleaned.get("recovery_authorized_keys") or []
+        recovery_ssh_user = str(cleaned.get("recovery_ssh_user") or "").strip()
+        if skip_recovery_ssh and (recovery_authorized_keys or recovery_ssh_user):
+            raise ValidationError(
+                _("Recovery SSH fields cannot be combined with the explicit recovery SSH skip option.")
+            )
+        if not skip_customize and not skip_recovery_ssh and not recovery_authorized_keys:
+            raise ValidationError(
+                _(
+                    "Recovery SSH is required for customized image builds. "
+                    "Provide at least one public key or explicitly opt out."
+                )
+            )
+        return cleaned
 
     @staticmethod
     def _resolved_within(path: Path, roots: tuple[Path, ...]) -> bool:
@@ -169,7 +214,13 @@ class RaspberryPiImageBuildForm(forms.Form):
         if parsed.scheme in {"http", "https"}:
             raise ValidationError(_("Remote URLs are not valid in this field."))
 
-        if parsed.scheme == "file":
+        if (
+            len(parsed.scheme) == 1
+            and parsed.scheme.isalpha()
+            and parsed.path.startswith(("/", "\\"))
+        ):
+            local_path = Path(f"{parsed.scheme}:{unquote(parsed.path)}")
+        elif parsed.scheme == "file":
             if not allow_file_uri:
                 raise ValidationError(_("File URIs are not valid in this field."))
             if parsed.netloc and parsed.netloc not in {"", "localhost"}:
@@ -286,6 +337,9 @@ class RaspberryPiImageArtifactAdmin(DjangoObjectActions, admin.ModelAdmin):
                     download_base_uri=cleaned["download_base_uri"],
                     git_url=cleaned["git_url"],
                     customize=not cleaned["skip_customize"],
+                    recovery_ssh_user=cleaned["recovery_ssh_user"],
+                    recovery_authorized_keys=cleaned["recovery_authorized_keys"],
+                    skip_recovery_ssh=cleaned["skip_recovery_ssh"],
                 )
             except (ImagerBuildError, OSError) as exc:
                 messages.error(request, str(exc))

--- a/apps/imager/admin.py
+++ b/apps/imager/admin.py
@@ -1,9 +1,9 @@
 """Admin integration for Raspberry Pi image artifacts."""
 
+import socket
 from contextlib import contextmanager, nullcontext
 from ipaddress import ip_address
 from pathlib import Path
-import socket
 from socket import getaddrinfo
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlparse
@@ -21,7 +21,12 @@ from django.utils.translation import gettext_lazy as _
 from django_object_actions import DjangoObjectActions
 
 from apps.imager.models import RaspberryPiImageArtifact
-from apps.imager.services import ImagerBuildError, build_rpi4b_image
+from apps.imager.services import (
+    ImagerBuildError,
+    RecoveryAuthorizedKeyError,
+    build_rpi4b_image,
+    normalize_recovery_authorized_key_line,
+)
 
 BLOCKED_ADDRESS_FLAGS = (
     "is_link_local",
@@ -173,16 +178,29 @@ class RaspberryPiImageBuildForm(forms.Form):
         return name
 
     def clean_recovery_authorized_keys(self) -> list[str]:
-        """Normalize admin-entered recovery authorized keys."""
+        """Normalize and validate admin-entered recovery authorized keys."""
 
         raw_value = self.cleaned_data.get("recovery_authorized_keys", "")
         if not raw_value:
             return []
-        return [
-            line.strip()
-            for line in raw_value.splitlines()
-            if line.strip() and not line.strip().startswith("#")
-        ]
+        keys: list[str] = []
+        errors: list[ValidationError] = []
+        for line_number, line in enumerate(raw_value.splitlines(), start=1):
+            try:
+                normalized = normalize_recovery_authorized_key_line(line)
+            except RecoveryAuthorizedKeyError as exc:
+                errors.append(
+                    ValidationError(
+                        _("Line %(line_number)d: %(error)s."),
+                        params={"line_number": line_number, "error": str(exc)},
+                    )
+                )
+                continue
+            if normalized:
+                keys.append(normalized)
+        if errors:
+            raise ValidationError(errors)
+        return keys
 
     def clean(self) -> dict[str, object]:
         cleaned = super().clean()

--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -1,38 +1,22 @@
 """Management command for Raspberry Pi image artifact workflows."""
 
 import json
-import re
 from pathlib import Path
 
-from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.hazmat.primitives.serialization import load_ssh_public_key
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.services import (
     DEFAULT_RECOVERY_SSH_USER,
     ImagerBuildError,
+    RecoveryAuthorizedKeyError,
     build_rpi4b_image,
     list_block_devices,
+    normalize_recovery_authorized_key_line,
     prepare_image_serve,
     serve_image_file,
     test_rpi_access,
     write_image_to_device,
-)
-
-VALID_PUBLIC_KEY_PREFIXES = (
-    "ecdsa-sha2-nistp256",
-    "ecdsa-sha2-nistp384",
-    "ecdsa-sha2-nistp521",
-    "sk-ecdsa-sha2-nistp256@openssh.com",
-    "sk-ssh-ed25519@openssh.com",
-    "ssh-ed25519",
-    "ssh-rsa",
-)
-VALID_PUBLIC_KEY_PATTERN = re.compile(
-    r"^(?:"
-    + "|".join(re.escape(prefix) for prefix in VALID_PUBLIC_KEY_PREFIXES)
-    + r")\s+[A-Za-z0-9+/=]+(?:\s+.+)?$"
 )
 
 
@@ -343,26 +327,17 @@ class Command(BaseCommand):
     def _append_recovery_key_line(self, *, keys: list[str], source: str, line: str) -> None:
         """Normalize and append a single recovery authorized-key line when valid."""
 
-        normalized = line.strip()
-        if not normalized or normalized.startswith("#"):
-            return
-        if not VALID_PUBLIC_KEY_PATTERN.match(normalized):
-            self.stderr.write(
-                self.style.WARNING(
-                    f"Skipping unrecognized key line from {source}."
-                )
-            )
-            return
         try:
-            load_ssh_public_key(normalized.encode("utf-8"))
-        except (TypeError, ValueError, UnsupportedAlgorithm):
+            normalized = normalize_recovery_authorized_key_line(line)
+        except RecoveryAuthorizedKeyError as exc:
             self.stderr.write(
                 self.style.WARNING(
-                    f"Skipping malformed public key line from {source}."
+                    f"Skipping {exc} from {source}."
                 )
             )
             return
-        keys.append(normalized)
+        if normalized:
+            keys.append(normalized)
 
     def _handle_list(self) -> None:
         """Print known Raspberry Pi image artifacts."""
@@ -449,6 +424,8 @@ class Command(BaseCommand):
             serve_image_file(image_path=result.image_path, host=result.host, port=result.port)
         except KeyboardInterrupt:
             self.stdout.write("Stopped image server.")
+        except OSError as exc:
+            raise CommandError(f"Could not start image server: {exc}") from exc
 
     def _handle_test_access(self, options: dict[str, object]) -> None:
         """Test access to an installed Raspberry Pi image."""

--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -14,6 +14,9 @@ from apps.imager.services import (
     ImagerBuildError,
     build_rpi4b_image,
     list_block_devices,
+    prepare_image_serve,
+    serve_image_file,
+    test_rpi_access,
     write_image_to_device,
 )
 
@@ -69,6 +72,32 @@ class Command(BaseCommand):
             "--skip-customize",
             action="store_true",
             help="Copy the base image without injecting bootstrap scripts.",
+        )
+        build_parser.add_argument(
+            "--no-bundle-suite",
+            action="store_true",
+            help="Do not bundle a static copy of this Arthexis checkout into the image.",
+        )
+        build_parser.add_argument(
+            "--suite-source",
+            default="",
+            help="Arthexis checkout path to bundle into the image (default: current suite base directory).",
+        )
+        build_parser.add_argument(
+            "--copy-all-host-networks",
+            action="store_true",
+            help="Copy all host NetworkManager connection profiles, including saved credentials, into the image.",
+        )
+        build_parser.add_argument(
+            "--copy-host-network",
+            action="append",
+            default=[],
+            help="Copy one host NetworkManager profile by connection id, filename, or filename stem. May be repeated.",
+        )
+        build_parser.add_argument(
+            "--host-network-profile-dir",
+            default="",
+            help="Host NetworkManager system-connections directory to read when copying network profiles.",
         )
         build_parser.add_argument(
             "--build-engine",
@@ -134,6 +163,56 @@ class Command(BaseCommand):
             help="Confirm destructive write operation.",
         )
 
+        serve_parser = subparsers.add_parser(
+            "serve",
+            help="Serve an existing image artifact over HTTP and print its deployment URL.",
+        )
+        serve_parser.add_argument("--artifact", default="", help="Registered artifact name to serve.")
+        serve_parser.add_argument(
+            "--image-path",
+            default="",
+            help="Direct local path to an image file to serve (alternative to --artifact).",
+        )
+        serve_parser.add_argument("--host", default="0.0.0.0", help="Interface to bind for serving.")
+        serve_parser.add_argument("--port", type=int, default=8088, help="TCP port to bind for serving.")
+        serve_parser.add_argument(
+            "--url-host",
+            default="",
+            help="Host/IP advertised in the generated URL. Use the address reachable by target devices.",
+        )
+        serve_parser.add_argument(
+            "--base-url",
+            default="",
+            help="Full base URL to advertise instead of composing one from --url-host and --port.",
+        )
+        serve_parser.add_argument(
+            "--no-update-artifact-url",
+            action="store_true",
+            help="Do not persist the generated URL on the artifact record.",
+        )
+
+        access_parser = subparsers.add_parser(
+            "test-access",
+            help="Test SSH and HTTP access to a burned Raspberry Pi image after it boots.",
+        )
+        access_parser.add_argument("--host", required=True, help="RPi hostname or IP address.")
+        access_parser.add_argument(
+            "--ssh-user",
+            default=DEFAULT_RECOVERY_SSH_USER,
+            help=f"Recovery SSH username to test (default: {DEFAULT_RECOVERY_SSH_USER}).",
+        )
+        access_parser.add_argument("--ssh-port", type=int, default=22, help="SSH port to test.")
+        access_parser.add_argument("--ssh-key", default="", help="Private key path for SSH auth testing.")
+        access_parser.add_argument(
+            "--http-url",
+            default="",
+            help="Suite URL to test. Defaults to http://HOST:8888/ when HTTP checks are enabled.",
+        )
+        access_parser.add_argument("--http-port", type=int, default=8888, help="Default suite HTTP port.")
+        access_parser.add_argument("--timeout", type=float, default=5.0, help="Per-check timeout in seconds.")
+        access_parser.add_argument("--skip-ssh", action="store_true", help="Skip SSH TCP/auth checks.")
+        access_parser.add_argument("--skip-http", action="store_true", help="Skip HTTP suite reachability check.")
+
     def handle(self, *args, **options) -> None:
         """Dispatch command to selected action."""
 
@@ -149,6 +228,12 @@ class Command(BaseCommand):
             return
         if action == "write":
             self._handle_write(options)
+            return
+        if action == "serve":
+            self._handle_serve(options)
+            return
+        if action == "test-access":
+            self._handle_test_access(options)
             return
         raise CommandError(f"Unsupported action '{action}'.")
 
@@ -194,6 +279,20 @@ class Command(BaseCommand):
                 profile_metadata=profile_metadata,
                 recovery_ssh_user=recovery_ssh_user,
                 recovery_authorized_keys=recovery_authorized_keys,
+                skip_recovery_ssh=bool(skip_recovery_ssh),
+                bundle_suite=not bool(options["no_bundle_suite"]),
+                suite_source_path=Path(str(options["suite_source"]))
+                if str(options["suite_source"]).strip()
+                else None,
+                copy_all_host_networks=bool(options["copy_all_host_networks"]),
+                host_network_names=[
+                    str(name)
+                    for name in options.get("copy_host_network", [])
+                    if str(name).strip()
+                ],
+                host_network_profile_dir=Path(str(options["host_network_profile_dir"]))
+                if str(options["host_network_profile_dir"]).strip()
+                else None,
             )
         except ImagerBuildError as exc:
             raise CommandError(str(exc)) from exc
@@ -321,3 +420,57 @@ class Command(BaseCommand):
         self.stdout.write(f"source_sha256={result.source_sha256}")
         self.stdout.write(f"written_sha256={result.written_sha256}")
         self.stdout.write(f"verified={'yes' if result.verified else 'no'}")
+
+    def _handle_serve(self, options: dict[str, object]) -> None:
+        """Serve an image artifact over HTTP for deployment workflows."""
+
+        artifact_name = str(options["artifact"])
+        image_path = str(options["image_path"])
+        if bool(artifact_name) == bool(image_path):
+            raise CommandError("Provide exactly one of --artifact or --image-path.")
+
+        try:
+            result = prepare_image_serve(
+                artifact_name=artifact_name,
+                image_path=image_path,
+                host=str(options["host"]),
+                port=int(options["port"]),
+                url_host=str(options["url_host"]),
+                base_url=str(options["base_url"]),
+                update_artifact_url=not bool(options["no_update_artifact_url"]),
+            )
+        except ImagerBuildError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(self.style.SUCCESS(f"Serving image: {result.image_path}"))
+        self.stdout.write(f"artifact_url={result.url}")
+        self.stdout.write("Press Ctrl+C to stop serving.")
+        try:
+            serve_image_file(image_path=result.image_path, host=result.host, port=result.port)
+        except KeyboardInterrupt:
+            self.stdout.write("Stopped image server.")
+
+    def _handle_test_access(self, options: dict[str, object]) -> None:
+        """Test access to an installed Raspberry Pi image."""
+
+        try:
+            result = test_rpi_access(
+                host=str(options["host"]),
+                ssh_user=str(options["ssh_user"]),
+                ssh_port=int(options["ssh_port"]),
+                ssh_key=str(options["ssh_key"]),
+                http_url=str(options["http_url"]),
+                http_port=int(options["http_port"]),
+                timeout=float(options["timeout"]),
+                skip_ssh=bool(options["skip_ssh"]),
+                skip_http=bool(options["skip_http"]),
+            )
+        except ImagerBuildError as exc:
+            raise CommandError(str(exc)) from exc
+
+        for check in result.checks:
+            status = "ok" if check.ok else "failed"
+            self.stdout.write(f"{check.name}={status} {check.detail}")
+        if not result.ok:
+            raise CommandError(f"RPi access test failed for {result.host}.")
+        self.stdout.write(self.style.SUCCESS(f"RPi access test passed for {result.host}."))

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -13,13 +13,15 @@ import shlex
 import shutil
 import socket
 import subprocess
+import tarfile
 import zipfile
 from dataclasses import dataclass
-from pathlib import Path
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
-from urllib.parse import ParseResult, unquote, urljoin, urlparse
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.parse import ParseResult, quote, unquote, urljoin, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 from django.conf import settings
 from django.db import transaction
@@ -31,6 +33,36 @@ TARGET_RPI4B = "rpi-4b"
 DEFAULT_RECOVERY_SSH_USER = "arthe"
 RECOVERY_SSH_USERNAME_PATTERN = re.compile(r"^[a-z_][a-z0-9_-]*$")
 RECOVERY_SSH_FORBIDDEN_USERS = frozenset({"root"})
+SUITE_BUNDLE_REMOTE_PATH = "/usr/local/share/arthexis/arthexis-suite.tar.gz"
+NETWORK_MANAGER_CONNECTIONS_REMOTE_PATH = "/etc/NetworkManager/system-connections"
+DEFAULT_HOST_NETWORK_PROFILE_DIR = "/etc/NetworkManager/system-connections"
+SUITE_BUNDLE_EXCLUDED_TOP_LEVEL = frozenset(
+    {
+        ".cache",
+        ".git",
+        ".locks",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "backups",
+        "build",
+        "logs",
+        "media",
+        "node_modules",
+        "staticfiles",
+        "work",
+    }
+)
+SUITE_BUNDLE_EXCLUDED_NAMES = frozenset(
+    {
+        ".env",
+        "__pycache__",
+        "db.sqlite3",
+        "test_db.sqlite3",
+    }
+)
 
 BOOTSTRAP_SCRIPT = """#!/usr/bin/env bash
 set -euo pipefail
@@ -49,11 +81,19 @@ if [ "${#missing_packages[@]}" -gt 0 ]; then
 fi
 
 APP_HOME=/opt/arthexis
-if [ ! -d "$APP_HOME/.git" ]; then
+ARTHEXIS_BUNDLE=/usr/local/share/arthexis/arthexis-suite.tar.gz
+if [ ! -x "$APP_HOME/start.sh" ] && [ -f "$ARTHEXIS_BUNDLE" ]; then
+  rm -rf "$APP_HOME"
+  install -d -m 755 "$APP_HOME"
+  tar -xzf "$ARTHEXIS_BUNDLE" -C "$APP_HOME"
+fi
+
+if [ ! -x "$APP_HOME/start.sh" ]; then
   git clone --depth 1 "${ARTHEXIS_GIT_URL}" "$APP_HOME"
 fi
 
 cd "$APP_HOME"
+chmod +x ./install.sh ./env-refresh.sh ./start.sh ./manage.py 2>/dev/null || true
 ./env-refresh.sh --deps-only
 ./start.sh
 """
@@ -193,6 +233,66 @@ class WriteResult:
     source_sha256: str
     written_sha256: str
     verified: bool
+
+
+@dataclass(frozen=True)
+class SuiteBundleInfo:
+    """Metadata for a static Arthexis source bundle injected into an image."""
+
+    source_path: Path
+    remote_path: str
+    sha256: str
+    size_bytes: int
+    file_count: int
+
+
+@dataclass(frozen=True)
+class NetworkProfileInfo:
+    """NetworkManager profile selected for copying into a generated image."""
+
+    name: str
+    filename: str
+    source_path: Path
+    remote_path: str
+
+
+@dataclass(frozen=True)
+class ImageCustomizationResult:
+    """Metadata produced while injecting first-boot customization files."""
+
+    suite_bundle: SuiteBundleInfo | None = None
+    network_profiles: tuple[NetworkProfileInfo, ...] = ()
+
+
+@dataclass(frozen=True)
+class ServeResult:
+    """Metadata for a locally served image artifact."""
+
+    image_path: Path
+    url: str
+    host: str
+    port: int
+
+
+@dataclass(frozen=True)
+class AccessCheckResult:
+    """Single RPi access check result."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class RpiAccessTestResult:
+    """Aggregate access-test result for a burned Raspberry Pi image."""
+
+    host: str
+    checks: tuple[AccessCheckResult, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(check.ok for check in self.checks)
 
 
 @dataclass(frozen=True)
@@ -385,6 +485,159 @@ def _ensure_guestfish() -> None:
     raise ImagerBuildError(
         "guestfish is required to customize Raspberry Pi images. Install libguestfs-tools first."
     )
+
+
+def _should_exclude_suite_bundle_path(relative_path: Path) -> bool:
+    """Return whether a repo path should be excluded from the static image bundle."""
+
+    parts = relative_path.parts
+    if not parts:
+        return False
+    if parts[0] in SUITE_BUNDLE_EXCLUDED_TOP_LEVEL:
+        return True
+    if any(part in SUITE_BUNDLE_EXCLUDED_NAMES for part in parts):
+        return True
+    name = relative_path.name
+    return name.endswith((".env", ".pyc", ".pyo"))
+
+
+def _create_suite_bundle(source_path: Path, archive_path: Path) -> SuiteBundleInfo:
+    """Create a sanitized tarball of the suite source for image injection."""
+
+    source = source_path.expanduser().resolve()
+    if not source.is_dir():
+        raise ImagerBuildError(f"Suite source path is not a directory: {source}")
+    for required_file in ("manage.py", "start.sh", "env-refresh.sh"):
+        if not (source / required_file).is_file():
+            raise ImagerBuildError(f"Suite source path is missing required file: {required_file}")
+
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    file_count = 0
+    with tarfile.open(archive_path, "w:gz") as archive:
+        for path in sorted(source.rglob("*")):
+            if path.is_symlink() or not path.is_file():
+                continue
+            relative_path = path.relative_to(source)
+            if _should_exclude_suite_bundle_path(relative_path):
+                continue
+            archive.add(path, arcname=relative_path.as_posix(), recursive=False)
+            file_count += 1
+    if file_count == 0:
+        raise ImagerBuildError(f"Suite source path did not contain any bundleable files: {source}")
+
+    return SuiteBundleInfo(
+        source_path=source,
+        remote_path=SUITE_BUNDLE_REMOTE_PATH,
+        sha256=_sha256_for_file(archive_path),
+        size_bytes=archive_path.stat().st_size,
+        file_count=file_count,
+    )
+
+
+def _parse_network_profile_id(profile_path: Path) -> str:
+    """Read a NetworkManager connection id from a keyfile profile when present."""
+
+    try:
+        lines = profile_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return profile_path.stem
+
+    in_connection_section = False
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_connection_section = line.lower() == "[connection]"
+            continue
+        if not in_connection_section or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key.strip().lower() == "id" and value.strip():
+            return value.strip()
+    return profile_path.stem
+
+
+def _network_profile_remote_filename(source_path: Path) -> str:
+    """Return a safe NetworkManager keyfile name for image injection."""
+
+    filename = source_path.name
+    if not filename.endswith(".nmconnection"):
+        filename = f"{filename}.nmconnection"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", filename)
+
+
+def select_host_network_profiles(
+    *,
+    profile_dir: Path | None = None,
+    names: list[str] | tuple[str, ...] | None = None,
+    copy_all: bool = False,
+) -> tuple[NetworkProfileInfo, ...]:
+    """Select host NetworkManager profiles for copying into the generated image."""
+
+    requested_names = tuple(name.strip() for name in (names or ()) if str(name).strip())
+    if not requested_names and not copy_all:
+        return ()
+
+    source_dir = (profile_dir or Path(DEFAULT_HOST_NETWORK_PROFILE_DIR)).expanduser().resolve()
+    if not source_dir.is_dir():
+        raise ImagerBuildError(f"Host NetworkManager profile directory does not exist: {source_dir}")
+
+    candidates: list[tuple[Path, str, set[str]]] = []
+    for path in sorted(source_dir.iterdir(), key=lambda item: item.name):
+        if not path.is_file() or path.name.startswith("."):
+            continue
+        profile_id = _parse_network_profile_id(path)
+        candidates.append(
+            (
+                path,
+                profile_id,
+                {path.name, path.stem, profile_id},
+            )
+        )
+
+    selected: list[tuple[Path, str]] = []
+    if copy_all:
+        selected.extend((path, profile_id) for path, profile_id, _aliases in candidates)
+
+    for requested_name in requested_names:
+        match = next(
+            (
+                (path, profile_id)
+                for path, profile_id, aliases in candidates
+                if requested_name in aliases
+            ),
+            None,
+        )
+        if match is None:
+            available = ", ".join(sorted({alias for _, _, aliases in candidates for alias in aliases}))
+            raise ImagerBuildError(
+                f"Host network profile '{requested_name}' was not found. Available profiles: {available or '(none)'}."
+            )
+        if match not in selected:
+            selected.append(match)
+
+    used_filenames: set[str] = set()
+    profiles: list[NetworkProfileInfo] = []
+    for source_path, profile_id in selected:
+        filename = _network_profile_remote_filename(source_path)
+        if filename in used_filenames:
+            stem = Path(filename).stem
+            suffix = Path(filename).suffix or ".nmconnection"
+            counter = 2
+            while f"{stem}-{counter}{suffix}" in used_filenames:
+                counter += 1
+            filename = f"{stem}-{counter}{suffix}"
+        used_filenames.add(filename)
+        profiles.append(
+            NetworkProfileInfo(
+                name=profile_id,
+                filename=filename,
+                source_path=source_path,
+                remote_path=f"{NETWORK_MANAGER_CONNECTIONS_REMOTE_PATH}/{filename}",
+            )
+        )
+    return tuple(profiles)
 
 
 def _normalize_local_source_path(base_image_uri: str, parsed_uri: ParseResult) -> Path | None:
@@ -727,7 +980,9 @@ def _customize_image(
     *,
     git_url: str,
     recovery_ssh_access: RecoverySSHAccess | None = None,
-) -> None:
+    suite_source_path: Path | None = None,
+    network_profiles: tuple[NetworkProfileInfo, ...] = (),
+) -> ImageCustomizationResult:
     """Inject bootstrap scripts and systemd units into the image."""
 
     _ensure_guestfish()
@@ -737,6 +992,7 @@ def _customize_image(
         service = work_dir / "arthexis-bootstrap.service"
         firstrun = work_dir / "firstrun.sh"
         recovery_service = work_dir / "arthexis-recovery-access.service"
+        suite_bundle_info: SuiteBundleInfo | None = None
 
         bootstrap.write_text(BOOTSTRAP_SCRIPT, encoding="utf-8")
         service.write_text(SYSTEMD_SERVICE.format(git_url=git_url), encoding="utf-8")
@@ -767,6 +1023,21 @@ def _customize_image(
             ],
             error_message="guestfish failed while injecting bootstrap files",
         )
+        if suite_source_path is not None:
+            suite_bundle = work_dir / "arthexis-suite.tar.gz"
+            suite_bundle_info = _create_suite_bundle(suite_source_path, suite_bundle)
+            _guestfish_run_commands(
+                image_path,
+                [
+                    _guestfish_mkdir_p_command(str(PurePosixPath(SUITE_BUNDLE_REMOTE_PATH).parent)),
+                    *_guestfish_upload_commands(
+                        suite_bundle,
+                        SUITE_BUNDLE_REMOTE_PATH,
+                        chmod_mode="0644",
+                    ),
+                ],
+                error_message="guestfish failed while injecting suite bundle",
+            )
         if recovery_ssh_access and recovery_ssh_access.enabled:
             recovery_keys = work_dir / "recovery_authorized_keys"
             recovery_script = work_dir / "arthexis-recovery-access.sh"
@@ -789,7 +1060,7 @@ def _customize_image(
                 image_path,
                 [
                     _guestfish_mkdir_p_command(
-                        str(Path(RECOVERY_AUTHORIZED_KEYS_REMOTE_PATH).parent)
+                        str(PurePosixPath(RECOVERY_AUTHORIZED_KEYS_REMOTE_PATH).parent)
                     ),
                     *_guestfish_upload_commands(
                         recovery_keys,
@@ -827,10 +1098,30 @@ def _customize_image(
                 ],
                 error_message="guestfish failed while removing stale recovery files",
             )
+        if network_profiles:
+            profile_commands = [_guestfish_mkdir_p_command(NETWORK_MANAGER_CONNECTIONS_REMOTE_PATH)]
+            for profile in network_profiles:
+                profile_commands.extend(
+                    _guestfish_upload_commands(
+                        profile.source_path,
+                        profile.remote_path,
+                        chmod_mode="0600",
+                    )
+                )
+            _guestfish_run_commands(
+                image_path,
+                profile_commands,
+                error_message="guestfish failed while injecting host network profiles",
+            )
         try:
             _guestfish_write(image_path, firstrun, "/boot/firstrun.sh", chmod_mode="0755")
         except ImagerBuildError:
             _guestfish_write(image_path, firstrun, "/boot/firmware/firstrun.sh", chmod_mode="0755")
+
+    return ImageCustomizationResult(
+        suite_bundle=suite_bundle_info,
+        network_profiles=network_profiles,
+    )
 
 
 def _coerce_profile_metadata(profile_metadata: dict[str, object] | None) -> dict[str, object]:
@@ -866,6 +1157,233 @@ def _build_download_uri(download_base_uri: str, output_filename: str) -> str:
 
     normalized_path = f"{parsed_base.path.rstrip('/')}/{output_filename}"
     return parsed_base._replace(path=normalized_path).geturl()
+
+
+def _suite_bundle_metadata(suite_bundle: SuiteBundleInfo | None) -> dict[str, object]:
+    """Return JSON-safe metadata for static suite bundle injection."""
+
+    if suite_bundle is None:
+        return {"enabled": False}
+    return {
+        "enabled": True,
+        "source_path": str(suite_bundle.source_path),
+        "remote_path": suite_bundle.remote_path,
+        "sha256": suite_bundle.sha256,
+        "size_bytes": suite_bundle.size_bytes,
+        "file_count": suite_bundle.file_count,
+    }
+
+
+def _network_profiles_metadata(network_profiles: tuple[NetworkProfileInfo, ...]) -> dict[str, object]:
+    """Return JSON-safe metadata for injected host network profiles."""
+
+    return {
+        "enabled": bool(network_profiles),
+        "count": len(network_profiles),
+        "profiles": [
+            {
+                "name": profile.name,
+                "filename": profile.filename,
+                "remote_path": profile.remote_path,
+            }
+            for profile in network_profiles
+        ],
+    }
+
+
+def _build_served_artifact_url(
+    *,
+    output_filename: str,
+    port: int,
+    url_host: str = "",
+    base_url: str = "",
+) -> str:
+    """Build the URL advertised for a locally served image artifact."""
+
+    if base_url:
+        parsed_base = urlparse(base_url)
+        if parsed_base.scheme not in {"http", "https"} or not parsed_base.hostname:
+            raise ImagerBuildError("Serve base URL must use http or https and include a host.")
+        normalized_path = f"{parsed_base.path.rstrip('/')}/{quote(output_filename)}"
+        return parsed_base._replace(path=normalized_path).geturl()
+
+    advertised_host = (url_host or "127.0.0.1").strip()
+    if ":" in advertised_host and not advertised_host.startswith("["):
+        advertised_host = f"[{advertised_host}]"
+    return f"http://{advertised_host}:{port}/{quote(output_filename)}"
+
+
+def prepare_image_serve(
+    *,
+    artifact_name: str = "",
+    image_path: str = "",
+    host: str = "0.0.0.0",
+    port: int = 8088,
+    url_host: str = "",
+    base_url: str = "",
+    update_artifact_url: bool = True,
+) -> ServeResult:
+    """Resolve an image and optionally persist the URL used for local artifact serving."""
+
+    resolved_path, artifact = _resolve_image_path_for_write(
+        artifact_name=artifact_name,
+        image_path=image_path,
+    )
+    artifact_url = _build_served_artifact_url(
+        output_filename=resolved_path.name,
+        port=port,
+        url_host=url_host,
+        base_url=base_url,
+    )
+    if artifact is not None and update_artifact_url:
+        artifact.download_uri = artifact_url
+        artifact.metadata = {
+            **artifact.metadata,
+            "local_serve": {
+                "host": host,
+                "port": port,
+                "url": artifact_url,
+                "updated_at": timezone.now().isoformat(),
+            },
+        }
+        artifact.save(update_fields=["download_uri", "metadata", "updated_at"])
+    return ServeResult(
+        image_path=resolved_path,
+        url=artifact_url,
+        host=host,
+        port=port,
+    )
+
+
+def serve_image_file(*, image_path: Path, host: str, port: int) -> None:
+    """Serve a single image file over HTTP until interrupted."""
+
+    image = image_path.resolve()
+    filename = image.name
+
+    class SingleImageHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self) -> None:  # noqa: N802
+            self._send_file(include_body=False)
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._send_file(include_body=True)
+
+        def _send_file(self, *, include_body: bool) -> None:
+            requested_name = Path(unquote(urlparse(self.path).path).lstrip("/")).name
+            if requested_name != filename:
+                self.send_error(404, "Image artifact not found")
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(image.stat().st_size))
+            self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
+            self.end_headers()
+            if include_body:
+                with image.open("rb") as handle:
+                    shutil.copyfileobj(handle, self.wfile, length=1024 * 1024)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    with ThreadingHTTPServer((host, port), SingleImageHandler) as server:
+        server.serve_forever()
+
+
+def _tcp_access_check(*, host: str, port: int, timeout: float, name: str) -> AccessCheckResult:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return AccessCheckResult(name=name, ok=True, detail=f"tcp/{port} reachable")
+    except OSError as exc:
+        return AccessCheckResult(name=name, ok=False, detail=f"tcp/{port} failed: {exc}")
+
+
+def _ssh_access_check(
+    *,
+    host: str,
+    user: str,
+    port: int,
+    key_path: str,
+    timeout: float,
+) -> AccessCheckResult:
+    ssh_path = shutil.which("ssh")
+    if not ssh_path:
+        return AccessCheckResult(name="ssh-auth", ok=False, detail="ssh command not found")
+
+    command = [
+        ssh_path,
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        f"ConnectTimeout={max(1, int(timeout))}",
+        "-p",
+        str(port),
+    ]
+    if key_path:
+        command.extend(["-i", str(Path(key_path).expanduser())])
+    command.extend([f"{user}@{host}", "true"])
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=max(1, int(timeout) + 2),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return AccessCheckResult(name="ssh-auth", ok=False, detail=f"ssh failed: {exc}")
+    if result.returncode == 0:
+        return AccessCheckResult(name="ssh-auth", ok=True, detail=f"{user}@{host}:{port} accepted key auth")
+    detail = (result.stderr or result.stdout or "ssh command failed").strip().splitlines()
+    return AccessCheckResult(name="ssh-auth", ok=False, detail=detail[-1] if detail else "ssh command failed")
+
+
+def _http_access_check(*, url: str, timeout: float) -> AccessCheckResult:
+    try:
+        with urlopen(Request(url), timeout=timeout) as response:
+            status = response.getcode()
+    except (OSError, HTTPError, URLError) as exc:
+        return AccessCheckResult(name="http", ok=False, detail=f"{url} failed: {exc}")
+    return AccessCheckResult(
+        name="http",
+        ok=200 <= status < 500,
+        detail=f"{url} returned HTTP {status}",
+    )
+
+
+def test_rpi_access(
+    *,
+    host: str,
+    ssh_user: str = DEFAULT_RECOVERY_SSH_USER,
+    ssh_port: int = 22,
+    ssh_key: str = "",
+    http_url: str = "",
+    http_port: int = 8888,
+    timeout: float = 5.0,
+    skip_ssh: bool = False,
+    skip_http: bool = False,
+) -> RpiAccessTestResult:
+    """Test SSH and HTTP access to a burned Raspberry Pi image."""
+
+    checks: list[AccessCheckResult] = []
+    if not skip_ssh:
+        checks.append(_tcp_access_check(host=host, port=ssh_port, timeout=timeout, name="ssh-tcp"))
+        checks.append(
+            _ssh_access_check(
+                host=host,
+                user=ssh_user,
+                port=ssh_port,
+                key_path=ssh_key,
+                timeout=timeout,
+            )
+        )
+    if not skip_http:
+        target_url = http_url or f"http://{host}:{http_port}/"
+        checks.append(_http_access_check(url=target_url, timeout=timeout))
+    if not checks:
+        raise ImagerBuildError("Enable at least one access check.")
+    return RpiAccessTestResult(host=host, checks=tuple(checks))
 
 
 def _resolve_root_disk_path() -> str | None:
@@ -1090,6 +1608,12 @@ def build_rpi4b_image(
     profile_metadata: dict[str, object] | None = None,
     recovery_ssh_user: str = "",
     recovery_authorized_keys: list[str] | tuple[str, ...] | None = None,
+    skip_recovery_ssh: bool = False,
+    bundle_suite: bool = True,
+    suite_source_path: Path | None = None,
+    copy_all_host_networks: bool = False,
+    host_network_names: list[str] | tuple[str, ...] | None = None,
+    host_network_profile_dir: Path | None = None,
 ) -> BuildResult:
     """Build and register a Raspberry Pi 4B Arthexis image artifact."""
 
@@ -1114,10 +1638,30 @@ def build_rpi4b_image(
         recovery_ssh_user=recovery_ssh_user,
         recovery_authorized_keys=recovery_authorized_keys,
     )
+    if skip_recovery_ssh and recovery_ssh_access and recovery_ssh_access.enabled:
+        raise ImagerBuildError("skip_recovery_ssh cannot be combined with recovery SSH keys.")
+    if customize and not skip_recovery_ssh and not (recovery_ssh_access and recovery_ssh_access.enabled):
+        raise ImagerBuildError(
+            "Recovery SSH is required for customized image builds. "
+            "Provide recovery authorized keys or explicitly skip recovery SSH."
+        )
     if recovery_ssh_access and recovery_ssh_access.enabled and not customize:
         raise ImagerBuildError(
             "Recovery SSH access requires image customization. Remove --skip-customize or omit recovery key options."
         )
+    if not customize:
+        bundle_suite = False
+        if copy_all_host_networks or host_network_names:
+            raise ImagerBuildError("Host network profile copying requires image customization.")
+
+    resolved_suite_source_path = suite_source_path
+    if customize and bundle_suite and resolved_suite_source_path is None:
+        resolved_suite_source_path = Path(settings.BASE_DIR)
+    network_profiles = select_host_network_profiles(
+        profile_dir=host_network_profile_dir,
+        names=host_network_names,
+        copy_all=copy_all_host_networks,
+    )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_filename = f"{name}-{TARGET_RPI4B}.img"
@@ -1128,12 +1672,17 @@ def build_rpi4b_image(
             raise ImagerBuildError("Base image path must differ from output artifact path.")
         shutil.copyfile(source_path, output_path)
 
+    customization_result = ImageCustomizationResult()
     if customize:
-        _customize_image(
+        raw_customization_result = _customize_image(
             output_path,
             git_url=git_url,
             recovery_ssh_access=recovery_ssh_access,
+            suite_source_path=resolved_suite_source_path if bundle_suite else None,
+            network_profiles=network_profiles,
         )
+        if isinstance(raw_customization_result, ImageCustomizationResult):
+            customization_result = raw_customization_result
 
     sha256 = _sha256_for_file(output_path)
     size_bytes = output_path.stat().st_size
@@ -1158,12 +1707,17 @@ def build_rpi4b_image(
                     "bootstrap_script": "/usr/local/bin/arthexis-bootstrap.sh",
                     "first_boot_script": "firstrun.sh",
                     "git_url": git_url,
+                    "suite_bundle": _suite_bundle_metadata(customization_result.suite_bundle),
+                    "host_network_profiles": _network_profiles_metadata(
+                        customization_result.network_profiles
+                    ),
                     "recovery_ssh": {
                         "enabled": bool(customize and recovery_ssh_access and recovery_ssh_access.enabled),
                         "user": recovery_ssh_access.username if recovery_ssh_access else "",
                         "authorized_key_count": len(recovery_ssh_access.authorized_keys)
                         if recovery_ssh_access
                         else 0,
+                        "explicitly_skipped": bool(customize and skip_recovery_ssh),
                     },
                 },
                 "build_engine": build_engine,

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -1442,8 +1442,114 @@ def _walk_block_descendants(entry: dict[str, object]) -> list[dict[str, object]]
     return descendants
 
 
+def _coerce_windows_json_rows(value: object) -> list[dict[str, object]]:
+    """Normalize PowerShell ConvertTo-Json array/singleton output."""
+
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _coerce_windows_access_paths(value: object) -> list[str]:
+    """Normalize Windows partition access paths from PowerShell JSON."""
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _list_windows_block_devices() -> list[BlockDeviceInfo]:
+    """Enumerate Windows physical disks with safety metadata."""
+
+    powershell = shutil.which("powershell") or shutil.which("powershell.exe")
+    if not powershell:
+        raise ImagerBuildError("PowerShell is required to enumerate Windows disks.")
+    script = (
+        "$ErrorActionPreference='Stop';"
+        "$disks=@(Get-Disk | Select-Object Number,FriendlyName,SerialNumber,BusType,Size,IsBoot,IsSystem,IsReadOnly,IsOffline,OperationalStatus);"
+        "$partitions=@(Get-Partition | Select-Object DiskNumber,PartitionNumber,DriveLetter,AccessPaths);"
+        "[pscustomobject]@{disks=$disks;partitions=$partitions} | ConvertTo-Json -Depth 6 -Compress"
+    )
+    try:
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                script,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ImagerBuildError("PowerShell is required to enumerate Windows disks.") from exc
+    if result.returncode != 0:
+        raise ImagerBuildError(result.stderr.strip() or "Unable to enumerate Windows disks.")
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise ImagerBuildError("Unable to parse Windows disk inventory output.") from exc
+
+    partitions_by_disk: dict[int, list[dict[str, object]]] = {}
+    for partition in _coerce_windows_json_rows(payload.get("partitions")):
+        try:
+            disk_number = int(partition.get("DiskNumber"))
+        except (TypeError, ValueError):
+            continue
+        partitions_by_disk.setdefault(disk_number, []).append(partition)
+
+    devices: list[BlockDeviceInfo] = []
+    for disk in _coerce_windows_json_rows(payload.get("disks")):
+        try:
+            number = int(disk.get("Number"))
+            size_bytes = int(disk.get("Size") or 0)
+        except (TypeError, ValueError):
+            continue
+
+        bus_type = str(disk.get("BusType") or "")
+        disk_partitions = partitions_by_disk.get(number, [])
+        mountpoints: list[str] = []
+        partitions: list[str] = []
+        for partition in disk_partitions:
+            partition_number = partition.get("PartitionNumber")
+            if partition_number not in (None, ""):
+                partitions.append(f"PhysicalDrive{number}Partition{partition_number}")
+            drive_letter = str(partition.get("DriveLetter") or "").strip()
+            if drive_letter:
+                mountpoints.append(f"{drive_letter.upper()}:\\")
+            mountpoints.extend(_coerce_windows_access_paths(partition.get("AccessPaths")))
+
+        devices.append(
+            BlockDeviceInfo(
+                path=f"\\\\.\\PhysicalDrive{number}",
+                size_bytes=size_bytes,
+                transport=bus_type,
+                removable=bus_type.lower() in {"usb", "sd", "mmc"},
+                mountpoints=sorted(set(mountpoints)),
+                partitions=partitions,
+                protected=bool(disk.get("IsBoot") or disk.get("IsSystem")),
+            )
+        )
+    return sorted(devices, key=lambda item: item.path)
+
+
 def list_block_devices() -> list[BlockDeviceInfo]:
     """Enumerate host block devices and safety-relevant metadata."""
+
+    if os.name == "nt":
+        return _list_windows_block_devices()
 
     try:
         result = subprocess.run(
@@ -1562,7 +1668,7 @@ def write_image_to_device(
     )
 
     source_hash = _sha256_for_file(source_path)
-    with source_path.open("rb") as source_handle, Path(device_path).open("wb") as device_handle:
+    with source_path.open("rb") as source_handle, open(device_path, "r+b", buffering=0) as device_handle:
         shutil.copyfileobj(source_handle, device_handle, length=1024 * 1024 * 4)
         device_handle.flush()
         os.fsync(device_handle.fileno())

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -23,6 +23,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import ParseResult, quote, unquote, urljoin, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives.serialization import load_ssh_public_key
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
@@ -33,6 +35,20 @@ TARGET_RPI4B = "rpi-4b"
 DEFAULT_RECOVERY_SSH_USER = "arthe"
 RECOVERY_SSH_USERNAME_PATTERN = re.compile(r"^[a-z_][a-z0-9_-]*$")
 RECOVERY_SSH_FORBIDDEN_USERS = frozenset({"root"})
+VALID_PUBLIC_KEY_PREFIXES = (
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "sk-ecdsa-sha2-nistp256@openssh.com",
+    "sk-ssh-ed25519@openssh.com",
+    "ssh-ed25519",
+    "ssh-rsa",
+)
+VALID_PUBLIC_KEY_PATTERN = re.compile(
+    r"^(?:"
+    + "|".join(re.escape(prefix) for prefix in VALID_PUBLIC_KEY_PREFIXES)
+    + r")\s+[A-Za-z0-9+/=]+(?:\s+.+)?$"
+)
 SUITE_BUNDLE_REMOTE_PATH = "/usr/local/share/arthexis/arthexis-suite.tar.gz"
 NETWORK_MANAGER_CONNECTIONS_REMOTE_PATH = "/etc/NetworkManager/system-connections"
 DEFAULT_HOST_NETWORK_PROFILE_DIR = "/etc/NetworkManager/system-connections"
@@ -192,6 +208,10 @@ fi"""
 
 class ImagerBuildError(RuntimeError):
     """Raised when a Raspberry Pi image build cannot complete."""
+
+
+class RecoveryAuthorizedKeyError(ValueError):
+    """Raised when a recovery authorized-key line is malformed."""
 
 
 @dataclass
@@ -487,6 +507,21 @@ def _ensure_guestfish() -> None:
     )
 
 
+def normalize_recovery_authorized_key_line(line: str) -> str | None:
+    """Normalize one recovery authorized-key line or raise a validation error."""
+
+    normalized = line.strip()
+    if not normalized or normalized.startswith("#"):
+        return None
+    if not VALID_PUBLIC_KEY_PATTERN.match(normalized):
+        raise RecoveryAuthorizedKeyError("unrecognized key line")
+    try:
+        load_ssh_public_key(normalized.encode("utf-8"))
+    except (TypeError, ValueError, UnsupportedAlgorithm) as exc:
+        raise RecoveryAuthorizedKeyError("malformed public key line") from exc
+    return normalized
+
+
 def _should_exclude_suite_bundle_path(relative_path: Path) -> bool:
     """Return whether a repo path should be excluded from the static image bundle."""
 
@@ -585,7 +620,11 @@ def select_host_network_profiles(
 
     candidates: list[tuple[Path, str, set[str]]] = []
     for path in sorted(source_dir.iterdir(), key=lambda item: item.name):
-        if not path.is_file() or path.name.startswith("."):
+        if path.name.startswith(".") or path.is_symlink() or not path.is_file():
+            continue
+        try:
+            path.resolve().relative_to(source_dir)
+        except ValueError:
             continue
         profile_id = _parse_network_profile_id(path)
         candidates.append(
@@ -1191,6 +1230,12 @@ def _network_profiles_metadata(network_profiles: tuple[NetworkProfileInfo, ...])
     }
 
 
+def _format_url_host(host: str) -> str:
+    """Bracket IPv6 hosts for URL construction."""
+
+    return f"[{host}]" if ":" in host and not host.startswith("[") else host
+
+
 def _build_served_artifact_url(
     *,
     output_filename: str,
@@ -1207,9 +1252,7 @@ def _build_served_artifact_url(
         normalized_path = f"{parsed_base.path.rstrip('/')}/{quote(output_filename)}"
         return parsed_base._replace(path=normalized_path).geturl()
 
-    advertised_host = (url_host or "127.0.0.1").strip()
-    if ":" in advertised_host and not advertised_host.startswith("["):
-        advertised_host = f"[{advertised_host}]"
+    advertised_host = _format_url_host((url_host or "127.0.0.1").strip())
     return f"http://{advertised_host}:{port}/{quote(output_filename)}"
 
 
@@ -1379,7 +1422,7 @@ def test_rpi_access(
             )
         )
     if not skip_http:
-        target_url = http_url or f"http://{host}:{http_port}/"
+        target_url = http_url or f"http://{_format_url_host(host)}:{http_port}/"
         checks.append(_http_access_check(url=target_url, timeout=timeout))
     if not checks:
         raise ImagerBuildError("Enable at least one access check.")

--- a/apps/imager/templates/admin/imager/raspberrypiimageartifact/create_rpi_image.html
+++ b/apps/imager/templates/admin/imager/raspberrypiimageartifact/create_rpi_image.html
@@ -35,6 +35,7 @@
   {% endif %}
   <form method="post" novalidate>
     {% csrf_token %}
+    {{ form.non_field_errors }}
     <fieldset class="module aligned">
       {% for field in form %}
         <div class="form-row">

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -76,10 +76,6 @@ def test_imager_admin_create_rpi_image_view_rejects_disallowed_paths(
     mock_build.assert_not_called()
 
 @patch("apps.imager.admin.build_rpi4b_image")
-@override_settings(
-    IMAGER_ADMIN_BASE_IMAGE_ALLOWED_ROOTS=("/tmp",),
-    IMAGER_ADMIN_OUTPUT_ALLOWED_ROOTS=("/tmp",),
-)
 def test_imager_admin_create_rpi_image_view_shows_artifact_download_actions(mock_build, admin_client, tmp_path):
     """Regression: successful builds should return to the wizard with artifact URL actions."""
 
@@ -102,17 +98,22 @@ def test_imager_admin_create_rpi_image_view_shows_artifact_download_actions(mock
 
     mock_build.return_value = type("BuildResult", (), {"output_path": output_path})()
 
-    response = admin_client.post(
-        reverse("admin:imager_raspberrypiimageartifact_create_rpi_image"),
-        data={
-            "name": "stable",
-            "base_image_uri": str(tmp_path / "base.img"),
-            "output_dir": str(output_dir),
-            "download_base_uri": "https://cdn.example.com/images",
-            "git_url": "https://github.com/arthexis/arthexis.git",
-        },
-        follow=True,
-    )
+    with override_settings(
+        IMAGER_ADMIN_BASE_IMAGE_ALLOWED_ROOTS=(str(tmp_path),),
+        IMAGER_ADMIN_OUTPUT_ALLOWED_ROOTS=(str(tmp_path),),
+    ):
+        response = admin_client.post(
+            reverse("admin:imager_raspberrypiimageartifact_create_rpi_image"),
+            data={
+                "name": "stable",
+                "base_image_uri": str(tmp_path / "base.img"),
+                "output_dir": str(output_dir),
+                "download_base_uri": "https://cdn.example.com/images",
+                "git_url": "https://github.com/arthexis/arthexis.git",
+                "skip_recovery_ssh": "on",
+            },
+            follow=True,
+        )
 
     assert response.status_code == 200
     assert any(f"?artifact={artifact.pk}" in url for url, _status in response.redirect_chain)
@@ -120,6 +121,37 @@ def test_imager_admin_create_rpi_image_view_shows_artifact_download_actions(mock
     assert "Latest build artifact" in body
     assert "Test URL" in body
     assert artifact.download_uri in body
+
+
+@patch("apps.imager.admin.build_rpi4b_image")
+def test_imager_admin_create_rpi_image_view_requires_recovery_or_explicit_skip(
+    mock_build,
+    admin_client,
+    tmp_path,
+):
+    """Regression: admin image builds should not bypass recovery SSH requirements."""
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    with override_settings(
+        IMAGER_ADMIN_BASE_IMAGE_ALLOWED_ROOTS=(str(tmp_path),),
+        IMAGER_ADMIN_OUTPUT_ALLOWED_ROOTS=(str(tmp_path),),
+    ):
+        response = admin_client.post(
+            reverse("admin:imager_raspberrypiimageartifact_create_rpi_image"),
+            data={
+                "name": "stable",
+                "base_image_uri": str(tmp_path / "base.img"),
+                "output_dir": str(output_dir),
+                "download_base_uri": "",
+                "git_url": "https://github.com/arthexis/arthexis.git",
+            },
+        )
+
+    assert response.status_code == 200
+    assert "Recovery SSH is required for customized image builds" in response.content.decode("utf-8")
+    mock_build.assert_not_called()
+
 
 @pytest.mark.parametrize(
     ("download_url", "expected_message"),

--- a/apps/imager/tests/test_admin.py
+++ b/apps/imager/tests/test_admin.py
@@ -153,6 +153,39 @@ def test_imager_admin_create_rpi_image_view_requires_recovery_or_explicit_skip(
     mock_build.assert_not_called()
 
 
+@patch("apps.imager.admin.build_rpi4b_image")
+def test_imager_admin_create_rpi_image_view_rejects_malformed_recovery_key(
+    mock_build,
+    admin_client,
+    tmp_path,
+):
+    """Regression: admin recovery SSH keys should use the same validation as CLI builds."""
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    with override_settings(
+        IMAGER_ADMIN_BASE_IMAGE_ALLOWED_ROOTS=(str(tmp_path),),
+        IMAGER_ADMIN_OUTPUT_ALLOWED_ROOTS=(str(tmp_path),),
+    ):
+        response = admin_client.post(
+            reverse("admin:imager_raspberrypiimageartifact_create_rpi_image"),
+            data={
+                "name": "stable",
+                "base_image_uri": str(tmp_path / "base.img"),
+                "output_dir": str(output_dir),
+                "download_base_uri": "",
+                "git_url": "https://github.com/arthexis/arthexis.git",
+                "recovery_authorized_keys": "not-a-public-key",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "Line 1" in body
+    assert "unrecognized key line" in body
+    mock_build.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("download_url", "expected_message"),
     [

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -37,8 +37,10 @@ from apps.imager.services import (
     list_block_devices,
     prepare_image_serve,
     select_host_network_profiles,
-    test_rpi_access as run_rpi_access_test,
     write_image_to_device,
+)
+from apps.imager.services import (
+    test_rpi_access as run_rpi_access_test,
 )
 
 VALID_RECOVERY_KEY_ONE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILOoi93uar4kpDufSrgJPoOKh8UzGiiAsz+GIspRlj7p recovery-one"
@@ -58,6 +60,7 @@ def make_suite_source(tmp_path: Path) -> Path:
     return suite_source
 
 
+@patch("apps.imager.services.os.name", "posix")
 def test_list_block_devices_requests_tree_output_for_partition_mountpoints() -> None:
     """Regression: lsblk JSON discovery should request tree mode for children[]."""
 
@@ -82,6 +85,7 @@ def test_list_block_devices_requests_tree_output_for_partition_mountpoints() -> 
     ]
 
 
+@patch("apps.imager.services.os.name", "posix")
 def test_list_block_devices_collects_mountpoints_from_nested_descendants() -> None:
     """Regression: nested children mountpoints must prevent in-use target writes."""
 
@@ -99,6 +103,7 @@ def test_list_block_devices_collects_mountpoints_from_nested_descendants() -> No
     assert devices[0].partitions == ["/dev/sdb1", "/dev/mapper/crypt"]
 
 
+@patch("apps.imager.services.os.name", "posix")
 def test_list_block_devices_marks_root_mount_disk_protected_when_findmnt_uses_dev_root() -> None:
     """Regression: root disks must stay protected even when findmnt reports /dev/root."""
 
@@ -122,6 +127,7 @@ def test_list_block_devices_marks_root_mount_disk_protected_when_findmnt_uses_de
     assert devices[1].protected is False
 
 
+@patch("apps.imager.services.os.name", "posix")
 def test_list_block_devices_raises_operator_error_when_lsblk_missing() -> None:
     """Regression: operators should get a clear error if lsblk is unavailable."""
 

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -17,9 +17,15 @@ from django.test import override_settings
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.services import (
     TARGET_RPI4B,
+    AccessCheckResult,
     BlockDeviceInfo,
+    ImageCustomizationResult,
     ImagerBuildError,
+    NetworkProfileInfo,
+    ServeResult,
+    SuiteBundleInfo,
     _build_download_uri,
+    _build_served_artifact_url,
     _customize_image,
     _download_remote_base_image,
     _guestfish_remove_file,
@@ -29,12 +35,27 @@ from apps.imager.services import (
     _validate_remote_base_image_url,
     build_rpi4b_image,
     list_block_devices,
+    prepare_image_serve,
+    select_host_network_profiles,
+    test_rpi_access as run_rpi_access_test,
     write_image_to_device,
 )
 
 VALID_RECOVERY_KEY_ONE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILOoi93uar4kpDufSrgJPoOKh8UzGiiAsz+GIspRlj7p recovery-one"
 VALID_RECOVERY_KEY_TWO = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPxEAcOg5erwB9w67f4eyf3DZiTLQ3sPik4Q6WLTl2XB recovery-two"
 MALFORMED_RECOVERY_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAA malformed"
+
+
+def make_suite_source(tmp_path: Path) -> Path:
+    suite_source = tmp_path / "suite"
+    suite_source.mkdir()
+    for name in ("manage.py", "start.sh", "env-refresh.sh"):
+        (suite_source / name).write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (suite_source / "apps").mkdir()
+    (suite_source / "apps" / "__init__.py").write_text("", encoding="utf-8")
+    (suite_source / "db.sqlite3").write_text("secret", encoding="utf-8")
+    (suite_source / ".env").write_text("SECRET=1", encoding="utf-8")
+    return suite_source
 
 
 def test_list_block_devices_requests_tree_output_for_partition_mountpoints() -> None:
@@ -260,6 +281,52 @@ def test_imager_build_command_passes_connect_ota_profile_metadata(mock_build, tm
 
     assert mock_build.call_args.kwargs["profile"] == "connect-ota"
     assert mock_build.call_args.kwargs["profile_metadata"]["ota_channel"] == "stable"
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_passes_bundle_and_host_network_options(mock_build, tmp_path: Path) -> None:
+    """Regression: CLI image builds should expose static-suite and network-copy controls."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    suite_source = make_suite_source(tmp_path)
+    network_dir = tmp_path / "networks"
+    network_dir.mkdir()
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+        },
+    )()
+
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "networked",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        "--suite-source",
+        str(suite_source),
+        "--copy-host-network",
+        "Shop WiFi",
+        "--host-network-profile-dir",
+        str(network_dir),
+    )
+
+    assert mock_build.call_args.kwargs["bundle_suite"] is True
+    assert mock_build.call_args.kwargs["suite_source_path"] == suite_source
+    assert mock_build.call_args.kwargs["host_network_names"] == ["Shop WiFi"]
+    assert mock_build.call_args.kwargs["host_network_profile_dir"] == network_dir
 
 
 @pytest.mark.django_db
@@ -497,6 +564,7 @@ def test_imager_build_command_allows_explicit_skip_recovery_ssh(mock_build, tmp_
 
     assert mock_build.call_args.kwargs["recovery_authorized_keys"] == []
     assert mock_build.call_args.kwargs["recovery_ssh_user"] == ""
+    assert mock_build.call_args.kwargs["skip_recovery_ssh"] is True
     assert "recovery_ssh=disabled (--skip-recovery-ssh)" in stdout.getvalue()
 
 
@@ -660,6 +728,57 @@ def test_customize_image_does_not_add_recovery_boot_hook_when_recovery_is_disabl
     ]
 
 
+def test_customize_image_writes_suite_bundle_and_selected_network_profiles(tmp_path: Path) -> None:
+    """Regression: customized images can boot from bundled source and copied Wi-Fi profiles."""
+
+    image_path = tmp_path / "artifact.img"
+    image_path.write_bytes(b"pi")
+    suite_source = make_suite_source(tmp_path)
+    network_dir = tmp_path / "networks"
+    network_dir.mkdir()
+    network_profile = network_dir / "home.nmconnection"
+    network_profile.write_text(
+        "[connection]\nid=Home WiFi\n\n[wifi-security]\npsk=secret\n",
+        encoding="utf-8",
+    )
+    selected_profiles = select_host_network_profiles(
+        profile_dir=network_dir,
+        names=("Home WiFi",),
+    )
+    guestfish_batches: list[list[str]] = []
+
+    def capture_guestfish(
+        image_path_arg: Path,
+        commands: list[str],
+        *,
+        error_message: str,
+    ) -> None:
+        assert image_path_arg == image_path
+        assert error_message
+        guestfish_batches.append(commands)
+
+    with (
+        patch("apps.imager.services._ensure_guestfish"),
+        patch("apps.imager.services._guestfish_run_commands", side_effect=capture_guestfish),
+    ):
+        result = _customize_image(
+            image_path,
+            git_url="https://github.com/arthexis/arthexis.git",
+            recovery_ssh_access=None,
+            suite_source_path=suite_source,
+            network_profiles=selected_profiles,
+        )
+
+    flattened_commands = "\n".join(command for batch in guestfish_batches for command in batch)
+    assert result.suite_bundle is not None
+    assert result.suite_bundle.file_count == 4
+    assert result.network_profiles[0].name == "Home WiFi"
+    assert f"upload {shlex.quote(str(network_profile))} /etc/NetworkManager/system-connections/home.nmconnection" in flattened_commands
+    assert "chmod 0600 /etc/NetworkManager/system-connections/home.nmconnection" in flattened_commands
+    assert "upload" in flattened_commands
+    assert "/usr/local/share/arthexis/arthexis-suite.tar.gz" in flattened_commands
+
+
 def test_build_rpi4b_image_rejects_invalid_recovery_ssh_username(tmp_path: Path) -> None:
     """Regression: recovery SSH usernames must be Linux-safe for first-boot scripting."""
 
@@ -739,6 +858,23 @@ def test_build_rpi4b_image_rejects_default_recovery_username_without_keys(tmp_pa
         )
 
 
+def test_build_rpi4b_image_requires_recovery_ssh_unless_explicitly_skipped(tmp_path: Path) -> None:
+    """Regression: service-layer callers must not bypass recovery SSH requirements."""
+
+    base_image = tmp_path / "base.img"
+    base_image.write_bytes(b"raspberrypi")
+
+    with pytest.raises(ImagerBuildError, match="Recovery SSH is required"):
+        build_rpi4b_image(
+            name="recovery-service-required",
+            base_image_uri=str(base_image),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+        )
+
+
 def test_build_rpi4b_image_rejects_root_recovery_username(tmp_path: Path) -> None:
     """Regression: root must not be accepted as a recovery SSH username."""
 
@@ -775,6 +911,7 @@ def test_build_rpi4b_image_creates_artifact_with_download_uri(tmp_path: Path) ->
             download_base_uri="https://cdn.example.com/images",
             git_url="https://github.com/arthexis/arthexis.git",
             customize=True,
+            skip_recovery_ssh=True,
         )
 
     artifact = RaspberryPiImageArtifact.objects.get(name="stable")
@@ -785,6 +922,13 @@ def test_build_rpi4b_image_creates_artifact_with_download_uri(tmp_path: Path) ->
         "enabled": False,
         "user": "",
         "authorized_key_count": 0,
+        "explicitly_skipped": True,
+    }
+    assert artifact.metadata["suite_bundle"] == {"enabled": False}
+    assert artifact.metadata["host_network_profiles"] == {
+        "enabled": False,
+        "count": 0,
+        "profiles": [],
     }
 
 
@@ -813,7 +957,58 @@ def test_build_rpi4b_image_persists_recovery_ssh_metadata(tmp_path: Path) -> Non
         "enabled": True,
         "user": "arthe",
         "authorized_key_count": 1,
+        "explicitly_skipped": False,
     }
+
+
+@pytest.mark.django_db
+def test_build_rpi4b_image_persists_suite_and_network_metadata(tmp_path: Path) -> None:
+    """Regression: build records static bundle and host network injection metadata."""
+
+    base_image = tmp_path / "base.img"
+    base_image.write_bytes(b"raspberrypi")
+    suite_source = make_suite_source(tmp_path)
+    network_profile = NetworkProfileInfo(
+        name="Home WiFi",
+        filename="home.nmconnection",
+        source_path=tmp_path / "home.nmconnection",
+        remote_path="/etc/NetworkManager/system-connections/home.nmconnection",
+    )
+    customization_result = ImageCustomizationResult(
+        suite_bundle=SuiteBundleInfo(
+            source_path=suite_source,
+            remote_path="/usr/local/share/arthexis/arthexis-suite.tar.gz",
+            sha256="bundle123",
+            size_bytes=1234,
+            file_count=4,
+        ),
+        network_profiles=(network_profile,),
+    )
+
+    with patch("apps.imager.services._customize_image", return_value=customization_result):
+        build_rpi4b_image(
+            name="bundled",
+            base_image_uri=str(base_image),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+            recovery_authorized_keys=[
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestRecovery recovery",
+            ],
+            suite_source_path=suite_source,
+        )
+
+    artifact = RaspberryPiImageArtifact.objects.get(name="bundled")
+    assert artifact.metadata["suite_bundle"]["enabled"] is True
+    assert artifact.metadata["suite_bundle"]["sha256"] == "bundle123"
+    assert artifact.metadata["host_network_profiles"]["profiles"] == [
+        {
+            "name": "Home WiFi",
+            "filename": "home.nmconnection",
+            "remote_path": "/etc/NetworkManager/system-connections/home.nmconnection",
+        }
+    ]
 
 
 @pytest.mark.django_db
@@ -833,6 +1028,7 @@ def test_build_rpi4b_image_decompresses_local_xz_source(tmp_path: Path) -> None:
             download_base_uri="",
             git_url="https://github.com/arthexis/arthexis.git",
             customize=True,
+            skip_recovery_ssh=True,
         )
 
     assert result.output_path.read_bytes() == source_bytes
@@ -870,6 +1066,7 @@ def test_build_rpi4b_image_persists_connect_ota_engine_profile_metadata(tmp_path
             customize=True,
             profile="connect-ota",
             profile_metadata=profile_metadata,
+            skip_recovery_ssh=True,
         )
 
     artifact = RaspberryPiImageArtifact.objects.get(name="connect-stable")
@@ -932,6 +1129,7 @@ def test_build_rpi4b_image_downloads_percent_encoded_http_source(
             download_base_uri="",
             git_url="https://github.com/arthexis/arthexis.git",
             customize=True,
+            skip_recovery_ssh=True,
         )
 
     assert result.output_path.exists()
@@ -962,6 +1160,7 @@ def test_build_rpi4b_image_downloads_and_decompresses_remote_xz_source(
             download_base_uri="",
             git_url="https://github.com/arthexis/arthexis.git",
             customize=True,
+            skip_recovery_ssh=True,
         )
 
     assert result.output_path.exists()
@@ -1144,7 +1343,107 @@ def test_build_rpi4b_image_rejects_corrupted_archives(tmp_path: Path, extension:
             download_base_uri="",
             git_url="https://github.com/arthexis/arthexis.git",
             customize=True,
+            skip_recovery_ssh=True,
         )
+
+
+@pytest.mark.django_db
+def test_prepare_image_serve_updates_artifact_download_url(tmp_path: Path) -> None:
+    """Regression: local serving should produce and persist a deployment URL."""
+
+    output_path = tmp_path / "stable-rpi-4b.img"
+    output_path.write_bytes(b"raspberrypi")
+    artifact = RaspberryPiImageArtifact.objects.create(
+        name="stable",
+        target=TARGET_RPI4B,
+        base_image_uri=str(output_path),
+        output_filename=output_path.name,
+        output_path=str(output_path),
+        sha256="",
+        size_bytes=output_path.stat().st_size,
+        download_uri="",
+        metadata={},
+    )
+
+    result = prepare_image_serve(
+        artifact_name="stable",
+        host="0.0.0.0",
+        port=8090,
+        url_host="10.42.0.138",
+    )
+
+    artifact.refresh_from_db()
+    assert isinstance(result, ServeResult)
+    assert result.url == "http://10.42.0.138:8090/stable-rpi-4b.img"
+    assert artifact.download_uri == result.url
+    assert artifact.metadata["local_serve"]["url"] == result.url
+
+
+def test_build_served_artifact_url_uses_base_url_and_quotes_filename() -> None:
+    """Regression: deployment URLs should be safe for filenames with spaces."""
+
+    assert (
+        _build_served_artifact_url(
+            output_filename="Raspberry Pi OS.img",
+            port=8090,
+            base_url="https://downloads.example.com/images/",
+        )
+        == "https://downloads.example.com/images/Raspberry%20Pi%20OS.img"
+    )
+
+
+@patch("apps.imager.management.commands.imager.serve_image_file")
+def test_imager_serve_command_prints_artifact_url(serve_mock, tmp_path: Path) -> None:
+    """Regression: the serve subcommand should expose the computed artifact URL."""
+
+    image_path = tmp_path / "stable-rpi-4b.img"
+    image_path.write_bytes(b"raspberrypi")
+    out = StringIO()
+
+    call_command(
+        "imager",
+        "serve",
+        "--image-path",
+        str(image_path),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8090",
+        "--url-host",
+        "10.42.0.138",
+        stdout=out,
+    )
+
+    assert "artifact_url=http://10.42.0.138:8090/stable-rpi-4b.img" in out.getvalue()
+    serve_mock.assert_called_once()
+
+
+@patch("apps.imager.services.urlopen")
+@patch("apps.imager.services.subprocess.run")
+@patch("apps.imager.services.shutil.which", return_value="/usr/bin/ssh")
+@patch("apps.imager.services.socket.create_connection")
+def test_test_rpi_access_checks_ssh_and_http(
+    create_connection_mock,
+    _which_mock,
+    run_mock,
+    urlopen_mock,
+) -> None:
+    """Regression: post-burn access checks should cover recovery SSH and suite HTTP."""
+
+    create_connection_mock.return_value.__enter__.return_value = None
+    run_mock.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+    urlopen_mock.return_value.__enter__.return_value = SimpleNamespace(getcode=lambda: 200)
+
+    result = run_rpi_access_test(
+        host="10.42.0.50",
+        ssh_user="arthe",
+        http_url="http://10.42.0.50:8888/login/",
+        timeout=1,
+    )
+
+    assert result.ok is True
+    assert [check.name for check in result.checks] == ["ssh-tcp", "ssh-auth", "http"]
+    assert all(isinstance(check, AccessCheckResult) for check in result.checks)
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -785,6 +785,28 @@ def test_customize_image_writes_suite_bundle_and_selected_network_profiles(tmp_p
     assert "/usr/local/share/arthexis/arthexis-suite.tar.gz" in flattened_commands
 
 
+def test_select_host_network_profiles_skips_symlinked_profiles(tmp_path: Path) -> None:
+    """Regression: host network copying should not follow symlinks out of the profile directory."""
+
+    network_dir = tmp_path / "networks"
+    network_dir.mkdir()
+    real_profile = network_dir / "home.nmconnection"
+    real_profile.write_text("[connection]\nid=Home WiFi\n", encoding="utf-8")
+    outside_profile = tmp_path / "outside.nmconnection"
+    outside_profile.write_text("[connection]\nid=Outside WiFi\n", encoding="utf-8")
+    try:
+        (network_dir / "outside-link.nmconnection").symlink_to(outside_profile)
+    except OSError as exc:
+        pytest.skip(f"Symlink creation is unavailable on this host: {exc}")
+
+    selected_profiles = select_host_network_profiles(
+        profile_dir=network_dir,
+        copy_all=True,
+    )
+
+    assert [profile.name for profile in selected_profiles] == ["Home WiFi"]
+
+
 def test_build_rpi4b_image_rejects_invalid_recovery_ssh_username(tmp_path: Path) -> None:
     """Regression: recovery SSH usernames must be Linux-safe for first-boot scripting."""
 
@@ -1424,6 +1446,26 @@ def test_imager_serve_command_prints_artifact_url(serve_mock, tmp_path: Path) ->
     serve_mock.assert_called_once()
 
 
+@patch("apps.imager.management.commands.imager.serve_image_file", side_effect=OSError("port in use"))
+def test_imager_serve_command_reports_server_startup_errors(_serve_mock, tmp_path: Path) -> None:
+    """Regression: serve startup failures should be clean command errors."""
+
+    image_path = tmp_path / "stable-rpi-4b.img"
+    image_path.write_bytes(b"raspberrypi")
+
+    with pytest.raises(CommandError, match="Could not start image server: port in use"):
+        call_command(
+            "imager",
+            "serve",
+            "--image-path",
+            str(image_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8090",
+        )
+
+
 @patch("apps.imager.services.urlopen")
 @patch("apps.imager.services.subprocess.run")
 @patch("apps.imager.services.shutil.which", return_value="/usr/bin/ssh")
@@ -1450,6 +1492,23 @@ def test_test_rpi_access_checks_ssh_and_http(
     assert result.ok is True
     assert [check.name for check in result.checks] == ["ssh-tcp", "ssh-auth", "http"]
     assert all(isinstance(check, AccessCheckResult) for check in result.checks)
+
+
+@patch("apps.imager.services.urlopen")
+def test_test_rpi_access_brackets_ipv6_default_http_url(urlopen_mock) -> None:
+    """Regression: IPv6 hosts need brackets in default HTTP test URLs."""
+
+    urlopen_mock.return_value.__enter__.return_value = SimpleNamespace(getcode=lambda: 200)
+
+    result = run_rpi_access_test(
+        host="2001:db8::50",
+        skip_ssh=True,
+        timeout=1,
+    )
+
+    assert result.ok is True
+    request = urlopen_mock.call_args.args[0]
+    assert request.full_url == "http://[2001:db8::50]:8888/"
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_windows_devices.py
+++ b/apps/imager/tests/test_windows_devices.py
@@ -1,0 +1,60 @@
+"""Windows-specific imager device discovery tests."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from apps.imager.services import list_block_devices
+
+
+@patch("apps.imager.services.os.name", "nt")
+@patch("apps.imager.services.shutil.which", return_value="powershell.exe")
+@patch("apps.imager.services.subprocess.run")
+def test_list_block_devices_uses_windows_physical_drives(run_mock, _which_mock) -> None:
+    """Regression: Windows writer targets should be discoverable without lsblk."""
+
+    run_mock.return_value = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "disks": [
+                    {
+                        "Number": 0,
+                        "BusType": "NVMe",
+                        "Size": 512000000000,
+                        "IsBoot": True,
+                        "IsSystem": True,
+                    },
+                    {
+                        "Number": 3,
+                        "BusType": "USB",
+                        "Size": 64000000000,
+                        "IsBoot": False,
+                        "IsSystem": False,
+                    },
+                ],
+                "partitions": [
+                    {
+                        "DiskNumber": 3,
+                        "PartitionNumber": 1,
+                        "DriveLetter": "E",
+                        "AccessPaths": ["E:\\"],
+                    }
+                ],
+            }
+        ),
+        stderr="",
+    )
+
+    devices = list_block_devices()
+
+    assert devices[0].path == "\\\\.\\PhysicalDrive0"
+    assert devices[0].protected is True
+    assert devices[1].path == "\\\\.\\PhysicalDrive3"
+    assert devices[1].removable is True
+    assert devices[1].protected is False
+    assert devices[1].mountpoints == ["E:\\"]
+    assert devices[1].partitions == ["PhysicalDrive3Partition1"]
+    assert run_mock.call_args.args[0][0] == "powershell.exe"

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -71,6 +71,9 @@ Inspect block devices before writing:
 .venv/bin/python manage.py imager devices
 ```
 
+On Windows, this reports physical writer targets as `\\.\PhysicalDriveN` using PowerShell
+disk inventory. On Linux/GWAY, it reports `/dev/*` block devices using `lsblk`.
+
 This output includes:
 
 - device path and size
@@ -168,6 +171,36 @@ Then write the recovery-enabled artifact:
 If you write with `--image-path`, verify that the image was already built with recovery
 metadata or use a freshly built recovery artifact. The write command verifies bytes on
 the target media, but it does not retrofit recovery SSH into an arbitrary image.
+
+## Windows/GWAY helper
+
+On a Windows operator host, use the repo-local helper when you want one entrypoint for
+local image creation plus either a local writer or a burner attached to GWAY:
+
+```bat
+gway-imager.bat devices-local
+gway-imager.bat create-burn-local --name field-kit --base-image-uri C:\images\raspios.img.xz --device \\.\PhysicalDrive3 --yes
+```
+
+The helper runs the local suite's `manage.py imager` command, sets `--suite-source` to the
+current checkout by default, and uses the first available public key from
+`%USERPROFILE%\.ssh\id_ed25519.pub`, `id_ecdsa.pub`, or `id_rsa.pub` for recovery SSH unless
+you pass `--recovery-authorized-key-file`, `--recovery-authorized-key`, or
+`--skip-recovery-ssh`. Set `GWAY_IMAGER_RECOVERY_KEY_FILE` to force a specific public key.
+
+When the SD-card writer is connected to the GWAY bastion instead of the Windows host, inspect
+remote devices and burn through the remote suite writer:
+
+```bat
+gway-imager.bat devices-gway --gway arthe@10.42.0.1
+gway-imager.bat create-burn-gway --name field-kit --base-image-uri C:\images\raspios.img.xz --device /dev/sdb --gway arthe@10.42.0.1 --yes
+```
+
+The GWAY path builds the image locally, uploads the generated `.img` to
+`/tmp/arthexis-imager`, then runs `/home/arthe/arthexis/.venv/bin/python manage.py imager write`
+on GWAY. Override the remote defaults with `--gway-suite`, `--remote-dir`, or
+`--remote-python`, or with `GWAY_IMAGER_SUITE`, `GWAY_IMAGER_REMOTE_DIR`, and
+`GWAY_IMAGER_REMOTE_PYTHON`.
 
 ## Post-install access test
 

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -15,7 +15,7 @@ Build a Raspberry Pi image artifact with first-boot bootstrap scripts:
 .venv/bin/python manage.py imager build \
   --name stable \
   --base-image-uri /path/to/raspios.img.xz \
-  --skip-recovery-ssh \
+  --recovery-authorized-key "ssh-ed25519 AAAAC3Nza... operator-laptop" \
   --download-base-uri https://downloads.example.com/images
 ```
 
@@ -27,13 +27,43 @@ Accepted base image inputs include:
 
 When bootstrap customization is enabled, the build now keeps `guestfish` temp and cache files under `build/rpi-imager` instead of relying on `/var/tmp`.
 
+Customized builds require recovery SSH keys by default. Use `--skip-recovery-ssh` only when the image is intentionally disposable or another recovery lane exists.
+
+Customized builds also inject a sanitized static source bundle from the current Arthexis checkout into `/usr/local/share/arthexis/arthexis-suite.tar.gz`. On first boot, the bootstrap service extracts that bundle into `/opt/arthexis` and starts the local copy before falling back to `git clone`. Use `--no-bundle-suite` to keep the older clone-on-first-boot behavior, or `--suite-source /path/to/arthexis` to bundle a specific checkout.
+
+To copy host Wi-Fi/Ethernet NetworkManager profiles into the image, pass one or more selected profiles:
+
+```bash
+.venv/bin/python manage.py imager build \
+  --name field-wifi \
+  --base-image-uri /path/to/raspios.img.xz \
+  --recovery-authorized-key "ssh-ed25519 AAAAC3Nza... operator-laptop" \
+  --copy-host-network "Shop WiFi"
+```
+
+Profile selectors match the NetworkManager connection id, filename, or filename stem from `/etc/NetworkManager/system-connections`. Use `--copy-all-host-networks` only when every saved profile and credential on the build host should be copied. For test rigs or nonstandard hosts, override the source directory with `--host-network-profile-dir`.
+
 List registered artifacts:
 
 ```bash
 .venv/bin/python manage.py imager list
 ```
 
-## 2) Discover candidate target devices
+## 2) Serve an artifact over HTTP
+
+Serve a registered image artifact from the CLI and persist the advertised URL on the artifact record:
+
+```bash
+.venv/bin/python manage.py imager serve \
+  --artifact stable \
+  --host 0.0.0.0 \
+  --port 8090 \
+  --url-host 10.42.0.138
+```
+
+The command prints `artifact_url=http://10.42.0.138:8090/stable-rpi-4b.img` and blocks until interrupted. Use that URL as the Raspberry Pi Connect image-release `artifact_url` or another deployment-model consumer URL. If an external reverse proxy owns the public path, pass `--base-url https://downloads.example.com/images` instead of `--url-host`.
+
+## 3) Discover candidate target devices
 
 Inspect block devices before writing:
 
@@ -50,7 +80,7 @@ This output includes:
 
 The protection check falls back to mountpoint inspection, so hosts that expose the live root disk as `/dev/root` still keep that disk marked as protected.
 
-## 3) Write an artifact to removable media
+## 4) Write an artifact to removable media
 
 Write a registered artifact to a target block device:
 
@@ -138,3 +168,17 @@ Then write the recovery-enabled artifact:
 If you write with `--image-path`, verify that the image was already built with recovery
 metadata or use a freshly built recovery artifact. The write command verifies bytes on
 the target media, but it does not retrofit recovery SSH into an arbitrary image.
+
+## Post-install access test
+
+After installing the burned SD card in the Pi and linking it by `eth0` or another network, test recovery SSH and suite HTTP reachability:
+
+```bash
+.venv/bin/python manage.py imager test-access \
+  --host 10.42.0.50 \
+  --ssh-user arthe \
+  --ssh-key ~/.ssh/id_ed25519 \
+  --http-url http://10.42.0.50:8888/login/
+```
+
+Use `--skip-http` while the suite is still bootstrapping, or `--skip-ssh` only when validating an HTTP-only deployment path.

--- a/gway-imager.bat
+++ b/gway-imager.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "PYTHON=%SCRIPT_DIR%\.venv\Scripts\python.exe"
+set "HELPER=%SCRIPT_DIR%scripts\gway_imager.py"
+
+if /I "%SCRIPT_DIR%"=="%SYSTEMDRIVE%\" (
+    echo Refusing to run from drive root.
+    exit /b 1
+)
+
+if not exist "%PYTHON%" (
+    echo Virtual environment not found. Run install.bat first.
+    exit /b 1
+)
+
+"%PYTHON%" "%HELPER%" %*
+set "EXITCODE=%ERRORLEVEL%"
+endlocal & exit /b %EXITCODE%

--- a/scripts/gway_imager.py
+++ b/scripts/gway_imager.py
@@ -1,0 +1,501 @@
+"""Windows/GWAY wrapper for Raspberry Pi image build and burn workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import posixpath
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+TARGET_RPI4B = "rpi-4b"
+DEFAULT_OUTPUT_DIR = "build/rpi-imager"
+DEFAULT_GWAY_TARGET = "arthe@10.42.0.1"
+DEFAULT_GWAY_SUITE = "/home/arthe/arthexis"
+DEFAULT_GWAY_REMOTE_DIR = "/tmp/arthexis-imager"
+DEFAULT_GWAY_PYTHON = ".venv/bin/python"
+DEFAULT_RECOVERY_KEY_NAMES = (
+    "id_ed25519.pub",
+    "id_ecdsa.pub",
+    "id_rsa.pub",
+)
+
+
+class ImagerScriptError(RuntimeError):
+    """Raised when the helper cannot safely prepare a requested operation."""
+
+
+class CommandRunner:
+    """Thin subprocess wrapper used by the CLI and tests."""
+
+    def run(self, command: Sequence[str], *, cwd: Path | None = None) -> None:
+        subprocess.run([str(part) for part in command], cwd=cwd, check=True)
+
+
+def repo_root_from_script() -> Path:
+    """Return the repository root for this helper script."""
+
+    return Path(__file__).resolve().parents[1]
+
+
+def venv_python(repo_root: Path) -> Path:
+    """Return the repo-local Python interpreter expected by batch entrypoints."""
+
+    if os.name == "nt":
+        candidate = repo_root / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = repo_root / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return candidate
+    if Path(sys.executable).exists():
+        return Path(sys.executable)
+    raise ImagerScriptError("Virtual environment not found. Run install.bat first.")
+
+
+def has_option(args: Sequence[str], *names: str) -> bool:
+    """Return True when args contains an option as --flag or --flag=value."""
+
+    prefixes = tuple(f"{name}=" for name in names)
+    return any(arg in names or arg.startswith(prefixes) for arg in args)
+
+
+def find_default_recovery_key(
+    *,
+    env: os._Environ[str] | dict[str, str] | None = None,
+    home: Path | None = None,
+) -> Path | None:
+    """Find the host public key used for default recovery SSH provisioning."""
+
+    environment = env if env is not None else os.environ
+    explicit = str(environment.get("GWAY_IMAGER_RECOVERY_KEY_FILE", "")).strip()
+    if explicit:
+        path = Path(explicit).expanduser()
+        return path if path.exists() else None
+
+    ssh_home = (home or Path.home()) / ".ssh"
+    for key_name in DEFAULT_RECOVERY_KEY_NAMES:
+        candidate = ssh_home / key_name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def enrich_build_args(
+    args: Sequence[str],
+    *,
+    repo_root: Path,
+    recovery_key_file: Path | None = None,
+) -> list[str]:
+    """Add suite-source and recovery-key defaults unless the operator supplied them."""
+
+    enriched = list(args)
+    skip_customize = has_option(enriched, "--skip-customize")
+    if (
+        not skip_customize
+        and not has_option(enriched, "--suite-source", "--no-bundle-suite")
+    ):
+        enriched.extend(["--suite-source", str(repo_root)])
+
+    if skip_customize or has_option(enriched, "--skip-recovery-ssh"):
+        return enriched
+    if has_option(
+        enriched,
+        "--recovery-authorized-key-file",
+        "--recovery-authorized-key",
+    ):
+        return enriched
+
+    key_file = recovery_key_file or find_default_recovery_key()
+    if key_file is None:
+        raise ImagerScriptError(
+            "Recovery SSH is required for customized images. "
+            "Pass --recovery-authorized-key-file, set GWAY_IMAGER_RECOVERY_KEY_FILE, "
+            "or explicitly pass --skip-recovery-ssh."
+        )
+    enriched.extend(["--recovery-authorized-key-file", str(key_file)])
+    return enriched
+
+
+def output_image_path(repo_root: Path, *, output_dir: str, name: str) -> Path:
+    """Return the conventional output image path for an imager build."""
+
+    path = Path(output_dir).expanduser()
+    if not path.is_absolute():
+        path = repo_root / path
+    return path / f"{name}-{TARGET_RPI4B}.img"
+
+
+def safe_remote_filename(path: Path) -> str:
+    """Return a conservative filename for uploading an image to GWAY."""
+
+    return re.sub(r"[^A-Za-z0-9._-]", "_", path.name)
+
+
+def run_local_imager(
+    imager_args: Sequence[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Run ``manage.py imager`` through the repo virtualenv."""
+
+    runner.run(
+        [str(venv_python(repo_root)), "manage.py", "imager", *imager_args],
+        cwd=repo_root,
+    )
+
+
+def gway_remote_command(
+    *,
+    suite_path: str,
+    python_path: str,
+    imager_args: Sequence[str],
+) -> str:
+    """Build the remote shell command that invokes GWAY's suite writer."""
+
+    return (
+        f"cd {shlex.quote(suite_path)} && "
+        f"{shlex.quote(python_path)} manage.py imager "
+        + " ".join(shlex.quote(str(arg)) for arg in imager_args)
+    ).strip()
+
+
+def upload_image_to_gway(
+    *,
+    image_path: Path,
+    ssh_target: str,
+    remote_dir: str,
+    runner: CommandRunner,
+) -> str:
+    """Copy a local image to GWAY and return its remote path."""
+
+    if not image_path.exists():
+        raise ImagerScriptError(f"Image file does not exist: {image_path}")
+    remote_directory = remote_dir.rstrip("/") or DEFAULT_GWAY_REMOTE_DIR
+    remote_path = posixpath.join(remote_directory, safe_remote_filename(image_path))
+    runner.run(["ssh", ssh_target, f"mkdir -p {shlex.quote(remote_directory)}"])
+    runner.run(["scp", str(image_path), f"{ssh_target}:{remote_path}"])
+    return remote_path
+
+
+def handle_build(args: argparse.Namespace, extra: list[str], *, repo_root: Path, runner: CommandRunner) -> None:
+    """Build an image using the local suite checkout."""
+
+    build_args = enrich_build_args(extra, repo_root=repo_root)
+    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+
+
+def handle_devices_local(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """List local writer devices."""
+
+    if extra:
+        raise ImagerScriptError(f"Unexpected arguments for devices-local: {' '.join(extra)}")
+    run_local_imager(["devices"], repo_root=repo_root, runner=runner)
+
+
+def handle_burn_local(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Burn an existing image/artifact through the local suite writer."""
+
+    if extra:
+        raise ImagerScriptError(f"Unexpected arguments for burn-local: {' '.join(extra)}")
+    source_args = ["--artifact", args.artifact] if args.artifact else ["--image-path", args.image_path]
+    write_args = ["write", *source_args, "--device", args.device]
+    if args.yes:
+        write_args.append("--yes")
+    run_local_imager(write_args, repo_root=repo_root, runner=runner)
+
+
+def handle_create_burn_local(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Build locally and burn through the local suite writer."""
+
+    build_args = [
+        "--name",
+        args.name,
+        "--base-image-uri",
+        args.base_image_uri,
+        "--output-dir",
+        args.output_dir,
+        *extra,
+    ]
+    build_args = enrich_build_args(build_args, repo_root=repo_root)
+    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+    image_path = output_image_path(repo_root, output_dir=args.output_dir, name=args.name)
+    write_args = ["write", "--image-path", str(image_path), "--device", args.device]
+    if args.yes:
+        write_args.append("--yes")
+    run_local_imager(write_args, repo_root=repo_root, runner=runner)
+
+
+def handle_devices_gway(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """List candidate writer devices on GWAY."""
+
+    if extra:
+        raise ImagerScriptError(f"Unexpected arguments for devices-gway: {' '.join(extra)}")
+    command = gway_remote_command(
+        suite_path=args.gway_suite,
+        python_path=args.remote_python,
+        imager_args=["devices"],
+    )
+    runner.run(["ssh", args.gway, command])
+
+
+def burn_gway_image(
+    *,
+    image_path: Path,
+    device: str,
+    yes: bool,
+    gway: str,
+    gway_suite: str,
+    remote_dir: str,
+    remote_python: str,
+    runner: CommandRunner,
+) -> None:
+    """Upload an image to GWAY and invoke the remote suite writer."""
+
+    remote_path = upload_image_to_gway(
+        image_path=image_path,
+        ssh_target=gway,
+        remote_dir=remote_dir,
+        runner=runner,
+    )
+    write_args = ["write", "--image-path", remote_path, "--device", device]
+    if yes:
+        write_args.append("--yes")
+    command = gway_remote_command(
+        suite_path=gway_suite,
+        python_path=remote_python,
+        imager_args=write_args,
+    )
+    runner.run(["ssh", gway, command])
+
+
+def handle_burn_gway(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Burn an existing local image through the GWAY suite writer."""
+
+    if extra:
+        raise ImagerScriptError(f"Unexpected arguments for burn-gway: {' '.join(extra)}")
+    image_path = (
+        Path(args.image_path).expanduser()
+        if args.image_path
+        else output_image_path(repo_root, output_dir=args.output_dir, name=args.artifact)
+    )
+    if not image_path.is_absolute():
+        image_path = repo_root / image_path
+    burn_gway_image(
+        image_path=image_path,
+        device=args.device,
+        yes=args.yes,
+        gway=args.gway,
+        gway_suite=args.gway_suite,
+        remote_dir=args.remote_dir,
+        remote_python=args.remote_python,
+        runner=runner,
+    )
+
+
+def handle_create_burn_gway(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Build locally and burn through the GWAY suite writer."""
+
+    build_args = [
+        "--name",
+        args.name,
+        "--base-image-uri",
+        args.base_image_uri,
+        "--output-dir",
+        args.output_dir,
+        *extra,
+    ]
+    build_args = enrich_build_args(build_args, repo_root=repo_root)
+    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+    image_path = output_image_path(repo_root, output_dir=args.output_dir, name=args.name)
+    burn_gway_image(
+        image_path=image_path,
+        device=args.device,
+        yes=args.yes,
+        gway=args.gway,
+        gway_suite=args.gway_suite,
+        remote_dir=args.remote_dir,
+        remote_python=args.remote_python,
+        runner=runner,
+    )
+
+
+def handle_test_access(
+    args: argparse.Namespace,
+    extra: list[str],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Pass through to the local imager access test."""
+
+    run_local_imager(["test-access", *extra], repo_root=repo_root, runner=runner)
+
+
+def add_gway_options(parser: argparse.ArgumentParser) -> None:
+    """Add shared GWAY SSH options to a subparser."""
+
+    parser.add_argument(
+        "--gway",
+        default=os.environ.get("GWAY_IMAGER_SSH_TARGET", DEFAULT_GWAY_TARGET),
+        help="SSH target for the GWAY bastion.",
+    )
+    parser.add_argument(
+        "--gway-suite",
+        default=os.environ.get("GWAY_IMAGER_SUITE", DEFAULT_GWAY_SUITE),
+        help="Suite checkout path on GWAY.",
+    )
+    parser.add_argument(
+        "--remote-dir",
+        default=os.environ.get("GWAY_IMAGER_REMOTE_DIR", DEFAULT_GWAY_REMOTE_DIR),
+        help="Temporary remote directory for uploaded images.",
+    )
+    parser.add_argument(
+        "--remote-python",
+        default=os.environ.get("GWAY_IMAGER_REMOTE_PYTHON", DEFAULT_GWAY_PYTHON),
+        help="Python executable relative to the GWAY suite path, or an absolute path.",
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Build and burn Arthexis Raspberry Pi images from Windows or through GWAY.",
+    )
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    build = subparsers.add_parser(
+        "build",
+        help="Build an image with local-suite and recovery-key defaults.",
+    )
+    build.set_defaults(handler=handle_build)
+
+    devices_local = subparsers.add_parser("devices-local", help="List local writer devices.")
+    devices_local.set_defaults(handler=handle_devices_local)
+
+    burn_local = subparsers.add_parser(
+        "burn-local",
+        aliases=["write-local"],
+        help="Burn an existing image/artifact through the local suite writer.",
+    )
+    local_source = burn_local.add_mutually_exclusive_group(required=True)
+    local_source.add_argument("--artifact", default="", help="Registered artifact name to burn.")
+    local_source.add_argument("--image-path", default="", help="Local image path to burn.")
+    burn_local.add_argument("--device", required=True, help="Local writer device path.")
+    burn_local.add_argument("--yes", action="store_true", help="Confirm destructive write.")
+    burn_local.set_defaults(handler=handle_burn_local)
+
+    create_burn_local = subparsers.add_parser(
+        "create-burn-local",
+        aliases=["create-write-local"],
+        help="Build locally, then burn through the local suite writer.",
+    )
+    create_burn_local.add_argument("--name", required=True, help="Artifact name.")
+    create_burn_local.add_argument("--base-image-uri", required=True, help="Base image URI/path.")
+    create_burn_local.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Build output directory.")
+    create_burn_local.add_argument("--device", required=True, help="Local writer device path.")
+    create_burn_local.add_argument("--yes", action="store_true", help="Confirm destructive write.")
+    create_burn_local.set_defaults(handler=handle_create_burn_local)
+
+    devices_gway = subparsers.add_parser("devices-gway", help="List writer devices on GWAY.")
+    add_gway_options(devices_gway)
+    devices_gway.set_defaults(handler=handle_devices_gway)
+
+    burn_gway = subparsers.add_parser(
+        "burn-gway",
+        aliases=["write-gway"],
+        help="Upload and burn an existing image through GWAY.",
+    )
+    gway_source = burn_gway.add_mutually_exclusive_group(required=True)
+    gway_source.add_argument("--image-path", default="", help="Local image path to upload and burn.")
+    gway_source.add_argument("--artifact", default="", help="Artifact name under --output-dir to upload and burn.")
+    burn_gway.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Artifact output directory.")
+    burn_gway.add_argument("--device", required=True, help="Remote writer device, for example /dev/sdb.")
+    burn_gway.add_argument("--yes", action="store_true", help="Confirm destructive remote write.")
+    add_gway_options(burn_gway)
+    burn_gway.set_defaults(handler=handle_burn_gway)
+
+    create_burn_gway = subparsers.add_parser(
+        "create-burn-gway",
+        aliases=["create-write-gway"],
+        help="Build locally, upload, then burn through GWAY.",
+    )
+    create_burn_gway.add_argument("--name", required=True, help="Artifact name.")
+    create_burn_gway.add_argument("--base-image-uri", required=True, help="Base image URI/path.")
+    create_burn_gway.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Build output directory.")
+    create_burn_gway.add_argument("--device", required=True, help="Remote writer device, for example /dev/sdb.")
+    create_burn_gway.add_argument("--yes", action="store_true", help="Confirm destructive remote write.")
+    add_gway_options(create_burn_gway)
+    create_burn_gway.set_defaults(handler=handle_create_burn_gway)
+
+    access = subparsers.add_parser("test-access", help="Pass through to imager test-access.")
+    access.set_defaults(handler=handle_test_access)
+
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    repo_root: Path | None = None,
+    runner: CommandRunner | None = None,
+) -> int:
+    """CLI entrypoint."""
+
+    parser = build_arg_parser()
+    parsed, extra = parser.parse_known_args(argv)
+    root = repo_root or repo_root_from_script()
+    command_runner = runner or CommandRunner()
+    try:
+        parsed.handler(parsed, extra, repo_root=root, runner=command_runner)
+    except ImagerScriptError as exc:
+        print(f"gway-imager: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gway_imager.py
+++ b/tests/test_gway_imager.py
@@ -1,0 +1,148 @@
+"""Tests for the Windows/GWAY imager helper script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from scripts import gway_imager
+
+
+class FakeRunner(gway_imager.CommandRunner):
+    """Record commands and synthesize build output for create-and-burn tests."""
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[list[str], Path | None]] = []
+
+    def run(self, command, *, cwd=None) -> None:
+        command_list = [str(part) for part in command]
+        self.commands.append((command_list, cwd))
+        if "manage.py" in command_list and "build" in command_list:
+            name = _option_value(command_list, "--name")
+            output_dir = _option_value(command_list, "--output-dir") or gway_imager.DEFAULT_OUTPUT_DIR
+            output_path = gway_imager.output_image_path(Path(cwd), output_dir=output_dir, name=name)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"rpi-image")
+
+
+def _option_value(command: list[str], option: str) -> str:
+    for index, value in enumerate(command):
+        if value == option:
+            return command[index + 1]
+        if value.startswith(f"{option}="):
+            return value.split("=", 1)[1]
+    return ""
+
+
+def test_enrich_build_args_adds_local_suite_and_default_recovery_key(tmp_path: Path) -> None:
+    """Regression: the helper should make the safe build path the default."""
+
+    key_path = tmp_path / "id_ed25519.pub"
+    key_path.write_text("ssh-ed25519 AAAA test\n", encoding="utf-8")
+
+    args = gway_imager.enrich_build_args(
+        ["--name", "field", "--base-image-uri", "raspios.img.xz"],
+        repo_root=tmp_path,
+        recovery_key_file=key_path,
+    )
+
+    assert args[-4:] == [
+        "--suite-source",
+        str(tmp_path),
+        "--recovery-authorized-key-file",
+        str(key_path),
+    ]
+
+
+def test_enrich_build_args_respects_explicit_recovery_skip(tmp_path: Path) -> None:
+    """Regression: explicit operator opt-out must remain possible."""
+
+    args = gway_imager.enrich_build_args(
+        ["--name", "field", "--base-image-uri", "raspios.img.xz", "--skip-recovery-ssh"],
+        repo_root=tmp_path,
+    )
+
+    assert "--suite-source" in args
+    assert "--recovery-authorized-key-file" not in args
+
+
+def test_create_burn_gway_builds_locally_uploads_and_runs_remote_writer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression: GWAY burns should use the local suite image and remote writer."""
+
+    key_path = tmp_path / "recovery.pub"
+    key_path.write_text("ssh-ed25519 AAAA test\n", encoding="utf-8")
+    monkeypatch.setenv("GWAY_IMAGER_RECOVERY_KEY_FILE", str(key_path))
+    runner = FakeRunner()
+
+    exit_code = gway_imager.main(
+        [
+            "create-burn-gway",
+            "--name",
+            "field",
+            "--base-image-uri",
+            "C:\\images\\raspios.img.xz",
+            "--device",
+            "/dev/sdb",
+            "--yes",
+        ],
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert exit_code == 0
+    build_command = runner.commands[0][0]
+    assert build_command[:3] == [sys.executable, "manage.py", "imager"]
+    assert build_command[3:5] == ["build", "--name"]
+    assert "--suite-source" in build_command
+    assert str(tmp_path) in build_command
+    assert "--recovery-authorized-key-file" in build_command
+    assert str(key_path) in build_command
+
+    assert runner.commands[1][0][:2] == ["ssh", gway_imager.DEFAULT_GWAY_TARGET]
+    assert runner.commands[2][0][0] == "scp"
+    assert runner.commands[2][0][2].endswith(":/tmp/arthexis-imager/field-rpi-4b.img")
+    remote_write = runner.commands[3][0]
+    assert remote_write[:2] == ["ssh", gway_imager.DEFAULT_GWAY_TARGET]
+    assert "manage.py imager write" in remote_write[2]
+    assert "--image-path /tmp/arthexis-imager/field-rpi-4b.img" in remote_write[2]
+    assert "--device /dev/sdb --yes" in remote_write[2]
+
+
+def test_burn_local_delegates_to_suite_writer(tmp_path: Path) -> None:
+    """Regression: local burns should stay inside the suite writer command."""
+
+    runner = FakeRunner()
+
+    exit_code = gway_imager.main(
+        [
+            "burn-local",
+            "--artifact",
+            "field",
+            "--device",
+            "\\\\.\\PhysicalDrive3",
+            "--yes",
+        ],
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert exit_code == 0
+    assert runner.commands == [
+        (
+            [
+                sys.executable,
+                "manage.py",
+                "imager",
+                "write",
+                "--artifact",
+                "field",
+                "--device",
+                "\\\\.\\PhysicalDrive3",
+                "--yes",
+            ],
+            tmp_path,
+        )
+    ]


### PR DESCRIPTION
## Summary
- bundle a sanitized static Arthexis checkout into customized RPi image artifacts and make first boot extract it before falling back to git clone
- enforce recovery SSH at the service/admin boundary unless explicitly skipped, and expose admin recovery-key controls
- add imager CLI support for selected/all host NetworkManager profile copying, local artifact HTTP serving, and post-burn RPi access tests
- document static bundling, network copying, serving URLs for deployment consumers, and access testing

## Validation
- .\.venv\Scripts\python.exe manage.py test run -- apps\imager\tests
- .\.venv\Scripts\python.exe manage.py check
- .\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run
- .\.venv\Scripts\python.exe scripts\check_import_resolution.py
- git diff --check

Closes #7593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR implements bundling of a static Arthexis suite into customized Raspberry Pi image artifacts, enables recovery SSH enforcement with admin controls, and adds CLI features for serving images over HTTP and testing post-install access. The changes span the admin form, CLI commands, service layer, and supporting tests/documentation.

## Key Changes

### Admin Interface (apps/imager/admin.py)
- Added recovery SSH configuration fields to `RaspberryPiImageBuildForm`: `recovery_ssh_user`, `recovery_authorized_keys`, and `skip_recovery_ssh`
- Implemented form validation logic including key normalization and enforcement rules ensuring recovery SSH is configured unless explicitly skipped
- Passes recovery SSH parameters to the image build process

### CLI Commands (apps/imager/management/commands/imager.py)
- Extended `build` subcommand with options for suite bundling:
  - `--no-bundle-suite` and `--suite-source` to control static suite injection
- Added host NetworkManager profile copying:
  - `--copy-all-host-networks`, `--copy-host-network`, `--host-network-profile-dir` flags
- Implemented new `serve` action to prepare images for HTTP serving with configurable host/port and optional URL persistence
- Implemented new `test-access` action to run post-deploy SSH/HTTP reachability checks

### Service Layer (apps/imager/services.py)
- Added dataclasses for suite bundle metadata (`SuiteBundleInfo`), network profile information (`NetworkProfileInfo`), and operation results (`ImageCustomizationResult`, `ServeResult`, `AccessCheckResult`, `RpiAccessTestResult`)
- Extended `build_rpi4b_image()` with parameters for:
  - Recovery SSH control (`skip_recovery_ssh`)
  - Suite bundling (`bundle_suite`, `suite_source_path`)
  - Network profile copying (`copy_all_host_networks`, `host_network_names`, `host_network_profile_dir`)
- Expanded `_customize_image()` to handle suite source sanitization/tarball creation and NetworkManager profile injection into the image
- Added public functions:
  - `prepare_image_serve()` to compute deployment URLs
  - `serve_image_file()` to expose images over HTTP
  - `test_rpi_access()` to validate SSH and HTTP connectivity to installed Raspberry Pi
- Persists suite bundle, network profile, and recovery SSH metadata to artifact records

### Templates (apps/imager/templates/admin/imager/raspberrypiimageartifact/create_rpi_image.html)
- Added rendering of form-level validation errors via `{{ form.non_field_errors }}` for clarity on recovery SSH enforcement failures

### Tests
- **test_admin.py**: Updated form tests to use isolated temporary directories; added regression test verifying that image builds fail without recovery SSH configuration or explicit skip
- **test_imager_command.py**: Added comprehensive coverage including:
  - Suite bundling and host network profile copying workflows
  - Recovery SSH requirement enforcement
  - Deployment URL generation and persistence
  - `imager serve` command output validation
  - Post-burn access checks (SSH and HTTP) via `test_rpi_access()`

### Documentation (docs/operations/imager-sd-card-recovery.md)
- Updated build workflow to demonstrate recovery SSH configuration by default
- Documented suite bundling defaults and options
- Added instructions for copying NetworkManager profiles
- Added new "Post-install access test" section with `imager test-access` usage examples

## Validation
- Recovery SSH is now required by default unless explicitly skipped via `skip_recovery_ssh=True` or `--skip-recovery-ssh`
- Static suite bundling is enabled by default and can be disabled or replaced with a custom source
- Metadata is persisted to artifact records for tracking bundled suite versions and network profiles
- Post-install access testing validates both recovery SSH and suite HTTP availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->