### PR TITLE
repos: require trusted or widely approved monitor issues

### DIFF
--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -368,7 +368,20 @@ def evaluate_readiness() -> dict[str, Any]:
 
 def _trusted_issue_authors(task: GitHubMonitorTask) -> set[str]:
     configured = getattr(settings, "GITHUB_MONITOR_TRUSTED_AUTHORS", ())
-    trusted = {str(author).strip().lower() for author in configured if str(author).strip()}
+    if isinstance(configured, str):
+        configured_authors = configured.replace(",", " ").split()
+    elif isinstance(configured, Mapping):
+        configured_authors = configured.values()
+    else:
+        try:
+            configured_authors = iter(configured)
+        except TypeError:
+            configured_authors = ()
+    trusted = {
+        str(author).strip().lower()
+        for author in configured_authors
+        if str(author).strip()
+    }
     repository_owner = str(task.repository.owner or "").strip().lower()
     if repository_owner:
         trusted.add(repository_owner)

--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -46,8 +46,7 @@ REQUEUEABLE_MONITOR_STATUSES = {
     GitHubMonitorItem.Status.TIMED_OUT,
     GitHubMonitorItem.Status.FAILED,
 }
-TRUSTED_ISSUE_AUTHOR = "arthexis"
-TRUSTED_ISSUE_APPROVALS = 1000
+DEFAULT_TRUSTED_ISSUE_APPROVALS = 1000
 
 
 GITHUB_MONITOR_FEATURE_FIELDS = {
@@ -367,6 +366,27 @@ def evaluate_readiness() -> dict[str, Any]:
     }
 
 
+def _trusted_issue_authors(task: GitHubMonitorTask) -> set[str]:
+    configured = getattr(settings, "GITHUB_MONITOR_TRUSTED_AUTHORS", ())
+    trusted = {str(author).strip().lower() for author in configured if str(author).strip()}
+    repository_owner = str(task.repository.owner or "").strip().lower()
+    if repository_owner:
+        trusted.add(repository_owner)
+    return trusted
+
+
+def _trusted_issue_approval_threshold() -> int:
+    raw_threshold = getattr(
+        settings,
+        "GITHUB_MONITOR_TRUSTED_ISSUE_APPROVALS",
+        DEFAULT_TRUSTED_ISSUE_APPROVALS,
+    )
+    try:
+        return max(0, int(raw_threshold))
+    except (TypeError, ValueError):
+        return DEFAULT_TRUSTED_ISSUE_APPROVALS
+
+
 def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
     if "pull_request" in item:
         return False
@@ -375,12 +395,16 @@ def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
     marker = (task.issue_marker or "").strip()
     if marker and marker not in str(item.get("body") or ""):
         return False
-    author_login = str((item.get("user") or {}).get("login") or "").strip().lower()
     try:
+        author_login = str((item.get("user") or {}).get("login") or "").strip().lower()
         approvals = int((item.get("reactions") or {}).get("+1") or 0)
-    except (TypeError, ValueError):
+    except (AttributeError, TypeError, ValueError):
+        author_login = ""
         approvals = 0
-    if author_login != TRUSTED_ISSUE_AUTHOR and approvals < TRUSTED_ISSUE_APPROVALS:
+    if (
+        author_login not in _trusted_issue_authors(task)
+        and approvals < _trusted_issue_approval_threshold()
+    ):
         return False
     return isinstance(item.get("number"), int)
 

--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -47,6 +47,7 @@ REQUEUEABLE_MONITOR_STATUSES = {
     GitHubMonitorItem.Status.FAILED,
 }
 DEFAULT_TRUSTED_ISSUE_APPROVALS = 1000
