### PR TITLE
Add patchwork hygiene to PR oversee

### DIFF
--- a/apps/repos/management/commands/pr_oversee.py
+++ b/apps/repos/management/commands/pr_oversee.py
@@ -9,7 +9,12 @@ from django.core.management.base import BaseCommand, CommandError
 
 from apps.release import DEFAULT_PACKAGE
 from apps.repos.github import parse_repository_url, resolve_active_repository
-from apps.repos.pr_oversee import PullRequestOverseeError, PullRequestOverseer
+from apps.repos.pr_oversee import (
+    PullRequestOverseeError,
+    PullRequestOverseer,
+    default_patchwork_dir,
+    patchwork_worktree_path,
+)
 
 
 class Command(BaseCommand):
@@ -55,8 +60,11 @@ class Command(BaseCommand):
         )
         self._add_pr_arg(checkout_parser)
         checkout_parser.add_argument(
-            "--worktree", required=True, help="Worktree path to create."
+            "--worktree",
+            default="",
+            help="Worktree path to create. Defaults to the patchwork directory.",
         )
+        self._add_patchwork_dir_arg(checkout_parser)
         checkout_parser.add_argument(
             "--branch", default="", help="Optional local branch name."
         )
@@ -118,6 +126,18 @@ class Command(BaseCommand):
         )
         self._add_pr_arg(hygiene_parser)
 
+        patchwork_parser = subparsers.add_parser(
+            "patchwork", help="Report or prune monitor-owned patchwork worktrees."
+        )
+        self._add_patchwork_dir_arg(patchwork_parser)
+        patchwork_parser.add_argument("--max-age-days", type=float, default=14.0)
+        patchwork_parser.add_argument("--force-stale-open", action="store_true")
+        patchwork_parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Required to remove patchwork worktrees.",
+        )
+
         monitor_parser = subparsers.add_parser(
             "monitor",
             help="Run the PR oversight workflow until completion or manual decision.",
@@ -134,6 +154,7 @@ class Command(BaseCommand):
         monitor_parser.add_argument(
             "--worktree", default="", help="Optional PR worktree path."
         )
+        self._add_patchwork_dir_arg(monitor_parser)
         monitor_parser.add_argument(
             "--branch", default="", help="Optional local branch for checkout."
         )
@@ -201,9 +222,10 @@ class Command(BaseCommand):
                 number, unresolved_only=bool(options.get("unresolved"))
             )
         if action == "checkout":
+            worktree = self._resolve_worktree_option(overseer, number, options)
             return overseer.checkout(
                 number,
-                worktree=Path(str(options["worktree"])).expanduser(),
+                worktree=worktree,
                 branch=str(options.get("branch") or ""),
             )
         if action == "test-plan":
@@ -259,12 +281,15 @@ class Command(BaseCommand):
             )
         if action == "hygiene":
             return overseer.hygiene(number)
