### PR TITLE
Harden strict RFID fallback and change default auth policy to OPEN

### DIFF
--- a/apps/features/fixtures/features__rfid_fallback_account.json
+++ b/apps/features/fixtures/features__rfid_fallback_account.json
@@ -14,7 +14,7 @@
       "created_at": "2026-05-05T00:00:00Z",
       "display": "RFID Fallback Account",
       "is_deleted": false,
-      "is_enabled": true,
+      "is_enabled": false,
       "is_seed_data": true,
       "main_app": [
         "ocpp"

--- a/apps/ocpp/consumers/base/rfid.py
+++ b/apps/ocpp/consumers/base/rfid.py
@@ -229,6 +229,7 @@ class RfidMixin:
             and tag is not None
             and not tag_created
             and tag.allowed
+            and tag.released
         ):
             return AuthorizationDecision(
                 status="Accepted",

--- a/apps/ocpp/consumers/base/rfid.py
+++ b/apps/ocpp/consumers/base/rfid.py
@@ -66,7 +66,7 @@ class RfidMixin:
             RFID_FALLBACK_ACCOUNT_FEATURE_SLUG,
             cache_key="feature-enabled:rfid-fallback-account",
             timeout=300,
-            default=True,
+            default=False,
         )
 
     def _resolve_fallback_account(self) -> CustomerAccount:
@@ -226,7 +226,9 @@ class RfidMixin:
             fallback_enabled
             and policy == self.charger.AuthorizationPolicy.STRICT
             and id_tag
-            and (tag is None or tag.allowed)
+            and tag is not None
+            and not tag_created
+            and tag.allowed
         ):
             return AuthorizationDecision(
                 status="Accepted",

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -4,11 +4,15 @@ from django.conf import settings
 from django.urls import NoReverseMatch
 
 from apps.locale.models import Language
-from apps.sites.utils import SITE_OPERATOR_GROUP_NAME, user_in_charge_station_manager_group
+from apps.sites.utils import (
+    SITE_OPERATOR_GROUP_NAME,
+    user_in_charge_station_manager_group,
+)
 
 from .. import store
 from .base import *
 from .transaction import annotate_transaction_energy_bounds
+
 
 class Charger(Ownable):
     """Known charge point."""
@@ -499,7 +503,7 @@ class Charger(Ownable):
 
         return self.last_status_timestamp or self.last_heartbeat
 
-    def station_record(self) -> "Charger | None":
+    def station_record(self) -> Charger | None:
         """Return the aggregate station record for this charge point when available."""
 
         if self.connector_id is None:
@@ -512,7 +516,7 @@ class Charger(Ownable):
             .first()
         )
 
-    def offline_notification_source(self) -> "Charger":
+    def offline_notification_source(self) -> Charger:
         """Return the charger record supplying offline notification settings."""
 
         if self.email_when_offline or self.maintenance_email:
@@ -716,6 +720,8 @@ class Charger(Ownable):
         configured = str(getattr(settings, "OCPP_AUTHORIZATION_POLICY", "") or "").strip().lower()
         if configured in self.AuthorizationPolicy.values:
             return configured
+        # Keep legacy compatibility unless the deployment or charger explicitly
+        # selects stricter access control.
         return self.AuthorizationPolicy.OPEN
 
     @classmethod

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -716,7 +716,7 @@ class Charger(Ownable):
         configured = str(getattr(settings, "OCPP_AUTHORIZATION_POLICY", "") or "").strip().lower()
         if configured in self.AuthorizationPolicy.values:
             return configured
-        return self.AuthorizationPolicy.STRICT
+        return self.AuthorizationPolicy.OPEN
 
     @classmethod
     def sanitize_auto_location_name(cls, value: str) -> str:

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -715,11 +715,15 @@ class Charger(Ownable):
     def resolved_authorization_policy(self) -> str:
         """Return charger-level auth policy with global fallback."""
         explicit = str(self.authorization_policy or "").strip().lower()
-        if explicit in self.AuthorizationPolicy.values:
-            return explicit
+        if explicit:
+            if explicit in self.AuthorizationPolicy.values:
+                return explicit
+            return self.AuthorizationPolicy.STRICT
         configured = str(getattr(settings, "OCPP_AUTHORIZATION_POLICY", "") or "").strip().lower()
-        if configured in self.AuthorizationPolicy.values:
-            return configured
+        if configured:
+            if configured in self.AuthorizationPolicy.values:
+                return configured
+            return self.AuthorizationPolicy.STRICT
         # Keep legacy compatibility unless the deployment or charger explicitly
         # selects stricter access control.
         return self.AuthorizationPolicy.OPEN

