### PR TITLE
Fix delegated upgrade fallback

### DIFF
--- a/apps/core/tests/test_delegated_upgrade_scripts.py
+++ b/apps/core/tests/test_delegated_upgrade_scripts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gate_markers import gate
+
+
+pytestmark = [gate.upgrade]
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _script(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_delegated_upgrade_passes_virtualenv_to_transient_unit() -> None:
+    script = _script("scripts/delegated-upgrade.sh")
+
+    assert 'PYTHON_BIN="$VENV_BIN/python"' in script
+    assert '--setenv "ARTHEXIS_PYTHON_BIN=$PYTHON_BIN"' in script
+    assert '--setenv "VIRTUAL_ENV=$VENV_DIR"' in script
+    assert '--setenv "PATH=$VENV_BIN:${PATH:-' in script
+    assert script.index('--setenv "ARTHEXIS_PYTHON_BIN=$PYTHON_BIN"') < script.index(
+        'DELEGATED_CMD+=("$WATCH_HELPER")'
+    )
+
+
+def test_watch_upgrade_exports_virtualenv_for_direct_invocations() -> None:
+    script = _script("scripts/helpers/watch-upgrade.sh")
+
+    assert 'export ARTHEXIS_PYTHON_BIN="$VENV_BIN/python"' in script
+    assert 'export VIRTUAL_ENV="${VIRTUAL_ENV:-$VENV_DIR}"' in script
+    assert 'export PATH="$VENV_BIN:${PATH:-' in script
+
+
+def test_predeploy_orchestrator_stops_service_stack_before_migrations() -> None:
+    script = _script("scripts/helpers/predeploy-migrate-orchestrator.sh")
+
+    assert '. "$BASE_DIR/scripts/helpers/service_manager.sh"' in script
+    assert "control_service_stack stop" in script
+    assert "trap cleanup_service_stack EXIT" in script
+    assert "control_service_stack start" in script
+    main_start = script.index('log_event "deploy_orchestration" "start"')
+    stop_index = script.index("control_service_stack stop", main_start)
+    migrate_index = script.index("run_predeploy_migrations", stop_index)
+    deploy_index = script.index(
+        'if [ -x "${DEPLOY_CMD[0]}" ]; then'
+    )
+    start_index = script.index("control_service_stack start", deploy_index)
+
+    assert stop_index < migrate_index < deploy_index < start_index

--- a/apps/release/management/commands/release.py
+++ b/apps/release/management/commands/release.py
@@ -435,9 +435,9 @@ class Command(BaseCommand):
         installed_version = self._resolve_installed_version(options.get("installed_version"))
         if not RELEASE_VERSION_PATTERN.fullmatch(installed_version):
             raise BundleVerificationError(f"Invalid installed version: {installed_version!r}")
-        bundle_dir = self._resolve_bundle_dir(target_version, options.get("bundle_dir"))
 
         try:
+            bundle_dir = self._resolve_bundle_dir(target_version, options.get("bundle_dir"))
             self._verify_bundle(bundle_dir)
             if installed_version == target_version:
                 call_command("migrate", "--noinput", stdout=self.stdout, stderr=self.stderr)
@@ -462,6 +462,15 @@ class Command(BaseCommand):
         except BundleVerificationError as exc:
             if bool(options.get("strict")):
                 raise
+            if installed_version == target_version:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"{exc}. Falling back to Django migration check."
+                    )
+                )
+                call_command("migrate", "--check", stdout=self.stdout, stderr=self.stderr)
+                return
+
             self.stderr.write(self.style.WARNING(f"{exc}. Falling back to Django migrate."))
             call_command("migrate", "--noinput", stdout=self.stdout, stderr=self.stderr)
             call_command("migrate", "--check", stdout=self.stdout, stderr=self.stderr)

