### PR TITLE
Gate Raspberry Pi Connect bootstrap behind explicit opt-in

### DIFF
--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -69,6 +69,11 @@ class Command(BaseCommand):
             help="Do not bundle a static copy of this Arthexis checkout into the image.",
         )
         build_parser.add_argument(
+            "--enable-connect-bootstrap",
+            action="store_true",
+            help="Bake in opt-in Raspberry Pi Connect bootstrap for this image.",
+        )
+        build_parser.add_argument(
             "--suite-source",
             default="",
             help="Arthexis checkout path to bundle into the image (default: current suite base directory).",
@@ -347,6 +352,7 @@ class Command(BaseCommand):
                 recovery_authorized_keys=recovery_authorized_keys,
                 skip_recovery_ssh=bool(skip_recovery_ssh),
                 bundle_suite=not bool(options["no_bundle_suite"]),
+                connect_bootstrap_enabled=bool(options["enable_connect_bootstrap"]),
                 suite_source_path=Path(str(options["suite_source"]))
                 if str(options["suite_source"]).strip()
                 else None,

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -219,6 +219,17 @@ RECOVERY_STALE_FILE_PATHS = (
     "/etc/sudoers.d/90-arthexis-recovery",
 )
 
+
+def _render_bootstrap_script(*, connect_bootstrap_enabled: bool = False) -> str:
+    """Render first-boot bootstrap script with image-level feature defaults."""
+
+    default = "1" if connect_bootstrap_enabled else "0"
+    return BOOTSTRAP_SCRIPT.replace(
+        'connect_bootstrap_enabled="${ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-0}"',
+        f'connect_bootstrap_enabled="${{ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-{default}}}"',
+    )
+
+
 RECOVERY_ACCESS_SCRIPT = """#!/usr/bin/env bash
 set -euo pipefail
 
@@ -1120,6 +1131,7 @@ def _customize_image(
     suite_source_path: Path | None = None,
     network_profiles: tuple[NetworkProfileInfo, ...] = (),
     reservation: ImageReservation | None = None,
+    connect_bootstrap_enabled: bool = False,
 ) -> ImageCustomizationResult:
     """Inject bootstrap scripts and systemd units into the image."""
 
@@ -1134,7 +1146,12 @@ def _customize_image(
         reservation_json = work_dir / "reserved-node.json"
         suite_bundle_info: SuiteBundleInfo | None = None
 
-        _write_linux_text(bootstrap, BOOTSTRAP_SCRIPT)
+        _write_linux_text(
+            bootstrap,
+            _render_bootstrap_script(
+                connect_bootstrap_enabled=connect_bootstrap_enabled
+            ),
+        )
         _write_linux_text(service, SYSTEMD_SERVICE.format(git_url=git_url))
         _write_linux_text(recovery_service, RECOVERY_SYSTEMD_SERVICE)
         _write_linux_text(
@@ -1898,6 +1915,7 @@ def build_rpi4b_image(
     reserve_hostname_prefix: str = "",
     reserve_number: int | None = None,
     reserve_role: str = "",
+    connect_bootstrap_enabled: bool = False,
 ) -> BuildResult:
     """Build and register a Raspberry Pi 4B Arthexis image artifact."""
 
@@ -1986,6 +2004,7 @@ def build_rpi4b_image(
             suite_source_path=resolved_suite_source_path if bundle_suite else None,
             network_profiles=network_profiles,
             reservation=reservation,
+            connect_bootstrap_enabled=connect_bootstrap_enabled,
         )
         if isinstance(raw_customization_result, ImageCustomizationResult):
             customization_result = raw_customization_result

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -117,11 +117,14 @@ elif [ ! -e /etc/ssl/certs/ca-certificates.crt ]; then
   required_packages+=(ca-certificates)
 fi
 optional_connect_packages=()
-for package in rpi-connect wayvnc wfplug-connect rpd-wayland-core lightdm pi-greeter; do
-  if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
-    optional_connect_packages+=("$package")
-  fi
-done
+connect_bootstrap_enabled="${ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-0}"
+if [ "$connect_bootstrap_enabled" = "1" ]; then
+  for package in rpi-connect wayvnc wfplug-connect rpd-wayland-core lightdm pi-greeter; do
+    if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
+      optional_connect_packages+=("$package")
+    fi
+  done
+fi
 
 if [ "${#required_packages[@]}" -gt 0 ]; then
   export DEBIAN_FRONTEND=noninteractive
@@ -139,7 +142,7 @@ if [ "${#optional_connect_packages[@]}" -gt 0 ]; then
 fi
 
 CONNECT_SCREEN_SHARE_USER="${ARTHEXIS_CONNECT_USER:-arthe}"
-if id "$CONNECT_SCREEN_SHARE_USER" >/dev/null 2>&1; then
+if [ "$connect_bootstrap_enabled" = "1" ] && id "$CONNECT_SCREEN_SHARE_USER" >/dev/null 2>&1; then
   systemctl stop userconfig.service >/dev/null 2>&1 || true
   systemctl disable userconfig.service >/dev/null 2>&1 || true
   loginctl enable-linger "$CONNECT_SCREEN_SHARE_USER" >/dev/null 2>&1 || true

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -38,6 +38,7 @@ from apps.imager.services import (
     _guestfish_remove_file,
     _guestfish_symlink,
     _guestfish_write,
+    _render_bootstrap_script,
     _resolve_root_disk_path,
     _should_exclude_suite_bundle_path,
     _validate_remote_base_image_url,
@@ -456,6 +457,45 @@ def test_imager_build_command_can_disable_reservation_env_default(
     )
 
     assert mock_build.call_args.kwargs["reserve_node"] is False
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_can_enable_connect_bootstrap(
+    mock_build,
+    tmp_path: Path,
+) -> None:
+    """The CLI opt-in should flow into image customization."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+            "reservation": None,
+        },
+    )()
+
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "connect-enabled",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        "--enable-connect-bootstrap",
+    )
+
+    assert mock_build.call_args.kwargs["connect_bootstrap_enabled"] is True
 
 
 @pytest.mark.django_db
