### PR TITLE
lcd: reduce summary and low-channel overlap

### DIFF
--- a/apps/screens/lcd_screen/locks.py
+++ b/apps/screens/lcd_screen/locks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import time
 from datetime import datetime, timedelta
@@ -75,6 +76,10 @@ CHANNEL_BASE_NAMES = {
     "stats": LCD_STATS_LOCK_FILE,
     "usb": LCD_USB_LOCK_FILE,
 }
+HOST_ATTENTION_BODY_RE = re.compile(
+    r"\b(?:action|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
+    re.IGNORECASE,
+)
 
 
 _SUITE_REACHABILITY_CACHE = {"checked_at": 0.0, "is_up": False}
@@ -89,7 +94,9 @@ def _package_override(name: str, default):
     return getattr(package, name, default)
 
 
-def _channel_lock_entries(lock_dir: Path, base_name: str) -> list[tuple[int, Path, float]]:
+def _channel_lock_entries(
+    lock_dir: Path, base_name: str
+) -> list[tuple[int, Path, float]]:
     entries: list[tuple[int, Path, float]] = []
     if not lock_dir.exists():
         return entries
@@ -153,9 +160,13 @@ def _read_lock_payload(lock_file: Path, *, now: datetime) -> LockPayload | None:
         try:
             lock_file.unlink()
         except OSError:
-            logger.debug("Failed to remove expired lock file: %s", lock_file, exc_info=True)
+            logger.debug(
+                "Failed to remove expired lock file: %s", lock_file, exc_info=True
+            )
         return None
-    if payload.expires_at is None and payload.subject.strip().upper().startswith("SIM "):
+    if payload.expires_at is None and payload.subject.strip().upper().startswith(
+        "SIM "
+    ):
         simulator_running = _simulator_running()
         if simulator_running is False:
             try:
