### PR TITLE
Fix RFID fallback authorization test isolation

### DIFF
--- a/apps/ocpp/tests/handlers/test_csms_action_handlers.py
+++ b/apps/ocpp/tests/handlers/test_csms_action_handlers.py
@@ -1,5 +1,6 @@
 import pytest
 from channels.db import database_sync_to_async
+from django.core.cache import cache
 
 from apps.cards.models import RFID
 from apps.features.models import Feature
@@ -21,6 +22,7 @@ async def test_authorize_handler_contract_uses_existing_energy_account_rules():
         charger_id="CP-EA-HANDLER",
         require_rfid=True,
     )
+    await database_sync_to_async(cache.clear)()
     await database_sync_to_async(Feature.objects.update_or_create)(
         slug="energy-accounts",
         defaults={

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -7,10 +7,12 @@ from unittest.mock import AsyncMock
 import anyio
 import pytest
 from channels.db import database_sync_to_async
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+from apps.features.models import Feature
 from apps.flows.models import Transition
 from apps.ocpp import call_error_handlers, store
 from apps.ocpp.call_result_handlers.profiles import handle_clear_charging_profile_result
@@ -101,6 +103,14 @@ def charger_factory():
         return await database_sync_to_async(Charger.objects.create)(**kwargs)
 
     return _create_charger
+
+
+async def _disable_rfid_fallback_account_feature() -> None:
+    await database_sync_to_async(cache.clear)()
+    await database_sync_to_async(Feature.objects.update_or_create)(
+        slug="rfid-fallback-account",
+        defaults={"display": "RFID Fallback Account", "is_enabled": False},
+    )
 
 
 def _reset_pending_calls() -> None:
@@ -1652,6 +1662,7 @@ async def test_transaction_event_updates_request_status(monkeypatch, charger_fac
 @pytest.mark.anyio
 @pytest.mark.django_db(transaction=True)
 async def test_transaction_event_does_not_start_request_when_authorization_fails(charger_factory):
+    await _disable_rfid_fallback_account_feature()
     charger = await charger_factory(
         charger_id="CP-TRX-RFID",
         authorization_policy=Charger.AuthorizationPolicy.STRICT,
@@ -1712,6 +1723,7 @@ async def test_transaction_event_does_not_start_request_when_authorization_fails
 @pytest.mark.anyio
 @pytest.mark.django_db(transaction=True)
 async def test_start_transaction_rejection_creates_transaction_record(charger_factory):
+    await _disable_rfid_fallback_account_feature()
     charger = await charger_factory(
         charger_id="CP-START-REJECT",
         authorization_policy=Charger.AuthorizationPolicy.STRICT,


### PR DESCRIPTION
## Summary
- clear cached feature state before the OCPP energy-account handler contract test
- explicitly disable the RFID fallback-account feature in strict rejection tests
- keep fallback-enabled behavior covered by the dedicated authorization policy tests

## Validation
- .\.venv\Scripts\python.exe -m ruff check apps\ocpp\tests\handlers\test_csms_action_handlers.py apps\ocpp\tests\test_ocpp_handlers.py
- .\.venv\Scripts\python.exe manage.py test run -- apps\ocpp\tests\handlers\test_csms_action_handlers.py::test_authorize_handler_contract_uses_existing_energy_account_rules apps\ocpp\tests\test_ocpp_handlers.py::test_transaction_event_does_not_start_request_when_authorization_fails apps\ocpp\tests\test_ocpp_handlers.py::test_start_transaction_rejection_creates_transaction_record
- .\.venv\Scripts\python.exe manage.py check --fail-level ERROR
- git diff --check

Closes #7674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes test isolation issues in the OCPP authorization test suite that were causing health check failures (issue #7674). The changes ensure that RFID fallback feature state does not leak between tests by introducing explicit cache clearing and feature flag management.

## Changes

**apps/ocpp/tests/handlers/test_csms_action_handlers.py**
- Added cache clearing at the start of `test_authorize_handler_contract_uses_existing_energy_account_rules` to ensure clean test state for energy account rules validation

**apps/ocpp/tests/test_ocpp_handlers.py**
- Created a test helper `_disable_rfid_fallback_account_feature` that explicitly disables the RFID fallback-account feature flag by clearing the Django cache and updating/creating the feature flag
- Applied this helper in two tests (`test_transaction_event_does_not_start_request_when_authorization_fails` and `test_start_transaction_rejection_creates_transaction_record`) to ensure strict rejection behavior is tested with fallback disabled
- Added necessary imports for Django cache and the Feature model

## Impact

These changes isolate test state to prevent the RFID fallback feature flag from causing test interference. Fallback-enabled behavior continues to be covered by dedicated authorization policy tests, while these tests now explicitly validate the strict rejection path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->