### PR TITLE
video: preserve legacy cv2 identifiers during discovery

### DIFF
--- a/apps/video/models/device.py
+++ b/apps/video/models/device.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-import uuid
 
 from django.db import models
 from django.utils.text import slugify
@@ -16,12 +16,12 @@ from apps.nodes.device_sync import sync_detected_devices
 from apps.nodes.feature_detection import is_feature_active_for_node
 from apps.video.services.capture import apply_image_rotation
 from apps.video.utils import (
+    OPENCV_CAMERA_IDENTIFIER_PREFIX,
     RPI_CAMERA_BINARIES,
     RPI_CAMERA_DEVICE,
-    OPENCV_CAMERA_IDENTIFIER_PREFIX,
-    _cv2_camera_index,
     capture_cv2_snapshot,
     capture_rpi_snapshot,
+    cv2_camera_index,
     detect_cv2_camera_devices,
     probe_rpi_camera_stack,
 )
@@ -137,35 +137,35 @@ class VideoDevice(Ownable):
     @classmethod
     def refresh_from_system(
         cls, *, node, return_objects: bool = False
-    ) -> tuple[int, int] | tuple[int, int, list["VideoDevice"], list["VideoDevice"]]:
+    ) -> tuple[int, int] | tuple[int, int, list[VideoDevice], list[VideoDevice]]:
         """Synchronize :class:`VideoDevice` entries for ``node``."""
 
         detected: list[DetectedVideoDevice] = []
         if is_feature_active_for_node(node=node, slug="video-cam"):
             detected = cls.detect_devices()
