### PR TITLE
Restrict GetConfiguration action to privileged charger managers

### DIFF
--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -412,6 +412,39 @@ async def test_get_configuration_action_requires_manager_or_superuser():
     )
 
     assert response.status_code == 403
+    assert json.loads(response.content) == {"detail": "insufficient permissions"}
+    assert ws.sent == []
+
+
+@pytest.mark.anyio
+async def test_get_configuration_action_without_request_fails_closed():
+    class DummyWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, message: str) -> None:  # pragma: no cover - async wrapper
+            self.sent.append(message)
+
+    log_key = store.identity_key("CP-PARTIAL-CONFIG-4", None)
+    ws = DummyWebSocket()
+    context = ActionContext(
+        "CP-PARTIAL-CONFIG-4",
+        None,
+        charger=None,
+        ws=ws,
+        log_key=log_key,
+        request=None,
+    )
+
+    response = await anyio.to_thread.run_sync(
+        lambda: actions._handle_get_configuration(
+            context,
+            {"key": ["AuthorizationKey"]},
+        )
+    )
+
+    assert response.status_code == 403
+    assert json.loads(response.content) == {"detail": "insufficient permissions"}
     assert ws.sent == []
 
 

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -335,6 +335,17 @@ async def test_unlock_connector_result_updates_state():
     assert (result.get("payload") or {}).get("status") == "Unlocked"
 
 
+
+class _DummyRequest:
+    def __init__(self, user):
+        self.user = user
+
+
+class _DummyUser:
+    def __init__(self, *, is_superuser=False):
+        self.is_superuser = is_superuser
+
+
 @pytest.mark.anyio
 async def test_get_configuration_action_records_filtered_key_metadata():
     _reset_pending_calls()
@@ -354,6 +365,7 @@ async def test_get_configuration_action_records_filtered_key_metadata():
         charger=None,
         ws=ws,
         log_key=log_key,
+        request=_DummyRequest(_DummyUser(is_superuser=True)),
     )
 
     action_call = await anyio.to_thread.run_sync(
@@ -369,6 +381,38 @@ async def test_get_configuration_action_records_filtered_key_metadata():
     assert store.pending_calls[action_call.message_id]["configuration_key_filter"] == [
         "MeterValuesSampledData"
     ]
+
+
+
+@pytest.mark.anyio
+async def test_get_configuration_action_requires_manager_or_superuser():
+    class DummyWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, message: str) -> None:  # pragma: no cover - async wrapper
+            self.sent.append(message)
+
+    log_key = store.identity_key("CP-PARTIAL-CONFIG-3", None)
+    ws = DummyWebSocket()
+    context = ActionContext(
+        "CP-PARTIAL-CONFIG-3",
+        None,
+        charger=None,
+        ws=ws,
+        log_key=log_key,
+        request=_DummyRequest(_DummyUser(is_superuser=False)),
+    )
+
+    response = await anyio.to_thread.run_sync(
+        lambda: actions._handle_get_configuration(
+            context,
+            {"key": ["AuthorizationKey"]},
+        )
+    )
+
+    assert response.status_code == 403
+    assert ws.sent == []
 
 
 @pytest.mark.anyio

--- a/apps/ocpp/views/actions/configuration.py
+++ b/apps/ocpp/views/actions/configuration.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from django.http import JsonResponse
+from django.http import HttpResponseForbidden, JsonResponse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -9,6 +9,7 @@ from asgiref.sync import async_to_sync
 
 from apps.protocols.decorators import protocol_call
 from apps.protocols.models import ProtocolCall as ProtocolCallModel
+from apps.sites.utils import user_in_charge_station_manager_group
 
 from ... import store
 from .common import (
@@ -22,6 +23,10 @@ from .common import (
 
 @protocol_call("ocpp16", ProtocolCallModel.CSMS_TO_CP, "GetConfiguration")
 def _handle_get_configuration(context: ActionContext, data: dict) -> JsonResponse | ActionCall:
+    user = getattr(context.request, "user", None)
+    is_manager = user_in_charge_station_manager_group(user) if user is not None else False
+    if not getattr(user, "is_superuser", False) and not is_manager:
+        return HttpResponseForbidden("insufficient permissions")
     payload: dict[str, object] = {}
     raw_key = data.get("key")
     keys: list[str] = []

--- a/apps/ocpp/views/actions/configuration.py
+++ b/apps/ocpp/views/actions/configuration.py
@@ -1,11 +1,10 @@
 import json
 import uuid
 
-from django.http import HttpResponseForbidden, JsonResponse
+from asgiref.sync import async_to_sync
+from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-
-from asgiref.sync import async_to_sync
 
 from apps.protocols.decorators import protocol_call
 from apps.protocols.models import ProtocolCall as ProtocolCallModel
@@ -23,10 +22,12 @@ from .common import (
 
 @protocol_call("ocpp16", ProtocolCallModel.CSMS_TO_CP, "GetConfiguration")
 def _handle_get_configuration(context: ActionContext, data: dict) -> JsonResponse | ActionCall:
-    user = getattr(context.request, "user", None)
-    is_manager = user_in_charge_station_manager_group(user) if user is not None else False
-    if not getattr(user, "is_superuser", False) and not is_manager:
-        return HttpResponseForbidden("insufficient permissions")
+    request = getattr(context, "request", None)
+    user = getattr(request, "user", None) if request else None
+    is_superuser = getattr(user, "is_superuser", False) if user else False
+    is_manager = user_in_charge_station_manager_group(user) if user else False
+    if not is_superuser and not is_manager:
+        return JsonResponse({"detail": "insufficient permissions"}, status=403)
     payload: dict[str, object] = {}
     raw_key = data.get("key")
     keys: list[str] = []


### PR DESCRIPTION
### Motivation
- A recent change made the `GetConfiguration` OCPP action reachable from a view-level endpoint that only enforces charger visibility, allowing low-privileged viewers to request sensitive charger configuration keys and then read full results from charger logs. 

### Description
- Add an explicit authorization gate to the `GetConfiguration` action handler so only superusers or users in the charge-station manager group may dispatch the call, returning `HttpResponseForbidden` for other authenticated viewers. 
- Use the existing helper `user_in_charge_station_manager_group` to detect charge-station managers and preserve superuser access. 
- Update tests to supply a `request` on the `ActionContext` for the allowed-path test and add a new regression test that verifies non-privileged users get `403` and that no OCPP message is sent. 
- Modified files: `apps/ocpp/views/actions/configuration.py` and `apps/ocpp/tests/test_ocpp_handlers.py`. 

### Testing
- Added unit tests in `apps/ocpp/tests/test_ocpp_handlers.py` covering both the allowed (superuser/manager) and denied (non-privileged) `GetConfiguration` paths; these tests were committed alongside the code changes. 
- Test execution was attempted but could not complete in this environment because repository bootstrap failed due to missing system dependency (`redis-server`) and `.venv` was not created, so `.venv/bin/python manage.py test run -- apps.ocpp.tests.test_ocpp_handlers` could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8688abe88326a8c899699f6c882a)