@@ -195,10 +206,26 @@ def _load_low_channel_payloads(
         payload = _read_lock_payload(path, now=now)
         if payload is None:
             continue
+        if _is_routine_host_payload(payload):
+            continue
         if num == 0:
             has_base_payload = True
         payloads.append(payload)
     return payloads, has_base_payload
+
+
+def _is_routine_host_payload(payload: LockPayload) -> bool:
+    subject_text = (payload.line1 or "").strip().lower()
+    subject_header, _separator, subject_body = subject_text.partition(":")
+    if subject_header != "host":
+        return False
+
+    body_text = " ".join(
+        part
+        for part in (subject_body.strip(), (payload.line2 or "").strip().lower())
+        if part
+    )
+    return not HOST_ATTENTION_BODY_RE.search(body_text)
 
 
 def _read_lock_file(lock_file: Path) -> LockPayload:
@@ -209,7 +236,9 @@ def _read_lock_file(lock_file: Path) -> LockPayload:
         try:
             lock_file.unlink()
         except OSError:
-            logger.debug("Failed to remove expired lock file: %s", lock_file, exc_info=True)
+            logger.debug(
+                "Failed to remove expired lock file: %s", lock_file, exc_info=True
+            )
         return LockPayload("", "", DEFAULT_SCROLL_MS)
     return LockPayload(
         payload.subject,
@@ -273,7 +302,9 @@ def _event_lock_sort_key(path: Path) -> tuple[int, str]:
     return 10**9, name
 
 
-def _parse_event_lock_file(lock_file: Path, now: datetime) -> tuple[EventPayload, datetime]:
+def _parse_event_lock_file(
+    lock_file: Path, now: datetime
+) -> tuple[EventPayload, datetime]:
     try:
         lines = lock_file.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
@@ -349,7 +380,9 @@ def _load_channel_order(lock_dir: Path = LOCK_DIR) -> list[str] | None:
     order: list[str] = []
     for name in requested:
         if name not in CHANNEL_BASE_NAMES:
-            logger.debug("Skipping unknown LCD channel '%s' in channel order lock", name)
+            logger.debug(
+                "Skipping unknown LCD channel '%s' in channel order lock", name
+            )
             continue
         order.append(name)
     return order or None
@@ -423,9 +456,7 @@ def _suite_reachable(
     return is_up
 
 
-def _boot_elapsed_seconds(
-    *, now: datetime | None = None
-) -> int | None:
+def _boot_elapsed_seconds(*, now: datetime | None = None) -> int | None:
     now_value = now or datetime.now(datetime_timezone.utc)
     try:
         boot_time = float(psutil.boot_time())
@@ -440,11 +471,15 @@ def _boot_elapsed_seconds(
     return seconds if seconds >= 0 else None
 
 
-def _on_seconds(base_dir: Path = BASE_DIR, *, now: datetime | None = None) -> int | None:
+def _on_seconds(
+    base_dir: Path = BASE_DIR, *, now: datetime | None = None
+) -> int | None:
     now_value = now or datetime.now(datetime_timezone.utc)
     suite_reachable = _package_override("_suite_reachable", _suite_reachable)
     boot_elapsed = _package_override("_boot_elapsed_seconds", _boot_elapsed_seconds)
-    availability_seconds = _package_override("_availability_seconds", _availability_seconds)
+    availability_seconds = _package_override(
+        "_availability_seconds", _availability_seconds
+    )
 
     is_up = suite_reachable(base_dir)
     elapsed_seconds = boot_elapsed(now=now_value)
@@ -556,7 +591,10 @@ def _install_date(
 
 
 def _down_seconds(
-    uptime_seconds: int | None, base_dir: Path = BASE_DIR, *, now: datetime | None = None
+    uptime_seconds: int | None,
+    base_dir: Path = BASE_DIR,
+    *,
+    now: datetime | None = None,
 ) -> int | None:
     if uptime_seconds is None:
         return None

--- a/apps/screens/lcd_screen/locks.py
+++ b/apps/screens/lcd_screen/locks.py
@@ -77,7 +77,7 @@ CHANNEL_BASE_NAMES = {
     "usb": LCD_USB_LOCK_FILE,
 }
 HOST_ATTENTION_BODY_RE = re.compile(
-    r"\b(?:action|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
+    r"\b(?:action|alert|attention|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
     re.IGNORECASE,
 )
 

--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -47,7 +47,9 @@ ROTATION_SECONDS = 10
 EVENT_LINE_SCROLL_SECONDS = 10
 EVENT_STATIC_REFRESH_SECONDS = 2.0
 BASE_RELIEF_BLOCKED_CYCLES = 3
-BASE_RELIEF_LONG_EXPIRY = timedelta(seconds=ROTATION_SECONDS * BASE_RELIEF_BLOCKED_CYCLES)
+BASE_RELIEF_LONG_EXPIRY = timedelta(
+    seconds=ROTATION_SECONDS * BASE_RELIEF_BLOCKED_CYCLES
+)
 
 _SHUTDOWN_REQUESTED = False
 _EVENT_INTERRUPT_REQUESTED = False
@@ -112,7 +114,9 @@ class LCDRunner:
     """Coordinate LCD startup, event handling, rotation, and shutdown."""
 
     history_recorder: LCDHistoryRecorder = field(
-        default_factory=lambda: LCDHistoryRecorder(base_dir=BASE_DIR, history_dir_name="work")
+        default_factory=lambda: LCDHistoryRecorder(
+            base_dir=BASE_DIR, history_dir_name="work"
+        )
     )
     scroll_scheduler: ScrollScheduler = field(default_factory=ScrollScheduler)
     health: LCDHealthMonitor = field(default_factory=LCDHealthMonitor)
@@ -126,7 +130,9 @@ class LCDRunner:
     relief_states: dict[str, ChannelReliefState] = field(default_factory=dict)
     cycle_prefetch_future: Future[PrefetchedCycle] | None = None
     cycle_prefetch_executor: ThreadPoolExecutor = field(
-        default_factory=lambda: ThreadPoolExecutor(max_workers=1, thread_name_prefix="lcd-cycle")
+        default_factory=lambda: ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="lcd-cycle"
+        )
     )
     cycle_state_lock: threading.Lock = field(default_factory=threading.Lock)
     high_repeat_signature: tuple[tuple[int, float], ...] | None = None
@@ -161,7 +167,9 @@ class LCDRunner:
 
         try:
             self.lcd = _initialize_lcd()
-            self.frame_writer = LCDFrameWriter(self.lcd, history_recorder=self.history_recorder)
+            self.frame_writer = LCDFrameWriter(
+                self.lcd, history_recorder=self.history_recorder
+            )
             self.health.record_success()
         except LCDUnavailableError as exc:
             self.disable_lcd("LCD unavailable during startup", exc)
@@ -174,7 +182,9 @@ class LCDRunner:
         if self.lcd is not None:
             return
         self.lcd = _initialize_lcd()
-        self.frame_writer = LCDFrameWriter(self.lcd, history_recorder=self.history_recorder)
+        self.frame_writer = LCDFrameWriter(
+            self.lcd, history_recorder=self.history_recorder
+        )
         self.health.record_success()
 
     def setup(self) -> None:
@@ -287,8 +297,15 @@ class LCDRunner:
                 now=now_dt,
             )
             if payload and _payload_has_text(payload):
-                refreshed = _refresh_uptime_payload(payload, base_dir=BASE_DIR, now=now_dt)
-                return self.apply_relief_if_needed("low", refreshed, base_payload, now_dt)
+                refreshed = _refresh_uptime_payload(
+                    payload, base_dir=BASE_DIR, now=now_dt
+                )
+                return self.apply_relief_if_needed(
+                    "low", refreshed, base_payload, now_dt
+                )
+            if payload and payload.is_base:
+                self.reset_relief_state("low")
+                return base_payload
             high_state = channel_info.get("high")
             if "high" in state_order and high_state and len(high_state.payloads) >= 2:
                 high_payload = _high_payload(high_state)
@@ -300,15 +317,21 @@ class LCDRunner:
         if state_label == "clock":
             if channel_state and channel_text[state_label]:
                 payload = _peek_payload(channel_state)
-                base_payload = _clock_base_payload(now_dt, use_fahrenheit=self.rotation.clock_cycle % 2 == 0)
-                resolved = self.apply_relief_if_needed("clock", payload, base_payload, now_dt)
+                base_payload = _clock_base_payload(
+                    now_dt, use_fahrenheit=self.rotation.clock_cycle % 2 == 0
+                )
+                resolved = self.apply_relief_if_needed(
+                    "clock", payload, base_payload, now_dt
+                )
                 if advance and resolved.is_base:
                     self.rotation.clock_cycle += 1
                 return resolved
             if _lcd_clock_enabled():
                 self.reset_relief_state("clock")
                 use_fahrenheit = self.rotation.clock_cycle % 2 == 0
-                base_payload = _clock_base_payload(now_dt, use_fahrenheit=use_fahrenheit)
+                base_payload = _clock_base_payload(
+                    now_dt, use_fahrenheit=use_fahrenheit
+                )
                 if advance:
                     self.rotation.clock_cycle += 1
                 return base_payload
@@ -331,7 +354,9 @@ class LCDRunner:
                 )
             if stats_payload and _payload_has_text(stats_payload):
                 base_payload = _stats_payload()
-                return self.apply_relief_if_needed("stats", stats_payload, base_payload, now_dt)
+                return self.apply_relief_if_needed(
+                    "stats", stats_payload, base_payload, now_dt
+                )
             self.reset_relief_state("stats")
             return _stats_payload()
         return locks.LockPayload("", "", locks.DEFAULT_SCROLL_MS)
@@ -359,8 +384,12 @@ class LCDRunner:
                     advance=False,
                 )
             _warn_on_non_ascii_payload(payload, order[index])
-            prepared_state = _prepare_display_state(payload.line1, payload.line2, payload.scroll_ms)
-            return PrefetchedCycle(order=order, index=index, display_state=prepared_state)
+            prepared_state = _prepare_display_state(
+                payload.line1, payload.line2, payload.scroll_ms
+            )
+            return PrefetchedCycle(
+                order=order, index=index, display_state=prepared_state
+            )
 
         self.cycle_prefetch_future = self.cycle_prefetch_executor.submit(_prefetch)
 
@@ -384,13 +413,10 @@ class LCDRunner:
                 return True
             return False
 
-        def _interleave_summary(normal_order: tuple[str, ...]) -> tuple[str, ...]:
+        def _append_summary(normal_order: tuple[str, ...]) -> tuple[str, ...]:
             if not normal_order:
                 return ("summary",)
-            interleaved: list[str] = []
-            for label in normal_order:
-                interleaved.extend((label, "summary"))
-            return tuple(interleaved)
+            return (*normal_order, "summary")
 
         previous_order = self.rotation.order
         if configured_order:
@@ -418,7 +444,7 @@ class LCDRunner:
                     ("low", *utility_order) if low_available else utility_order
                 )
             self.rotation.order = (
-                _interleave_summary(normal_order) if summary_available else normal_order
+                _append_summary(normal_order) if summary_available else normal_order
             )
 
         if previous_order and 0 <= self.rotation.index < len(previous_order):
