### PR TITLE
Reduce release readiness windows

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -2,7 +2,7 @@ name: Release Simulator
 
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
   push:
     branches:
@@ -514,7 +514,7 @@ jobs:
             const body = [
               marker,
               '',
-              'Automated release readiness report. Scheduled every 3 hours for 8 release windows per day.',
+              'Automated release readiness report. Scheduled every 6 hours for 4 release windows per day.',
               '',
               `- Workflow run: ${runUrl}`,
               `- Ref: ${context.ref}`,


### PR DESCRIPTION
## Summary
- reduce the scheduled Release Simulator cadence from every 3 hours to every 6 hours
- update the generated readiness report wording from 8 to 4 release windows per day

## Verification
- git diff --check HEAD~1 HEAD
- inspected `.github/workflows/release-simulator.yml` for the updated cron and report text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the Release Simulator workflow schedule and documentation to reflect the new cadence.

## Changes

- Modified the workflow schedule from every 3 hours to every 6 hours by updating the cron expression from `0 */3 * * *` to `0 */6 * * *`
- Updated the generated release readiness report text to state "Scheduled every 6 hours for 4 release windows per day" (previously stated "8 release windows per day")

These changes reduce the frequency of scheduled release readiness checks while maintaining consistent coverage throughout the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->