-            existing_identifiers = set(
-                cls.objects.filter(node=node).values_list("identifier", flat=True)
-            )
-            compatible_detected: list[DetectedVideoDevice] = []
-            for device in detected:
-                identifier = device.identifier
-                index = _cv2_camera_index(identifier)
-                legacy_identifier = str(index) if index is not None else None
-                if (
-                    identifier.startswith(OPENCV_CAMERA_IDENTIFIER_PREFIX)
-                    and legacy_identifier in existing_identifiers
-                    and identifier not in existing_identifiers
-                ):
-                    compatible_detected.append(
-                        DetectedVideoDevice(
-                            identifier=legacy_identifier,
-                            description=device.description,
-                            raw_info=device.raw_info,
+            if detected:
+                existing_identifiers = set(
+                    cls.objects.filter(node=node).values_list("identifier", flat=True)
+                )
+                compatible_detected: list[DetectedVideoDevice] = []
+                for device in detected:
+                    identifier = device.identifier
+                    index = cv2_camera_index(identifier)
+                    legacy_identifier = str(index) if index is not None else None
+                    if (
+                        identifier.startswith(OPENCV_CAMERA_IDENTIFIER_PREFIX)
+                        and legacy_identifier in existing_identifiers
+                    ):
+                        compatible_detected.append(
+                            DetectedVideoDevice(
+                                identifier=legacy_identifier,
+                                description=device.description,
+                                raw_info=device.raw_info,
+                            )
                         )
-                    )
-                    continue
-                compatible_detected.append(device)
-            detected = compatible_detected
+                        continue
+                    compatible_detected.append(device)
+                detected = compatible_detected
         result = sync_detected_devices(
             model_cls=cls,
             node=node,
@@ -200,13 +200,15 @@ class VideoDevice(Ownable):
             )
             return
 
-        first_device = cls.objects.filter(node=node).order_by("identifier", "pk").first()
+        first_device = (
+            cls.objects.filter(node=node).order_by("identifier", "pk").first()
+        )
         if first_device is not None:
             first_device.is_default = True
             first_device.save(update_fields=["is_default"])
 
     @classmethod
-    def get_default_for_node(cls, node) -> "VideoDevice | None":
+    def get_default_for_node(cls, node) -> VideoDevice | None:
         return (
             cls.objects.filter(node=node).order_by("-is_default", "pk").first()
             if node

--- a/apps/video/models/device.py
+++ b/apps/video/models/device.py
@@ -18,6 +18,8 @@ from apps.video.services.capture import apply_image_rotation
 from apps.video.utils import (
     RPI_CAMERA_BINARIES,
     RPI_CAMERA_DEVICE,
+    OPENCV_CAMERA_IDENTIFIER_PREFIX,
+    _cv2_camera_index,
     capture_cv2_snapshot,
     capture_rpi_snapshot,
     detect_cv2_camera_devices,
@@ -141,6 +143,29 @@ class VideoDevice(Ownable):
         detected: list[DetectedVideoDevice] = []
         if is_feature_active_for_node(node=node, slug="video-cam"):
             detected = cls.detect_devices()
+            existing_identifiers = set(
+                cls.objects.filter(node=node).values_list("identifier", flat=True)
+            )
+            compatible_detected: list[DetectedVideoDevice] = []
+            for device in detected:
+                identifier = device.identifier
+                index = _cv2_camera_index(identifier)
+                legacy_identifier = str(index) if index is not None else None
+                if (
+                    identifier.startswith(OPENCV_CAMERA_IDENTIFIER_PREFIX)
+                    and legacy_identifier in existing_identifiers
+                    and identifier not in existing_identifiers
+                ):
+                    compatible_detected.append(
+                        DetectedVideoDevice(
+                            identifier=legacy_identifier,
+                            description=device.description,
+                            raw_info=device.raw_info,
+                        )
+                    )
+                    continue
+                compatible_detected.append(device)
+            detected = compatible_detected
         result = sync_detected_devices(
             model_cls=cls,
             node=node,

--- a/apps/video/tests/test_models_device.py
+++ b/apps/video/tests/test_models_device.py
@@ -93,7 +93,9 @@ def test_detect_devices_describes_cv2_fallback(monkeypatch):
 
 @pytest.mark.django_db
 def test_refresh_from_system_updates_returned_default_state(monkeypatch):
-    node = Node.objects.create(hostname="video-default", public_endpoint="video-default")
+    node = Node.objects.create(
+        hostname="video-default", public_endpoint="video-default"
+    )
     monkeypatch.setattr(
         device_module,
         "is_feature_active_for_node",
@@ -113,9 +115,11 @@ def test_refresh_from_system_updates_returned_default_state(monkeypatch):
         ),
     )
 
-    created, updated, created_objects, updated_objects = VideoDevice.refresh_from_system(
-        node=node,
-        return_objects=True,
+    created, updated, created_objects, updated_objects = (
+        VideoDevice.refresh_from_system(
+            node=node,
+            return_objects=True,
+        )
     )
 
     assert (created, updated) == (1, 0)
@@ -155,9 +159,94 @@ def test_refresh_from_system_keeps_legacy_cv2_identifier(monkeypatch):
     assert (created, updated) == (0, 1)
     legacy_device.refresh_from_db()
     assert legacy_device.description == "OpenCV Camera 0"
-    assert VideoDevice.objects.filter(node=node).values_list("identifier", flat=True) == [
-        "0"
-    ]
+    identifiers = list(
+        VideoDevice.objects.filter(node=node).values_list("identifier", flat=True)
+    )
+    assert identifiers == ["0"]
+
+
+@pytest.mark.django_db
+def test_refresh_from_system_recovers_legacy_cv2_identifier_with_duplicate(
+    monkeypatch,
+):
+    node = Node.objects.create(
+        hostname="video-legacy-duplicate",
+        public_endpoint="video-legacy-duplicate",
+    )
+    legacy_device = VideoDevice.objects.create(
+        node=node,
+        identifier="0",
+        description="Legacy Camera",
+    )
+    VideoDevice.objects.create(
+        node=node,
+        identifier="opencv:0",
+        description="Duplicate Camera",
+    )
+    monkeypatch.setattr(
+        device_module,
+        "is_feature_active_for_node",
+        lambda *, node, slug: True,
+    )
+    monkeypatch.setattr(
+        VideoDevice,
+        "detect_devices",
+        classmethod(
+            lambda cls: [
+                DetectedVideoDevice(
+                    identifier="opencv:0",
+                    description="OpenCV Camera 0",
+                    raw_info="device_index=0 backend=FAKE frame_size=640x480",
+                )
+            ]
+        ),
+    )
+
+    created, updated = VideoDevice.refresh_from_system(node=node)
+
+    assert (created, updated) == (0, 1)
+    legacy_device.refresh_from_db()
+    assert legacy_device.description == "OpenCV Camera 0"
+    identifiers = list(
+        VideoDevice.objects.filter(node=node).values_list("identifier", flat=True)
+    )
+    assert identifiers == ["0"]
+
+
+@pytest.mark.django_db
+def test_refresh_from_system_skips_cv2_identifier_query_without_devices(monkeypatch):
+    node = Node.objects.create(
+        hostname="video-no-devices",
+        public_endpoint="video-no-devices",
+    )
+    monkeypatch.setattr(
+        device_module,
+        "is_feature_active_for_node",
+        lambda *, node, slug: True,
+    )
+    monkeypatch.setattr(VideoDevice, "detect_devices", classmethod(lambda cls: []))
+
+    original_filter = VideoDevice.objects.filter
+
+    class QuerySetProbe:
+        def __init__(self, queryset):
+            self.queryset = queryset
+
+        def __iter__(self):
+            return iter(self.queryset)
+
+        def __getattr__(self, name):
+            return getattr(self.queryset, name)
+
+        def values_list(self, *args, **kwargs):
+            raise AssertionError("unexpected identifier compatibility query")
+
+    def filter_probe(*args, **kwargs):
+        return QuerySetProbe(original_filter(*args, **kwargs))
+
+    monkeypatch.setattr(VideoDevice.objects, "filter", filter_probe)
+
+    assert VideoDevice.refresh_from_system(node=node) == (0, 0)
 
 
 @pytest.mark.django_db
@@ -167,7 +256,9 @@ def test_ensure_single_default_clears_extra_defaults():
         public_endpoint="video-extra-defaults",
     )
     VideoDevice.objects.create(node=node, identifier="opencv:0", is_default=True)
-    extra = VideoDevice.objects.create(node=node, identifier="opencv:1", is_default=True)
+    extra = VideoDevice.objects.create(
+        node=node, identifier="opencv:1", is_default=True
+    )
 
     VideoDevice._ensure_single_default_for_node(node)
 

--- a/apps/video/tests/test_models_device.py
+++ b/apps/video/tests/test_models_device.py
@@ -125,6 +125,42 @@ def test_refresh_from_system_updates_returned_default_state(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_refresh_from_system_keeps_legacy_cv2_identifier(monkeypatch):
+    node = Node.objects.create(
+        hostname="video-legacy-identifier",
+        public_endpoint="video-legacy-identifier",
+    )
+    legacy_device = VideoDevice.objects.create(node=node, identifier="0")
+    monkeypatch.setattr(
+        device_module,
+        "is_feature_active_for_node",
+        lambda *, node, slug: True,
+    )
+    monkeypatch.setattr(
+        VideoDevice,
+        "detect_devices",
+        classmethod(
+            lambda cls: [
+                DetectedVideoDevice(
+                    identifier="opencv:0",
+                    description="OpenCV Camera 0",
+                    raw_info="device_index=0 backend=FAKE frame_size=640x480",
+                )
+            ]
+        ),
+    )
+
+    created, updated = VideoDevice.refresh_from_system(node=node)
+
+    assert (created, updated) == (0, 1)
+    legacy_device.refresh_from_db()
+    assert legacy_device.description == "OpenCV Camera 0"
+    assert VideoDevice.objects.filter(node=node).values_list("identifier", flat=True) == [
+        "0"
+    ]
+
+
+@pytest.mark.django_db
 def test_ensure_single_default_clears_extra_defaults():
     node = Node.objects.create(
         hostname="video-extra-defaults",

--- a/apps/video/utils.py
+++ b/apps/video/utils.py
@@ -199,7 +199,7 @@ def cv2_camera_identifier(index: int) -> str:
     return f"{OPENCV_CAMERA_IDENTIFIER_PREFIX}{int(index)}"
 
 
-def _cv2_camera_index(device_identifier: str | int) -> int | None:
+def cv2_camera_index(device_identifier: str | int) -> int | None:
     """Return an OpenCV camera index parsed from a supported identifier."""
 
     if type(device_identifier) is int:
@@ -211,10 +211,16 @@ def _cv2_camera_index(device_identifier: str | int) -> int | None:
     return int(identifier) if identifier.isdigit() else None
 
 
+def _cv2_camera_index(device_identifier: str | int) -> int | None:
+    """Compatibility wrapper for the former private OpenCV index helper."""
+
+    return cv2_camera_index(device_identifier)
+
+
 def open_cv2_capture(cv2, device_identifier: str | int):
     """Open an OpenCV capture source using the best local backend."""
 
-    index = _cv2_camera_index(device_identifier)
+    index = cv2_camera_index(device_identifier)
     if index is not None:
         if os.name == "nt" and hasattr(cv2, "CAP_DSHOW"):
             return cv2.VideoCapture(index, cv2.CAP_DSHOW)
@@ -404,7 +410,9 @@ def capture_rpi_snapshot(
                 command.extend(["--width", str(width), "--height", str(height)])
             result = _run_command(command, tool_path)
             if result.returncode != 0 and _has_ffmpeg_capture_support():
-                error = (result.stderr or result.stdout or "Snapshot capture failed").strip()
+                error = (
+                    result.stderr or result.stdout or "Snapshot capture failed"
+                ).strip()
                 logger.warning(
                     "rpicam-still failed (%s); attempting ffmpeg fallback", error
                 )
@@ -486,6 +494,7 @@ __all__ = [
     "RPI_CAMERA_DEVICE",
     "has_rpicam_binaries",
     "capture_rpi_snapshot",
+    "cv2_camera_index",
     "cv2_camera_identifier",
     "get_camera_resolutions",
     "has_rpi_camera_stack",


### PR DESCRIPTION
### Motivation

- Discovery changed OpenCV camera identifiers from bare numeric strings like `"0"` to prefixed values like `"opencv:0"`, which caused strict identifier matching to create a new row and then delete the legacy row; that delete can raise `ProtectedError` when related `MjpegStream` rows use `on_delete=PROTECT` and thus abort discovery. 
- The change needs a minimal backward-compatible adaptation so upgraded deployments keep using existing numeric `VideoDevice` rows for the same physical camera instead of creating/deleting them.

### Description

- Import `OPENCV_CAMERA_IDENTIFIER_PREFIX` and `_cv2_camera_index` from `apps/video/utils.py` and use them in `VideoDevice.refresh_from_system` to detect when a newly-detected `opencv:<index>` device corresponds to an existing legacy numeric identifier for the same `node`.
- When such a legacy numeric identifier exists and the prefixed identifier does not, map the detected device to the legacy numeric identifier so `sync_detected_devices` updates the existing row instead of creating a new one and later deleting the legacy row.
- Add a regression test `test_refresh_from_system_keeps_legacy_cv2_identifier` in `apps/video/tests/test_models_device.py` that seeds a legacy `VideoDevice(identifier="0")`, simulates discovery of `DetectedVideoDevice(identifier="opencv:0")`, and asserts the legacy row is updated (not recreated) and that `(created, updated) == (0, 1)`.
- Modified files: `apps/video/models/device.py` and `apps/video/tests/test_models_device.py`.

### Testing

- Added a unit test `test_refresh_from_system_keeps_legacy_cv2_identifier` to cover the regression and ensure detected `opencv:<index>` maps to existing numeric identifiers when present.
- Attempted to run tests with `.venv/bin/python manage.py test run -- apps/video/tests/test_models_device.py` but the environment lacks `.venv`; running `./install.sh` to provision the environment failed because Redis is not installed in this container, so the test run could not be executed here.
- The patch is minimal and constrained to detection-to-sync mapping and a unit test; CI or a local developer environment with `.venv` and Redis should be able to run the added tests and validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63c214b648326a82bd46d56e3aac4)