### PR TITLE
Suppress command.sh invocation log and manage.py version banner

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -32,12 +32,6 @@ fi
 
 chmod 600 "$LOG_FILE"
 exec > >(tee -a "$LOG_FILE") 2>&1
-# Keep command logging minimal to avoid exposing sensitive arguments in logs.
-printf "%s command.sh invocation" "$(date -Iseconds)"
-if [[ $# -gt 0 ]]; then
-  printf " command=%q" "$1"
-fi
-echo " args=<redacted>"
 cd "$BASE_DIR"
 
 # Ensure virtual environment is available

--- a/manage.py
+++ b/manage.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from config.loadenv import loadenv
 from config.sqlite_driver import bootstrap_sqlite_driver
-from utils import revision
 
 _RUNSERVER_STARTED_AT: float | None = None
 logger = logging.getLogger(__name__)
@@ -48,19 +47,7 @@ def _resolve_interrupt_main() -> Callable[[], None]:
     return _raise_keyboard_interrupt
 
 
-def _print_version(base_dir: Path) -> None:
-    ver_path = base_dir / "VERSION"
-    version = ver_path.read_text().strip() if ver_path.exists() else ""
-    rev_value = revision.get_revision()
-    rev_short = rev_value[-6:] if rev_value else ""
-    msg = f"Version: v{version}"
-    if rev_short:
-        msg += f" r{rev_short}"
-    print(msg)
-
-
 def _execute_django(argv: Sequence[str], base_dir: Path) -> None:
-    _print_version(base_dir)
     try:
         from daphne.management.commands.runserver import (
             Command as DaphneRunserver,


### PR DESCRIPTION
### Motivation
- The command wrapper and Django CLI entrypoint emit two informational lines that should be suppressed from operator output: the `command.sh invocation ... args=<redacted>` line and the `Version: v... r...` banner. 
- Removing these lines reduces noise and avoids exposing even redacted wrapper invocation metadata in normal command output.

### Description
- Removed the invocation logging lines from `command.sh` so the wrapper no longer prints the `command.sh invocation` and `args=<redacted>` lines. 
- Deleted the `_print_version` function from `manage.py` and removed the call to it from `_execute_django`, and removed the unused `revision` import. 
- Changes are limited to `command.sh` and `manage.py` and do not alter the runtime behavior beyond suppressing the two output lines.

### Testing
- Attempted to run the repository test `tests/test_startup_orchestration.py` with `.venv/bin/python manage.py test run -- tests/test_startup_orchestration.py`, but the run failed because `.venv/bin/python` is not present in this environment. 
- No other automated tests were executed in this environment after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9de71d9408326a0c1069b2847f167)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR suppresses two informational output lines that appear in operator logs: the `command.sh invocation` wrapper log and the Django CLI version banner.

### Changes

**command.sh:**
- Removed 6 lines that logged timestamped command invocation details, including the first argument via `command=%q` and the fixed `args=<redacted>` message
- Log redirection (`exec > >(tee -a "$LOG_FILE") 2>&1`) remains in place
- No functional changes to the script's behavior

**manage.py:**
- Removed the `revision` import from `utils`
- Deleted the `_print_version()` function that previously printed version and revision information
- Removed the call to `_print_version(base_dir)` from `_execute_django()`
- All runserver, celery, session, and migration-control logic remains unchanged
- Total of 13 lines removed

### Impact

Output suppression only; no runtime behavior changes beyond removing these two informational log lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->