### PR TITLE
Default RPi images to full Connect package

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -31,9 +31,9 @@ from django.utils import timezone
 
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.reservations import (
-    ImageReservation,
     RESERVATION_ENV_PATH,
     RESERVATION_JSON_PATH,
+    ImageReservation,
     active_parent_network_names,
     commit_image_reservation,
     plan_image_reservation,
@@ -110,22 +110,33 @@ if [ -n "${NODE_HOSTNAME:-}" ]; then
   hostnamectl set-hostname "$NODE_HOSTNAME" 2>/dev/null || hostname "$NODE_HOSTNAME" 2>/dev/null || true
 fi
 
-missing_packages=()
+required_packages=()
 if ! command -v git >/dev/null 2>&1; then
-  missing_packages+=(git ca-certificates)
+  required_packages+=(git ca-certificates)
 elif [ ! -e /etc/ssl/certs/ca-certificates.crt ]; then
-  missing_packages+=(ca-certificates)
+  required_packages+=(ca-certificates)
 fi
+
+optional_connect_packages=()
 for package in rpi-connect wayvnc wfplug-connect; do
   if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
-    missing_packages+=("$package")
+    optional_connect_packages+=("$package")
   fi
 done
 
-if [ "${#missing_packages[@]}" -gt 0 ]; then
+if [ "${#required_packages[@]}" -gt 0 ]; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get update || { sleep 10; apt-get update; }
-  apt-get install -y --no-install-recommends "${missing_packages[@]}"
+  apt-get install -y --no-install-recommends "${required_packages[@]}"
+fi
+
+if [ "${#optional_connect_packages[@]}" -gt 0 ]; then
+  export DEBIAN_FRONTEND=noninteractive
+  if apt-get update || { sleep 10; apt-get update; }; then
+    apt-get install -y --no-install-recommends "${optional_connect_packages[@]}" || echo "Optional Raspberry Pi Connect packages failed to install; continuing bootstrap" >&2
+  else
+    echo "Optional Raspberry Pi Connect package index update failed; continuing bootstrap" >&2
+  fi
 fi
 
 APP_HOME=/opt/arthexis

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -116,6 +116,11 @@ if ! command -v git >/dev/null 2>&1; then
 elif [ ! -e /etc/ssl/certs/ca-certificates.crt ]; then
   missing_packages+=(ca-certificates)
 fi
+for package in rpi-connect wayvnc wfplug-connect; do
+  if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
+    missing_packages+=("$package")
+  fi
+done
 
 if [ "${#missing_packages[@]}" -gt 0 ]; then
   export DEBIAN_FRONTEND=noninteractive

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -797,8 +797,11 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
     sshd_config, sshd_mode = written_files["/etc/ssh/sshd_config.d/20-arthexis-recovery.conf"]
 
     assert bootstrap_mode == "0755"
-    assert "missing_packages+=(git ca-certificates)" in bootstrap_script
+    assert "required_packages+=(git ca-certificates)" in bootstrap_script
     assert "for package in rpi-connect wayvnc wfplug-connect" in bootstrap_script
+    assert 'optional_connect_packages+=("$package")' in bootstrap_script
+    assert '"${optional_connect_packages[@]}" || echo' in bootstrap_script
+    assert "continuing bootstrap" in bootstrap_script
     assert "rpi-connect-lite" not in bootstrap_script
     apt_update_retry = "apt-get update || { sleep 10; apt-get update; }"
     assert apt_update_retry in bootstrap_script

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -798,6 +798,8 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
 
     assert bootstrap_mode == "0755"
     assert "missing_packages+=(git ca-certificates)" in bootstrap_script
+    assert "for package in rpi-connect wayvnc wfplug-connect" in bootstrap_script
+    assert "rpi-connect-lite" not in bootstrap_script
     apt_update_retry = "apt-get update || { sleep 10; apt-get update; }"
     assert apt_update_retry in bootstrap_script
     assert "apt-get install -y --no-install-recommends" in bootstrap_script


### PR DESCRIPTION
## Summary
- install full Raspberry Pi Connect packages from the RPi image bootstrap by default
- explicitly include wayvnc and wfplug-connect because bootstrap uses --no-install-recommends
- add a regression assertion that the bootstrap does not fall back to rpi-connect-lite

## Tests
- `ARTHEXIS_SQLITE_TEST_PATH=$env:TEMP\arthexis-imager-test-<pid>.sqlite3 ARTHEXIS_SQLITE_PATH=$env:TEMP\arthexis-imager-db-<pid>.sqlite3 python -m pytest apps/imager/tests/test_imager_command.py -q` (75 passed from main checkout)
- `python -m pytest apps/imager/tests/test_imager_command.py::test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided -q` (1 passed from clean PR worktree)