### PR TITLE
summary: prevent llm summaries from activating lcd output implicitly

### DIFF
--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -414,8 +414,11 @@ def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -
             lock_file=lock_file,
             expires_at=now + LCD_SUMMARY_EXPIRES_AFTER,
         )
-    else:
-        lock_file.unlink(missing_ok=True)
+    elif lock_dir.exists():
+        try:
+            _write_lcd_frames([], lock_file=lock_file)
+        except OSError:
+            pass
 
     config.last_run_at = now
     config.last_prompt = prompt

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -408,11 +408,14 @@ def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -
 
     lock_file = lock_dir / LCD_SUMMARY_LOCK_FILE
     frames = fixed_frame_window(screens)
-    _write_lcd_frames(
-        frames,
-        lock_file=lock_file,
-        expires_at=now + LCD_SUMMARY_EXPIRES_AFTER,
-    )
+    if node.has_feature("lcd-screen"):
+        _write_lcd_frames(
+            frames,
+            lock_file=lock_file,
+            expires_at=now + LCD_SUMMARY_EXPIRES_AFTER,
+        )
+    else:
+        lock_file.unlink(missing_ok=True)
 
     config.last_run_at = now
     config.last_prompt = prompt

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -196,3 +196,52 @@ def test_suite_gate_skip_preserves_low_channel_messages(
     assert result == "skipped:suite-feature-disabled"
     assert (lock_dir / "lcd-low").exists()
     assert (lock_dir / "lcd-low-1").exists()
+
+
+def test_generation_without_lcd_feature_does_not_write_summary_lock(
+    monkeypatch, settings, tmp_path
+) -> None:
+    from apps.nodes.models import Node
+
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir()
+    (lock_dir / "lcd-summary").write_text("stale\nsummary\n", encoding="utf-8")
+
+    class FakeNode:
+        def has_feature(self, slug: str) -> bool:
+            return slug in {"llm-summary"}
+
+    class FakeConfig:
+        is_active = True
+        last_run_at = None
+
+        def save(self, *, update_fields):
+            self.update_fields = update_fields
+
+    settings.BASE_DIR = tmp_path
+    monkeypatch.setattr(Node, "get_local", staticmethod(lambda: FakeNode()))
+    monkeypatch.setattr(
+        services,
+        "is_suite_feature_enabled",
+        lambda slug, default=True: True,
+    )
+    monkeypatch.setattr(services, "get_summary_config", lambda: FakeConfig())
+    monkeypatch.setattr(services, "ensure_local_model", lambda config: None)
+    monkeypatch.setattr(services, "collect_recent_logs", lambda config, since: ["ERR hi"])
+    monkeypatch.setattr(services, "build_summary_prompt", lambda logs, now: "prompt")
+    monkeypatch.setattr(
+        services,
+        "parse_screens",
+        lambda output: [("Issue", "1 line error")],
+    )
+
+    class FakeSummarizer:
+        def summarize(self, prompt: str) -> str:
+            return "SCREEN 1:\nIssue\n1 line error"
+
+    monkeypatch.setattr(services, "LocalLLMSummarizer", FakeSummarizer)
+
+    result = services.execute_log_summary_generation()
+
+    assert result == "wrote:1"
+    assert not (lock_dir / "lcd-summary").exists()

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from apps.summary import services
+from apps.tasks import tasks as task_services
 from apps.tasks.tasks import _write_lcd_frames
 
 
@@ -206,6 +207,8 @@ def test_generation_without_lcd_feature_does_not_write_summary_lock(
     lock_dir = tmp_path / ".locks"
     lock_dir.mkdir()
     (lock_dir / "lcd-summary").write_text("stale\nsummary\n", encoding="utf-8")
+    (lock_dir / "lcd-summary-1").write_text("stale\nsummary\n", encoding="utf-8")
+    (lock_dir / "lcd-summary-2").write_text("stale\nsummary\n", encoding="utf-8")
 
     class FakeNode:
         def has_feature(self, slug: str) -> bool:
@@ -227,7 +230,13 @@ def test_generation_without_lcd_feature_does_not_write_summary_lock(
     )
     monkeypatch.setattr(services, "get_summary_config", lambda: FakeConfig())
     monkeypatch.setattr(services, "ensure_local_model", lambda config: None)
-    monkeypatch.setattr(services, "collect_recent_logs", lambda config, since: ["ERR hi"])
+    monkeypatch.setattr(
+        services,
+        "collect_recent_logs",
+        lambda config, since: [
+            services.LogChunk(path=tmp_path / "journal.log", content="ERR hi")
+        ],
+    )
     monkeypatch.setattr(services, "build_summary_prompt", lambda logs, now: "prompt")
     monkeypatch.setattr(
         services,
@@ -239,9 +248,11 @@ def test_generation_without_lcd_feature_does_not_write_summary_lock(
         def summarize(self, prompt: str) -> str:
             return "SCREEN 1:\nIssue\n1 line error"
 
-    monkeypatch.setattr(services, "LocalLLMSummarizer", FakeSummarizer)
+    monkeypatch.setattr(task_services, "LocalLLMSummarizer", FakeSummarizer)
 
     result = services.execute_log_summary_generation()
 
     assert result == "wrote:1"
     assert not (lock_dir / "lcd-summary").exists()
+    assert not (lock_dir / "lcd-summary-1").exists()
+    assert not (lock_dir / "lcd-summary-2").exists()


### PR DESCRIPTION
### Motivation

- Prevent automated LLM summary generation from creating `.locks/lcd-summary` on nodes that do not have LCD output, which could cause unintended LCD activation and exposure of summarized logs.

### Description

- Change `execute_log_summary_generation` in `apps/summary/services.py` to only write LCD summary frames when the local node reports the `lcd-screen` feature via `node.has_feature("lcd-screen")` and to remove any stale `lcd-summary` lock when the node lacks that feature.
- Add a regression test `test_generation_without_lcd_feature_does_not_write_summary_lock` in `apps/summary/tests/test_services.py` that simulates a node with `llm-summary` enabled but `lcd-screen` disabled and asserts no `lcd-summary` lock file remains.
- Files changed: `apps/summary/services.py` and `apps/summary/tests/test_services.py`.

### Testing

- Attempted to run the summary test suite with `.venv/bin/python manage.py test run -- apps.summary.tests.test_services`, but it failed because `.venv/bin/python` is not present in the environment.
- Attempted to run `./install.sh` to bootstrap the environment, but it aborted because `redis-server` is not installed, so a virtualenv could not be created to run tests.
- The new unit test was added and committed, but automated tests could not be executed in this environment due to the missing prerequisites described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8686957c8326895df23e83c13fd9)