### PR TITLE
Add /ocpp and /ws/ocpp URL prefixes to OCPP forwarding and update health checks

### DIFF
--- a/apps/ocpp/forwarder/__init__.py
+++ b/apps/ocpp/forwarder/__init__.py
@@ -85,7 +85,7 @@ class Forwarder:
                     continue
             scheme = "wss" if parsed.scheme == "https" else "ws"
             base_path = parsed.path.rstrip("/")
-            for prefix in ("", "/ws"):
+            for prefix in ("/ocpp", "/ws/ocpp", ""):
                 path = f"{base_path}{prefix}/{encoded_id}".replace("//", "/")
                 if not path.startswith("/"):
                     path = f"/{path}"

--- a/apps/ocpp/forwarder/__init__.py
+++ b/apps/ocpp/forwarder/__init__.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 from django.utils import timezone
 from websocket import WebSocketException, create_connection
 
+from apps.ocpp.forwarding_paths import FORWARDING_WEBSOCKET_PREFIXES
 from apps.ocpp.forwarder_feature import ocpp_forwarder_enabled
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class Forwarder:
                     continue
             scheme = "wss" if parsed.scheme == "https" else "ws"
             base_path = parsed.path.rstrip("/")
-            for prefix in ("/ocpp", "/ws/ocpp", ""):
+            for prefix in FORWARDING_WEBSOCKET_PREFIXES:
                 path = f"{base_path}{prefix}/{encoded_id}".replace("//", "/")
                 if not path.startswith("/"):
                     path = f"/{path}"

--- a/apps/ocpp/forwarding_paths.py
+++ b/apps/ocpp/forwarding_paths.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Final
+
+FORWARDING_WEBSOCKET_PREFIXES: Final[tuple[str, ...]] = (
+    "/ocpp",
+    "/ws/ocpp",
+    "",
+    "/ws",
+)
+
+FORWARDING_WEBSOCKET_PATHS: Final[tuple[str, ...]] = (
+    "/ocpp/<charger_id>",
+    "/ws/ocpp/<charger_id>",
+)
+
+LEGACY_FORWARDING_WEBSOCKET_PATHS: Final[tuple[str, ...]] = (
+    "/ws/<charger_id>",
+    "/<charger_id>",
+)

--- a/apps/ocpp/forwarding_utils.py
+++ b/apps/ocpp/forwarding_utils.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext_lazy as _
 from requests import RequestException
 
 from apps.nodes.models import Node
+from apps.ocpp.forwarding_paths import FORWARDING_WEBSOCKET_PREFIXES
 from apps.ocpp.network import serialize_charger_for_network
 
 
@@ -84,7 +85,7 @@ def _iter_forwarding_urls(node: Node, charger_id: str) -> Iterable[str]:
                 continue
         scheme = "wss" if parsed.scheme == "https" else "ws"
         base_path = parsed.path.rstrip("/")
-        for prefix in ("/ocpp", "/ws/ocpp", ""):
+        for prefix in FORWARDING_WEBSOCKET_PREFIXES:
             path = f"{base_path}{prefix}/{safe_id}".replace("//", "/")
             if not path.startswith("/"):
                 path = f"/{path}"

--- a/apps/ocpp/forwarding_utils.py
+++ b/apps/ocpp/forwarding_utils.py
@@ -84,7 +84,7 @@ def _iter_forwarding_urls(node: Node, charger_id: str) -> Iterable[str]:
                 continue
         scheme = "wss" if parsed.scheme == "https" else "ws"
         base_path = parsed.path.rstrip("/")
-        for prefix in ("", "/ws"):
+        for prefix in ("/ocpp", "/ws/ocpp", ""):
             path = f"{base_path}{prefix}/{safe_id}".replace("//", "/")
             if not path.startswith("/"):
                 path = f"/{path}"

--- a/apps/ocpp/services/health_checks.py
+++ b/apps/ocpp/services/health_checks.py
@@ -8,6 +8,10 @@ from urllib.parse import urlsplit, urlunsplit
 from apps.core.system_ui import build_nginx_report, format_timestamp
 from apps.nginx import config_utils
 from apps.nodes.models import Node
+from apps.ocpp.forwarding_paths import (
+    FORWARDING_WEBSOCKET_PATHS,
+    LEGACY_FORWARDING_WEBSOCKET_PATHS,
+)
 from apps.ocpp.models import CPForwarder, Charger
 
 
@@ -32,6 +36,13 @@ def _iter_websocket_urls(node: Node, path: str) -> list[str]:
     return candidates
 
 
+def _iter_websocket_urls_for_paths(node: Node, paths: tuple[str, ...]) -> list[str]:
+    candidates: list[str] = []
+    for path in paths:
+        candidates.extend(_iter_websocket_urls(node, path))
+    return candidates
+
+
 def _has_external_websocket_config(nginx_content: str) -> bool:
     return all(directive in nginx_content for directive in config_utils.websocket_directives())
 
