### PR TITLE
repos: prevent pr_oversee metadata symlink overwrite

### DIFF
--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -882,12 +882,14 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
         }
         metadata_path = worktree / PATCHWORK_METADATA
         try:
-            descriptor = os.open(
+            with open(
                 metadata_path,
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW,
-                0o600,
-            )
-            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                "x",
+                encoding="utf-8",
+                opener=lambda path, flags: os.open(
+                    path, flags | getattr(os, "O_NOFOLLOW", 0), 0o600
+                ),
+            ) as handle:
                 handle.write(json.dumps(metadata, indent=2) + "\n")
         except OSError:
             metadata["metadataWriteError"] = True

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -880,11 +880,15 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             "baseRefOid": pr.get("baseRefOid"),
             "worktree": str(worktree),
         }
+        metadata_path = worktree / PATCHWORK_METADATA
         try:
-            (worktree / PATCHWORK_METADATA).write_text(
-                json.dumps(metadata, indent=2) + "\n",
-                encoding="utf-8",
+            descriptor = os.open(
+                metadata_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW,
+                0o600,
             )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(metadata, indent=2) + "\n")
         except OSError:
             metadata["metadataWriteError"] = True
         return metadata

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -369,6 +369,39 @@ def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
     )
 
 
+def test_checkout_does_not_follow_metadata_symlink(tmp_path: Path):
+    class SymlinkRunner(FakeRunner):
+        def run(
+            self, command: list[str], *, cwd: Path | None = None, check: bool = False
+        ) -> CommandResult:
+            result = super().run(command, cwd=cwd, check=check)
+            if command[:3] == ["git", "worktree", "add"]:
+                outside_target = tmp_path / "outside.txt"
+                outside_target.write_text("sensitive\n", encoding="utf-8")
+                (Path(command[-2]) / ".arthexis-pr-oversee.json").symlink_to(
+                    outside_target
+                )
+            return result
+
+    runner = SymlinkRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload())),
+            CommandResult(0),
+            CommandResult(0),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+    worktree = tmp_path / "pr-123"
+    outside_target = tmp_path / "outside.txt"
+
+    result = overseer.checkout(123, worktree=worktree, branch="repos-pr-123")
+
+    assert result["metadataWriteError"] is True
+    assert outside_target.read_text(encoding="utf-8") == "sensitive\n"
+
+
 def test_patchwork_worktree_path_is_deterministic(tmp_path: Path):
     assert patchwork_worktree_path(tmp_path, "arthexis/arthexis", 123) == (
         tmp_path / "arthexis-arthexis-pr-123"

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from io import StringIO
 from pathlib import Path
@@ -400,6 +401,31 @@ def test_checkout_does_not_follow_metadata_symlink(tmp_path: Path):
 
     assert result["metadataWriteError"] is True
     assert outside_target.read_text(encoding="utf-8") == "sensitive\n"
+
+
+def test_checkout_writes_metadata_when_no_no_follow_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload())),
+            CommandResult(0),
+            CommandResult(0),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+    worktree = tmp_path / "pr-123"
+
+    result = overseer.checkout(123, worktree=worktree, branch="repos-pr-123")
+
+    assert "metadataWriteError" not in result
+    assert (
+        json.loads((worktree / ".arthexis-pr-oversee.json").read_text())["headRefOid"]
+        == "head-sha"
+    )
 
 
 def test_patchwork_worktree_path_is_deterministic(tmp_path: Path):


### PR DESCRIPTION
### Motivation

- Fix a vulnerability where `PullRequestOverseer.checkout()` wrote `.arthexis-pr-oversee.json` inside an untrusted PR worktree and could follow a malicious symlink to overwrite arbitrary files.
- Prevent an attacker-controlled PR from causing local file corruption when an operator runs the `pr_oversee checkout` flow.

### Description

- Replace the insecure `Path.write_text()` metadata write with an `os.open(..., O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW)` + `os.fdopen()` write so the metadata file is created as a fresh regular file and symlinks are not followed in `PullRequestOverseer.checkout()` (`apps/repos/pr_oversee.py`).
- Preserve existing failure semantics by setting `metadata["metadataWriteError"] = True` on write failures so callers can observe the write problem without silently following a symlink.
- Add a regression test `test_checkout_does_not_follow_metadata_symlink` to `apps/repos/tests/test_pr_oversee.py` which simulates a pre-planted `.arthexis-pr-oversee.json` symlink and asserts the external target remains unchanged and `metadataWriteError` is set.

### Testing

- Added unit test `apps/repos/tests/test_pr_oversee.py::test_checkout_does_not_follow_metadata_symlink` and committed the changes; the test demonstrates the symlink-write is not followed.
- Attempted to run the tests with the repository test entrypoint ` .venv/bin/python manage.py test run -- apps/repos/tests/test_pr_oversee.py`, but the local environment is missing `.venv/bin/python` so automated tests were not executed here.
- Recommend CI/maintainers run the full test suite (via ` .venv/bin/python manage.py test run -- <targets>`) to validate the change across platforms and confirm no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8688b3b88326a72d9f01edf94023)