+TRUSTED_AUTHOR_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
 
 GITHUB_MONITOR_FEATURE_FIELDS = {
@@ -371,7 +372,9 @@ def _trusted_issue_authors(task: GitHubMonitorTask) -> set[str]:
     if isinstance(configured, str):
         configured_authors = configured.replace(",", " ").split()
     elif isinstance(configured, Mapping):
-        configured_authors = configured.values()
+        configured_authors = [
+            author for author, enabled in configured.items() if enabled
+        ]
     else:
         try:
             configured_authors = iter(configured)
@@ -409,13 +412,19 @@ def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
     if marker and marker not in str(item.get("body") or ""):
         return False
     try:
-        author_login = str((item.get("user") or {}).get("login") or "").strip().lower()
-        approvals = int((item.get("reactions") or {}).get("+1") or 0)
+        author_login = (
+            str((item.get("user") or {}).get("login") or "").strip().lower()
+        )
     except (AttributeError, TypeError, ValueError):
         author_login = ""
+    try:
+        approvals = int((item.get("reactions") or {}).get("+1") or 0)
+    except (AttributeError, TypeError, ValueError):
         approvals = 0
+    author_association = str(item.get("author_association") or "").strip().upper()
     if (
         author_login not in _trusted_issue_authors(task)
+        and author_association not in TRUSTED_AUTHOR_ASSOCIATIONS
         and approvals < _trusted_issue_approval_threshold()
     ):
         return False

--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -46,6 +46,8 @@ REQUEUEABLE_MONITOR_STATUSES = {
     GitHubMonitorItem.Status.TIMED_OUT,
     GitHubMonitorItem.Status.FAILED,
 }
+TRUSTED_ISSUE_AUTHOR = "arthexis"
+TRUSTED_ISSUE_APPROVALS = 1000
 
 
 GITHUB_MONITOR_FEATURE_FIELDS = {
@@ -372,6 +374,13 @@ def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
         return False
     marker = (task.issue_marker or "").strip()
     if marker and marker not in str(item.get("body") or ""):
+        return False
+    author_login = str((item.get("user") or {}).get("login") or "").strip().lower()
+    try:
+        approvals = int((item.get("reactions") or {}).get("+1") or 0)
+    except (TypeError, ValueError):
+        approvals = 0
+    if author_login != TRUSTED_ISSUE_AUTHOR and approvals < TRUSTED_ISSUE_APPROVALS:
         return False
     return isinstance(item.get("number"), int)
 

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -43,6 +43,52 @@ def _issue(number: int, title: str, marker: str) -> dict[str, object]:
 
 
 @pytest.mark.django_db
+def test_sync_monitor_items_ignores_unapproved_untrusted_issues(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        71, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = {"login": "outsider"}
+    issue["reactions"] = {"+1": 999}
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 0
+    assert GitHubMonitorItem.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_accepts_trusted_or_highly_approved_issues(monkeypatch):
+    _configure_defaults()
+    trusted = _issue(
+        72, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    trusted["user"] = {"login": "arthexis"}
+    trusted["reactions"] = {"+1": 0}
+    approved = _issue(
+        73, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    approved["user"] = {"login": "outsider"}
+    approved["reactions"] = {"+1": 1000}
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [trusted, approved],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 2
+    assert GitHubMonitorItem.objects.filter(issue_number=72).exists()
+    assert GitHubMonitorItem.objects.filter(issue_number=73).exists()
+
+
+@pytest.mark.django_db
 def test_configure_default_monitoring_writes_feature_tasks_and_policy_skills():
     result = github_monitor.configure_default_monitoring(
         repository="octo/demo",

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -141,10 +141,55 @@ def test_sync_monitor_items_accepts_string_configured_trusted_author(monkeypatch
 
 
 @pytest.mark.django_db
-def test_sync_monitor_items_rejects_malformed_trust_payloads(monkeypatch):
+def test_sync_monitor_items_accepts_mapping_configured_trusted_author(monkeypatch):
     _configure_defaults()
     issue = _issue(
         76, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = {"login": "release-bot"}
+    monkeypatch.setattr(
+        settings,
+        "GITHUB_MONITOR_TRUSTED_AUTHORS",
+        {"release-bot": True, "disabled-bot": False},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 1
+    assert GitHubMonitorItem.objects.filter(issue_number=76).exists()
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_accepts_repository_member_issue(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        77, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = {"login": "repo-member"}
+    issue["author_association"] = "MEMBER"
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 1
+    assert GitHubMonitorItem.objects.filter(issue_number=77).exists()
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_rejects_malformed_trust_payloads(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        78, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
     )
     issue["user"] = "octo"
     issue["reactions"] = "1000"

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -116,10 +116,35 @@ def test_sync_monitor_items_accepts_configured_trusted_author(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_sync_monitor_items_rejects_malformed_trust_payloads(monkeypatch):
+def test_sync_monitor_items_accepts_string_configured_trusted_author(monkeypatch):
     _configure_defaults()
     issue = _issue(
         75, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = {"login": "release-bot"}
+    monkeypatch.setattr(
+        settings,
+        "GITHUB_MONITOR_TRUSTED_AUTHORS",
+        "release-bot",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 1
+    assert GitHubMonitorItem.objects.filter(issue_number=75).exists()
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_rejects_malformed_trust_payloads(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        76, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
     )
     issue["user"] = "octo"
     issue["reactions"] = "1000"

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -39,6 +39,8 @@ def _issue(number: int, title: str, marker: str) -> dict[str, object]:
         "body": f"{marker}\n\nFailure body",
         "state": "open",
         "html_url": f"https://github.example/issues/{number}",
+        "user": {"login": "octo"},
+        "reactions": {"+1": 0},
     }
 
 
@@ -68,7 +70,7 @@ def test_sync_monitor_items_accepts_trusted_or_highly_approved_issues(monkeypatc
     trusted = _issue(
         72, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
     )
-    trusted["user"] = {"login": "arthexis"}
+    trusted["user"] = {"login": "octo"}
     trusted["reactions"] = {"+1": 0}
     approved = _issue(
         73, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
@@ -86,6 +88,51 @@ def test_sync_monitor_items_accepts_trusted_or_highly_approved_issues(monkeypatc
     assert result["matched"] == 2
     assert GitHubMonitorItem.objects.filter(issue_number=72).exists()
     assert GitHubMonitorItem.objects.filter(issue_number=73).exists()
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_accepts_configured_trusted_author(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        74, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = {"login": "release-bot"}
+    monkeypatch.setattr(
+        settings,
+        "GITHUB_MONITOR_TRUSTED_AUTHORS",
+        ["release-bot"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 1
+    assert GitHubMonitorItem.objects.filter(issue_number=74).exists()
+
+
+@pytest.mark.django_db
+def test_sync_monitor_items_rejects_malformed_trust_payloads(monkeypatch):
+    _configure_defaults()
+    issue = _issue(
+        75, github_monitor.INSTALL_HEALTH_TITLE, github_monitor.INSTALL_HEALTH_MARKER
+    )
+    issue["user"] = "octo"
+    issue["reactions"] = "1000"
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_repository_issues",
+        lambda **_: [issue],
+    )
+
+    result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
+
+    assert result["matched"] == 0
+    assert GitHubMonitorItem.objects.count() == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Motivation
- Prevent untrusted GitHub issue bodies from being automatically enqueued and launched into a local Codex/agent session by requiring either a trusted author or broad explicit community approval.
- Close the prompt-injection attack path where an attacker could open a matching issue and have its body forwarded as a prompt to a locally launched command.

### Description
- Added `TRUSTED_ISSUE_AUTHOR` and `TRUSTED_ISSUE_APPROVALS` constants and tightened `_issue_matches` to only accept issues that match title/marker and are either authored by `arthexis` or have at least `1000` `+1` reactions. (`apps/repos/github_monitor.py`).
- Added defensive parsing around `reactions['+1']` to avoid `TypeError`/`ValueError` on malformed payloads. (`apps/repos/github_monitor.py`).
- Added regression tests `test_sync_monitor_items_ignores_unapproved_untrusted_issues` and `test_sync_monitor_items_accepts_trusted_or_highly_approved_issues` to validate rejection/acceptance behavior. (`apps/repos/tests/test_gh_monitor.py`).
- Committed changes and updated test suite file, leaving the scheduled monitor behavior unchanged in this patch. (`git` changes include `apps/repos/github_monitor.py` and `apps/repos/tests/test_gh_monitor.py`).

### Testing
- Added unit tests under `apps/repos/tests/test_gh_monitor.py` to cover the new matching policy and they are included in the commit. 
- Attempted to run the repository test entrypoint `python3 manage.py test run -- apps/repos/tests/test_gh_monitor.py`, but execution was blocked by the repository environment guard because `.venv/bin/python` is not present and the repo requests running `./install.sh --terminal` first, so tests could not be run in this environment. 
- No other automated test runs were executed here due to the missing virtualenv; the new tests should be run in CI or a correctly provisioned dev environment using `.venv/bin/python manage.py test run -- apps/repos/tests/test_gh_monitor.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc589c4388326a73c1691f985e0ef)