### PR TITLE
gallery: harden AP guest identity against session-rotation abuse

### DIFF
--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -536,6 +536,10 @@ class GalleryApGuestTests(TestCase):
         self.assertFalse(GalleryImage.objects.filter(title="Evening").exists())
 
     def test_ap_guest_upload_limit_applies_across_fresh_sessions(self):
+        extra = {
+            "REMOTE_ADDR": "203.0.113.10",
+            "HTTP_USER_AGENT": "gallery-tests",
+        }
         first_response = self.client.post(
             reverse("gallery:ap"),
             {
@@ -543,6 +547,7 @@ class GalleryApGuestTests(TestCase):
                 "title": "Morning Session One",
                 "image": self._upload("morning-session-one.jpg"),
             },
+            **extra,
         )
         self.assertEqual(first_response.status_code, 302)
 
@@ -554,6 +559,7 @@ class GalleryApGuestTests(TestCase):
                 "title": "Morning Session Two",
                 "image": self._upload("morning-session-two.jpg"),
             },
+            **extra,
         )
 
         self.assertEqual(second_response.status_code, 200)
@@ -561,6 +567,42 @@ class GalleryApGuestTests(TestCase):
         self.assertTrue(GalleryImage.objects.filter(title="Morning Session One").exists())
         self.assertFalse(
             GalleryImage.objects.filter(title="Morning Session Two").exists()
+        )
+
+    def test_ap_guest_upload_limit_ignores_spoofable_headers(self):
+        first_response = self.client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "upload",
+                "title": "Trusted Address",
+                "image": self._upload("trusted-address.jpg"),
+            },
+            REMOTE_ADDR="203.0.113.30",
+            HTTP_X_FORWARDED_FOR="198.51.100.10",
+            HTTP_USER_AGENT="gallery-tests/one",
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        fresh_client = Client()
+        second_response = fresh_client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "upload",
+                "title": "Spoofed Headers",
+                "image": self._upload("spoofed-headers.jpg"),
+            },
+            REMOTE_ADDR="203.0.113.30",
+            HTTP_X_FORWARDED_FOR="198.51.100.99",
+            HTTP_USER_AGENT="gallery-tests/two",
+        )
+
+        self.assertEqual(second_response.status_code, 200)
+        self.assertContains(second_response, "You can upload one image per day.")
+        self.assertTrue(
+            GalleryImage.objects.filter(title="Trusted Address").exists()
+        )
+        self.assertFalse(
+            GalleryImage.objects.filter(title="Spoofed Headers").exists()
         )
 
     @override_settings(GALLERY_AP_GUEST_MAX_UPLOAD_BYTES=10)
@@ -670,6 +712,10 @@ class GalleryApGuestTests(TestCase):
         self.assertFalse(GalleryImageReaction.objects.exists())
 
     def test_ap_guest_reaction_is_scoped_across_fresh_sessions(self):
+        extra = {
+            "REMOTE_ADDR": "203.0.113.20",
+            "HTTP_USER_AGENT": "gallery-tests",
+        }
         image = self._create_public_image("Scoped", color="purple")
         first_response = self.client.post(
             reverse("gallery:ap"),
@@ -678,6 +724,7 @@ class GalleryApGuestTests(TestCase):
                 "image_slug": image.slug,
                 "reaction": "like",
             },
+            **extra,
         )
         self.assertEqual(first_response.status_code, 302)
 
@@ -689,6 +736,7 @@ class GalleryApGuestTests(TestCase):
                 "image_slug": image.slug,
                 "reaction": "dislike",
             },
+            **extra,
         )
         self.assertEqual(second_response.status_code, 302)
 

--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.core import signing
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from PIL import Image
@@ -535,6 +535,34 @@ class GalleryApGuestTests(TestCase):
         self.assertTrue(GalleryImage.objects.filter(title="Morning").exists())
         self.assertFalse(GalleryImage.objects.filter(title="Evening").exists())
 
+    def test_ap_guest_upload_limit_applies_across_fresh_sessions(self):
+        first_response = self.client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "upload",
+                "title": "Morning Session One",
+                "image": self._upload("morning-session-one.jpg"),
+            },
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        fresh_client = Client()
+        second_response = fresh_client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "upload",
+                "title": "Morning Session Two",
+                "image": self._upload("morning-session-two.jpg"),
+            },
+        )
+
+        self.assertEqual(second_response.status_code, 200)
+        self.assertContains(second_response, "You can upload one image per day.")
+        self.assertTrue(GalleryImage.objects.filter(title="Morning Session One").exists())
+        self.assertFalse(
+            GalleryImage.objects.filter(title="Morning Session Two").exists()
+        )
+
     @override_settings(GALLERY_AP_GUEST_MAX_UPLOAD_BYTES=10)
     def test_ap_guest_upload_enforces_size_limit(self):
         response = self.client.post(
@@ -640,6 +668,35 @@ class GalleryApGuestTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertJSONEqual(response.content, {"detail": "invalid image"})
         self.assertFalse(GalleryImageReaction.objects.exists())
+
+    def test_ap_guest_reaction_is_scoped_across_fresh_sessions(self):
+        image = self._create_public_image("Scoped", color="purple")
+        first_response = self.client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "react",
+                "image_slug": image.slug,
+                "reaction": "like",
+            },
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        fresh_client = Client()
+        second_response = fresh_client.post(
+            reverse("gallery:ap"),
+            {
+                "action": "react",
+                "image_slug": image.slug,
+                "reaction": "dislike",
+            },
+        )
+        self.assertEqual(second_response.status_code, 302)
+
+        self.assertEqual(GalleryImageReaction.objects.filter(image=image).count(), 1)
+        self.assertEqual(
+            GalleryImageReaction.objects.get(image=image).value,
+            GalleryImageReaction.DISLIKE,
+        )
 
     @override_settings(GALLERY_AP_GUEST_PAGE_SIZE=2)
     def test_ap_guest_gallery_paginates_public_images(self):

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -1,3 +1,4 @@
+import hashlib
 from pathlib import Path
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
@@ -220,15 +221,21 @@ def _rf_card_store_url_for_image(image: GalleryImage) -> str:
 
 
 def _ap_guest_key(request) -> str:
