### PR TITLE
Decouple LLM summary generation from LCD output

### DIFF
--- a/apps/features/fixtures/features__llm_summary_suite.json
+++ b/apps/features/fixtures/features__llm_summary_suite.json
@@ -22,7 +22,7 @@
       ],
       "metadata": {},
       "node_feature": [
-        "lcd-screen"
+        "llm-summary"
       ],
       "protocol_coverage": {},
       "public_requirements": "No direct public interface; summarization updates internal displays.",

--- a/apps/features/migrations/0008_link_llm_summary_suite_feature.py
+++ b/apps/features/migrations/0008_link_llm_summary_suite_feature.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+
+
+def link_llm_summary_suite_feature(apps, schema_editor):
+    Feature = apps.get_model("features", "Feature")
+    NodeFeature = apps.get_model("nodes", "NodeFeature")
+
+    llm_summary_feature, _created = NodeFeature.objects.get_or_create(
+        slug="llm-summary",
+        defaults={"display": "LLM Summary"},
+    )
+    Feature.objects.filter(slug="llm-summary-suite").update(
+        node_feature=llm_summary_feature,
+    )
+
+
+def restore_lcd_summary_suite_feature(apps, schema_editor):
+    Feature = apps.get_model("features", "Feature")
+    NodeFeature = apps.get_model("nodes", "NodeFeature")
+
+    lcd_feature, _created = NodeFeature.objects.get_or_create(
+        slug="lcd-screen",
+        defaults={"display": "LCD Screen"},
+    )
+    Feature.objects.filter(slug="llm-summary-suite").update(
+        node_feature=lcd_feature,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("features", "0007_shorten_feature_slugs"),
+        ("nodes", "0012_upgrade_policy_custom_controls"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            link_llm_summary_suite_feature,
+            restore_lcd_summary_suite_feature,
+        ),
+    ]

--- a/apps/features/tests/test_models.py
+++ b/apps/features/tests/test_models.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from django.core.management import call_command
-from django.core.exceptions import ValidationError
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.management import call_command
 
 from apps.features.models import Feature
+from apps.nodes.models import NodeFeature
 
 
 @pytest.mark.django_db
@@ -23,7 +24,9 @@ from apps.features.models import Feature
         ({}, 0),
     ],
 )