@@ -512,7 +538,9 @@ class LCDRunner:
             self.event.payload.scroll_ms,
         )
         self.event.line_deadline = (
-            now + EVENT_LINE_SCROLL_SECONDS if len(self.event.payload.lines) > 2 else 0.0
+            now + EVENT_LINE_SCROLL_SECONDS
+            if len(self.event.payload.lines) > 2
+            else 0.0
         )
         self.event.refresh_deadline = 0.0
 
@@ -533,7 +561,9 @@ class LCDRunner:
                 or refresh_now >= self.event.refresh_deadline
             )
         ):
-            display_state = display_state._replace(last_segment1=None, last_segment2=None)
+            display_state = display_state._replace(
+                last_segment1=None, last_segment2=None
+            )
             self.event.refresh_deadline = refresh_now + EVENT_STATIC_REFRESH_SECONDS
         self.event.display_state, write_success, shutdown_triggered = _advance_display(
             display_state,
@@ -571,7 +601,9 @@ class LCDRunner:
                 channel_text,
                 now_dt,
             )
-        _warn_on_non_ascii_payload(current_payload, self.rotation.order[self.rotation.index])
+        _warn_on_non_ascii_payload(
+            current_payload, self.rotation.order[self.rotation.index]
+        )
         self.rotation.display_state = _prepare_display_state(
             current_payload.line1,
             current_payload.line2,
@@ -612,20 +644,28 @@ class LCDRunner:
         self.ensure_lcd()
         self.scroll_scheduler.sleep_until_ready()
         frame_timestamp = datetime.now(datetime_timezone.utc)
-        label = self.rotation.order[self.rotation.index] if self.rotation.order else None
-        self.rotation.display_state, write_success, shutdown_triggered = _advance_display(
-            self.rotation.display_state,
-            self.frame_writer,
-            shutdown_requested=_shutdown_requested,
-            label=label,
-            timestamp=frame_timestamp,
+        label = (
+            self.rotation.order[self.rotation.index] if self.rotation.order else None
+        )
+        self.rotation.display_state, write_success, shutdown_triggered = (
+            _advance_display(
+                self.rotation.display_state,
+                self.frame_writer,
+                shutdown_requested=_shutdown_requested,
+                label=label,
+                timestamp=frame_timestamp,
+            )
         )
         if shutdown_triggered:
             _handle_shutdown_request(self.lcd)
             raise StopIteration
         self.record_health(write_success, "LCD write failed during rotation display")
         self.scroll_scheduler.advance(
-            (self.rotation.display_state.scroll_sec if self.rotation.display_state else 0)
+            (
+                self.rotation.display_state.scroll_sec
+                if self.rotation.display_state
+                else 0
+            )
             or DEFAULT_FALLBACK_SCROLL_SEC
         )
 
@@ -673,7 +713,9 @@ class LCDRunner:
                         channel_text,
                         now_dt,
                     )
-                _warn_on_non_ascii_payload(next_payload, self.rotation.order[next_index])
+                _warn_on_non_ascii_payload(
+                    next_payload, self.rotation.order[next_index]
+                )
                 self.rotation.next_display_state = _prepare_display_state(
                     next_payload.line1,
                     next_payload.line2,
@@ -767,7 +809,9 @@ def _reset_shutdown_flag() -> None:
     _SHUTDOWN_REQUESTED = False
 
 
-def _request_event_interrupt(signum, frame) -> None:  # pragma: no cover - signal handler
+def _request_event_interrupt(
+    signum, frame
+) -> None:  # pragma: no cover - signal handler
     """Interrupt the LCD cycle to show event lock files immediately."""
 
     global _EVENT_INTERRUPT_REQUESTED
@@ -857,20 +901,32 @@ def _load_channel_states(
         signature = tuple((num, mtime) for num, _, mtime in entries)
         payloads: list[locks.LockPayload] = []
         if label == "low":
-            payloads, has_base_payload = locks._load_low_channel_payloads(entries, now=now_dt)
-            if not has_base_payload:
-                payloads.insert(0, locks.LockPayload("", "", locks.DEFAULT_SCROLL_MS))
-                signature = ((0, -1.0),) + signature
+            payloads, _has_base_payload = locks._load_low_channel_payloads(
+                entries, now=now_dt
+            )
+            payloads.insert(
+                0,
+                locks.LockPayload("", "", locks.DEFAULT_SCROLL_MS, is_base=True),
+            )
+            signature = ((-1, -1.0),) + signature
         else:
             payloads = locks._load_channel_payloads(entries, now=now_dt)
-        if existing is None or existing.signature != signature or payloads != existing.payloads:
+        if (
+            existing is None
+            or existing.signature != signature
+            or payloads != existing.payloads
+        ):
             next_index = 0
             if existing and payloads:
                 next_index = existing.index % len(payloads)
-            existing = ChannelCycle(payloads=payloads, signature=signature, index=next_index)
+            existing = ChannelCycle(
+                payloads=payloads, signature=signature, index=next_index
+            )
         current_states[label] = existing
         channel_info[label] = existing
-        channel_text[label] = any(_payload_has_text(payload) for payload in existing.payloads)
+        channel_text[label] = any(
+            _payload_has_text(payload) for payload in existing.payloads
+        )
     return channel_info, channel_text
 
 
@@ -890,7 +946,9 @@ def _load_next_event(
             try:
                 candidate.unlink()
             except OSError:
-                logger.debug("Failed to remove expired event lock: %s", candidate, exc_info=True)
+                logger.debug(
+                    "Failed to remove expired event lock: %s", candidate, exc_info=True
+                )
             continue
         return payload, expires_at, candidate
     return None, None, None

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -561,6 +561,9 @@ def test_low_channel_filters_routine_host_payloads_but_keeps_host_alerts(
     (lock_dir / "lcd-low-2").write_text(
         "Host\nfailed journal writer\n", encoding="utf-8"
     )
+    (lock_dir / "lcd-low-3").write_text(
+        "Host\nattention: thermal alert\n", encoding="utf-8"
+    )
 
     monkeypatch.setattr(runner.locks, "LOCK_DIR", lock_dir)
 
@@ -571,6 +574,7 @@ def test_low_channel_filters_routine_host_payloads_but_keeps_host_alerts(
 
     assert ("Host", "t66C d51% m42%") not in payloads
     assert ("Host", "failed journal writer") in payloads
+    assert ("Host", "attention: thermal alert") in payloads
 
 
 def test_rotation_order_includes_usb_channel_when_active(monkeypatch):

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -276,7 +276,9 @@ def test_render_event_frame_raises_stop_iteration_on_shutdown(monkeypatch):
     coordinator.scroll_scheduler = FakeScheduler()
     coordinator.frame_writer = FakeWriter(object())
     coordinator.lcd = object()
-    coordinator.event.display_state = SimpleNamespace(scroll_sec=0.25, steps1=2, steps2=2)
+    coordinator.event.display_state = SimpleNamespace(
+        scroll_sec=0.25, steps1=2, steps2=2
+    )
 
     shutdown_calls: list[object] = []
     monkeypatch.setattr(
@@ -346,7 +348,9 @@ def test_high_payloads_repeat_three_times_across_high_and_low_slots(monkeypatch)
     monkeypatch.setattr(
         runner,
         "_select_low_payload",
-        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+        lambda *args, **kwargs: runner.locks.LockPayload(
+            "LO BASE", "", 0, is_base=True
+        ),
     )
 
     high_cycle = runner.ChannelCycle(
@@ -366,7 +370,9 @@ def test_high_payloads_repeat_three_times_across_high_and_low_slots(monkeypatch)
     channel_text = {"high": True, "low": False}
 
     seen = [
-        coordinator.payload_for_state(("high", "low"), slot, channel_info, channel_text, now_dt).line1
+        coordinator.payload_for_state(
+            ("high", "low"), slot, channel_info, channel_text, now_dt
+        ).line1
         for slot in (0, 1, 0, 1, 0, 1, 0)
     ]
 
@@ -380,7 +386,9 @@ def test_high_payloads_repeat_three_times_across_high_and_low_slots(monkeypatch)
     high_cycle.index = 1
 
     churn_seen = [
-        coordinator.payload_for_state(("high", "low"), slot, channel_info, channel_text, now_dt).line1
+        coordinator.payload_for_state(
+            ("high", "low"), slot, channel_info, channel_text, now_dt
+        ).line1
         for slot in (0, 1, 0, 1)
     ]
 
@@ -396,7 +404,9 @@ def test_low_slot_keeps_default_when_only_one_high_payload_exists(monkeypatch):
     monkeypatch.setattr(
         runner,
         "_select_low_payload",
-        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+        lambda *args, **kwargs: runner.locks.LockPayload(
+            "LO BASE", "", 0, is_base=True
+        ),
     )
 
     high_cycle = runner.ChannelCycle(
@@ -440,7 +450,9 @@ def test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high(monkeyp
     monkeypatch.setattr(
         runner,
         "_select_low_payload",
-        lambda *args, **kwargs: runner.locks.LockPayload("LO BASE", "", 0, is_base=True),
+        lambda *args, **kwargs: runner.locks.LockPayload(
+            "LO BASE", "", 0, is_base=True
+        ),
     )
 
     high_cycle = runner.ChannelCycle(
@@ -472,7 +484,7 @@ def test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high(monkeyp
     assert coordinator.high_repeat_count == 0
 
 
-def test_rotation_order_interleaves_summary_channel_when_active(monkeypatch):
+def test_rotation_order_appends_summary_channel_once_when_active(monkeypatch):
     coordinator = runner.LCDRunner()
 
     monkeypatch.setattr(runner.locks, "_load_channel_order", lambda lock_dir: None)
@@ -501,14 +513,64 @@ def test_rotation_order_interleaves_summary_channel_when_active(monkeypatch):
 
     assert coordinator.rotation.order == (
         "high",
-        "summary",
         "low",
-        "summary",
         "stats",
-        "summary",
         "clock",
         "summary",
     )
+
+
+def test_low_channel_keeps_generated_base_with_lock_payloads(monkeypatch, tmp_path):
+    now_dt = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir()
+    (lock_dir / "lcd-low").write_text("Status\n0 failed units\n", encoding="utf-8")
+
+    monkeypatch.setattr(runner.locks, "LOCK_DIR", lock_dir)
+    monkeypatch.setattr(
+        runner,
+        "_select_low_payload",
+        lambda *args, **kwargs: runner.locks.LockPayload(
+            "UP 0d1h1m", "ON 1m1s 88.2F", 0, is_base=True
+        ),
+    )
+
+    channel_info, channel_text = runner._load_channel_states({}, now_dt)
+    payload = runner.LCDRunner().payload_for_state(
+        ("low",),
+        0,
+        channel_info,
+        channel_text,
+        now_dt,
+    )
+
+    assert channel_info["low"].payloads[0].is_base is True
+    assert channel_info["low"].payloads[1].line1 == "Status"
+    assert payload.line1 == "UP 0d1h1m"
+    assert payload.line2 == "ON 1m1s 88.2F"
+
+
+def test_low_channel_filters_routine_host_payloads_but_keeps_host_alerts(
+    monkeypatch, tmp_path
+):
+    now_dt = datetime(2026, 5, 4, tzinfo=timezone.utc)
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir()
+    (lock_dir / "lcd-low").write_text("Status\n0 failed units\n", encoding="utf-8")
+    (lock_dir / "lcd-low-1").write_text("Host\nt66C d51% m42%\n", encoding="utf-8")
+    (lock_dir / "lcd-low-2").write_text(
+        "Host\nfailed journal writer\n", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(runner.locks, "LOCK_DIR", lock_dir)
+
+    channel_info, _channel_text = runner._load_channel_states({}, now_dt)
+    payloads = [
+        (payload.line1, payload.line2) for payload in channel_info["low"].payloads
+    ]
+
+    assert ("Host", "t66C d51% m42%") not in payloads
+    assert ("Host", "failed journal writer") in payloads
 
 
 def test_rotation_order_includes_usb_channel_when_active(monkeypatch):

--- a/apps/summary/constants.py
+++ b/apps/summary/constants.py
@@ -3,3 +3,5 @@ from __future__ import annotations
 LLM_SUMMARY_NODE_FEATURE_SLUG = "llm-summary"
 LLM_SUMMARY_SUITE_FEATURE_SLUG = "llm-summary-suite"
 LLM_SUMMARY_CELERY_TASK_NAME = "apps.summary.tasks.generate_lcd_log_summary"
+LCD_SUMMARY_WINDOW_MINUTES = 5
+LCD_SUMMARY_WINDOW_LABEL = f"{LCD_SUMMARY_WINDOW_MINUTES}m"

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -26,6 +26,7 @@ LCD_ROWS = 2
 LCD_SUMMARY_BUFFER_CELLS = LCD_COLUMNS * LCD_ROWS
 LCD_SUMMARY_FRAME_COUNT = 10
 LCD_SUMMARY_EXPIRES_AFTER = timedelta(minutes=10)
+LCD_SUMMARY_WINDOW_LABEL = "5m"
 DEFAULT_MODEL_DIR = Path(settings.BASE_DIR) / "work" / "llm" / "lcd-summary"
 DEFAULT_MODEL_FILE = "MODEL.README"
 
@@ -46,6 +47,10 @@ HOST_ATTENTION_BODY_RE = re.compile(
     re.IGNORECASE,
 )
 INLINE_BUFFER_RE = re.compile(r"^[A-Z0-9][A-Z0-9 /&+.\-]{0,15}:.+")
+SUMMARY_STATUS_COUNT_RE = re.compile(
+    r"^(?P<count>\d+)\s*(?P<unit>lines?|lns?|x)\b(?:\s*/\s*\d+\s*[smhd])?(?P<rest>.*)$",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -182,13 +187,14 @@ def compact_log_chunks(chunks: Iterable[LogChunk]) -> str:
 
 
 def build_summary_prompt(compacted_logs: str, *, now: datetime) -> str:
-    cutoff = (now - timedelta(minutes=4)).strftime("%H:%M")
+    cutoff = (now - timedelta(minutes=5)).strftime("%H:%M")
     instructions = textwrap.dedent(f"""
-        You summarize system logs as 16x2 LCD buffers. Focus on the last 4 minutes (cutoff {cutoff}).
+        You summarize system logs as 16x2 LCD buffers. Focus on the last 5 minutes (cutoff {cutoff}).
         Highlight urgent operator actions or failures. Think in 32 visible cells per screen, not as a document.
         Output 8-10 LCD screens. Each screen is two 16-cell rows.
         Row 1 is the log extract, status phrase, or longer description.
-        Row 2 starts with a compact count such as "12 ln" for log lines or "3x" for repeated events.
+        Row 2 starts with a compact count such as "12 ln/5m" for log lines or "3x/5m" for repeated events.
+        Never write "line" or "lines" on row 2; use "ln".
         Use the remaining right-side cells on row 2 for one operator word such as NORMAL, WARNING, ERROR, CHECK, FIX, or WAIT.
         Keep short phrases on one row when they fit; for example, "Journal failed 3" must not be split after "Journal".
         Shorten words aggressively, drop grammar when helpful, and use abbreviations, symbols, arrows, or LCD-friendly drawing characters when they compress meaning.
@@ -268,9 +274,44 @@ def _normalize_lcd_text(text: str, *, collapse_whitespace: bool = True) -> str:
     return normalized.strip()
 
 
+def normalize_summary_status_row(row: str) -> str:
+    """Return a normalized LCD summary status row when it starts with a count."""
+
+    raw = _normalize_lcd_text(row, collapse_whitespace=False)
+    text = _normalize_lcd_text(row)
+    match = SUMMARY_STATUS_COUNT_RE.match(text)
+    if not match:
+        return raw
+
+    count = match.group("count")
+    unit = match.group("unit").lower()
+    metric = (
+        f"{count}x/{LCD_SUMMARY_WINDOW_LABEL}"
+        if unit == "x"
+        else f"{count} ln/{LCD_SUMMARY_WINDOW_LABEL}"
+    )
+    evaluation = _normalize_lcd_text(match.group("rest")).upper()
+    return _format_summary_status_row(metric, evaluation)
+
+
+def _format_summary_status_row(metric: str, evaluation: str) -> str:
+    left = _normalize_lcd_text(metric)
+    right = _normalize_lcd_text(evaluation).upper()
+    if not left:
+        return right[:LCD_COLUMNS]
+    if not right:
+        return left[:LCD_COLUMNS]
+    if len(left) + len(right) == LCD_COLUMNS:
+        return f"{left}{right}"
+    if len(left) + len(right) > LCD_COLUMNS:
+        return f"{left} {right}"[:LCD_COLUMNS]
+    return f"{left}{' ' * (LCD_COLUMNS - len(left) - len(right))}{right}"
+
+
 def _normalize_summary_buffer(subject: str, body: str) -> tuple[str, str]:
     subject_text = _normalize_lcd_text(subject)
     body_text = _normalize_lcd_text(body, collapse_whitespace=False)
+    body_text = normalize_summary_status_row(body_text)
     if body_text:
         return (
             subject_text[:LCD_COLUMNS].ljust(LCD_COLUMNS),

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -16,7 +16,11 @@ from apps.features.parameters import get_feature_parameter
 from apps.features.utils import is_suite_feature_enabled
 from apps.screens.startup_notifications import render_lcd_lock_file
 
-from .constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from .constants import (
+    LCD_SUMMARY_WINDOW_LABEL,
+    LCD_SUMMARY_WINDOW_MINUTES,
+    LLM_SUMMARY_SUITE_FEATURE_SLUG,
+)
 from .models import LLMSummaryConfig
 
 logger = logging.getLogger(__name__)
@@ -26,7 +30,6 @@ LCD_ROWS = 2
 LCD_SUMMARY_BUFFER_CELLS = LCD_COLUMNS * LCD_ROWS
 LCD_SUMMARY_FRAME_COUNT = 10
 LCD_SUMMARY_EXPIRES_AFTER = timedelta(minutes=10)
-LCD_SUMMARY_WINDOW_LABEL = "5m"
 DEFAULT_MODEL_DIR = Path(settings.BASE_DIR) / "work" / "llm" / "lcd-summary"
 DEFAULT_MODEL_FILE = "MODEL.README"
 
@@ -43,7 +46,7 @@ HOST_RESOURCE_BODY_RE = re.compile(
     re.IGNORECASE,
 )
 HOST_ATTENTION_BODY_RE = re.compile(
-    r"\b(?:action|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
+    r"\b(?:action|alert|attention|blocked|check|critical|down|err(?:or)?|exception|fail(?:ed|ure)?|fix|offline|panic|warn(?:ing)?)\b",
     re.IGNORECASE,
 )
 INLINE_BUFFER_RE = re.compile(r"^[A-Z0-9][A-Z0-9 /&+.\-]{0,15}:.+")
@@ -187,13 +190,13 @@ def compact_log_chunks(chunks: Iterable[LogChunk]) -> str:
 
 
 def build_summary_prompt(compacted_logs: str, *, now: datetime) -> str:
-    cutoff = (now - timedelta(minutes=5)).strftime("%H:%M")
+    cutoff = (now - timedelta(minutes=LCD_SUMMARY_WINDOW_MINUTES)).strftime("%H:%M")
     instructions = textwrap.dedent(f"""
-        You summarize system logs as 16x2 LCD buffers. Focus on the last 5 minutes (cutoff {cutoff}).
+        You summarize system logs as 16x2 LCD buffers. Focus on the last {LCD_SUMMARY_WINDOW_MINUTES} minutes (cutoff {cutoff}).
         Highlight urgent operator actions or failures. Think in 32 visible cells per screen, not as a document.
         Output 8-10 LCD screens. Each screen is two 16-cell rows.
         Row 1 is the log extract, status phrase, or longer description.
-        Row 2 starts with a compact count such as "12 ln/5m" for log lines or "3x/5m" for repeated events.
+        Row 2 starts with a compact count such as "12 ln/{LCD_SUMMARY_WINDOW_LABEL}" for log lines or "3x/{LCD_SUMMARY_WINDOW_LABEL}" for repeated events.
         Never write "line" or "lines" on row 2; use "ln".
         Use the remaining right-side cells on row 2 for one operator word such as NORMAL, WARNING, ERROR, CHECK, FIX, or WAIT.
         Keep short phrases on one row when they fit; for example, "Journal failed 3" must not be split after "Journal".

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -33,7 +33,8 @@ def test_build_summary_prompt_excludes_dedicated_resource_screens() -> None:
 
     assert "Think in 32 visible cells per screen" in prompt
     assert "Row 1 is the log extract" in prompt
-    assert '"12 ln" for log lines' in prompt
+    assert '"12 ln/5m" for log lines' in prompt
+    assert 'Never write "line" or "lines" on row 2' in prompt
     assert "Shorten words aggressively" in prompt
     assert "Do not emit routine Host screens" in prompt
     assert "LOGS:\nlog line" in prompt
@@ -62,11 +63,15 @@ def test_normalize_screens_flows_header_and_message_across_buffer() -> None:
 
 
 def test_normalize_screens_keeps_log_extract_and_status_on_separate_rows() -> None:
-    frames = services.normalize_screens(
-        [("Journal failed 3", "12 ln      ERROR")]
-    )
+    frames = services.normalize_screens([("Journal failed 3", "12 lines      error")])
 
-    assert frames == [("Journal failed 3", "12 ln      ERROR")]
+    assert frames == [("Journal failed 3", "12 ln/5m   ERROR")]
+
+
+def test_normalize_screens_adds_window_to_repeat_counts() -> None:
+    frames = services.normalize_screens([("refresh usb lcd", "10x       normal")])
+
+    assert frames == [("refresh usb lcd ", "10x/5m    NORMAL")]
 
 
 def test_normalize_screens_preserves_existing_inline_header() -> None:
@@ -95,7 +100,7 @@ def test_deterministic_summary_round_trips_thirty_two_cell_buffer() -> None:
 
     frames = services.normalize_screens(services.parse_screens(output))
 
-    assert frames[0] == ("ABCDEFGHIJKLMNOP", "1 ln       ERROR")
+    assert frames[0] == ("ABCDEFGHIJKLMNOP", "1 ln/5m    ERROR")
     assert len(frames[0][0]) == 16
     assert len(frames[0][1]) == 16
 

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -12,14 +12,16 @@ from django.apps import apps as django_apps
 from django.db import models
 from django.utils import timezone
 
-from apps.summary.constants import LLM_SUMMARY_CELERY_TASK_NAME
+from apps.summary.constants import (
+    LCD_SUMMARY_WINDOW_LABEL,
+    LLM_SUMMARY_CELERY_TASK_NAME,
+)
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SLEEP_SECONDS = 30
 DEFAULT_PROMPT_TIMEOUT = 240
 LCD_SUMMARY_COLUMNS = 16
-LCD_SUMMARY_WINDOW_LABEL = "5m"
 SUMMARY_COUNT_METRIC_RE = re.compile(
     r"^(?P<count>\d+)\s*(?P<unit>lines?|lns?|x)\b(?:\s*/\s*\d+\s*[smhd])?",
     re.IGNORECASE,

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_SLEEP_SECONDS = 30
 DEFAULT_PROMPT_TIMEOUT = 240
 LCD_SUMMARY_COLUMNS = 16
+LCD_SUMMARY_WINDOW_LABEL = "5m"
+SUMMARY_COUNT_METRIC_RE = re.compile(
+    r"^(?P<count>\d+)\s*(?P<unit>lines?|lns?|x)\b(?:\s*/\s*\d+\s*[smhd])?",
+    re.IGNORECASE,
+)
 
 
 @shared_task
@@ -260,8 +265,12 @@ class LocalLLMSummarizer:
             for idx, line in enumerate(event_lines)
             if (severity := _summary_severity(line)) != "OK"
         ]
-        error_lines = [line for _, line, severity in attention_events if severity == "ERR"]
-        warn_lines = [line for _, line, severity in attention_events if severity == "WRN"]
+        error_lines = [
+            line for _, line, severity in attention_events if severity == "ERR"
+        ]
+        warn_lines = [
+            line for _, line, severity in attention_events if severity == "WRN"
+        ]
         task_counts: dict[str, int] = {}
         source_counts: dict[str, int] = {}
 
@@ -298,9 +307,11 @@ class LocalLLMSummarizer:
                 )
             )
 
-        detail_events = [
-            event for event in attention_events if event[0] != headline_idx
-        ][-3:] if attention_events else []
+        detail_events = (
+            [event for event in attention_events if event[0] != headline_idx][-3:]
+            if attention_events
+            else []
+        )
         for _idx, line, severity in detail_events:
             screens.append(
                 (
@@ -412,7 +423,7 @@ def _summary_compact_line(line: str) -> str:
 
 
 def _summary_status_line(metric: str, evaluation: str) -> str:
-    left = re.sub(r"\s+", " ", str(metric or "")).strip()
+    left = _summary_metric_text(metric)
     right = re.sub(r"\s+", " ", str(evaluation or "")).strip().upper()
     if not left:
         return right[:LCD_SUMMARY_COLUMNS]
@@ -425,10 +436,21 @@ def _summary_status_line(metric: str, evaluation: str) -> str:
     return f"{left}{' ' * (LCD_SUMMARY_COLUMNS - len(left) - len(right))}{right}"
 
 
+def _summary_metric_text(metric: str) -> str:
+    left = re.sub(r"\s+", " ", str(metric or "")).strip()
+    match = SUMMARY_COUNT_METRIC_RE.match(left)
+    if not match:
+        return left
+
+    count = match.group("count")
+    unit = match.group("unit").lower()
+    if unit == "x":
+        return f"{count}x/{LCD_SUMMARY_WINDOW_LABEL}"
+    return f"{count} ln/{LCD_SUMMARY_WINDOW_LABEL}"
+
+
 def _summary_lcd_line(text: str, *, collapse_whitespace: bool = True) -> str:
-    normalized = "".join(
-        ch if 32 <= ord(ch) < 127 else " " for ch in str(text or "")
-    )
+    normalized = "".join(ch if 32 <= ord(ch) < 127 else " " for ch in str(text or ""))
     if collapse_whitespace:
         normalized = re.sub(r"\s+", " ", normalized)
     return normalized.strip()[:LCD_SUMMARY_COLUMNS]

--- a/apps/tasks/tests/test_lcd_log_summary.py
+++ b/apps/tasks/tests/test_lcd_log_summary.py
@@ -21,26 +21,24 @@ def test_local_lcd_summary_uses_dense_event_labels() -> None:
     output = LocalLLMSummarizer().summarize(prompt)
 
     assert "LOG 1" not in output
-    assert "6 ln       ERROR" in output
+    assert "6 ln/5m    ERROR" in output
     assert "Panic failure" in output
     assert "HB OK" in output
     assert "OCPP FWD" in output
-    assert "2x        NORMAL" in output
+    assert "2x/5m     NORMAL" in output
 
 
 def test_local_lcd_summary_reports_quiet_logs() -> None:
     output = LocalLLMSummarizer().summarize("LOGS:\n[celery.log]\n")
 
-    assert output == "No recent logs\n0 ln      NORMAL"
+    assert output == "No recent logs\n0 ln/5m   NORMAL"
 
 
 def test_local_lcd_summary_keeps_journal_failure_on_first_row() -> None:
-    output = LocalLLMSummarizer().summarize(
-        "LOGS:\nERR apps.demo: Journal failed 3\n"
-    )
+    output = LocalLLMSummarizer().summarize("LOGS:\nERR apps.demo: Journal failed 3\n")
 
-    assert output.split("\n---\n")[0] == "Journal failed 3\n1 ln       ERROR"
-    assert "Check logs\n1x           FIX" in output
+    assert output.split("\n---\n")[0] == "Journal failed 3\n1 ln/5m    ERROR"
+    assert "Check logs\n1x/5m        FIX" in output
     assert output.count("Journal failed 3") == 1
 
 
@@ -57,10 +55,14 @@ def test_local_lcd_summary_keeps_latest_warning_detail_with_errors() -> None:
         )
     )
 
-    assert "Boom failure\n4 ln       ERROR" in output
-    assert "Disk warning 3\n1 ln     WARNING" in output
+    assert "Boom failure\n4 ln/5m    ERROR" in output
+    assert "Disk warning 3\n1 ln/5m  WARNING" in output
     assert output.count("Boom failure") == 1
 
 
 def test_summary_status_line_preserves_exact_fit_status() -> None:
     assert _summary_status_line("123456789", "WARNING") == "123456789WARNING"
+
+
+def test_summary_status_line_normalizes_line_words() -> None:
+    assert _summary_status_line("12 lines", "normal") == "12 ln/5m  NORMAL"


### PR DESCRIPTION
## Summary\n- filter routine low-channel Host LCD frames while preserving Host alerts\n- keep the generated UP/ON temperature main screen in low-channel rotation alongside lock-file messages\n- show LCD summaries once per rotation and normalize count rows to ln/5m or x/5m\n\nCloses #7637.\n\n## Validation\n- .\\.venv\\Scripts\\python.exe manage.py test run -- apps/tasks/tests/test_lcd_log_summary.py apps/summary/tests/test_services.py apps/screens/tests/test_lcd_runner.py apps/screens/tests/test_lcd_rendering_temperature.py\n- .\\.venv\\Scripts\\python.exe manage.py check\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses three core issues from #7637:

### 1. Filter Routine Low-Channel Host Frames
- **apps/screens/lcd_screen/locks.py** adds `HOST_ATTENTION_BODY_RE` regex pattern to distinguish "host attention" alert messages from routine host resource frames
- When loading low-channel lock payloads, routine host messages (line1 = "host" and body not matching alert keywords) are now excluded, while host alerts are preserved

### 2. Preserve Generated Temperature Main Screen
- **apps/screens/lcd_screen/runner.py** modifies the synthetic "base" payload for the low channel to use `is_base=True` with sentinel signature `(-1, -1.0)`, improving base-payload detection
- This ensures the generated temperature main screen remains available alongside low-channel lock-file messages

### 3. Normalize Summary Format and Display Frequency
- **apps/summary/services.py** and **apps/tasks/tasks.py** update LCD summary formatting:
  - Changes log-rate notation from generic "line/lines" to standardized "ln/5m" or "x/5m" format (5-minute window)
  - Adds `normalize_summary_status_row()` function to reformat count rows for 16x2 LCD cell width
- **apps/screens/lcd_screen/runner.py** changes rotation order: summary channel is now appended once at the end of rotation (instead of interleaved after each element), ensuring summaries appear once per rotation cycle

### Test Coverage
- **apps/screens/tests/test_lcd_runner.py**: New tests verify (1) low-channel retains base payload while incorporating lock entries, (2) low-channel filtering removes routine host payloads but preserves alerts, and (3) summary is appended once per rotation
- **apps/summary/tests/test_services.py**: Updated assertions verify normalized "ln/5m" and "x/5m" formatting in generated summaries
- **apps/tasks/tests/test_lcd_log_summary.py**: Updated to validate dense status formatting with time-window suffixes and verification of specific event line formatting

All changes maintain backward compatibility with existing rotation logic while applying targeted filtering and normalization only to the affected low-channel and summary rendering paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->