### PR TITLE
Compact LCD summaries and USB slots

### DIFF
--- a/apps/sensors/constants.py
+++ b/apps/sensors/constants.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 USB_LCD_LABEL_WIDTH = 7
 USB_LCD_PORT_COUNT = 4
-USB_LCD_EMPTY_LABEL = "EMPTY"
+USB_LCD_EMPTY_LABEL = "FREE"
+USB_LCD_PORT_ICONS = ("▘", "▝", "▖", "▗")
 USB_LCD_STATUS_CELERY_TASK_NAME = "apps.sensors.tasks.refresh_usb_lcd_status"

--- a/apps/sensors/tests/test_usb_lcd.py
+++ b/apps/sensors/tests/test_usb_lcd.py
@@ -19,7 +19,7 @@ from apps.video.models import VideoDevice
 pytestmark = pytest.mark.django_db
 
 
-def test_render_usb_lcd_lines_fits_four_seven_character_labels() -> None:
+def test_render_usb_lcd_lines_fits_four_fixed_icon_slots() -> None:
     statuses = [
         UsbPortStatus(port_number=1, label="LISTEN", connected=True),
         UsbPortStatus(port_number=2, label="OBSERVE", connected=True),
@@ -27,10 +27,23 @@ def test_render_usb_lcd_lines_fits_four_seven_character_labels() -> None:
         UsbPortStatus(port_number=4, label="USB-KEY-LONG", connected=True),
     ]
 
-    assert render_usb_lcd_lines(statuses) == (
-        "LISTEN  OBSERVE",
-        "BASTION USB-KEY",
+    line1, line2 = render_usb_lcd_lines(statuses)
+
+    assert (line1, line2) == ("▘LISTEN ▝OBSERVE", "▖BASTION▗USB-KEY")
+    assert len(line1) == 16
+    assert len(line2) == 16
+
+
+def test_render_usb_lcd_lines_keeps_port_positions_for_sparse_statuses() -> None:
+    line1, line2 = render_usb_lcd_lines(
+        [
+            UsbPortStatus(port_number=2, label="SPARE", connected=False),
+            UsbPortStatus(port_number=4, label="CAM", connected=True),
+        ]
     )
+
+    assert line1 == "▘FREE   ▝FREE   "
+    assert line2 == "▖FREE   ▗CAM    "
 
 
 def test_build_usb_lcd_statuses_uses_local_mappings_and_default_labels() -> None:
@@ -93,7 +106,7 @@ def test_build_usb_lcd_statuses_uses_local_mappings_and_default_labels() -> None
         "BASTION",
         "LISTEN",
         "OBSERVE",
-        "EMPTY",
+        "FREE",
     ]
     assert [status.connected for status in statuses] == [True, True, True, False]
 
@@ -131,7 +144,7 @@ def test_node_scoped_devices_fail_closed_without_local_node(monkeypatch) -> None
     statuses = build_usb_lcd_statuses(mappings=mappings)
 
     assert [status.connected for status in statuses[:2]] == [False, False]
-    assert [status.label for status in statuses[:2]] == ["EMPTY", "EMPTY"]
+    assert [status.label for status in statuses[:2]] == ["FREE", "FREE"]
 
 
 def test_build_usb_lcd_statuses_ignores_other_node_mappings() -> None:
@@ -153,7 +166,7 @@ def test_build_usb_lcd_statuses_ignores_other_node_mappings() -> None:
 
     statuses = build_usb_lcd_statuses(node=local)
 
-    assert [status.label for status in statuses] == ["EMPTY", "EMPTY", "EMPTY", "EMPTY"]
+    assert [status.label for status in statuses] == ["FREE", "FREE", "FREE", "FREE"]
 
 
 def test_build_usb_lcd_statuses_filters_explicit_mappings_by_node() -> None:
@@ -184,7 +197,7 @@ def test_build_usb_lcd_statuses_filters_explicit_mappings_by_node() -> None:
         mappings=[local_mapping, remote_mapping], node=local
     )
 
-    assert [status.label for status in statuses] == ["LOCAL", "EMPTY", "EMPTY", "EMPTY"]
+    assert [status.label for status in statuses] == ["LOCAL", "FREE", "FREE", "FREE"]
 
 
 def test_write_usb_lcd_status_writes_lock_file(tmp_path: Path) -> None:
