### PR TITLE
Add deterministic PR oversight command

### DIFF
--- a/apps/repos/management/commands/pr_oversee.py
+++ b/apps/repos/management/commands/pr_oversee.py
@@ -1,0 +1,224 @@
+"""Deterministic GitHub pull-request oversight command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.release import DEFAULT_PACKAGE
+from apps.repos.github import parse_repository_url, resolve_active_repository
+from apps.repos.pr_oversee import PullRequestOverseeError, PullRequestOverseer
+
+
+class Command(BaseCommand):
+    """Expose deterministic PR oversight operations."""
+
+    help = "Inspect, gate, prepare, validate, merge, and clean up GitHub pull requests."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--repo",
+            default="",
+            help=(
+                "Repository slug in owner/name format. Defaults to active package repository "
+                f"or {DEFAULT_PACKAGE.repository_url}."
+            ),
+        )
+        parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output.")
+
+        subparsers = parser.add_subparsers(dest="action", required=True)
+
+        inspect_parser = subparsers.add_parser("inspect", help="Return a complete PR state snapshot.")
+        self._add_pr_arg(inspect_parser)
+
+        gate_parser = subparsers.add_parser("gate", help="Fail unless the PR is merge-ready.")
+        self._add_pr_arg(gate_parser)
+        gate_parser.add_argument("--require-approval", action="store_true")
+        gate_parser.add_argument("--allow-pending", action="store_true")
+
+        comments_parser = subparsers.add_parser("comments", help="List PR review threads.")
+        self._add_pr_arg(comments_parser)
+        comments_parser.add_argument("--unresolved", action="store_true")
+
+        checkout_parser = subparsers.add_parser("checkout", help="Create an isolated worktree for a PR.")
+        self._add_pr_arg(checkout_parser)
+        checkout_parser.add_argument("--worktree", required=True, help="Worktree path to create.")
+        checkout_parser.add_argument("--branch", default="", help="Optional local branch name.")
+
+        test_plan_parser = subparsers.add_parser("test-plan", help="Map changed files to test commands.")
+        self._add_pr_arg(test_plan_parser)
+
+        ci_parser = subparsers.add_parser("ci", help="Collect failed or pending CI checks.")
+        self._add_pr_arg(ci_parser)
+        ci_parser.add_argument("--failures", action="store_true", help="Return failing/pending checks.")
+        ci_parser.add_argument("--logs", action="store_true", help="Fetch failed run log snippets.")
+
+        dedupe_parser = subparsers.add_parser(
+            "dependency-dedupe",
+            help="Find duplicate or superseded dependency PR groups.",
+        )
+        dedupe_parser.add_argument("--limit", type=int, default=80)
+
+        merge_parser = subparsers.add_parser("merge", help="Gate and merge a PR.")
+        self._add_pr_arg(merge_parser)
+        merge_parser.add_argument("--method", choices=["squash", "merge", "rebase"], default="squash")
+        merge_parser.add_argument("--delete-branch", action="store_true")
+        merge_parser.add_argument("--require-approval", action="store_true")
+        merge_parser.add_argument("--expected-head-sha", default="")
+        merge_parser.add_argument("--allow-pending", action="store_true")
+        merge_parser.add_argument("--admin", action="store_true")
+        merge_parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Required to perform the merge. Without it the command only reports the gated plan.",
+        )
+
+        cleanup_parser = subparsers.add_parser("cleanup", help="Clean local PR artifacts after merge.")
+        self._add_pr_arg(cleanup_parser)
+        cleanup_parser.add_argument("--worktree", default="", help="Worktree path to remove.")
+        cleanup_parser.add_argument("--delete-local-branch", default="")
+        cleanup_parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Required to perform cleanup. Without it the command only reports the plan.",
+        )
+
+        hygiene_parser = subparsers.add_parser("hygiene", help="Run deterministic PR hygiene checks.")
+        self._add_pr_arg(hygiene_parser)
+
+    def handle(self, *args, **options) -> None:
+        repo = self._resolve_repository(str(options.get("repo") or ""))
+        overseer = PullRequestOverseer(repo=repo)
+        action = str(options["action"])
+
+        try:
+            result = self._run_action(overseer, action, options)
+        except PullRequestOverseeError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self._write_result(result, json_output=bool(options.get("json")))
+        if action == "gate" and not result.get("ready"):
+            raise CommandError("PR is not merge-ready: " + ", ".join(result.get("blockers") or []))
+        if action == "hygiene" and not result.get("ok"):
+            raise CommandError("PR hygiene failed: " + ", ".join(result.get("failures") or []))
+
+    def _run_action(
+        self,
+        overseer: PullRequestOverseer,
+        action: str,
+        options: dict[str, object],
+    ) -> dict[str, object]:
+        number = int(options.get("pr") or 0)
+        if action == "inspect":
+            return overseer.inspect(number)
+        if action == "gate":
+            return overseer.gate(
+                number,
+                require_approval=bool(options.get("require_approval")),
+                allow_pending=bool(options.get("allow_pending")),
+            )
+        if action == "comments":
+            return overseer.comments(number, unresolved_only=bool(options.get("unresolved")))
+        if action == "checkout":
+            return overseer.checkout(
+                number,
+                worktree=Path(str(options["worktree"])).expanduser(),
+                branch=str(options.get("branch") or ""),
+            )
+        if action == "test-plan":
+            return overseer.test_plan(number)
+        if action == "ci":
+            _ = options.get("failures")
+            return overseer.ci_failures(number, include_logs=bool(options.get("logs")))
+        if action == "dependency-dedupe":
+            return overseer.dependency_dedupe(limit=int(options.get("limit") or 80))
+        if action == "merge":
+            if not options.get("write"):
+                gate = overseer.gate(
+                    number,
+                    require_approval=bool(options.get("require_approval")),
+                    allow_pending=bool(options.get("allow_pending")),
+                )
+                return {"write": False, "plannedCommand": "gh pr merge", "gate": gate}
+            return overseer.merge(
+                number,
+                method=str(options.get("method") or "squash"),
+                delete_branch=bool(options.get("delete_branch")),
+                require_approval=bool(options.get("require_approval")),
+                expected_head_sha=str(options.get("expected_head_sha") or ""),
+                allow_pending=bool(options.get("allow_pending")),
+                admin=bool(options.get("admin")),
+            )
+        if action == "cleanup":
+            if not options.get("write"):
+                return {
+                    "write": False,
+                    "plannedActions": [
+                        item
+                        for item in (
+                            "remove-worktree" if options.get("worktree") else "",
+                            "fetch-main-prune",
+                            "delete-local-branch" if options.get("delete_local_branch") else "",
+                        )
+                        if item
+                    ],
+                }
+            worktree = (
+                Path(str(options["worktree"])).expanduser()
+                if str(options.get("worktree") or "").strip()
+                else None
+            )
+            return overseer.cleanup(
+                number,
+                worktree=worktree,
+                delete_local_branch=str(options.get("delete_local_branch") or ""),
+            )
+        if action == "hygiene":
+            return overseer.hygiene(number)
+        raise CommandError(f"Unsupported action: {action}")
+
+    def _add_pr_arg(self, parser) -> None:
+        parser.add_argument("--pr", type=int, required=True, help="Pull request number.")
+
+    def _resolve_repository(self, raw_repo: str) -> str:
+        cleaned = raw_repo.strip()
+        if cleaned:
+            try:
+                owner, name = parse_repository_url(cleaned)
+            except ValueError as exc:
+                raise CommandError(str(exc)) from exc
+            return f"{owner}/{name}"
+
+        try:
+            active = resolve_active_repository()
+        except ValueError:
+            owner, name = parse_repository_url(DEFAULT_PACKAGE.repository_url)
+            return f"{owner}/{name}"
+        return f"{active.owner}/{active.name}"
+
+    def _write_result(self, result: dict[str, object], *, json_output: bool) -> None:
+        if json_output:
+            self.stdout.write(json.dumps(result, indent=2, sort_keys=True))
+            return
+
+        if "ready" in result:
+            state = "READY" if result.get("ready") else "BLOCKED"
+            self.stdout.write(f"state={state}")
+            for blocker in result.get("blockers") or []:
+                self.stdout.write(f"blocker={blocker}")
+            for warning in result.get("warnings") or []:
+                self.stdout.write(f"warning={warning}")
+            return
+
+        if "ok" in result:
+            state = "OK" if result.get("ok") else "FAILED"
+            self.stdout.write(f"hygiene={state}")
+            for failure in result.get("failures") or []:
+                self.stdout.write(f"failure={failure}")
+            for warning in result.get("warnings") or []:
+                self.stdout.write(f"warning={warning}")
+            return
+
+        self.stdout.write(json.dumps(result, indent=2, sort_keys=True))

--- a/apps/repos/management/commands/pr_oversee.py
+++ b/apps/repos/management/commands/pr_oversee.py
@@ -26,34 +26,56 @@ class Command(BaseCommand):
                 f"or {DEFAULT_PACKAGE.repository_url}."
             ),
         )
-        parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output.")
+        parser.add_argument(
+            "--json", action="store_true", help="Emit machine-readable JSON output."
+        )
 
         subparsers = parser.add_subparsers(dest="action", required=True)
 
-        inspect_parser = subparsers.add_parser("inspect", help="Return a complete PR state snapshot.")
+        inspect_parser = subparsers.add_parser(
+            "inspect", help="Return a complete PR state snapshot."
+        )
         self._add_pr_arg(inspect_parser)
 
-        gate_parser = subparsers.add_parser("gate", help="Fail unless the PR is merge-ready.")
+        gate_parser = subparsers.add_parser(
+            "gate", help="Fail unless the PR is merge-ready."
+        )
         self._add_pr_arg(gate_parser)
         gate_parser.add_argument("--require-approval", action="store_true")
         gate_parser.add_argument("--allow-pending", action="store_true")
 
-        comments_parser = subparsers.add_parser("comments", help="List PR review threads.")
+        comments_parser = subparsers.add_parser(
+            "comments", help="List PR review threads."
+        )
         self._add_pr_arg(comments_parser)
         comments_parser.add_argument("--unresolved", action="store_true")
 
-        checkout_parser = subparsers.add_parser("checkout", help="Create an isolated worktree for a PR.")
+        checkout_parser = subparsers.add_parser(
+            "checkout", help="Create an isolated worktree for a PR."
+        )
         self._add_pr_arg(checkout_parser)
-        checkout_parser.add_argument("--worktree", required=True, help="Worktree path to create.")
-        checkout_parser.add_argument("--branch", default="", help="Optional local branch name.")
+        checkout_parser.add_argument(
+            "--worktree", required=True, help="Worktree path to create."
+        )
+        checkout_parser.add_argument(
+            "--branch", default="", help="Optional local branch name."
+        )
 
-        test_plan_parser = subparsers.add_parser("test-plan", help="Map changed files to test commands.")
+        test_plan_parser = subparsers.add_parser(
+            "test-plan", help="Map changed files to test commands."
+        )
         self._add_pr_arg(test_plan_parser)
 
-        ci_parser = subparsers.add_parser("ci", help="Collect failed or pending CI checks.")
+        ci_parser = subparsers.add_parser(
+            "ci", help="Collect failed or pending CI checks."
+        )
         self._add_pr_arg(ci_parser)
-        ci_parser.add_argument("--failures", action="store_true", help="Return failing/pending checks.")
-        ci_parser.add_argument("--logs", action="store_true", help="Fetch failed run log snippets.")
+        ci_parser.add_argument(
+            "--failures", action="store_true", help="Return failing/pending checks."
+        )
+        ci_parser.add_argument(
+            "--logs", action="store_true", help="Fetch failed run log snippets."
+        )
 
         dedupe_parser = subparsers.add_parser(
             "dependency-dedupe",
@@ -63,7 +85,9 @@ class Command(BaseCommand):
 
         merge_parser = subparsers.add_parser("merge", help="Gate and merge a PR.")
         self._add_pr_arg(merge_parser)
-        merge_parser.add_argument("--method", choices=["squash", "merge", "rebase"], default="squash")
+        merge_parser.add_argument(
+            "--method", choices=["squash", "merge", "rebase"], default="squash"
+        )
         merge_parser.add_argument("--delete-branch", action="store_true")
         merge_parser.add_argument("--require-approval", action="store_true")
         merge_parser.add_argument("--expected-head-sha", default="")
@@ -75,9 +99,13 @@ class Command(BaseCommand):
             help="Required to perform the merge. Without it the command only reports the gated plan.",
         )
 
-        cleanup_parser = subparsers.add_parser("cleanup", help="Clean local PR artifacts after merge.")
+        cleanup_parser = subparsers.add_parser(
+            "cleanup", help="Clean local PR artifacts after merge."
+        )
         self._add_pr_arg(cleanup_parser)
-        cleanup_parser.add_argument("--worktree", default="", help="Worktree path to remove.")
+        cleanup_parser.add_argument(
+            "--worktree", default="", help="Worktree path to remove."
+        )
         cleanup_parser.add_argument("--delete-local-branch", default="")
         cleanup_parser.add_argument(
             "--write",
@@ -85,7 +113,9 @@ class Command(BaseCommand):
             help="Required to perform cleanup. Without it the command only reports the plan.",
         )
 
-        hygiene_parser = subparsers.add_parser("hygiene", help="Run deterministic PR hygiene checks.")
+        hygiene_parser = subparsers.add_parser(
+            "hygiene", help="Run deterministic PR hygiene checks."
+        )
         self._add_pr_arg(hygiene_parser)
 
     def handle(self, *args, **options) -> None:
@@ -100,9 +130,13 @@ class Command(BaseCommand):
 
         self._write_result(result, json_output=bool(options.get("json")))
         if action == "gate" and not result.get("ready"):
-            raise CommandError("PR is not merge-ready: " + ", ".join(result.get("blockers") or []))
+            raise CommandError(
+                "PR is not merge-ready: " + ", ".join(result.get("blockers") or [])
+            )
         if action == "hygiene" and not result.get("ok"):
-            raise CommandError("PR hygiene failed: " + ", ".join(result.get("failures") or []))
+            raise CommandError(
+                "PR hygiene failed: " + ", ".join(result.get("failures") or [])
+            )
 
     def _run_action(
         self,
@@ -120,7 +154,9 @@ class Command(BaseCommand):
                 allow_pending=bool(options.get("allow_pending")),
             )
         if action == "comments":
-            return overseer.comments(number, unresolved_only=bool(options.get("unresolved")))
+            return overseer.comments(
+                number, unresolved_only=bool(options.get("unresolved"))
+            )
         if action == "checkout":
             return overseer.checkout(
                 number,
@@ -130,7 +166,6 @@ class Command(BaseCommand):
         if action == "test-plan":
             return overseer.test_plan(number)
         if action == "ci":
-            _ = options.get("failures")
             return overseer.ci_failures(number, include_logs=bool(options.get("logs")))
         if action == "dependency-dedupe":
             return overseer.dependency_dedupe(limit=int(options.get("limit") or 80))
@@ -159,8 +194,12 @@ class Command(BaseCommand):
                         item
                         for item in (
                             "remove-worktree" if options.get("worktree") else "",
-                            "fetch-main-prune",
-                            "delete-local-branch" if options.get("delete_local_branch") else "",
+                            "fetch-base-prune",
+                            (
+                                "delete-local-branch"
+                                if options.get("delete_local_branch")
+                                else ""
+                            ),
                         )
                         if item
                     ],
@@ -180,7 +219,9 @@ class Command(BaseCommand):
         raise CommandError(f"Unsupported action: {action}")
 
     def _add_pr_arg(self, parser) -> None:
-        parser.add_argument("--pr", type=int, required=True, help="Pull request number.")
+        parser.add_argument(
+            "--pr", type=int, required=True, help="Pull request number."
+        )
 
     def _resolve_repository(self, raw_repo: str) -> str:
         cleaned = raw_repo.strip()

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -1,0 +1,686 @@
+"""Deterministic pull-request oversight helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+JSONValue = dict[str, Any] | list[Any] | str | int | float | bool | None
+
+PR_FIELDS = ",".join(
+    [
+        "number",
+        "title",
+        "author",
+        "body",
+        "baseRefName",
+        "baseRefOid",
+        "commits",
+        "files",
+        "headRefName",
+        "headRefOid",
+        "isDraft",
+        "mergeStateStatus",
+        "mergeable",
+        "reviewDecision",
+        "state",
+        "statusCheckRollup",
+        "updatedAt",
+        "url",
+    ]
+)
+
+GOOD_CHECKS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+BAD_CHECKS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+PENDING_CHECKS = {"EXPECTED", "PENDING", "QUEUED", "REQUESTED", "IN_PROGRESS", "WAITING"}
+BAD_MERGE_STATES = {"BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"}
+README_RE = re.compile(r"(^|/)(README|README\.[^/]+)$", re.IGNORECASE)
+DEPENDENCY_TITLE_PATTERNS = (
+    re.compile(r"\bbump\s+(.+?)\s+from\s+([^\s]+)\s+to\s+([^\s]+)", re.IGNORECASE),
+    re.compile(r"\bbump\s+(.+?)\s+to\s+([^\s]+)", re.IGNORECASE),
+    re.compile(r"\bupdate\s+dependency\s+(.+?)\s+to\s+([^\s]+)", re.IGNORECASE),
+)
+
+
+class PullRequestOverseeError(RuntimeError):
+    """Raised when PR oversight cannot complete deterministically."""
+
+
+@dataclass(slots=True)
+class CommandResult:
+    """Subprocess result captured by the command runner."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class CommandRunner:
+    """Small command runner wrapper for GitHub and Git commands."""
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        cwd: Path | None = None,
+        check: bool = False,
+    ) -> CommandResult:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+        )
+        result = CommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+        )
+        if check and result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or f"{command[0]} failed"
+            raise PullRequestOverseeError(message)
+        return result
+
+
+def _json_loads(raw_value: str) -> JSONValue:
+    if not raw_value.strip():
+        return None
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise PullRequestOverseeError(f"Command did not return valid JSON: {exc}") from exc
+
+
+def _coerce_mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _coerce_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _author_login(pr: Mapping[str, Any]) -> str:
+    author = pr.get("author")
+    if isinstance(author, Mapping):
+        return str(author.get("login") or "")
+    return str(author or "")
+
+
+def _check_name(check: Mapping[str, Any]) -> str:
+    return str(
+        check.get("name")
+        or check.get("context")
+        or check.get("workflowName")
+        or check.get("workflow")
+        or "check"
+    )
+
+
+def check_rollup_state(pr: Mapping[str, Any]) -> dict[str, list[dict[str, str]]]:
+    """Classify status check rollup entries as failing, pending, or passing."""
+
+    failing: list[dict[str, str]] = []
+    pending: list[dict[str, str]] = []
+    passing: list[dict[str, str]] = []
+    for raw_check in _coerce_list(pr.get("statusCheckRollup")):
+        check = _coerce_mapping(raw_check)
+        name = _check_name(check)
+        conclusion = str(check.get("conclusion") or "").upper()
+        status = str(check.get("status") or "").upper()
+        state = str(check.get("state") or "").upper()
+        value = conclusion or state or status or "UNKNOWN"
+        entry = {
+            "name": name,
+            "status": status,
+            "state": state,
+            "conclusion": conclusion,
+            "value": value,
+            "detailsUrl": str(check.get("detailsUrl") or check.get("link") or ""),
+        }
+        if conclusion in BAD_CHECKS or state in BAD_CHECKS:
+            failing.append(entry)
+        elif conclusion and conclusion not in GOOD_CHECKS:
+            failing.append(entry)
+        elif state and state not in GOOD_CHECKS and state not in {"COMPLETED"}:
+            if state in PENDING_CHECKS:
+                pending.append(entry)
+            else:
+                failing.append(entry)
+        elif status and status not in {"COMPLETED", "SUCCESS"}:
+            if status in PENDING_CHECKS:
+                pending.append(entry)
+            else:
+                failing.append(entry)
+        else:
+            passing.append(entry)
+    return {"failing": failing, "pending": pending, "passing": passing}
+
+
+def readiness_gate(
+    pr: Mapping[str, Any],
+    *,
+    require_approval: bool = False,
+    allow_pending: bool = False,
+    require_conversation_resolution: bool = True,
+) -> dict[str, Any]:
+    """Return deterministic PR readiness blockers and warnings."""
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if pr.get("isDraft"):
+        blockers.append("draft")
+
+    merge_state = str(pr.get("mergeStateStatus") or "").upper()
+    if merge_state in BAD_MERGE_STATES:
+        blockers.append(f"merge_state:{merge_state}")
+    elif not merge_state:
+        warnings.append("merge_state:EMPTY")
+
+    mergeable = str(pr.get("mergeable") or "").upper()
+    if mergeable in {"CONFLICTING", "FALSE"}:
+        blockers.append(f"mergeable:{mergeable}")
+
+    review_decision = str(pr.get("reviewDecision") or "").upper()
+    if review_decision in {"CHANGES_REQUESTED", "REVIEW_REQUIRED"}:
+        blockers.append(f"review:{review_decision}")
+    elif require_approval and review_decision != "APPROVED":
+        blockers.append(f"review:{review_decision or 'MISSING_APPROVAL'}")
+
+    checks = check_rollup_state(pr)
+    blockers.extend(f"check:{item['name']}:{item['value']}" for item in checks["failing"])
+    pending_values = [f"pending:{item['name']}:{item['value']}" for item in checks["pending"]]
+    if pending_values and allow_pending:
+        warnings.extend(pending_values)
+    else:
+        blockers.extend(pending_values)
+
+    unresolved_threads = int(pr.get("unresolvedReviewThreadCount") or 0)
+    if require_conversation_resolution and unresolved_threads:
+        blockers.append(f"review_threads:UNRESOLVED:{unresolved_threads}")
+
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "author": _author_login(pr),
+        "url": pr.get("url"),
+        "headRefName": pr.get("headRefName"),
+        "headRefOid": pr.get("headRefOid"),
+        "baseRefName": pr.get("baseRefName"),
+        "baseRefOid": pr.get("baseRefOid"),
+        "ready": not blockers,
+        "blockers": blockers,
+        "warnings": warnings,
+        "mergeStateStatus": pr.get("mergeStateStatus"),
+        "mergeable": pr.get("mergeable"),
+        "reviewDecision": pr.get("reviewDecision"),
+        "checks": checks,
+        "unresolvedReviewThreadCount": unresolved_threads,
+        "updatedAt": pr.get("updatedAt"),
+    }
+
+
+def dependency_key(pr: Mapping[str, Any]) -> str:
+    """Return a stable dependency grouping key for a PR."""
+
+    title = str(pr.get("title") or "")
+    for pattern in DEPENDENCY_TITLE_PATTERNS:
+        match = pattern.search(title)
+        if match:
+            return re.sub(r"\s+", " ", match.group(1).strip().lower())
+    head = str(pr.get("headRefName") or "").lower()
+    head = re.sub(r"^dependabot/[^/]+/", "", head)
+    head = re.sub(r"[-_/]?v?\d+(?:\.\d+)+(?:[-_.][a-z0-9]+)?$", "", head)
+    return head or title.lower()
+
+
+def dependency_target_version(pr: Mapping[str, Any]) -> str:
+    """Best-effort dependency target version from title or branch."""
+
+    title = str(pr.get("title") or "")
+    for pattern in DEPENDENCY_TITLE_PATTERNS:
+        match = pattern.search(title)
+        if match:
+            return match.group(match.lastindex or 1)
+    head = str(pr.get("headRefName") or "")
+    match = re.search(r"v?(\d+(?:\.\d+)+(?:[-_.][A-Za-z0-9]+)?)$", head)
+    return match.group(1) if match else ""
+
+
+def is_dependency_pr(pr: Mapping[str, Any]) -> bool:
+    """Return True when a PR appears to be a dependency update."""
+
+    login = _author_login(pr).lower()
+    title = str(pr.get("title") or "").lower()
+    head = str(pr.get("headRefName") or "").lower()
+    return "dependabot" in login or "dependabot" in head or title.startswith("build(deps") or "bump " in title
+
+
+def dependency_duplicates(prs: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Group duplicate or superseded dependency PR candidates."""
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for pr in prs:
+        if not is_dependency_pr(pr):
+            continue
+        key = dependency_key(pr)
+        grouped.setdefault(key, []).append(
+            {
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "headRefName": pr.get("headRefName"),
+                "targetVersion": dependency_target_version(pr),
+                "updatedAt": pr.get("updatedAt"),
+                "url": pr.get("url"),
+            }
+        )
+
+    duplicates: dict[str, Any] = {}
+    for key, items in grouped.items():
+        if len(items) < 2:
+            continue
+        ordered = sorted(items, key=lambda item: str(item.get("updatedAt") or ""))
+        duplicates[key] = {
+            "items": ordered,
+            "superseded": ordered[:-1],
+            "preferred": ordered[-1],
+        }
+    return duplicates
+
+
+def changed_files_to_test_plan(paths: Iterable[str]) -> dict[str, Any]:
+    """Map changed file paths to deterministic local validation commands."""
+
+    files = sorted({path for path in paths if path})
+    apps: set[str] = set()
+    commands: list[list[str]] = []
+    notes: list[str] = []
+    model_change = False
+    migration_change = False
+    docs_only = bool(files)
+    workflow_change = False
+    generated_candidates: list[str] = []
+
+    for path in files:
+        if path.startswith("apps/"):
+            docs_only = False
+            parts = path.split("/")
+            if len(parts) > 1:
+                apps.add(parts[1])
+            if "/models" in path or path.endswith("models.py"):
+                model_change = True
+            if "/migrations/" in path:
+                migration_change = True
+        elif not path.startswith("docs/") and not path.endswith(".md"):
+            docs_only = False
+        if path.startswith(".github/workflows/"):
+            workflow_change = True
+        if path.endswith((".pyc", ".sqlite3", ".log")) or "__pycache__" in path:
+            generated_candidates.append(path)
+
+    commands.append([".venv/bin/python", "manage.py", "check", "--fail-level", "ERROR"])
+    for app_label in sorted(apps):
+        test_dir = f"apps/{app_label}/tests"
+        commands.append([".venv/bin/python", "manage.py", "test", "run", "--", test_dir])
+    if model_change or migration_change:
+        commands.append([".venv/bin/python", "manage.py", "makemigrations", "--check", "--dry-run"])
+        commands.append([".venv/bin/python", "manage.py", "migrate", "--check"])
+    if workflow_change:
+        notes.append("Workflow files changed; inspect GitHub Actions syntax and required checks.")
+    if docs_only:
+        notes.append("Docs-only change; app tests may be unnecessary beyond Django checks.")
+    if generated_candidates:
+        notes.append("Generated artifacts detected: " + ", ".join(generated_candidates))
+
+    return {
+        "files": files,
+        "apps": sorted(apps),
+        "modelChange": model_change,
+        "migrationChange": migration_change,
+        "docsOnly": docs_only,
+        "commands": commands,
+        "notes": notes,
+    }
+
+
+def hygiene_report(pr: Mapping[str, Any], files: Iterable[str]) -> dict[str, Any]:
+    """Return deterministic PR hygiene warnings and failures."""
+
+    body = str(pr.get("body") or "")
+    changed = sorted({path for path in files if path})
+    warnings: list[str] = []
+    failures: list[str] = []
+    lower_body = body.lower()
+    if "summary" not in lower_body:
+        warnings.append("body:missing-summary")
+    if "validation" not in lower_body and "test" not in lower_body:
+        warnings.append("body:missing-validation")
+    if not re.search(r"\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+", body, re.IGNORECASE):
+        warnings.append("body:missing-issue-link")
+
+    model_paths = [path for path in changed if path.startswith("apps/") and ("/models" in path or path.endswith("models.py"))]
+    migration_paths = [path for path in changed if "/migrations/" in path]
+    if model_paths and not migration_paths:
+        failures.append("model-change:missing-migration")
+    if any(README_RE.search(path) for path in changed):
+        warnings.append("readme:changed")
+    generated = [
+        path
+        for path in changed
+        if path.endswith((".pyc", ".sqlite3", ".log")) or "__pycache__" in path
+    ]
+    if generated:
+        failures.append("generated-artifacts:" + ",".join(generated))
+    if changed and not any(path.startswith("docs/") for path in changed) and len(changed) > 5:
+        warnings.append("docs:not-updated")
+
+    return {
+        "ok": not failures,
+        "failures": failures,
+        "warnings": warnings,
+        "files": changed,
+    }
+
+
+class PullRequestOverseer:
+    """Command-backed deterministic PR oversight surface."""
+
+    def __init__(
+        self,
+        *,
+        repo: str,
+        runner: CommandRunner | None = None,
+        cwd: Path | None = None,
+    ) -> None:
+        self.repo = repo
+        self.runner = runner or CommandRunner()
+        self.cwd = cwd or Path.cwd()
+
+    def gh_json(self, args: list[str]) -> JSONValue:
+        result = self.runner.run(["gh", *args], cwd=self.cwd, check=True)
+        return _json_loads(result.stdout)
+
+    def gh_text(self, args: list[str]) -> str:
+        result = self.runner.run(["gh", *args], cwd=self.cwd, check=True)
+        return result.stdout.strip()
+
+    def git(self, args: list[str]) -> str:
+        result = self.runner.run(["git", *args], cwd=self.cwd, check=True)
+        return result.stdout.strip()
+
+    def pr_view(self, number: int) -> dict[str, Any]:
+        payload = self.gh_json(["pr", "view", str(number), "--repo", self.repo, "--json", PR_FIELDS])
+        return _coerce_mapping(payload)
+
+    def list_open_prs(self, limit: int = 80) -> list[dict[str, Any]]:
+        payload = self.gh_json(
+            [
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,author,headRefName,baseRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,url,updatedAt",
+            ]
+        )
+        return [_coerce_mapping(item) for item in _coerce_list(payload)]
+
+    def comments(self, number: int, *, unresolved_only: bool = False) -> dict[str, Any]:
+        owner, name = self.repo.split("/", 1)
+        query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            nodes {
+              author { login }
+              body
+              createdAt
+              url
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+        payload = self.gh_json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={number}",
+            ]
+        )
+        data = _coerce_mapping(payload)
+        pr = _coerce_mapping(
+            _coerce_mapping(_coerce_mapping(data.get("data")).get("repository")).get("pullRequest")
+        )
+        threads = _coerce_list(_coerce_mapping(pr.get("reviewThreads")).get("nodes"))
+        normalized: list[dict[str, Any]] = []
+        for raw_thread in threads:
+            thread = _coerce_mapping(raw_thread)
+            is_resolved = bool(thread.get("isResolved"))
+            if unresolved_only and is_resolved:
+                continue
+            comments = []
+            for raw_comment in _coerce_list(_coerce_mapping(thread.get("comments")).get("nodes")):
+                comment = _coerce_mapping(raw_comment)
+                comments.append(
+                    {
+                        "author": str(_coerce_mapping(comment.get("author")).get("login") or ""),
+                        "body": str(comment.get("body") or ""),
+                        "createdAt": str(comment.get("createdAt") or ""),
+                        "url": str(comment.get("url") or ""),
+                        "path": str(comment.get("path") or thread.get("path") or ""),
+                        "line": comment.get("line") or thread.get("line"),
+                    }
+                )
+            normalized.append(
+                {
+                    "isResolved": is_resolved,
+                    "isOutdated": bool(thread.get("isOutdated")),
+                    "path": str(thread.get("path") or ""),
+                    "line": thread.get("line"),
+                    "comments": comments,
+                }
+            )
+        return {
+            "number": number,
+            "threads": normalized,
+            "unresolvedCount": sum(1 for thread in normalized if not thread["isResolved"]),
+        }
+
+    def inspect(self, number: int) -> dict[str, Any]:
+        pr = self.pr_view(number)
+        review_threads = self.comments(number, unresolved_only=False)
+        pr["reviewThreads"] = review_threads["threads"]
+        pr["unresolvedReviewThreadCount"] = review_threads["unresolvedCount"]
+        return {
+            "pullRequest": pr,
+            "readiness": readiness_gate(pr),
+        }
+
+    def gate(
+        self,
+        number: int,
+        *,
+        require_approval: bool = False,
+        allow_pending: bool = False,
+    ) -> dict[str, Any]:
+        pr = self.inspect(number)["pullRequest"]
+        return readiness_gate(pr, require_approval=require_approval, allow_pending=allow_pending)
+
+    def changed_files(self, number: int) -> list[str]:
+        output = self.gh_text(["pr", "diff", str(number), "--repo", self.repo, "--name-only"])
+        return [line.strip() for line in output.splitlines() if line.strip()]
+
+    def test_plan(self, number: int) -> dict[str, Any]:
+        return changed_files_to_test_plan(self.changed_files(number))
+
+    def ci_failures(self, number: int, *, include_logs: bool = False, log_limit: int = 4000) -> dict[str, Any]:
+        pr = self.pr_view(number)
+        checks = check_rollup_state(pr)
+        failures = [*checks["failing"], *checks["pending"]]
+        log_snippets: dict[str, str] = {}
+        if include_logs:
+            for failure in failures:
+                details_url = failure.get("detailsUrl", "")
+                match = re.search(r"/actions/runs/(\d+)", details_url)
+                if not match:
+                    continue
+                result = self.runner.run(
+                    ["gh", "run", "view", match.group(1), "--repo", self.repo, "--log-failed"],
+                    cwd=self.cwd,
+                    check=False,
+                )
+                if result.returncode == 0 and result.stdout:
+                    log_snippets[failure["name"]] = result.stdout[:log_limit]
+        return {
+            "number": number,
+            "failures": failures,
+            "logs": log_snippets,
+        }
+
+    def dependency_dedupe(self, *, limit: int = 80) -> dict[str, Any]:
+        return dependency_duplicates(self.list_open_prs(limit=limit))
+
+    def checkout(
+        self,
+        number: int,
+        *,
+        worktree: Path,
+        branch: str = "",
+    ) -> dict[str, Any]:
+        if worktree.exists():
+            raise PullRequestOverseeError(f"Worktree path already exists: {worktree}")
+        pr = self.pr_view(number)
+        remote_ref = f"refs/remotes/origin/pr/{number}"
+        self.git(["fetch", "origin", f"pull/{number}/head:{remote_ref}"])
+        args = ["worktree", "add"]
+        if branch:
+            args.extend(["-b", branch])
+        else:
+            args.append("--detach")
+        args.extend([str(worktree), remote_ref])
+        self.git(args)
+        metadata = {
+            "number": number,
+            "repo": self.repo,
+            "headRefName": pr.get("headRefName"),
+            "headRefOid": pr.get("headRefOid"),
+            "baseRefName": pr.get("baseRefName"),
+            "baseRefOid": pr.get("baseRefOid"),
+            "worktree": str(worktree),
+        }
+        try:
+            (worktree / ".arthexis-pr-oversee.json").write_text(
+                json.dumps(metadata, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            metadata["metadataWriteError"] = True
+        return metadata
+
+    def merge(
+        self,
+        number: int,
+        *,
+        method: str = "squash",
+        delete_branch: bool = False,
+        require_approval: bool = False,
+        expected_head_sha: str = "",
+        allow_pending: bool = False,
+        admin: bool = False,
+    ) -> dict[str, Any]:
+        gate = self.gate(number, require_approval=require_approval, allow_pending=allow_pending)
+        if not gate["ready"]:
+            raise PullRequestOverseeError("PR is not merge-ready: " + ", ".join(gate["blockers"]))
+        head_sha = str(gate.get("headRefOid") or "")
+        if expected_head_sha and expected_head_sha != head_sha:
+            raise PullRequestOverseeError(
+                f"PR head changed before merge: expected {expected_head_sha}, got {head_sha}"
+            )
+        command = ["pr", "merge", str(number), "--repo", self.repo, f"--{method}"]
+        if delete_branch:
+            command.append("--delete-branch")
+        if admin:
+            command.append("--admin")
+        output = self.gh_text(command)
+        after = self.pr_view(number)
+        return {
+            "number": number,
+            "merged": str(after.get("state") or "").upper() == "MERGED",
+            "command": ["gh", *command],
+            "stdout": output,
+            "pullRequest": after,
+        }
+
+    def cleanup(
+        self,
+        number: int,
+        *,
+        worktree: Path | None = None,
+        delete_local_branch: str = "",
+    ) -> dict[str, Any]:
+        pr = self.pr_view(number)
+        state = str(pr.get("state") or "").upper()
+        if state != "MERGED":
+            raise PullRequestOverseeError(f"PR #{number} is not merged; refusing cleanup")
+        actions: list[dict[str, Any]] = []
+        if worktree:
+            result = self.runner.run(["git", "worktree", "remove", str(worktree)], cwd=self.cwd, check=False)
+            actions.append(
+                {
+                    "action": "remove-worktree",
+                    "path": str(worktree),
+                    "returncode": result.returncode,
+                    "stderr": result.stderr.strip(),
+                }
+            )
+        self.git(["fetch", "origin", "main", "--prune"])
+        actions.append({"action": "fetch-main-prune", "returncode": 0})
+        if delete_local_branch:
+            result = self.runner.run(
+                ["git", "branch", "-D", delete_local_branch],
+                cwd=self.cwd,
+                check=False,
+            )
+            actions.append(
+                {
+                    "action": "delete-local-branch",
+                    "branch": delete_local_branch,
+                    "returncode": result.returncode,
+                    "stderr": result.stderr.strip(),
+                }
+            )
+        return {"number": number, "state": state, "actions": actions}
+
+    def hygiene(self, number: int) -> dict[str, Any]:
+        return hygiene_report(self.pr_view(number), self.changed_files(number))

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -772,6 +772,9 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                 f"PR head changed before merge: expected {expected_head_sha}, got {head_sha}"
             )
         command = ["pr", "merge", str(number), "--repo", self.repo, f"--{method}"]
+        guard_sha = expected_head_sha or head_sha
+        if guard_sha:
+            command.extend(["--match-head-commit", guard_sha])
         if delete_branch:
             command.append("--delete-branch")
         if admin:

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping
-
 
 JSONValue = dict[str, Any] | list[Any] | str | int | float | bool | None
 
@@ -37,14 +37,17 @@ PR_FIELDS = ",".join(
 
 GOOD_CHECKS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 BAD_CHECKS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}
-PENDING_CHECKS = {"EXPECTED", "PENDING", "QUEUED", "REQUESTED", "IN_PROGRESS", "WAITING"}
+PENDING_CHECKS = {
+    "EXPECTED",
+    "PENDING",
+    "QUEUED",
+    "REQUESTED",
+    "IN_PROGRESS",
+    "WAITING",
+}
 BAD_MERGE_STATES = {"BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"}
 README_RE = re.compile(r"(^|/)(README|README\.[^/]+)$", re.IGNORECASE)
-DEPENDENCY_TITLE_PATTERNS = (
-    re.compile(r"\bbump\s+(.+?)\s+from\s+([^\s]+)\s+to\s+([^\s]+)", re.IGNORECASE),
-    re.compile(r"\bbump\s+(.+?)\s+to\s+([^\s]+)", re.IGNORECASE),
-    re.compile(r"\bupdate\s+dependency\s+(.+?)\s+to\s+([^\s]+)", re.IGNORECASE),
-)
+VERSION_SUFFIX_SEPARATORS = "-_/"
 
 
 class PullRequestOverseeError(RuntimeError):
@@ -85,7 +88,9 @@ class CommandRunner:
             stderr=completed.stderr or "",
         )
         if check and result.returncode != 0:
