### PR TITLE
Keep thermometer sampling active for LCD

### DIFF
--- a/apps/sensors/tests/test_tasks.py
+++ b/apps/sensors/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ def test_thermometer_sampling_is_in_static_beat_schedule() -> None:
     schedule = settings.CELERY_BEAT_SCHEDULE["thermometer_sampling"]
 
     assert schedule["task"] == sample_thermometers.name
+    assert schedule["schedule"] == timedelta(minutes=1)
 
 
 def test_scan_usb_trackers_records_passive_match(settings, tmp_path: Path) -> None:

--- a/apps/sensors/tests/test_tasks.py
+++ b/apps/sensors/tests/test_tasks.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from django.conf import settings
 
 from apps.sensors.models import Thermometer, UsbTracker
 from apps.sensors.tasks import sample_thermometers, scan_usb_trackers
 
 pytestmark = pytest.mark.django_db
+
+
+def test_thermometer_sampling_is_in_static_beat_schedule() -> None:
+    schedule = settings.CELERY_BEAT_SCHEDULE["thermometer_sampling"]
+
+    assert schedule["task"] == sample_thermometers.name
 
 
 def test_scan_usb_trackers_records_passive_match(settings, tmp_path: Path) -> None:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -62,6 +62,17 @@ NET_MESSAGE_DISABLE_PROPAGATION = env_bool("NET_MESSAGE_DISABLE_PROPAGATION", Fa
 NODES_ENABLE_SIBLING_IPC = env_bool("NODES_ENABLE_SIBLING_IPC", False)
 ENABLE_USAGE_ANALYTICS = env_bool("ENABLE_USAGE_ANALYTICS", False)
 REPORTS_HTML_TO_PDF_ENABLED = env_bool("REPORTS_HTML_TO_PDF_ENABLED", True)
+THERMOMETER_SOURCE = os.environ.get("THERMOMETER_SOURCE", "auto").strip() or "auto"
+THERMOMETER_PATH_TEMPLATE = (
+    os.environ.get(
+        "THERMOMETER_PATH_TEMPLATE",
+        "/sys/bus/w1/devices/{slug}/temperature",
+    ).strip()
+    or "/sys/bus/w1/devices/{slug}/temperature"
+)
+THERMOMETER_I2C_PATH_TEMPLATE = os.environ.get(
+    "THERMOMETER_I2C_PATH_TEMPLATE", ""
+).strip()
 ROUTE_PROVIDERS = [
     "apps.actions.routes",
     "apps.awg.routes",

--- a/config/settings/celery.py
+++ b/config/settings/celery.py
@@ -41,6 +41,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": LLM_SUMMARY_CELERY_TASK_NAME,
         "schedule": timedelta(minutes=5),
     },
+    "thermometer_sampling": {
+        "task": "apps.sensors.tasks.sample_thermometers",
+        "schedule": timedelta(minutes=1),
+    },
     "ocpp_configuration_check": {
         "task": "apps.ocpp.tasks.schedule_daily_charge_point_configuration_checks",
         "schedule": crontab(minute=0, hour=0),


### PR DESCRIPTION
## Summary
- expose thermometer source and path settings from environment
- add thermometer sampling to the static Celery Beat schedule used by suite deployments
- cover the static schedule entry with a focused sensor task test

## Validation
- C:\Users\arthexis\Repos\arthexis\.venv\Scripts\python -m pytest apps\sensors\tests\test_tasks.py apps\sensors\tests\test_thermometers.py

## Deployment note
GWAY still needs deployment-local values such as THERMOMETER_SOURCE=i2c and THERMOMETER_I2C_PATH_TEMPLATE for its hwmon path; those are intentionally not committed.