-def test_params_count_reads_feature_metadata_parameters(metadata, expected_count: int) -> None:
+def test_params_count_reads_feature_metadata_parameters(
+    metadata, expected_count: int
+) -> None:
     """params_count should only count dictionary-backed parameter values."""
 
     feature = Feature.objects.create(
@@ -33,6 +36,7 @@ def test_params_count_reads_feature_metadata_parameters(metadata, expected_count
     )
 
     assert feature.params_count == expected_count
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
@@ -112,3 +116,29 @@ def test_pages_feature_fixtures_load_after_register_site_apps(
     feature = Feature.objects.get(slug=slug)
     assert feature.main_app is not None
     assert feature.main_app.name == "pages"
+
+
+@pytest.mark.django_db
+def test_llm_summary_suite_fixture_links_summary_node_feature() -> None:
+    """The suite gate should unlock summary generation, not LCD hardware."""
+
+    NodeFeature.objects.get_or_create(
+        slug="llm-summary",
+        defaults={"display": "LLM Summary"},
+    )
+    fixture_path = (
+        Path(settings.BASE_DIR)
+        / "apps"
+        / "features"
+        / "fixtures"
+        / "features__llm_summary_suite.json"
+    )
+
+    call_command("register_site_apps")
+    call_command("loaddata", str(fixture_path))
+
+    feature = Feature.objects.select_related("node_feature").get(
+        slug="llm-summary-suite"
+    )
+    assert feature.node_feature is not None
+    assert feature.node_feature.slug == "llm-summary"

--- a/apps/nodes/tests/test_models_split.py
+++ b/apps/nodes/tests/test_models_split.py
@@ -292,13 +292,11 @@ def test_detect_auto_feature_enables_llm_summary_without_lcd_when_config_active(
 ):
     """llm-summary detection should reflect generation capability, not LCD output."""
 
-    from apps.summary.services import get_summary_config
+    from apps.summary.models import LLMSummaryConfig
 
     node, tmp_path = llm_summary_node
 
-    config = get_summary_config()
-    config.is_active = True
-    config.save(update_fields=["is_active", "updated_at"])
+    LLMSummaryConfig.objects.create(is_active=True)
 
     result = node._detect_auto_feature(
         "llm-summary", base_dir=tmp_path, base_path=tmp_path
@@ -313,19 +311,33 @@ def test_detect_auto_feature_skips_llm_summary_when_config_inactive(
 ):
     """Inactive summary config should keep the node summary feature off."""
 
-    from apps.summary.services import get_summary_config
+    from apps.summary.models import LLMSummaryConfig
 
     node, tmp_path = llm_summary_node
 
-    config = get_summary_config()
-    config.is_active = False
-    config.save(update_fields=["is_active", "updated_at"])
+    LLMSummaryConfig.objects.create(is_active=False)
 
     result = node._detect_auto_feature(
         "llm-summary", base_dir=tmp_path, base_path=tmp_path
     )
 
     assert result is False
+
+
+@pytest.mark.django_db
+def test_detect_auto_feature_does_not_create_llm_summary_config(llm_summary_node):
+    """Feature detection should be a read-only probe."""
+
+    from apps.summary.models import LLMSummaryConfig
+
+    node, tmp_path = llm_summary_node
+
+    result = node._detect_auto_feature(
+        "llm-summary", base_dir=tmp_path, base_path=tmp_path
+    )
+
+    assert result is False
+    assert LLMSummaryConfig.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/apps/nodes/tests/test_models_split.py
+++ b/apps/nodes/tests/test_models_split.py
@@ -148,8 +148,6 @@ def test_refresh_features_skips_auto_enable_when_linked_suite_feature_disabled(
 
 
 @pytest.mark.django_db
-
-
 @pytest.mark.django_db
 def test_refresh_features_skips_lazy_rfid_auto_detection(monkeypatch, tmp_path):
     """Feature refresh should not probe lazy RFID scanner auto-detection."""
@@ -249,9 +247,7 @@ def test_ensure_feature_enabled_does_not_probe_lazy_feature_on_remote_node(
 
 
 @pytest.mark.django_db
-def test_ensure_feature_enabled_handles_lazy_detection_exception(
-    monkeypatch, tmp_path
-):
+def test_ensure_feature_enabled_handles_lazy_detection_exception(monkeypatch, tmp_path):
     """Lazy detection exceptions should be treated as unavailable features."""
 
     node = Node.objects.create(
@@ -277,33 +273,28 @@ def test_ensure_feature_enabled_handles_lazy_detection_exception(
 
 
 @pytest.fixture
-def llm_summary_node_with_locks(tmp_path):
-    """Provide a node with lock files required for llm-summary detection."""
-    from apps.screens.startup_notifications import LCD_RUNTIME_LOCK_FILE
+def llm_summary_node(tmp_path):
+    """Provide a node for llm-summary detection."""
 
-    node = Node(
-        hostname="summary-node",
-        base_path=str(tmp_path),
-        public_endpoint="summary-node",
+    return (
+        Node(
+            hostname="summary-node",
+            base_path=str(tmp_path),
+            public_endpoint="summary-node",
+        ),
+        tmp_path,
     )
-
-    locks_dir = tmp_path / ".locks"
-    locks_dir.mkdir()
-    (locks_dir / "celery.lck").write_text("1")
-    (locks_dir / LCD_RUNTIME_LOCK_FILE).write_text("1")
-
-    return node, tmp_path
 
 
 @pytest.mark.django_db
-def test_detect_auto_feature_enables_llm_summary_when_prereqs_met(
-    llm_summary_node_with_locks,
+def test_detect_auto_feature_enables_llm_summary_without_lcd_when_config_active(
+    llm_summary_node,
 ):
-    """llm-summary auto-detection should pass when locks and config are active."""
+    """llm-summary detection should reflect generation capability, not LCD output."""
 
     from apps.summary.services import get_summary_config
 
-    node, tmp_path = llm_summary_node_with_locks
+    node, tmp_path = llm_summary_node
 
     config = get_summary_config()
     config.is_active = True
@@ -317,6 +308,24 @@ def test_detect_auto_feature_enables_llm_summary_when_prereqs_met(
 
 
 @pytest.mark.django_db
+def test_detect_auto_feature_skips_llm_summary_when_config_inactive(
+    llm_summary_node,
+):
+    """Inactive summary config should keep the node summary feature off."""
+
+    from apps.summary.services import get_summary_config
+
+    node, tmp_path = llm_summary_node
+
+    config = get_summary_config()
+    config.is_active = False
+    config.save(update_fields=["is_active", "updated_at"])
+
+    result = node._detect_auto_feature(
+        "llm-summary", base_dir=tmp_path, base_path=tmp_path
+    )
+
+    assert result is False
 
 
 @pytest.mark.django_db
@@ -410,9 +419,9 @@ def test_detect_auto_feature_uses_app_node_feature_hooks(
     monkeypatch.setattr(
         cards_node_features,
         "check_node_feature",
-        lambda slug, *, node, base_dir, base_path: True
-        if slug == "rfid-scanner"
-        else None,
+        lambda slug, *, node, base_dir, base_path: (
+            True if slug == "rfid-scanner" else None
+        ),
     )
 
     def _setup(slug, *, node, base_dir, base_path):

--- a/apps/summary/admin.py
+++ b/apps/summary/admin.py
@@ -16,7 +16,7 @@ from apps.features.models import Feature
 from apps.features.parameters import set_feature_parameter_values
 from apps.nodes.models import NodeFeature
 
-from .constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from .constants import LLM_SUMMARY_NODE_FEATURE_SLUG, LLM_SUMMARY_SUITE_FEATURE_SLUG
 from .models import LLMSummaryConfig
 from .services import DEFAULT_MODEL_DIR, ensure_local_model, get_summary_config, resolve_model_path
 
@@ -88,19 +88,23 @@ class LLMSummaryConfigAdmin(admin.ModelAdmin):
     def _sync_summary_suite_feature(self, config: LLMSummaryConfig) -> Feature:
         """Persist suite feature parameters and ensure node-feature linkage is present."""
 
-        lcd_node_feature = NodeFeature.objects.filter(slug="lcd-screen").first()
+        summary_node_feature = NodeFeature.objects.filter(
+            slug=LLM_SUMMARY_NODE_FEATURE_SLUG
+        ).first()
         suite_feature, _created = Feature.objects.get_or_create(
             slug=LLM_SUMMARY_SUITE_FEATURE_SLUG,
             defaults={
                 "display": "LLM Summary Suite",
                 "source": Feature.Source.CUSTOM,
                 "is_enabled": True,
-                "node_feature": lcd_node_feature,
+                "node_feature": summary_node_feature,
             },
         )
         updated_fields: set[str] = set()
-        if suite_feature.node_feature_id != (lcd_node_feature.pk if lcd_node_feature else None):
-            suite_feature.node_feature = lcd_node_feature
+        if suite_feature.node_feature_id != (
+            summary_node_feature.pk if summary_node_feature else None
+        ):
+            suite_feature.node_feature = summary_node_feature
             updated_fields.add("node_feature")
 
         set_feature_parameter_values(

--- a/apps/summary/management/commands/summary.py
+++ b/apps/summary/management/commands/summary.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--enabled",
             action="store_true",
-            help="Enable LCD/Celery locks and node features for displayed summaries.",
+            help="Enable LCD/Celery locks and node features for summary generation and display.",
         )
         parser.add_argument(
             "--run-now",

--- a/apps/summary/management/commands/summary.py
+++ b/apps/summary/management/commands/summary.py
@@ -28,11 +28,11 @@ from apps.summary.services import (
 
 
 class Command(BaseCommand):
-    """Report LCD summarizer status and optionally auto-enable prerequisites."""
+    """Report LLM summarizer status and optionally enable LCD output."""
 
     REQUIRED_FEATURE_SLUGS = ("celery-queue", "lcd-screen", "llm-summary")
 
-    help = "Show LCD summarizer status and the current summary LCD rotation plan."
+    help = "Show LLM summarizer status and the current summary rotation plan."
 
     def add_arguments(self, parser) -> None:
         """Register command-line flags."""
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--enabled",
             action="store_true",
-            help="Enable required locks/features so LCD summary can run.",
+            help="Enable LCD/Celery locks and node features for displayed summaries.",
         )
         parser.add_argument(
             "--run-now",
@@ -71,7 +71,9 @@ class Command(BaseCommand):
             self._enable_prerequisites(node=node, config=config, base_dir=base_dir)
 
         if options["run_now"]:
-            if not is_suite_feature_enabled(LLM_SUMMARY_SUITE_FEATURE_SLUG, default=True):
+            if not is_suite_feature_enabled(
+                LLM_SUMMARY_SUITE_FEATURE_SLUG, default=True
+            ):
                 if options["allow_disabled_feature"]:
                     self.stdout.write(
                         self.style.WARNING(
@@ -79,7 +81,9 @@ class Command(BaseCommand):
                             "running manual override via --allow-disabled-feature."
                         )
                     )
-                    run_status = self._run_summary_task_now(ignore_suite_feature_gate=True)
+                    run_status = self._run_summary_task_now(
+                        ignore_suite_feature_gate=True
+                    )
                 else:
                     run_status = "skipped:suite-feature-disabled"
                     self.stdout.write(
@@ -113,7 +117,7 @@ class Command(BaseCommand):
             else None
         )
 
-        self.stdout.write(self.style.MIGRATE_HEADING("LCD Summary Status"))
+        self.stdout.write(self.style.MIGRATE_HEADING("LLM Summary Status"))
         self.stdout.write(f"Node: {node.hostname} (id={node.pk})")
         self.stdout.write(
             "Feature assignments: "
@@ -122,10 +126,10 @@ class Command(BaseCommand):
                 slugs=self.REQUIRED_FEATURE_SLUGS,
             )
         )
-        self.stdout.write(f"Summary config active: {'yes' if config.is_active else 'no'}")
         self.stdout.write(
-            f"Model path: {config.model_path or '(default)'}"
+            f"Summary config active: {'yes' if config.is_active else 'no'}"
         )
+        self.stdout.write(f"Model path: {config.model_path or '(default)'}")
         self.stdout.write(
             f"Installed at: {config.installed_at.isoformat() if config.installed_at else 'never'}"
         )
@@ -133,17 +137,21 @@ class Command(BaseCommand):
             f"Last run: {config.last_run_at.isoformat() if config.last_run_at else 'never'}"
         )
         self.stdout.write(
-            "Prerequisites: "
+            "Output/schedule state: "
             f"lcd={'ok' if prereqs['lcd_enabled'] else 'missing'}, "
             f"celery={'ok' if prereqs['celery_enabled'] else 'missing'}"
         )
 
         channel_plan = self._load_channel_plan(base_dir)
-        self.stdout.write(f"Channel order: {', '.join(channel_plan) if channel_plan else '(default)'}")
+        self.stdout.write(
+            f"Channel order: {', '.join(channel_plan) if channel_plan else '(default)'}"
+        )
 
         self.stdout.write(self.style.MIGRATE_HEADING("Summary Plan"))
         if not planned_screens:
-            self.stdout.write("No summary plan captured yet. Run the summary task first.")
+            self.stdout.write(
+                "No summary plan captured yet. Run the summary task first."
+            )
             return
 
         for index, (subject, body) in enumerate(planned_screens, start=1):
@@ -161,7 +169,9 @@ class Command(BaseCommand):
         (lock_dir / LCD_RUNTIME_LOCK_FILE).touch(exist_ok=True)
         ensure_local_model(config)
         config.is_active = True
-        config.save(update_fields=["is_active", "model_path", "installed_at", "updated_at"])
+        config.save(
+            update_fields=["is_active", "model_path", "installed_at", "updated_at"]
+        )
 
         feature_displays = {
             "celery-queue": "Celery Queue",
@@ -181,8 +191,12 @@ class Command(BaseCommand):
     def _feature_assignment_line(self, node: Node, *, slugs: tuple[str, ...]) -> str:
         """Return a compact feature-assignment status string for the node."""
 
-        assigned = set(node.features.filter(slug__in=slugs).values_list("slug", flat=True))
-        return ", ".join(f"{slug}={'yes' if slug in assigned else 'no'}" for slug in slugs)
+        assigned = set(
+            node.features.filter(slug__in=slugs).values_list("slug", flat=True)
+        )
+        return ", ".join(
+            f"{slug}={'yes' if slug in assigned else 'no'}" for slug in slugs
+        )
 
     def _load_channel_plan(self, base_dir: Path) -> list[str]:
         """Return configured LCD channel order from lock file if available."""

--- a/apps/summary/node_features.py
+++ b/apps/summary/node_features.py
@@ -28,15 +28,11 @@ def _celery_lock_enabled(base_dir: Path, base_path: Path) -> bool:
 
 
 def _is_llm_summary_active(*, base_dir: Path, base_path: Path) -> bool:
-    """Return whether llm-summary runtime requirements are met."""
+    """Return whether this node can generate LLM summary values."""
 
     try:
         from apps.summary.services import get_summary_config
     except ImportError:
-        return False
-
-    prereqs = get_llm_summary_prereq_state(base_dir=base_dir, base_path=base_path)
-    if not (prereqs.get("lcd_enabled") and prereqs.get("celery_enabled")):
         return False
 
     try:
@@ -80,10 +76,8 @@ def setup_node_feature(
     )
 
 
-def get_llm_summary_prereq_state(
-    *, base_dir: Path, base_path: Path
-) -> dict[str, bool]:
-    """Return lock- and screen-based prerequisites for llm-summary."""
+def get_llm_summary_prereq_state(*, base_dir: Path, base_path: Path) -> dict[str, bool]:
+    """Return optional LCD output and Celery scheduling state for summaries."""
 
     return {
         "lcd_enabled": lcd_feature_enabled_for_paths(base_dir, base_path),

--- a/apps/summary/node_features.py
+++ b/apps/summary/node_features.py
@@ -7,6 +7,7 @@ from django.db.utils import OperationalError, ProgrammingError
 
 from apps.nodes.feature_detection import NodeFeatureDetectionRegistry
 from apps.screens.startup_notifications import lcd_feature_enabled_for_paths
+from apps.summary.models import LLMSummaryConfig
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from apps.nodes.models import Node
@@ -31,16 +32,12 @@ def _is_llm_summary_active(*, base_dir: Path, base_path: Path) -> bool:
     """Return whether this node can generate LLM summary values."""
 
     try:
-        from apps.summary.services import get_summary_config
-    except ImportError:
-        return False
-
-    try:
-        config = get_summary_config()
+        return LLMSummaryConfig.objects.filter(
+            slug="lcd-log-summary",
+            is_active=True,
+        ).exists()
     except (OperationalError, ProgrammingError):
         return False
-
-    return bool(config.is_active)
 
 
 def check_node_feature(

--- a/apps/summary/tests/test_admin.py
+++ b/apps/summary/tests/test_admin.py
@@ -1,0 +1,29 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+
+from apps.features.models import Feature
+from apps.nodes.models import NodeFeature
+from apps.summary.admin import LLMSummaryConfigAdmin
+from apps.summary.constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from apps.summary.models import LLMSummaryConfig
+
+
+@pytest.mark.django_db
+def test_summary_admin_sync_links_suite_feature_to_summary_node_feature() -> None:
+    NodeFeature.objects.create(slug="lcd-screen", display="LCD Screen")
+    summary_feature = NodeFeature.objects.create(
+        slug="llm-summary",
+        display="LLM Summary",
+    )
+    suite_feature = Feature.objects.create(
+        slug=LLM_SUMMARY_SUITE_FEATURE_SLUG,
+        display="LLM Summary Suite",
+        node_feature=NodeFeature.objects.get(slug="lcd-screen"),
+    )
+    config = LLMSummaryConfig.objects.create()
+    admin = LLMSummaryConfigAdmin(LLMSummaryConfig, AdminSite())
+
+    admin._sync_summary_suite_feature(config)
+
+    suite_feature.refresh_from_db()
+    assert suite_feature.node_feature == summary_feature


### PR DESCRIPTION
## Summary
- make the `llm-summary` node feature reflect summary generation capability instead of requiring LCD/Celery locks
- link the `llm-summary-suite` suite feature to the `llm-summary` node feature via fixture and migration
- clarify the summary command output so LCD and Celery are reported as output/scheduling state

## Tests
- `.venv\Scripts\python.exe manage.py migrations check`
- `.venv\Scripts\python.exe -m black --check --target-version py312 apps\summary\node_features.py apps\summary\management\commands\summary.py apps\features\migrations\0008_link_llm_summary_suite_feature.py apps\nodes\tests\test_models_split.py apps\features\tests\test_models.py`
- `.venv\Scripts\python.exe manage.py test run -- apps/nodes/tests/test_models_split.py apps/nodes/tests/test_node_feature_sync_tasks.py apps/features/tests/test_models.py apps/summary/tests`

No matching open issue found for `llm summary lcd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR decouples LLM summary generation from LCD/Celery dependencies by redefining the `llm-summary` node feature to represent summary-generation capability rather than requiring LCD and Celery lock prerequisites. The `llm-summary-suite` suite feature is now explicitly linked to this capability via both fixture and database migration.

## Changes

**Node Feature Capability Redefinition:**
- Updated `_is_llm_summary_active()` to determine LLM-summary availability solely from `get_summary_config().is_active`, removing the prior prerequisite check for LCD output and Celery lock state
- Updated docstring to reflect that the function checks node capability rather than runtime requirements

**Feature Linkage:**
- Updated `features__llm_summary_suite.json` fixture to reference the `llm-summary` node feature instead of `lcd-screen`
- Added migration `0008_link_llm_summary_suite_feature` that links the `llm-summary-suite` feature to the `llm-summary` node feature, with a reversible operation to restore the prior `lcd-screen` reference

**Command Output Clarity:**
- Updated `summary` management command to use "LLM Summary" terminology instead of "LCD Summary"
- Reorganized status output to explicitly separate active configuration/model/installation/run state from a distinct "Output/schedule state" section, clarifying that LCD and Celery are output and scheduling mechanisms rather than enablement prerequisites

**Test Coverage:**
- Added `test_llm_summary_suite_fixture_links_summary_node_feature()` to verify the fixture correctly links the suite feature to the summary node feature
- Updated `test_models_split.py` with new test cases confirming `llm-summary` auto-enables when summary config is active independently of LCD lock state, and added `llm_summary_node` fixture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->