### PR TITLE
sites: keep charge points module pill and landings for guests

### DIFF
--- a/apps/sites/context_processors.py
+++ b/apps/sites/context_processors.py
@@ -456,23 +456,8 @@ def _assign_module_menu(module):
 
 
 def _limit_anon_ocpp_landings(module, request, landings: list):
-    """Keep only public supported-model navigation for anonymous OCPP visits."""
+    """Return OCPP landings unchanged for anonymous and authenticated users."""
 
-    user = getattr(request, "user", None)
-    if getattr(user, "is_authenticated", False):
-        return landings
-    if (module.path.rstrip("/") or "/").lower() != "/ocpp":
-        return landings
-
-    supported_models_path = "/ocpp/charge-point-models"
-    filtered_landings = [
-        landing
-        for landing in landings
-        if (landing.path.rstrip("/") or "/").lower() == supported_models_path
-    ]
-    if filtered_landings:
-        module.menu = _("Supported CP Models")
-        return filtered_landings
     return landings
 
 

--- a/apps/sites/tests/test_context_processor_module_landings.py
+++ b/apps/sites/tests/test_context_processor_module_landings.py
@@ -36,7 +36,7 @@ def test_sort_module_landings_keeps_non_ocpp_order():
     ]
 
 
-def test_limit_anon_ocpp_landings_handles_request_without_user():
+def test_limit_anon_ocpp_landings_keeps_charge_point_entries_for_guests():
     module = SimpleNamespace(path="/ocpp/", menu="Charge Points")
     landings = [
         SimpleNamespace(path="/ocpp/cpms/dashboard/"),
@@ -45,5 +45,8 @@ def test_limit_anon_ocpp_landings_handles_request_without_user():
 
     filtered = _limit_anon_ocpp_landings(module, SimpleNamespace(), landings)
 
-    assert [landing.path for landing in filtered] == ["/ocpp/charge-point-models/"]
-    assert str(module.menu) == "Supported CP Models"
+    assert [landing.path for landing in filtered] == [
+        "/ocpp/cpms/dashboard/",
+        "/ocpp/charge-point-models/",
+    ]
+    assert module.menu == "Charge Points"


### PR DESCRIPTION
### Motivation

- Preserve the OCPP module pill as “Charge Points” for anonymous visitors instead of forcing a direct landing to the supported-models page and relabeling the pill.
- Ensure guest users still see the full set of Charge Points landings and that pages requiring authentication continue to enforce login via per-landing lock state rather than being hidden from navigation.

### Description

- Change `_limit_anon_ocpp_landings` in `apps/sites/context_processors.py` to return OCPP landings unchanged for anonymous and authenticated users, removing the filtering to `/ocpp/charge-point-models` and the menu relabel to `"Supported CP Models"`.
- Update `apps/sites/tests/test_context_processor_module_landings.py` to assert guests retain both charge-point landings and that the module `menu` remains `"Charge Points"`.
- No behavior changes were made to per-landing lock/visibility logic; pages that require a logged-in profile will still present a login/lock flow rather than being removed from the list.

### Testing

- Bootstrapped the environment with `./install.sh --terminal` and refreshed CI deps with `./env-refresh.sh --deps-only` to provide test dependencies.
- Executed the module tests with `.venv/bin/python manage.py test run -- apps/sites/tests/test_context_processor_module_landings.py`.
- Test result: `3 passed` (all assertions in the updated context-processor test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc9e732888326b94c4c7951b2e9c9)