+    remote_addr = (request.META.get("REMOTE_ADDR") or "").strip()
+    forwarded_for = (request.META.get("HTTP_X_FORWARDED_FOR") or "").strip()
+    user_agent = (request.META.get("HTTP_USER_AGENT") or "").strip()
+    client_identity = "|".join((forwarded_for, remote_addr, user_agent))
+    if client_identity:
+        return hashlib.sha256(client_identity.encode("utf-8")).hexdigest()
     session = getattr(request, "session", None)
-    if not hasattr(session, "get"):
-        return uuid4().hex
-    guest_key = (session.get(GALLERY_AP_GUEST_SESSION_KEY) or "").strip()
-    if guest_key:
+    if hasattr(session, "get"):
+        guest_key = (session.get(GALLERY_AP_GUEST_SESSION_KEY) or "").strip()
+        if guest_key:
+            return guest_key
+        guest_key = uuid4().hex
+        session[GALLERY_AP_GUEST_SESSION_KEY] = guest_key
         return guest_key
-    guest_key = uuid4().hex
-    session[GALLERY_AP_GUEST_SESSION_KEY] = guest_key
-    return guest_key
+    return uuid4().hex
 
 
 def _ap_gallery_redirect(sort_key: str, *, page_number=None):

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -222,10 +222,8 @@ def _rf_card_store_url_for_image(image: GalleryImage) -> str:
 
 def _ap_guest_key(request) -> str:
     remote_addr = (request.META.get("REMOTE_ADDR") or "").strip()
-    forwarded_for = (request.META.get("HTTP_X_FORWARDED_FOR") or "").strip()
-    user_agent = (request.META.get("HTTP_USER_AGENT") or "").strip()
-    client_identity = "|".join((forwarded_for, remote_addr, user_agent))
-    if client_identity:
+    if remote_addr:
+        client_identity = f"remote:{remote_addr}"
         return hashlib.sha256(client_identity.encode("utf-8")).hexdigest()
     session = getattr(request, "session", None)
     if hasattr(session, "get"):

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 from pathlib import Path
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
@@ -224,7 +225,11 @@ def _ap_guest_key(request) -> str:
     remote_addr = (request.META.get("REMOTE_ADDR") or "").strip()
     if remote_addr:
         client_identity = f"remote:{remote_addr}"
-        return hashlib.sha256(client_identity.encode("utf-8")).hexdigest()
+        return hmac.new(
+            str(settings.SECRET_KEY).encode("utf-8"),
+            client_identity.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
     session = getattr(request, "session", None)
     if hasattr(session, "get"):
         guest_key = (session.get(GALLERY_AP_GUEST_SESSION_KEY) or "").strip()


### PR DESCRIPTION
### Motivation

- Fix an unauthenticated abuse vector where the AP guest flow derived a `guest_key` only from the Django session, allowing attackers to rotate cookies/sessions to bypass daily upload and one-reaction limits.

### Description

- Replace the session-only `guest_key` derivation in `_ap_guest_key` with a deterministic client fingerprint hash computed from `HTTP_X_FORWARDED_FOR`, `REMOTE_ADDR`, and `HTTP_USER_AGENT`, falling back to the existing session UUID behavior when metadata is unavailable.
- Add `import hashlib` and preserve a UUID-based session fallback so edge cases without request metadata continue to work.
- Add regression tests `test_ap_guest_upload_limit_applies_across_fresh_sessions` and `test_ap_guest_reaction_is_scoped_across_fresh_sessions` to `apps/gallery/tests/test_gallery.py` to assert upload and reaction limits still apply when a fresh `Client()` (new session/cookies) is used.

### Testing

- Added automated tests in `apps/gallery/tests/test_gallery.py` but full test execution could not be run in this environment because `.venv` is missing and `./install.sh` failed due to a missing system dependency (`redis-server`).
- Attempted to run ` .venv/bin/python manage.py test run -- apps/gallery/tests/test_gallery.py` which could not be executed because the virtualenv is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69e114cf083268acec33346e0c44d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

### apps/gallery/views.py
Added `hashlib` import and rewrote `_ap_guest_key()` to derive guest identity from a deterministic client fingerprint based on REMOTE_ADDR:

- Primary mechanism: if `REMOTE_ADDR` is present, return SHA-256 of `f"remote:{remote_addr}"`.
- Fallbacks: if `REMOTE_ADDR` is absent, attempt to read or create a UUID-based guest key stored in the session via `GALLERY_AP_GUEST_SESSION_KEY`; if session access is unavailable, return a fresh `uuid4().hex`.

This prevents session-only derived `guest_key` values and makes guest identity persist across session/cookie rotations.

### apps/gallery/tests/test_gallery.py
Added Django `Client` usage and two regression tests verifying quotas apply across fresh sessions:

- `test_ap_guest_upload_limit_applies_across_fresh_sessions`: Verifies the one-image-per-day upload limit is enforced when a second upload is attempted from a fresh `Client()` (new session/cookies), demonstrating the limit is scoped by the new fingerprint mechanism rather than session.
- `test_ap_guest_reaction_is_scoped_across_fresh_sessions`: Verifies guest reactions are scoped by the derived guest identity across fresh sessions (a fresh `Client()` replacing a prior reaction results in a single reaction record with the updated value).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->