### PR TITLE
Require Agent/Hook permissions for skill package imports

### DIFF
--- a/apps/skills/admin.py
+++ b/apps/skills/admin.py
@@ -79,10 +79,22 @@ class SkillAdmin(admin.ModelAdmin):
             f"{file_opts.app_label}.{action}_{file_opts.model_name}"
             for action in ("add", "change", "delete")
         ]
+        agent_opts = Agent._meta
+        required_agent_perms = [
+            f"{agent_opts.app_label}.{action}_{agent_opts.model_name}"
+            for action in ("add", "change")
+        ]
+        hook_opts = Hook._meta
+        required_hook_perms = [
+            f"{hook_opts.app_label}.{action}_{hook_opts.model_name}"
+            for action in ("add", "change")
+        ]
         return (
             self.has_add_permission(request)
             and self.has_change_permission(request)
-            and request.user.has_perms(required_file_perms)
+            and request.user.has_perms(
+                required_file_perms + required_agent_perms + required_hook_perms,
+            )
         )
 
     def import_package_view(self, request: HttpRequest):

--- a/apps/skills/tests/test_admin.py
+++ b/apps/skills/tests/test_admin.py
@@ -381,6 +381,36 @@ def test_import_package_blocks_staff_without_add_and_change_permissions(
     assert not Skill.objects.filter(slug="blocked-import").exists()
 
 
+def test_import_package_blocks_staff_without_agent_and_hook_permissions(
+    client,
+    django_user_model,
+):
+    user = django_user_model.objects.create_user(
+        username="skill-import-missing-agent-hook-perms",
+        password="pw",
+        is_staff=True,
+    )
+    skill_and_file_perms = Permission.objects.filter(
+        codename__in=(
+            "add_skill",
+            "change_skill",
+            "add_skillfile",
+            "change_skillfile",
+            "delete_skillfile",
+        ),
+    )
+    user.user_permissions.add(*skill_and_file_perms)
+    client.force_login(user)
+
+    response = client.post(
+        reverse("admin:skills_skill_import_package"),
+        {"action": "preview", "package": _valid_package_upload("blocked-agent-hook-perms")},
+    )
+
+    assert response.status_code == 403
+    assert not Skill.objects.filter(slug="blocked-agent-hook-perms").exists()
+
+
 def test_import_package_blocks_staff_without_skill_file_permissions(
     client,
     django_user_model,


### PR DESCRIPTION
### Motivation

- A package import flow allowed uploaded operator framework packages to create or overwrite `Agent` and `Hook` records (including executable hook `command` entries) while the admin import check only required `Skill` and `SkillFile` permissions, creating a privilege-bypass risk. 

### Description

- Tighten `SkillAdmin.has_import_package_permission()` to require `add`/`change` permissions for both `Agent` and `Hook` in addition to existing `Skill` and `SkillFile` permission checks. 
- Add a focused regression test `test_import_package_blocks_staff_without_agent_and_hook_permissions` in `apps/skills/tests/test_admin.py` that asserts a staff user with only `Skill` + `SkillFile` permissions is denied package preview/import (`403`).
- Change is minimal and preserves the existing import logic and dry-run preview behavior for users who hold the required model permissions. 

### Testing

- Ran the skill admin test module with `manage.py test run -- apps/skills/tests/test_admin.py` and the suite for that file completed successfully with `11 passed`.
- Environment setup commands used during verification were `./install.sh --terminal` and `./env-refresh.sh --deps-only` to ensure test dependencies and virtualenv were prepared before running the tests.
- The new regression test verifies the authorization restriction and passed as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb62200c0083268d98b8e150b9830f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Fix: Enforce Agent/Hook Permissions for Skill Package Imports

### Changes Made

**apps/skills/admin.py** - Updated `SkillAdmin.has_import_package_permission()` to require additional model permissions:
- Builds required permission strings for `Agent` (add/change) and `Hook` (add/change)
- Aggregates these with the existing `SkillFile` (add/change/delete) permission checks
- Enforces that users have all aggregated permissions before allowing package preview/import
- Previously only checked `Skill` (add/change) and `SkillFile` (add/change/delete) permissions

### Security Impact

This change closes a privilege-bypass vulnerability where staff users with only Skill and SkillFile permissions could import operator framework packages and create or overwrite Agent and Hook records—including executable hook command entries—without the required permissions for those models.

### Testing

**apps/skills/tests/test_admin.py** - Added regression test `test_import_package_blocks_staff_without_agent_and_hook_permissions`:
- Creates a staff user with Skill and SkillFile permissions only
- Attempts to preview a skill package import
- Asserts HTTP 403 response and verifies no Skill object is created
- Validates the new permission enforcement directly

### Implementation Details

The change is minimal and preserves:
- Existing import logic for authorized users
- Dry-run preview behavior for users with required permissions
- All other import package functionality

All skill admin tests pass (11 tests), including the new regression test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->