### PR TITLE
Add reserved node support to RPi imager

### DIFF
--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -247,7 +247,7 @@ class Command(BaseCommand):
 
         watch_parser = subparsers.add_parser(
             "watch-reservations",
-            help="Watch reserved image nodes on wlanX/eth0 and clear reservations after first contact.",
+            help="Watch reserved image nodes on wlanX/eth0 and report peers awaiting signed registration.",
         )
         watch_parser.add_argument(
             "--interfaces",
@@ -548,7 +548,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"RPi access test passed for {result.host}."))
 
     def _handle_watch_reservations(self, options: dict[str, object]) -> None:
-        """Watch reserved nodes and clear reservations after first contact."""
+        """Watch reserved nodes and report peers awaiting signed registration."""
 
         interfaces = [
             token.strip()

--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.imager.models import RaspberryPiImageArtifact
+from apps.imager.reservations import (
+    DEFAULT_RESERVATION_PORTS,
+    resolve_optional_env_bool,
+    watch_reserved_nodes_loop,
+    watch_reserved_nodes_once,
+)
 from apps.imager.services import (
     DEFAULT_RECOVERY_SSH_USER,
     ImagerBuildError,
@@ -82,6 +88,48 @@ class Command(BaseCommand):
             "--host-network-profile-dir",
             default="",
             help="Host NetworkManager system-connections directory to read when copying network profiles.",
+        )
+        build_parser.add_argument(
+            "--copy-parent-network",
+            dest="copy_parent_network",
+            action="store_true",
+            default=None,
+            help="Copy active parent Wi-Fi NetworkManager profiles into the image.",
+        )
+        build_parser.add_argument(
+            "--no-copy-parent-network",
+            dest="copy_parent_network",
+            action="store_false",
+            help="Disable IMAGER_COPY_PARENT_NETWORK_DEFAULT for this build.",
+        )
+        build_parser.add_argument(
+            "--reserve",
+            dest="reserve",
+            action="store_true",
+            default=None,
+            help="Reserve a peer node row before first boot and bake its hostname into the image.",
+        )
+        build_parser.add_argument(
+            "--no-reserve",
+            dest="reserve",
+            action="store_false",
+            help="Disable IMAGER_RESERVE_DEFAULT for this build.",
+        )
+        build_parser.add_argument(
+            "--reserve-number",
+            type=int,
+            default=None,
+            help="Specific numeric suffix to reserve, for example 4 for gway-004.",
+        )
+        build_parser.add_argument(
+            "--reserve-prefix",
+            default="",
+            help="Hostname prefix for reserved images. Defaults to the parent node prefix.",
+        )
+        build_parser.add_argument(
+            "--reserve-role",
+            default="",
+            help="Optional node role name to assign to the reserved peer.",
         )
         build_parser.add_argument(
             "--build-engine",
@@ -197,6 +245,24 @@ class Command(BaseCommand):
         access_parser.add_argument("--skip-ssh", action="store_true", help="Skip SSH TCP/auth checks.")
         access_parser.add_argument("--skip-http", action="store_true", help="Skip HTTP suite reachability check.")
 
+        watch_parser = subparsers.add_parser(
+            "watch-reservations",
+            help="Watch reserved image nodes on wlanX/eth0 and clear reservations after first contact.",
+        )
+        watch_parser.add_argument(
+            "--interfaces",
+            default="",
+            help="Comma-separated interfaces to watch. Defaults to IMAGER_RESERVATION_WATCH_INTERFACES or active wlanX plus eth0.",
+        )
+        watch_parser.add_argument(
+            "--ports",
+            default=",".join(str(port) for port in DEFAULT_RESERVATION_PORTS),
+            help="Comma-separated /nodes/info/ ports to probe.",
+        )
+        watch_parser.add_argument("--timeout", type=float, default=1.5, help="Per-probe timeout in seconds.")
+        watch_parser.add_argument("--interval", type=float, default=30.0, help="Loop interval in seconds.")
+        watch_parser.add_argument("--once", action="store_true", help="Run one watch pass and exit.")
+
     def handle(self, *args, **options) -> None:
         """Dispatch command to selected action."""
 
@@ -218,6 +284,9 @@ class Command(BaseCommand):
             return
         if action == "test-access":
             self._handle_test_access(options)
+            return
+        if action == "watch-reservations":
+            self._handle_watch_reservations(options)
             return
         raise CommandError(f"Unsupported action '{action}'.")
 
@@ -249,6 +318,19 @@ class Command(BaseCommand):
             )
         if recovery_authorized_keys:
             recovery_ssh_user = recovery_ssh_user or DEFAULT_RECOVERY_SSH_USER
+        reserve_node = resolve_optional_env_bool(
+            options.get("reserve"),
+            "IMAGER_RESERVE_DEFAULT",
+            default=False,
+        )
+        copy_parent_networks = resolve_optional_env_bool(
+            options.get("copy_parent_network"),
+            "IMAGER_COPY_PARENT_NETWORK_DEFAULT",
+            default=False,
+        )
+        reserve_number = options.get("reserve_number")
+        if reserve_number is not None and int(reserve_number) <= 0:
+            raise CommandError("--reserve-number must be greater than zero.")
 
         try:
             result = build_rpi4b_image(
@@ -277,6 +359,11 @@ class Command(BaseCommand):
                 host_network_profile_dir=Path(str(options["host_network_profile_dir"]))
                 if str(options["host_network_profile_dir"]).strip()
                 else None,
+                copy_parent_networks=copy_parent_networks,
+                reserve_node=reserve_node,
+                reserve_hostname_prefix=str(options["reserve_prefix"]),
+                reserve_number=reserve_number,
+                reserve_role=str(options["reserve_role"]),
             )
         except ImagerBuildError as exc:
             raise CommandError(str(exc)) from exc
@@ -288,6 +375,14 @@ class Command(BaseCommand):
             self.stdout.write(f"download_uri={result.download_uri}")
         if customize and skip_recovery_ssh:
             self.stdout.write("recovery_ssh=disabled (--skip-recovery-ssh)")
+        reservation = getattr(result, "reservation", None)
+        if reservation:
+            self.stdout.write(
+                "reserved_node="
+                f"{reservation.get('hostname')} "
+                f"address={reservation.get('ipv4_address') or '(none)'} "
+                f"id={reservation.get('node_id')}"
+            )
 
     def _read_recovery_authorized_keys(
         self,
@@ -451,3 +546,59 @@ class Command(BaseCommand):
         if not result.ok:
             raise CommandError(f"RPi access test failed for {result.host}.")
         self.stdout.write(self.style.SUCCESS(f"RPi access test passed for {result.host}."))
+
+    def _handle_watch_reservations(self, options: dict[str, object]) -> None:
+        """Watch reserved nodes and clear reservations after first contact."""
+
+        interfaces = [
+            token.strip()
+            for token in str(options["interfaces"]).split(",")
+            if token.strip()
+        ] or None
+        ports = self._parse_ports(str(options["ports"]))
+        timeout = float(options["timeout"])
+        interval = float(options["interval"])
+
+        if options["once"]:
+            result_sets = [
+                watch_reserved_nodes_once(
+                    interfaces=interfaces,
+                    ports=ports,
+                    timeout=timeout,
+                )
+            ]
+        else:
+            result_sets = watch_reserved_nodes_loop(
+                interfaces=interfaces,
+                ports=ports,
+                timeout=timeout,
+                interval=interval,
+            )
+
+        for results in result_sets:
+            if not results:
+                self.stdout.write("reserved_nodes=none")
+            for result in results:
+                detail = f" {result.detail}" if result.detail else ""
+                self.stdout.write(
+                    f"{result.hostname} id={result.node_id} status={result.status}{detail}"
+                )
+            if options["once"]:
+                return
+
+    def _parse_ports(self, raw_value: str) -> tuple[int, ...]:
+        ports: list[int] = []
+        for token in raw_value.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                port = int(token)
+            except ValueError as exc:
+                raise CommandError(f"Invalid port: {token}") from exc
+            if not 1 <= port <= 65535:
+                raise CommandError(f"Port out of range: {port}")
+            ports.append(port)
+        if not ports:
+            raise CommandError("At least one port is required.")
+        return tuple(ports)

--- a/apps/imager/reservations.py
+++ b/apps/imager/reservations.py
@@ -172,17 +172,22 @@ def _interface_networks() -> list[ipaddress.IPv4Network]:
     return ordered
 
 
-def _known_neighbor_ips() -> set[str]:
+def _collect_neighbor_ips(
+    interface_name: str | None = None, *, timeout: float = 1.5
+) -> set[str]:
     ip_path = shutil_which("ip")
     if not ip_path:
         return set()
+    command = [ip_path, "-4", "neigh", "show"]
+    if interface_name:
+        command.extend(["dev", interface_name])
     try:
         result = subprocess.run(
-            [ip_path, "-4", "neigh", "show"],
+            command,
             capture_output=True,
             text=True,
             check=False,
-            timeout=1.5,
+            timeout=timeout,
         )
     except (OSError, subprocess.SubprocessError):
         return set()
@@ -196,6 +201,10 @@ def _known_neighbor_ips() -> set[str]:
         except ValueError:
             continue
     return values
+
+
+def _known_neighbor_ips() -> set[str]:
+    return _collect_neighbor_ips()
 
 
 def shutil_which(command: str) -> str | None:
@@ -380,29 +389,7 @@ def watch_interfaces_from_env() -> list[str]:
 
 
 def _known_interface_hosts(interface_name: str) -> set[str]:
-    ip_path = shutil_which("ip")
-    if not ip_path:
-        return set()
-    try:
-        result = subprocess.run(
-            [ip_path, "-4", "neigh", "show", "dev", interface_name],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=1.0,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return set()
-    if result.returncode != 0:
-        return set()
-    hosts: set[str] = set()
-    for line in result.stdout.splitlines():
-        token = line.split(maxsplit=1)[0] if line.split() else ""
-        try:
-            hosts.add(str(ipaddress.ip_address(token)))
-        except ValueError:
-            continue
-    return hosts
+    return _collect_neighbor_ips(interface_name, timeout=1.0)
 
 
 def _node_candidate_hosts(node: Node, interfaces: list[str]) -> list[str]:
@@ -439,6 +426,17 @@ def _fetch_node_info(host: str, ports: tuple[int, ...], timeout: float) -> dict[
     return None
 
 
+def _node_info_port(info: dict[str, Any]) -> int:
+    for raw_value in (info.get("port"), info.get("_watch_port"), 8888):
+        if raw_value in (None, ""):
+            continue
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            continue
+    return 8888
+
+
 def _info_matches_reservation(node: Node, info: dict[str, Any]) -> bool:
     expected_hostname = (node.hostname or "").strip().lower()
     reported_hostname = str(info.get("hostname") or "").strip().lower()
@@ -468,6 +466,18 @@ def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchR
             status="conflict",
             detail=f"MAC address already belongs to another node: {mac_address}",
         )
+    reserved_claimed = False
+    if node.reserved:
+        claimed = Node.objects.filter(pk=node.pk, reserved=True).update(reserved=False)
+        if not claimed:
+            return ReservationWatchResult(
+                node_id=node.id,
+                hostname=node.hostname,
+                status="conflict",
+                detail="Reserved node was already claimed.",
+            )
+        node.reserved = False
+        reserved_claimed = True
 
     fields = {
         "hostname": str(info.get("hostname") or node.hostname).strip(),
@@ -476,7 +486,7 @@ def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchR
         "ipv4_address": ",".join(Node.sanitize_ipv4_addresses(info.get("ipv4_address") or [])),
         "ipv6_address": str(info.get("ipv6_address") or "").strip(),
         "host_instance_id": str(info.get("host_instance_id") or "").strip(),
-        "port": int(info.get("port") or 8888),
+        "port": _node_info_port(info),
         "installed_version": str(info.get("installed_version") or "")[:20],
         "installed_revision": str(info.get("installed_revision") or "")[:40],
         "public_key": str(info.get("public_key") or ""),
@@ -488,6 +498,8 @@ def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchR
     if role:
         fields["role"] = role
     update_fields: list[str] = []
+    if reserved_claimed:
+        update_fields.append("reserved")
     for field, value in fields.items():
         if getattr(node, field) != value:
             setattr(node, field, value)

--- a/apps/imager/reservations.py
+++ b/apps/imager/reservations.py
@@ -1,0 +1,560 @@
+"""Reservation helpers for Raspberry Pi image builds."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import shlex
+import socket
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import psutil
+from django.db import IntegrityError, transaction
+
+from apps.nodes.models import Node, NodeRole
+
+DEFAULT_RESERVATION_PORTS = (8888, 80, 443)
+RESERVATION_ENV_PATH = "/usr/local/share/arthexis/reserved-node.env"
+RESERVATION_JSON_PATH = "/usr/local/share/arthexis/reserved-node.json"
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
+FALSY_VALUES = {"0", "false", "no", "off"}
+HOSTNAME_WITH_NUMBER_RE = re.compile(r"^(?P<prefix>[A-Za-z][A-Za-z0-9-]*?)-(?P<number>\d+)$")
+
+
+@dataclass(frozen=True)
+class ImageReservation:
+    """Planned node identity for an image before the device first boots."""
+
+    hostname: str
+    hostname_prefix: str
+    number: int
+    ipv4_address: str
+    network_cidr: str
+    parent_hostname: str
+    port: int = 8888
+    role_name: str = ""
+
+    def metadata(self) -> dict[str, object]:
+        """Return JSON-safe reservation metadata."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ImageReservationCommit:
+    """Result of writing a planned image reservation to the node table."""
+
+    node_id: int
+    created: bool
+    reservation: ImageReservation
+
+    def metadata(self) -> dict[str, object]:
+        """Return JSON-safe metadata including the node table row."""
+
+        return {
+            "node_id": self.node_id,
+            "created": self.created,
+            **self.reservation.metadata(),
+        }
+
+
+@dataclass(frozen=True)
+class ReservationWatchResult:
+    """Single reservation watcher result."""
+
+    node_id: int
+    hostname: str
+    status: str
+    detail: str = ""
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    """Return a boolean environment value using shell-style truthy strings."""
+
+    raw = (os.environ.get(name) or "").strip().lower()
+    if not raw:
+        return default
+    if raw in TRUTHY_VALUES:
+        return True
+    if raw in FALSY_VALUES:
+        return False
+    return default
+
+
+def resolve_optional_env_bool(value: object, env_name: str, *, default: bool = False) -> bool:
+    """Resolve an optional CLI boolean with an environment-backed default."""
+
+    if value is None:
+        return env_bool(env_name, default)
+    return bool(value)
+
+
+def _clean_hostname_prefix(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", value.strip().lower()).strip("-")
+    return cleaned or "node"
+
+
+def default_hostname_prefix() -> str:
+    """Return the default hostname prefix for reservations on this originator."""
+
+    env_prefix = (os.environ.get("IMAGER_RESERVE_HOSTNAME_PREFIX") or "").strip()
+    if env_prefix:
+        return _clean_hostname_prefix(env_prefix)
+
+    local = Node.get_local()
+    hostname = (getattr(local, "hostname", "") or socket.gethostname() or "").strip()
+    match = HOSTNAME_WITH_NUMBER_RE.match(hostname)
+    if match:
+        return _clean_hostname_prefix(match.group("prefix"))
+    return _clean_hostname_prefix(hostname)
+
+
+def _existing_numbers_for_prefix(prefix: str) -> set[int]:
+    numbers: set[int] = set()
+    pattern = re.compile(rf"^{re.escape(prefix)}-(\d+)$", re.IGNORECASE)
+    for hostname in Node.objects.filter(hostname__istartswith=f"{prefix}-").values_list(
+        "hostname", flat=True
+    ):
+        match = pattern.match(hostname or "")
+        if match:
+            numbers.add(int(match.group(1)))
+    return numbers
+
+
+def next_reservation_number(prefix: str) -> int:
+    """Return the next hostname number for a reservation prefix."""
+
+    numbers = _existing_numbers_for_prefix(prefix)
+    return max(numbers, default=0) + 1
+
+
+def _interface_networks() -> list[ipaddress.IPv4Network]:
+    env_network = (os.environ.get("IMAGER_RESERVE_NETWORK_CIDR") or "").strip()
+    if env_network:
+        try:
+            return [ipaddress.ip_network(env_network, strict=False)]
+        except ValueError:
+            return []
+
+    networks: list[tuple[int, ipaddress.IPv4Network]] = []
+    for name, addresses in psutil.net_if_addrs().items():
+        for addr in addresses:
+            if getattr(addr.family, "name", "") != "AF_INET":
+                continue
+            if not addr.address or not addr.netmask:
+                continue
+            try:
+                interface = ipaddress.ip_interface(f"{addr.address}/{addr.netmask}")
+            except ValueError:
+                continue
+            if interface.ip.is_loopback or interface.ip.is_link_local:
+                continue
+            priority = 10
+            if name.startswith("wlan"):
+                priority = 0
+            elif name == "eth0":
+                priority = 1
+            elif interface.ip.is_private:
+                priority = 5
+            networks.append((priority, interface.network))
+    ordered: list[ipaddress.IPv4Network] = []
+    for _priority, network in sorted(networks, key=lambda item: (item[0], str(item[1]))):
+        if network not in ordered:
+            ordered.append(network)
+    return ordered
+
+
+def _known_neighbor_ips() -> set[str]:
+    ip_path = shutil_which("ip")
+    if not ip_path:
+        return set()
+    try:
+        result = subprocess.run(
+            [ip_path, "-4", "neigh", "show"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=1.5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    values: set[str] = set()
+    for line in result.stdout.splitlines():
+        token = line.split(maxsplit=1)[0] if line.split() else ""
+        try:
+            values.add(str(ipaddress.ip_address(token)))
+        except ValueError:
+            continue
+    return values
+
+
+def shutil_which(command: str) -> str | None:
+    """Small wrapper to keep command discovery patchable in tests."""
+
+    from shutil import which
+
+    return which(command)
+
+
+def _used_ipv4_addresses() -> set[str]:
+    used: set[str] = set(_known_neighbor_ips())
+    for node in Node.objects.all().only("address", "ipv4_address"):
+        for raw_value in (node.address, node.ipv4_address):
+            for token in re.split(r"[\s,]+", raw_value or ""):
+                if not token:
+                    continue
+                try:
+                    address = ipaddress.ip_address(token)
+                except ValueError:
+                    continue
+                if address.version == 4:
+                    used.add(str(address))
+    for addresses in psutil.net_if_addrs().values():
+        for addr in addresses:
+            if getattr(addr.family, "name", "") == "AF_INET" and addr.address:
+                used.add(addr.address)
+    return used
+
+
+def _candidate_number_address(
+    network: ipaddress.IPv4Network,
+    number: int,
+) -> ipaddress.IPv4Address | None:
+    if number <= 0:
+        return None
+    candidate = ipaddress.ip_address(int(network.network_address) + number)
+    if candidate in network and candidate not in {network.network_address, network.broadcast_address}:
+        return candidate
+    return None
+
+
+def choose_free_ipv4_address(number: int | None = None) -> tuple[str, str]:
+    """Choose a currently unassigned IPv4 address on a preferred local network."""
+
+    networks = _interface_networks()
+    used = _used_ipv4_addresses()
+    for network in networks:
+        if number is not None:
+            numbered = _candidate_number_address(network, number)
+            if numbered and str(numbered) not in used:
+                return str(numbered), str(network)
+        for address in network.hosts():
+            value = str(address)
+            if value not in used:
+                return value, str(network)
+    return "", ""
+
+
+def plan_image_reservation(
+    *,
+    hostname_prefix: str = "",
+    number: int | None = None,
+    role_name: str = "",
+) -> ImageReservation:
+    """Build a reservation plan without writing it to the database."""
+
+    prefix = _clean_hostname_prefix(hostname_prefix) if hostname_prefix else default_hostname_prefix()
+    if number is not None and number <= 0:
+        raise ValueError("Reservation number must be greater than zero.")
+    resolved_number = number or next_reservation_number(prefix)
+    ipv4_address, network_cidr = choose_free_ipv4_address(resolved_number)
+    hostname = f"{prefix}-{resolved_number:03d}"
+    parent = Node.get_local()
+    return ImageReservation(
+        hostname=hostname,
+        hostname_prefix=prefix,
+        number=resolved_number,
+        ipv4_address=ipv4_address,
+        network_cidr=network_cidr,
+        parent_hostname=(getattr(parent, "hostname", "") or socket.gethostname() or "").strip(),
+        role_name=(role_name or "").strip(),
+    )
+
+
+def commit_image_reservation(reservation: ImageReservation) -> ImageReservationCommit:
+    """Create or update the reserved peer row for an image reservation."""
+
+    role = (
+        NodeRole.objects.filter(name=reservation.role_name).first()
+        if reservation.role_name
+        else None
+    )
+    defaults: dict[str, Any] = {
+        "address": reservation.ipv4_address,
+        "ipv4_address": reservation.ipv4_address,
+        "network_hostname": reservation.hostname,
+        "port": reservation.port,
+        "current_relation": Node.Relation.PEER,
+        "reserved": True,
+    }
+    if role:
+        defaults["role"] = role
+
+    with transaction.atomic():
+        node = Node.objects.filter(hostname__iexact=reservation.hostname).first()
+        created = False
+        if node is None:
+            node = Node.objects.create(hostname=reservation.hostname, **defaults)
+            created = True
+        else:
+            update_fields: list[str] = []
+            for field, value in defaults.items():
+                if getattr(node, field) != value:
+                    setattr(node, field, value)
+                    update_fields.append(field)
+            if update_fields:
+                node.save(update_fields=update_fields)
+    return ImageReservationCommit(node_id=node.id, created=created, reservation=reservation)
+
+
+def render_reservation_env(reservation: ImageReservation) -> str:
+    """Render a shell environment file that makes first boot use the reservation hostname."""
+
+    lines = [
+        f"NODE_HOSTNAME={shlex.quote(reservation.hostname)}",
+        f"NODE_RESERVED_HOSTNAME={shlex.quote(reservation.hostname)}",
+    ]
+    if reservation.ipv4_address:
+        lines.append(f"NODE_RESERVED_IPV4={shlex.quote(reservation.ipv4_address)}")
+    return "\n".join(lines) + "\n"
+
+
+def render_reservation_json(reservation: ImageReservation) -> str:
+    """Render JSON metadata baked into the generated image."""
+
+    return json.dumps(reservation.metadata(), indent=2, sort_keys=True) + "\n"
+
+
+def active_parent_network_names() -> list[str]:
+    """Return active Wi-Fi NetworkManager connection names on the originator."""
+
+    nmcli = shutil_which("nmcli")
+    if not nmcli:
+        return []
+    try:
+        result = subprocess.run(
+            [nmcli, "-t", "-f", "NAME,TYPE,DEVICE", "connection", "show", "--active"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=3.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    names: list[str] = []
+    for raw_line in result.stdout.splitlines():
+        parts = raw_line.split(":")
+        if len(parts) < 3:
+            continue
+        name, connection_type, device = parts[0], parts[1], parts[2]
+        if connection_type == "wifi" and device.startswith("wlan") and name not in names:
+            names.append(name)
+    return names
+
+
+def watch_interfaces_from_env() -> list[str]:
+    """Return configured reservation-watch interfaces or discover wlanX plus eth0."""
+
+    raw = (os.environ.get("IMAGER_RESERVATION_WATCH_INTERFACES") or "").strip()
+    if raw:
+        return [token.strip() for token in raw.split(",") if token.strip()]
+    stats = psutil.net_if_stats()
+    return [
+        name
+        for name, stat in stats.items()
+        if stat.isup and (name.startswith("wlan") or name == "eth0")
+    ]
+
+
+def _known_interface_hosts(interface_name: str) -> set[str]:
+    ip_path = shutil_which("ip")
+    if not ip_path:
+        return set()
+    try:
+        result = subprocess.run(
+            [ip_path, "-4", "neigh", "show", "dev", interface_name],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=1.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    hosts: set[str] = set()
+    for line in result.stdout.splitlines():
+        token = line.split(maxsplit=1)[0] if line.split() else ""
+        try:
+            hosts.add(str(ipaddress.ip_address(token)))
+        except ValueError:
+            continue
+    return hosts
+
+
+def _node_candidate_hosts(node: Node, interfaces: list[str]) -> list[str]:
+    hosts: list[str] = []
+    for raw in (node.address, node.network_hostname, node.hostname, node.ipv4_address):
+        for token in re.split(r"[\s,]+", raw or ""):
+            token = token.strip()
+            if token and token not in hosts:
+                hosts.append(token)
+    for interface in interfaces:
+        for host in sorted(_known_interface_hosts(interface)):
+            if host not in hosts:
+                hosts.append(host)
+    return hosts
+
+
+def _fetch_node_info(host: str, ports: tuple[int, ...], timeout: float) -> dict[str, Any] | None:
+    for port in ports:
+        schemes = ("https",) if port == 443 else ("http", "https")
+        for scheme in schemes:
+            url = f"{scheme}://{host}:{port}/nodes/info/"
+            request = Request(url, headers={"User-Agent": "arthexis-reservation-watch/1.0"})
+            try:
+                with urlopen(request, timeout=timeout) as response:
+                    if response.status != 200:
+                        continue
+                    payload = json.loads(response.read(8192).decode("utf-8"))
+            except (OSError, URLError, ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict) and payload.get("hostname"):
+                payload["_watch_host"] = host
+                payload["_watch_port"] = port
+                return payload
+    return None
+
+
+def _info_matches_reservation(node: Node, info: dict[str, Any]) -> bool:
+    expected_hostname = (node.hostname or "").strip().lower()
+    reported_hostname = str(info.get("hostname") or "").strip().lower()
+    if expected_hostname:
+        return reported_hostname == expected_hostname
+    candidates = {
+        token
+        for raw in (node.address, node.ipv4_address, node.network_hostname)
+        for token in re.split(r"[\s,]+", raw or "")
+        if token
+    }
+    return bool(str(info.get("_watch_host") or "") in candidates)
+
+
+def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchResult:
+    """Apply discovered node information to a reservation and clear its flag."""
+
+    role = None
+    role_name = str(info.get("role") or info.get("role_name") or "").strip()
+    if role_name:
+        role = NodeRole.objects.filter(name=role_name).first()
+    mac_address = str(info.get("mac_address") or "").strip().lower()
+    if mac_address and Node.objects.filter(mac_address=mac_address).exclude(pk=node.pk).exists():
+        return ReservationWatchResult(
+            node_id=node.id,
+            hostname=node.hostname,
+            status="conflict",
+            detail=f"MAC address already belongs to another node: {mac_address}",
+        )
+
+    fields = {
+        "hostname": str(info.get("hostname") or node.hostname).strip(),
+        "network_hostname": str(info.get("network_hostname") or "").strip(),
+        "address": str(info.get("address") or info.get("_watch_host") or "").strip(),
+        "ipv4_address": ",".join(Node.sanitize_ipv4_addresses(info.get("ipv4_address") or [])),
+        "ipv6_address": str(info.get("ipv6_address") or "").strip(),
+        "host_instance_id": str(info.get("host_instance_id") or "").strip(),
+        "port": int(info.get("port") or 8888),
+        "installed_version": str(info.get("installed_version") or "")[:20],
+        "installed_revision": str(info.get("installed_revision") or "")[:40],
+        "public_key": str(info.get("public_key") or ""),
+        "mac_address": mac_address,
+        "current_relation": Node.Relation.PEER,
+        "trusted": True,
+        "reserved": False,
+    }
+    if role:
+        fields["role"] = role
+    update_fields: list[str] = []
+    for field, value in fields.items():
+        if getattr(node, field) != value:
+            setattr(node, field, value)
+            update_fields.append(field)
+    if update_fields:
+        try:
+            node.save(update_fields=update_fields)
+        except IntegrityError as exc:
+            return ReservationWatchResult(
+                node_id=node.id,
+                hostname=node.hostname,
+                status="error",
+                detail=str(exc),
+            )
+    return ReservationWatchResult(
+        node_id=node.id,
+        hostname=node.hostname,
+        status="confirmed",
+        detail=f"{fields['address']}:{fields['port']}",
+    )
+
+
+def watch_reserved_nodes_once(
+    *,
+    interfaces: list[str] | None = None,
+    ports: tuple[int, ...] = DEFAULT_RESERVATION_PORTS,
+    timeout: float = 1.5,
+) -> list[ReservationWatchResult]:
+    """Probe reserved nodes and clear reservations that respond as expected."""
+
+    selected_interfaces = interfaces if interfaces is not None else watch_interfaces_from_env()
+    results: list[ReservationWatchResult] = []
+    for node in Node.objects.filter(reserved=True).order_by("hostname", "id"):
+        candidates = _node_candidate_hosts(node, selected_interfaces)
+        matched = False
+        for host in candidates:
+            info = _fetch_node_info(host, ports, timeout)
+            if not info or not _info_matches_reservation(node, info):
+                continue
+            results.append(confirm_reserved_node(node, info))
+            matched = True
+            break
+        if not matched:
+            results.append(
+                ReservationWatchResult(
+                    node_id=node.id,
+                    hostname=node.hostname,
+                    status="pending",
+                    detail="no matching /nodes/info/ response",
+                )
+            )
+    return results
+
+
+def watch_reserved_nodes_loop(
+    *,
+    interfaces: list[str] | None = None,
+    ports: tuple[int, ...] = DEFAULT_RESERVATION_PORTS,
+    timeout: float = 1.5,
+    interval: float = 30.0,
+):
+    """Yield watcher results forever at a fixed interval."""
+
+    while True:
+        yield watch_reserved_nodes_once(
+            interfaces=interfaces,
+            ports=ports,
+            timeout=timeout,
+        )
+        time.sleep(interval)

--- a/apps/imager/reservations.py
+++ b/apps/imager/reservations.py
@@ -406,17 +406,23 @@ def _node_candidate_hosts(node: Node, interfaces: list[str]) -> list[str]:
     return hosts
 
 
+def _url_host(host: str) -> str:
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def _fetch_node_info(host: str, ports: tuple[int, ...], timeout: float) -> dict[str, Any] | None:
     for port in ports:
         schemes = ("https",) if port == 443 else ("http", "https")
         for scheme in schemes:
-            url = f"{scheme}://{host}:{port}/nodes/info/"
+            url = f"{scheme}://{_url_host(host)}:{port}/nodes/info/"
             request = Request(url, headers={"User-Agent": "arthexis-reservation-watch/1.0"})
             try:
                 with urlopen(request, timeout=timeout) as response:
                     if response.status != 200:
                         continue
-                    payload = json.loads(response.read(8192).decode("utf-8"))
+                    payload = json.loads(response.read())
             except (OSError, URLError, ValueError, json.JSONDecodeError):
                 continue
             if isinstance(payload, dict) and payload.get("hostname"):
@@ -435,6 +441,13 @@ def _node_info_port(info: dict[str, Any]) -> int:
         except (TypeError, ValueError):
             continue
     return 8888
+
+
+def _node_info_ipv4_addresses(info: dict[str, Any]) -> str:
+    raw_value = info.get("ipv4_address") or []
+    if isinstance(raw_value, str):
+        raw_value = re.split(r"[\s,]+", raw_value)
+    return ",".join(Node.sanitize_ipv4_addresses(raw_value))
 
 
 def _info_matches_reservation(node: Node, info: dict[str, Any]) -> bool:
@@ -483,7 +496,7 @@ def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchR
         "hostname": str(info.get("hostname") or node.hostname).strip(),
         "network_hostname": str(info.get("network_hostname") or "").strip(),
         "address": str(info.get("address") or info.get("_watch_host") or "").strip(),
-        "ipv4_address": ",".join(Node.sanitize_ipv4_addresses(info.get("ipv4_address") or [])),
+        "ipv4_address": _node_info_ipv4_addresses(info),
         "ipv6_address": str(info.get("ipv6_address") or "").strip(),
         "host_instance_id": str(info.get("host_instance_id") or "").strip(),
         "port": _node_info_port(info),

--- a/apps/imager/reservations.py
+++ b/apps/imager/reservations.py
@@ -17,7 +17,7 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 import psutil
-from django.db import IntegrityError, transaction
+from django.db import transaction
 
 from apps.nodes.models import Node, NodeRole
 
@@ -310,12 +310,20 @@ def commit_image_reservation(reservation: ImageReservation) -> ImageReservationC
         defaults["role"] = role
 
     with transaction.atomic():
-        node = Node.objects.filter(hostname__iexact=reservation.hostname).first()
+        node = (
+            Node.objects.select_for_update()
+            .filter(hostname__iexact=reservation.hostname)
+            .first()
+        )
         created = False
         if node is None:
             node = Node.objects.create(hostname=reservation.hostname, **defaults)
             created = True
         else:
+            if not node.reserved:
+                raise ValueError(
+                    f"Reservation hostname is already used by active node: {reservation.hostname}"
+                )
             update_fields: list[str] = []
             for field, value in defaults.items():
                 if getattr(node, field) != value:
@@ -443,13 +451,6 @@ def _node_info_port(info: dict[str, Any]) -> int:
     return 8888
 
 
-def _node_info_ipv4_addresses(info: dict[str, Any]) -> str:
-    raw_value = info.get("ipv4_address") or []
-    if isinstance(raw_value, str):
-        raw_value = re.split(r"[\s,]+", raw_value)
-    return ",".join(Node.sanitize_ipv4_addresses(raw_value))
-
-
 def _info_matches_reservation(node: Node, info: dict[str, Any]) -> bool:
     expected_hostname = (node.hostname or "").strip().lower()
     reported_hostname = str(info.get("hostname") or "").strip().lower()
@@ -464,13 +465,9 @@ def _info_matches_reservation(node: Node, info: dict[str, Any]) -> bool:
     return bool(str(info.get("_watch_host") or "") in candidates)
 
 
-def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchResult:
-    """Apply discovered node information to a reservation and clear its flag."""
+def observe_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchResult:
+    """Report a matching reservation candidate without trusting the peer."""
 
-    role = None
-    role_name = str(info.get("role") or info.get("role_name") or "").strip()
-    if role_name:
-        role = NodeRole.objects.filter(name=role_name).first()
     mac_address = str(info.get("mac_address") or "").strip().lower()
     if mac_address and Node.objects.filter(mac_address=mac_address).exclude(pk=node.pk).exists():
         return ReservationWatchResult(
@@ -479,59 +476,13 @@ def confirm_reserved_node(node: Node, info: dict[str, Any]) -> ReservationWatchR
             status="conflict",
             detail=f"MAC address already belongs to another node: {mac_address}",
         )
-    reserved_claimed = False
-    if node.reserved:
-        claimed = Node.objects.filter(pk=node.pk, reserved=True).update(reserved=False)
-        if not claimed:
-            return ReservationWatchResult(
-                node_id=node.id,
-                hostname=node.hostname,
-                status="conflict",
-                detail="Reserved node was already claimed.",
-            )
-        node.reserved = False
-        reserved_claimed = True
-
-    fields = {
-        "hostname": str(info.get("hostname") or node.hostname).strip(),
-        "network_hostname": str(info.get("network_hostname") or "").strip(),
-        "address": str(info.get("address") or info.get("_watch_host") or "").strip(),
-        "ipv4_address": _node_info_ipv4_addresses(info),
-        "ipv6_address": str(info.get("ipv6_address") or "").strip(),
-        "host_instance_id": str(info.get("host_instance_id") or "").strip(),
-        "port": _node_info_port(info),
-        "installed_version": str(info.get("installed_version") or "")[:20],
-        "installed_revision": str(info.get("installed_revision") or "")[:40],
-        "public_key": str(info.get("public_key") or ""),
-        "mac_address": mac_address,
-        "current_relation": Node.Relation.PEER,
-        "trusted": True,
-        "reserved": False,
-    }
-    if role:
-        fields["role"] = role
-    update_fields: list[str] = []
-    if reserved_claimed:
-        update_fields.append("reserved")
-    for field, value in fields.items():
-        if getattr(node, field) != value:
-            setattr(node, field, value)
-            update_fields.append(field)
-    if update_fields:
-        try:
-            node.save(update_fields=update_fields)
-        except IntegrityError as exc:
-            return ReservationWatchResult(
-                node_id=node.id,
-                hostname=node.hostname,
-                status="error",
-                detail=str(exc),
-            )
+    address = str(info.get("address") or info.get("_watch_host") or "").strip()
+    port = _node_info_port(info)
     return ReservationWatchResult(
         node_id=node.id,
         hostname=node.hostname,
-        status="confirmed",
-        detail=f"{fields['address']}:{fields['port']}",
+        status="observed",
+        detail=f"{address}:{port} matched; waiting for signed registration",
     )
 
 
@@ -541,7 +492,7 @@ def watch_reserved_nodes_once(
     ports: tuple[int, ...] = DEFAULT_RESERVATION_PORTS,
     timeout: float = 1.5,
 ) -> list[ReservationWatchResult]:
-    """Probe reserved nodes and clear reservations that respond as expected."""
+    """Probe reserved nodes and report peers that still need signed registration."""
 
     selected_interfaces = interfaces if interfaces is not None else watch_interfaces_from_env()
     results: list[ReservationWatchResult] = []
@@ -552,7 +503,7 @@ def watch_reserved_nodes_once(
             info = _fetch_node_info(host, ports, timeout)
             if not info or not _info_matches_reservation(node, info):
                 continue
-            results.append(confirm_reserved_node(node, info))
+            results.append(observe_reserved_node(node, info))
             matched = True
             break
         if not matched:

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -30,6 +30,16 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.imager.models import RaspberryPiImageArtifact
+from apps.imager.reservations import (
+    ImageReservation,
+    RESERVATION_ENV_PATH,
+    RESERVATION_JSON_PATH,
+    active_parent_network_names,
+    commit_image_reservation,
+    plan_image_reservation,
+    render_reservation_env,
+    render_reservation_json,
+)
 
 TARGET_RPI4B = "rpi-4b"
 DEFAULT_RECOVERY_SSH_USER = "arthe"
@@ -88,6 +98,18 @@ SUITE_BUNDLE_EXCLUDED_NAMES = frozenset(
 BOOTSTRAP_SCRIPT = """#!/usr/bin/env bash
 set -euo pipefail
 
+RESERVED_NODE_ENV=/usr/local/share/arthexis/reserved-node.env
+if [ -f "$RESERVED_NODE_ENV" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$RESERVED_NODE_ENV"
+  set +a
+fi
+
+if [ -n "${NODE_HOSTNAME:-}" ]; then
+  hostnamectl set-hostname "$NODE_HOSTNAME" 2>/dev/null || hostname "$NODE_HOSTNAME" 2>/dev/null || true
+fi
+
 missing_packages=()
 if ! command -v git >/dev/null 2>&1; then
   missing_packages+=(git ca-certificates)
@@ -111,6 +133,21 @@ fi
 
 if [ ! -x "$APP_HOME/start.sh" ]; then
   git clone --depth 1 "${ARTHEXIS_GIT_URL}" "$APP_HOME"
+fi
+
+if [ -f "$RESERVED_NODE_ENV" ]; then
+  touch "$APP_HOME/arthexis.env"
+  chmod 600 "$APP_HOME/arthexis.env" || true
+  while IFS= read -r line; do
+    case "$line" in
+      NODE_*=*)
+        key="${line%%=*}"
+        if ! grep -q "^${key}=" "$APP_HOME/arthexis.env"; then
+          printf '%s\\n' "$line" >> "$APP_HOME/arthexis.env"
+        fi
+        ;;
+    esac
+  done < "$RESERVED_NODE_ENV"
 fi
 
 cd "$APP_HOME"
@@ -233,6 +270,7 @@ class BuildResult:
     build_engine: str
     build_profile: str
     profile_manifest: dict[str, object]
+    reservation: dict[str, object] | None = None
 
 
 @dataclass
@@ -287,6 +325,7 @@ class ImageCustomizationResult:
 
     suite_bundle: SuiteBundleInfo | None = None
     network_profiles: tuple[NetworkProfileInfo, ...] = ()
+    reservation: ImageReservation | None = None
 
 
 @dataclass(frozen=True)
@@ -1026,6 +1065,7 @@ def _customize_image(
     recovery_ssh_access: RecoverySSHAccess | None = None,
     suite_source_path: Path | None = None,
     network_profiles: tuple[NetworkProfileInfo, ...] = (),
+    reservation: ImageReservation | None = None,
 ) -> ImageCustomizationResult:
     """Inject bootstrap scripts and systemd units into the image."""
 
@@ -1036,6 +1076,8 @@ def _customize_image(
         service = work_dir / "arthexis-bootstrap.service"
         firstrun = work_dir / "firstrun.sh"
         recovery_service = work_dir / "arthexis-recovery-access.service"
+        reservation_env = work_dir / "reserved-node.env"
+        reservation_json = work_dir / "reserved-node.json"
         suite_bundle_info: SuiteBundleInfo | None = None
 
         bootstrap.write_text(BOOTSTRAP_SCRIPT, encoding="utf-8")
@@ -1067,6 +1109,26 @@ def _customize_image(
             ],
             error_message="guestfish failed while injecting bootstrap files",
         )
+        if reservation is not None:
+            reservation_env.write_text(render_reservation_env(reservation), encoding="utf-8")
+            reservation_json.write_text(render_reservation_json(reservation), encoding="utf-8")
+            _guestfish_run_commands(
+                image_path,
+                [
+                    _guestfish_mkdir_p_command(str(PurePosixPath(RESERVATION_ENV_PATH).parent)),
+                    *_guestfish_upload_commands(
+                        reservation_env,
+                        RESERVATION_ENV_PATH,
+                        chmod_mode="0600",
+                    ),
+                    *_guestfish_upload_commands(
+                        reservation_json,
+                        RESERVATION_JSON_PATH,
+                        chmod_mode="0644",
+                    ),
+                ],
+                error_message="guestfish failed while injecting reserved node metadata",
+            )
         if suite_source_path is not None:
             suite_bundle = work_dir / "arthexis-suite.tar.gz"
             suite_bundle_info = _create_suite_bundle(suite_source_path, suite_bundle)
@@ -1165,6 +1227,7 @@ def _customize_image(
     return ImageCustomizationResult(
         suite_bundle=suite_bundle_info,
         network_profiles=network_profiles,
+        reservation=reservation,
     )
 
 
@@ -1233,6 +1296,14 @@ def _network_profiles_metadata(network_profiles: tuple[NetworkProfileInfo, ...])
             for profile in network_profiles
         ],
     }
+
+
+def _reservation_metadata(reservation: dict[str, object] | None) -> dict[str, object]:
+    """Return JSON-safe metadata for an image reservation."""
+
+    if not reservation:
+        return {"enabled": False}
+    return {"enabled": True, **reservation}
 
 
 def _format_url_host(host: str) -> str:
@@ -1768,6 +1839,11 @@ def build_rpi4b_image(
     copy_all_host_networks: bool = False,
     host_network_names: list[str] | tuple[str, ...] | None = None,
     host_network_profile_dir: Path | None = None,
+    copy_parent_networks: bool = False,
+    reserve_node: bool = False,
+    reserve_hostname_prefix: str = "",
+    reserve_number: int | None = None,
+    reserve_role: str = "",
 ) -> BuildResult:
     """Build and register a Raspberry Pi 4B Arthexis image artifact."""
 
@@ -1805,17 +1881,34 @@ def build_rpi4b_image(
         )
     if not customize:
         bundle_suite = False
-        if copy_all_host_networks or host_network_names:
+        if copy_all_host_networks or host_network_names or copy_parent_networks:
             raise ImagerBuildError("Host network profile copying requires image customization.")
 
     resolved_suite_source_path = suite_source_path
     if customize and bundle_suite and resolved_suite_source_path is None:
         resolved_suite_source_path = Path(settings.BASE_DIR)
+    resolved_host_network_names = list(host_network_names or ())
+    if copy_parent_networks and not copy_all_host_networks:
+        for profile_name in active_parent_network_names():
+            if profile_name not in resolved_host_network_names:
+                resolved_host_network_names.append(profile_name)
     network_profiles = select_host_network_profiles(
         profile_dir=host_network_profile_dir,
-        names=host_network_names,
+        names=resolved_host_network_names,
         copy_all=copy_all_host_networks,
     )
+    try:
+        reservation = (
+            plan_image_reservation(
+                hostname_prefix=reserve_hostname_prefix,
+                number=reserve_number,
+                role_name=reserve_role,
+            )
+            if reserve_node
+            else None
+        )
+    except ValueError as exc:
+        raise ImagerBuildError(str(exc)) from exc
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_filename = f"{name}-{TARGET_RPI4B}.img"
@@ -1834,6 +1927,7 @@ def build_rpi4b_image(
             recovery_ssh_access=recovery_ssh_access,
             suite_source_path=resolved_suite_source_path if bundle_suite else None,
             network_profiles=network_profiles,
+            reservation=reservation,
         )
         if isinstance(raw_customization_result, ImageCustomizationResult):
             customization_result = raw_customization_result
@@ -1843,6 +1937,16 @@ def build_rpi4b_image(
     download_uri = _build_download_uri(download_base_uri, output_filename)
 
     with transaction.atomic():
+        reservation_commit = (
+            commit_image_reservation(reservation)
+            if reservation is not None
+            else None
+        )
+        reservation_payload = (
+            reservation_commit.metadata()
+            if reservation_commit is not None
+            else None
+        )
         RaspberryPiImageArtifact.objects.update_or_create(
             name=name,
             defaults={
@@ -1865,6 +1969,7 @@ def build_rpi4b_image(
                     "host_network_profiles": _network_profiles_metadata(
                         customization_result.network_profiles
                     ),
+                    "reserved_node": _reservation_metadata(reservation_payload),
                     "recovery_ssh": {
                         "enabled": bool(customize and recovery_ssh_access and recovery_ssh_access.enabled),
                         "user": recovery_ssh_access.username if recovery_ssh_access else "",
@@ -1890,4 +1995,5 @@ def build_rpi4b_image(
         build_engine=build_engine,
         build_profile=profile,
         profile_manifest=profile_manifest,
+        reservation=reservation_payload,
     )

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -1881,6 +1881,10 @@ def build_rpi4b_image(
         )
     if not customize:
         bundle_suite = False
+        if reserve_node:
+            raise ImagerBuildError(
+                "Reserved node images require image customization. Remove --skip-customize or omit --reserve."
+            )
         if copy_all_host_networks or host_network_names or copy_parent_networks:
             raise ImagerBuildError("Host network profile copying requires image customization.")
 

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -1941,11 +1941,14 @@ def build_rpi4b_image(
     download_uri = _build_download_uri(download_base_uri, output_filename)
 
     with transaction.atomic():
-        reservation_commit = (
-            commit_image_reservation(reservation)
-            if reservation is not None
-            else None
-        )
+        try:
+            reservation_commit = (
+                commit_image_reservation(reservation)
+                if reservation is not None
+                else None
+            )
+        except ValueError as exc:
+            raise ImagerBuildError(str(exc)) from exc
         reservation_payload = (
             reservation_commit.metadata()
             if reservation_commit is not None

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -18,6 +18,7 @@ from django.test import override_settings
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.reservations import (
     ImageReservation,
+    confirm_reserved_node,
     plan_image_reservation,
     watch_reserved_nodes_once,
 )
@@ -1051,6 +1052,24 @@ def test_build_rpi4b_image_rejects_recovery_ssh_when_customize_is_disabled(tmp_p
         )
 
 
+def test_build_rpi4b_image_rejects_reservation_when_customize_is_disabled(tmp_path: Path) -> None:
+    """Regression: reserved node images need injected metadata to be claimable."""
+
+    base_image = tmp_path / "base.img"
+    base_image.write_bytes(b"raspberrypi")
+
+    with pytest.raises(ImagerBuildError, match="Reserved node images require image customization"):
+        build_rpi4b_image(
+            name="reserved-no-customize",
+            base_image_uri=str(base_image),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=False,
+            reserve_node=True,
+        )
+
+
 def test_build_rpi4b_image_rejects_recovery_username_without_keys(tmp_path: Path) -> None:
     """Regression: explicit recovery usernames without keys should fail fast."""
 
@@ -1323,9 +1342,10 @@ def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
             "hostname": "gway-004",
             "address": "10.42.0.4",
             "ipv4_address": "10.42.0.4",
-            "port": 8888,
+            "port": "not-a-port",
             "mac_address": "aa:bb:cc:dd:ee:04",
             "_watch_host": host,
+            "_watch_port": 8888,
         }
 
     monkeypatch.setattr("apps.imager.reservations._fetch_node_info", fake_fetch)
@@ -1336,7 +1356,40 @@ def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
     node.refresh_from_db()
     assert node.reserved is False
     assert node.mac_address == "aa:bb:cc:dd:ee:04"
+    assert node.port == 8888
     assert node.trusted is True
+
+
+@pytest.mark.django_db
+def test_confirm_reserved_node_reports_already_claimed_reservation() -> None:
+    """A stale watcher result must not overwrite a reservation claimed elsewhere."""
+
+    node = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+    stale_node = Node.objects.get(pk=node.pk)
+    Node.objects.filter(pk=node.pk).update(reserved=False)
+
+    result = confirm_reserved_node(
+        stale_node,
+        {
+            "hostname": "gway-004",
+            "address": "10.42.0.4",
+            "ipv4_address": "10.42.0.4",
+            "mac_address": "aa:bb:cc:dd:ee:04",
+            "_watch_host": "10.42.0.4",
+            "_watch_port": 8888,
+        },
+    )
+
+    node.refresh_from_db()
+    assert result.status == "conflict"
+    assert node.reserved is False
+    assert node.mac_address == ""
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -19,7 +19,6 @@ from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.reservations import (
     ImageReservation,
     _fetch_node_info,
-    confirm_reserved_node,
     plan_image_reservation,
     watch_reserved_nodes_once,
 )
@@ -1306,6 +1305,52 @@ def test_build_rpi4b_image_reserves_peer_node(tmp_path: Path) -> None:
 
 
 @pytest.mark.django_db
+def test_build_rpi4b_image_rejects_reserving_active_node_hostname(tmp_path: Path) -> None:
+    """A reservation must not overwrite an existing active node row."""
+
+    base_image = tmp_path / "base.img"
+    base_image.write_bytes(b"raspberrypi")
+    Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        current_relation=Node.Relation.SELF,
+        reserved=False,
+    )
+    reservation = ImageReservation(
+        hostname="gway-004",
+        hostname_prefix="gway",
+        number=4,
+        ipv4_address="10.42.0.44",
+        network_cidr="10.42.0.0/16",
+        parent_hostname="gway-001",
+    )
+    customization_result = ImageCustomizationResult(reservation=reservation)
+
+    with (
+        patch("apps.imager.services.plan_image_reservation", return_value=reservation),
+        patch("apps.imager.services._customize_image", return_value=customization_result),
+        pytest.raises(ImagerBuildError, match="already used by active node"),
+    ):
+        build_rpi4b_image(
+            name="gway-004-repair",
+            base_image_uri=str(base_image),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+            skip_recovery_ssh=True,
+            reserve_node=True,
+            reserve_number=4,
+        )
+
+    node = Node.objects.get(hostname="gway-004")
+    assert node.reserved is False
+    assert node.current_relation == Node.Relation.SELF
+    assert node.address == "10.42.0.4"
+    assert not RaspberryPiImageArtifact.objects.filter(name="gway-004-repair").exists()
+
+
+@pytest.mark.django_db
 def test_plan_image_reservation_uses_next_prefix_number_and_numbered_ip(monkeypatch) -> None:
     """The default reservation for gway-001 after gway-005 should be gway-006."""
 
@@ -1324,8 +1369,8 @@ def test_plan_image_reservation_uses_next_prefix_number_and_numbered_ip(monkeypa
 
 
 @pytest.mark.django_db
-def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
-    """The reservation watcher clears a placeholder after /nodes/info/ matches."""
+def test_watch_reserved_nodes_observes_matching_node_without_claiming(monkeypatch) -> None:
+    """The watcher reports matches but leaves trust to signed registration."""
 
     node = Node.objects.create(
         hostname="gway-004",
@@ -1353,13 +1398,14 @@ def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
 
     results = watch_reserved_nodes_once(interfaces=[], ports=(8888,), timeout=0.1)
 
-    assert results[0].status == "confirmed"
+    assert results[0].status == "observed"
+    assert "waiting for signed registration" in results[0].detail
     node.refresh_from_db()
-    assert node.reserved is False
+    assert node.reserved is True
     assert node.ipv4_address == "10.42.0.4"
-    assert node.mac_address == "aa:bb:cc:dd:ee:04"
+    assert node.mac_address == ""
     assert node.port == 8888
-    assert node.trusted is True
+    assert node.trusted is False
 
 
 def test_fetch_node_info_brackets_ipv6_hosts_and_reads_full_json() -> None:
@@ -1384,38 +1430,6 @@ def test_fetch_node_info_brackets_ipv6_hosts_and_reads_full_json() -> None:
     assert request.full_url == "http://[fd00::6]:8888/nodes/info/"
     assert payload["hostname"] == "gway-006"
     assert len(payload["note"]) == 9000
-
-
-@pytest.mark.django_db
-def test_confirm_reserved_node_reports_already_claimed_reservation() -> None:
-    """A stale watcher result must not overwrite a reservation claimed elsewhere."""
-
-    node = Node.objects.create(
-        hostname="gway-004",
-        address="10.42.0.4",
-        ipv4_address="10.42.0.4",
-        current_relation=Node.Relation.PEER,
-        reserved=True,
-    )
-    stale_node = Node.objects.get(pk=node.pk)
-    Node.objects.filter(pk=node.pk).update(reserved=False)
-
-    result = confirm_reserved_node(
-        stale_node,
-        {
-            "hostname": "gway-004",
-            "address": "10.42.0.4",
-            "ipv4_address": "10.42.0.4",
-            "mac_address": "aa:bb:cc:dd:ee:04",
-            "_watch_host": "10.42.0.4",
-            "_watch_port": 8888,
-        },
-    )
-
-    node.refresh_from_db()
-    assert result.status == "conflict"
-    assert node.reserved is False
-    assert node.mac_address == ""
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -1,5 +1,6 @@
 """Regression tests for Raspberry Pi imager workflows."""
 
+import json
 import lzma
 import shlex
 import socket
@@ -15,6 +16,11 @@ from django.core.management.base import CommandError
 from django.test import override_settings
 
 from apps.imager.models import RaspberryPiImageArtifact
+from apps.imager.reservations import (
+    ImageReservation,
+    plan_image_reservation,
+    watch_reserved_nodes_once,
+)
 from apps.imager.services import (
     TARGET_RPI4B,
     AccessCheckResult,
@@ -43,6 +49,7 @@ from apps.imager.services import (
 from apps.imager.services import (
     test_rpi_access as run_rpi_access_test,
 )
+from apps.nodes.models import Node
 
 VALID_RECOVERY_KEY_ONE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILOoi93uar4kpDufSrgJPoOKh8UzGiiAsz+GIspRlj7p recovery-one"
 VALID_RECOVERY_KEY_TWO = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPxEAcOg5erwB9w67f4eyf3DZiTLQ3sPik4Q6WLTl2XB recovery-two"
@@ -355,6 +362,121 @@ def test_imager_build_command_passes_bundle_and_host_network_options(mock_build,
     assert mock_build.call_args.kwargs["suite_source_path"] == suite_source
     assert mock_build.call_args.kwargs["host_network_names"] == ["Shop WiFi"]
     assert mock_build.call_args.kwargs["host_network_profile_dir"] == network_dir
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_resolves_reservation_env_defaults(
+    mock_build,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Operators can make reservation and parent-network copying the build default."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    monkeypatch.setenv("IMAGER_RESERVE_DEFAULT", "1")
+    monkeypatch.setenv("IMAGER_COPY_PARENT_NETWORK_DEFAULT", "1")
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+            "reservation": {
+                "hostname": "gway-004",
+                "ipv4_address": "10.42.0.4",
+                "node_id": 4,
+            },
+        },
+    )()
+
+    stdout = StringIO()
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "reserved",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        "--reserve-number",
+        "4",
+        stdout=stdout,
+    )
+
+    assert mock_build.call_args.kwargs["reserve_node"] is True
+    assert mock_build.call_args.kwargs["reserve_number"] == 4
+    assert mock_build.call_args.kwargs["copy_parent_networks"] is True
+    assert "reserved_node=gway-004 address=10.42.0.4 id=4" in stdout.getvalue()
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_can_disable_reservation_env_default(
+    mock_build,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """An explicit --no-reserve must override the instance default."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    monkeypatch.setenv("IMAGER_RESERVE_DEFAULT", "1")
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+            "reservation": None,
+        },
+    )()
+
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "unreserved",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        "--no-reserve",
+    )
+
+    assert mock_build.call_args.kwargs["reserve_node"] is False
+
+
+@pytest.mark.django_db
+def test_imager_build_command_rejects_nonpositive_reserve_number(tmp_path: Path) -> None:
+    """Reservation suffixes are node numbers, so zero and negatives are invalid."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+
+    with pytest.raises(CommandError, match="--reserve-number must be greater than zero"):
+        call_command(
+            "imager",
+            "build",
+            "--name",
+            "reserved",
+            "--base-image-uri",
+            str(output_path),
+            "--skip-recovery-ssh",
+            "--reserve",
+            "--reserve-number",
+            "0",
+        )
 
 
 @pytest.mark.django_db
@@ -756,6 +878,65 @@ def test_customize_image_does_not_add_recovery_boot_hook_when_recovery_is_disabl
     ]
 
 
+def test_customize_image_writes_reserved_node_metadata(tmp_path: Path) -> None:
+    """Reserved images should carry the planned hostname into first boot."""
+
+    image_path = tmp_path / "artifact.img"
+    image_path.write_bytes(b"pi")
+    reservation = ImageReservation(
+        hostname="gway-004",
+        hostname_prefix="gway",
+        number=4,
+        ipv4_address="10.42.0.4",
+        network_cidr="10.42.0.0/16",
+        parent_hostname="gway-001",
+    )
+    written_files: dict[str, tuple[str, str | None]] = {}
+    guestfish_batches: list[list[str]] = []
+
+    def capture_guestfish(
+        image_path_arg: Path,
+        commands: list[str],
+        *,
+        error_message: str,
+    ) -> None:
+        assert image_path_arg == image_path
+        assert error_message
+        guestfish_batches.append(commands)
+        for command in commands:
+            parts = shlex.split(command)
+            if parts and parts[0] == "upload":
+                written_files[parts[2]] = (Path(parts[1]).read_text(encoding="utf-8"), None)
+            elif parts and parts[0] == "chmod":
+                content, _mode = written_files[parts[2]]
+                written_files[parts[2]] = (content, parts[1])
+
+    with (
+        patch("apps.imager.services._ensure_guestfish"),
+        patch("apps.imager.services._guestfish_run_commands", side_effect=capture_guestfish),
+    ):
+        _customize_image(
+            image_path,
+            git_url="https://github.com/arthexis/arthexis.git",
+            reservation=reservation,
+        )
+
+    assert "/usr/local/share/arthexis/reserved-node.env" in written_files
+    assert "/usr/local/share/arthexis/reserved-node.json" in written_files
+    env_payload, env_mode = written_files["/usr/local/share/arthexis/reserved-node.env"]
+    json_payload, json_mode = written_files["/usr/local/share/arthexis/reserved-node.json"]
+    bootstrap_script, _bootstrap_mode = written_files["/usr/local/bin/arthexis-bootstrap.sh"]
+    assert env_mode == "0600"
+    assert json_mode == "0644"
+    assert "NODE_HOSTNAME=gway-004" in env_payload
+    assert json.loads(json_payload)["hostname"] == "gway-004"
+    assert "hostnamectl set-hostname" in bootstrap_script
+    assert any(
+        "upload" in command and "/usr/local/share/arthexis/reserved-node.env" in command
+        for command in guestfish_batches[1]
+    )
+
+
 def test_customize_image_writes_suite_bundle_and_selected_network_profiles(tmp_path: Path) -> None:
     """Regression: customized images can boot from bundled source and copied Wi-Fi profiles."""
 
@@ -1059,6 +1240,135 @@ def test_build_rpi4b_image_persists_suite_and_network_metadata(tmp_path: Path) -
             "remote_path": "/etc/NetworkManager/system-connections/home.nmconnection",
         }
     ]
+
+
+@pytest.mark.django_db
+def test_build_rpi4b_image_reserves_peer_node(tmp_path: Path) -> None:
+    """A reserved build should create a peer placeholder after the artifact succeeds."""
+
+    base_image = tmp_path / "base.img"
+    base_image.write_bytes(b"raspberrypi")
+    reservation = ImageReservation(
+        hostname="gway-004",
+        hostname_prefix="gway",
+        number=4,
+        ipv4_address="10.42.0.4",
+        network_cidr="10.42.0.0/16",
+        parent_hostname="gway-001",
+    )
+    customization_result = ImageCustomizationResult(reservation=reservation)
+
+    with (
+        patch("apps.imager.services.plan_image_reservation", return_value=reservation),
+        patch("apps.imager.services._customize_image", return_value=customization_result),
+    ):
+        result = build_rpi4b_image(
+            name="gway-004-repair",
+            base_image_uri=str(base_image),
+            output_dir=tmp_path,
+            download_base_uri="",
+            git_url="https://github.com/arthexis/arthexis.git",
+            customize=True,
+            skip_recovery_ssh=True,
+            reserve_node=True,
+            reserve_number=4,
+        )
+
+    node = Node.objects.get(hostname="gway-004")
+    artifact = RaspberryPiImageArtifact.objects.get(name="gway-004-repair")
+    assert node.reserved is True
+    assert node.current_relation == Node.Relation.PEER
+    assert node.address == "10.42.0.4"
+    assert result.reservation["hostname"] == "gway-004"
+    assert result.reservation["node_id"] == node.id
+    assert artifact.metadata["reserved_node"]["enabled"] is True
+    assert artifact.metadata["reserved_node"]["hostname"] == "gway-004"
+
+
+@pytest.mark.django_db
+def test_plan_image_reservation_uses_next_prefix_number_and_numbered_ip(monkeypatch) -> None:
+    """The default reservation for gway-001 after gway-005 should be gway-006."""
+
+    Node.objects.create(hostname="gway-001")
+    Node.objects.create(hostname="gway-005")
+    monkeypatch.setenv("IMAGER_RESERVE_HOSTNAME_PREFIX", "gway")
+    monkeypatch.setenv("IMAGER_RESERVE_NETWORK_CIDR", "10.42.0.0/16")
+    monkeypatch.setattr("apps.imager.reservations._known_neighbor_ips", lambda: set())
+    monkeypatch.setattr("apps.imager.reservations.psutil.net_if_addrs", lambda: {})
+
+    reservation = plan_image_reservation()
+
+    assert reservation.hostname == "gway-006"
+    assert reservation.number == 6
+    assert reservation.ipv4_address == "10.42.0.6"
+
+
+@pytest.mark.django_db
+def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
+    """The reservation watcher clears a placeholder after /nodes/info/ matches."""
+
+    node = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+
+    def fake_fetch(host: str, ports: tuple[int, ...], timeout: float):
+        assert ports == (8888,)
+        if host != "10.42.0.4":
+            return None
+        return {
+            "hostname": "gway-004",
+            "address": "10.42.0.4",
+            "ipv4_address": "10.42.0.4",
+            "port": 8888,
+            "mac_address": "aa:bb:cc:dd:ee:04",
+            "_watch_host": host,
+        }
+
+    monkeypatch.setattr("apps.imager.reservations._fetch_node_info", fake_fetch)
+
+    results = watch_reserved_nodes_once(interfaces=[], ports=(8888,), timeout=0.1)
+
+    assert results[0].status == "confirmed"
+    node.refresh_from_db()
+    assert node.reserved is False
+    assert node.mac_address == "aa:bb:cc:dd:ee:04"
+    assert node.trusted is True
+
+
+@pytest.mark.django_db
+def test_watch_reserved_nodes_rejects_hostname_mismatch(monkeypatch) -> None:
+    """A different node at the reserved IP must not claim the reservation."""
+
+    node = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+
+    def fake_fetch(host: str, ports: tuple[int, ...], timeout: float):
+        if host != "10.42.0.4":
+            return None
+        return {
+            "hostname": "gway-099",
+            "address": "10.42.0.4",
+            "ipv4_address": "10.42.0.4",
+            "port": 8888,
+            "_watch_host": host,
+        }
+
+    monkeypatch.setattr("apps.imager.reservations._fetch_node_info", fake_fetch)
+
+    results = watch_reserved_nodes_once(interfaces=[], ports=(8888,), timeout=0.1)
+
+    assert results[0].status == "pending"
+    node.refresh_from_db()
+    assert node.reserved is True
 
 
 @pytest.mark.django_db

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -18,6 +18,7 @@ from django.test import override_settings
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.reservations import (
     ImageReservation,
+    _fetch_node_info,
     confirm_reserved_node,
     plan_image_reservation,
     watch_reserved_nodes_once,
@@ -1355,9 +1356,34 @@ def test_watch_reserved_nodes_confirms_matching_node(monkeypatch) -> None:
     assert results[0].status == "confirmed"
     node.refresh_from_db()
     assert node.reserved is False
+    assert node.ipv4_address == "10.42.0.4"
     assert node.mac_address == "aa:bb:cc:dd:ee:04"
     assert node.port == 8888
     assert node.trusted is True
+
+
+def test_fetch_node_info_brackets_ipv6_hosts_and_reads_full_json() -> None:
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps({"hostname": "gway-006", "note": "x" * 9000}).encode(
+                "utf-8"
+            )
+
+    with patch("apps.imager.reservations.urlopen", return_value=FakeResponse()) as open_mock:
+        payload = _fetch_node_info("fd00::6", (8888,), timeout=0.1)
+
+    request = open_mock.call_args.args[0]
+    assert request.full_url == "http://[fd00::6]:8888/nodes/info/"
+    assert payload["hostname"] == "gway-006"
+    assert len(payload["note"]) == 9000
 
 
 @pytest.mark.django_db

--- a/apps/nodes/admin/node_admin.py
+++ b/apps/nodes/admin/node_admin.py
@@ -92,6 +92,7 @@ class NodeAdmin(SaveBeforeChangeAction, EntityModelAdmin):
         "role",
         "relation",
         "trusted",
+        "reserved",
         "mesh_status_badge",
         "last_mesh_heartbeat",
         "version_display",
@@ -124,6 +125,7 @@ class NodeAdmin(SaveBeforeChangeAction, EntityModelAdmin):
                     "message_queue_length",
                     "current_relation",
                     "trusted",
+                    "reserved",
                 )
             },
         ),

--- a/apps/nodes/migrations/0013_node_reserved.py
+++ b/apps/nodes/migrations/0013_node_reserved.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0012_upgrade_policy_custom_controls"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="node",
+            name="reserved",
+            field=models.BooleanField(
+                default=False,
+                help_text="Marks a peer placeholder reserved by an image build before first contact.",
+            ),
+        ),
+    ]

--- a/apps/nodes/models/node.py
+++ b/apps/nodes/models/node.py
@@ -127,6 +127,10 @@ class Node(NodeFeatureMixin, NodeNetworkingMixin, Entity):
         default=False,
         help_text="Mark the node as trusted for network interactions.",
     )
+    reserved = models.BooleanField(
+        default=False,
+        help_text="Marks a peer placeholder reserved by an image build before first contact.",
+    )
     message_queue_length = models.PositiveSmallIntegerField(
         default=10,
         help_text="Maximum queued NetMessages to retain for this peer.",

--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -134,6 +134,44 @@ def test_register_node_updates_mesh_identity_fields(admin_user):
 
 
 @pytest.mark.django_db
+def test_register_node_claims_reserved_placeholder_by_hostname(admin_user):
+    """First contact from a reserved image should reuse and clear its peer row."""
+
+    reserved = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+    payload = {
+        "hostname": "gway-004",
+        "mac_address": "aa:bb:cc:dd:ee:04",
+        "address": "10.42.0.4",
+        "ipv4_address": "10.42.0.4",
+        "port": 8888,
+        "trusted": True,
+        "current_relation": "Peer",
+    }
+
+    factory = RequestFactory()
+    request = _build_request(factory, payload)
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    response = register_node(request)
+
+    assert response.status_code == 200
+    body = json.loads(response.content.decode())
+    assert body["id"] == reserved.id
+    reserved.refresh_from_db()
+    assert reserved.reserved is False
+    assert reserved.mac_address == "aa:bb:cc:dd:ee:04"
+    assert reserved.trusted is True
+    assert Node.objects.count() == 1
+
+
+@pytest.mark.django_db
 def test_node_info_omits_sensitive_identity_fields():
     node = Node.objects.create(
         hostname="mesh-local",

--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -172,6 +172,112 @@ def test_register_node_claims_reserved_placeholder_by_hostname(admin_user):
 
 
 @pytest.mark.django_db
+def test_register_node_does_not_claim_reserved_placeholder_by_address_with_different_hostname(
+    admin_user,
+):
+    reserved = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+    payload = {
+        "hostname": "gway-099",
+        "mac_address": "aa:bb:cc:dd:ee:99",
+        "address": "10.42.0.4",
+        "ipv4_address": "10.42.0.4",
+        "port": 8888,
+        "current_relation": "Peer",
+    }
+
+    factory = RequestFactory()
+    request = _build_request(factory, payload)
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    response = register_node(request)
+
+    assert response.status_code == 200
+    body = json.loads(response.content.decode())
+    assert body["id"] != reserved.id
+    reserved.refresh_from_db()
+    assert reserved.reserved is True
+    assert reserved.mac_address == ""
+    assert Node.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_find_reserved_node_uses_address_fallback_only_without_hostname():
+    reserved = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+    request = _build_request(
+        RequestFactory(),
+        {
+            "hostname": "",
+            "mac_address": "aa:bb:cc:dd:ee:04",
+            "address": "10.42.0.4",
+            "ipv4_address": "10.42.0.4",
+        },
+    )
+    payload = handlers.parse_registration_request(request).payload
+
+    match = handlers._find_reserved_node_for_payload(
+        payload,
+        address_value="10.42.0.4",
+        ipv4_value="10.42.0.4",
+    )
+
+    assert match == reserved
+
+
+@pytest.mark.django_db
+def test_register_node_reports_conflict_when_reserved_placeholder_was_already_claimed(
+    admin_user, monkeypatch
+):
+    reserved = Node.objects.create(
+        hostname="gway-004",
+        address="10.42.0.4",
+        ipv4_address="10.42.0.4",
+        current_relation=Node.Relation.PEER,
+        reserved=True,
+    )
+    stale_reserved = Node.objects.get(pk=reserved.pk)
+    Node.objects.filter(pk=reserved.pk).update(reserved=False)
+    monkeypatch.setattr(
+        handlers,
+        "_find_reserved_node_for_payload",
+        lambda *_args, **_kwargs: stale_reserved,
+    )
+    payload = {
+        "hostname": "gway-004",
+        "mac_address": "aa:bb:cc:dd:ee:04",
+        "address": "10.42.0.4",
+        "ipv4_address": "10.42.0.4",
+        "port": 8888,
+        "current_relation": "Peer",
+    }
+
+    factory = RequestFactory()
+    request = _build_request(factory, payload)
+    request.user = admin_user
+    request._cached_user = admin_user
+
+    response = register_node(request)
+
+    reserved.refresh_from_db()
+    assert response.status_code == 409
+    assert reserved.reserved is False
+    assert reserved.mac_address == ""
+    assert Node.objects.count() == 1
+
+
+@pytest.mark.django_db
 def test_node_info_omits_sensitive_identity_fields():
     node = Node.objects.create(
         hostname="mesh-local",

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -761,16 +761,17 @@ def register_node(request):
                 base_site=base_site,
                 request=request,
             )
-        except ReservedNodeClaimError as error:
+        except ReservedNodeClaimError:
+            detail = "Reserved node was already claimed."
             _log_registration_event(
                 "failed",
                 payload,
                 request,
-                detail=str(error),
+                detail=detail,
                 level=logging.WARNING,
             )
             return add_cors_headers(
-                request, JsonResponse({"detail": str(error)}, status=409)
+                request, JsonResponse({"detail": detail}, status=409)
             )
         _log_registration_event(
             "succeeded", payload, request, detail=f"updated node {node.id}"

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -62,6 +62,10 @@ logger = logging.getLogger("apps.nodes.views")
 registration_logger = get_register_visitor_logger()
 
 
+class ReservedNodeClaimError(RuntimeError):
+    """Raised when a reserved placeholder was claimed by another registration."""
+
+
 def _extract_response_detail(response) -> str:
     """Extract detail text from JSON and non-JSON responses."""
 
@@ -406,9 +410,19 @@ def _update_existing_node(
 ):
     """Update an existing node while preserving response compatibility."""
 
+    reserved_claimed = False
+    if node.reserved:
+        claimed = Node.objects.filter(pk=node.pk, reserved=True).update(reserved=False)
+        if not claimed:
+            raise ReservedNodeClaimError("Reserved node was already claimed.")
+        node.reserved = False
+        reserved_claimed = True
+
     previous_version = (node.installed_version or "").strip()
     previous_revision = (node.installed_revision or "").strip()
     update_fields: list[str] = []
+    if reserved_claimed:
+        update_fields.append("reserved")
     for field, value in (
         ("hostname", payload.hostname),
         ("network_hostname", payload.network_hostname),
@@ -471,9 +485,6 @@ def _update_existing_node(
     if trusted_allowed and not node.trusted:
         node.trusted = True
         update_fields.append("trusted")
-    if node.reserved:
-        node.reserved = False
-        update_fields.append("reserved")
     if base_site and node.base_site_id != base_site.id:
         node.base_site = base_site
         update_fields.append("base_site")
@@ -513,17 +524,17 @@ def _find_reserved_node_for_payload(
     """Return a reserved placeholder that matches a first-contact payload."""
 
     hostname = (payload.hostname or "").strip()
+    queryset = Node.objects.filter(reserved=True)
+    if hostname:
+        return queryset.filter(hostname__iexact=hostname).first()
     address_tokens = {
         token
         for raw_value in (address_value, ipv4_value, payload.network_hostname)
         for token in re.split(r"[\s,]+", raw_value or "")
         if token
     }
-    queryset = Node.objects.filter(reserved=True)
-    if hostname:
-        node = queryset.filter(hostname__iexact=hostname).first()
-        if node:
-            return node
+    if not address_tokens:
+        return None
     for node in queryset.only("id", "address", "ipv4_address", "network_hostname"):
         node_tokens = {
             token
@@ -749,6 +760,17 @@ def register_node(request):
                 trusted_allowed=trusted_allowed,
                 base_site=base_site,
                 request=request,
+            )
+        except ReservedNodeClaimError as error:
+            _log_registration_event(
+                "failed",
+                payload,
+                request,
+                detail=str(error),
+                level=logging.WARNING,
+            )
+            return add_cors_headers(
+                request, JsonResponse({"detail": str(error)}, status=409)
             )
         _log_registration_event(
             "succeeded", payload, request, detail=f"updated node {node.id}"

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import logging
+import re
 from collections.abc import Mapping
 from urllib.parse import urlsplit
 
@@ -414,6 +415,7 @@ def _update_existing_node(
         ("address", address_value),
         ("ipv4_address", ipv4_value),
         ("ipv6_address", ipv6_value),
+        ("mac_address", payload.mac_address.lower()),
         ("host_instance_id", payload.host_instance_id),
         ("port", payload.port),
     ):
@@ -469,6 +471,9 @@ def _update_existing_node(
     if trusted_allowed and not node.trusted:
         node.trusted = True
         update_fields.append("trusted")
+    if node.reserved:
+        node.reserved = False
+        update_fields.append("reserved")
     if base_site and node.base_site_id != base_site.id:
         node.base_site = base_site
         update_fields.append("base_site")
@@ -497,6 +502,38 @@ def _update_existing_node(
             "detail": f"Node already exists (id: {node.id})",
         }
     )
+
+
+def _find_reserved_node_for_payload(
+    payload: NodeRegistrationPayload,
+    *,
+    address_value: str,
+    ipv4_value: str,
+) -> Node | None:
+    """Return a reserved placeholder that matches a first-contact payload."""
+
+    hostname = (payload.hostname or "").strip()
+    address_tokens = {
+        token
+        for raw_value in (address_value, ipv4_value, payload.network_hostname)
+        for token in re.split(r"[\s,]+", raw_value or "")
+        if token
+    }
+    queryset = Node.objects.filter(reserved=True)
+    if hostname:
+        node = queryset.filter(hostname__iexact=hostname).first()
+        if node:
+            return node
+    for node in queryset.only("id", "address", "ipv4_address", "network_hostname"):
+        node_tokens = {
+            token
+            for raw_value in (node.address, node.ipv4_address, node.network_hostname)
+            for token in re.split(r"[\s,]+", raw_value or "")
+            if token
+        }
+        if node_tokens & address_tokens:
+            return node
+    return None
 
 
 @csrf_exempt
@@ -570,6 +607,12 @@ def register_node(request):
         else None
     )
     existing_node = Node.objects.filter(mac_address=mac_address).first()
+    if existing_node is None:
+        existing_node = _find_reserved_node_for_payload(
+            payload,
+            address_value=address_value,
+            ipv4_value=ipv4_value,
+        )
     relation_value = payload.relation_value
     if relation_value == Node.Relation.SELF and payload.host_instance_id:
         other_self_exists = (
@@ -650,24 +693,28 @@ def register_node(request):
     if relation_value is not None:
         defaults["current_relation"] = relation_value
 
-    try:
-        node, created = Node.objects.get_or_create(
-            mac_address=mac_address,
-            defaults=defaults,
-        )
-    except IntegrityError as error:
-        if not _is_self_host_conflict_error(
-            error,
-            relation_value=relation_value,
-            host_instance_id=payload.host_instance_id,
-        ):
-            raise
-        relation_value = Node.Relation.SIBLING
-        defaults["current_relation"] = relation_value
-        node, created = Node.objects.get_or_create(
-            mac_address=mac_address,
-            defaults=defaults,
-        )
+    if existing_node is not None:
+        node = existing_node
+        created = False
+    else:
+        try:
+            node, created = Node.objects.get_or_create(
+                mac_address=mac_address,
+                defaults=defaults,
+            )
+        except IntegrityError as error:
+            if not _is_self_host_conflict_error(
+                error,
+                relation_value=relation_value,
+                host_instance_id=payload.host_instance_id,
+            ):
+                raise
+            relation_value = Node.Relation.SIBLING
+            defaults["current_relation"] = relation_value
+            node, created = Node.objects.get_or_create(
+                mac_address=mac_address,
+                defaults=defaults,
+            )
     if not created:
         try:
             response = _update_existing_node(

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -43,6 +43,14 @@ To copy host Wi-Fi/Ethernet NetworkManager profiles into the image, pass one or 
 
 Profile selectors match the NetworkManager connection id, filename, or filename stem from `/etc/NetworkManager/system-connections`. Use `--copy-all-host-networks` only when every saved profile and credential on the build host should be copied. For test rigs or nonstandard hosts, override the source directory with `--host-network-profile-dir`.
 
+To reserve the target node before first boot, add `--reserve`. The build creates or updates a peer `Node` row with `reserved=True`, preassigns a hostname from the parent prefix, and bakes that hostname into the image. Use `--reserve-number 4` to force a suffix such as `gway-004`, or `--reserve-prefix gway` to override the parent-derived prefix. `IMAGER_RESERVE_DEFAULT=1` makes reservation the instance default, and `--no-reserve` disables it for one build.
+
+Reserved builds can also copy the active parent Wi-Fi profile by default with `--copy-parent-network` or `IMAGER_COPY_PARENT_NETWORK_DEFAULT=1`. The reservation watcher can clear pending reservations after the burned node responds on `/nodes/info/`:
+
+```bash
+.venv/bin/python manage.py imager watch-reservations --interfaces wlan0,wlan1,eth0 --interval 30
+```
+
 List registered artifacts:
 
 ```bash

--- a/docs/operations/imager-sd-card-recovery.md
+++ b/docs/operations/imager-sd-card-recovery.md
@@ -45,7 +45,7 @@ Profile selectors match the NetworkManager connection id, filename, or filename 
 
 To reserve the target node before first boot, add `--reserve`. The build creates or updates a peer `Node` row with `reserved=True`, preassigns a hostname from the parent prefix, and bakes that hostname into the image. Use `--reserve-number 4` to force a suffix such as `gway-004`, or `--reserve-prefix gway` to override the parent-derived prefix. `IMAGER_RESERVE_DEFAULT=1` makes reservation the instance default, and `--no-reserve` disables it for one build.
 
-Reserved builds can also copy the active parent Wi-Fi profile by default with `--copy-parent-network` or `IMAGER_COPY_PARENT_NETWORK_DEFAULT=1`. The reservation watcher can clear pending reservations after the burned node responds on `/nodes/info/`:
+Reserved builds can also copy the active parent Wi-Fi profile by default with `--copy-parent-network` or `IMAGER_COPY_PARENT_NETWORK_DEFAULT=1`. The reservation watcher reports pending reservations after a burned node responds on `/nodes/info/`; the reservation is cleared only by the node's signed registration request:
 
 ```bash
 .venv/bin/python manage.py imager watch-reservations --interfaces wlan0,wlan1,eth0 --interval 30


### PR DESCRIPTION
## Summary
- Add reserved Raspberry Pi image builds with `--reserve`, `--reserve-number`, `--reserve-prefix`, env-backed defaults, hostname/IP planning, and reserved metadata baked into the image.
- Add `Node.reserved`, admin visibility, migration, first-contact registration claiming, and a watcher command that clears reservations only after a matching `/nodes/info/` hostname responds.
- Add parent Wi-Fi copy defaults plus docs for reserved image repair workflows.

## GWAY config applied
- `IMAGER_RESERVE_DEFAULT=1`
- `IMAGER_COPY_PARENT_NETWORK_DEFAULT=1`
- `IMAGER_RESERVE_HOSTNAME_PREFIX=gway`
- `IMAGER_RESERVE_NETWORK_CIDR=10.42.0.0/16`
- `IMAGER_RESERVATION_WATCH_INTERFACES=wlan0,wlan1,eth0`

No matching open GitHub issue was found for this request.

## Validation
- `.venv\Scripts\python.exe -m py_compile apps\imager\reservations.py apps\imager\services.py apps\imager\management\commands\imager.py apps\nodes\views\registration\handlers.py`
- `.venv\Scripts\python.exe manage.py test run -- apps/imager/tests/test_imager_command.py apps/nodes/tests/test_register_node.py` (83 passed)
- `.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.venv\Scripts\python.exe manage.py migrate --check`
- `git diff --cached --check`