### PR TITLE
Collapse anonymous OCPP nav to "Supported CP Models" and theme‑align supported charger pages

### DIFF
--- a/apps/ocpp/templates/ocpp/supported_charger_detail.html
+++ b/apps/ocpp/templates/ocpp/supported_charger_detail.html
@@ -37,7 +37,7 @@
     border-radius: 1rem;
     overflow: hidden;
     border: 1px solid var(--bs-border-color-translucent);
-    box-shadow: 0 0.85rem 1.5rem rgba(15, 23, 42, 0.1);
+    box-shadow: var(--bs-box-shadow);
     background: var(--bs-body-bg);
   }
   .hero-media img {
@@ -56,7 +56,7 @@
     overflow: hidden;
     border: 1px solid var(--bs-border-color-translucent);
     background: var(--bs-body-bg);
-    box-shadow: 0 0.45rem 0.9rem rgba(15, 23, 42, 0.06);
+    box-shadow: var(--bs-box-shadow-sm);
   }
   .thumb-item img {
     width: 100%;

--- a/apps/ocpp/templates/ocpp/supported_chargers.html
+++ b/apps/ocpp/templates/ocpp/supported_chargers.html
@@ -30,12 +30,12 @@
     border: 1px solid var(--bs-border-color-translucent);
     border-radius: 1rem;
     background-color: var(--bs-body-bg);
-    box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.04);
+    box-shadow: var(--bs-box-shadow-sm);
     transition: transform 0.15s ease, box-shadow 0.15s ease;
   }
   .supported-card:hover {
     transform: translateY(-1px);
-    box-shadow: 0 0.8rem 1.25rem rgba(15, 23, 42, 0.08);
+    box-shadow: var(--bs-box-shadow);
   }
   .rating-pill {
     border-radius: 0.85rem;
@@ -58,7 +58,7 @@
     text-transform: uppercase;
   }
   .rating-stars {
-    color: #f5c74e;
+    color: var(--bs-warning);
     letter-spacing: 0.1rem;
     font-size: 0.85rem;
   }

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -458,7 +458,8 @@ def _assign_module_menu(module):
 def _limit_anon_ocpp_landings(module, request, landings: list):
     """Keep only public supported-model navigation for anonymous OCPP visits."""
 
-    if request.user.is_authenticated:
+    user = getattr(request, "user", None)
+    if getattr(user, "is_authenticated", False):
         return landings
     if (module.path.rstrip("/") or "/").lower() != "/ocpp":
         return landings
@@ -470,7 +471,7 @@ def _limit_anon_ocpp_landings(module, request, landings: list):
         if (landing.path.rstrip("/") or "/").lower() == supported_models_path
     ]
     if filtered_landings:
-        module.menu = "Supported CP Models"
+        module.menu = _("Supported CP Models")
         return filtered_landings
     return landings
 

--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -455,6 +455,26 @@ def _assign_module_menu(module):
     return module
 
 
+def _limit_anon_ocpp_landings(module, request, landings: list):
+    """Keep only public supported-model navigation for anonymous OCPP visits."""
+
+    if request.user.is_authenticated:
+        return landings
+    if (module.path.rstrip("/") or "/").lower() != "/ocpp":
+        return landings
+
+    supported_models_path = "/ocpp/charge-point-models"
+    filtered_landings = [
+        landing
+        for landing in landings
+        if (landing.path.rstrip("/") or "/").lower() == supported_models_path
+    ]
+    if filtered_landings:
+        module.menu = "Supported CP Models"
+        return filtered_landings
+    return landings
+
+
 def _annotate_module_landings(
     module,
     request,
@@ -515,6 +535,7 @@ def _annotate_module_landings(
         module.path,
         _select_primary_landings(module.path, landings),
     )
+    landings = _limit_anon_ocpp_landings(module, request, landings)
 
     if not landings:
         return None

--- a/apps/sites/tests/test_context_processor_module_landings.py
+++ b/apps/sites/tests/test_context_processor_module_landings.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
-from apps.sites.context_processors import _sort_module_landings
+from apps.sites.context_processors import (
+    _limit_anon_ocpp_landings,
+    _sort_module_landings,
+)
 
 
 def test_sort_module_landings_prioritizes_ocpp_navigation_paths():
@@ -31,3 +34,16 @@ def test_sort_module_landings_keeps_non_ocpp_order():
         "/docs/library/",
         "/docs/help/",
     ]
+
+
+def test_limit_anon_ocpp_landings_handles_request_without_user():
+    module = SimpleNamespace(path="/ocpp/", menu="Charge Points")
+    landings = [
+        SimpleNamespace(path="/ocpp/cpms/dashboard/"),
+        SimpleNamespace(path="/ocpp/charge-point-models/"),
+    ]
+
+    filtered = _limit_anon_ocpp_landings(module, SimpleNamespace(), landings)
+
+    assert [landing.path for landing in filtered] == ["/ocpp/charge-point-models/"]
+    assert str(module.menu) == "Supported CP Models"


### PR DESCRIPTION
### Motivation
- Prevent anonymous visitors from seeing a multi‑item “Charge Points” module pill and instead surface the public landing directly as a single link labelled "Supported CP Models". 
- Remove hardcoded visual styling from the supported charger list/detail pages so they inherit the regular site theme and avoid visual clashing.

### Description
- Added `_limit_anon_ocpp_landings(module, request, landings)` in `apps/sites/context_processors.py` and invoke it from `_annotate_module_landings` to filter OCPP landings for anonymous requests and set `module.menu` to `"Supported CP Models"` when the public landing exists.
- Replaced hardcoded shadow and color values in `apps/ocpp/templates/ocpp/supported_chargers.html` with theme tokens `--bs-box-shadow-sm`, `--bs-box-shadow`, and `--bs-warning` to better align with the site styling.
- Applied the same box‑shadow token replacements in `apps/ocpp/templates/ocpp/supported_charger_detail.html` to maintain consistent media card styling.

### Testing
- Ran the targeted template and context processor tests using `.venv/bin/python manage.py test run -- apps/sites/tests/test_context_processor_module_landings.py apps/ocpp/tests/test_supported_charger_templates.py` and all tests passed.
- Test suite summary: `7 passed` for the invoked test targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa63b0945883268f4c43141f39bdb6)