### PR TITLE
Add host status fallback to LCD summaries

### DIFF
--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
+import shutil
+import subprocess
 import textwrap
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -24,6 +27,10 @@ logger = logging.getLogger(__name__)
 LCD_COLUMNS = 16
 LCD_SUMMARY_FRAME_COUNT = 10
 LCD_SUMMARY_EXPIRES_AFTER = timedelta(minutes=10)
+STATUS_COMMAND_TIMEOUT_SECONDS = 1.5
+STATUS_JOURNAL_LOOKBACK = "2 hours ago"
+STATUS_JOURNAL_MAX_LINES = 80
+STATUS_SOURCE_LINE_LIMIT = 8
 DEFAULT_MODEL_DIR = Path(settings.BASE_DIR) / "work" / "llm" / "lcd-summary"
 DEFAULT_MODEL_FILE = "MODEL.README"
 
@@ -35,6 +42,27 @@ TIMESTAMP_RE = re.compile(
 )
 LEVEL_RE = re.compile(r"\b(INFO|DEBUG|WARNING|ERROR|CRITICAL)\b")
 WHITESPACE_RE = re.compile(r"\s+")
+JOURNAL_TIME_RE = re.compile(r"\d{4}-\d{2}-\d{2}T(?P<hhmm>\d{2}:\d{2}):")
+
+STATUS_JOURNAL_KEEP_PATTERNS = (
+    "fat-fs",
+    "fat read failed",
+    "asking for cache data failed",
+    "i/o error",
+    "usb write fail",
+    "failed to start",
+    "failed with result",
+)
+STATUS_JOURNAL_DROP_PATTERNS = (
+    "bluetoothd",
+    "connection closed by remote host",
+    "kex_exchange_identification",
+    "src/plugin.c:init_plugin",
+)
+USB_ROLE_LABELS = {
+    "bastion-unlock": "bastion",
+    "kindle-postbox": "kindle",
+}
 
 
 @dataclass(frozen=True)
@@ -170,11 +198,267 @@ def compact_log_chunks(chunks: Iterable[LogChunk]) -> str:
     return "\n".join(compacted)
 
 