@@ -49,8 +60,10 @@ def run_check_forwarders(*, stdout, **_kwargs) -> None:
     else:
         host_candidates = local.get_remote_host_candidates(resolve_dns=False)
         metadata_urls = list(local.iter_remote_urls("/nodes/network/chargers/forward/"))
-        ocpp_urls = _iter_websocket_urls(local, "/ocpp/<charger_id>")
-        ocpp_ws_urls = _iter_websocket_urls(local, "/ws/ocpp/<charger_id>")
+        ocpp_urls = _iter_websocket_urls_for_paths(local, FORWARDING_WEBSOCKET_PATHS)
+        legacy_ocpp_urls = _iter_websocket_urls_for_paths(
+            local, LEGACY_FORWARDING_WEBSOCKET_PATHS
+        )
         nginx_report = build_nginx_report()
 
         stdout.write("  Registered: True")
@@ -59,7 +72,10 @@ def run_check_forwarders(*, stdout, **_kwargs) -> None:
         stdout.write(f"  Public key configured: {_format_bool(bool(local.public_key))}")
         stdout.write(f"  Metadata endpoints: {_format_list(metadata_urls)}")
         stdout.write(f"  OCPP websocket endpoints: {_format_list(ocpp_urls)}")
-        stdout.write(f"  OCPP websocket endpoints (legacy /ws): {_format_list(ocpp_ws_urls)}")
+        stdout.write(
+            "  OCPP websocket endpoints (legacy / and /ws): "
+            f"{_format_list(legacy_ocpp_urls)}"
+        )
         stdout.write("  Nginx configuration:")
         stdout.write(f"    Mode: {nginx_report.get('mode') or '—'}")
         stdout.write(f"    Backend port: {nginx_report.get('port') or '—'}")

--- a/apps/ocpp/services/health_checks.py
+++ b/apps/ocpp/services/health_checks.py
@@ -49,8 +49,8 @@ def run_check_forwarders(*, stdout, **_kwargs) -> None:
     else:
         host_candidates = local.get_remote_host_candidates(resolve_dns=False)
         metadata_urls = list(local.iter_remote_urls("/nodes/network/chargers/forward/"))
-        ocpp_urls = _iter_websocket_urls(local, "/<charger_id>")
-        ocpp_ws_urls = _iter_websocket_urls(local, "/ws/<charger_id>")
+        ocpp_urls = _iter_websocket_urls(local, "/ocpp/<charger_id>")
+        ocpp_ws_urls = _iter_websocket_urls(local, "/ws/ocpp/<charger_id>")
         nginx_report = build_nginx_report()
 
         stdout.write("  Registered: True")
@@ -59,7 +59,7 @@ def run_check_forwarders(*, stdout, **_kwargs) -> None:
         stdout.write(f"  Public key configured: {_format_bool(bool(local.public_key))}")
         stdout.write(f"  Metadata endpoints: {_format_list(metadata_urls)}")
         stdout.write(f"  OCPP websocket endpoints: {_format_list(ocpp_urls)}")
-        stdout.write(f"  OCPP websocket endpoints (/ws): {_format_list(ocpp_ws_urls)}")
+        stdout.write(f"  OCPP websocket endpoints (legacy /ws): {_format_list(ocpp_ws_urls)}")
         stdout.write("  Nginx configuration:")
         stdout.write(f"    Mode: {nginx_report.get('mode') or '—'}")
         stdout.write(f"    Backend port: {nginx_report.get('port') or '—'}")

--- a/apps/ocpp/tests/test_forwarder_service.py
+++ b/apps/ocpp/tests/test_forwarder_service.py
@@ -33,10 +33,12 @@ def test_candidate_forwarding_urls_builds_ws_and_wss(forwarder_instance):
     urls = list(forwarder_instance._candidate_forwarding_urls(node, charger))
 
     assert urls == [
+        "ws://example.com/base/ocpp/CP%2F42",
+        "ws://example.com/base/ws/ocpp/CP%2F42",
         "ws://example.com/base/CP%2F42",
-        "ws://example.com/base/ws/CP%2F42",
+        "wss://secure.example.com/root/ocpp/CP%2F42",
+        "wss://secure.example.com/root/ws/ocpp/CP%2F42",
         "wss://secure.example.com/root/CP%2F42",
-        "wss://secure.example.com/root/ws/CP%2F42",
     ]
 
 
