### PR TITLE
ocpp: render supported charge-point models with public site chrome

### DIFF
--- a/apps/ocpp/views/public.py
+++ b/apps/ocpp/views/public.py
@@ -748,7 +748,10 @@ def supported_chargers(request):
     return render(
         request,
         "ocpp/supported_chargers.html",
-        {"station_models": station_models},
+        {
+            "station_models": station_models,
+            "operator_interface_mode": False,
+        },
     )
 
 
@@ -783,5 +786,6 @@ def supported_charger_detail(request, station_model_id: int):
             "instructions_html": instructions_html,
             "images": images,
             "documents": documents,
+            "operator_interface_mode": False,
         },
     )


### PR DESCRIPTION
### Motivation
- Supported charge-point pages were appearing without the normal public site chrome (navigation, feedback widget, alerts), so the views should force the public layout instead of the operator interface shell.

### Description
- Set `operator_interface_mode: False` in the template context for `supported_chargers` and `supported_charger_detail` in `apps/ocpp/views/public.py` so the pages render with the full public site chrome.

### Testing
- Attempted to run ` .venv/bin/python manage.py test run -- apps.ocpp.tests.test_supported_charger_templates` but the command could not be executed in this environment because `.venv/bin/python` is not present, so no tests were run locally here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb50afe8e883268ba2a016fe7b1cb2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the `operator_interface_mode: False` flag to the template context in two public-facing views to ensure the supported charge-point model pages render with the full public site chrome (navigation, feedback widget, and alerts) instead of the operator interface shell.

## Changes

Modified `apps/ocpp/views/public.py`:
- `supported_chargers` view: Added `"operator_interface_mode": False` to the context dictionary (line 753)
- `supported_charger_detail` view: Added `"operator_interface_mode": False` to the context dictionary (line 789)

## Testing

The existing test suite in `apps/ocpp/tests/test_supported_charger_templates.py` covers the functionality of both views, including:
- Data attribute casing preservation for vendor and OCPP versions
- Detail page rendering with various media file configurations
- Landing page validator logic
- Route fixture validation

No additional tests were added as the change is a simple template context modification that is covered by existing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->