### PR TITLE
tests: avoid collation-sensitive skill import assertion

### DIFF
--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -143,15 +143,10 @@ def test_superuser_can_import_valid_package(admin_client, isolated_import_storag
     skill = AgentSkill.objects.get(slug="admin-import")
     assert skill.title == "Admin Upload"
     assert skill.markdown == "---\nname: admin-upload\n---\n"
-    assert list(
-        skill.package_files.order_by("relative_path").values_list(
-            "relative_path",
-            "content",
-        )
-    ) == [
-        ("SKILL.md", "---\nname: admin-upload\n---\n"),
-        ("references/rules.md", "portable rules"),
-    ]
+    assert dict(skill.package_files.values_list("relative_path", "content")) == {
+        "SKILL.md": "---\nname: admin-upload\n---\n",
+        "references/rules.md": "portable rules",
+    }
     assert not isolated_import_storage.exists(storage_name)
 
 


### PR DESCRIPTION
## Summary
- Update the skill package admin import regression to compare imported package files by path instead of relying on database collation order.
- Keeps the same import behavior while allowing PostgreSQL and SQLite to return package rows in different relative_path orders.

Closes #7569

## Validation
- `python -m pytest apps/skills/tests/test_admin.py::test_superuser_can_import_valid_package -q`
- `python -m pytest apps/skills/tests/test_admin.py -q`
- `python manage.py check`
- `git diff --check`