### PR TITLE
Improve public site for PS4 browser navigation

### DIFF
--- a/apps/docs/templates/docs/readme.html
+++ b/apps/docs/templates/docs/readme.html
@@ -79,6 +79,13 @@
       fullDocumentLinks[linkIndex].removeAttribute("hidden");
     }
     var hasControllerFlag = function () {
+      var decodeQueryPart = function (value) {
+        try {
+          return decodeURIComponent(value || "").toLowerCase();
+        } catch (error) {
+          return "";
+        }
+      };
       var falseValues = ["0", "false", "off", "no"];
       var parts = window.location.search.replace(/^\?/, "").split("&");
       for (var index = 0; index < parts.length; index += 1) {
@@ -86,8 +93,8 @@
           continue;
         }
         var keyValue = parts[index].split("=");
-        var key = decodeURIComponent(keyValue[0] || "").toLowerCase();
-        var value = decodeURIComponent(keyValue[1] || "").toLowerCase();
+        var key = decodeQueryPart(keyValue[0]);
+        var value = decodeQueryPart(keyValue[1]);
         if ((key === "controller" || key === "tv" || key === "ps4") && falseValues.indexOf(value) === -1) {
           return true;
         }

--- a/apps/docs/templates/docs/readme.html
+++ b/apps/docs/templates/docs/readme.html
@@ -44,6 +44,9 @@
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
             <span>{% trans "Loading remaining sections…" %}</span>
           </div>
+          <a class="btn btn-outline-primary btn-sm reader-full-document-link" href="{{ full_document_url }}">
+            {% trans "Load full document" %}
+          </a>
           <noscript>
             <a class="btn btn-outline-primary btn-sm mt-3" href="{{ full_document_url }}">
               {% trans "Load full document" %}
@@ -71,15 +74,21 @@
 {% endif %}
 <script>
   (function () {
-    const RELOAD_DELAY = 5 * 60 * 1000;
-    let timer;
-    const resetTimer = () => {
+    var controllerMode = document.documentElement.classList.contains("controller-mode") ||
+      /(?:\?|&)(controller|tv|ps4)(?:=1|=true|&|$)/i.test(window.location.search);
+    var reloadDelay = controllerMode ? 30 * 60 * 1000 : 5 * 60 * 1000;
+    var timer;
+    var resetTimer = function () {
       clearTimeout(timer);
-      timer = setTimeout(() => {
+      timer = setTimeout(function () {
+        if (document.body && document.body.classList.contains("user-story-open")) {
+          resetTimer();
+          return;
+        }
         window.location.reload();
-      }, RELOAD_DELAY);
+      }, reloadDelay);
     };
-    ["click", "mousemove", "keydown", "scroll", "touchstart"].forEach((evt) => {
+    ["click", "mousemove", "pointermove", "focusin", "keydown", "scroll", "touchstart"].forEach(function (evt) {
       document.addEventListener(evt, resetTimer, { passive: true });
     });
     resetTimer();

--- a/apps/docs/templates/docs/readme.html
+++ b/apps/docs/templates/docs/readme.html
@@ -44,7 +44,7 @@
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
             <span>{% trans "Loading remaining sections…" %}</span>
           </div>
-          <a class="btn btn-outline-primary btn-sm reader-full-document-link" href="{{ full_document_url }}">
+          <a class="btn btn-outline-primary btn-sm reader-full-document-link" href="{{ full_document_url }}" hidden>
             {% trans "Load full document" %}
           </a>
           <noscript>
@@ -74,8 +74,28 @@
 {% endif %}
 <script>
   (function () {
+    var fullDocumentLinks = document.querySelectorAll(".reader-full-document-link[hidden]");
+    for (var linkIndex = 0; linkIndex < fullDocumentLinks.length; linkIndex += 1) {
+      fullDocumentLinks[linkIndex].removeAttribute("hidden");
+    }
+    var hasControllerFlag = function () {
+      var falseValues = ["0", "false", "off", "no"];
+      var parts = window.location.search.replace(/^\?/, "").split("&");
+      for (var index = 0; index < parts.length; index += 1) {
+        if (!parts[index]) {
+          continue;
+        }
+        var keyValue = parts[index].split("=");
+        var key = decodeURIComponent(keyValue[0] || "").toLowerCase();
+        var value = decodeURIComponent(keyValue[1] || "").toLowerCase();
+        if ((key === "controller" || key === "tv" || key === "ps4") && falseValues.indexOf(value) === -1) {
+          return true;
+        }
+      }
+      return false;
+    };
     var controllerMode = document.documentElement.classList.contains("controller-mode") ||
-      /(?:\?|&)(controller|tv|ps4)(?:=1|=true|&|$)/i.test(window.location.search);
+      hasControllerFlag();
     var reloadDelay = controllerMode ? 30 * 60 * 1000 : 5 * 60 * 1000;
     var timer;
     var resetTimer = function () {

--- a/apps/docs/templates/includes/reader_qr_script.html
+++ b/apps/docs/templates/includes/reader_qr_script.html
@@ -154,7 +154,8 @@
     };
 
     const summarizeFirstRow = (table) => {
-      const firstBodyRow = table.tBodies[0]?.rows[0] || table.rows[1];
+      const firstBody = table.tBodies[0];
+      const firstBodyRow = (firstBody && firstBody.rows[0]) || table.rows[1];
       if (!firstBodyRow) {
         return "";
       }
@@ -198,6 +199,8 @@
 
         table.id = tableId;
         table.classList.add("reader-collapsible-table");
+        table.tabIndex = 0;
+        table.setAttribute("aria-label", headingText);
         table.setAttribute("hidden", "");
         table.dataset.tableToggleReady = "true";
 

--- a/apps/docs/tests/test_controller_reading_mode.py
+++ b/apps/docs/tests/test_controller_reading_mode.py
@@ -1,0 +1,18 @@
+import pytest
+from django.test import RequestFactory
+
+from apps.docs import views
+
+
+@pytest.mark.parametrize("query", ["controller=1", "tv=true", "ps4", "ps4=on"])
+def test_controller_query_flags_force_full_document(query):
+    request = RequestFactory().get(f"/docs/?{query}")
+
+    assert views._should_force_controller_full_document(request) is True
+
+
+@pytest.mark.parametrize("query", ["controller=0", "tv=false", "ps4=off", "ps4=no"])
+def test_controller_query_flags_allow_opt_out(query):
+    request = RequestFactory().get(f"/docs/?{query}")
+
+    assert views._should_force_controller_full_document(request) is False

--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -10,12 +10,11 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.db.models import Q
-from django.http import HttpRequest
-from django.http import FileResponse, Http404, HttpResponse
+from django.http import FileResponse, Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch, reverse
-from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.utils import timezone
+from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.views.decorators.cache import never_cache
 
 from apps.gallery.models import GalleryImage
@@ -56,6 +55,8 @@ LIBRARY_ROOT_QUERY_PARAMETER = "virtual_root"
 FULL_CONTENT_DEFAULT_DOCUMENTS = {
     "docs/development/install-lifecycle-scripts-manual.md",
 }
+CONTROLLER_FULL_DOCUMENT_QUERY_PARAMS = ("controller", "tv", "ps4")
+CONTROLLER_FALSE_QUERY_VALUES = {"0", "false", "off", "no"}
 
 
 DEVELOPER_DOCUMENTS_SECURITY_GROUP_NAMES = (
@@ -224,6 +225,16 @@ def _build_render_cache_key(file_path: Path, lang: str) -> str:
     except OSError:
         mtime = 0
     return f"docs:render:{file_path}:{mtime}:{lang}"
+
+
+def _should_force_controller_full_document(request: HttpRequest) -> bool:
+    for query_param in CONTROLLER_FULL_DOCUMENT_QUERY_PARAMS:
+        if query_param not in request.GET:
+            continue
+        value = (request.GET.get(query_param) or "").strip().lower()
+        if value not in CONTROLLER_FALSE_QUERY_VALUES:
+            return True
+    return False
 
 
 def _iter_document_paths(root: Path) -> list[Path]:
@@ -871,8 +882,10 @@ def render_readme_page(
     else:
         html, toc_html = _render_document_cached(document.file, cache_key)
     force_full_document = _should_default_full_document(normalized_doc)
-    full_document = request.GET.get("full") == "1" or (
-        force_full_document and "full" not in request.GET
+    full_document = (
+        request.GET.get("full") == "1"
+        or _should_force_controller_full_document(request)
+        or (force_full_document and "full" not in request.GET)
     )
     initial_content, remaining_content = rendering.split_html_sections(html, 2)
     if full_document:

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -16,8 +16,94 @@
   --user-story-accent-text: #f8fafc;
   --bs-primary: var(--site-primary);
   --bs-primary-rgb: var(--site-primary-rgb);
+  --bs-body-bg: #ffffff;
+  --bs-body-color: #212529;
+  --bs-dark: #212529;
+  --bs-white: #ffffff;
+  --bs-secondary-color: #6c757d;
+  --bs-emphasis-color-rgb: 0, 0, 0;
+  --bs-border-width: 1px;
+  --bs-border-radius: 0.375rem;
+  --bs-border-radius-lg: 0.5rem;
+  --bs-border-color: #dee2e6;
+  --bs-border-color-translucent: rgba(0, 0, 0, 0.175);
+  --bs-spacer: 1rem;
+  --bs-gap: 0.5rem;
   --bs-link-color: var(--site-primary);
   --bs-link-hover-color: var(--site-primary-strong);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  margin: 0;
+}
+
+:where(.container),
+:where(.container-fluid) {
+  margin-inline: auto;
+  padding-inline: 0.75rem;
+  width: 100%;
+}
+
+:where(.container) {
+  max-width: 1140px;
+}
+
+:where(.btn) {
+  align-items: center;
+  border: var(--bs-border-width) solid transparent;
+  border-radius: var(--bs-border-radius);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 1.5;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.75rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+:where(.navbar-nav),
+:where(.dropdown-menu) {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+a:focus,
+button:focus,
+[role='button']:focus,
+input:focus,
+select:focus,
+textarea:focus,
+.btn:focus,
+.dropdown-item:focus,
+.nav-link:focus,
+.reader-table-toggle:focus,
+.markdown-body table:focus {
+  outline: 0.2rem solid var(--bs-primary);
+  outline-offset: 0.2rem;
+}
+
+a:focus:not(:focus-visible),
+button:focus:not(:focus-visible),
+[role='button']:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+select:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible),
+.btn:focus:not(:focus-visible),
+.dropdown-item:focus:not(:focus-visible),
+.nav-link:focus:not(:focus-visible),
+.reader-table-toggle:focus:not(:focus-visible),
+.markdown-body table:focus:not(:focus-visible) {
+  outline: 0;
 }
 
 .btn-primary {
@@ -45,9 +131,20 @@
 html[data-bs-theme='light'] {
   --bs-body-bg: #ffffff;
   --bs-body-bg-rgb: 255, 255, 255;
+  --bs-body-color: #212529;
+  --bs-secondary-color: #6c757d;
+  --bs-emphasis-color-rgb: 0, 0, 0;
+  --bs-border-color: #dee2e6;
+  --bs-border-color-translucent: rgba(0, 0, 0, 0.175);
 }
 
 html[data-bs-theme='dark'] {
+  --bs-body-bg: #212529;
+  --bs-body-color: #dee2e6;
+  --bs-secondary-color: rgba(222, 226, 230, 0.75);
+  --bs-emphasis-color-rgb: 255, 255, 255;
+  --bs-border-color: #495057;
+  --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
   --user-story-accent: #84cc16;
   --user-story-accent-rgb: 132, 204, 22;
   --user-story-accent-strong: #bef264;
@@ -241,6 +338,7 @@ html[data-bs-theme='dark'] .language-select {
   background:
     linear-gradient(180deg, rgba(var(--site-primary-rgb), 0.2), rgba(var(--site-primary-rgb), 0.08)),
     var(--bs-body-bg);
+  border: var(--bs-border-width) solid rgba(var(--site-primary-rgb), 0.4);
   border: var(--bs-border-width) solid color-mix(in srgb, rgb(var(--site-primary-rgb)) 40%, transparent);
   border-radius: var(--bs-border-radius-lg);
   box-shadow: var(--bs-box-shadow);
@@ -439,6 +537,26 @@ html[data-bs-theme='dark'] .markdown-body tbody tr:nth-of-type(odd) td {
   border-top-right-radius: 0;
 }
 
+.markdown-body .reader-full-document-link {
+  margin-top: 0.75rem;
+}
+
+.markdown-body table:focus {
+  outline-offset: 0.35rem;
+}
+
+.controller-mode .markdown-body table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+
+.controller-mode .markdown-body th,
+.controller-mode .markdown-body td {
+  min-width: 10.5rem;
+}
+
 @media (max-width: 991.98px) {
   .markdown-body table {
     display: block;
@@ -531,6 +649,7 @@ body.user-story-open {
 
 .user-story-card {
   width: min(28rem, 100%);
+  max-height: calc(100vh - 3rem);
   max-height: calc(100dvh - 3rem);
   border-radius: 1rem;
   box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.45);
@@ -668,6 +787,7 @@ body.user-story-open {
 
 .user-story-rating label:hover,
 .user-story-rating label:focus-visible,
+.user-story-rating input:focus + label,
 .user-story-rating label:hover ~ label {
   color: var(--user-story-accent-strong);
 }
@@ -710,9 +830,75 @@ body.user-story-open {
   .user-story-card {
     width: 100%;
     max-width: none;
+    min-height: calc(100vh - 2rem);
+    max-height: calc(100vh - 2rem);
     min-height: calc(100dvh - 2rem);
     max-height: calc(100dvh - 2rem);
   }
+}
+
+.controller-mode .navbar-nav-wrap,
+.controller-mode .toolbar,
+.controller-mode .user-story-rating,
+.controller-mode .user-story-feedback-options {
+  gap: 0.75rem;
+}
+
+.controller-mode .navbar .nav-link,
+.controller-mode .dropdown-item,
+.controller-mode nav.toc a,
+.controller-mode footer a,
+.controller-mode .btn,
+.controller-mode .reader-table-toggle,
+.controller-mode .funding-banner__link {
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.controller-mode .toolbar .btn {
+  min-width: 2.75rem;
+  padding-inline: 0.65rem;
+}
+
+.controller-mode .language-select,
+.controller-mode .form-control,
+.controller-mode .form-select {
+  min-height: 2.75rem;
+}
+
+.controller-mode .reader-sidebar nav.toc {
+  font-size: 1rem;
+}
+
+.controller-mode .user-story-toggle {
+  bottom: 2rem;
+  height: 4rem;
+  right: 2rem;
+  width: 4rem;
+}
+
+.controller-mode .user-story-toggle svg {
+  height: 2.25rem;
+  width: 2.25rem;
+}
+
+.controller-mode .user-story-card .btn-close {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+}
+
+.controller-mode .user-story-rating label {
+  font-size: 2.15rem;
+  min-height: 3rem;
+  min-width: 3rem;
+}
+
+.controller-mode .user-story-copy-link {
+  min-height: 2.25rem;
+}
+
+.controller-mode .user-story-chat-optin {
+  min-height: 2.75rem;
 }
 
 .share-thumbnail {

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -9,6 +9,7 @@ const getLocalStorage = () => {
 };
 
 const hasQueryFlag = names => {
+  const falseValues = ['0', 'false', 'off', 'no'];
   const search = window.location.search.replace(/^\?/, '').split('&');
   return search.some(part => {
     if (!part) {
@@ -17,7 +18,7 @@ const hasQueryFlag = names => {
     const keyValue = part.split('=');
     const key = decodeURIComponent(keyValue[0] || '').toLowerCase();
     const value = decodeURIComponent(keyValue[1] || '').toLowerCase();
-    return names.indexOf(key) !== -1 && value !== '0' && value !== 'false';
+    return names.indexOf(key) !== -1 && falseValues.indexOf(value) === -1;
   });
 };
 

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -1,5 +1,41 @@
 const MOBILE_BREAKPOINT = '(max-width: 767.98px)';
 
+const getLocalStorage = () => {
+  try {
+    return window.localStorage;
+  } catch (error) {
+    return null;
+  }
+};
+
+const hasQueryFlag = names => {
+  const search = window.location.search.replace(/^\?/, '').split('&');
+  return search.some(part => {
+    if (!part) {
+      return false;
+    }
+    const keyValue = part.split('=');
+    const key = decodeURIComponent(keyValue[0] || '').toLowerCase();
+    const value = decodeURIComponent(keyValue[1] || '').toLowerCase();
+    return names.indexOf(key) !== -1 && value !== '0' && value !== 'false';
+  });
+};
+
+const setupControllerMode = () => {
+  const userAgent = window.navigator ? window.navigator.userAgent || '' : '';
+  const isPlayStation = /PlayStation 4/i.test(userAgent);
+  const isControllerRequested = hasQueryFlag(['controller', 'tv', 'ps4']);
+  const isCoarsePointer = window.matchMedia && window.matchMedia('(hover: none), (pointer: coarse)').matches;
+  if (!isPlayStation && !isControllerRequested && !isCoarsePointer) {
+    return;
+  }
+
+  document.documentElement.classList.add('controller-mode');
+  if (document.body) {
+    document.body.classList.add('controller-mode');
+  }
+};
+
 /**
  * Apply site theme variables from data attributes on the html element.
  */
@@ -30,7 +66,14 @@ const applySiteThemeVariables = () => {
 const setTheme = (theme, persist = true) => {
   document.documentElement.setAttribute('data-bs-theme', theme);
   if (persist) {
-    localStorage.setItem('theme', theme);
+    const storage = getLocalStorage();
+    if (storage) {
+      try {
+        storage.setItem('theme', theme);
+      } catch (error) {
+        // Keep theme switching working when storage is restricted.
+      }
+    }
   }
 
   const toggle = document.getElementById('theme-toggle');
@@ -86,7 +129,8 @@ const setupThemeToggle = () => {
  * Initialize the theme state from storage or default.
  */
 const initThemeState = () => {
-  const saved = localStorage.getItem('theme');
+  const storage = getLocalStorage();
+  const saved = storage ? storage.getItem('theme') : null;
   if (saved) {
     setTheme(saved);
     return;
@@ -103,10 +147,14 @@ const syncDebugToolbarTheme = () => {
     return;
   }
   const apply = () => {
-    if (localStorage.getItem('theme')) {
+    const storage = getLocalStorage();
+    if (!storage) {
       return;
     }
-    const djdtTheme = localStorage.getItem('djdt.user-theme');
+    if (storage.getItem('theme')) {
+      return;
+    }
+    const djdtTheme = storage.getItem('djdt.user-theme');
     if (!djdtTheme) {
       return;
     }
@@ -248,7 +296,8 @@ const setupLanguageSelect = () => {
     select.addEventListener('change', () => {
       const form = select.form;
       const data = new FormData(form);
-      const csrfToken = form.querySelector('input[name="csrfmiddlewaretoken"]')?.value;
+      const csrfInput = form.querySelector('input[name="csrfmiddlewaretoken"]');
+      const csrfToken = csrfInput ? csrfInput.value : '';
       fetch(form.action, {
         method: 'POST',
         body: data,
@@ -260,7 +309,8 @@ const setupLanguageSelect = () => {
             form.submit();
             return;
           }
-          const rawNext = form.querySelector('input[name="next"]')?.value;
+          const nextInput = form.querySelector('input[name="next"]');
+          const rawNext = nextInput ? nextInput.value : '';
           window.location.href = getSafeRedirect(rawNext);
         })
         .catch(() => {
@@ -398,6 +448,7 @@ const setupFundingBannerDismissal = () => {
   });
 };
 
+setupControllerMode();
 applySiteThemeVariables();
 setupThemeToggle();
 initThemeState();

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -9,6 +9,13 @@ const getLocalStorage = () => {
 };
 
 const hasQueryFlag = names => {
+  const decodeQueryPart = value => {
+    try {
+      return decodeURIComponent(value || '').toLowerCase();
+    } catch (error) {
+      return '';
+    }
+  };
   const falseValues = ['0', 'false', 'off', 'no'];
   const search = window.location.search.replace(/^\?/, '').split('&');
   return search.some(part => {
@@ -16,8 +23,8 @@ const hasQueryFlag = names => {
       return false;
     }
     const keyValue = part.split('=');
-    const key = decodeURIComponent(keyValue[0] || '').toLowerCase();
-    const value = decodeURIComponent(keyValue[1] || '').toLowerCase();
+    const key = decodeQueryPart(keyValue[0]);
+    const value = decodeQueryPart(keyValue[1]);
     return names.indexOf(key) !== -1 && falseValues.indexOf(value) === -1;
   });
 };

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -41,12 +41,31 @@
   let autocompleteAbortController = null;
   let autocompleteRequestId = 0;
 
+  const createBubblingEvent = eventName => {
+    if (typeof Event === 'function') {
+      return new Event(eventName, { bubbles: true });
+    }
+    const event = document.createEvent('Event');
+    event.initEvent(eventName, true, false);
+    return event;
+  };
+
+  const dispatchFeedbackDialogOpened = () => {
+    if (typeof CustomEvent === 'function') {
+      document.dispatchEvent(new CustomEvent(DIALOG_OPENED_EVENT, { detail: { source: 'feedback' } }));
+      return;
+    }
+    const event = document.createEvent('CustomEvent');
+    event.initCustomEvent(DIALOG_OPENED_EVENT, false, false, { source: 'feedback' });
+    document.dispatchEvent(event);
+  };
+
   const setCommentValue = value => {
     if (!commentField) {
       return;
     }
     commentField.value = value;
-    commentField.dispatchEvent(new Event('input', { bubbles: true }));
+    commentField.dispatchEvent(createBubblingEvent('input'));
     commentField.focus();
     commentField.setSelectionRange(commentField.value.length, commentField.value.length);
   };
@@ -89,13 +108,13 @@
     autocompleteContainer.appendChild(list);
   };
 
-  const fetchAutocompleteSuggestions = async () => {
-    if (autocompleteAbortController) {
+  const fetchAutocompleteSuggestions = () => {
+    if (autocompleteAbortController && autocompleteAbortController.abort) {
       autocompleteAbortController.abort();
       autocompleteAbortController = null;
     }
 
-    if (!autocompleteUrl || !commentField || commentField.value.trim().length < 2) {
+    if (!window.fetch || !autocompleteUrl || !commentField || commentField.value.trim().length < 2) {
       clearAutocompleteSuggestions();
       return;
     }
@@ -103,13 +122,11 @@
     const requestId = autocompleteRequestId + 1;
     autocompleteRequestId = requestId;
     const query = commentField.value;
-    const abortController = new AbortController();
+    const abortController = typeof window.AbortController === 'function' ? new AbortController() : null;
     autocompleteAbortController = abortController;
 
-    const payload = new URLSearchParams();
     const csrfToken = form.querySelector('input[name="csrfmiddlewaretoken"]');
-    payload.set('q', query);
-    payload.set('limit', '5');
+    const payload = `q=${encodeURIComponent(query)}&limit=5`;
     const headers = {
       'Content-Type': 'application/x-www-form-urlencoded',
       'X-Requested-With': 'XMLHttpRequest',
@@ -124,31 +141,38 @@
       commentField &&
       commentField.value === query;
 
-    try {
-      const response = await fetch(autocompleteUrl, {
-        method: 'POST',
-        headers,
-        body: payload,
-        signal: abortController.signal,
-      });
-      if (!response.ok) {
+    const fetchOptions = {
+      method: 'POST',
+      headers,
+      body: payload,
+    };
+    if (abortController) {
+      fetchOptions.signal = abortController.signal;
+    }
+
+    fetch(autocompleteUrl, fetchOptions)
+      .then(response => {
+        if (!response.ok) {
+          if (isCurrentAutocompleteRequest()) {
+            clearAutocompleteSuggestions();
+          }
+          return null;
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (data && isCurrentAutocompleteRequest()) {
+          renderAutocompleteSuggestions(data.suggestions || []);
+        }
+      })
+      .catch(error => {
+        if (error && error.name === 'AbortError') {
+          return;
+        }
         if (isCurrentAutocompleteRequest()) {
           clearAutocompleteSuggestions();
         }
-        return;
-      }
-      const data = await response.json();
-      if (isCurrentAutocompleteRequest()) {
-        renderAutocompleteSuggestions(data.suggestions || []);
-      }
-    } catch (error) {
-      if (error && error.name === 'AbortError') {
-        return;
-      }
-      if (isCurrentAutocompleteRequest()) {
-        clearAutocompleteSuggestions();
-      }
-    }
+      });
   };
 
   const debounce = (fn, waitMs) => {
@@ -164,6 +188,60 @@
   const requestAutocompleteSuggestions = debounce(fetchAutocompleteSuggestions, 150);
   let previousFocus = null;
   let copyFeedbackTimeout = null;
+
+  const focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'textarea:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  const isInsideHiddenContainer = element => {
+    let node = element;
+    while (node && node !== overlay) {
+      if (node.hasAttribute && node.hasAttribute('hidden')) {
+        return true;
+      }
+      node = node.parentNode;
+    }
+    return false;
+  };
+
+  const getFocusableOverlayElements = () =>
+    Array.from(overlay.querySelectorAll(focusableSelector)).filter(element => {
+      if (isInsideHiddenContainer(element)) {
+        return false;
+      }
+      const style = window.getComputedStyle(element);
+      return style.visibility !== 'hidden' && style.display !== 'none';
+    });
+
+  const trapOverlayFocus = event => {
+    if (event.key !== 'Tab' || overlay.hasAttribute('hidden')) {
+      return;
+    }
+    const focusableElements = getFocusableOverlayElements();
+    if (!focusableElements.length) {
+      event.preventDefault();
+      if (card) {
+        card.focus();
+      }
+      return;
+    }
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const ratingMessages = Array.from({ length: 6 }, (_, index) => {
     if (!ratingHint) {
@@ -251,7 +329,7 @@
     if (!overlay.hasAttribute('hidden')) {
       return;
     }
-    document.dispatchEvent(new CustomEvent(DIALOG_OPENED_EVENT, { detail: { source: 'feedback' } }));
+    dispatchFeedbackDialogOpened();
     previousFocus = document.activeElement;
     overlay.removeAttribute('hidden');
     requestAnimationFrame(() => {
@@ -300,6 +378,7 @@
   });
 
   document.addEventListener('keydown', event => {
+    trapOverlayFocus(event);
     if (event.key === 'Escape' && !overlay.hasAttribute('hidden')) {
       closeOverlay();
     }
@@ -325,11 +404,37 @@
   initializeTextareaAutoExpand();
 
   if (ratingInputs && ratingInputs.length) {
+    const ratingInputList = Array.from(ratingInputs);
+    const selectRatingByValue = nextValue => {
+      const targetInput = ratingInputList.find(input => Number(input.value) === nextValue);
+      if (!targetInput) {
+        return;
+      }
+      targetInput.checked = true;
+      targetInput.focus();
+      targetInput.dispatchEvent(createBubblingEvent('change'));
+    };
     ratingInputs.forEach(input => {
       const showHint = () => setRatingHintText(Number(input.value));
       input.addEventListener('change', setRatingHint);
       input.addEventListener('focus', showHint);
       input.addEventListener('blur', setRatingHint);
+      input.addEventListener('keydown', event => {
+        const currentValue = Number(input.value);
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+          event.preventDefault();
+          selectRatingByValue(Math.max(1, currentValue - 1));
+        } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          selectRatingByValue(Math.min(5, currentValue + 1));
+        } else if (event.key === 'Home') {
+          event.preventDefault();
+          selectRatingByValue(1);
+        } else if (event.key === 'End') {
+          event.preventDefault();
+          selectRatingByValue(5);
+        }
+      });
     });
     setRatingHint();
   }
@@ -587,7 +692,10 @@
     });
   }
 
-  form.addEventListener('submit', async event => {
+  form.addEventListener('submit', event => {
+    if (!window.fetch || !window.FormData) {
+      return;
+    }
     event.preventDefault();
     resetAlerts();
     syncMessageField(getPageMessages());
@@ -597,53 +705,66 @@
     }
 
     const formData = new FormData(form);
-    try {
-      const response = await fetch(form.action, {
-        method: 'POST',
-        headers: {
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: formData,
-      });
-
-      if (response.ok) {
-        form.reset();
-        setCharCount();
-        clearAutocompleteSuggestions();
-        setRatingHint();
-        resizeFeedbackTextareas({ force: true });
-        if (successAlert) {
-          successAlert.textContent = defaultSuccessMessage;
-          successAlert.classList.remove('is-hidden');
-          successAlert.removeAttribute('hidden');
-        }
-      } else {
-        const data = await response.json().catch(() => ({}));
-        let message = '';
-        if (data && data.errors) {
-          message = Object.values(data.errors)
-            .flat()
-            .join(' ');
-        }
-        if (!message) {
-          message = errorMessage || '';
-        }
-        if (errorAlert) {
-          errorAlert.textContent = message;
-          errorAlert.classList.remove('is-hidden');
-          errorAlert.removeAttribute('hidden');
-        }
-      }
-    } catch (error) {
-      if (errorAlert) {
-        errorAlert.textContent = networkErrorMessage || '';
-        errorAlert.classList.remove('is-hidden');
-        errorAlert.removeAttribute('hidden');
-      }
-    } finally {
+    const enableSubmit = () => {
       if (submitBtn) {
         submitBtn.disabled = false;
       }
-    }
+    };
+    fetch(form.action, {
+      method: 'POST',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: formData,
+    })
+      .then(response => {
+        if (response.ok) {
+          form.reset();
+          setCharCount();
+          clearAutocompleteSuggestions();
+          setRatingHint();
+          resizeFeedbackTextareas({ force: true });
+          if (successAlert) {
+            successAlert.textContent = defaultSuccessMessage;
+            successAlert.classList.remove('is-hidden');
+            successAlert.removeAttribute('hidden');
+          }
+          return null;
+        }
+        return response.json()
+          .catch(() => ({}))
+          .then(data => {
+            let message = '';
+            if (data && data.errors) {
+              const values = [];
+              Object.keys(data.errors).forEach(key => {
+                const value = data.errors[key];
+                if (Array.isArray(value)) {
+                  value.forEach(item => values.push(item));
+                } else if (value) {
+                  values.push(value);
+                }
+              });
+              message = values.join(' ');
+            }
+            if (!message) {
+              message = errorMessage || '';
+            }
+            if (errorAlert) {
+              errorAlert.textContent = message;
+              errorAlert.classList.remove('is-hidden');
+              errorAlert.removeAttribute('hidden');
+            }
+            return null;
+          });
+      })
+      .catch(() => {
+        if (errorAlert) {
+          errorAlert.textContent = networkErrorMessage || '';
+          errorAlert.classList.remove('is-hidden');
+          errorAlert.removeAttribute('hidden');
+        }
+      })
+      .then(enableSubmit, enableSubmit);
   });
 })();

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -736,16 +736,12 @@
           .then(data => {
             let message = '';
             if (data && data.errors) {
-              const values = [];
+              let values = [];
               Object.keys(data.errors).forEach(key => {
                 const value = data.errors[key];
-                if (Array.isArray(value)) {
-                  value.forEach(item => values.push(item));
-                } else if (value) {
-                  values.push(value);
-                }
+                values = values.concat(Array.isArray(value) ? value : [value]);
               });
-              message = values.join(' ');
+              message = values.filter(Boolean).join(' ');
             }
             if (!message) {
               message = errorMessage || '';

--- a/apps/sites/templates/pages/includes/public_feedback_widget.html
+++ b/apps/sites/templates/pages/includes/public_feedback_widget.html
@@ -32,7 +32,7 @@
         <h5 class="card-title mb-1" id="user-story-title">{% trans 'Please provide feedback!' %}</h5>
         <p class="card-subtitle text-muted small mb-0">{% trans 'Tell us how this page worked for you.' %}</p>
       </div>
-      <button type="button" class="btn-close" data-feedback-close>
+      <button type="button" class="btn-close" data-feedback-close aria-label="{% trans 'Close feedback dialog' %}">
         <span class="visually-hidden">{% trans "Close" %}</span>
       </button>
     </div>

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -1,0 +1,84 @@
+import re
+from pathlib import Path
+
+BASE_CSS = Path("apps/sites/static/pages/css/base.css")
+BASE_JS = Path("apps/sites/static/pages/js/base.js")
+FEEDBACK_JS = Path("apps/sites/static/pages/js/user_story_feedback.js")
+PUBLIC_FEEDBACK_TEMPLATE = Path(
+    "apps/sites/templates/pages/includes/public_feedback_widget.html"
+)
+DOCS_README_TEMPLATE = Path("apps/docs/templates/docs/readme.html")
+READER_SCRIPT_TEMPLATE = Path("apps/docs/templates/includes/reader_qr_script.html")
+
+
+def test_controller_mode_adds_large_targets_and_legacy_focus_fallbacks():
+    css = BASE_CSS.read_text(encoding="utf-8")
+    script = BASE_JS.read_text(encoding="utf-8")
+
+    assert "setupControllerMode();" in script
+    assert "PlayStation 4" in script
+    assert "['controller', 'tv', 'ps4']" in script
+    assert ".controller-mode .navbar .nav-link" in css
+    assert ".controller-mode .user-story-rating label" in css
+    assert ".controller-mode .markdown-body table" in css
+    assert "a:focus," in css
+    assert ".reader-table-toggle:focus," in css
+    assert ":focus-visible" in css
+
+
+def test_docs_reader_has_controller_safe_full_document_and_reload_paths():
+    template = DOCS_README_TEMPLATE.read_text(encoding="utf-8")
+
+    visible_link_index = template.index("reader-full-document-link")
+    noscript_index = template.index("<noscript>")
+    assert visible_link_index < noscript_index
+    assert 'href="{{ full_document_url }}"' in template
+    assert "30 * 60 * 1000" in template
+    assert '"pointermove"' in template
+    assert '"focusin"' in template
+    assert 'body.classList.contains("user-story-open")' in template
+
+
+def test_reader_tables_are_focusable_for_controller_scrolling():
+    script = READER_SCRIPT_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "table.tabIndex = 0;" in script
+    assert 'table.setAttribute("aria-label", headingText);' in script
+    assert "?." not in script
+
+
+def test_public_feedback_dialog_traps_focus_and_keeps_visible_rating_focus():
+    script = FEEDBACK_JS.read_text(encoding="utf-8")
+    template = PUBLIC_FEEDBACK_TEMPLATE.read_text(encoding="utf-8")
+    css = BASE_CSS.read_text(encoding="utf-8")
+
+    assert "trapOverlayFocus(event);" in script
+    assert "selectRatingByValue" in script
+    assert "typeof window.AbortController === 'function'" in script
+    assert "data-feedback-close aria-label" in template
+    assert ".user-story-rating input:focus + label" in css
+
+
+def test_public_scripts_avoid_selected_modern_syntax_in_ps4_paths():
+    scripts = [
+        BASE_JS.read_text(encoding="utf-8"),
+        FEEDBACK_JS.read_text(encoding="utf-8"),
+        READER_SCRIPT_TEMPLATE.read_text(encoding="utf-8"),
+    ]
+
+    for script in scripts:
+        assert "?." not in script
+        assert re.search(r"\basync\b|\bawait\b", script) is None
+
+
+def test_local_css_keeps_public_pages_readable_without_bootstrap_cdn():
+    css = BASE_CSS.read_text(encoding="utf-8")
+    base_template = Path("apps/sites/templates/pages/base.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "--bs-body-bg: #ffffff;" in css
+    assert "--bs-border-color-translucent" in css
+    assert ":where(.container)" in css
+    assert ":where(.btn)" in css
+    assert "{% static 'pages/css/base.css' %}" in base_template

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -18,6 +18,7 @@ def test_controller_mode_adds_large_targets_and_legacy_focus_fallbacks():
     assert "setupControllerMode();" in script
     assert "PlayStation 4" in script
     assert "['controller', 'tv', 'ps4']" in script
+    assert "['0', 'false', 'off', 'no']" in script
     assert ".controller-mode .navbar .nav-link" in css
     assert ".controller-mode .user-story-rating label" in css
     assert ".controller-mode .markdown-body table" in css
@@ -32,7 +33,11 @@ def test_docs_reader_has_controller_safe_full_document_and_reload_paths():
     visible_link_index = template.index("reader-full-document-link")
     noscript_index = template.index("<noscript>")
     assert visible_link_index < noscript_index
+    assert 'reader-full-document-link" href="{{ full_document_url }}" hidden' in template
+    assert 'removeAttribute("hidden")' in template
     assert 'href="{{ full_document_url }}"' in template
+    assert '"0", "false", "off", "no"' in template
+    assert 'key === "controller" || key === "tv" || key === "ps4"' in template
     assert "30 * 60 * 1000" in template
     assert '"pointermove"' in template
     assert '"focusin"' in template

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -19,6 +19,8 @@ def test_controller_mode_adds_large_targets_and_legacy_focus_fallbacks():
     assert "PlayStation 4" in script
     assert "['controller', 'tv', 'ps4']" in script
     assert "['0', 'false', 'off', 'no']" in script
+    assert "decodeQueryPart" in script
+    assert "catch (error)" in script
     assert ".controller-mode .navbar .nav-link" in css
     assert ".controller-mode .user-story-rating label" in css
     assert ".controller-mode .markdown-body table" in css
@@ -38,6 +40,8 @@ def test_docs_reader_has_controller_safe_full_document_and_reload_paths():
     assert 'href="{{ full_document_url }}"' in template
     assert '"0", "false", "off", "no"' in template
     assert 'key === "controller" || key === "tv" || key === "ps4"' in template
+    assert "var decodeQueryPart = function" in template
+    assert "catch (error)" in template
     assert "30 * 60 * 1000" in template
     assert '"pointermove"' in template
     assert '"focusin"' in template


### PR DESCRIPTION
## Summary
- Add controller/TV mode for the public site with larger focus targets, visible focus fallbacks, table scrolling, and feedback-dialog sizing.
- Make docs reader pages controller-safe by serving full content for `?controller`, `?tv`, or `?ps4`, keeping a visible full-document fallback link, and extending auto-reload while reading with a controller.
- Reduce public JS fragility by removing optional chaining/async-await from the touched PS4 paths, guarding AbortController use, trapping feedback-modal focus, and adding rating keyboard controls.

## Validation
- `python -m pytest apps\docs\tests\test_controller_reading_mode.py apps\sites\tests\test_public_controller_mode.py apps\sites\tests\test_funding_banner_template.py -q`
- `node --check apps\sites\static\pages\js\base.js`
- `node --check apps\sites\static\pages\js\user_story_feedback.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `git diff --check`
- `python -m pytest apps\sites\tests\test_public_routes.py apps\sites\tests\test_user_story_autocomplete.py apps\sites\tests\test_user_story_feedback_form.py -q`
- `python -m ruff check apps\docs\views.py apps\docs\tests\test_controller_reading_mode.py apps\sites\tests\test_public_controller_mode.py`
- `python -m pytest apps\docs\tests\test_controller_reading_mode.py apps\sites\tests\test_public_controller_mode.py -q`

Fixes #7625