### PR TITLE
Fix release readiness to block on unresolved untagged tickets

### DIFF
--- a/dashboard/widgets/release_readiness.py
+++ b/dashboard/widgets/release_readiness.py
@@ -98,11 +98,10 @@ def summarize_release_readiness(
 ) -> ReadinessSummary:
     """Build a go-live readiness summary for the current release."""
 
-    current_release_tickets = (
-        ticket for ticket in tickets if current_release in ticket.tags
-    )
     unresolved_blockers = tuple(
-        ticket for ticket in current_release_tickets if not ticket.is_resolved
+        ticket
+        for ticket in tickets
+        if not ticket.is_resolved and (not ticket.tags or current_release in ticket.tags)
     )
 
     missing_approvals = tuple(

--- a/tests/test_release_readiness_widget.py
+++ b/tests/test_release_readiness_widget.py
@@ -62,3 +62,24 @@ def test_readiness_ignores_unresolved_tickets_for_other_releases() -> None:
 
     assert summary.go_no_go == "go"
     assert summary.unresolved_blockers == ()
+
+
+def test_readiness_counts_unresolved_untagged_tickets_as_blockers() -> None:
+    summary = summarize_release_readiness(
+        current_release="2026.04",
+        tickets=[
+            BlockerTicket(
+                key="PR-103",
+                title="Investigate intermittent charger disconnects",
+                url="https://example.test/pr/103",
+                status="open",
+                tags=(),
+            )
+        ],
+        checklist_items=[ChecklistItem(name="Smoke test", owner="QA", verified=True)],
+        blocker_list_url="https://example.test/blockers",
+        checklist_admin_url="https://example.test/checklist",
+    )
+
+    assert summary.go_no_go == "no-go"
+    assert len(summary.unresolved_blockers) == 1


### PR DESCRIPTION
### Motivation
- Restore correct release-readiness behavior so unresolved blocker tickets that lack release tags are still treated as blockers and cannot be ignored by the gating logic.

### Description
- Update `summarize_release_readiness` in `dashboard/widgets/release_readiness.py` to compute `unresolved_blockers` from all tickets and treat an unresolved ticket as a blocker when it is untagged or tagged with the `current_release` while still ignoring tickets tagged for other releases.
- Add a targeted regression test `test_readiness_counts_unresolved_untagged_tickets_as_blockers` in `tests/test_release_readiness_widget.py` to ensure untagged unresolved blockers force `no-go`.

### Testing
- Ran `pytest -q tests/test_release_readiness_widget.py` and the test suite for that file passed (`4 passed`).
- Attempted repository bootstrap via `./install.sh` but it failed in this environment due to `redis-server` not being installed, so the canonical `.venv` setup could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63d533b408326a83ecfee86b004e7)