@@ -208,9 +221,11 @@ def test_write_usb_lcd_status_writes_lock_file(tmp_path: Path) -> None:
 
     assert result["written"] is True
     assert result["connected"] == 1
+    assert result["line1"] == "▘BASTION▝FREE   "
+    assert result["line2"] == "▖FREE   ▗FREE   "
     assert message is not None
-    assert message.subject == "BASTION EMPTY"
-    assert message.body == "EMPTY   EMPTY"
+    assert message.subject == "▘BASTION▝FREE"
+    assert message.body == "▖FREE   ▗FREE"
 
 
 def test_write_usb_lcd_status_removes_stale_lock_without_mappings(

--- a/apps/sensors/usb_lcd.py
+++ b/apps/sensors/usb_lcd.py
@@ -13,7 +13,12 @@ from django.db.utils import OperationalError, ProgrammingError
 
 from apps.screens.startup_notifications import LCD_USB_LOCK_FILE, write_lcd_message
 
-from .constants import USB_LCD_EMPTY_LABEL, USB_LCD_LABEL_WIDTH, USB_LCD_PORT_COUNT
+from .constants import (
+    USB_LCD_EMPTY_LABEL,
+    USB_LCD_LABEL_WIDTH,
+    USB_LCD_PORT_COUNT,
+    USB_LCD_PORT_ICONS,
+)
 from .models import UsbPortMapping, UsbTracker
 
 logger = logging.getLogger(__name__)
@@ -21,6 +26,7 @@ logger = logging.getLogger(__name__)
 MICROPHONE_TERMS = ("microphone", "mic", "audio", "capture", "alsa")
 CAMERA_TERMS = ("camera", "cam", "video", "v4l", "opencv", "rpicam")
 BASTION_TERMS = ("bastion", "usb-key", "usb_key", "usb key", "security-key")
+USB_LCD_SLOT_WIDTH = 1 + USB_LCD_LABEL_WIDTH
 
 
 @dataclass(frozen=True)
@@ -114,17 +120,26 @@ def build_usb_lcd_statuses(
 
 
 def render_usb_lcd_lines(statuses: Iterable[UsbPortStatus]) -> tuple[str, str]:
-    """Render four USB port labels across two LCD rows."""
+    """Render four fixed USB port slots across two LCD rows."""
 
-    labels = [
-        normalize_usb_lcd_label(status.label)
-        for status in list(statuses)[:USB_LCD_PORT_COUNT]
+    slot_statuses = {
+        port_number: UsbPortStatus(
+            port_number=port_number,
+            label=USB_LCD_EMPTY_LABEL,
+            connected=False,
+        )
+        for port_number in range(1, USB_LCD_PORT_COUNT + 1)
+    }
+    for status in statuses:
+        port_number = int(status.port_number or 0)
+        if port_number in slot_statuses:
+            slot_statuses[port_number] = status
+
+    slots = [
+        _render_usb_lcd_slot(slot_statuses[port_number])
+        for port_number in range(1, USB_LCD_PORT_COUNT + 1)
     ]
-    while len(labels) < USB_LCD_PORT_COUNT:
-        labels.append(USB_LCD_EMPTY_LABEL)
-    return _render_label_pair(labels[0], labels[1]), _render_label_pair(
-        labels[2], labels[3]
-    )
+    return f"{slots[0]}{slots[1]}", f"{slots[2]}{slots[3]}"
 
 
 def write_usb_lcd_status(
@@ -187,10 +202,18 @@ def write_usb_lcd_status(
     }
 
 
-def _render_label_pair(first: str, second: str) -> str:
-    first_label = normalize_usb_lcd_label(first)
-    second_label = normalize_usb_lcd_label(second)
-    return f"{first_label:<{USB_LCD_LABEL_WIDTH}} {second_label:<{USB_LCD_LABEL_WIDTH}}".rstrip()
+def _usb_lcd_port_icon(port_number: int) -> str:
+    port_index = max(1, min(int(port_number or 1), USB_LCD_PORT_COUNT)) - 1
+    return USB_LCD_PORT_ICONS[port_index]
+
+
+def _render_usb_lcd_slot(status: UsbPortStatus) -> str:
+    label = normalize_usb_lcd_label(
+        status.label if status.connected else USB_LCD_EMPTY_LABEL
+    )
+    return f"{_usb_lcd_port_icon(status.port_number)}{label:<{USB_LCD_LABEL_WIDTH}}"[
+        :USB_LCD_SLOT_WIDTH
+    ]
 
 
 def _remove_lock_file(lock_file: Path) -> None:

--- a/apps/sensors/usb_lcd.py
+++ b/apps/sensors/usb_lcd.py
@@ -203,7 +203,10 @@ def write_usb_lcd_status(
 
 
 def _usb_lcd_port_icon(port_number: int) -> str:
-    port_index = max(1, min(int(port_number or 1), USB_LCD_PORT_COUNT)) - 1
+    icon_count = len(USB_LCD_PORT_ICONS)
+    if icon_count <= 0:
+        return "?"
+    port_index = max(0, min(int(port_number or 1) - 1, icon_count - 1))
     return USB_LCD_PORT_ICONS[port_index]
 
 

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -41,6 +41,7 @@ HOST_RESOURCE_BODY_RE = re.compile(
     r"\bt\d+(?:\.\d+)?[cf]?\b.*\bd\d+%.*\bm\d+%",
     re.IGNORECASE,
 )
+INLINE_BUFFER_RE = re.compile(r"^[A-Z0-9][A-Z0-9 /&+.\-]{0,15}:.+")
 
 
 @dataclass(frozen=True)
@@ -223,7 +224,8 @@ def parse_screens(output: str) -> list[tuple[str, str]]:
     screens: list[tuple[str, str]] = []
     for group in groups:
         if len(group) == 1:
-            screens.append((group[0], ""))
+            if INLINE_BUFFER_RE.match(group[0]):
+                screens.append((group[0], ""))
             continue
         screens.append((group[0], " ".join(group[1:])))
     return screens

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -261,12 +261,16 @@ def _normalize_lcd_text(text: str) -> str:
 def _normalize_summary_buffer(subject: str, body: str) -> tuple[str, str]:
     subject_text = _normalize_lcd_text(subject)
     body_text = _normalize_lcd_text(body)
-    if subject_text and body_text:
-        combined = (
-            f"{subject_text} {body_text}"
-            if ":" in subject_text
-            else f"{subject_text}:{body_text}"
+    if ":" in subject_text:
+        overflow = subject_text[LCD_COLUMNS:]
+        line2_source = " ".join(part for part in (overflow, body_text) if part)
+        return (
+            subject_text[:LCD_COLUMNS].ljust(LCD_COLUMNS),
+            line2_source[:LCD_COLUMNS].ljust(LCD_COLUMNS),
         )
+
+    if subject_text and body_text:
+        combined = f"{subject_text}:{body_text}"
     else:
         combined = subject_text or body_text
 

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -22,6 +22,8 @@ from .models import LLMSummaryConfig
 logger = logging.getLogger(__name__)
 
 LCD_COLUMNS = 16
+LCD_ROWS = 2
+LCD_SUMMARY_BUFFER_CELLS = LCD_COLUMNS * LCD_ROWS
 LCD_SUMMARY_FRAME_COUNT = 10
 LCD_SUMMARY_EXPIRES_AFTER = timedelta(minutes=10)
 DEFAULT_MODEL_DIR = Path(settings.BASE_DIR) / "work" / "llm" / "lcd-summary"
@@ -177,19 +179,21 @@ def compact_log_chunks(chunks: Iterable[LogChunk]) -> str:
 def build_summary_prompt(compacted_logs: str, *, now: datetime) -> str:
     cutoff = (now - timedelta(minutes=4)).strftime("%H:%M")
     instructions = textwrap.dedent(f"""
-        You summarize system logs for a 16x2 LCD. Focus on the last 4 minutes (cutoff {cutoff}).
-        Highlight urgent operator actions or failures. Use shorthand, abbreviations, and ASCII symbols.
-        Output 8-10 LCD screens. Each screen is two lines (subject then body).
-        Aim for 14-18 chars per line, avoid scrolling when possible.
+        You summarize system logs as 16x2 LCD buffers. Focus on the last 4 minutes (cutoff {cutoff}).
+        Highlight urgent operator actions or failures. Think in 32 visible cells per screen, not as a document.
+        Output 8-10 LCD screens. Each screen is two 16-cell rows.
+        Start each screen with a compact uppercase header, then a single ":" and continue the message immediately.
+        Do not waste row 1 on only the header; wrap the compact message into row 2 when useful.
+        Shorten words aggressively, drop grammar when helpful, and use abbreviations, symbols, arrows, or LCD-friendly drawing characters when they compress meaning.
         Do not emit routine host resource screens; RAM, disk, swap, CPU, and temperature already have dedicated LCD screens.
         Format:
         SCREEN 1:
-        <subject line>
-        <body line>
+        <HDR>:<message row 1>
+        <message row 2>
         ---
         SCREEN 2:
-        <subject line>
-        <body line>
+        <HDR>:<message row 1>
+        <message row 2>
         ...
         Only output the screens, no extra commentary.
         """).strip()
@@ -218,9 +222,10 @@ def parse_screens(output: str) -> list[tuple[str, str]]:
 
     screens: list[tuple[str, str]] = []
     for group in groups:
-        if len(group) < 2:
+        if len(group) == 1:
+            screens.append((group[0], ""))
             continue
-        screens.append((group[0], group[1]))
+        screens.append((group[0], " ".join(group[1:])))
     return screens
 
 
@@ -232,8 +237,13 @@ def filter_redundant_lcd_summary_screens(
     filtered: list[tuple[str, str]] = []
     for subject, body in screens:
         subject_text = (subject or "").strip().lower()
-        body_text = (body or "").strip().lower()
-        if subject_text in {
+        subject_header, _separator, subject_body = subject_text.partition(":")
+        body_text = " ".join(
+            part
+            for part in (subject_body.strip(), (body or "").strip().lower())
+            if part
+        )
+        if subject_header in {
             "host",
             "resource",
             "resources",
@@ -243,19 +253,33 @@ def filter_redundant_lcd_summary_screens(
     return filtered
 
 
-def _normalize_line(text: str) -> str:
-    normalized = "".join(ch if 32 <= ord(ch) < 127 else " " for ch in text)
-    normalized = normalized.strip()
-    if len(normalized) <= LCD_COLUMNS:
-        return normalized.ljust(LCD_COLUMNS)
-    trimmed = normalized[: LCD_COLUMNS - 3].rstrip()
-    return f"{trimmed}...".ljust(LCD_COLUMNS)
+def _normalize_lcd_text(text: str) -> str:
+    normalized = "".join(ch if ch.isprintable() else " " for ch in str(text or ""))
+    return WHITESPACE_RE.sub(" ", normalized).strip()
+
+
+def _normalize_summary_buffer(subject: str, body: str) -> tuple[str, str]:
+    subject_text = _normalize_lcd_text(subject)
+    body_text = _normalize_lcd_text(body)
+    if subject_text and body_text:
+        combined = (
+            f"{subject_text} {body_text}"
+            if ":" in subject_text
+            else f"{subject_text}:{body_text}"
+        )
+    else:
+        combined = subject_text or body_text
+
+    combined = combined[:LCD_SUMMARY_BUFFER_CELLS]
+    line1 = combined[:LCD_COLUMNS].ljust(LCD_COLUMNS)
+    line2 = combined[LCD_COLUMNS:LCD_SUMMARY_BUFFER_CELLS].ljust(LCD_COLUMNS)
+    return line1, line2
 
 
 def normalize_screens(screens: Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
     normalized: list[tuple[str, str]] = []
     for subject, body in screens:
-        normalized.append((_normalize_line(subject), _normalize_line(body)))
+        normalized.append(_normalize_summary_buffer(subject, body))
     return normalized
 
 

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -28,8 +28,44 @@ def test_filter_redundant_lcd_summary_screens_drops_host_resource_frame() -> Non
 def test_build_summary_prompt_excludes_dedicated_resource_screens() -> None:
     prompt = services.build_summary_prompt("log line", now=datetime(2026, 5, 3))
 
+    assert "Think in 32 visible cells per screen" in prompt
+    assert 'then a single ":" and continue the message immediately' in prompt
+    assert "Shorten words aggressively" in prompt
     assert "Do not emit routine host resource screens" in prompt
     assert "LOGS:\nlog line" in prompt
+
+
+def test_parse_screens_accepts_single_line_colon_buffers() -> None:
+    screens = services.parse_screens("SCREEN 1:\nERR:svc fail -> rst\n---\n")
+
+    assert screens == [("ERR:svc fail -> rst", "")]
+
+
+def test_normalize_screens_flows_header_and_message_across_buffer() -> None:
+    frames = services.normalize_screens(
+        [("ERR", "scheduler raised unexpected reboot required")]
+    )
+
+    assert frames == [("ERR:scheduler ra", "ised unexpected ")]
+    assert len(frames[0][0]) == 16
+    assert len(frames[0][1]) == 16
+
+
+def test_normalize_screens_preserves_existing_inline_header() -> None:
+    frames = services.normalize_screens([("ERR:svc fail", "manual rst")])
+
+    assert frames == [("ERR:svc fail man", "ual rst         ")]
+
+
+def test_filter_redundant_lcd_summary_screens_handles_inline_headers() -> None:
+    frames = services.filter_redundant_lcd_summary_screens(
+        [
+            ("HOST:t65C d51% m44%", ""),
+            ("ERR:svc failed", "manual"),
+        ]
+    )
+
+    assert frames == [("ERR:svc failed", "manual")]
 
 
 def test_summary_frames_are_written_with_expiry(tmp_path) -> None:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -54,7 +54,13 @@ def test_normalize_screens_flows_header_and_message_across_buffer() -> None:
 def test_normalize_screens_preserves_existing_inline_header() -> None:
     frames = services.normalize_screens([("ERR:svc fail", "manual rst")])
 
-    assert frames == [("ERR:svc fail man", "ual rst         ")]
+    assert frames == [("ERR:svc fail    ", "manual rst      ")]
+
+
+def test_normalize_screens_preserves_prewrapped_inline_buffer() -> None:
+    frames = services.normalize_screens([("ERR2 WRN1:Panic", "failure")])
+
+    assert frames == [("ERR2 WRN1:Panic ", "failure         ")]
 
 
 def test_filter_redundant_lcd_summary_screens_handles_inline_headers() -> None:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -41,6 +41,12 @@ def test_parse_screens_accepts_single_line_colon_buffers() -> None:
     assert screens == [("ERR:svc fail -> rst", "")]
 
 
+def test_parse_screens_ignores_single_line_prose() -> None:
+    screens = services.parse_screens("Here is your summary:\n---\nERR:svc fail\n")
+
+    assert screens == [("ERR:svc fail", "")]
+
+
 def test_normalize_screens_flows_header_and_message_across_buffer() -> None:
     frames = services.normalize_screens(
         [("ERR", "scheduler raised unexpected reboot required")]

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -69,6 +69,25 @@ def test_normalize_screens_preserves_prewrapped_inline_buffer() -> None:
     assert frames == [("ERR2 WRN1:Panic ", "failure         ")]
 
 
+def test_deterministic_summary_round_trips_thirty_two_cell_buffer() -> None:
+    from apps.tasks.tasks import LocalLLMSummarizer
+
+    output = LocalLLMSummarizer().summarize(
+        "\n".join(
+            [
+                "LOGS:",
+                "ERR apps.demo: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            ]
+        )
+    )
+
+    frames = services.normalize_screens(services.parse_screens(output))
+
+    assert frames[0] == ("ERR1 WRN0:apps.d", "emo: ABCDEFGHIJK")
+    assert len(frames[0][0]) == 16
+    assert len(frames[0][1]) == 16
+
+
 def test_filter_redundant_lcd_summary_screens_handles_inline_headers() -> None:
     frames = services.filter_redundant_lcd_summary_screens(
         [

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -250,7 +250,7 @@ class LocalLLMSummarizer:
             if not (line.startswith("[") and line.endswith("]"))
         ]
         if not event_lines:
-            return "Quiet\nNo new logs\n---"
+            return _summary_screen("QUIET", "no logs")
 
         error_lines = [line for line in event_lines if _summary_severity(line) == "ERR"]
         warn_lines = [line for line in event_lines if _summary_severity(line) == "WRN"]
@@ -270,12 +270,12 @@ class LocalLLMSummarizer:
         if error_lines or warn_lines:
             screens.append(
                 (
-                    f"ERR {len(error_lines)} WRN {len(warn_lines)}",
+                    f"ERR{len(error_lines)} WRN{len(warn_lines)}",
                     _summary_compact_line((error_lines or warn_lines)[-1]),
                 )
             )
         else:
-            screens.append(("OK no err/warn", f"{len(event_lines)} lines"))
+            screens.append(("OK", f"{len(event_lines)}ln no err/wrn"))
 
         for line in (error_lines + warn_lines)[-3:]:
             screens.append((_summary_severity(line), _summary_compact_line(line)))
@@ -288,9 +288,11 @@ class LocalLLMSummarizer:
                 screens.append((label, f"{count}x /5m"))
 
         if len(screens) == 1:
-            screens.append(("Routine only", "No action"))
+            screens.append(("ROUTINE", "no action"))
 
-        return "\n---\n".join(f"{subject}\n{body}" for subject, body in screens)
+        return "\n---\n".join(
+            _summary_screen(subject, body) for subject, body in screens
+        )
 
 
 SUMMARY_TASK_ALIASES = {
@@ -314,7 +316,11 @@ SUMMARY_SOURCE_RE = re.compile(r"^(?:DBG|INF|WRN|ERR|CRI)\s+([\w.]+):")
 
 
 def _summary_severity(line: str) -> str:
-    if line.startswith("ERR ") or line.startswith("CRI ") or " raised unexpected" in line:
+    if (
+        line.startswith("ERR ")
+        or line.startswith("CRI ")
+        or " raised unexpected" in line
+    ):
         return "ERR"
     if line.startswith("WRN "):
         return "WRN"
@@ -357,7 +363,14 @@ def _summary_compact_line(line: str) -> str:
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if not cleaned:
         return "-"
-    return cleaned[:16]
+    return cleaned[:24]
+
+
+def _summary_screen(subject: str, body: str) -> str:
+    combined = re.sub(r"\s+", " ", f"{subject}:{body}").strip()[:32]
+    line1 = combined[:16]
+    line2 = combined[16:32]
+    return f"{line1}\n{line2}" if line2 else line1
 
 
 def _write_lcd_frames(

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -367,10 +367,9 @@ def _summary_compact_line(line: str) -> str:
 
 
 def _summary_screen(subject: str, body: str) -> str:
-    combined = re.sub(r"\s+", " ", f"{subject}:{body}").strip()[:32]
-    line1 = combined[:16]
-    line2 = combined[16:32]
-    return f"{line1}\n{line2}" if line2 else line1
+    header = re.sub(r"\s+", " ", str(subject or "")).strip().upper()
+    message = re.sub(r"\s+", " ", str(body or "")).strip()
+    return f"{header}:{message}"[:32]
 
 
 def _write_lcd_frames(

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -22,8 +22,8 @@ def test_local_lcd_summary_uses_dense_event_labels() -> None:
 
     assert "LOG 1" not in output
     assert "ERR2 WRN1:" in output
-    assert "HB ok" in output
-    assert "OCPP fwd" in output
+    assert "HB OK" in output
+    assert "OCPP FWD" in output
 
 
 def test_local_lcd_summary_reports_quiet_logs() -> None:

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -21,7 +21,7 @@ def test_local_lcd_summary_uses_dense_event_labels() -> None:
     output = LocalLLMSummarizer().summarize(prompt)
 
     assert "LOG 1" not in output
-    assert "ERR 2 WRN 1" in output
+    assert "ERR2 WRN1:" in output
     assert "HB ok" in output
     assert "OCPP fwd" in output
 
@@ -29,4 +29,4 @@ def test_local_lcd_summary_uses_dense_event_labels() -> None:
 def test_local_lcd_summary_reports_quiet_logs() -> None:
     output = LocalLLMSummarizer().summarize("LOGS:\n[celery.log]\n")
 
-    assert output == "Quiet\nNo new logs\n---"
+    assert output == "QUIET:no logs"


### PR DESCRIPTION
## Summary
- prompt and normalize LCD log summaries as 16x2 `HDR:message` buffers instead of separate header/body lines
- keep deterministic fallback summaries in the same compact colon-buffer shape
- render the USB LCD screen as four fixed icon+7-character slots and show `FREE` for empty/disconnected ports

Fixes #7630

## Validation
- `python -m pytest apps\sensors\tests\test_usb_lcd.py apps\summary\tests\test_services.py apps\tasks\tests\test_lcd_log_summary.py`
- `python -m pytest apps\sensors\tests\test_command.py apps\sensors\tests\test_tasks.py apps\summary\tests\test_celery_schedule.py`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python -m black --target-version py312 --check apps\sensors\constants.py apps\sensors\usb_lcd.py apps\sensors\tests\test_usb_lcd.py apps\summary\services.py apps\summary\tests\test_services.py apps\tasks\tasks.py apps\tasks\tests\test_lcd_log_summary.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements compact 16x2 LCD buffer formatting for summaries and fixed four-slot USB port rendering on the LCD display.

## Changes

### LCD Summary Compaction

**apps/summary/services.py**
- Added explicit LCD buffer sizing: `LCD_ROWS = 2` with corresponding `LCD_SUMMARY_BUFFER_CELLS` constant
- Updated LLM prompt instructions to favor compact formatting with inline headers in `"HEADER:message"` format (no forced newline after header)
- Removed prior line-length and ASCII-specific constraints; adjusted guidance to favor short words and abbreviations for improved density
- Enhanced `parse_screens` to treat single-line content as `(header, "")` tuples and join multi-line groups into space-delimited body strings
- Replaced `_normalize_line` with `_normalize_lcd_text` (printable coercion + whitespace compaction) and `_normalize_summary_buffer` (subject/body combination, truncation to buffer cells, partition into two 16-cell rows)
- Updated `filter_redundant_lcd_summary_screens` to parse inline headers and construct combined body from subject remainder plus body text for redundancy checking

**apps/summary/tests/test_services.py**
- Added test coverage for single-line colon buffers, header/message flow across fixed-size buffers, preservation of inline headers, and redundancy filtering with inline headers

**apps/tasks/tasks.py**
- Changed fallback quiet summary to use compact `_summary_screen("QUIET", "no logs")` format instead of multi-line string
- Updated error/warning labels from spaced format (`"ERR {n} WRN {m}"`) to compact concatenation (`"ERR{n} WRN{m}"`)
- Changed OK state summary to `"Xln no err/wrn"` format
- Renamed single-screen "routine" case to use `"ROUTINE"` subject with `"no action"` body
- Truncated `_summary_compact_line` from 16 to 24 characters and rewrote `_summary_screen` to compress subject/body into two 16-character LCD rows

**apps/tasks/tests/test_lcd_log_summary.py**
- Updated test expectations to validate compact label format (`"ERR2 WRN1:"`) and quiet summary format (`"QUIET:no logs"`)

### USB Port Slot Rendering

**apps/sensors/constants.py**
- Changed `USB_LCD_EMPTY_LABEL` from `"EMPTY"` to `"FREE"`
- Added `USB_LCD_PORT_ICONS` tuple with four Unicode characters (`("▘", "▝", "▖", "▗")`) representing port states

**apps/sensors/usb_lcd.py**
- Reworked `render_usb_lcd_lines` to render four fixed USB LCD slots
- Added internal helpers: `_usb_lcd_port_icon` (per-port icon selection), `_render_usb_lcd_slot` (icon + normalized label formatting), and `USB_LCD_SLOT_WIDTH` constant
- Each slot combines a per-port icon with a normalized device label padded/truncated to fixed slot width
- Removed `_render_label_pair` helper as slots now handle their own formatting

**apps/sensors/tests/test_usb_lcd.py**
- Renamed `test_render_usb_lcd_lines_fits_four_seven_character_labels` to `test_render_usb_lcd_lines_fits_four_fixed_icon_slots`
- Updated test assertions to verify fixed four-slot icon layout and exact icon character usage
- Added `test_render_usb_lcd_lines_keeps_port_positions_for_sparse_statuses` to verify sparse port mappings preserve correct positions
- Updated `build_usb_lcd_statuses` and `write_usb_lcd_status` test expectations to reflect `"FREE"` label for unmapped/unused ports and icon-based formatting

## Validation

- Tests added/updated across summary, USB LCD, and task modules
- Compact 16x2 buffer rendering contract validated by new tests
- Deterministic fallback summaries follow compact inline-header format
- USB port slots with icons render with fixed positioning and width

<!-- end of auto-generated comment: release notes by coderabbit.ai -->