### PR TITLE
tests: include gateway in gallery module roles

### DIFF
--- a/apps/gallery/tests/test_gallery.py
+++ b/apps/gallery/tests/test_gallery.py
@@ -678,7 +678,7 @@ def test_gallery_module_fixture_exposes_ap_guest_landing():
     )
 
     assert module["fields"]["path"] == "/gallery/"
-    assert module["fields"]["roles"] == [["Control"], ["Satellite"]]
+    assert module["fields"]["roles"] == [["Control"], ["Satellite"], ["Gateway"]]
     assert landing["fields"]["module"] == ["/gallery/"]
     assert landing["fields"]["path"] == reverse("gallery:ap")
 


### PR DESCRIPTION
### Motivation
- Fix install-health issue #7610 where the full pytest smoke fails after the gallery module fixture gained the Gateway role while the fixture regression test still expected only Control and Satellite.

### Description
- Update `test_gallery_module_fixture_exposes_ap_guest_landing` to expect `Gateway` alongside `Control` and `Satellite`.

### Testing
- `manage.py test run -- apps/gallery/tests/test_gallery.py -k test_gallery_module_fixture_exposes_ap_guest_landing` (1 passed)
- `manage.py test run -- apps/gallery/tests/test_gallery.py` (40 passed)
- `python -m ruff check apps/gallery/tests/test_gallery.py`
- `manage.py check --fail-level ERROR`

Fixes #7610