--- a/apps/release/tests/test_release_command.py
+++ b/apps/release/tests/test_release_command.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from apps.release import DEFAULT_PACKAGE
+from apps.release.management.commands import release as release_command
 from apps.release.services.builder import (
     _git_modified_paths,
     _pep639_license_metadata,
@@ -264,3 +265,34 @@ def test_build_rejects_unapproved_package_test_command(
             twine=False,
             package=package,
         )
+
+
+def test_apply_migrations_same_version_missing_bundle_uses_check_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source checkouts without release bundles should avoid write migrations."""
+
+    command = release_command.Command()
+    calls: list[tuple[str, ...]] = []
+
+    def fail_bundle_dir(*args, **kwargs):
+        raise release_command.BundleVerificationError("Bundle directory not found")
+
+    monkeypatch.setattr(command, "_resolve_bundle_dir", fail_bundle_dir)
+    monkeypatch.setattr(
+        release_command,
+        "call_command",
+        lambda *args, **kwargs: calls.append(tuple(str(arg) for arg in args)),
+    )
+
+    command._handle_apply_migrations(
+        {
+            "target_version": "1.2.3",
+            "installed_version": "1.2.3",
+            "bundle_dir": None,
+            "strict": False,
+            "skip_data_transforms": False,
+        }
+    )
+
+    assert calls == [("migrate", "--check")]

--- a/docs/auto-upgrade.md
+++ b/docs/auto-upgrade.md
@@ -44,13 +44,15 @@ delegated systemd unit is launched, and what to check if something fails.
    - `WorkingDirectory` to the project root so relative commands like
      `./upgrade.sh` resolve correctly.
    - `ARTHEXIS_BASE_DIR` and `ARTHEXIS_LOG_DIR` for the watcher.
+   - `ARTHEXIS_PYTHON_BIN`, `VIRTUAL_ENV`, and `PATH` when the repository
+     virtualenv exists, so predeploy checks use suite dependencies.
    - `StandardOutput`/`StandardError` appended to
      `logs/delegated-upgrade.log` for easy inspection.
 3. The transient unit runs `/usr/local/bin/watch-upgrade`, which:
-   - Stops the managed service.
+   - Stops the managed service stack before predeploy migration checks.
    - Executes `upgrade.sh` (default `--stable`; Celery can pass `--regular` or
      `--latest`).
-   - Restarts the service and exits with the upgrade status.
+   - Restarts the service stack and exits with the upgrade status.
 4. Celery schedules a post-upgrade health check after the run to confirm HTTP
    200 responses and records any failures.
 

--- a/scripts/delegated-upgrade.sh
+++ b/scripts/delegated-upgrade.sh
@@ -46,6 +46,15 @@ fi
 
 RUN_USER="$(resolve_run_user)"
 RUN_HOME="$(resolve_home_dir "$RUN_USER")"
+VENV_DIR="$BASE_DIR/.venv"
+VENV_BIN="$VENV_DIR/bin"
+PYTHON_BIN=""
+
+if [ -n "${ARTHEXIS_PYTHON_BIN:-}" ] && [ -x "$ARTHEXIS_PYTHON_BIN" ]; then
+  PYTHON_BIN="$ARTHEXIS_PYTHON_BIN"
+elif [ -x "$VENV_BIN/python" ]; then
+  PYTHON_BIN="$VENV_BIN/python"
+fi
 
 mkdir -p "$LOG_DIR"
 
@@ -93,8 +102,20 @@ fi
 DELEGATED_CMD+=(
   --setenv "ARTHEXIS_BASE_DIR=$BASE_DIR"
   --setenv "ARTHEXIS_LOG_DIR=$LOG_DIR"
-  "$WATCH_HELPER"
 )
+
+if [ -n "$PYTHON_BIN" ]; then
+  DELEGATED_CMD+=(--setenv "ARTHEXIS_PYTHON_BIN=$PYTHON_BIN")
+fi
+
+if [ -d "$VENV_DIR" ]; then
+  DELEGATED_CMD+=(
+    --setenv "VIRTUAL_ENV=$VENV_DIR"
+    --setenv "PATH=$VENV_BIN:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+  )
+fi
+
+DELEGATED_CMD+=("$WATCH_HELPER")
 
 if [ -n "$SERVICE_NAME" ]; then
   DELEGATED_CMD+=("$SERVICE_NAME")

--- a/scripts/helpers/predeploy-migrate-orchestrator.sh
+++ b/scripts/helpers/predeploy-migrate-orchestrator.sh
@@ -20,8 +20,11 @@ DEPLOY_CMD=("$@")
 
 # shellcheck source=scripts/helpers/common.sh
 . "$BASE_DIR/scripts/helpers/common.sh"
+# shellcheck source=scripts/helpers/service_manager.sh
+. "$BASE_DIR/scripts/helpers/service_manager.sh"
 # shellcheck source=scripts/helpers/runserver_preflight.sh
 . "$BASE_DIR/scripts/helpers/runserver_preflight.sh"
+SERVICE_STACK_STOPPED=0
 
 log_event() {
   local phase="$1"
@@ -33,11 +36,16 @@ log_event() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$phase" "$status" "$started_at" "$ended_at" "${elapsed:-0}"
 }
 
-control_service() {
+control_unit() {
   local action="$1"
   local unit="$2"
 
   if [ -z "$unit" ] || ! command -v systemctl >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if declare -F _arthexis_systemd_unit_present >/dev/null 2>&1 \
+    && ! _arthexis_systemd_unit_present "$unit"; then
     return 0
   fi
 
@@ -47,6 +55,31 @@ control_service() {
   fi
 
   "${runner[@]}" "$action" "$unit" || true
+}
+
+control_service_stack() {
+  local action="$1"
+  local service_name="$2"
+  local unit
+
+  if [ -z "$service_name" ]; then
+    return 0
+  fi
+
+  while IFS= read -r unit; do
+    control_unit "$action" "$unit"
+  done < <(arthexis_service_unit_names "$service_name" true true true true)
+}
+
+cleanup_service_stack() {
+  local status=$?
+
+  if [ "$SERVICE_STACK_STOPPED" -eq 1 ]; then
+    control_service_stack start "$SERVICE_NAME"
+    SERVICE_STACK_STOPPED=0
+  fi
+
+  exit "$status"
 }
 
 run_predeploy_migrations() {
@@ -117,10 +150,14 @@ started_at_epoch="$(date +%s)"
 started_at_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 log_event "deploy_orchestration" "start" "$started_at_iso" "" 0
 
-run_predeploy_migrations
-
 log_event "service_switch" "start" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "" 0
-control_service stop "$SERVICE_NAME"
+trap cleanup_service_stack EXIT
+control_service_stack stop "$SERVICE_NAME"
+if [ -n "$SERVICE_NAME" ]; then
+  SERVICE_STACK_STOPPED=1
+fi
+
+run_predeploy_migrations
 
 STATUS=0
 if [ -x "${DEPLOY_CMD[0]}" ]; then
@@ -130,7 +167,8 @@ else
   STATUS=1
 fi
 
-control_service start "$SERVICE_NAME"
+control_service_stack start "$SERVICE_NAME"
+SERVICE_STACK_STOPPED=0
 
 ended_at_epoch="$(date +%s)"
 ended_at_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/helpers/watch-upgrade.sh
+++ b/scripts/helpers/watch-upgrade.sh
@@ -14,6 +14,17 @@ fi
 BASE_DIR="${ARTHEXIS_BASE_DIR:-$(pwd)}"
 LOG_DIR="${ARTHEXIS_LOG_DIR:-$BASE_DIR/logs}"
 LOG_FILE="${LOG_DIR}/watch-upgrade.log"
+VENV_DIR="$BASE_DIR/.venv"
+VENV_BIN="$VENV_DIR/bin"
+
+if [ -z "${ARTHEXIS_PYTHON_BIN:-}" ] && [ -x "$VENV_BIN/python" ]; then
+  export ARTHEXIS_PYTHON_BIN="$VENV_BIN/python"
+fi
+
+if [ -d "$VENV_DIR" ]; then
+  export VIRTUAL_ENV="${VIRTUAL_ENV:-$VENV_DIR}"
+  export PATH="$VENV_BIN:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+fi
 
 log() {
   echo "$(date --iso-8601=seconds) $*" >&2


### PR DESCRIPTION
## Summary
- pass the repo virtualenv into delegated upgrade systemd units and direct watcher runs
- stop the managed service stack before predeploy migration checks and restart it on failure
- let missing same-version release bundles fall back to a read-only migration check
- document the delegated upgrade environment and service-stack behavior

## Verification
- `.venv\\Scripts\\python.exe manage.py test run -- apps/core/tests/test_delegated_upgrade_scripts.py apps/release/tests/test_release_command.py`
- `C:\\Program Files\\Git\\bin\\bash.exe -n scripts/delegated-upgrade.sh scripts/helpers/watch-upgrade.sh scripts/helpers/predeploy-migrate-orchestrator.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Enhances the delegated upgrade process to support Python virtual environment propagation and improves service lifecycle management during migrations.

## Key Changes

### Virtual Environment Support in Upgrade Scripts

- **delegated-upgrade.sh**: Added virtualenv detection and propagation logic. Automatically discovers local `.venv` directory and exports `ARTHEXIS_PYTHON_BIN`, `VIRTUAL_ENV`, and `PATH` to delegated upgrade systemd units.

- **watch-upgrade.sh**: Implements virtualenv bootstrap for direct script invocations. Detects local `.venv` and sets up environment variables to ensure the correct Python binary is used when running upgrade operations directly.

### Service Stack Lifecycle Management

- **predeploy-migrate-orchestrator.sh**: Restructured service management to stop the managed service stack before running migrations and restart it afterward. Introduces new functions (`control_unit`, `control_service_stack`, `cleanup_service_stack`) with systemd availability guards to ensure robust operation. Uses EXIT trap to guarantee stack restart even if migrations fail.

### Same-Version Release Fallback

- **release.py**: When a `BundleVerificationError` occurs during migration setup and the installed version matches the target version, the process now falls back to a read-only migration check (`migrate --check`) instead of attempting a full migration. This handles the case where release bundles for the same version are missing without failing the upgrade.

### Test Coverage

- **test_delegated_upgrade_scripts.py**: New test module with three tests validating:
  - Virtualenv variable exports in delegated upgrade units
  - Virtualenv exports for direct watcher invocations
  - Service stack stop/restart ordering in predeploy orchestrator

- **test_release_command.py**: Added test for same-version missing bundle scenario to verify fallback to check-only migration behavior.

### Documentation

- **auto-upgrade.md**: Updated to document virtualenv environment propagation and new service stack lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->