@@ -52,8 +54,9 @@ def test_candidate_forwarding_urls_skips_tls_ip_targets(forwarder_instance):
     urls = list(forwarder_instance._candidate_forwarding_urls(node, charger))
 
     assert urls == [
+        "ws://192.0.2.10/base/ocpp/CP%2F42",
+        "ws://192.0.2.10/base/ws/ocpp/CP%2F42",
         "ws://192.0.2.10/base/CP%2F42",
-        "ws://192.0.2.10/base/ws/CP%2F42",
     ]
 
 

--- a/apps/ocpp/tests/test_forwarder_service.py
+++ b/apps/ocpp/tests/test_forwarder_service.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from websocket import WebSocketException
 
 from apps.ocpp.forwarder import Forwarder, ForwardingSession
+from apps.ocpp.services import health_checks
 from apps.ocpp.models import CPForwarder, Charger
 from apps.nodes.models import Node
 
@@ -36,9 +37,11 @@ def test_candidate_forwarding_urls_builds_ws_and_wss(forwarder_instance):
         "ws://example.com/base/ocpp/CP%2F42",
         "ws://example.com/base/ws/ocpp/CP%2F42",
         "ws://example.com/base/CP%2F42",
+        "ws://example.com/base/ws/CP%2F42",
         "wss://secure.example.com/root/ocpp/CP%2F42",
         "wss://secure.example.com/root/ws/ocpp/CP%2F42",
         "wss://secure.example.com/root/CP%2F42",
+        "wss://secure.example.com/root/ws/CP%2F42",
     ]
 
 
@@ -57,7 +60,50 @@ def test_candidate_forwarding_urls_skips_tls_ip_targets(forwarder_instance):
         "ws://192.0.2.10/base/ocpp/CP%2F42",
         "ws://192.0.2.10/base/ws/ocpp/CP%2F42",
         "ws://192.0.2.10/base/CP%2F42",
+        "ws://192.0.2.10/base/ws/CP%2F42",
     ]
+
+
+@pytest.mark.django_db
+def test_run_check_forwarders_reports_current_and_legacy_websocket_paths(monkeypatch):
+    class Stdout:
+        def __init__(self):
+            self.lines: list[str] = []
+
+        def write(self, message: str) -> None:
+            self.lines.append(message)
+
+    local = SimpleNamespace(
+        public_endpoint="example.test",
+        public_key="public-key",
+        get_remote_host_candidates=lambda resolve_dns=False: ["example.test"],
+        iter_remote_urls=lambda path: [f"http://example.test{path}"],
+        __str__=lambda self: "local",
+    )
+    monkeypatch.setattr(health_checks.Node, "get_local", staticmethod(lambda: local))
+    monkeypatch.setattr(
+        health_checks,
+        "build_nginx_report",
+        lambda: {"mode": "", "port": "", "actual_path": "", "differs": False},
+    )
+    stdout = Stdout()
+
+    health_checks.run_check_forwarders(stdout=stdout)
+
+    current_line = next(
+        line
+        for line in stdout.lines
+        if line.startswith("  OCPP websocket endpoints: ")
+    )
+    legacy_line = next(
+        line
+        for line in stdout.lines
+        if line.startswith("  OCPP websocket endpoints (legacy / and /ws): ")
+    )
+    assert "ws://example.test/ocpp/<charger_id>" in current_line
+    assert "ws://example.test/ws/ocpp/<charger_id>" in current_line
+    assert "ws://example.test/ws/<charger_id>" in legacy_line
+    assert "ws://example.test/<charger_id>" in legacy_line
 
 
 


### PR DESCRIPTION
### Motivation
- Include explicit OCPP endpoint prefixes so remote nodes exposing `/ocpp` or `/ws/ocpp` are discovered as forwarding targets. 
- Preserve legacy compatibility by keeping the older `/ws` path but marking it as legacy in health output. 
- Ensure probes and URL generation handle the new endpoint variants used by some deployments.

### Description
- Added `/ocpp` and `/ws/ocpp` to the prefix lists in `Forwarder._candidate_forwarding_urls` and `_iter_forwarding_urls` in `apps/ocpp/forwarder/__init__.py` and `apps/ocpp/forwarding_utils.py` so candidate websocket URLs now include those paths. 
- Updated `run_check_forwarders` in `apps/ocpp/services/health_checks.py` to look for `/ocpp/<charger_id>` and `/ws/ocpp/<charger_id>` and to label the original `/ws` endpoint as "legacy /ws" in the health output. 
- Adjusted unit expectations in `apps/ocpp/tests/test_forwarder_service.py` to assert the new URL variants are produced. 
- No changes to connection option handling or session closing logic beyond URL generation and reporting.

### Testing
- Ran `pytest apps/ocpp/tests/test_forwarder_service.py` and the updated tests passed. 
- Ran the `apps.ocpp` unit test subset with `pytest` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c827d77c83268e21deeca32b354f)