### PR TITLE
summary: stop deleting low-channel locks during legacy cleanup

### DIFF
--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 from apps.features.parameters import get_feature_parameter
 from apps.features.utils import is_suite_feature_enabled
-from apps.screens.startup_notifications import LCD_LOW_LOCK_FILE, render_lcd_lock_file
+from apps.screens.startup_notifications import render_lcd_lock_file
 
 from .constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
 from .models import LLMSummaryConfig
@@ -299,12 +299,6 @@ def render_lcd_payload(subject: str, body: str, *, expires_at=None) -> str:
     return render_lcd_lock_file(subject=subject, body=body, expires_at=expires_at)
 
 
-def clear_legacy_low_summary_frames(lock_dir: Path) -> None:
-    """Legacy helper kept as a no-op to avoid deleting active low-channel messages."""
-
-    _ = lock_dir
-
-
 def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -> str:
     """Generate LCD log summary output and persist latest run metadata."""
 
@@ -316,7 +310,6 @@ def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -
     )
 
     lock_dir = Path(settings.BASE_DIR) / ".locks"
-    clear_legacy_low_summary_frames(lock_dir)
 
     node = Node.get_local()
     if not node:

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -300,19 +300,9 @@ def render_lcd_payload(subject: str, body: str, *, expires_at=None) -> str:
 
 
 def clear_legacy_low_summary_frames(lock_dir: Path) -> None:
-    """Remove old summary frames written into the low LCD channel."""
+    """Legacy helper kept as a no-op to avoid deleting active low-channel messages."""
 
-    prefix = f"{LCD_LOW_LOCK_FILE}-"
-    legacy_frames = [
-        candidate
-        for candidate in lock_dir.glob(f"{prefix}*")
-        if candidate.name[len(prefix) :].isdigit()
-    ]
-    if not legacy_frames:
-        return
-
-    for candidate in [lock_dir / LCD_LOW_LOCK_FILE, *legacy_frames]:
-        candidate.unlink(missing_ok=True)
+    _ = lock_dir
 
 
 def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -> str:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -115,20 +115,6 @@ def test_summary_frames_are_written_with_expiry(tmp_path) -> None:
     ]
 
 
-def test_legacy_low_summary_frames_are_preserved(tmp_path) -> None:
-    (tmp_path / "lcd-low").write_text("old\nsummary\n", encoding="utf-8")
-    (tmp_path / "lcd-low-1").write_text("old\nsummary\n", encoding="utf-8")
-    (tmp_path / "lcd-low-2").write_text("old\nsummary\n", encoding="utf-8")
-    (tmp_path / "lcd-low-extra").write_text("keep\nme\n", encoding="utf-8")
-
-    services.clear_legacy_low_summary_frames(tmp_path)
-
-    assert (tmp_path / "lcd-low").exists()
-    assert (tmp_path / "lcd-low-1").exists()
-    assert (tmp_path / "lcd-low-2").exists()
-    assert (tmp_path / "lcd-low-extra").exists()
-
-
 def test_no_log_generation_preserves_low_channel_messages(
     monkeypatch, settings, tmp_path
 ) -> None:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -115,7 +115,7 @@ def test_summary_frames_are_written_with_expiry(tmp_path) -> None:
     ]
 
 
-def test_legacy_low_summary_frames_are_removed(tmp_path) -> None:
+def test_legacy_low_summary_frames_are_preserved(tmp_path) -> None:
     (tmp_path / "lcd-low").write_text("old\nsummary\n", encoding="utf-8")
     (tmp_path / "lcd-low-1").write_text("old\nsummary\n", encoding="utf-8")
     (tmp_path / "lcd-low-2").write_text("old\nsummary\n", encoding="utf-8")
@@ -123,13 +123,13 @@ def test_legacy_low_summary_frames_are_removed(tmp_path) -> None:
 
     services.clear_legacy_low_summary_frames(tmp_path)
 
-    assert not (tmp_path / "lcd-low").exists()
-    assert not (tmp_path / "lcd-low-1").exists()
-    assert not (tmp_path / "lcd-low-2").exists()
+    assert (tmp_path / "lcd-low").exists()
+    assert (tmp_path / "lcd-low-1").exists()
+    assert (tmp_path / "lcd-low-2").exists()
     assert (tmp_path / "lcd-low-extra").exists()
 
 
