### PR TITLE
Fix reserved-node hijack by disabling first-contact placeholder claim

### DIFF
--- a/apps/nodes/tests/test_register_node.py
+++ b/apps/nodes/tests/test_register_node.py
@@ -134,8 +134,8 @@ def test_register_node_updates_mesh_identity_fields(admin_user):
 
 
 @pytest.mark.django_db
-def test_register_node_claims_reserved_placeholder_by_hostname(admin_user):
-    """First contact from a reserved image should reuse and clear its peer row."""
+def test_register_node_does_not_claim_reserved_placeholder_by_hostname(admin_user):
+    """First contact must not claim reserved placeholder rows by hostname alone."""
 
     reserved = Node.objects.create(
         hostname="gway-004",
@@ -163,12 +163,11 @@ def test_register_node_claims_reserved_placeholder_by_hostname(admin_user):
 
     assert response.status_code == 200
     body = json.loads(response.content.decode())
-    assert body["id"] == reserved.id
+    assert body["id"] != reserved.id
     reserved.refresh_from_db()
-    assert reserved.reserved is False
-    assert reserved.mac_address == "aa:bb:cc:dd:ee:04"
-    assert reserved.trusted is True
-    assert Node.objects.count() == 1
+    assert reserved.reserved is True
+    assert reserved.mac_address == ""
+    assert Node.objects.count() == 2
 
 
 @pytest.mark.django_db
@@ -234,47 +233,6 @@ def test_find_reserved_node_uses_address_fallback_only_without_hostname():
     )
 
     assert match == reserved
-
-
-@pytest.mark.django_db
-def test_register_node_reports_conflict_when_reserved_placeholder_was_already_claimed(
-    admin_user, monkeypatch
-):
-    reserved = Node.objects.create(
-        hostname="gway-004",
-        address="10.42.0.4",
-        ipv4_address="10.42.0.4",
-        current_relation=Node.Relation.PEER,
-        reserved=True,
-    )
-    stale_reserved = Node.objects.get(pk=reserved.pk)
-    Node.objects.filter(pk=reserved.pk).update(reserved=False)
-    monkeypatch.setattr(
-        handlers,
-        "_find_reserved_node_for_payload",
-        lambda *_args, **_kwargs: stale_reserved,
-    )
-    payload = {
-        "hostname": "gway-004",
-        "mac_address": "aa:bb:cc:dd:ee:04",
-        "address": "10.42.0.4",
-        "ipv4_address": "10.42.0.4",
-        "port": 8888,
-        "current_relation": "Peer",
-    }
-
-    factory = RequestFactory()
-    request = _build_request(factory, payload)
-    request.user = admin_user
-    request._cached_user = admin_user
-
-    response = register_node(request)
-
-    reserved.refresh_from_db()
-    assert response.status_code == 409
-    assert reserved.reserved is False
-    assert reserved.mac_address == ""
-    assert Node.objects.count() == 1
 
 
 @pytest.mark.django_db

--- a/apps/nodes/views/registration/handlers.py
+++ b/apps/nodes/views/registration/handlers.py
@@ -618,12 +618,6 @@ def register_node(request):
         else None
     )
     existing_node = Node.objects.filter(mac_address=mac_address).first()
-    if existing_node is None:
-        existing_node = _find_reserved_node_for_payload(
-            payload,
-            address_value=address_value,
-            ipv4_value=ipv4_value,
-        )
     relation_value = payload.relation_value
     if relation_value == Node.Relation.SELF and payload.host_instance_id:
         other_self_exists = (


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated attackers from claiming predictable reserved node placeholders by removing the weak first-contact matching path that allowed hostname/address-based claims. 
- Preserve the stronger trust model where node identity is bound to MAC or an enrollment token rather than attacker-supplied public keys on first contact.

### Description

- Removed the registration fallback that searched reserved placeholders when no existing node matched by MAC, so `register_node` now only reuses a node when the MAC address already matches. 
- Updated tests in `apps/nodes/tests/test_register_node.py` to assert that reserved placeholders are not claimed by hostname-only first-contact traffic and adjusted expectations accordingly. 
- Deleted the obsolete race/conflict test that depended on the removed reserved-claim code path.

### Testing

- Attempted to run unit tests with `.venv/bin/python manage.py test run -- apps/nodes/tests/test_register_node.py`, but execution failed because `.venv` is not present in the environment. 
- Attempted to bootstrap the environment with `./install.sh`, but the installer failed due to missing system dependency `redis-server`, so the test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa42b4dde083269a8584a36b15dc55)