-            message = result.stderr.strip() or result.stdout.strip() or f"{command[0]} failed"
+            message = (
+                result.stderr.strip() or result.stdout.strip() or f"{command[0]} failed"
+            )
             raise PullRequestOverseeError(message)
         return result
 
@@ -96,7 +101,9 @@ def _json_loads(raw_value: str) -> JSONValue:
     try:
         return json.loads(raw_value)
     except json.JSONDecodeError as exc:
-        raise PullRequestOverseeError(f"Command did not return valid JSON: {exc}") from exc
+        raise PullRequestOverseeError(
+            f"Command did not return valid JSON: {exc}"
+        ) from exc
 
 
 def _coerce_mapping(value: object) -> dict[str, Any]:
@@ -195,8 +202,12 @@ def readiness_gate(
         blockers.append(f"review:{review_decision or 'MISSING_APPROVAL'}")
 
     checks = check_rollup_state(pr)
-    blockers.extend(f"check:{item['name']}:{item['value']}" for item in checks["failing"])
-    pending_values = [f"pending:{item['name']}:{item['value']}" for item in checks["pending"]]
+    blockers.extend(
+        f"check:{item['name']}:{item['value']}" for item in checks["failing"]
+    )
+    pending_values = [
+        f"pending:{item['name']}:{item['value']}" for item in checks["pending"]
+    ]
     if pending_values and allow_pending:
         warnings.extend(pending_values)
     else:
@@ -227,17 +238,86 @@ def readiness_gate(
     }
 
 
+def _split_marker(value: str, marker: str) -> tuple[str, str] | None:
+    index = value.lower().find(marker)
+    if index == -1:
+        return None
+    return value[:index], value[index + len(marker) :]
+
+
+def _normalize_dependency_name(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _parse_dependency_title(title: str) -> tuple[str, str] | None:
+    stripped = title.strip()
+    lowered = stripped.lower()
+    if lowered.startswith("bump "):
+        body = stripped[5:].strip()
+    elif lowered.startswith("update dependency "):
+        body = stripped[len("update dependency ") :].strip()
+    else:
+        return None
+
+    from_split = _split_marker(body, " from ")
+    if from_split:
+        name, remaining = from_split
+        to_split = _split_marker(remaining, " to ")
+        if to_split:
+            return name.strip(), to_split[1].strip().split(maxsplit=1)[0]
+        return None
+
+    to_split = _split_marker(body, " to ")
+    if to_split:
+        return to_split[0].strip(), to_split[1].strip().split(maxsplit=1)[0]
+    return None
+
+
+def _looks_like_version_suffix(value: str) -> bool:
+    normalized = value.strip().lstrip("vV")
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+    return (
+        bool(normalized)
+        and normalized[0].isdigit()
+        and "." in normalized
+        and all(character in allowed for character in normalized)
+    )
+
+
+def _version_suffix_match(value: str) -> tuple[int, str] | None:
+    for index, character in enumerate(value):
+        if character not in VERSION_SUFFIX_SEPARATORS:
+            continue
+        candidate = value[index + 1 :]
+        if _looks_like_version_suffix(candidate):
+            return index, candidate.lstrip("vV")
+    return None
+
+
+def _version_suffix(value: str) -> str:
+    match = _version_suffix_match(value)
+    return match[1] if match else ""
+
+
+def _strip_version_suffix(value: str) -> str:
+    match = _version_suffix_match(value)
+    if not match:
+        return value
+    return value[: match[0]].rstrip(VERSION_SUFFIX_SEPARATORS)
+
+
 def dependency_key(pr: Mapping[str, Any]) -> str:
     """Return a stable dependency grouping key for a PR."""
 
     title = str(pr.get("title") or "")
-    for pattern in DEPENDENCY_TITLE_PATTERNS:
-        match = pattern.search(title)
-        if match:
-            return re.sub(r"\s+", " ", match.group(1).strip().lower())
+    title_parts = _parse_dependency_title(title)
+    if title_parts:
+        return _normalize_dependency_name(title_parts[0])
     head = str(pr.get("headRefName") or "").lower()
-    head = re.sub(r"^dependabot/[^/]+/", "", head)
-    head = re.sub(r"[-_/]?v?\d+(?:\.\d+)+(?:[-_.][a-z0-9]+)?$", "", head)
+    if head.startswith("dependabot/"):
+        parts = head.split("/", 2)
+        head = parts[2] if len(parts) == 3 else parts[-1]
+    head = _strip_version_suffix(head)
     return head or title.lower()
 
 
@@ -245,13 +325,11 @@ def dependency_target_version(pr: Mapping[str, Any]) -> str:
     """Best-effort dependency target version from title or branch."""
 
     title = str(pr.get("title") or "")
-    for pattern in DEPENDENCY_TITLE_PATTERNS:
-        match = pattern.search(title)
-        if match:
-            return match.group(match.lastindex or 1)
+    title_parts = _parse_dependency_title(title)
+    if title_parts:
+        return title_parts[1]
     head = str(pr.get("headRefName") or "")
-    match = re.search(r"v?(\d+(?:\.\d+)+(?:[-_.][A-Za-z0-9]+)?)$", head)
-    return match.group(1) if match else ""
+    return _version_suffix(head)
 
 
 def is_dependency_pr(pr: Mapping[str, Any]) -> bool:
@@ -260,7 +338,12 @@ def is_dependency_pr(pr: Mapping[str, Any]) -> bool:
     login = _author_login(pr).lower()
     title = str(pr.get("title") or "").lower()
     head = str(pr.get("headRefName") or "").lower()
-    return "dependabot" in login or "dependabot" in head or title.startswith("build(deps") or "bump " in title
+    return (
+        "dependabot" in login
+        or "dependabot" in head
+        or title.startswith("build(deps")
+        or "bump " in title
+    )
 
 
 def dependency_duplicates(prs: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
@@ -325,17 +408,23 @@ def changed_files_to_test_plan(paths: Iterable[str]) -> dict[str, Any]:
         if path.endswith((".pyc", ".sqlite3", ".log")) or "__pycache__" in path:
             generated_candidates.append(path)
 
-    commands.append([".venv/bin/python", "manage.py", "check", "--fail-level", "ERROR"])
-    for app_label in sorted(apps):
-        test_dir = f"apps/{app_label}/tests"
-        commands.append([".venv/bin/python", "manage.py", "test", "run", "--", test_dir])
+    commands.append([sys.executable, "manage.py", "check", "--fail-level", "ERROR"])
+    test_paths = [f"apps/{app_label}/tests" for app_label in sorted(apps)]
+    if test_paths:
+        commands.append([sys.executable, "manage.py", "test", "run", "--", *test_paths])
     if model_change or migration_change:
-        commands.append([".venv/bin/python", "manage.py", "makemigrations", "--check", "--dry-run"])
-        commands.append([".venv/bin/python", "manage.py", "migrate", "--check"])
+        commands.append(
+            [sys.executable, "manage.py", "makemigrations", "--check", "--dry-run"]
+        )
+        commands.append([sys.executable, "manage.py", "migrate", "--check"])
     if workflow_change:
-        notes.append("Workflow files changed; inspect GitHub Actions syntax and required checks.")
+        notes.append(
+            "Workflow files changed; inspect GitHub Actions syntax and required checks."
+        )
     if docs_only:
-        notes.append("Docs-only change; app tests may be unnecessary beyond Django checks.")
+        notes.append(
+            "Docs-only change; app tests may be unnecessary beyond Django checks."
+        )
     if generated_candidates:
         notes.append("Generated artifacts detected: " + ", ".join(generated_candidates))
 
@@ -362,10 +451,17 @@ def hygiene_report(pr: Mapping[str, Any], files: Iterable[str]) -> dict[str, Any
         warnings.append("body:missing-summary")
     if "validation" not in lower_body and "test" not in lower_body:
         warnings.append("body:missing-validation")
-    if not re.search(r"\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+", body, re.IGNORECASE):
+    if not re.search(
+        r"\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+", body, re.IGNORECASE
+    ):
         warnings.append("body:missing-issue-link")
 
-    model_paths = [path for path in changed if path.startswith("apps/") and ("/models" in path or path.endswith("models.py"))]
+    model_paths = [
+        path
+        for path in changed
+        if path.startswith("apps/")
+        and ("/models" in path or path.endswith("models.py"))
+    ]
     migration_paths = [path for path in changed if "/migrations/" in path]
     if model_paths and not migration_paths:
         failures.append("model-change:missing-migration")
@@ -378,7 +474,11 @@ def hygiene_report(pr: Mapping[str, Any], files: Iterable[str]) -> dict[str, Any
     ]
     if generated:
         failures.append("generated-artifacts:" + ",".join(generated))
-    if changed and not any(path.startswith("docs/") for path in changed) and len(changed) > 5:
+    if (
+        changed
+        and not any(path.startswith("docs/") for path in changed)
+        and len(changed) > 5
+    ):
         warnings.append("docs:not-updated")
 
     return {
@@ -416,7 +516,9 @@ class PullRequestOverseer:
         return result.stdout.strip()
 
     def pr_view(self, number: int) -> dict[str, Any]:
-        payload = self.gh_json(["pr", "view", str(number), "--repo", self.repo, "--json", PR_FIELDS])
+        payload = self.gh_json(
+            ["pr", "view", str(number), "--repo", self.repo, "--json", PR_FIELDS]
+        )
         return _coerce_mapping(payload)
 
     def list_open_prs(self, limit: int = 80) -> list[dict[str, Any]]:
@@ -439,10 +541,10 @@ class PullRequestOverseer:
     def comments(self, number: int, *, unresolved_only: bool = False) -> dict[str, Any]:
         owner, name = self.repo.split("/", 1)
         query = """
-query($owner: String!, $name: String!, $number: Int!) {
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $after) {
         nodes {
           isResolved
           isOutdated
@@ -459,13 +561,19 @@ query($owner: String!, $name: String!, $number: Int!) {
             }
           }
         }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
     }
   }
 }
 """.strip()
-        payload = self.gh_json(
-            [
+        threads: list[Any] = []
+        after = ""
+        while True:
+            command = [
                 "api",
                 "graphql",
                 "-f",
@@ -477,12 +585,24 @@ query($owner: String!, $name: String!, $number: Int!) {
                 "-F",
                 f"number={number}",
             ]
-        )
-        data = _coerce_mapping(payload)
-        pr = _coerce_mapping(
-            _coerce_mapping(_coerce_mapping(data.get("data")).get("repository")).get("pullRequest")
-        )
-        threads = _coerce_list(_coerce_mapping(pr.get("reviewThreads")).get("nodes"))
+            if after:
+                command.extend(["-F", f"after={after}"])
+            payload = self.gh_json(command)
+            data = _coerce_mapping(payload)
+            pr = _coerce_mapping(
+                _coerce_mapping(
+                    _coerce_mapping(data.get("data")).get("repository")
+                ).get("pullRequest")
+            )
+            review_threads = _coerce_mapping(pr.get("reviewThreads"))
+            threads.extend(_coerce_list(review_threads.get("nodes")))
+            page_info = _coerce_mapping(review_threads.get("pageInfo"))
+            if not page_info.get("hasNextPage"):
+                break
+            next_cursor = str(page_info.get("endCursor") or "")
+            if not next_cursor or next_cursor == after:
+                break
+            after = next_cursor
         normalized: list[dict[str, Any]] = []
         for raw_thread in threads:
             thread = _coerce_mapping(raw_thread)
@@ -490,11 +610,15 @@ query($owner: String!, $name: String!, $number: Int!) {
             if unresolved_only and is_resolved:
                 continue
             comments = []
-            for raw_comment in _coerce_list(_coerce_mapping(thread.get("comments")).get("nodes")):
+            for raw_comment in _coerce_list(
+                _coerce_mapping(thread.get("comments")).get("nodes")
+            ):
                 comment = _coerce_mapping(raw_comment)
                 comments.append(
                     {
-                        "author": str(_coerce_mapping(comment.get("author")).get("login") or ""),
+                        "author": str(
+                            _coerce_mapping(comment.get("author")).get("login") or ""
+                        ),
                         "body": str(comment.get("body") or ""),
                         "createdAt": str(comment.get("createdAt") or ""),
                         "url": str(comment.get("url") or ""),
@@ -514,7 +638,9 @@ query($owner: String!, $name: String!, $number: Int!) {
         return {
             "number": number,
             "threads": normalized,
-            "unresolvedCount": sum(1 for thread in normalized if not thread["isResolved"]),
+            "unresolvedCount": sum(
+                1 for thread in normalized if not thread["isResolved"]
+            ),
         }
 
     def inspect(self, number: int) -> dict[str, Any]:
@@ -535,16 +661,22 @@ query($owner: String!, $name: String!, $number: Int!) {
         allow_pending: bool = False,
     ) -> dict[str, Any]:
         pr = self.inspect(number)["pullRequest"]
-        return readiness_gate(pr, require_approval=require_approval, allow_pending=allow_pending)
+        return readiness_gate(
+            pr, require_approval=require_approval, allow_pending=allow_pending
+        )
 
     def changed_files(self, number: int) -> list[str]:
-        output = self.gh_text(["pr", "diff", str(number), "--repo", self.repo, "--name-only"])
+        output = self.gh_text(
+            ["pr", "diff", str(number), "--repo", self.repo, "--name-only"]
+        )
         return [line.strip() for line in output.splitlines() if line.strip()]
 
     def test_plan(self, number: int) -> dict[str, Any]:
         return changed_files_to_test_plan(self.changed_files(number))
 
-    def ci_failures(self, number: int, *, include_logs: bool = False, log_limit: int = 4000) -> dict[str, Any]:
+    def ci_failures(
+        self, number: int, *, include_logs: bool = False, log_limit: int = 4000
+    ) -> dict[str, Any]:
         pr = self.pr_view(number)
         checks = check_rollup_state(pr)
         failures = [*checks["failing"], *checks["pending"]]
@@ -556,7 +688,15 @@ query($owner: String!, $name: String!, $number: Int!) {
                 if not match:
                     continue
                 result = self.runner.run(
-                    ["gh", "run", "view", match.group(1), "--repo", self.repo, "--log-failed"],
+                    [
+                        "gh",
+                        "run",
+                        "view",
+                        match.group(1),
+                        "--repo",
+                        self.repo,
+                        "--log-failed",
+                    ],
                     cwd=self.cwd,
                     check=False,
                 )
@@ -619,9 +759,13 @@ query($owner: String!, $name: String!, $number: Int!) {
         allow_pending: bool = False,
         admin: bool = False,
     ) -> dict[str, Any]:
-        gate = self.gate(number, require_approval=require_approval, allow_pending=allow_pending)
+        gate = self.gate(
+            number, require_approval=require_approval, allow_pending=allow_pending
+        )
         if not gate["ready"]:
-            raise PullRequestOverseeError("PR is not merge-ready: " + ", ".join(gate["blockers"]))
+            raise PullRequestOverseeError(
+                "PR is not merge-ready: " + ", ".join(gate["blockers"])
+            )
         head_sha = str(gate.get("headRefOid") or "")
         if expected_head_sha and expected_head_sha != head_sha:
             raise PullRequestOverseeError(
@@ -652,10 +796,14 @@ query($owner: String!, $name: String!, $number: Int!) {
         pr = self.pr_view(number)
         state = str(pr.get("state") or "").upper()
         if state != "MERGED":
-            raise PullRequestOverseeError(f"PR #{number} is not merged; refusing cleanup")
+            raise PullRequestOverseeError(
+                f"PR #{number} is not merged; refusing cleanup"
+            )
         actions: list[dict[str, Any]] = []
         if worktree:
-            result = self.runner.run(["git", "worktree", "remove", str(worktree)], cwd=self.cwd, check=False)
+            result = self.runner.run(
+                ["git", "worktree", "remove", str(worktree)], cwd=self.cwd, check=False
+            )
             actions.append(
                 {
                     "action": "remove-worktree",
@@ -664,8 +812,11 @@ query($owner: String!, $name: String!, $number: Int!) {
                     "stderr": result.stderr.strip(),
                 }
             )
-        self.git(["fetch", "origin", "main", "--prune"])
-        actions.append({"action": "fetch-main-prune", "returncode": 0})
+        base_branch = str(pr.get("baseRefName") or "main")
+        self.git(["fetch", "origin", base_branch, "--prune"])
+        actions.append(
+            {"action": "fetch-base-prune", "branch": base_branch, "returncode": 0}
+        )
         if delete_local_branch:
             result = self.runner.run(
                 ["git", "branch", "-D", delete_local_branch],

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from apps.repos.pr_oversee import (
+    CommandResult,
+    PullRequestOverseeError,
+    PullRequestOverseer,
+    changed_files_to_test_plan,
+    dependency_duplicates,
+    hygiene_report,
+    readiness_gate,
+)
+
+
+class FakeRunner:
+    def __init__(self, responses: list[CommandResult] | None = None) -> None:
+        self.responses = list(responses or [])
+        self.commands: list[list[str]] = []
+
+    def run(self, command: list[str], *, cwd: Path | None = None, check: bool = False) -> CommandResult:
+        self.commands.append(command)
+        if command[:3] == ["git", "worktree", "add"]:
+            Path(command[-2]).mkdir(parents=True, exist_ok=True)
+        result = self.responses.pop(0) if self.responses else CommandResult(returncode=0)
+        if check and result.returncode != 0:
+            raise PullRequestOverseeError(result.stderr or result.stdout or "failed")
+        return result
+
+
+def _pr_payload(**overrides):
+    payload = {
+        "number": 123,
+        "title": "Add deterministic PR oversee",
+        "author": {"login": "alice"},
+        "body": "Summary\n\nValidation\n\nFixes #1",
+        "baseRefName": "main",
+        "baseRefOid": "base-sha",
+        "headRefName": "repos-pr-oversee-cli",
+        "headRefOid": "head-sha",
+        "isDraft": False,
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "state": "OPEN",
+        "statusCheckRollup": [
+            {"name": "Tests", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        ],
+        "updatedAt": "2026-05-05T18:00:00Z",
+        "url": "https://github.com/arthexis/arthexis/pull/123",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_readiness_gate_reports_blockers_for_review_checks_and_threads():
+    result = readiness_gate(
+        _pr_payload(
+            reviewDecision="CHANGES_REQUESTED",
+            statusCheckRollup=[
+                {"name": "Tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {"name": "CodeQL", "status": "IN_PROGRESS", "conclusion": ""},
+            ],
+            unresolvedReviewThreadCount=2,
+        )
+    )
+
+    assert result["ready"] is False
+    assert "review:CHANGES_REQUESTED" in result["blockers"]
+    assert "check:Tests:FAILURE" in result["blockers"]
+    assert "pending:CodeQL:IN_PROGRESS" in result["blockers"]
+    assert "review_threads:UNRESOLVED:2" in result["blockers"]
+
+
+def test_comments_normalizes_unresolved_review_threads():
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "path": "apps/repos/pr_oversee.py",
+                                "line": 42,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "author": {"login": "reviewer"},
+                                            "body": "Please cover failures.",
+                                            "createdAt": "2026-05-05T18:01:00Z",
+                                            "url": "https://example.test/comment",
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "isResolved": True,
+                                "isOutdated": False,
+                                "path": "docs/x.md",
+                                "line": 1,
+                                "comments": {"nodes": []},
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    runner = FakeRunner([CommandResult(0, json.dumps(payload))])
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.comments(123, unresolved_only=True)
+
+    assert result["unresolvedCount"] == 1
+    assert result["threads"][0]["path"] == "apps/repos/pr_oversee.py"
+    assert result["threads"][0]["comments"][0]["author"] == "reviewer"
+
+
+def test_test_plan_maps_changed_apps_and_migrations_to_commands():
+    result = changed_files_to_test_plan(
+        [
+            "apps/repos/pr_oversee.py",
+            "apps/repos/models/review.py",
+            "apps/repos/migrations/0005_review.py",
+            ".github/workflows/test.yml",
+        ]
+    )
+
+    assert result["apps"] == ["repos"]
+    assert result["modelChange"] is True
+    assert result["migrationChange"] is True
+    assert [".venv/bin/python", "manage.py", "test", "run", "--", "apps/repos/tests"] in result["commands"]
+    assert [".venv/bin/python", "manage.py", "makemigrations", "--check", "--dry-run"] in result["commands"]
+    assert result["notes"] == ["Workflow files changed; inspect GitHub Actions syntax and required checks."]
+
+
+def test_ci_failures_collects_failed_run_log_snippet():
+    pr = _pr_payload(
+        statusCheckRollup=[
+            {
+                "name": "Tests",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "detailsUrl": "https://github.com/arthexis/arthexis/actions/runs/42/job/99",
+            }
+        ]
+    )
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(pr)),
+            CommandResult(0, "failed test log"),
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.ci_failures(123, include_logs=True)
+
+    assert result["failures"][0]["name"] == "Tests"
+    assert result["logs"] == {"Tests": "failed test log"}
+    assert runner.commands[-1] == ["gh", "run", "view", "42", "--repo", "arthexis/arthexis", "--log-failed"]
+
+
+def test_dependency_duplicates_marks_older_updates_superseded():
+    result = dependency_duplicates(
+        [
+            {
+                "number": 1,
+                "title": "Bump django from 5.2.11 to 5.2.12",
+                "author": {"login": "dependabot[bot]"},
+                "headRefName": "dependabot/pip/django-5.2.12",
+                "updatedAt": "2026-05-01T00:00:00Z",
+            },
+            {
+                "number": 2,
+                "title": "Bump django from 5.2.11 to 5.2.13",
+                "author": {"login": "dependabot[bot]"},
+                "headRefName": "dependabot/pip/django-5.2.13",
+                "updatedAt": "2026-05-02T00:00:00Z",
+            },
+        ]
+    )
+
+    assert result["django"]["superseded"][0]["number"] == 1
+    assert result["django"]["preferred"]["number"] == 2
+
+
+def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
+    runner = FakeRunner([CommandResult(0, json.dumps(_pr_payload())), CommandResult(0), CommandResult(0)])
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner, cwd=tmp_path)
+    worktree = tmp_path / "pr-123"
+
+    result = overseer.checkout(123, worktree=worktree, branch="repos-pr-123")
+
+    assert result["worktree"] == str(worktree)
+    assert runner.commands[1] == ["git", "fetch", "origin", "pull/123/head:refs/remotes/origin/pr/123"]
+    assert runner.commands[2] == [
+        "git",
+        "worktree",
+        "add",
+        "-b",
+        "repos-pr-123",
+        str(worktree),
+        "refs/remotes/origin/pr/123",
+    ]
+    assert json.loads((worktree / ".arthexis-pr-oversee.json").read_text())["headRefOid"] == "head-sha"
+
+
+def test_merge_gates_expected_head_before_calling_gh_merge():
+    comments = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+    merged = _pr_payload(state="MERGED")
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload())),
+            CommandResult(0, json.dumps(comments)),
+            CommandResult(0, "merged"),
+            CommandResult(0, json.dumps(merged)),
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.merge(123, expected_head_sha="head-sha", delete_branch=True)
+
+    assert result["merged"] is True
+    assert runner.commands[2] == [
+        "gh",
+        "pr",
+        "merge",
+        "123",
+        "--repo",
+        "arthexis/arthexis",
+        "--squash",
+        "--delete-branch",
+    ]
+
+
+def test_cleanup_refuses_unmerged_pr():
+    runner = FakeRunner([CommandResult(0, json.dumps(_pr_payload(state="OPEN")))])
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    with pytest.raises(PullRequestOverseeError, match="not merged"):
+        overseer.cleanup(123)
+
+
+def test_hygiene_detects_missing_migration_and_generated_files():
+    result = hygiene_report(
+        _pr_payload(body="No sections"),
+        ["apps/repos/models/review.py", "apps/repos/__pycache__/x.pyc"],
+    )
+
+    assert result["ok"] is False
+    assert "model-change:missing-migration" in result["failures"]
+    assert "body:missing-summary" in result["warnings"]
+    assert "body:missing-validation" in result["warnings"]
+
+
+def test_management_command_merge_without_write_reports_plan():
+    fake = PullRequestOverseer(repo="arthexis/arthexis")
+    fake.gate = lambda *args, **kwargs: {"ready": True, "blockers": [], "warnings": []}
+
+    with patch("apps.repos.management.commands.pr_oversee.PullRequestOverseer", return_value=fake):
+        output = call_command(
+            "pr_oversee",
+            "--repo",
+            "arthexis/arthexis",
+            "--json",
+            "merge",
+            "--pr",
+            "123",
+        )
+
+    assert output is None

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from io import StringIO
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from django.core.management import call_command
@@ -363,6 +364,8 @@ def test_merge_gates_expected_head_before_calling_gh_merge():
         "--repo",
         "arthexis/arthexis",
         "--squash",
+        "--match-head-commit",
+        "head-sha",
         "--delete-branch",
     ]
 
@@ -407,13 +410,17 @@ def test_hygiene_detects_missing_migration_and_generated_files():
 
 def test_management_command_merge_without_write_reports_plan():
     fake = PullRequestOverseer(repo="arthexis/arthexis")
-    fake.gate = lambda *args, **kwargs: {"ready": True, "blockers": [], "warnings": []}
+    fake.gate = Mock(return_value={"ready": True, "blockers": [], "warnings": []})
+    fake.merge = Mock(
+        side_effect=AssertionError("merge should not run in dry-run mode")
+    )
+    buffer = StringIO()
 
     with patch(
         "apps.repos.management.commands.pr_oversee.PullRequestOverseer",
         return_value=fake,
     ):
-        output = call_command(
+        call_command(
             "pr_oversee",
             "--repo",
             "arthexis/arthexis",
@@ -421,6 +428,16 @@ def test_management_command_merge_without_write_reports_plan():
             "merge",
             "--pr",
             "123",
+            stdout=buffer,
         )
 
-    assert output is None
+    payload = json.loads(buffer.getvalue())
+    assert payload["write"] is False
+    assert payload["plannedCommand"] == "gh pr merge"
+    assert payload["gate"]["ready"] is True
+    fake.gate.assert_called_once_with(
+        123,
+        require_approval=False,
+        allow_pending=False,
+    )
+    fake.merge.assert_not_called()

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,11 +24,15 @@ class FakeRunner:
         self.responses = list(responses or [])
         self.commands: list[list[str]] = []
 
-    def run(self, command: list[str], *, cwd: Path | None = None, check: bool = False) -> CommandResult:
+    def run(
+        self, command: list[str], *, cwd: Path | None = None, check: bool = False
+    ) -> CommandResult:
         self.commands.append(command)
         if command[:3] == ["git", "worktree", "add"]:
             Path(command[-2]).mkdir(parents=True, exist_ok=True)
-        result = self.responses.pop(0) if self.responses else CommandResult(returncode=0)
+        result = (
+            self.responses.pop(0) if self.responses else CommandResult(returncode=0)
+        )
         if check and result.returncode != 0:
             raise PullRequestOverseeError(result.stderr or result.stdout or "failed")
         return result
@@ -107,7 +112,8 @@ def test_comments_normalizes_unresolved_review_threads():
                                 "line": 1,
                                 "comments": {"nodes": []},
                             },
-                        ]
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
                     }
                 }
             }
@@ -123,6 +129,62 @@ def test_comments_normalizes_unresolved_review_threads():
     assert result["threads"][0]["comments"][0]["author"] == "reviewer"
 
 
+def test_comments_paginates_review_threads():
+    first_page = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "path": "apps/repos/pr_oversee.py",
+                                "line": 42,
+                                "comments": {"nodes": []},
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                    }
+                }
+            }
+        }
+    }
+    second_page = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "path": "apps/repos/management/commands/pr_oversee.py",
+                                "line": 12,
+                                "comments": {"nodes": []},
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        }
+    }
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(first_page)),
+            CommandResult(0, json.dumps(second_page)),
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.comments(123)
+
+    assert result["unresolvedCount"] == 2
+    assert len(result["threads"]) == 2
+    assert runner.commands[1][-1] == "after=cursor-1"
+
+
 def test_test_plan_maps_changed_apps_and_migrations_to_commands():
     result = changed_files_to_test_plan(
         [
@@ -136,9 +198,24 @@ def test_test_plan_maps_changed_apps_and_migrations_to_commands():
     assert result["apps"] == ["repos"]
     assert result["modelChange"] is True
     assert result["migrationChange"] is True
-    assert [".venv/bin/python", "manage.py", "test", "run", "--", "apps/repos/tests"] in result["commands"]
-    assert [".venv/bin/python", "manage.py", "makemigrations", "--check", "--dry-run"] in result["commands"]
-    assert result["notes"] == ["Workflow files changed; inspect GitHub Actions syntax and required checks."]
+    assert [
+        sys.executable,
+        "manage.py",
+        "test",
+        "run",
+        "--",
+        "apps/repos/tests",
+    ] in result["commands"]
+    assert [
+        sys.executable,
+        "manage.py",
+        "makemigrations",
+        "--check",
+        "--dry-run",
+    ] in result["commands"]
+    assert result["notes"] == [
+        "Workflow files changed; inspect GitHub Actions syntax and required checks."
+    ]
 
 
 def test_ci_failures_collects_failed_run_log_snippet():
@@ -164,7 +241,15 @@ def test_ci_failures_collects_failed_run_log_snippet():
 
     assert result["failures"][0]["name"] == "Tests"
     assert result["logs"] == {"Tests": "failed test log"}
-    assert runner.commands[-1] == ["gh", "run", "view", "42", "--repo", "arthexis/arthexis", "--log-failed"]
+    assert runner.commands[-1] == [
+        "gh",
+        "run",
+        "view",
+        "42",
+        "--repo",
+        "arthexis/arthexis",
+        "--log-failed",
+    ]
 
 
 def test_dependency_duplicates_marks_older_updates_superseded():
@@ -191,15 +276,52 @@ def test_dependency_duplicates_marks_older_updates_superseded():
     assert result["django"]["preferred"]["number"] == 2
 
 
+def test_dependency_duplicates_groups_versioned_dependabot_branches():
+    result = dependency_duplicates(
+        [
+            {
+                "number": 1,
+                "title": "build(deps): update django",
+                "author": {"login": "dependabot[bot]"},
+                "headRefName": "dependabot/pip/django-v5.2.12",
+                "updatedAt": "2026-05-01T00:00:00Z",
+            },
+            {
+                "number": 2,
+                "title": "build(deps): update django",
+                "author": {"login": "dependabot[bot]"},
+                "headRefName": "dependabot/pip/django-v5.2.13",
+                "updatedAt": "2026-05-02T00:00:00Z",
+            },
+        ]
+    )
+
+    assert result["django"]["items"][0]["targetVersion"] == "5.2.12"
+    assert result["django"]["preferred"]["number"] == 2
+
+
 def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
-    runner = FakeRunner([CommandResult(0, json.dumps(_pr_payload())), CommandResult(0), CommandResult(0)])
-    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner, cwd=tmp_path)
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload())),
+            CommandResult(0),
+            CommandResult(0),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
     worktree = tmp_path / "pr-123"
 
     result = overseer.checkout(123, worktree=worktree, branch="repos-pr-123")
 
     assert result["worktree"] == str(worktree)
-    assert runner.commands[1] == ["git", "fetch", "origin", "pull/123/head:refs/remotes/origin/pr/123"]
+    assert runner.commands[1] == [
+        "git",
+        "fetch",
+        "origin",
+        "pull/123/head:refs/remotes/origin/pr/123",
+    ]
     assert runner.commands[2] == [
         "git",
         "worktree",
@@ -209,11 +331,16 @@ def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
         str(worktree),
         "refs/remotes/origin/pr/123",
     ]
-    assert json.loads((worktree / ".arthexis-pr-oversee.json").read_text())["headRefOid"] == "head-sha"
+    assert (
+        json.loads((worktree / ".arthexis-pr-oversee.json").read_text())["headRefOid"]
+        == "head-sha"
+    )
 
 
 def test_merge_gates_expected_head_before_calling_gh_merge():
-    comments = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+    comments = {
+        "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
+    }
     merged = _pr_payload(state="MERGED")
     runner = FakeRunner(
         [
@@ -248,6 +375,24 @@ def test_cleanup_refuses_unmerged_pr():
         overseer.cleanup(123)
 
 
+def test_cleanup_fetches_merged_pr_base_branch(tmp_path: Path):
+    runner = FakeRunner(
+        [CommandResult(0, json.dumps(_pr_payload(state="MERGED", baseRefName="trunk")))]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+
+    result = overseer.cleanup(123)
+
+    assert runner.commands[1] == ["git", "fetch", "origin", "trunk", "--prune"]
+    assert result["actions"][0] == {
+        "action": "fetch-base-prune",
+        "branch": "trunk",
+        "returncode": 0,
+    }
+
+
 def test_hygiene_detects_missing_migration_and_generated_files():
     result = hygiene_report(
         _pr_payload(body="No sections"),
@@ -264,7 +409,10 @@ def test_management_command_merge_without_write_reports_plan():
     fake = PullRequestOverseer(repo="arthexis/arthexis")
     fake.gate = lambda *args, **kwargs: {"ready": True, "blockers": [], "warnings": []}
 
-    with patch("apps.repos.management.commands.pr_oversee.PullRequestOverseer", return_value=fake):
+    with patch(
+        "apps.repos.management.commands.pr_oversee.PullRequestOverseer",
+        return_value=fake,
+    ):
         output = call_command(
             "pr_oversee",
             "--repo",

--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -23,6 +23,7 @@ Maintain a **single canonical migrations graph only** under `apps/*/migrations/`
 | Local QA (app tests) | `.venv/bin/python manage.py test run -- <target>` | Canonical path for app test execution. |
 | Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
 | Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
+| PR oversight | `.venv/bin/python manage.py pr_oversee <action> --pr <number>` | Deterministic PR state, gates, comments, test plans, CI failure collection, guarded merge, and cleanup. |
 | CI pipelines | `python -m pytest ...` inside workflow jobs | Valid in CI workflow implementation where jobs already manage interpreter/bootstrap lifecycle. |
 | Initial local bootstrap | `./install.sh` or `install.bat` | Run when `.venv` is missing. The install entrypoints create `.venv` before migrations and environment refresh. |
 | Troubleshooting missing deps | `./env-refresh.sh --deps-only` or `env-refresh.bat` | Run only after `.venv` already exists; then rerun the canonical command. |

--- a/docs/development/pr-oversee.md
+++ b/docs/development/pr-oversee.md
@@ -1,0 +1,18 @@
+# Pull Request Oversight CLI
+
+Use `pr_oversee` when PR supervision needs deterministic state, blockers, and local commands instead of prose-only inspection.
+
+```bash
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis inspect --pr 123 --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis gate --pr 123
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis comments --pr 123 --unresolved --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis checkout --pr 123 --worktree ../arthexis-pr-123 --branch repos-pr-123
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis test-plan --pr 123 --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis ci --pr 123 --failures --logs --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis dependency-dedupe --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis merge --pr 123 --write --method squash --delete-branch
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis cleanup --pr 123 --write --worktree ../arthexis-pr-123
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis hygiene --pr 123
+```
+
+The command delegates GitHub state and merge operations to `gh`, but normalizes the output into stable JSON. `gate` exits nonzero when a PR is blocked by draft state, merge state, review state, failed or pending checks, or unresolved review threads. `merge` always re-runs the gate immediately before calling `gh pr merge`, and `cleanup` refuses to remove local artifacts unless the PR is already merged.

--- a/docs/development/pr-oversee.md
+++ b/docs/development/pr-oversee.md
@@ -3,16 +3,16 @@
 Use `pr_oversee` when PR supervision needs deterministic state, blockers, and local commands instead of prose-only inspection.
 
 ```bash
-.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis inspect --pr 123 --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis --json inspect --pr 123
 .venv/bin/python manage.py pr_oversee --repo arthexis/arthexis gate --pr 123
-.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis comments --pr 123 --unresolved --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis --json comments --pr 123 --unresolved
 .venv/bin/python manage.py pr_oversee --repo arthexis/arthexis checkout --pr 123 --worktree ../arthexis-pr-123 --branch repos-pr-123
-.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis test-plan --pr 123 --json
-.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis ci --pr 123 --failures --logs --json
-.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis dependency-dedupe --json
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis --json test-plan --pr 123
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis --json ci --pr 123 --failures --logs
+.venv/bin/python manage.py pr_oversee --repo arthexis/arthexis --json dependency-dedupe
 .venv/bin/python manage.py pr_oversee --repo arthexis/arthexis merge --pr 123 --write --method squash --delete-branch
 .venv/bin/python manage.py pr_oversee --repo arthexis/arthexis cleanup --pr 123 --write --worktree ../arthexis-pr-123
 .venv/bin/python manage.py pr_oversee --repo arthexis/arthexis hygiene --pr 123
 ```
 
-The command delegates GitHub state and merge operations to `gh`, but normalizes the output into stable JSON. `gate` exits nonzero when a PR is blocked by draft state, merge state, review state, failed or pending checks, or unresolved review threads. `merge` always re-runs the gate immediately before calling `gh pr merge`, and `cleanup` refuses to remove local artifacts unless the PR is already merged.
+The command delegates GitHub state and merge operations to `gh`, but normalizes the output into stable JSON. `gate` exits nonzero when a PR is blocked by draft state, merge state, review state, failed or pending checks, or unresolved review threads. `merge` always re-runs the gate immediately before calling `gh pr merge` and passes a head-commit guard to GitHub, and `cleanup` refuses to remove local artifacts unless the PR is already merged.


### PR DESCRIPTION
## Summary
- Add `manage.py pr_oversee` with deterministic subcommands for all 10 requested PR oversight tasks: `inspect`, `gate`, `comments`, `checkout`, `test-plan`, `ci`, `dependency-dedupe`, `merge`, `cleanup`, and `hygiene`.
- Add `apps.repos.pr_oversee` service helpers for gh/git JSON normalization, readiness blockers, review-thread extraction, test command selection, CI failure snippets, dependency duplicate grouping, guarded merge, and cleanup refusal unless merged.
- Document the CLI and add it to the command matrix.

No matching open GitHub issue was found for this request.

## Validation
- `.venv\Scripts\python.exe -m py_compile apps\repos\pr_oversee.py apps\repos\management\commands\pr_oversee.py apps\repos\tests\test_pr_oversee.py`
- `.venv\Scripts\python.exe manage.py test run -- apps/repos/tests/test_pr_oversee.py apps/repos/tests/test_github_command.py` (12 passed)
- `.venv\Scripts\python.exe manage.py pr_oversee --repo arthexis/arthexis --json inspect --pr 7657` (live smoke; correctly reported blockers)
- `.venv\Scripts\python.exe manage.py pr_oversee --repo arthexis/arthexis --json test-plan --pr 7657` (live smoke; returned imager/nodes test plan)
- `.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.venv\Scripts\python.exe manage.py migrate --check`
- `git diff --cached --check`

Note: the fresh worktree DB needed migration application before `migrate --check`; an initial `.venv\Scripts\python.exe manage.py migrate --noinput --verbosity 0` exceeded the 10-minute local timeout while applying the full project migration set, but the subsequent `migrate --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds a new Django management command `pr_oversee` that provides deterministic oversight of GitHub pull requests via subcommands for inspecting, gating, preparing, validating, merging, and cleaning up PRs. The implementation deterministically classifies PR readiness based on draft status, merge state, review decisions, check results, and unresolved review threads.

## Core Components

### Management Command (`apps/repos/management/commands/pr_oversee.py`)
Defines a `Command` class with 10 subcommands:
- `inspect` – returns complete PR state snapshot as JSON
- `gate` – verifies PR merge-readiness; exits nonzero if blocked (supports `--require-approval`, `--allow-pending`)
- `comments` – lists review threads (supports `--unresolved` for unresolved-only filtering)
- `checkout` – creates isolated git worktree for the PR and writes metadata
- `test-plan` – maps changed files to Django test commands
- `ci` – collects failed/pending checks (supports `--logs` to fetch failed run log snippets)
- `dependency-dedupe` – groups and deduplicates dependency PRs
- `merge` – gates readiness then calls `gh pr merge` with merge method, branch deletion, and approval/pending/admin controls (requires `--write` to execute)
- `cleanup` – removes worktree and optionally local branch (refuses unless PR is merged; requires `--write`)
- `hygiene` – reports hygiene failures (missing migrations, generated files)

Repository resolution prefers `--repo owner/name`, falling back to active repository or `DEFAULT_PACKAGE.repository_url`.

### Service Module (`apps/repos/pr_oversee.py`)
Provides helpers for deterministic PR state classification:
- `CommandRunner` – wrapper executing external `gh`/`git` commands with UTF-8 text capture, raising `PullRequestOverseeError` on JSON parse failures or non-zero exits when `check=True`
- `check_rollup_state()` – classifies status checks into failing/pending/passing based on predefined allow/fail/pending sets
- `readiness_gate()` – computes `ready` boolean, `blockers` list, and `warnings` from draft status, mergeability, review decision, check results, and unresolved review thread count
- `dependency_duplicates()` – detects dependency PRs and groups by stable key and target version, marking superseded updates
- `changed_files_to_test_plan()` – deterministically maps changed paths to Django management commands, detecting migrations, models, workflows, and generated artifacts
- `hygiene_report()` – inspects PR body and changed files for missing migrations and invalid generated files
- `PullRequestOverseer` class – shells out to `gh`/`git` to fetch PR details, list open PRs, collect review thread comments with GraphQL pagination, compute readiness gates, gather changed files, aggregate CI failures with optional logs, perform worktree checkout with metadata, merge with head-SHA consistency checks, cleanup merged PRs, and expose combined hygiene reports

### Tests (`apps/repos/tests/test_pr_oversee.py`)
12 unit tests using a `FakeRunner` to simulate command execution, covering:
- Readiness gate blocker composition from review decisions, check results, and unresolved threads
- Review thread normalization and cursor-based pagination in `comments(unresolved_only=...)`
- Changed file mapping to test commands via `changed_files_to_test_plan`
- CI failure aggregation with optional log retrieval
- Dependency deduplication and version grouping
- Worktree creation with metadata writing
- Merge head-SHA consistency validation before `gh pr merge`
- Cleanup refusal for unmerged PRs
- Hygiene reporting for missing migrations
- Management command JSON output routing

### Documentation
- `docs/development/pr-oversee.md` – describes subcommands with concrete usage examples, observable behavior (gate exits nonzero when blocked, merge re-runs gate before merge, cleanup refuses unmerged PRs)
- `docs/development/command-matrix.md` – adds PR oversight to allowed command context

## Design Principles
- **Deterministic classification**: PR state is computed from stable fields (merge state, review decision, check conclusions) using predefined allow/fail/pending sets
- **Shell delegation**: `gh` and `git` CLI tools execute GitHub operations; output normalized to stable JSON
- **Readiness gates**: Operations blocked by draft status, merge state, review state, failing/pending checks, or unresolved review threads
- **Safety checks**: Head-SHA consistency validation before merge; refusal to cleanup unmerged PRs; guard conditions for pending/approval states

## Validation
- Python byte-compile of key modules
- 12 test cases passed (test_pr_oversee.py and test_github_command.py)
- Live smoke runs of `inspect` and `test-plan` subcommands reporting correct blockers and test plans
- Django checks: `check --fail-level ERROR`, `makemigrations --check --dry-run`, `migrate --check`
- Pre-commit/git checks: `git diff --cached --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->