### PR TITLE
lcd: improve summary status frames

### DIFF
--- a/apps/screens/lcd_screen/rendering.py
+++ b/apps/screens/lcd_screen/rendering.py
@@ -188,6 +188,12 @@ def _select_low_payload(
     )
     interface_label = interface_label_func()
     body_parts = [f"ON {on_label}"]
+    temperature_label_func = _package_override(
+        "_lcd_temperature_label", _lcd_temperature_label
+    )
+    temperature = temperature_label_func()
+    if temperature:
+        body_parts.append(temperature)
     if interface_label:
         body_parts.append(interface_label)
     body = " ".join(body_parts).strip()
@@ -453,7 +459,17 @@ def _lcd_temperature_label_from_sysfs() -> str | None:
 
     if format_temperature:
         try:
-            label = format_temperature()
+            from django.conf import settings
+
+            label = format_temperature(
+                source=str(getattr(settings, "THERMOMETER_SOURCE", "auto") or "auto"),
+                w1_paths=_configured_temperature_paths(
+                    getattr(settings, "THERMOMETER_PATH_TEMPLATE", "")
+                ),
+                i2c_paths=_configured_temperature_paths(
+                    getattr(settings, "THERMOMETER_I2C_PATH_TEMPLATE", "")
+                ),
+            )
         except Exception:
             logger.debug("Unable to load sysfs thermometer reading", exc_info=True)
         else:
@@ -476,6 +492,13 @@ def _lcd_temperature_label_from_sysfs() -> str | None:
             value = value / Decimal("1000")
         return _format_temperature_value(value, "C")
     return None
+
+
+def _configured_temperature_paths(template: object) -> list[str] | None:
+    raw = str(template or "").strip()
+    if not raw or "{slug" in raw:
+        return None
+    return [raw]
 
 
 def _clock_payload(

--- a/apps/screens/tests/test_lcd_rendering_temperature.py
+++ b/apps/screens/tests/test_lcd_rendering_temperature.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 from django.utils import timezone
 
+import apps.screens.lcd_screen as lcd_package
 from apps.screens.lcd_screen import rendering
 from apps.sensors.models import Thermometer
 
@@ -53,3 +54,57 @@ def test_lcd_temperature_label_from_sensors_ignores_inactive_and_empty() -> None
     )
 
     assert rendering._lcd_temperature_label_from_sensors() is None
+
+
+def test_lcd_temperature_label_from_sysfs_uses_configured_i2c_path(
+    monkeypatch, settings
+) -> None:
+    settings.THERMOMETER_SOURCE = "i2c"
+    settings.THERMOMETER_I2C_PATH_TEMPLATE = "/sys/bus/i2c/devices/1-0068/temp1_input"
+    captured = {}
+
+    def fake_format_temperature(*, source, w1_paths, i2c_paths):
+        captured["source"] = source
+        captured["w1_paths"] = w1_paths
+        captured["i2c_paths"] = i2c_paths
+        return "31.3C"
+
+    monkeypatch.setattr(
+        "apps.sensors.thermometers.format_temperature",
+        fake_format_temperature,
+    )
+
+    assert rendering._lcd_temperature_label_from_sysfs() == "31.3C"
+    assert captured == {
+        "source": "i2c",
+        "w1_paths": None,
+        "i2c_paths": ["/sys/bus/i2c/devices/1-0068/temp1_input"],
+    }
+
+
+def test_select_low_payload_includes_temperature_on_main_screen(
+    monkeypatch, tmp_path
+) -> None:
+    now = timezone.now()
+    monkeypatch.setattr(
+        lcd_package,
+        "_uptime_seconds",
+        lambda base_dir, now: 3661,
+    )
+    monkeypatch.setattr(
+        lcd_package,
+        "_on_seconds",
+        lambda base_dir, now: 61,
+    )
+    monkeypatch.setattr(lcd_package, "_ap_mode_enabled", lambda: False)
+    monkeypatch.setattr(lcd_package, "_internet_interface_label", lambda: "NET")
+    monkeypatch.setattr(lcd_package, "_lcd_temperature_label", lambda: "88.2F")
+
+    payload = rendering._select_low_payload(
+        rendering.locks.LockPayload("", "", rendering.locks.DEFAULT_SCROLL_MS),
+        base_dir=tmp_path,
+        now=now,
+    )
+
+    assert payload.line1 == "UP 0d1h1m"
+    assert payload.line2 == "ON 1m1s 88.2F NET"

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -41,6 +41,10 @@ HOST_RESOURCE_BODY_RE = re.compile(
     r"\bt\d+(?:\.\d+)?[cf]?\b.*\bd\d+%.*\bm\d+%",
     re.IGNORECASE,
 )