--- a/apps/ocpp/tests/test_authorization_policy.py
+++ b/apps/ocpp/tests/test_authorization_policy.py
@@ -22,7 +22,7 @@ async def feature_cache_setup():
     )
     await database_sync_to_async(Feature.objects.update_or_create)(
         slug="rfid-fallback-account",
-        defaults={"display": "RFID Fallback Account", "is_enabled": True},
+        defaults={"display": "RFID Fallback Account", "is_enabled": False},
     )
 
 
@@ -80,10 +80,14 @@ async def _assert_fallback_transaction_bound(
 
 @pytest.mark.anyio
 @pytest.mark.django_db(transaction=True)
-async def test_authorization_policy_strict_accepts_unknown_tag_with_fallback_feature(
+async def test_authorization_policy_strict_rejects_unknown_tag_even_with_fallback_feature(
     feature_cache_setup,
     consumer_factory,
 ):
+    await database_sync_to_async(Feature.objects.update_or_create)(
+        slug="rfid-fallback-account",
+        defaults={"display": "RFID Fallback Account", "is_enabled": True},
+    )
     consumer = await consumer_factory(
         charger_id="CP-POLICY-STRICT",
         policy=Charger.AuthorizationPolicy.STRICT,
@@ -96,14 +100,10 @@ async def test_authorization_policy_strict_accepts_unknown_tag_with_fallback_fea
         "",
     )
 
-    assert result["idTagInfo"]["status"] == "Accepted"
+    assert result["idTagInfo"]["status"] == "Invalid"
 
     attempt = await database_sync_to_async(RFIDAttempt.objects.latest)("attempted_at")
-    assert attempt.payload["authorization_reason"] == "rfid_fallback_account_authorized"
-    account = await _fallback_account()
-    assert account.service_account is True
-    assert attempt.account_id == account.pk
-    assert await database_sync_to_async(account.rfids.filter(rfid="STRICT-UNKNOWN").exists)()
+    assert attempt.payload["authorization_reason"] == "strict_account_required"
 
 
 @pytest.mark.anyio
@@ -260,6 +260,10 @@ async def test_strict_fallback_binds_debt_account_for_transaction_flows(
     consumer_factory,
     flow,
 ):
+    await database_sync_to_async(Feature.objects.update_or_create)(
+        slug="rfid-fallback-account",
+        defaults={"display": "RFID Fallback Account", "is_enabled": True},
+    )
     consumer = await consumer_factory(
         charger_id=f"CP-POLICY-{flow.upper()}-FALLBACK",
         policy=Charger.AuthorizationPolicy.STRICT,
@@ -270,6 +274,7 @@ async def test_strict_fallback_binds_debt_account_for_transaction_flows(
     )
 
     if flow == "start_transaction":
+        await database_sync_to_async(RFID.objects.create)(rfid="START-FALLBACK", allowed=True, released=True)
         result = await consumer._handle_start_transaction_action(
             {
                 "idTag": "start-fallback",
@@ -288,6 +293,7 @@ async def test_strict_fallback_binds_debt_account_for_transaction_flows(
         )
         tag_rfid = "START-FALLBACK"
     else:
+        await database_sync_to_async(RFID.objects.create)(rfid="EVENT-FALLBACK", allowed=True, released=True)
         result = await consumer._handle_transaction_event_action(
             {
                 "eventType": "Started",

--- a/apps/ocpp/tests/test_authorization_policy.py
+++ b/apps/ocpp/tests/test_authorization_policy.py
@@ -68,13 +68,14 @@ async def _assert_fallback_transaction_bound(
     account: CustomerAccount,
     transaction: Transaction,
     tag_rfid: str,
+    discovered_via_ocpp: bool = False,
 ) -> None:
     assert transaction.account_id == account.pk
     attempt = await database_sync_to_async(RFIDAttempt.objects.latest)("attempted_at")
     assert attempt.account_id == account.pk
     assert attempt.transaction_id == transaction.pk
     tag = await database_sync_to_async(RFID.objects.get)(rfid=tag_rfid)
-    assert tag.discovered_via_ocpp is True
+    assert tag.discovered_via_ocpp is discovered_via_ocpp
     assert await database_sync_to_async(account.rfids.filter(pk=tag.pk).exists)()
 
 
@@ -101,6 +102,18 @@ async def test_authorization_policy_strict_rejects_unknown_tag_even_with_fallbac
     )
 
     assert result["idTagInfo"]["status"] == "Invalid"
+
+    repeat_result = await consumer._handle_authorize_action(
+        {"idTag": "strict-unknown"},
+        "msg-auth-policy-strict-repeat",
+        "",
+        "",
+    )
+
+    assert repeat_result["idTagInfo"]["status"] == "Invalid"
+    tag = await database_sync_to_async(RFID.objects.get)(rfid="STRICT-UNKNOWN")
+    assert tag.allowed is True
+    assert tag.released is False
 
     attempt = await database_sync_to_async(RFIDAttempt.objects.latest)("attempted_at")
     assert attempt.payload["authorization_reason"] == "strict_account_required"

--- a/apps/ocpp/tests/test_charger_model.py
+++ b/apps/ocpp/tests/test_charger_model.py
@@ -140,3 +140,19 @@ def test_resolved_authorization_policy_honors_global_setting():
     charger = Charger.objects.create(charger_id="CH-POLICY-STRICT")
 
     assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.STRICT
+
+
+@override_settings(OCPP_AUTHORIZATION_POLICY="strcit")
+def test_resolved_authorization_policy_invalid_global_setting_fails_closed():
+    charger = Charger.objects.create(charger_id="CH-POLICY-BAD-GLOBAL")
+
+    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.STRICT
+
+
+def test_resolved_authorization_policy_invalid_charger_setting_fails_closed():
+    charger = Charger.objects.create(
+        charger_id="CH-POLICY-BAD-LOCAL",
+        authorization_policy="strcit",
+    )
+
+    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.STRICT

--- a/apps/ocpp/tests/test_charger_model.py
+++ b/apps/ocpp/tests/test_charger_model.py
@@ -6,10 +6,9 @@ from django.test import override_settings
 from django.utils import timezone
 
 from apps.groups.constants import NETWORK_OPERATOR_GROUP_NAME, SITE_OPERATOR_GROUP_NAME
-from apps.ocpp.models import Charger
 from apps.groups.models import SecurityGroup
 from apps.nodes.models import Node
-
+from apps.ocpp.models import Charger
 
 pytestmark = pytest.mark.django_db
 

--- a/apps/ocpp/tests/test_charger_model.py
+++ b/apps/ocpp/tests/test_charger_model.py
@@ -2,6 +2,7 @@ import datetime as dt
 from datetime import timedelta
 
 import pytest
+from django.test import override_settings
 from django.utils import timezone
 
 from apps.groups.constants import NETWORK_OPERATOR_GROUP_NAME, SITE_OPERATOR_GROUP_NAME
@@ -127,3 +128,16 @@ def test_charge_station_manager_is_authorized_for_ws_auth(django_user_model):
     )
 
     assert charger.is_ws_user_authorized(manager) is True
+
+
+def test_resolved_authorization_policy_defaults_to_open():
+    charger = Charger.objects.create(charger_id="CH-POLICY-DEFAULT")
+
+    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.OPEN
+
+
+@override_settings(OCPP_AUTHORIZATION_POLICY="strict")
+def test_resolved_authorization_policy_honors_global_setting():
+    charger = Charger.objects.create(charger_id="CH-POLICY-STRICT")
+
+    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.STRICT


### PR DESCRIPTION
### Motivation
- Close a fail-open authorization path where unknown RFIDs were auto-enrolled and authorized via a seeded/enabled fallback service account under STRICT policy. 
- Ensure strict/account-linked RFID semantics reject unknown tags by default and avoid surprising permissive behavior when feature rows are missing. 
- Avoid making `STRICT` the implicit default policy for chargers so deployments are not surprised by stricter-than-expected behavior.

### Description
- Disable the seeded `rfid-fallback-account` feature in fixtures by setting `is_enabled` to `false` in `apps/features/fixtures/features__rfid_fallback_account.json`.
- Make the runtime feature lookup for RFID fallback fail closed by changing `_rfid_fallback_enabled()` to call `get_cached_feature_enabled(..., default=False)` in `apps/ocpp/consumers/base/rfid.py`.
- Tighten the strict-policy fallback branch so it no longer accepts newly-created/unknown tags by requiring an existing allowed tag (`tag is not None and not tag_created and tag.allowed`) in `apps/ocpp/consumers/base/rfid.py`.
- Change unresolved charger authorization fallback from `STRICT` to `OPEN` in `apps/ocpp/models/charger.py` so unspecified configuration defaults to the more permissive compatibility mode rather than silently applying `STRICT`.
- Update tests in `apps/ocpp/tests/test_authorization_policy.py` and add model tests in `apps/ocpp/tests/test_charger_model.py` to reflect the hardened behavior and explicit test enablement of the fallback feature when needed.

### Testing
- Attempted to run the repository tests with `.venv/bin/python manage.py test run -- apps.ocpp.tests.test_authorization_policy apps.ocpp.tests.test_charger_model`, but the environment lacked `.venv`, so tests could not be executed there.
- Attempted the project bootstrap via `./install.sh`, but the container environment failed bootstrap due to a missing system dependency (`redis-server`) required by the install script, preventing a local test run.
- Unit tests in `apps/ocpp/tests/` were updated to assert the hardened strict behavior and to explicitly enable the fallback feature in tests that exercise the fallback path; these tests are present but were not executed in this environment due to the bootstrap constraints described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc60c7a308326beb505b02678efc7)