### PR TITLE
ops: avoid overflow in migration step resequencing

### DIFF
--- a/apps/ops/migrations/0012_remove_product_developer_github_setup_step.py
+++ b/apps/ops/migrations/0012_remove_product_developer_github_setup_step.py
@@ -2,6 +2,7 @@ from django.db import migrations
 
 PRODUCT_DEVELOPER_JOURNEY_SLUG = "product-developer-github-access"
 GITHUB_SETUP_STEP_SLUG = "setup-github-token"
+MAX_POSTGRES_INTEGER = 2_147_483_647
 
 
 def remove_product_developer_github_setup_step(apps, schema_editor):
@@ -25,10 +26,18 @@ def remove_product_developer_github_setup_step(apps, schema_editor):
     if not remaining_steps:
         return
 
-    max_order = max(step.order for step in remaining_steps) + len(remaining_steps)
+    existing_orders = {step.order for step in remaining_steps}
+    temp_start = 0
+    temp_span = len(remaining_steps)
+    while any(order in existing_orders for order in range(temp_start, temp_start + temp_span)):
+        temp_start += temp_span
+
+    if temp_start + temp_span - 1 > MAX_POSTGRES_INTEGER:
+        raise OverflowError("Unable to allocate temporary order range for journey step resequencing")
+
     temp_steps = []
     for position, step in enumerate(remaining_steps, start=1):
-        step.order = max_order + position
+        step.order = temp_start + position - 1
         temp_steps.append(step)
 
     OperatorJourneyStep.objects.bulk_update(temp_steps, ["order"])

--- a/apps/ops/migrations/0012_remove_product_developer_github_setup_step.py
+++ b/apps/ops/migrations/0012_remove_product_developer_github_setup_step.py
@@ -26,14 +26,21 @@ def remove_product_developer_github_setup_step(apps, schema_editor):
     if not remaining_steps:
         return
 
-    existing_orders = {step.order for step in remaining_steps}
+    existing_orders = set(
+        OperatorJourneyStep.objects.filter(journey=journey).values_list(
+            "order",
+            flat=True,
+        )
+    )
     temp_start = 0
     temp_span = len(remaining_steps)
-    while any(order in existing_orders for order in range(temp_start, temp_start + temp_span)):
+    while not existing_orders.isdisjoint(range(temp_start, temp_start + temp_span)):
         temp_start += temp_span
 
     if temp_start + temp_span - 1 > MAX_POSTGRES_INTEGER:
-        raise OverflowError("Unable to allocate temporary order range for journey step resequencing")
+        raise OverflowError(
+            "Unable to allocate temporary order range for journey step resequencing"
+        )
 
     temp_steps = []
     for position, step in enumerate(remaining_steps, start=1):


### PR DESCRIPTION
### Motivation
- The migration `apps/ops/migrations/0012_remove_product_developer_github_setup_step.py` previously computed temporary orders as `max(order) + offset`, which can overflow PostgreSQL `int4` when existing `order` values are near the DB maximum. 
- The change aims to keep the normalization behavior but ensure temporary resequencing never writes out-of-range integer values during an upgrade.

### Description
- Added a `MAX_POSTGRES_INTEGER` constant and compute a disjoint temporary contiguous range instead of adding to `max(order)` to avoid producing values outside the PostgreSQL `int4` range. 
- Determine `existing_orders`, use `temp_span = len(remaining_steps)`, and advance `temp_start` by `temp_span` until the candidate range does not collide with current orders. 
- Raise `OverflowError` with a clear message if no safe temporary range can be allocated within PostgreSQL bounds. 
- Assign the safe temporary orders, `bulk_update` them, and then normalize back to `1..N` exactly as before.

### Testing
- Attempted to run the targeted tests with `.venv/bin/python manage.py test run -- apps/ops/tests/test_operator_journey.py`, but the test run could not be executed because `.venv/bin/python` is not present in this environment. 
- Attempted `./install.sh` per repository guidance to provision the environment, but installation failed because `redis-server` is not installed in the execution environment, so no repository tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64aed2d9c8326a32b3c8ae81628b8)