+HOST_ATTENTION_BODY_RE = re.compile(
+    r"\b(?:action|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
+    re.IGNORECASE,
+)
 INLINE_BUFFER_RE = re.compile(r"^[A-Z0-9][A-Z0-9 /&+.\-]{0,15}:.+")
 
 
@@ -247,7 +251,7 @@ def filter_redundant_lcd_summary_screens(
             for part in (subject_body.strip(), (body or "").strip().lower())
             if part
         )
-        if subject_header == "host":
+        if subject_header == "host" and not HOST_ATTENTION_BODY_RE.search(body_text):
             continue
         if subject_header in {"resource", "resources"} and HOST_RESOURCE_BODY_RE.search(
             body_text

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -183,18 +183,20 @@ def build_summary_prompt(compacted_logs: str, *, now: datetime) -> str:
         You summarize system logs as 16x2 LCD buffers. Focus on the last 4 minutes (cutoff {cutoff}).
         Highlight urgent operator actions or failures. Think in 32 visible cells per screen, not as a document.
         Output 8-10 LCD screens. Each screen is two 16-cell rows.
-        Start each screen with a compact uppercase header, then a single ":" and continue the message immediately.
-        Do not waste row 1 on only the header; wrap the compact message into row 2 when useful.
+        Row 1 is the log extract, status phrase, or longer description.
+        Row 2 starts with a compact count such as "12 ln" for log lines or "3x" for repeated events.
+        Use the remaining right-side cells on row 2 for one operator word such as NORMAL, WARNING, ERROR, CHECK, FIX, or WAIT.
+        Keep short phrases on one row when they fit; for example, "Journal failed 3" must not be split after "Journal".
         Shorten words aggressively, drop grammar when helpful, and use abbreviations, symbols, arrows, or LCD-friendly drawing characters when they compress meaning.
-        Do not emit routine host resource screens; RAM, disk, swap, CPU, and temperature already have dedicated LCD screens.
+        Do not emit routine Host screens; RAM, disk, swap, CPU, and temperature already have dedicated LCD screens.
         Format:
         SCREEN 1:
-        <HDR>:<message row 1>
-        <message row 2>
+        <log extract or description>
+        <count>        <OPERATOR-WORD>
         ---
         SCREEN 2:
-        <HDR>:<message row 1>
-        <message row 2>
+        <log extract or description>
+        <count>        <OPERATOR-WORD>
         ...
         Only output the screens, no extra commentary.
         """).strip()
@@ -245,37 +247,33 @@ def filter_redundant_lcd_summary_screens(
             for part in (subject_body.strip(), (body or "").strip().lower())
             if part
         )
-        if subject_header in {
-            "host",
-            "resource",
-            "resources",
-        } and HOST_RESOURCE_BODY_RE.search(body_text):
+        if subject_header == "host":
+            continue
+        if subject_header in {"resource", "resources"} and HOST_RESOURCE_BODY_RE.search(
+            body_text
+        ):
             continue
         filtered.append((subject, body))
     return filtered
 
 
-def _normalize_lcd_text(text: str) -> str:
+def _normalize_lcd_text(text: str, *, collapse_whitespace: bool = True) -> str:
     normalized = "".join(ch if ch.isprintable() else " " for ch in str(text or ""))
-    return WHITESPACE_RE.sub(" ", normalized).strip()
+    if collapse_whitespace:
+        normalized = WHITESPACE_RE.sub(" ", normalized)
+    return normalized.strip()
 
 
 def _normalize_summary_buffer(subject: str, body: str) -> tuple[str, str]:
     subject_text = _normalize_lcd_text(subject)
-    body_text = _normalize_lcd_text(body)
-    if ":" in subject_text:
-        overflow = subject_text[LCD_COLUMNS:]
-        line2_source = " ".join(part for part in (overflow, body_text) if part)
+    body_text = _normalize_lcd_text(body, collapse_whitespace=False)
+    if body_text:
         return (
             subject_text[:LCD_COLUMNS].ljust(LCD_COLUMNS),
-            line2_source[:LCD_COLUMNS].ljust(LCD_COLUMNS),
+            body_text[:LCD_COLUMNS].ljust(LCD_COLUMNS),
         )
 
-    if subject_text and body_text:
-        combined = f"{subject_text}:{body_text}"
-    else:
-        combined = subject_text or body_text
-
+    combined = subject_text
     combined = combined[:LCD_SUMMARY_BUFFER_CELLS]
     line1 = combined[:LCD_COLUMNS].ljust(LCD_COLUMNS)
     line2 = combined[LCD_COLUMNS:LCD_SUMMARY_BUFFER_CELLS].ljust(LCD_COLUMNS)

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -15,12 +15,14 @@ def test_filter_redundant_lcd_summary_screens_drops_host_resource_frame() -> Non
         [
             ("Host", "t65C d51% m44%"),
             ("HOST:gway-001", "routine status"),
+            ("Host", "failed journal writer"),
             ("Status", "0 failed units"),
             ("USB key", "sda1 ro bastion"),
         ]
     )
 
     assert frames == [
+        ("Host", "failed journal writer"),
         ("Status", "0 failed units"),
         ("USB key", "sda1 ro bastion"),
     ]
@@ -103,11 +105,12 @@ def test_filter_redundant_lcd_summary_screens_handles_inline_headers() -> None:
         [
             ("HOST:t65C d51% m44%", ""),
             ("Host:gway-001", "active"),
+            ("HOST:gway-001", "down"),
             ("ERR:svc failed", "manual"),
         ]
     )
 
-    assert frames == [("ERR:svc failed", "manual")]
+    assert frames == [("HOST:gway-001", "down"), ("ERR:svc failed", "manual")]
 
 
 def test_summary_frames_are_written_with_expiry(tmp_path) -> None:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -14,6 +14,7 @@ def test_filter_redundant_lcd_summary_screens_drops_host_resource_frame() -> Non
     frames = services.filter_redundant_lcd_summary_screens(
         [
             ("Host", "t65C d51% m44%"),
+            ("HOST:gway-001", "routine status"),
             ("Status", "0 failed units"),
             ("USB key", "sda1 ro bastion"),
         ]
@@ -29,9 +30,10 @@ def test_build_summary_prompt_excludes_dedicated_resource_screens() -> None:
     prompt = services.build_summary_prompt("log line", now=datetime(2026, 5, 3))
 
     assert "Think in 32 visible cells per screen" in prompt
-    assert 'then a single ":" and continue the message immediately' in prompt
+    assert "Row 1 is the log extract" in prompt
+    assert '"12 ln" for log lines' in prompt
     assert "Shorten words aggressively" in prompt
-    assert "Do not emit routine host resource screens" in prompt
+    assert "Do not emit routine Host screens" in prompt
     assert "LOGS:\nlog line" in prompt
 
 
@@ -52,9 +54,17 @@ def test_normalize_screens_flows_header_and_message_across_buffer() -> None:
         [("ERR", "scheduler raised unexpected reboot required")]
     )
 
-    assert frames == [("ERR:scheduler ra", "ised unexpected ")]
+    assert frames == [("ERR             ", "scheduler raised")]
     assert len(frames[0][0]) == 16
     assert len(frames[0][1]) == 16
+
+
+def test_normalize_screens_keeps_log_extract_and_status_on_separate_rows() -> None:
+    frames = services.normalize_screens(
+        [("Journal failed 3", "12 ln      ERROR")]
+    )
+
+    assert frames == [("Journal failed 3", "12 ln      ERROR")]
 
 
 def test_normalize_screens_preserves_existing_inline_header() -> None:
@@ -83,7 +93,7 @@ def test_deterministic_summary_round_trips_thirty_two_cell_buffer() -> None:
 
     frames = services.normalize_screens(services.parse_screens(output))
 
-    assert frames[0] == ("ERR1 WRN0:apps.d", "emo: ABCDEFGHIJK")
+    assert frames[0] == ("ABCDEFGHIJKLMNOP", "1 ln       ERROR")
     assert len(frames[0][0]) == 16
     assert len(frames[0][1]) == 16
 
@@ -92,6 +102,7 @@ def test_filter_redundant_lcd_summary_screens_handles_inline_headers() -> None:
     frames = services.filter_redundant_lcd_summary_screens(
         [
             ("HOST:t65C d51% m44%", ""),
+            ("Host:gway-001", "active"),
             ("ERR:svc failed", "manual"),
         ]
     )

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SLEEP_SECONDS = 30
 DEFAULT_PROMPT_TIMEOUT = 240
+LCD_SUMMARY_COLUMNS = 16
 
 
 @shared_task
@@ -250,7 +251,9 @@ class LocalLLMSummarizer:
             if not (line.startswith("[") and line.endswith("]"))
         ]
         if not event_lines:
-            return _summary_screen("QUIET", "no logs")
+            return _summary_screen(
+                "No recent logs", _summary_status_line("0 ln", "NORMAL")
+            )
 
         error_lines = [line for line in event_lines if _summary_severity(line) == "ERR"]
         warn_lines = [line for line in event_lines if _summary_severity(line) == "WRN"]
@@ -258,6 +261,8 @@ class LocalLLMSummarizer:
         source_counts: dict[str, int] = {}
 
         for line in event_lines:
+            if _summary_severity(line) != "OK":
+                continue
             task_label = _summary_task_label(line)
             if task_label:
                 task_counts[task_label] = task_counts.get(task_label, 0) + 1
@@ -268,27 +273,46 @@ class LocalLLMSummarizer:
 
         screens: list[tuple[str, str]] = []
         if error_lines or warn_lines:
+            evaluation = _summary_evaluation(len(error_lines), len(warn_lines))
             screens.append(
                 (
-                    f"ERR{len(error_lines)} WRN{len(warn_lines)}",
                     _summary_compact_line((error_lines or warn_lines)[-1]),
+                    _summary_status_line(f"{len(event_lines)} ln", evaluation),
                 )
             )
         else:
-            screens.append(("OK", f"{len(event_lines)}ln no err/wrn"))
+            screens.append(
+                (
+                    "No err/wrn logs",
+                    _summary_status_line(f"{len(event_lines)} ln", "NORMAL"),
+                )
+            )
 
-        for line in (error_lines + warn_lines)[-3:]:
-            screens.append((_summary_severity(line), _summary_compact_line(line)))
+        for line in (error_lines + warn_lines)[-4:-1]:
+            severity = _summary_severity(line)
+            screens.append(
+                (
+                    _summary_compact_line(line),
+                    _summary_status_line(
+                        "1 ln", "WARNING" if severity == "WRN" else "ERROR"
+                    ),
+                )
+            )
 
         for label, count in _summary_top_counts(task_counts, limit=4):
-            screens.append((label, f"{count}x /5m"))
+            screens.append((label, _summary_status_line(f"{count}x", "NORMAL")))
 
         if len(screens) < 3:
             for label, count in _summary_top_counts(source_counts, limit=3):
-                screens.append((label, f"{count}x /5m"))
+                screens.append((label, _summary_status_line(f"{count}x", "NORMAL")))
 
         if len(screens) == 1:
-            screens.append(("ROUTINE", "no action"))
+            if error_lines:
+                screens.append(("Check logs", _summary_status_line("1x", "FIX")))
+            elif warn_lines:
+                screens.append(("Review logs", _summary_status_line("1x", "CHECK")))
+            else:
+                screens.append(("Routine", _summary_status_line("0x", "NORMAL")))
 
         return "\n---\n".join(
             _summary_screen(subject, body) for subject, body in screens
@@ -296,10 +320,10 @@ class LocalLLMSummarizer:
 
 
 SUMMARY_TASK_ALIASES = {
-    "apps.core.tasks.heartbeat": "HB ok",
-    "apps.ocpp.tasks.setup_forwarders": "OCPP fwd",
-    "apps.ocpp.tasks.send_offline_charge_point_notifications": "OCPP note",
-    "terminals.ensure_agent_terminals": "Term chk",
+    "apps.core.tasks.heartbeat": "HB OK",
+    "apps.ocpp.tasks.setup_forwarders": "OCPP FWD",
+    "apps.ocpp.tasks.send_offline_charge_point_notifications": "OCPP NOTE",
+    "terminals.ensure_agent_terminals": "TERM CHK",
 }
 
 SUMMARY_SOURCE_ALIASES = {
@@ -327,6 +351,14 @@ def _summary_severity(line: str) -> str:
     return "OK"
 
 
+def _summary_evaluation(error_count: int, warn_count: int) -> str:
+    if error_count:
+        return "ERROR"
+    if warn_count:
+        return "WARNING"
+    return "NORMAL"
+
+
 def _summary_alias(value: str, aliases: dict[str, str]) -> str:
     for prefix, label in aliases.items():
         if value == prefix or value.startswith(f"{prefix}."):
@@ -338,7 +370,7 @@ def _summary_task_label(line: str) -> str | None:
     match = SUMMARY_DUE_TASK_RE.search(line) or SUMMARY_TASK_RE.search(line)
     if not match:
         if "Heartbeat task executed" in line:
-            return "HB ok"
+            return "HB OK"
         return None
     return _summary_alias(match.group(1), SUMMARY_TASK_ALIASES)
 
@@ -357,6 +389,7 @@ def _summary_top_counts(counts: dict[str, int], *, limit: int) -> list[tuple[str
 def _summary_compact_line(line: str) -> str:
     cleaned = re.sub(r"^(?:DBG|INF|WRN|ERR|CRI)\s+", "", line)
     cleaned = re.sub(r"\[[^\]]+\]", "", cleaned)
+    cleaned = re.sub(r"^[\w.]+:\s+", "", cleaned)
     cleaned = cleaned.replace("Task ", "")
     cleaned = cleaned.replace("raised unexpected:", "raised:")
     cleaned = cleaned.replace("Scheduler: Sending due task", "due")
@@ -366,10 +399,31 @@ def _summary_compact_line(line: str) -> str:
     return cleaned[:24]
 
 
+def _summary_status_line(metric: str, evaluation: str) -> str:
+    left = re.sub(r"\s+", " ", str(metric or "")).strip()
+    right = re.sub(r"\s+", " ", str(evaluation or "")).strip().upper()
+    if not left:
+        return right[:LCD_SUMMARY_COLUMNS]
+    if not right:
+        return left[:LCD_SUMMARY_COLUMNS]
+    if len(left) + len(right) >= LCD_SUMMARY_COLUMNS:
+        return f"{left} {right}"[:LCD_SUMMARY_COLUMNS]
+    return f"{left}{' ' * (LCD_SUMMARY_COLUMNS - len(left) - len(right))}{right}"
+
+
+def _summary_lcd_line(text: str, *, collapse_whitespace: bool = True) -> str:
+    normalized = "".join(
+        ch if 32 <= ord(ch) < 127 else " " for ch in str(text or "")
+    )
+    if collapse_whitespace:
+        normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()[:LCD_SUMMARY_COLUMNS]
+
+
 def _summary_screen(subject: str, body: str) -> str:
-    header = re.sub(r"\s+", " ", str(subject or "")).strip().upper()
-    message = re.sub(r"\s+", " ", str(body or "")).strip()
-    return f"{header}:{message}"[:32]
+    line1 = _summary_lcd_line(subject)
+    line2 = _summary_lcd_line(body, collapse_whitespace=False)
+    return f"{line1}\n{line2}".rstrip()
 
 
 def _write_lcd_frames(

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -255,8 +255,13 @@ class LocalLLMSummarizer:
                 "No recent logs", _summary_status_line("0 ln", "NORMAL")
             )
 
-        error_lines = [line for line in event_lines if _summary_severity(line) == "ERR"]
-        warn_lines = [line for line in event_lines if _summary_severity(line) == "WRN"]
+        attention_events = [
+            (idx, line, severity)
+            for idx, line in enumerate(event_lines)
+            if (severity := _summary_severity(line)) != "OK"
+        ]
+        error_lines = [line for _, line, severity in attention_events if severity == "ERR"]
+        warn_lines = [line for _, line, severity in attention_events if severity == "WRN"]
         task_counts: dict[str, int] = {}
         source_counts: dict[str, int] = {}
 
@@ -274,9 +279,14 @@ class LocalLLMSummarizer:
         screens: list[tuple[str, str]] = []
         if error_lines or warn_lines:
             evaluation = _summary_evaluation(len(error_lines), len(warn_lines))
+            headline_idx, headline_line, _headline_severity = next(
+                event
+                for event in reversed(attention_events)
+                if event[2] == ("ERR" if error_lines else "WRN")
+            )
             screens.append(
                 (
-                    _summary_compact_line((error_lines or warn_lines)[-1]),
+                    _summary_compact_line(headline_line),
                     _summary_status_line(f"{len(event_lines)} ln", evaluation),
                 )
             )
@@ -288,8 +298,10 @@ class LocalLLMSummarizer:
                 )
             )
 
-        for line in (error_lines + warn_lines)[-4:-1]:
-            severity = _summary_severity(line)
+        detail_events = [
+            event for event in attention_events if event[0] != headline_idx
+        ][-3:] if attention_events else []
+        for _idx, line, severity in detail_events:
             screens.append(
                 (
                     _summary_compact_line(line),

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -418,7 +418,9 @@ def _summary_status_line(metric: str, evaluation: str) -> str:
         return right[:LCD_SUMMARY_COLUMNS]
     if not right:
         return left[:LCD_SUMMARY_COLUMNS]
-    if len(left) + len(right) >= LCD_SUMMARY_COLUMNS:
+    if len(left) + len(right) == LCD_SUMMARY_COLUMNS:
+        return f"{left}{right}"
+    if len(left) + len(right) > LCD_SUMMARY_COLUMNS:
         return f"{left} {right}"[:LCD_SUMMARY_COLUMNS]
     return f"{left}{' ' * (LCD_SUMMARY_COLUMNS - len(left) - len(right))}{right}"
 

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -42,3 +42,21 @@ def test_local_lcd_summary_keeps_journal_failure_on_first_row() -> None:
     assert output.split("\n---\n")[0] == "Journal failed 3\n1 ln       ERROR"
     assert "Check logs\n1x           FIX" in output
     assert output.count("Journal failed 3") == 1
+
+
+def test_local_lcd_summary_keeps_latest_warning_detail_with_errors() -> None:
+    output = LocalLLMSummarizer().summarize(
+        "\n".join(
+            [
+                "LOGS:",
+                "ERR apps.demo: Boom failure",
+                "WRN apps.demo: Disk warning 1",
+                "WRN apps.demo: Disk warning 2",
+                "WRN apps.demo: Disk warning 3",
+            ]
+        )
+    )
+
+    assert "Boom failure\n4 ln       ERROR" in output
+    assert "Disk warning 3\n1 ln     WARNING" in output
+    assert output.count("Boom failure") == 1

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -1,4 +1,4 @@
-from apps.tasks.tasks import LocalLLMSummarizer
+from apps.tasks.tasks import LocalLLMSummarizer, _summary_status_line
 
 
 def test_local_lcd_summary_uses_dense_event_labels() -> None:
@@ -60,3 +60,7 @@ def test_local_lcd_summary_keeps_latest_warning_detail_with_errors() -> None:
     assert "Boom failure\n4 ln       ERROR" in output
     assert "Disk warning 3\n1 ln     WARNING" in output
     assert output.count("Boom failure") == 1
+
+
+def test_summary_status_line_preserves_exact_fit_status() -> None:
+    assert _summary_status_line("123456789", "WARNING") == "123456789WARNING"

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -21,12 +21,24 @@ def test_local_lcd_summary_uses_dense_event_labels() -> None:
     output = LocalLLMSummarizer().summarize(prompt)
 
     assert "LOG 1" not in output
-    assert "ERR2 WRN1:" in output
+    assert "6 ln       ERROR" in output
+    assert "Panic failure" in output
     assert "HB OK" in output
     assert "OCPP FWD" in output
+    assert "2x        NORMAL" in output
 
 
 def test_local_lcd_summary_reports_quiet_logs() -> None:
     output = LocalLLMSummarizer().summarize("LOGS:\n[celery.log]\n")
 
-    assert output == "QUIET:no logs"
+    assert output == "No recent logs\n0 ln      NORMAL"
+
+
+def test_local_lcd_summary_keeps_journal_failure_on_first_row() -> None:
+    output = LocalLLMSummarizer().summarize(
+        "LOGS:\nERR apps.demo: Journal failed 3\n"
+    )
+
+    assert output.split("\n---\n")[0] == "Journal failed 3\n1 ln       ERROR"
+    assert "Check logs\n1x           FIX" in output
+    assert output.count("Journal failed 3") == 1


### PR DESCRIPTION
## Summary
- keep LCD summary row 1 focused on the log extract/description and row 2 on compact counts plus operator status words
- suppress generated Host summary frames and keep Journal failure phrases on one row
- show configured thermometer data on the main LCD screen and honor configured sysfs/I2C temperature paths

## Validation
- .\.venv\Scripts\python.exe manage.py test run -- apps\tasks\tests\test_lcd_log_summary.py apps\summary\tests\test_services.py apps\screens\tests\test_lcd_rendering_temperature.py apps\sensors\tests\test_tasks.py apps\sensors\tests\test_celery_schedule.py
- .\.venv\Scripts\python.exe manage.py check
- .\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run
- git diff --check