### PR TITLE
Support Windows WLAN profiles in imager helper

### DIFF
--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -179,7 +179,7 @@ local image creation plus either a local writer or a burner attached to GWAY:
 
 ```bat
 gway-imager.bat devices-local
-gway-imager.bat create-burn-local --name field-kit --base-image-uri C:\images\raspios.img.xz --device \\.\PhysicalDrive3 --yes
+gway-imager.bat create-burn-local --name field-kit --base-image-uri C:\images\raspios.img.xz --device \\.\PhysicalDrive3 --copy-windows-wlan-profile IZZI-158E-5G --copy-windows-wlan-profile arthexis-1 --yes
 ```
 
 The helper runs the local suite's `manage.py imager` command, sets `--suite-source` to the
@@ -187,13 +187,23 @@ current checkout by default, and uses the first available public key from
 `%USERPROFILE%\.ssh\id_ed25519.pub`, `id_ecdsa.pub`, or `id_rsa.pub` for recovery SSH unless
 you pass `--recovery-authorized-key-file`, `--recovery-authorized-key`, or
 `--skip-recovery-ssh`. Set `GWAY_IMAGER_RECOVERY_KEY_FILE` to force a specific public key.
+Customized builds still need `guestfish` available on the Windows host path before the
+helper downloads a base image or writes media.
+
+Use `--copy-windows-wlan-profile` to copy selected saved Windows WLAN profiles into the
+image as NetworkManager profiles. The helper exports the selected profiles with
+`netsh wlan export profile key=clear`, converts them in a temporary directory, and passes
+only selected connection names to the suite build. The temporary files contain Wi-Fi
+credentials and are deleted when the build exits; the helper does not print PSKs or persist
+them in artifact metadata. Repeat the option for every profile the field image should join,
+including open profiles such as `arthexis-1`.
 
 When the SD-card writer is connected to the GWAY bastion instead of the Windows host, inspect
 remote devices and burn through the remote suite writer:
 
 ```bat
 gway-imager.bat devices-gway --gway arthe@10.42.0.1
-gway-imager.bat create-burn-gway --name field-kit --base-image-uri C:\images\raspios.img.xz --device /dev/sdb --gway arthe@10.42.0.1 --yes
+gway-imager.bat create-burn-gway --name field-kit --base-image-uri C:\images\raspios.img.xz --device /dev/sdb --gway arthe@10.42.0.1 --copy-windows-wlan-profile IZZI-158E-5G --copy-windows-wlan-profile arthexis-1 --yes
 ```
 
 The GWAY path builds the image locally, uploads the generated `.img` to

