### PR TITLE
sites-feedback: neutral disabled styling for submit button

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -674,6 +674,9 @@ body.user-story-open {
   --bs-btn-color: var(--user-story-accent-text);
   --bs-btn-hover-color: var(--user-story-accent-text);
   --bs-btn-active-color: var(--user-story-accent-text);
+  --bs-btn-disabled-bg: var(--bs-secondary-bg);
+  --bs-btn-disabled-border-color: var(--bs-border-color);
+  --bs-btn-disabled-color: var(--bs-secondary-color);
 }
 
 .user-story-card .btn-link {

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -564,7 +564,7 @@ body.user-story-open {
     cursor: not-allowed;
     box-shadow: none;
     background: var(--admin-ui-color-neutral-500, var(--user-story-muted));
-    color: var(--admin-ui-color-neutral-0, #fff);
+    color: var(--admin-ui-color-neutral-0, var(--user-story-accent-text));
 }
 
 .user-story-card .user-story-close {

--- a/apps/sites/static/sites/css/admin/base_site.css
+++ b/apps/sites/static/sites/css/admin/base_site.css
@@ -560,9 +560,11 @@ body.user-story-open {
 }
 
 .user-story-card .user-story-submit:disabled {
-    opacity: 0.6;
+    opacity: 1;
     cursor: not-allowed;
     box-shadow: none;
+    background: var(--admin-ui-color-neutral-500, var(--user-story-muted));
+    color: var(--admin-ui-color-neutral-0, #fff);
 }
 
 .user-story-card .user-story-close {


### PR DESCRIPTION
### Motivation
- Fix the feedback form submit button showing the accent (blue) while submitting so the disabled/in-progress state is visually neutral/grey and does not imply an active primary action.

### Description
- Set disabled color variables for the feedback card `.btn-primary` in `apps/sites/static/pages/css/base.css` and update the admin dialog `.user-story-submit:disabled` rule in `apps/sites/static/sites/css/admin/base_site.css` to use a neutral background and text color instead of only reducing opacity.

### Testing
- Attempted to run `./.venv/bin/python manage.py test run -- apps/sites/tests/test_public_controller_mode.py` but the test could not be executed because `./.venv/bin/python` is not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a38116788326bee7eae5fc5f2c5f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Updates CSS styling for disabled states of feedback form submit buttons to display in neutral grey instead of the accent blue color, ensuring the disabled/in-progress state appears visually neutral and does not imply an active primary action.

## Changes

### `apps/sites/static/pages/css/base.css`
Added disabled-state styling custom properties to `.user-story-card .btn-primary`:
- `--bs-btn-disabled-bg: var(--bs-secondary-bg);`
- `--bs-btn-disabled-border-color: var(--bs-border-color);`
- `--bs-btn-disabled-color: var(--bs-secondary-color);`

### `apps/sites/static/sites/css/admin/base_site.css`
Updated `.user-story-card .user-story-submit:disabled` styling:
- Changed opacity from `0.6` to `1`
- Added theme-based background color: `--admin-ui-color-neutral-500` (fallback: `--user-story-muted`)
- Added theme-based text color: `--admin-ui-color-neutral-0` (fallback: `#fff`)

Retained `cursor: not-allowed` and `box-shadow: none` properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->