-        if action == "monitor":
-            worktree = (
-                Path(str(options["worktree"])).expanduser()
-                if str(options.get("worktree") or "").strip()
-                else None
+        if action == "patchwork":
+            return overseer.patchwork_hygiene(
+                root=self._resolve_patchwork_dir(options),
+                max_age_days=float(options.get("max_age_days") or 0.0),
+                write=bool(options.get("write")),
+                force_stale_open=bool(options.get("force_stale_open")),
             )
+        if action == "monitor":
+            worktree = self._resolve_monitor_worktree(overseer, number, options)
             return overseer.monitor(
                 number,
                 interval_seconds=float(options.get("interval") or 0.0),
@@ -292,6 +317,50 @@ class Command(BaseCommand):
         parser.add_argument(
             "--pr", type=int, required=True, help="Pull request number."
         )
+
+    def _add_patchwork_dir_arg(self, parser) -> None:
+        parser.add_argument(
+            "--patchwork-dir",
+            default="",
+            help=(
+                "Directory for temporary PR worktrees. Defaults to "
+                f"{default_patchwork_dir()} or ARTHEXIS_PATCHWORK_DIR."
+            ),
+        )
+
+    def _resolve_patchwork_dir(self, options: dict[str, object]) -> Path:
+        raw_value = str(options.get("patchwork_dir") or "").strip()
+        if raw_value:
+            return Path(raw_value).expanduser()
+        return default_patchwork_dir()
+
+    def _resolve_worktree_option(
+        self,
+        overseer: PullRequestOverseer,
+        number: int,
+        options: dict[str, object],
+    ) -> Path:
+        raw_value = str(options.get("worktree") or "").strip()
+        if raw_value:
+            return Path(raw_value).expanduser()
+        return patchwork_worktree_path(
+            self._resolve_patchwork_dir(options), overseer.repo, number
+        )
+
+    def _resolve_monitor_worktree(
+        self,
+        overseer: PullRequestOverseer,
+        number: int,
+        options: dict[str, object],
+    ) -> Path | None:
+        raw_value = str(options.get("worktree") or "").strip()
+        if raw_value:
+            return Path(raw_value).expanduser()
+        if options.get("run_test_plan"):
+            return patchwork_worktree_path(
+                self._resolve_patchwork_dir(options), overseer.repo, number
+            )
+        return None
 
     def _resolve_repository(self, raw_repo: str) -> str:
         cleaned = raw_repo.strip()

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -50,6 +51,57 @@ PENDING_CHECKS = {
 BAD_MERGE_STATES = {"BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"}
 README_RE = re.compile(r"(^|/)(README|README\.[^/]+)$", re.IGNORECASE)
 VERSION_SUFFIX_SEPARATORS = "-_/"
+PATCHWORK_ENV_VAR = "ARTHEXIS_PATCHWORK_DIR"
+PATCHWORK_METADATA = ".arthexis-pr-oversee.json"
+PATCHWORK_OWNED_NOISE = {PATCHWORK_METADATA, ".venv"}
+
+
+def default_patchwork_dir() -> Path:
+    """Return the default directory for temporary PR worktrees."""
+
+    configured = os.environ.get(PATCHWORK_ENV_VAR, "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / "patchwork"
+
+
+def _slugify_path_segment(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return slug.strip("-") or "repo"
+
+
+def patchwork_worktree_path(root: Path, repo: str, number: int) -> Path:
+    """Return the deterministic patchwork worktree path for a PR."""
+
+    return root.expanduser() / f"{_slugify_path_segment(repo)}-pr-{number}"
+
+
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _status_path(line: str) -> str:
+    if len(line) < 4:
+        return ""
+    value = line[3:].strip()
+    if " -> " in value:
+        return ""
+    return value.rstrip("/")
+
+
+def _status_is_patchwork_noise(lines: Iterable[str]) -> bool:
+    paths = [_status_path(line) for line in lines if line.strip()]
+    if not paths:
+        return True
+    return all(
+        path in PATCHWORK_OWNED_NOISE
+        or any(path.startswith(f"{noise}/") for noise in PATCHWORK_OWNED_NOISE)
+        for path in paths
+    )
 
 
 class PullRequestOverseeError(RuntimeError):
@@ -544,6 +596,37 @@ class PullRequestOverseer:
         )
         return [_coerce_mapping(item) for item in _coerce_list(payload)]
 
+    def pull_request_state_lookup(self, numbers: Iterable[int]) -> dict[int, str]:
+        """Return PR states for a set of PR numbers using a batched list call."""
+
+        wanted = sorted({number for number in numbers if number})
+        if not wanted:
+            return {}
+        payload = self.gh_json(
+            [
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "all",
+                "--limit",
+                str(max(100, len(wanted))),
+                "--json",
+                "number,state",
+            ]
+        )
+        lookup: dict[int, str] = {}
+        for item in _coerce_list(payload):
+            row = _coerce_mapping(item)
+            try:
+                number = int(row.get("number") or 0)
+            except (TypeError, ValueError):
+                continue
+            if number in wanted:
+                lookup[number] = str(row.get("state") or "").upper()
+        return lookup
+
     def comments(self, number: int, *, unresolved_only: bool = False) -> dict[str, Any]:
         owner, name = self.repo.split("/", 1)
         query = """
@@ -777,6 +860,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
     ) -> dict[str, Any]:
         if worktree.exists():
             raise PullRequestOverseeError(f"Worktree path already exists: {worktree}")
+        worktree.parent.mkdir(parents=True, exist_ok=True)
         pr = self.pr_view(number)
         remote_ref = f"refs/remotes/origin/pr/{number}"
         self.git(["fetch", "origin", f"pull/{number}/head:{remote_ref}"])
@@ -797,13 +881,72 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             "worktree": str(worktree),
         }
         try:
-            (worktree / ".arthexis-pr-oversee.json").write_text(
+            (worktree / PATCHWORK_METADATA).write_text(
                 json.dumps(metadata, indent=2) + "\n",
                 encoding="utf-8",
             )
         except OSError:
             metadata["metadataWriteError"] = True
         return metadata
+
+    def _worktree_status_lines(self, worktree: Path) -> list[str]:
+        result = self.runner.run(
+            [
+                "git",
+                "-C",
+                str(worktree),
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+            ],
+            cwd=self.cwd,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [line for line in result.stdout.splitlines() if line.strip()]
+
+    def _remove_worktree(
+        self,
+        worktree: Path,
+        *,
+        patchwork_root: Path | None = None,
+    ) -> dict[str, Any]:
+        result = self.runner.run(
+            ["git", "worktree", "remove", str(worktree)], cwd=self.cwd, check=False
+        )
+        action: dict[str, Any] = {
+            "action": "remove-worktree",
+            "path": str(worktree),
+            "returncode": result.returncode,
+            "stderr": result.stderr.strip(),
+        }
+        if result.returncode == 0:
+            return action
+
+        metadata_exists = (worktree / PATCHWORK_METADATA).exists()
+        status_lines = self._worktree_status_lines(worktree)
+        can_force = metadata_exists and _status_is_patchwork_noise(status_lines)
+        if patchwork_root is not None:
+            can_force = can_force and _path_is_relative_to(worktree, patchwork_root)
+        if not can_force:
+            action["forced"] = False
+            action["status"] = status_lines
+            return action
+
+        forced = self.runner.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=self.cwd,
+            check=False,
+        )
+        action.update(
+            {
+                "forced": True,
+                "forceReturncode": forced.returncode,
+                "forceStderr": forced.stderr.strip(),
+            }
+        )
+        return action
 
     def sync_worktree(self, number: int, *, worktree: Path) -> dict[str, Any]:
         """Fetch the current PR head and move an existing worktree to it."""
@@ -885,17 +1028,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             )
         actions: list[dict[str, Any]] = []
         if worktree:
-            result = self.runner.run(
-                ["git", "worktree", "remove", str(worktree)], cwd=self.cwd, check=False
-            )
-            actions.append(
-                {
-                    "action": "remove-worktree",
-                    "path": str(worktree),
-                    "returncode": result.returncode,
-                    "stderr": result.stderr.strip(),
-                }
-            )
+            actions.append(self._remove_worktree(worktree))
         base_branch = str(pr.get("baseRefName") or "main")
         self.git(["fetch", "origin", base_branch, "--prune"])
         actions.append(
@@ -916,6 +1049,115 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                 }
             )
         return {"number": number, "state": state, "actions": actions}
+
+    def patchwork_hygiene(
+        self,
+        *,
+        root: Path | None = None,
+        max_age_days: float = 14.0,
+        write: bool = False,
+        force_stale_open: bool = False,
+    ) -> dict[str, Any]:
+        """Report and optionally prune monitor-owned patchwork worktrees."""
+
+        if max_age_days < 0:
+            raise PullRequestOverseeError("max_age_days must be zero or positive")
+        patchwork_root = (root or default_patchwork_dir()).expanduser()
+        if not patchwork_root.exists():
+            return {
+                "root": str(patchwork_root),
+                "exists": False,
+                "maxAgeDays": max_age_days,
+                "write": write,
+                "items": [],
+                "pruned": [],
+            }
+
+        items: list[dict[str, Any]] = []
+        pruned: list[dict[str, Any]] = []
+        pending_items: list[dict[str, Any]] = []
+        state_numbers: list[int] = []
+        now = time.time()
+        for metadata_path in sorted(patchwork_root.glob(f"*/{PATCHWORK_METADATA}")):
+            worktree = metadata_path.parent
+            try:
+                metadata = _coerce_mapping(json.loads(metadata_path.read_text()))
+            except (OSError, json.JSONDecodeError):
+                metadata = {}
+            repo = str(metadata.get("repo") or "")
+            raw_number = metadata.get("number") or 0
+            invalid_number = False
+            try:
+                number = int(raw_number)
+            except (TypeError, ValueError):
+                number = 0
+                invalid_number = True
+            age_days = max(0.0, (now - metadata_path.stat().st_mtime) / 86400)
+            reason = ""
+            if repo and repo != self.repo:
+                reason = "foreign-repo"
+            elif invalid_number:
+                reason = "invalid-pr-number"
+            elif not number:
+                reason = "missing-pr-number"
+            elif number:
+                state_numbers.append(number)
+            pending_items.append(
+                {
+                    "worktree": worktree,
+                    "repo": repo,
+                    "number": number,
+                    "ageDays": age_days,
+                    "reason": reason,
+                }
+            )
+
+        state_lookup = self.pull_request_state_lookup(state_numbers)
+        for pending in pending_items:
+            worktree = pending["worktree"]
+            repo = str(pending["repo"])
+            number = int(pending["number"] or 0)
+            age_days = float(pending["ageDays"])
+            reason = str(pending["reason"])
+            state = ""
+            if number and not reason:
+                state = state_lookup.get(number, "")
+                if not state:
+                    try:
+                        state = str(self.pr_view(number).get("state") or "").upper()
+                    except PullRequestOverseeError as exc:
+                        reason = f"pr-state-error:{exc}"
+
+            stale = age_days >= max_age_days
+            candidate = state in {"MERGED", "CLOSED"} or (
+                force_stale_open and stale and not reason
+            )
+            if not reason and not candidate:
+                reason = "active-or-recent"
+            item = {
+                "worktree": str(worktree),
+                "repo": repo,
+                "number": number,
+                "state": state,
+                "ageDays": round(age_days, 2),
+                "stale": stale,
+                "candidate": candidate,
+                "reason": "prune" if candidate else reason,
+            }
+            if write and candidate:
+                item["remove"] = self._remove_worktree(
+                    worktree, patchwork_root=patchwork_root
+                )
+                pruned.append(item)
+            items.append(item)
+        return {
+            "root": str(patchwork_root),
+            "exists": True,
+            "maxAgeDays": max_age_days,
+            "write": write,
+            "items": items,
+            "pruned": pruned,
+        }
 
     def hygiene(self, number: int) -> dict[str, Any]:
         return hygiene_report(self.pr_view(number), self.changed_files(number))
@@ -1012,7 +1254,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                 )
                 synced_worktree_head = head_sha
 
-            if run_test_plan:
+            if run_test_plan and state != "MERGED":
                 validation_cwd = worktree if worktree else self.cwd
                 validation_head = head_sha or f"iteration-{iteration}"
                 validation_key = f"{validation_head}:{validation_cwd}"

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -8,14 +8,17 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from apps.repos.pr_oversee import (
     CommandResult,
     PullRequestOverseeError,
     PullRequestOverseer,
     changed_files_to_test_plan,
+    default_patchwork_dir,
     dependency_duplicates,
     hygiene_report,
+    patchwork_worktree_path,
     readiness_gate,
 )
 
@@ -366,6 +369,20 @@ def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
     )
 
 
+def test_patchwork_worktree_path_is_deterministic(tmp_path: Path):
+    assert patchwork_worktree_path(tmp_path, "arthexis/arthexis", 123) == (
+        tmp_path / "arthexis-arthexis-pr-123"
+    )
+
+
+def test_default_patchwork_dir_respects_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("ARTHEXIS_PATCHWORK_DIR", str(tmp_path))
+
+    assert default_patchwork_dir() == tmp_path
+
+
 def test_merge_gates_expected_head_before_calling_gh_merge():
     comments = {
         "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
@@ -424,6 +441,124 @@ def test_cleanup_fetches_merged_pr_base_branch(tmp_path: Path):
     }
 
 
+def test_cleanup_forces_removal_for_owned_patchwork_metadata(tmp_path: Path):
+    worktree = tmp_path / "patchwork" / "arthexis-arthexis-pr-123"
+    worktree.mkdir(parents=True)
+    (worktree / ".arthexis-pr-oversee.json").write_text('{"number": 123}\n')
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload(state="MERGED"))),
+            CommandResult(128, stderr="contains modified or untracked files"),
+            CommandResult(0, "?? .arthexis-pr-oversee.json\n?? .venv/\n"),
+            CommandResult(0),
+            CommandResult(0),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+
+    result = overseer.cleanup(123, worktree=worktree)
+
+    assert result["actions"][0]["forced"] is True
+    assert runner.commands[3] == [
+        "git",
+        "worktree",
+        "remove",
+        "--force",
+        str(worktree),
+    ]
+
+
+def test_patchwork_remove_respects_git_force_failure(tmp_path: Path):
+    patchwork_root = tmp_path / "patchwork"
+    worktree = patchwork_root / "arthexis-arthexis-pr-123"
+    worktree.mkdir(parents=True)
+    (worktree / ".arthexis-pr-oversee.json").write_text('{"number": 123}\n')
+    runner = FakeRunner(
+        [
+            CommandResult(128, stderr="contains modified or untracked files"),
+            CommandResult(0, "?? .arthexis-pr-oversee.json\n"),
+            CommandResult(128, stderr="worktree is locked"),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+
+    result = overseer._remove_worktree(worktree, patchwork_root=patchwork_root)
+
+    assert result["forced"] is True
+    assert result["forceReturncode"] == 128
+    assert worktree.exists()
+    assert len(runner.commands) == 3
+
+
+def test_patchwork_hygiene_marks_merged_worktrees_for_prune(tmp_path: Path):
+    worktree = tmp_path / "arthexis-arthexis-pr-123"
+    worktree.mkdir()
+    (worktree / ".arthexis-pr-oversee.json").write_text(
+        json.dumps({"repo": "arthexis/arthexis", "number": 123})
+    )
+    runner = FakeRunner([CommandResult(0, json.dumps([{"number": 123, "state": "MERGED"}]))])
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.patchwork_hygiene(root=tmp_path)
+
+    assert result["items"][0]["candidate"] is True
+    assert result["items"][0]["reason"] == "prune"
+    assert runner.commands[0][:6] == [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        "arthexis/arthexis",
+        "--state",
+    ]
+
+
+def test_patchwork_hygiene_batches_pr_state_lookup(tmp_path: Path):
+    for number in (123, 124):
+        worktree = tmp_path / f"arthexis-arthexis-pr-{number}"
+        worktree.mkdir()
+        (worktree / ".arthexis-pr-oversee.json").write_text(
+            json.dumps({"repo": "arthexis/arthexis", "number": number})
+        )
+    runner = FakeRunner(
+        [
+            CommandResult(
+                0,
+                json.dumps(
+                    [
+                        {"number": 123, "state": "MERGED"},
+                        {"number": 124, "state": "OPEN"},
+                    ]
+                ),
+            )
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.patchwork_hygiene(root=tmp_path)
+
+    assert [item["state"] for item in result["items"]] == ["MERGED", "OPEN"]
+    assert len(runner.commands) == 1
+
+
+def test_patchwork_hygiene_marks_invalid_metadata_without_crashing(tmp_path: Path):
+    worktree = tmp_path / "arthexis-arthexis-pr-bad"
+    worktree.mkdir()
+    (worktree / ".arthexis-pr-oversee.json").write_text(
+        json.dumps({"repo": "arthexis/arthexis", "number": "abc"})
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=FakeRunner())
+
+    result = overseer.patchwork_hygiene(root=tmp_path)
+
+    assert result["items"][0]["candidate"] is False
+    assert result["items"][0]["reason"] == "invalid-pr-number"
+
+
 def test_hygiene_detects_missing_migration_and_generated_files():
     result = hygiene_report(
         _pr_payload(body="No sections"),
@@ -469,6 +604,40 @@ def test_management_command_merge_without_write_reports_plan():
         allow_pending=False,
     )
     fake.merge.assert_not_called()
+
+
+def test_management_command_checkout_defaults_to_patchwork_dir(tmp_path: Path):
+    fake = PullRequestOverseer(repo="arthexis/arthexis")
+    fake.checkout = Mock(
+        return_value={
+            "number": 123,
+            "worktree": str(tmp_path / "arthexis-arthexis-pr-123"),
+        }
+    )
+    buffer = StringIO()
+
+    with patch(
+        "apps.repos.management.commands.pr_oversee.PullRequestOverseer",
+        return_value=fake,
+    ):
+        call_command(
+            "pr_oversee",
+            "--repo",
+            "arthexis/arthexis",
+            "--json",
+            "checkout",
+            "--pr",
+            "123",
+            "--patchwork-dir",
+            str(tmp_path),
+            stdout=buffer,
+        )
+
+    payload = json.loads(buffer.getvalue())
+    assert payload["worktree"] == str(tmp_path / "arthexis-arthexis-pr-123")
+    fake.checkout.assert_called_once()
+    _, kwargs = fake.checkout.call_args
+    assert kwargs["worktree"] == tmp_path / "arthexis-arthexis-pr-123"
 
 
 def test_monitor_stops_for_manual_review_blocker():
@@ -669,6 +838,31 @@ def test_monitor_resyncs_reused_worktree_when_pr_head_changes(tmp_path: Path):
     assert sleeps == [0]
 
 
+def test_monitor_skips_validation_for_already_merged_missing_patchwork(tmp_path: Path):
+    worktree = tmp_path / "missing-patchwork"
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload(state="MERGED"))),
+            CommandResult(0, json.dumps(_review_threads_payload())),
+            CommandResult(0, "apps/repos/pr_oversee.py\n"),
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.monitor(
+        123,
+        interval_seconds=0,
+        max_iterations=1,
+        dependency_limit=0,
+        worktree=worktree,
+        run_test_plan=True,
+    )
+
+    assert result["status"] == "complete"
+    assert "localValidation" not in result["last"]
+    assert worktree not in runner.cwd_history
+
+
 def test_management_command_monitor_invokes_overseer_monitor():
     fake = PullRequestOverseer(repo="arthexis/arthexis")
     fake.monitor = Mock(
@@ -710,3 +904,38 @@ def test_management_command_monitor_invokes_overseer_monitor():
     assert kwargs["max_iterations"] == 1
     assert kwargs["merge"] is True
     assert kwargs["write"] is True
+
+
+def test_management_command_monitor_defaults_validation_to_patchwork(tmp_path: Path):
+    fake = PullRequestOverseer(repo="arthexis/arthexis")
+    fake.monitor = Mock(
+        return_value={
+            "status": "manual_decision_required",
+            "complete": False,
+            "manualDecisionRequired": True,
+            "manualDecisionReasons": ["merge_decision_required"],
+        }
+    )
+    buffer = StringIO()
+
+    with patch(
+        "apps.repos.management.commands.pr_oversee.PullRequestOverseer",
+        return_value=fake,
+    ):
+        with pytest.raises(CommandError):
+            call_command(
+                "pr_oversee",
+                "--repo",
+                "arthexis/arthexis",
+                "--json",
+                "monitor",
+                "--pr",
+                "123",
+                "--run-test-plan",
+                "--patchwork-dir",
+                str(tmp_path),
+                stdout=buffer,
+            )
+
+    _, kwargs = fake.monitor.call_args
+    assert kwargs["worktree"] == tmp_path / "arthexis-arthexis-pr-123"


### PR DESCRIPTION
### Summary
- add deterministic patchwork worktree paths for `pr_oversee checkout` and `monitor --run-test-plan`
- add `pr_oversee patchwork` to report/prune monitor-owned temporary worktrees under `ARTHEXIS_PATCHWORK_DIR` or `~/patchwork`
- make cleanup force-remove worktrees when only monitor-owned metadata/noise such as `.arthexis-pr-oversee.json` or `.venv` is dirty, while respecting Git locked-worktree failures
- harden patchwork hygiene against malformed metadata, batch PR state lookup, and skip validation for already-merged PRs without a checked-out patchwork worktree

### Validation
- `.venv\Scripts\ruff.exe check apps\repos\pr_oversee.py apps\repos\management\commands\pr_oversee.py apps\repos\tests\test_pr_oversee.py`
- `.venv\Scripts\python.exe -m py_compile apps\repos\pr_oversee.py apps\repos\management\commands\pr_oversee.py`
- `.venv\Scripts\python.exe manage.py test run -- apps/repos/tests/test_pr_oversee.py` (`28 passed`)
- `.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- `.venv\Scripts\python.exe manage.py pr_oversee --repo arthexis/arthexis --json patchwork --patchwork-dir C:\Users\arthexis\patchwork --max-age-days 14`
- `git diff --check`