### PR TITLE
[codex] Fix GetConfiguration action dispatch

### DIFF
--- a/apps/ocpp/call_result_handlers/legacy.py
+++ b/apps/ocpp/call_result_handlers/legacy.py
@@ -539,9 +539,22 @@ async def handle_get_configuration_result(
         f"GetConfiguration result: {payload_text}",
         log_type="charger",
     )
-    configuration = await database_sync_to_async(consumer._persist_configuration_result)(
-        payload_data, metadata.get("connector_id")
+    configuration_key_filter = metadata.get("configuration_key_filter")
+    filtered_request = (
+        isinstance(configuration_key_filter, (list, tuple))
+        and len(configuration_key_filter) > 0
     )
+    configuration = None
+    if filtered_request:
+        store.add_log(
+            log_key,
+            "Partial GetConfiguration result was not persisted as a full configuration snapshot.",
+            log_type="charger",
+        )
+    else:
+        configuration = await database_sync_to_async(consumer._persist_configuration_result)(
+            payload_data, metadata.get("connector_id")
+        )
     if configuration:
         if getattr(consumer, "charger", None) and getattr(consumer, "charger_id", None):
             if getattr(consumer.charger, "charger_id", None) == consumer.charger_id:

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -24,6 +24,7 @@ from apps.ocpp.models import (
     CertificateRequest,
     CertificateStatusCheck,
     Charger,
+    ChargerConfiguration,
     ChargingProfile,
     ChargingSchedule,
     ClearedChargingLimitEvent,
@@ -322,6 +323,148 @@ async def test_unlock_connector_result_updates_state():
     assert result is not None
     assert result.get("success") is True
     assert (result.get("payload") or {}).get("status") == "Unlocked"
+
+
+@pytest.mark.anyio
+async def test_get_configuration_action_records_filtered_key_metadata():
+    _reset_pending_calls()
+
+    class DummyWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, message: str) -> None:  # pragma: no cover - async wrapper
+            self.sent.append(message)
+
+    log_key = store.identity_key("CP-PARTIAL-CONFIG-2", None)
+    ws = DummyWebSocket()
+    context = ActionContext(
+        "CP-PARTIAL-CONFIG-2",
+        None,
+        charger=None,
+        ws=ws,
+        log_key=log_key,
+    )
+
+    action_call = await anyio.to_thread.run_sync(
+        lambda: actions._handle_get_configuration(
+            context,
+            {"key": ["MeterValuesSampledData", ""]},
+        )
+    )
+
+    sent_message = json.loads(ws.sent[0])
+    assert sent_message[2] == "GetConfiguration"
+    assert sent_message[3] == {"key": ["MeterValuesSampledData"]}
+    assert store.pending_calls[action_call.message_id]["configuration_key_filter"] == [
+        "MeterValuesSampledData"
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.django_db(transaction=True)
+async def test_filtered_get_configuration_result_does_not_replace_snapshot():
+    _reset_pending_calls()
+
+    def _create_existing_configuration(charger: Charger) -> int:
+        configuration = ChargerConfiguration.objects.create(
+            charger_identifier=charger.charger_id,
+            raw_payload={
+                "configurationKey": [
+                    {
+                        "key": "BootNotification",
+                        "readonly": False,
+                        "value": "enabled",
+                    },
+                    {
+                        "key": "MeterValuesSampledData",
+                        "readonly": False,
+                        "value": "Energy.Active.Import.Register",
+                    },
+                ]
+            },
+        )
+        configuration.replace_configuration_keys(
+            [
+                {
+                    "key": "BootNotification",
+                    "readonly": False,
+                    "value": "enabled",
+                },
+                {
+                    "key": "MeterValuesSampledData",
+                    "readonly": False,
+                    "value": "Energy.Active.Import.Register",
+                },
+            ]
+        )
+        charger.configuration = configuration
+        charger.save(update_fields=["configuration"])
+        return configuration.pk
+
+    charger = await database_sync_to_async(Charger.objects.create)(
+        charger_id="CP-PARTIAL-CONFIG-1"
+    )
+    existing_pk = await database_sync_to_async(_create_existing_configuration)(charger)
+    log_key = store.identity_key(charger.charger_id, charger.connector_id)
+    message_id = "msg-partial-config"
+    metadata = {
+        "action": "GetConfiguration",
+        "charger_id": charger.charger_id,
+        "connector_id": charger.connector_id,
+        "log_key": log_key,
+        "configuration_key_filter": ["MeterValuesSampledData"],
+    }
+    store.register_pending_call(message_id, metadata)
+
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    consumer.store_key = log_key
+    consumer.charger_id = charger.charger_id
+    consumer.charger = charger
+    consumer.aggregate_charger = None
+
+    await consumer._handle_call_result(
+        message_id,
+        {
+            "configurationKey": [
+                {
+                    "key": "MeterValuesSampledData",
+                    "readonly": False,
+                    "value": "Power.Active.Import",
+                }
+            ]
+        },
+    )
+
+    configuration_count = await database_sync_to_async(
+        ChargerConfiguration.objects.filter(
+            charger_identifier=charger.charger_id
+        ).count
+    )()
+    updated_charger = await database_sync_to_async(Charger.objects.get)(pk=charger.pk)
+
+    def _configuration_keys() -> list[dict[str, object]]:
+        return ChargerConfiguration.objects.get(pk=existing_pk).configuration_keys
+
+    assert configuration_count == 1
+    assert updated_charger.configuration_id == existing_pk
+    assert await database_sync_to_async(_configuration_keys)() == [
+        {
+            "key": "BootNotification",
+            "readonly": False,
+            "value": "enabled",
+        },
+        {
+            "key": "MeterValuesSampledData",
+            "readonly": False,
+            "value": "Energy.Active.Import.Register",
+        },
+    ]
+    result = store.wait_for_pending_call(message_id, timeout=0.5)
+    assert result is not None
+    assert result.get("payload", {}).get("configurationKey", [])[0]["value"] == (
+        "Power.Active.Import"
+    )
 
 
 @pytest.mark.anyio

--- a/apps/ocpp/views/actions/configuration.py
+++ b/apps/ocpp/views/actions/configuration.py
@@ -45,6 +45,26 @@ def _handle_get_configuration(context: ActionContext, data: dict) -> JsonRespons
     ocpp_action = "GetConfiguration"
     expected_statuses = CALL_EXPECTED_STATUSES.get(ocpp_action)
     msg = json.dumps([2, message_id, "GetConfiguration", payload])
+    async_to_sync(context.ws.send)(msg)
+    store.register_pending_call(
+        message_id,
+        {
+            "action": ocpp_action,
+            "charger_id": context.cid,
+            "connector_id": context.connector_value,
+            "log_key": context.log_key,
+            "requested_at": timezone.now(),
+        },
+    )
+    store.schedule_call_timeout(
+        message_id,
+        action=ocpp_action,
+        log_key=context.log_key,
+        message=(
+            "GetConfiguration timed out: charger did not respond"
+            " (operation may not be supported)"
+        ),
+    )
     return ActionCall(
         msg=msg,
         message_id=message_id,

--- a/apps/ocpp/views/actions/configuration.py
+++ b/apps/ocpp/views/actions/configuration.py
@@ -46,15 +46,18 @@ def _handle_get_configuration(context: ActionContext, data: dict) -> JsonRespons
     expected_statuses = CALL_EXPECTED_STATUSES.get(ocpp_action)
     msg = json.dumps([2, message_id, "GetConfiguration", payload])
     async_to_sync(context.ws.send)(msg)
+    metadata = {
+        "action": ocpp_action,
+        "charger_id": context.cid,
+        "connector_id": context.connector_value,
+        "log_key": context.log_key,
+        "requested_at": timezone.now(),
+    }
+    if keys:
+        metadata["configuration_key_filter"] = list(keys)
     store.register_pending_call(
         message_id,
-        {
-            "action": ocpp_action,
-            "charger_id": context.cid,
-            "connector_id": context.connector_value,
-            "log_key": context.log_key,
-            "requested_at": timezone.now(),
-        },
+        metadata,
     )
     store.schedule_call_timeout(
         message_id,

--- a/apps/ocpp/views/actions/configuration.py
+++ b/apps/ocpp/views/actions/configuration.py
@@ -60,10 +60,10 @@ def _handle_get_configuration(context: ActionContext, data: dict) -> JsonRespons
         message_id,
         action=ocpp_action,
         log_key=context.log_key,
-        message=(
+        message=str(_(
             "GetConfiguration timed out: charger did not respond"
             " (operation may not be supported)"
-        ),
+        )),
     )
     return ActionCall(
         msg=msg,


### PR DESCRIPTION
## Summary

Fixes the OCPP `get_configuration` API action so it actually sends the `GetConfiguration` call over the active charger websocket, registers the pending call metadata, and schedules the same timeout notice used by other configuration requests.

## Root Cause

The handler built and returned an `ActionCall`, which caused the request to be logged, but it never called `context.ws.send(...)` or registered the pending call. As a result, the UI/API path timed out without the charger receiving the request.

## Impact

Operators can now fetch and persist charger configuration snapshots through the suite action endpoint.

## Validation

- `python manage.py check` passed.
- Live `GetConfiguration` request against charger `GSCSC0824110052X0124` succeeded and persisted 336 configuration keys.
- Focused pytest run was blocked because `pytest-django` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes the GetConfiguration OCPP action handler to properly dispatch requests to the charger via websocket. Previously, the handler built the request message but failed to send it, register the pending call, or schedule the timeout mechanism, causing API calls to time out without reaching the charger.

## Changes

**apps/ocpp/views/actions/configuration.py**

The `_handle_get_configuration` handler now performs the critical side effects that were missing:
- Sends the OCPP message over the websocket via `async_to_sync(context.ws.send)`
- Registers the pending call with `store.register_pending_call`, capturing action, charger_id, connector_id, log_key, and requested_at timestamp
- Schedules a timeout handler via `store.schedule_call_timeout` with an internationalized message: "GetConfiguration timed out: charger did not respond (operation may not be supported)"

The handler continues to return the ActionCall object with the same message_id, ocpp_action, and expected_statuses as before, maintaining the existing API contract.

## Impact

Operators can now successfully fetch and persist charger configuration snapshots through the suite action endpoint, as the requests are properly transmitted and tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->