### PR TITLE
imager: exclude ignored runtime paths from suite bundle

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -64,16 +64,21 @@ SUITE_BUNDLE_EXCLUDED_TOP_LEVEL = frozenset(
         ".venv",
         "backups",
         "build",
+        "cache",
+        "env",
         "logs",
+        "locks",
         "media",
         "node_modules",
         "staticfiles",
+        "venv",
         "work",
     }
 )
 SUITE_BUNDLE_EXCLUDED_NAMES = frozenset(
     {
         ".env",
+        ".envrc",
         "__pycache__",
         "db.sqlite3",
         "test_db.sqlite3",
@@ -533,7 +538,7 @@ def _should_exclude_suite_bundle_path(relative_path: Path) -> bool:
     if any(part in SUITE_BUNDLE_EXCLUDED_NAMES for part in parts):
         return True
     name = relative_path.name
-    return name.endswith((".env", ".pyc", ".pyo"))
+    return name == ".envrc" or name.startswith(".env.") or name.endswith((".env", ".pyc", ".pyo"))
 
 
 def _create_suite_bundle(source_path: Path, archive_path: Path) -> SuiteBundleInfo:

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -32,6 +32,7 @@ from apps.imager.services import (
     _guestfish_symlink,
     _guestfish_write,
     _resolve_root_disk_path,
+    _should_exclude_suite_bundle_path,
     _validate_remote_base_image_url,
     build_rpi4b_image,
     list_block_devices,
@@ -206,6 +207,27 @@ def test_guestfish_symlink_uses_guestfish_ln_sf(tmp_path: Path) -> None:
     assert env["TMPDIR"].startswith(str(tmp_path))
     assert env["LIBGUESTFS_TMPDIR"] == env["TMPDIR"]
     assert env["LIBGUESTFS_CACHEDIR"] == str(tmp_path / ".libguestfs-cache")
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected"),
+    [
+        (Path(".env.production"), True),
+        (Path(".envrc"), True),
+        (Path("cache/token.txt"), True),
+        (Path("locks/private.lock"), True),
+        (Path("env/secret.txt"), True),
+        (Path("venv/private.txt"), True),
+        (Path("config/.env.local"), True),
+        (Path("apps/imager/services.py"), False),
+    ],
+)
+def test_should_exclude_suite_bundle_path_covers_ignored_runtime_paths(
+    relative_path: Path, expected: bool
+) -> None:
+    """Regression: suite bundle filtering should exclude common local runtime/secret paths."""
+
+    assert _should_exclude_suite_bundle_path(relative_path) is expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation

- The suite bundler walked the entire checkout and used a small hard-coded denylist that missed common gitignored runtime/secret paths, which could leak local secrets into generated Raspberry Pi image artifacts.

### Description

- Expand the suite-bundle exclusion set to include additional top-level runtime directories (`cache`, `env`, `locks`, `venv`) and add `venv` to ensure both dotted and plain variants are excluded. 
- Add `.envrc` to `SUITE_BUNDLE_EXCLUDED_NAMES` and change the name check to also exclude `.env.*` files so files like `.env.production` are filtered. 
- Add a focused regression test `test_should_exclude_suite_bundle_path_covers_ignored_runtime_paths` that asserts common ignored paths (`.env.production`, `.envrc`, `cache/`, `locks/`, `env/`, `venv/`, `config/.env.local`) are excluded and a control path is not. 
- Keep existing bundling behavior intact (still archives `settings.BASE_DIR` when enabled) while tightening the exclusion heuristics.

### Testing

- Added a unit test in `apps/imager/tests/test_imager_command.py` to cover the new exclusion cases (test added but not executed in this environment). 
- Attempted to run tests with the repository entrypoint `./venv/bin/python manage.py test run -- apps/imager/tests/test_imager_command.py` but the environment lacks `.venv/bin/python` so the run could not be executed. 
- Attempted to bootstrap the environment with `./install.sh`, but the installer failed because `redis-server` is not installed in this environment, preventing creation of the validated `.venv` and subsequent test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64defcfec8326beb478572db72ca9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses a security vulnerability where the suite bundler could inadvertently include local runtime and secret files into Raspberry Pi image artifacts. The fix expands the exclusion heuristics to catch common gitignored runtime paths that were previously missed by the hardcoded denylist.

## Changes

**apps/imager/services.py**

Expanded the exclusion logic for suite bundle creation:
- Added `cache`, `env`, `logs`, and `locks` to `SUITE_BUNDLE_EXCLUDED_TOP_LEVEL`, complementing existing exclusions like `.venv`, `venv`, and `.git`
- Added `.envrc` to `SUITE_BUNDLE_EXCLUDED_NAMES`
- Enhanced `_should_exclude_suite_bundle_path()` to exclude files matching `.envrc`, starting with `.env.` (e.g., `.env.production`), or ending with `.env` in addition to existing bytecode exclusions

**apps/imager/tests/test_imager_command.py**

Added a parametrized regression test `test_should_exclude_suite_bundle_path_covers_ignored_runtime_paths()` that verifies the exclusion of common runtime/secret paths:
- Confirms exclusion of `.env.production`, `.envrc`, `cache/token.txt`, `locks/private.lock`, `env/secret.txt`, `venv/private.txt`, and `config/.env.local`
- Confirms that legitimate suite source files (e.g., `apps/imager/services.py`) are not excluded

## Impact

Prevents accidental inclusion of local environment variables, cache, and other runtime artifacts in distributed image bundles, reducing the risk of information disclosure when artifacts are shared or deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->