--- a/scripts/gway_imager.py
+++ b/scripts/gway_imager.py
@@ -188,7 +188,7 @@ def _networkmanager_keyfile_content(profile: WindowsWlanProfile) -> str:
 
     lines = [
         "[connection]",
-        f"id={profile.ssid}",
+        f"id={profile.name}",
         "type=wifi",
         "autoconnect=true",
         "",
@@ -317,14 +317,14 @@ def windows_wlan_build_args(
                 export_dir=export_dir,
                 runner=runner,
             )
-            filename = _safe_networkmanager_filename(profile.ssid)
+            filename = _safe_networkmanager_filename(profile.name)
             output_path = profile_dir / filename
             counter = 2
             while output_path.exists():
                 output_path = profile_dir / f"{Path(filename).stem}-{counter}.nmconnection"
                 counter += 1
             output_path.write_text(_networkmanager_keyfile_content(profile), encoding="utf-8")
-            copied_names.append(profile.ssid)
+            copied_names.append(profile.name)
 
         args: list[str] = ["--host-network-profile-dir", str(profile_dir)]
         for profile_name in copied_names:

--- a/scripts/gway_imager.py
+++ b/scripts/gway_imager.py
@@ -7,10 +7,15 @@ import os
 import posixpath
 import re
 import shlex
+import shutil
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from collections.abc import Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 TARGET_RPI4B = "rpi-4b"
 DEFAULT_OUTPUT_DIR = "build/rpi-imager"
@@ -27,6 +32,17 @@ DEFAULT_RECOVERY_KEY_NAMES = (
 
 class ImagerScriptError(RuntimeError):
     """Raised when the helper cannot safely prepare a requested operation."""
+
+
+@dataclass(frozen=True)
+class WindowsWlanProfile:
+    """A saved Windows WLAN profile converted for NetworkManager injection."""
+
+    name: str
+    ssid: str
+    authentication: str
+    encryption: str
+    key_material: str = ""
 
 
 class CommandRunner:
@@ -61,6 +77,259 @@ def has_option(args: Sequence[str], *names: str) -> bool:
 
     prefixes = tuple(f"{name}=" for name in names)
     return any(arg in names or arg.startswith(prefixes) for arg in args)
+
+
+def build_uses_customization(args: Sequence[str]) -> bool:
+    """Return True when a build needs local image customization tooling."""
+
+    return not has_option(args, "--skip-customize")
+
+
+def ensure_customization_toolchain(args: Sequence[str]) -> None:
+    """Fail before downloading images when local customization tools are absent."""
+
+    if not build_uses_customization(args):
+        return
+    if shutil.which("guestfish"):
+        return
+    raise ImagerScriptError(
+        "guestfish is required to customize Raspberry Pi images with suite, network, "
+        "or recovery SSH files. Install libguestfs-tools/guestfish on this host or "
+        "build on a host where guestfish is available before writing media."
+    )
+
+
+def _local_xml_name(tag: str) -> str:
+    """Return the namespace-free name for an XML tag."""
+
+    return tag.rsplit("}", 1)[-1]
+
+
+def _first_descendant(element: ET.Element | None, tag_name: str) -> ET.Element | None:
+    """Find the first descendant by local tag name, ignoring XML namespaces."""
+
+    if element is None:
+        return None
+    for candidate in element.iter():
+        if _local_xml_name(candidate.tag) == tag_name:
+            return candidate
+    return None
+
+
+def _text_from_descendant(element: ET.Element | None, tag_name: str) -> str:
+    """Return stripped text from the first matching descendant."""
+
+    candidate = _first_descendant(element, tag_name)
+    if candidate is None or candidate.text is None:
+        return ""
+    return candidate.text.strip()
+
+
+def _validate_keyfile_value(value: str, *, label: str) -> str:
+    """Reject values that would break NetworkManager keyfile structure."""
+
+    if any(character in value for character in ("\x00", "\n", "\r")):
+        raise ImagerScriptError(f"Windows WLAN {label} contains unsupported control characters.")
+    return value
+
+
+def parse_windows_wlan_profile_xml(profile_xml: Path) -> WindowsWlanProfile:
+    """Parse a ``netsh wlan export profile`` XML file."""
+
+    try:
+        root = ET.parse(profile_xml).getroot()
+    except ET.ParseError as exc:
+        raise ImagerScriptError(f"Unable to parse exported Windows WLAN profile: {profile_xml}") from exc
+    profile_name = _text_from_descendant(root, "name")
+    ssid_config = _first_descendant(root, "SSIDConfig")
+    ssid = _text_from_descendant(ssid_config, "name") or profile_name
+    auth_encryption = _first_descendant(root, "authEncryption")
+    authentication = _text_from_descendant(auth_encryption, "authentication").upper()
+    encryption = _text_from_descendant(auth_encryption, "encryption").upper()
+    shared_key = _first_descendant(root, "sharedKey")
+    key_material = _text_from_descendant(shared_key, "keyMaterial")
+
+    if not ssid:
+        raise ImagerScriptError(f"Windows WLAN profile did not include an SSID: {profile_xml}")
+    if not authentication:
+        raise ImagerScriptError(f"Windows WLAN profile did not include authentication metadata: {profile_xml}")
+
+    return WindowsWlanProfile(
+        name=_validate_keyfile_value(profile_name or ssid, label="profile name"),
+        ssid=_validate_keyfile_value(ssid, label="SSID"),
+        authentication=authentication,
+        encryption=encryption,
+        key_material=_validate_keyfile_value(key_material, label="password"),
+    )
+
+
+def _networkmanager_keyfile_content(profile: WindowsWlanProfile) -> str:
+    """Render a NetworkManager keyfile for a Windows WLAN profile."""
+
+    security_lines: list[str] = []
+    if profile.authentication in {"OPEN", "OPENSYSTEM"}:
+        security_lines = []
+    elif profile.authentication in {"WPAPSK", "WPA2PSK"}:
+        if not profile.key_material:
+            raise ImagerScriptError(
+                f"Windows WLAN profile '{profile.name}' does not expose a saved Wi-Fi key."
+            )
+        security_lines = ["", "[wifi-security]", "key-mgmt=wpa-psk", f"psk={profile.key_material}"]
+    elif profile.authentication == "WPA3SAE":
+        if not profile.key_material:
+            raise ImagerScriptError(
+                f"Windows WLAN profile '{profile.name}' does not expose a saved Wi-Fi key."
+            )
+        security_lines = ["", "[wifi-security]", "key-mgmt=sae", f"psk={profile.key_material}"]
+    else:
+        raise ImagerScriptError(
+            f"Windows WLAN profile '{profile.name}' uses unsupported authentication '{profile.authentication}'."
+        )
+
+    lines = [
+        "[connection]",
+        f"id={profile.ssid}",
+        "type=wifi",
+        "autoconnect=true",
+        "",
+        "[wifi]",
+        "mode=infrastructure",
+        f"ssid={profile.ssid}",
+        "",
+        "[ipv4]",
+        "method=auto",
+        "",
+        "[ipv6]",
+        "method=auto",
+        *security_lines,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _windows_wlan_profile_fingerprint(profile: WindowsWlanProfile) -> tuple[str, str, str, str]:
+    """Return the fields that must match for duplicate interface exports."""
+
+    return (
+        profile.ssid,
+        profile.authentication,
+        profile.encryption,
+        profile.key_material,
+    )
+
+
+def select_exported_windows_wlan_profile(
+    profile_name: str,
+    profile_xmls: Sequence[Path],
+) -> WindowsWlanProfile:
+    """Select one exported profile, accepting equivalent per-interface duplicates."""
+
+    if not profile_xmls:
+        raise ImagerScriptError(f"Windows WLAN export for '{profile_name}' did not produce an XML file.")
+    parsed_profiles = [parse_windows_wlan_profile_xml(path) for path in profile_xmls]
+    fingerprints = {
+        _windows_wlan_profile_fingerprint(profile)
+        for profile in parsed_profiles
+    }
+    if len(fingerprints) == 1:
+        return parsed_profiles[0]
+    raise ImagerScriptError(
+        f"Windows WLAN export for '{profile_name}' matched multiple interface profiles with different settings."
+    )
+
+
+def _safe_networkmanager_filename(profile_name: str) -> str:
+    """Return a conservative NetworkManager keyfile filename."""
+
+    name = re.sub(r"[^A-Za-z0-9_.-]", "_", profile_name.strip()) or "windows-wlan"
+    if not name.endswith(".nmconnection"):
+        name = f"{name}.nmconnection"
+    return name
+
+
+def export_windows_wlan_profile(
+    profile_name: str,
+    *,
+    export_dir: Path,
+    runner: CommandRunner,
+) -> WindowsWlanProfile:
+    """Export one saved Windows WLAN profile using ``netsh`` and parse it."""
+
+    if os.name != "nt":
+        raise ImagerScriptError("--copy-windows-wlan-profile can only run on Windows.")
+    before = {path.resolve() for path in export_dir.glob("*.xml")}
+    try:
+        runner.run(
+            [
+                "netsh",
+                "wlan",
+                "export",
+                "profile",
+                f"name={profile_name}",
+                "key=clear",
+                f"folder={export_dir}",
+            ]
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ImagerScriptError(
+            f"Unable to export saved Windows WLAN profile '{profile_name}'."
+        ) from exc
+    after = sorted(path for path in export_dir.glob("*.xml") if path.resolve() not in before)
+    return select_exported_windows_wlan_profile(profile_name, after)
+
+
+def _dedupe_names(names: Sequence[str]) -> list[str]:
+    """Preserve the first occurrence of each nonblank name."""
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for raw_name in names:
+        name = str(raw_name).strip()
+        if name and name not in seen:
+            seen.add(name)
+            unique.append(name)
+    return unique
+
+
+@contextmanager
+def windows_wlan_build_args(
+    profile_names: Sequence[str],
+    *,
+    runner: CommandRunner,
+):
+    """Yield build arguments that inject selected Windows WLAN profiles."""
+
+    selected_names = _dedupe_names(profile_names)
+    if not selected_names:
+        yield []
+        return
+
+    with TemporaryDirectory(prefix="arthexis-wlan-") as temp_directory:
+        root = Path(temp_directory)
+        export_dir = root / "windows-export"
+        profile_dir = root / "networkmanager"
+        export_dir.mkdir()
+        profile_dir.mkdir()
+        copied_names: list[str] = []
+        for profile_name in selected_names:
+            profile = export_windows_wlan_profile(
+                profile_name,
+                export_dir=export_dir,
+                runner=runner,
+            )
+            filename = _safe_networkmanager_filename(profile.ssid)
+            output_path = profile_dir / filename
+            counter = 2
+            while output_path.exists():
+                output_path = profile_dir / f"{Path(filename).stem}-{counter}.nmconnection"
+                counter += 1
+            output_path.write_text(_networkmanager_keyfile_content(profile), encoding="utf-8")
+            copied_names.append(profile.ssid)
+
+        args: list[str] = ["--host-network-profile-dir", str(profile_dir)]
+        for profile_name in copied_names:
+            args.extend(["--copy-host-network", profile_name])
+        yield args
 
 
 def find_default_recovery_key(
@@ -149,6 +418,33 @@ def run_local_imager(
     )
 
 
+def run_local_build(
+    build_args: Sequence[str],
+    *,
+    windows_wlan_profiles: Sequence[str],
+    repo_root: Path,
+    runner: CommandRunner,
+) -> None:
+    """Run an imager build with helper-provided defaults and temp profiles."""
+
+    enriched_args = enrich_build_args(build_args, repo_root=repo_root)
+    selected_windows_profiles = _dedupe_names(windows_wlan_profiles)
+    if selected_windows_profiles and not build_uses_customization(enriched_args):
+        raise ImagerScriptError("--copy-windows-wlan-profile requires image customization.")
+    if selected_windows_profiles and has_option(
+        enriched_args,
+        "--copy-all-host-networks",
+        "--host-network-profile-dir",
+    ):
+        raise ImagerScriptError(
+            "--copy-windows-wlan-profile cannot be combined with --copy-all-host-networks "
+            "or an explicit --host-network-profile-dir."
+        )
+    ensure_customization_toolchain(enriched_args)
+    with windows_wlan_build_args(selected_windows_profiles, runner=runner) as wlan_args:
+        run_local_imager(["build", *enriched_args, *wlan_args], repo_root=repo_root, runner=runner)
+
+
 def gway_remote_command(
     *,
     suite_path: str,
@@ -185,8 +481,12 @@ def upload_image_to_gway(
 def handle_build(args: argparse.Namespace, extra: list[str], *, repo_root: Path, runner: CommandRunner) -> None:
     """Build an image using the local suite checkout."""
 
-    build_args = enrich_build_args(extra, repo_root=repo_root)
-    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+    run_local_build(
+        extra,
+        windows_wlan_profiles=args.copy_windows_wlan_profile,
+        repo_root=repo_root,
+        runner=runner,
+    )
 
 
 def handle_devices_local(
@@ -239,8 +539,12 @@ def handle_create_burn_local(
         args.output_dir,
         *extra,
     ]
-    build_args = enrich_build_args(build_args, repo_root=repo_root)
-    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+    run_local_build(
+        build_args,
+        windows_wlan_profiles=args.copy_windows_wlan_profile,
+        repo_root=repo_root,
+        runner=runner,
+    )
     image_path = output_image_path(repo_root, output_dir=args.output_dir, name=args.name)
     write_args = ["write", "--image-path", str(image_path), "--device", args.device]
     if args.yes:
@@ -345,8 +649,12 @@ def handle_create_burn_gway(
         args.output_dir,
         *extra,
     ]
-    build_args = enrich_build_args(build_args, repo_root=repo_root)
-    run_local_imager(["build", *build_args], repo_root=repo_root, runner=runner)
+    run_local_build(
+        build_args,
+        windows_wlan_profiles=args.copy_windows_wlan_profile,
+        repo_root=repo_root,
+        runner=runner,
+    )
     image_path = output_image_path(repo_root, output_dir=args.output_dir, name=args.name)
     burn_gway_image(
         image_path=image_path,
@@ -397,6 +705,20 @@ def add_gway_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_windows_wlan_options(parser: argparse.ArgumentParser) -> None:
+    """Add Windows WLAN profile-copying options to a build-style subparser."""
+
+    parser.add_argument(
+        "--copy-windows-wlan-profile",
+        action="append",
+        default=[],
+        help=(
+            "Export a saved Windows WLAN profile with netsh and copy it into the image "
+            "as a NetworkManager profile. May be repeated."
+        ),
+    )
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build the command-line parser."""
 
@@ -409,6 +731,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "build",
         help="Build an image with local-suite and recovery-key defaults.",
     )
+    add_windows_wlan_options(build)
     build.set_defaults(handler=handle_build)
 
     devices_local = subparsers.add_parser("devices-local", help="List local writer devices.")
@@ -436,6 +759,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     create_burn_local.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Build output directory.")
     create_burn_local.add_argument("--device", required=True, help="Local writer device path.")
     create_burn_local.add_argument("--yes", action="store_true", help="Confirm destructive write.")
+    add_windows_wlan_options(create_burn_local)
     create_burn_local.set_defaults(handler=handle_create_burn_local)
 
     devices_gway = subparsers.add_parser("devices-gway", help="List writer devices on GWAY.")
@@ -467,6 +791,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     create_burn_gway.add_argument("--device", required=True, help="Remote writer device, for example /dev/sdb.")
     create_burn_gway.add_argument("--yes", action="store_true", help="Confirm destructive remote write.")
     add_gway_options(create_burn_gway)
+    add_windows_wlan_options(create_burn_gway)
     create_burn_gway.set_defaults(handler=handle_create_burn_gway)
 
     access = subparsers.add_parser("test-access", help="Pass through to imager test-access.")

--- a/tests/test_gway_imager.py
+++ b/tests/test_gway_imager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 from scripts import gway_imager
@@ -66,6 +67,109 @@ def test_enrich_build_args_respects_explicit_recovery_skip(tmp_path: Path) -> No
     assert "--recovery-authorized-key-file" not in args
 
 
+def test_windows_wlan_profile_xml_converts_wpa2_keyfile(tmp_path: Path) -> None:
+    """Regression: saved Windows PSK profiles become NetworkManager keyfiles."""
+
+    profile_xml = tmp_path / "Wi-Fi-IZZI.xml"
+    profile_xml.write_text(
+        """<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>IZZI-158E-5G</name>
+  <SSIDConfig>
+    <SSID>
+      <name>IZZI-158E-5G</name>
+    </SSID>
+  </SSIDConfig>
+  <MSM>
+    <security>
+      <authEncryption>
+        <authentication>WPA2PSK</authentication>
+        <encryption>AES</encryption>
+      </authEncryption>
+      <sharedKey>
+        <keyMaterial>example-password</keyMaterial>
+      </sharedKey>
+    </security>
+  </MSM>
+</WLANProfile>
+""",
+        encoding="utf-8",
+    )
+
+    profile = gway_imager.parse_windows_wlan_profile_xml(profile_xml)
+    keyfile = gway_imager._networkmanager_keyfile_content(profile)
+
+    assert profile.ssid == "IZZI-158E-5G"
+    assert "[wifi-security]" in keyfile
+    assert "key-mgmt=wpa-psk" in keyfile
+    assert "psk=example-password" in keyfile
+
+
+def test_windows_wlan_profile_xml_converts_open_keyfile(tmp_path: Path) -> None:
+    """Regression: open saved profiles such as arthexis-1 do not need key material."""
+
+    profile_xml = tmp_path / "Wi-Fi-arthexis-1.xml"
+    profile_xml.write_text(
+        """<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>arthexis-1</name>
+  <SSIDConfig>
+    <SSID>
+      <name>arthexis-1</name>
+    </SSID>
+  </SSIDConfig>
+  <MSM>
+    <security>
+      <authEncryption>
+        <authentication>open</authentication>
+        <encryption>none</encryption>
+      </authEncryption>
+    </security>
+  </MSM>
+</WLANProfile>
+""",
+        encoding="utf-8",
+    )
+
+    profile = gway_imager.parse_windows_wlan_profile_xml(profile_xml)
+    keyfile = gway_imager._networkmanager_keyfile_content(profile)
+
+    assert profile.ssid == "arthexis-1"
+    assert "ssid=arthexis-1" in keyfile
+    assert "[wifi-security]" not in keyfile
+
+
+def test_duplicate_windows_wlan_exports_accept_equivalent_profiles(tmp_path: Path) -> None:
+    """Regression: netsh may export the same profile once per Wi-Fi interface."""
+
+    profile_xml = """<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>arthexis-1</name>
+  <SSIDConfig>
+    <SSID>
+      <name>arthexis-1</name>
+    </SSID>
+  </SSIDConfig>
+  <MSM>
+    <security>
+      <authEncryption>
+        <authentication>open</authentication>
+        <encryption>none</encryption>
+      </authEncryption>
+    </security>
+  </MSM>
+</WLANProfile>
+"""
+    first = tmp_path / "Wi-Fi 2-arthexis-1.xml"
+    second = tmp_path / "Wi-Fi 3-arthexis-1.xml"
+    first.write_text(profile_xml, encoding="utf-8")
+    second.write_text(profile_xml, encoding="utf-8")
+
+    selected = gway_imager.select_exported_windows_wlan_profile("arthexis-1", [first, second])
+
+    assert selected.ssid == "arthexis-1"
+
+
 def test_create_burn_gway_builds_locally_uploads_and_runs_remote_writer(
     tmp_path: Path,
     monkeypatch,
@@ -75,6 +179,7 @@ def test_create_burn_gway_builds_locally_uploads_and_runs_remote_writer(
     key_path = tmp_path / "recovery.pub"
     key_path.write_text("ssh-ed25519 AAAA test\n", encoding="utf-8")
     monkeypatch.setenv("GWAY_IMAGER_RECOVERY_KEY_FILE", str(key_path))
+    monkeypatch.setattr(gway_imager.shutil, "which", lambda command: "guestfish")
     runner = FakeRunner()
 
     exit_code = gway_imager.main(
@@ -109,6 +214,95 @@ def test_create_burn_gway_builds_locally_uploads_and_runs_remote_writer(
     assert "manage.py imager write" in remote_write[2]
     assert "--image-path /tmp/arthexis-imager/field-rpi-4b.img" in remote_write[2]
     assert "--device /dev/sdb --yes" in remote_write[2]
+
+
+def test_create_burn_local_passes_selected_windows_wlan_profiles(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression: selected Windows WLAN profiles are injected into build args."""
+
+    key_path = tmp_path / "recovery.pub"
+    key_path.write_text("ssh-ed25519 AAAA test\n", encoding="utf-8")
+    network_dir = tmp_path / "nm"
+    network_dir.mkdir()
+    monkeypatch.setenv("GWAY_IMAGER_RECOVERY_KEY_FILE", str(key_path))
+    monkeypatch.setattr(gway_imager.shutil, "which", lambda command: "guestfish")
+
+    @contextmanager
+    def fake_windows_wlan_build_args(profile_names, *, runner):
+        assert list(profile_names) == ["IZZI-158E-5G", "arthexis-1"]
+        yield [
+            "--host-network-profile-dir",
+            str(network_dir),
+            "--copy-host-network",
+            "IZZI-158E-5G",
+            "--copy-host-network",
+            "arthexis-1",
+        ]
+
+    monkeypatch.setattr(gway_imager, "windows_wlan_build_args", fake_windows_wlan_build_args)
+    runner = FakeRunner()
+
+    exit_code = gway_imager.main(
+        [
+            "create-burn-local",
+            "--name",
+            "field",
+            "--base-image-uri",
+            "C:\\images\\raspios.img.xz",
+            "--device",
+            "\\\\.\\PhysicalDrive3",
+            "--copy-windows-wlan-profile",
+            "IZZI-158E-5G",
+            "--copy-windows-wlan-profile",
+            "arthexis-1",
+            "--yes",
+        ],
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert exit_code == 0
+    build_command = runner.commands[0][0]
+    assert "--host-network-profile-dir" in build_command
+    assert str(network_dir) in build_command
+    assert build_command.count("--copy-host-network") == 2
+    assert "IZZI-158E-5G" in build_command
+    assert "arthexis-1" in build_command
+
+
+def test_create_burn_local_fails_before_build_when_guestfish_missing(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Regression: missing customization tools should block before write."""
+
+    key_path = tmp_path / "recovery.pub"
+    key_path.write_text("ssh-ed25519 AAAA test\n", encoding="utf-8")
+    monkeypatch.setenv("GWAY_IMAGER_RECOVERY_KEY_FILE", str(key_path))
+    monkeypatch.setattr(gway_imager.shutil, "which", lambda command: None)
+    runner = FakeRunner()
+
+    exit_code = gway_imager.main(
+        [
+            "create-burn-local",
+            "--name",
+            "field",
+            "--base-image-uri",
+            "C:\\images\\raspios.img.xz",
+            "--device",
+            "\\\\.\\PhysicalDrive3",
+            "--yes",
+        ],
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert exit_code == 2
+    assert runner.commands == []
+    assert "guestfish is required" in capsys.readouterr().err
 
 
 def test_burn_local_delegates_to_suite_writer(tmp_path: Path) -> None:

--- a/tests/test_gway_imager.py
+++ b/tests/test_gway_imager.py
@@ -105,6 +105,42 @@ def test_windows_wlan_profile_xml_converts_wpa2_keyfile(tmp_path: Path) -> None:
     assert "psk=example-password" in keyfile
 
 
+def test_windows_wlan_keyfile_uses_profile_name_as_connection_id(tmp_path: Path) -> None:
+    """Regression: profile names avoid collisions when profiles share an SSID."""
+
+    profile_xml = tmp_path / "Wi-Fi-office.xml"
+    profile_xml.write_text(
+        """<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>Office Preferred</name>
+  <SSIDConfig>
+    <SSID>
+      <name>Office</name>
+    </SSID>
+  </SSIDConfig>
+  <MSM>
+    <security>
+      <authEncryption>
+        <authentication>WPA2PSK</authentication>
+        <encryption>AES</encryption>
+      </authEncryption>
+      <sharedKey>
+        <keyMaterial>example-password</keyMaterial>
+      </sharedKey>
+    </security>
+  </MSM>
+</WLANProfile>
+""",
+        encoding="utf-8",
+    )
+
+    profile = gway_imager.parse_windows_wlan_profile_xml(profile_xml)
+    keyfile = gway_imager._networkmanager_keyfile_content(profile)
+
+    assert "id=Office Preferred" in keyfile
+    assert "ssid=Office" in keyfile
+
+
 def test_windows_wlan_profile_xml_converts_open_keyfile(tmp_path: Path) -> None:
     """Regression: open saved profiles such as arthexis-1 do not need key material."""
 


### PR DESCRIPTION
## Summary

- adds `--copy-windows-wlan-profile` to the Windows/GWAY imager build and create/burn flows
- exports selected Windows WLAN profiles with `netsh`, converts them to temporary NetworkManager keyfiles, and passes only selected connection names to the existing suite build path
- fails early when `guestfish` is missing so local customized builds do not download or write media before the toolchain blocker is clear
- documents the local/GWAY recovery-ready Windows command shape for IZZI/arthexis-1 style profile injection

Closes #7598.

## Validation

- `python -m pytest tests/test_gway_imager.py`
- `python -m ruff check scripts/gway_imager.py tests/test_gway_imager.py`
- `git diff --check`
- `python manage.py check`
- live non-destructive export conversion for `IZZI-158E-5G` and `arthexis-1`
- live local create/burn preflight confirmed no write occurs when `guestfish` is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds Windows WLAN profile support to the imager helper, enabling operators to select saved Windows WLAN profiles and convert them into NetworkManager keyfiles for injection into Raspberry Pi recovery images. It also introduces early validation to detect missing image customization dependencies (`guestfish`) before any destructive media writes occur.

## Key Changes

### Implementation (scripts/gway_imager.py)
- Introduced `WindowsWlanProfile` dataclass to represent exported Windows WLAN configurations with fields for name, SSID, authentication type, encryption, and optional key material
- Added Windows WLAN profile XML parsing and validation to handle outputs from `netsh wlan export profile`, supporting OPEN, WPA/WPA2 PSK, and WPA3-SAE authentication types
- Implemented conversion pipeline from Windows WLAN XML formats into NetworkManager `.nmconnection` keyfile content
- Added deduplication logic to handle multiple per-interface exports by comparing "fingerprint" fields
- Created `windows_wlan_build_args()` context manager to generate temporary profile directories and inject selected profiles via `--host-network-profile-dir` and `--copy-host-network` arguments
- Added `run_local_build()` wrapper that enriches build arguments, applies WLAN injection, and validates incompatible flag combinations (e.g., preventing simultaneous use of `--copy-windows-wlan-profile` with `--copy-all-host-networks` or explicit `--host-network-profile-dir`)
- Implemented `ensure_customization_toolchain()` function that detects when image customization is needed and enforces `guestfish` availability, failing fast before downloads or media writes
- Added `--copy-windows-wlan-profile` (repeatable) CLI option wired through `build`, `create-burn-local`, and `create-burn-gway` command handlers

### Documentation (docs/operations/imager-sd-card-recovery.md)
- Updated Windows/GWAY recovery documentation with example commands showing `--copy-windows-wlan-profile` usage in both local and remote burn operations

### Tests (tests/test_gway_imager.py)
- Added regression tests validating WPA2-PSK profile XML conversion to NetworkManager keyfile format with correct `key-mgmt` and `psk` fields
- Added test for open network profile conversion (omits Wi-Fi security section)
- Added test for duplicate export handling that selects equivalent profile objects
- Added tests for `create-burn-local` flow ensuring selected WLAN profile names are correctly injected into build commands
- Added test validating early exit (code 2) with proper error reporting when `guestfish` is missing, confirming no runner commands execute before failure

## Validation Against Objectives
✓ Allows selecting saved Windows WLAN profiles by name  
✓ Converts profiles into NetworkManager `.nmconnection` files  
✓ Preserves secret hygiene—key material handled safely without echo in output  
✓ Supports open networks without stored keys  
✓ create/burn flows pass generated profile directory into suite build path  
✓ Early failure detection for missing `guestfish` before destructive operations  
✓ Unit tests cover XML→keyfile conversion, helper argument composition, and flow validation  
✓ Existing imager tests continue to pass (no breaking changes to public APIs)

## Public API Additions
- `WindowsWlanProfile` dataclass
- `build_uses_customization(args: Sequence[str]) -> bool`
- `ensure_customization_toolchain(args: Sequence[str]) -> None`
- `parse_windows_wlan_profile_xml(profile_xml: Path) -> WindowsWlanProfile`
- `select_exported_windows_wlan_profile(profile_name: str, profile_xmls: Sequence[Path]) -> WindowsWlanProfile`
- `export_windows_wlan_profile(profile_name: str, *, export_dir: Path, runner: CommandRunner) -> WindowsWlanProfile`
- `windows_wlan_build_args(profile_names: Sequence[str], *, runner: CommandRunner)` context manager
- `run_local_build(build_args: Sequence[str], *, windows_wlan_profiles: Sequence[str], repo_root: Path, runner: CommandRunner) -> None`
- `add_windows_wlan_options(parser: argparse.ArgumentParser) -> None`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->