### PR TITLE
ocpp: restore strict default authorization fallback

### DIFF
--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -720,10 +720,8 @@ class Charger(Ownable):
                 return explicit
             return self.AuthorizationPolicy.STRICT
         configured = str(getattr(settings, "OCPP_AUTHORIZATION_POLICY", "") or "").strip().lower()
-        if configured:
-            if configured in self.AuthorizationPolicy.values:
-                return configured
-            return self.AuthorizationPolicy.STRICT
+        if configured in self.AuthorizationPolicy.values:
+            return configured
         return self.AuthorizationPolicy.STRICT
 
     @classmethod

--- a/apps/ocpp/models/charger.py
+++ b/apps/ocpp/models/charger.py
@@ -724,9 +724,7 @@ class Charger(Ownable):
             if configured in self.AuthorizationPolicy.values:
                 return configured
             return self.AuthorizationPolicy.STRICT
-        # Keep legacy compatibility unless the deployment or charger explicitly
-        # selects stricter access control.
-        return self.AuthorizationPolicy.OPEN
+        return self.AuthorizationPolicy.STRICT
 
     @classmethod
     def sanitize_auto_location_name(cls, value: str) -> str:

--- a/apps/ocpp/tests/test_charger_model.py
+++ b/apps/ocpp/tests/test_charger_model.py
@@ -129,10 +129,10 @@ def test_charge_station_manager_is_authorized_for_ws_auth(django_user_model):
     assert charger.is_ws_user_authorized(manager) is True
 
 
-def test_resolved_authorization_policy_defaults_to_open():
+def test_resolved_authorization_policy_defaults_to_strict():
     charger = Charger.objects.create(charger_id="CH-POLICY-DEFAULT")
 
-    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.OPEN
+    assert charger.resolved_authorization_policy() == Charger.AuthorizationPolicy.STRICT
 
 
 @override_settings(OCPP_AUTHORIZATION_POLICY="strict")


### PR DESCRIPTION
### Motivation
- Prevent insecure default behavior where unset charger/global policies resolved to `OPEN`, which auto-accepts and auto-enrolls arbitrary RFID tokens and allows unauthorized charging.

### Description
- Change `Charger.resolved_authorization_policy()` to return `AuthorizationPolicy.STRICT` when neither a per-charger nor global `OCPP_AUTHORIZATION_POLICY` is configured, and update the model test to assert the strict default (`apps/ocpp/models/charger.py`, `apps/ocpp/tests/test_charger_model.py`).

### Testing
- Attempted environment bootstrap with `./install.sh` but it failed because Redis is required for this node role and is not installed in the container, so `.venv` was not created and test execution was blocked. 
- Could not run `.venv/bin/python manage.py test run -- apps.ocpp.tests.test_charger_model apps.ocpp.tests.test_authorization_policy` due to the missing `.venv`; no automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc85237d648326af3fafbc2ae04f85)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the OCPP authorization policy fallback behavior to fail securely by default. When neither a charger-specific nor global `OCPP_AUTHORIZATION_POLICY` configuration is provided, `Charger.resolved_authorization_policy()` now returns `AuthorizationPolicy.STRICT` instead of the previous permissive `OPEN` default.

## Changes

### `apps/ocpp/models/charger.py`
The `resolved_authorization_policy()` method was updated to enforce strict authorization as the ultimate fallback. The method now:
1. Returns the charger's explicit `authorization_policy` if set and valid
2. Falls back to `STRICT` if the charger's policy is set but invalid
3. Checks the global `OCPP_AUTHORIZATION_POLICY` setting if no charger-level policy exists
4. Falls back to `STRICT` if the global setting is invalid
5. Returns `STRICT` as the final default (previously `OPEN`)

### `apps/ocpp/tests/test_charger_model.py`
Test coverage was updated to reflect the new strict default behavior:
- `test_resolved_authorization_policy_defaults_to_strict()` — Verifies that unconfigured chargers default to `STRICT`
- `test_resolved_authorization_policy_honors_global_setting()` — Confirms global settings are respected
- `test_resolved_authorization_policy_invalid_global_setting_fails_closed()` — Validates that invalid global settings fail to `STRICT`
- `test_resolved_authorization_policy_invalid_charger_setting_fails_closed()` — Validates that invalid charger-level settings fail to `STRICT`

## Security Impact

This change eliminates the insecure default behavior where unconfigured chargers would auto-accept and auto-enroll arbitrary RFID tokens in `OPEN` mode. All chargers without explicit policy configuration will now require proper authorization, preventing unauthorized charging access by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->