@@ -897,6 +937,22 @@ def test_customize_image_does_not_add_recovery_boot_hook_when_recovery_is_disabl
         ),
         "rm-f /etc/sudoers.d/90-arthexis-recovery",
     ]
+
+
+def test_render_bootstrap_script_can_enable_connect_default() -> None:
+    """Rendered bootstrap can bake in the Raspberry Pi Connect opt-in."""
+
+    default_script = _render_bootstrap_script()
+    enabled_script = _render_bootstrap_script(connect_bootstrap_enabled=True)
+
+    assert (
+        'connect_bootstrap_enabled="${ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-0}"'
+        in default_script
+    )
+    assert (
+        'connect_bootstrap_enabled="${ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-1}"'
+        in enabled_script
+    )
 
 
 def test_customize_image_writes_reserved_node_metadata(tmp_path: Path) -> None:

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -800,14 +800,20 @@ def test_customize_image_writes_recovery_ssh_files_when_authorized_keys_provided
 
     assert bootstrap_mode == "0755"
     assert "required_packages+=(git ca-certificates)" in bootstrap_script
+    assert 'connect_bootstrap_enabled="${ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP:-0}"' in bootstrap_script
     assert (
         "for package in rpi-connect wayvnc wfplug-connect rpd-wayland-core lightdm pi-greeter"
         in bootstrap_script
     )
+    assert 'if [ "$connect_bootstrap_enabled" = "1" ]; then' in bootstrap_script
     assert 'optional_connect_packages+=("$package")' in bootstrap_script
     assert '"${optional_connect_packages[@]}" || echo' in bootstrap_script
     assert "continuing bootstrap" in bootstrap_script
     assert "rpi-connect-lite" not in bootstrap_script
+    assert (
+        'if [ "$connect_bootstrap_enabled" = "1" ] && id "$CONNECT_SCREEN_SHARE_USER" >/dev/null 2>&1; then'
+        in bootstrap_script
+    )
     assert "systemctl disable userconfig.service" in bootstrap_script
     assert "autologin-user=$CONNECT_SCREEN_SHARE_USER" in bootstrap_script
     assert "autologin-session=rpd-labwc" in bootstrap_script


### PR DESCRIPTION
### Motivation

- Prevent generated Raspberry Pi images from enabling remote shell/VNC/autologin by default because that created a predictable attack path when the recovery `arthe` account is present with passwordless sudo.

### Description

- Add an opt-in gate `ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP` (default `0`) to the `BOOTSTRAP_SCRIPT` so connect-related package installation only runs when the variable is set to `1` in the target image environment.
- Guard the connect/autologin enablement block so `loginctl` lingering, LightDM autologin, per-user systemd start, and `rpi-connect shell on`/`rpi-connect vnc on` are executed only when `ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP=1` and the target user exists.
- Update `apps/imager/tests/test_imager_command.py` assertions to verify the new `connect_bootstrap_enabled` gate and the conditional blocks remain present in the generated bootstrap script.

### Testing

- Ran `python3 -m py_compile apps/imager/services.py apps/imager/tests/test_imager_command.py` which completed successfully.
- Attempted to run the repository test entrypoint, but `./install.sh` failed in this environment due to missing `redis-server` so `.venv/bin/python manage.py test run -- ...` could not be executed here; regression assertions in `test_imager_command.py` were updated and validated via static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc6cf2c488326971d103bcce4e4cd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds an opt-in mechanism to gate Raspberry Pi Connect bootstrap behind explicit user enablement via a new `--enable-connect-bootstrap` CLI flag. By default, remote shell, VNC, and autologin are disabled in generated images, preventing exposure of a predictable attack path when the recovery `arthe` account is present.

## Changes

**apps/imager/management/commands/imager.py**
- Added `--enable-connect-bootstrap` boolean flag to the `build` subcommand
- The flag is passed through to `build_rpi4b_image()` as `connect_bootstrap_enabled`

**apps/imager/services.py**
- Updated `_customize_image()` and `build_rpi4b_image()` function signatures to accept `connect_bootstrap_enabled: bool = False` parameter
- Introduced `_render_bootstrap_script()` helper that sets the default value of `ARTHEXIS_ENABLE_CONNECT_BOOTSTRAP` environment variable in the bootstrap script based on the opt-in flag (defaults to `0` when disabled, `1` when enabled)
- The existing bootstrap script logic already conditionally installs Raspberry Pi Connect packages and wraps desktop/screen-share provisioning (loginctl lingering, LightDM autologin, per-user systemd start, and `rpi-connect shell on`/`rpi-connect vnc on`) behind `connect_bootstrap_enabled` checks

**apps/imager/tests/test_imager_command.py**
- Added `test_imager_build_command_can_enable_connect_bootstrap()` test verifying that the CLI flag propagates to the image build backend as `connect_bootstrap_enabled=True`

## Impact

Generated Raspberry Pi images now require explicit opt-in to enable Connect-related packages and remote access features. Existing builds without the flag maintain the secure default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->