+def collect_noteworthy_status_lines() -> list[str]:
+    """Return compact host status lines that are useful when log deltas are quiet."""
+
+    lines: list[str] = []
+    lines.extend(_systemd_failed_status_lines())
+    lines.extend(_journal_status_lines())
+    lines.extend(_usb_inventory_status_lines())
+
+    host_line = _host_resource_status_line()
+    if host_line:
+        lines.append(host_line)
+
+    return _dedupe_status_lines(lines)[:STATUS_SOURCE_LINE_LIMIT]
+
+
+def _run_status_command(args: list[str]) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=STATUS_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+
+
+def _systemd_failed_status_lines() -> list[str]:
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return []
+
+    result = _run_status_command(
+        [systemctl, "--failed", "--no-legend", "--plain", "--no-pager"]
+    )
+    if result is None:
+        return []
+    if result.returncode not in {0, 1}:
+        return []
+
+    units: list[str] = []
+    for raw_line in result.stdout.splitlines():
+        parts = raw_line.split()
+        if not parts:
+            continue
+        units.append(parts[0].removesuffix(".service"))
+
+    if not units:
+        return ["OK status: 0 failed units"]
+
+    shown = ", ".join(units[:3])
+    suffix = "" if len(units) <= 3 else f" +{len(units) - 3}"
+    return [f"ERR status: failed units {shown}{suffix}"]
+
+
+def _journal_status_lines() -> list[str]:
+    journalctl = shutil.which("journalctl")
+    if not journalctl:
+        return []
+
+    result = _run_status_command(
+        [
+            journalctl,
+            "-p",
+            "3",
+            "-b",
+            "--since",
+            STATUS_JOURNAL_LOOKBACK,
+            "--lines",
+            str(STATUS_JOURNAL_MAX_LINES),
+            "--no-pager",
+            "--output=short-iso",
+        ]
+    )
+    if result is None or result.returncode not in {0, 1}:
+        return []
+
+    grouped: dict[str, dict[str, object]] = {}
+    for raw_line in result.stdout.splitlines():
+        if not _is_noteworthy_journal_line(raw_line):
+            continue
+        label = _journal_status_label(raw_line)
+        entry = grouped.setdefault(label, {"count": 0, "last": ""})
+        entry["count"] = int(entry["count"]) + 1
+        line_time = _journal_line_time(raw_line)
+        if line_time:
+            entry["last"] = line_time
+
+    lines: list[str] = []
+    for label, entry in sorted(
+        grouped.items(),
+        key=lambda item: (-int(item[1]["count"]), item[0]),
+    )[:3]:
+        last = f" last {entry['last']}" if entry.get("last") else ""
+        lines.append(f"ERR journal: {label} x{entry['count']}{last}")
+    return lines
+
+
+def _is_noteworthy_journal_line(raw_line: str) -> bool:
+    lowered = raw_line.lower()
+    if not lowered.strip():
+        return False
+    if any(pattern in lowered for pattern in STATUS_JOURNAL_DROP_PATTERNS):
+        return False
+    return any(pattern in lowered for pattern in STATUS_JOURNAL_KEEP_PATTERNS)
+
+
+def _journal_status_label(raw_line: str) -> str:
+    lowered = raw_line.lower()
+    if "fat-fs" in lowered or "fat read failed" in lowered:
+        return "USB FAT sda1"
+    if "asking for cache data failed" in lowered:
+        return "USB cache sda"
+    if "usb write fail" in lowered:
+        return "USB write fail"
+
+    failed_start = re.search(r"Failed to start ([^:.]+)", raw_line)
+    if failed_start:
+        return f"failed start {failed_start.group(1).strip()[:24]}"
+    if "failed with result" in lowered:
+        return "unit failed"
+    return "system error"
+
+
+def _journal_line_time(raw_line: str) -> str:
+    match = JOURNAL_TIME_RE.search(raw_line)
+    if not match:
+        return ""
+    return match.group("hhmm")
+
+
+def _usb_inventory_status_lines() -> list[str]:
+    inventory = _read_usb_inventory()
+    if not isinstance(inventory, dict):
+        return []
+
+    devices = inventory.get("devices")
+    if not isinstance(devices, list):
+        return []
+
+    lines: list[str] = []
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+        if device.get("transport") != "usb" or device.get("type") != "part":
+            continue
+
+        name = str(device.get("name") or device.get("path") or "usb")
+        label = str(device.get("label") or device.get("fstype") or "device")
+        roles = device.get("claimed_roles") or []
+        role = _usb_role_label(str(roles[0])) if roles else "mounted"
+        mounts = device.get("mounts") or []
+        if not mounts:
+            lines.append(f"WRN usb: {name} {label} unmounted")
+            continue
+
+        is_read_only = any(
+            isinstance(mount, dict) and mount.get("read_only") for mount in mounts
+        )
+        mode = "ro" if is_read_only else "rw"
+        if role != "mounted":
+            lines.append(f"OK usb: {name} {mode} {role}")
+        else:
+            lines.append(f"OK usb: {name} {label} {mode}")
+
+    return lines[:2]
+
+
+def _usb_role_label(role: str) -> str:
+    return USB_ROLE_LABELS.get(role, role)
+
+
+def _read_usb_inventory() -> dict[str, object] | None:
+    path = Path(os.getenv("ARTHEXIS_USB_INVENTORY", "/run/arthexis-usb/devices.json"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _host_resource_status_line() -> str:
+    parts: list[str] = []
+
+    temp_c = _read_cpu_temp_c()
+    if temp_c is not None:
+        parts.append(f"t{temp_c}C")
+
+    try:
+        usage = shutil.disk_usage(settings.BASE_DIR)
+    except OSError:
+        usage = None
+    if usage and usage.total:
+        disk_percent = round((usage.used / usage.total) * 100)
+        parts.append(f"d{disk_percent}%")
+
+    mem_percent = _read_memory_used_percent()
+    if mem_percent is not None:
+        parts.append(f"m{mem_percent}%")
+
+    if not parts:
+        return ""
+    return f"OK host: {' '.join(parts)}"
+
+
+def _read_cpu_temp_c() -> int | None:
+    path = Path("/sys/class/thermal/thermal_zone0/temp")
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+        value = float(raw)
+    except (OSError, ValueError):
+        return None
+    if value > 1000:
+        value = value / 1000
+    return round(value)
+
+
+def _read_memory_used_percent() -> int | None:
+    path = Path("/proc/meminfo")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    values: dict[str, int] = {}
+    for line in lines:
+        key, _separator, rest = line.partition(":")
+        if key not in {"MemTotal", "MemAvailable"}:
+            continue
+        raw_value = rest.strip().split()[0]
+        try:
+            values[key] = int(raw_value)
+        except (IndexError, ValueError):
+            continue
+
+    total = values.get("MemTotal")
+    available = values.get("MemAvailable")
+    if not total or available is None:
+        return None
+    used = max(total - available, 0)
+    return round((used / total) * 100)
+
+
+def _dedupe_status_lines(lines: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for line in lines:
+        cleaned = WHITESPACE_RE.sub(" ", line).strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return deduped
+
+
 def build_summary_prompt(compacted_logs: str, *, now: datetime) -> str:
     cutoff = (now - timedelta(minutes=4)).strftime("%H:%M")
     instructions = textwrap.dedent(
         f"""
         You summarize system logs for a 16x2 LCD. Focus on the last 4 minutes (cutoff {cutoff}).
+        When LOGS contains current host-status lines, show the useful facts directly.
         Highlight urgent operator actions or failures. Use shorthand, abbreviations, and ASCII symbols.
         Output 8-10 LCD screens. Each screen is two lines (subject then body).
         Aim for 14-18 chars per line, avoid scrolling when possible.
@@ -304,9 +588,21 @@ def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -
     chunks = collect_recent_logs(config, since=since)
     compacted_logs = compact_log_chunks(chunks)
     if not compacted_logs:
-        config.last_run_at = now
-        config.save(update_fields=["last_run_at", "log_offsets", "model_path", "installed_at", "updated_at"])
-        return "skipped:no-logs"
+        status_lines = collect_noteworthy_status_lines()
+        if status_lines:
+            compacted_logs = "[status]\n" + "\n".join(status_lines)
+        else:
+            config.last_run_at = now
+            config.save(
+                update_fields=[
+                    "last_run_at",
+                    "log_offsets",
+                    "model_path",
+                    "installed_at",
+                    "updated_at",
+                ]
+            )
+            return "skipped:no-logs"
 
     prompt = build_summary_prompt(compacted_logs, now=now)
     summarizer = LocalLLMSummarizer()

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -222,7 +222,7 @@ def _run_status_command(args: list[str]) -> subprocess.CompletedProcess[str] | N
             check=False,
             timeout=STATUS_COMMAND_TIMEOUT_SECONDS,
         )
-    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError):
         return None
 
 
@@ -341,30 +341,34 @@ def _usb_inventory_status_lines() -> list[str]:
 
     lines: list[str] = []
     for device in devices:
-        if not isinstance(device, dict):
-            continue
-        if device.get("transport") != "usb" or device.get("type") != "part":
-            continue
-
-        name = str(device.get("name") or device.get("path") or "usb")
-        label = str(device.get("label") or device.get("fstype") or "device")
-        roles = device.get("claimed_roles") or []
-        role = _usb_role_label(str(roles[0])) if roles else "mounted"
-        mounts = device.get("mounts") or []
-        if not mounts:
-            lines.append(f"WRN usb: {name} {label} unmounted")
-            continue
-
-        is_read_only = any(
-            isinstance(mount, dict) and mount.get("read_only") for mount in mounts
-        )
-        mode = "ro" if is_read_only else "rw"
-        if role != "mounted":
-            lines.append(f"OK usb: {name} {mode} {role}")
-        else:
-            lines.append(f"OK usb: {name} {label} {mode}")
+        line = _usb_device_status_line(device)
+        if line:
+            lines.append(line)
 
     return lines[:2]
+
+
+def _usb_device_status_line(device: object) -> str:
+    if not isinstance(device, dict):
+        return ""
+    if device.get("transport") != "usb" or device.get("type") != "part":
+        return ""
+
+    name = str(device.get("name") or device.get("path") or "usb")
+    label = str(device.get("label") or device.get("fstype") or "device")
+    roles = device.get("claimed_roles") or []
+    role = _usb_role_label(str(roles[0])) if roles else "mounted"
+    mounts = device.get("mounts") or []
+    if not mounts:
+        return f"WRN usb: {name} {label} unmounted"
+
+    is_read_only = any(
+        isinstance(mount, dict) and mount.get("read_only") for mount in mounts
+    )
+    mode = "ro" if is_read_only else "rw"
+    if role != "mounted":
+        return f"OK usb: {name} {mode} {role}"
+    return f"OK usb: {name} {label} {mode}"
 
 
 def _usb_role_label(role: str) -> str:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import subprocess
 
 from apps.summary import services
 from apps.tasks.tasks import _write_lcd_frames
@@ -71,6 +72,7 @@ def test_no_log_generation_removes_legacy_low_summary_frames(
     monkeypatch.setattr(services, "get_summary_config", lambda: FakeConfig())
     monkeypatch.setattr(services, "ensure_local_model", lambda config: None)
     monkeypatch.setattr(services, "collect_recent_logs", lambda config, since: [])
+    monkeypatch.setattr(services, "collect_noteworthy_status_lines", lambda: [])
 
     result = services.execute_log_summary_generation()
 
@@ -102,3 +104,63 @@ def test_suite_gate_skip_removes_legacy_low_summary_frames(
     assert result == "skipped:suite-feature-disabled"
     assert not (lock_dir / "lcd-low").exists()
     assert not (lock_dir / "lcd-low-1").exists()
+
+
+def test_collect_noteworthy_status_lines_adds_host_fallback_sources(monkeypatch) -> None:
+    def fake_which(name: str) -> str | None:
+        if name in {"journalctl", "systemctl"}:
+            return f"/usr/bin/{name}"
+        return None
+
+    def fake_run(args: list[str]):
+        if "systemctl" in args[0]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if "journalctl" in args[0]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout="\n".join(
+                    [
+                        "2026-05-03T08:32:27-0600 host kernel: FAT-fs (sda1): "
+                        "Directory bread(block 32768) failed",
+                        "2026-05-03T08:32:46-0600 host kernel: FAT-fs (sda1): "
+                        "FAT read failed (blocknr 1986)",
+                        "2026-05-03T09:59:22-0600 host sshd[1]: error: "
+                        "kex_exchange_identification: Connection closed by remote host",
+                    ]
+                ),
+                stderr="",
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(services.shutil, "which", fake_which)
+    monkeypatch.setattr(services, "_run_status_command", fake_run)
+    monkeypatch.setattr(
+        services,
+        "_read_usb_inventory",
+        lambda: {
+            "devices": [
+                {
+                    "claimed_roles": ["bastion-unlock"],
+                    "label": "ESD-USB",
+                    "mounts": [{"read_only": True}],
+                    "name": "sda1",
+                    "transport": "usb",
+                    "type": "part",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        services,
+        "_host_resource_status_line",
+        lambda: "OK host: t62C d54% m46%",
+    )
+
+    lines = services.collect_noteworthy_status_lines()
+
+    assert "OK status: 0 failed units" in lines
+    assert "ERR journal: USB FAT sda1 x2 last 08:32" in lines
+    assert "OK usb: sda1 ro bastion" in lines
+    assert "OK host: t62C d54% m46%" in lines
+    assert not any("kex_exchange" in line for line in lines)

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -325,9 +325,6 @@ SUMMARY_SOURCE_ALIASES = {
 SUMMARY_TASK_RE = re.compile(r"Task ([\w.]+)\[")
 SUMMARY_DUE_TASK_RE = re.compile(r"Sending due task [\w-]+ \(([\w.]+)\)")
 SUMMARY_SOURCE_RE = re.compile(r"^(?:DBG|INF|WRN|ERR|CRI)\s+([\w.]+):")
-SUMMARY_STATUS_RE = re.compile(
-    r"^(?P<severity>OK|ERR|WRN|CRI)\s+(?P<source>[a-z][\w-]*):\s+(?P<body>.+)$"
-)
 SUMMARY_STATUS_SOURCE_LABELS = {
     "host": "Host",
     "journal": "Journal",
@@ -368,15 +365,21 @@ def _summary_source_label(line: str) -> str | None:
 
 
 def _summary_status_screen(line: str) -> tuple[str, str] | None:
-    match = SUMMARY_STATUS_RE.match(line)
-    if not match:
+    severity, separator, remainder = line.partition(" ")
+    if separator == "" or severity not in {"OK", "ERR", "WRN", "CRI"}:
         return None
 
-    severity = match.group("severity")
-    source = match.group("source")
+    source, separator, body = remainder.partition(":")
+    source = source.strip()
+    body = body.strip()
+    if separator == "" or not source or not body:
+        return None
+    if not all(ch.isalnum() or ch in {"_", "-"} for ch in source):
+        return None
+
     label = SUMMARY_STATUS_SOURCE_LABELS.get(source, source.replace("-", " ").title())
     subject = label if severity == "OK" else f"{severity} {label}"
-    return (subject[:16], _summary_compact_line(match.group("body")))
+    return (subject[:16], _summary_compact_line(body))
 
 
 def _summary_top_counts(counts: dict[str, int], *, limit: int) -> list[tuple[str, int]]:

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -254,6 +254,11 @@ class LocalLLMSummarizer:
 
         error_lines = [line for line in event_lines if _summary_severity(line) == "ERR"]
         warn_lines = [line for line in event_lines if _summary_severity(line) == "WRN"]
+        status_screens = [
+            screen
+            for line in event_lines
+            if (screen := _summary_status_screen(line)) is not None
+        ]
         task_counts: dict[str, int] = {}
         source_counts: dict[str, int] = {}
 
@@ -267,6 +272,11 @@ class LocalLLMSummarizer:
                 source_counts[source_label] = source_counts.get(source_label, 0) + 1
 
         screens: list[tuple[str, str]] = []
+        if status_screens and len(status_screens) == len(event_lines):
+            return "\n---\n".join(
+                f"{subject}\n{body}" for subject, body in status_screens[:5]
+            )
+
         if error_lines or warn_lines:
             screens.append(
                 (
@@ -286,6 +296,10 @@ class LocalLLMSummarizer:
         if len(screens) < 3:
             for label, count in _summary_top_counts(source_counts, limit=3):
                 screens.append((label, f"{count}x /5m"))
+
+        for screen in status_screens[:3]:
+            if screen not in screens:
+                screens.append(screen)
 
         if len(screens) == 1:
             screens.append(("Routine only", "No action"))
@@ -311,6 +325,15 @@ SUMMARY_SOURCE_ALIASES = {
 SUMMARY_TASK_RE = re.compile(r"Task ([\w.]+)\[")
 SUMMARY_DUE_TASK_RE = re.compile(r"Sending due task [\w-]+ \(([\w.]+)\)")
 SUMMARY_SOURCE_RE = re.compile(r"^(?:DBG|INF|WRN|ERR|CRI)\s+([\w.]+):")
+SUMMARY_STATUS_RE = re.compile(
+    r"^(?P<severity>OK|ERR|WRN|CRI)\s+(?P<source>[a-z][\w-]*):\s+(?P<body>.+)$"
+)
+SUMMARY_STATUS_SOURCE_LABELS = {
+    "host": "Host",
+    "journal": "Journal",
+    "status": "Status",
+    "usb": "USB key",
+}
 
 
 def _summary_severity(line: str) -> str:
@@ -344,6 +367,18 @@ def _summary_source_label(line: str) -> str | None:
     return _summary_alias(match.group(1), SUMMARY_SOURCE_ALIASES)
 
 
+def _summary_status_screen(line: str) -> tuple[str, str] | None:
+    match = SUMMARY_STATUS_RE.match(line)
+    if not match:
+        return None
+
+    severity = match.group("severity")
+    source = match.group("source")
+    label = SUMMARY_STATUS_SOURCE_LABELS.get(source, source.replace("-", " ").title())
+    subject = label if severity == "OK" else f"{severity} {label}"
+    return (subject[:16], _summary_compact_line(match.group("body")))
+
+
 def _summary_top_counts(counts: dict[str, int], *, limit: int) -> list[tuple[str, int]]:
     return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit]
 
@@ -357,7 +392,7 @@ def _summary_compact_line(line: str) -> str:
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if not cleaned:
         return "-"
-    return cleaned[:16]
+    return cleaned[:16].rstrip()
 
 
 def _write_lcd_frames(

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -30,3 +30,21 @@ def test_local_lcd_summary_reports_quiet_logs() -> None:
     output = LocalLLMSummarizer().summarize("LOGS:\n[celery.log]\n")
 
     assert output == "Quiet\nNo new logs\n---"
+
+
+def test_local_lcd_summary_renders_status_lines_directly() -> None:
+    prompt = "\n".join(
+        [
+            "LOGS:",
+            "[status]",
+            "ERR journal: USB FAT sda1 x18 last 08:32",
+            "OK usb: sda1 ro bastion",
+            "OK host: t62C d54% m46%",
+        ]
+    )
+
+    output = LocalLLMSummarizer().summarize(prompt)
+
+    assert "ERR Journal\nUSB FAT sda1 x18" in output
+    assert "USB key\nsda1 ro bastion" in output
+    assert "Host\nt62C d54% m46%" in output


### PR DESCRIPTION
## Summary
- add a quiet-window host status source for LCD summaries
- include systemd failed-unit state, filtered recent journal errors, USB inventory status, and compact host resource data
- render status lines directly in the deterministic LCD summarizer so limited 16x2 space carries useful facts

## Validation
- .venv/bin/python manage.py test run apps/tasks/tests/test_lcd_log_summary.py apps/summary/tests/test_services.py apps/summary/tests/test_celery_schedule.py apps/nodes/tests/test_node_feature_sync_tasks.py apps/screens/tests/test_lcd_runner.py --verbosity 1
- .venv/bin/python manage.py check
- live preview on gway-001 showed Status / 0 failed units, USB key / sda1 ro bastion, Host / t68C d51% m51%