-def test_no_log_generation_removes_legacy_low_summary_frames(
+def test_no_log_generation_preserves_low_channel_messages(
     monkeypatch, settings, tmp_path
 ) -> None:
     from apps.nodes.models import Node
@@ -164,11 +164,11 @@ def test_no_log_generation_removes_legacy_low_summary_frames(
     result = services.execute_log_summary_generation()
 
     assert result == "skipped:no-logs"
-    assert not (lock_dir / "lcd-low").exists()
-    assert not (lock_dir / "lcd-low-1").exists()
+    assert (lock_dir / "lcd-low").exists()
+    assert (lock_dir / "lcd-low-1").exists()
 
 
-def test_suite_gate_skip_removes_legacy_low_summary_frames(
+def test_suite_gate_skip_preserves_low_channel_messages(
     monkeypatch, settings, tmp_path
 ) -> None:
     from apps.nodes.models import Node
@@ -189,5 +189,5 @@ def test_suite_gate_skip_removes_legacy_low_summary_frames(
     result = services.execute_log_summary_generation()
 
     assert result == "skipped:suite-feature-disabled"
-    assert not (lock_dir / "lcd-low").exists()
-    assert not (lock_dir / "lcd-low-1").exists()
+    assert (lock_dir / "lcd-low").exists()
+    assert (lock_dir / "lcd-low-1").exists()


### PR DESCRIPTION
### Motivation
- The legacy cleanup in `clear_legacy_low_summary_frames()` treated any numeric `lcd-low-*` file as an old summary frame and deleted both numeric files and the base `lcd-low`, which can erase legitimate low-channel notifications. 
- The deletion also ran before local-node and suite-feature gates, causing removals even when summary generation was skipped.

### Description
- Make `clear_legacy_low_summary_frames(lock_dir: Path)` a no-op to avoid deleting active `lcd-low` and `lcd-low-N` files. 
- Update tests in `apps/summary/tests/test_services.py` to expect low-channel files to be preserved and rename the tests to reflect the new preserved behavior. 
- Keep the call site in `execute_log_summary_generation()` unchanged so cleanup does not run prior to gate checks anymore (behavior preserved by turning the helper into a no-op).

### Testing
- Updated unit tests in `apps/summary/tests/test_services.py` to assert that `lcd-low` and `lcd-low-N` files are preserved in normal and skipped execution paths. 
- Attempted to run tests with `.venv/bin/python manage.py test run -- apps.summary.tests.test_services`, but the environment lacks `.venv` so the invocation could not be executed. 
- Attempted to run `./install.sh` to prepare the environment, but the container is missing `redis-server` so installation failed and automated tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c64b7684832680e70c6c6cf89e34)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes the `clear_legacy_low_summary_frames()` helper function and its call site in `execute_log_summary_generation()` to prevent unintended deletion of low-channel notification files (`lcd-low` and `lcd-low-N`).

## Changes

**apps/summary/services.py:**
- Removed the unused `clear_legacy_low_summary_frames(lock_dir: Path)` function
- Removed the corresponding function call from `execute_log_summary_generation()`
- Updated imports to remove the now-unused `LCD_LOW_LOCK_FILE` constant

The removal is clean—the function had no other call sites in the codebase and the main generation logic continues without it.

**apps/summary/tests/test_services.py:**
- Renamed `test_no_log_generation_removes_legacy_low_summary_frames()` → `test_no_log_generation_preserves_low_channel_messages()` 
- Renamed `test_suite_gate_skip_removes_legacy_low_summary_frames()` → `test_suite_gate_skip_preserves_low_channel_messages()`
- Updated assertions in both tests to verify that `lcd-low` and `lcd-low-N` files remain intact after execution in their respective scenarios (no-logs path and suite-feature-disabled path)

## Rationale

The deleted cleanup logic was treating any numeric `lcd-low-*` file as legacy and deleting both the base `lcd-low` file and all numbered variants, which could incorrectly remove legitimate low-channel notifications. Additionally, the deletions occurred early in execution flow before local-node and suite-feature gates, causing removals even when summary generation was skipped downstream.

Removing the function entirely prevents this issue while preserving the documented call structure of `execute_log_summary_generation()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->