### PR TITLE
MTG hypergeometric: add draws-to-probability estimates, expose public calculators, and move Energy Tariff nav item

### DIFF
--- a/apps/awg/templates/awg/_calculator_nav.html
+++ b/apps/awg/templates/awg/_calculator_nav.html
@@ -3,9 +3,6 @@
   <a class="btn btn-sm btn-outline-secondary{% if active_calculator == 'cable' %} active{% endif %}" {% if active_calculator == 'cable' %}aria-current="page"{% endif %} href="{% url 'awg:calculator' %}">
     {% trans "Cable & Conduit" %}
   </a>
-  <a class="btn btn-sm btn-outline-secondary{% if active_calculator == 'energy_tariff' %} active{% endif %}" {% if active_calculator == 'energy_tariff' %}aria-current="page"{% endif %} href="{% url 'awg:energy_tariff' %}">
-    {% trans "Energy Tariff" %}
-  </a>
   <a class="btn btn-sm btn-outline-secondary{% if active_calculator == 'electrical_power' %} active{% endif %}" {% if active_calculator == 'electrical_power' %}aria-current="page"{% endif %} href="{% url 'awg:electrical_power' %}">
     {% trans "Electrical Power" %}
   </a>
@@ -14,5 +11,8 @@
   </a>
   <a class="btn btn-sm btn-outline-secondary{% if active_calculator == 'mtg_hypergeometric' %} active{% endif %}" {% if active_calculator == 'mtg_hypergeometric' %}aria-current="page"{% endif %} href="{% url 'awg:mtg_hypergeometric' %}">
     {% trans "MTG Hypergeometric" %}
+  </a>
+  <a class="btn btn-sm btn-outline-secondary{% if active_calculator == 'energy_tariff' %} active{% endif %}" {% if active_calculator == 'energy_tariff' %}aria-current="page"{% endif %} href="{% url 'awg:energy_tariff' %}">
+    {% trans "Energy Tariff" %}
   </a>
 </nav>

--- a/apps/awg/templates/awg/mtg_hypergeometric_calculator.html
+++ b/apps/awg/templates/awg/mtg_hypergeometric_calculator.html
@@ -69,6 +69,9 @@
             <tr><th>{% trans "Chance of at least target amount" %}</th><td>{{ result.probability_at_least|floatformat:4 }}</td></tr>
             <tr><th>{% trans "Chance of any target card" %}</th><td>{{ result.probability_any|floatformat:4 }}</td></tr>
             <tr><th>{% trans "Chance of no target cards" %}</th><td>{{ result.probability_none|floatformat:4 }}</td></tr>
+            <tr><th>{% trans "Estimated draws to reach 80% chance of any target" %}</th><td>{% if result.draws_to_80_percent %}{{ result.draws_to_80_percent }}{% else %}{% trans "Not reachable" %}{% endif %}</td></tr>
+            <tr><th>{% trans "Estimated draws to reach 90% chance of any target" %}</th><td>{% if result.draws_to_90_percent %}{{ result.draws_to_90_percent }}{% else %}{% trans "Not reachable" %}{% endif %}</td></tr>
+            <tr><th>{% trans "Estimated draws to reach 99% chance of any target" %}</th><td>{% if result.draws_to_99_percent %}{{ result.draws_to_99_percent }}{% else %}{% trans "Not reachable" %}{% endif %}</td></tr>
             {% if result.probability_exact is not None %}
             <tr><th>{% trans "Chance of exact target amount" %}</th><td>{{ result.probability_exact|floatformat:4 }}</td></tr>
             {% endif %}

--- a/apps/awg/tests/test_hypergeometric_calculator.py
+++ b/apps/awg/tests/test_hypergeometric_calculator.py
@@ -5,10 +5,10 @@ from django.urls import reverse
 
 from apps.awg.models import HypergeometricTemplate
 from apps.awg.views.reports import (
-    _calculate_hypergeometric_totals,
+    MAX_HYPERGEOMETRIC_INPUT,
+    MTG_PROBABILITY_THRESHOLDS,
     _draws_for_probability_thresholds,
 )
-
 
 hypergeometric_presets_migration = importlib.import_module(
     "apps.awg.migrations.0004_hypergeometric_presets"
@@ -198,13 +198,24 @@ def test_energy_tariff_is_last_navigation_tab(db):
 
 
 def test_draws_for_probability_thresholds_returns_none_without_targets():
+    thresholds = tuple(MTG_PROBABILITY_THRESHOLDS)
     result = _draws_for_probability_thresholds(
         deck_size=60,
         success_states=0,
-        thresholds=(0.8, 0.9, 0.99),
+        thresholds=thresholds,
     )
 
-    assert result == {0.8: None, 0.9: None, 0.99: None}
+    assert result == dict.fromkeys(thresholds)
+
+
+def test_draws_for_probability_thresholds_caps_large_decks():
+    result = _draws_for_probability_thresholds(
+        deck_size=MAX_HYPERGEOMETRIC_INPUT + 100,
+        success_states=1,
+        thresholds=(1.0,),
+    )
+
+    assert result == {1.0: None}
 
 
 def test_mtg_hypergeometric_results_include_draws_to_high_probability(db):

--- a/apps/awg/tests/test_hypergeometric_calculator.py
+++ b/apps/awg/tests/test_hypergeometric_calculator.py
@@ -4,7 +4,10 @@ from django.test import Client
 from django.urls import reverse
 
 from apps.awg.models import HypergeometricTemplate
-from apps.awg.views.reports import _calculate_hypergeometric_totals
+from apps.awg.views.reports import (
+    _calculate_hypergeometric_totals,
+    _draws_for_probability_thresholds,
+)
 
 
 hypergeometric_presets_migration = importlib.import_module(
@@ -168,3 +171,71 @@ def test_mtg_hypergeometric_calculator_rejects_excessive_deck_size(db):
 
     assert response.status_code == 200
     assert "Deck size must be 500 or less." in response.content.decode()
+
+
+def test_public_calculators_accessible_without_login(db):
+    client = Client()
+
+    assert client.get(reverse("awg:calculator")).status_code == 200
+    assert client.get(reverse("awg:electrical_power")).status_code == 200
+    assert client.get(reverse("awg:ev_charging")).status_code == 200
+    assert client.get(reverse("awg:mtg_hypergeometric")).status_code == 200
+
+
+def test_energy_tariff_requires_login(db):
+    response = Client().get(reverse("awg:energy_tariff"))
+
+    assert response.status_code == 302
+    assert response["Location"].startswith("/login/?next=")
+
+
+def test_energy_tariff_is_last_navigation_tab(db):
+    response = Client().get(reverse("awg:calculator"))
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert body.rfind("MTG Hypergeometric") < body.rfind("Energy Tariff")
+
+
+def test_draws_for_probability_thresholds_returns_none_without_targets():
+    result = _draws_for_probability_thresholds(
+        deck_size=60,
+        success_states=0,
+        thresholds=(0.8, 0.9, 0.99),
+    )
+
+    assert result == {0.8: None, 0.9: None, 0.99: None}
+
+
+def test_mtg_hypergeometric_results_include_draws_to_high_probability(db):
+    response = Client().post(
+        reverse("awg:mtg_hypergeometric"),
+        data={
+            "deck_size": "60",
+            "success_states": "4",
+            "draws": "7",
+            "min_successes": "1",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "Estimated draws to reach 80% chance of any target" in body
+    assert "Estimated draws to reach 90% chance of any target" in body
+    assert "Estimated draws to reach 99% chance of any target" in body
+
+
+def test_mtg_hypergeometric_results_show_not_reachable_when_no_targets(db):
+    response = Client().post(
+        reverse("awg:mtg_hypergeometric"),
+        data={
+            "deck_size": "60",
+            "success_states": "0",
+            "draws": "7",
+            "min_successes": "0",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert body.count("Not reachable") >= 3

--- a/apps/awg/views/reports.py
+++ b/apps/awg/views/reports.py
@@ -3,23 +3,28 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from math import comb
 from typing import Optional
 
 from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from django.test import signals as test_signals
-from django.utils.translation import gettext as _, gettext_lazy as _lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _lazy
 
 from apps.energy.models import EnergyTariff
 from apps.sites.utils import landing
 
 from ..models import HypergeometricTemplate
 
-
 MAX_POWER_CALCULATOR_INPUT = Decimal("1000000000")
 MAX_HYPERGEOMETRIC_INPUT = 500
+MTG_PROBABILITY_THRESHOLDS = {
+    0.8: "draws_to_80_percent",
+    0.9: "draws_to_90_percent",
+    0.99: "draws_to_99_percent",
+}
 
 
 def _format_decimal(value: Decimal, places: str = "0.0000") -> Decimal:
@@ -241,22 +246,20 @@ def _hypergeometric_probability(
     return numerator / denominator
 
 
-
-
 def _draws_for_probability_thresholds(
     *,
     deck_size: int,
     success_states: int,
     thresholds: tuple[float, ...],
-) -> dict[float, Optional[int]]:
+) -> dict[float, int | None]:
     """Return minimum draws needed to reach each probability threshold."""
 
     if success_states <= 0:
-        return {threshold: None for threshold in thresholds}
+        return dict.fromkeys(thresholds)
 
-    draws_needed: dict[float, Optional[int]] = {threshold: None for threshold in thresholds}
+    draws_needed: dict[float, int | None] = dict.fromkeys(thresholds)
     remaining = set(thresholds)
-    for draw_count in range(1, deck_size + 1):
+    for draw_count in range(1, min(deck_size, MAX_HYPERGEOMETRIC_INPUT) + 1):
         probability_none = _hypergeometric_probability(
             population_size=deck_size,
             success_states=success_states,
@@ -272,6 +275,7 @@ def _draws_for_probability_thresholds(
             break
 
     return draws_needed
+
 
 def _calculate_hypergeometric_totals(
     *,
@@ -314,7 +318,7 @@ def _calculate_hypergeometric_totals(
     draws_to_high_chance = _draws_for_probability_thresholds(
         deck_size=deck_size,
         success_states=success_states,
-        thresholds=(0.8, 0.9, 0.99),
+        thresholds=tuple(MTG_PROBABILITY_THRESHOLDS),
     )
 
     return {
@@ -322,9 +326,10 @@ def _calculate_hypergeometric_totals(
         "probability_at_least": probability_at_least,
         "probability_none": probability_none,
         "probability_any": probability_any,
-        "draws_to_80_percent": draws_to_high_chance[0.8],
-        "draws_to_90_percent": draws_to_high_chance[0.9],
-        "draws_to_99_percent": draws_to_high_chance[0.99],
+        **{
+            result_key: draws_to_high_chance[threshold]
+            for threshold, result_key in MTG_PROBABILITY_THRESHOLDS.items()
+        },
     }
 
 

--- a/apps/awg/views/reports.py
+++ b/apps/awg/views/reports.py
@@ -241,6 +241,38 @@ def _hypergeometric_probability(
     return numerator / denominator
 
 
+
+
+def _draws_for_probability_thresholds(
+    *,
+    deck_size: int,
+    success_states: int,
+    thresholds: tuple[float, ...],
+) -> dict[float, Optional[int]]:
+    """Return minimum draws needed to reach each probability threshold."""
+
+    if success_states <= 0:
+        return {threshold: None for threshold in thresholds}
+
+    draws_needed: dict[float, Optional[int]] = {threshold: None for threshold in thresholds}
+    remaining = set(thresholds)
+    for draw_count in range(1, deck_size + 1):
+        probability_none = _hypergeometric_probability(
+            population_size=deck_size,
+            success_states=success_states,
+            draws=draw_count,
+            successes_drawn=0,
+        )
+        probability_any = 1 - probability_none
+        met = {threshold for threshold in remaining if probability_any >= threshold}
+        for threshold in met:
+            draws_needed[threshold] = draw_count
+        remaining -= met
+        if not remaining:
+            break
+
+    return draws_needed
+
 def _calculate_hypergeometric_totals(
     *,
     deck_size: int,
@@ -278,11 +310,21 @@ def _calculate_hypergeometric_totals(
         draws=draws,
         successes_drawn=0,
     )
+    probability_any = 1 - probability_none
+    draws_to_high_chance = _draws_for_probability_thresholds(
+        deck_size=deck_size,
+        success_states=success_states,
+        thresholds=(0.8, 0.9, 0.99),
+    )
+
     return {
         "probability_exact": probability_exact,
         "probability_at_least": probability_at_least,
         "probability_none": probability_none,
-        "probability_any": 1 - probability_none,
+        "probability_any": probability_any,
+        "draws_to_80_percent": draws_to_high_chance[0.8],
+        "draws_to_90_percent": draws_to_high_chance[0.9],
+        "draws_to_99_percent": draws_to_high_chance[0.99],
     }
 
 
@@ -356,7 +398,6 @@ def energy_tariff_calculator(request):
 
 
 @landing(_lazy("Electrical Power Calculator"))
-@login_required(login_url="pages:login")
 def electrical_power_calculator(request):
     """Estimate kVA, kW, and kVAr from field voltage/current measurements."""
 
@@ -442,7 +483,6 @@ def electrical_power_calculator(request):
 
 
 @landing(_lazy("EV Charging Session Calculator"))
-@login_required(login_url="pages:login")
 def ev_charging_calculator(request):
     """Estimate EV charging time and energy cost for a target SOC window."""
 


### PR DESCRIPTION
### Motivation

- Provide users with estimated draw counts to reach common probability thresholds for the MTG hypergeometric calculator and make most calculators publicly accessible while keeping the Energy Tariff restricted.

### Description

- Added `_draws_for_probability_thresholds` helper and wired it into `_calculate_hypergeometric_totals` to compute minimum draws for 80%, 90%, and 99% chances, and expose `probability_any` separately. 
- Updated `mtg_hypergeometric_calculator.html` to display the estimated draws (or "Not reachable") for 80%, 90%, and 99% probability levels. 
- Made `electrical_power_calculator` and `ev_charging_calculator` public by removing their `@login_required` decorators while leaving `energy_tariff_calculator` protected. 
- Moved the "Energy Tariff" navigation link to the end of the calculators nav bar so it appears as the last tab. 
- Added and updated tests in `tests/test_hypergeometric_calculator.py` to cover public access for calculators, nav ordering, draws-to-threshold behavior, and template output.

### Testing

- Ran the updated hypergeometric calculator tests in `apps/awg/tests/test_hypergeometric_calculator.py`, which include checks for draws-to-threshold logic and template output, and they passed. 
- Exercised public access assertions for `calculator`, `electrical_power`, `ev_charging`, and the login requirement for `energy_tariff` via the test client, which passed. 
- Included a unit test for `_draws_for_probability_thresholds` that verifies it returns `None` when there are no target successes, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc99acad3c8326925a20f5fc8abe3a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## MTG Hypergeometric Calculator Enhancements and Navigation Updates

### Draws-to-Probability Estimates

Added minimum draw count estimation to the MTG hypergeometric calculator:
- Implemented `_draws_for_probability_thresholds()` helper function that determines the minimum number of draws required to achieve 80%, 90%, and 99% probability of drawing at least one target card
- Integrated the helper into `_calculate_hypergeometric_totals()` to compute `draws_to_80_percent`, `draws_to_90_percent`, and `draws_to_99_percent` values
- Updated `mtg_hypergeometric_calculator.html` template to display estimated draw counts for each probability threshold, with a "Not reachable" fallback when success states equal zero

### Calculator Access Control

Adjusted public/protected visibility for calculator views:
- Made `electrical_power_calculator` and `ev_charging_calculator` publicly accessible by removing the `@login_required` decorator
- Retained `energy_tariff_calculator` as login-protected
- Applied `@landing()` decorator consistently across all calculator views

### Navigation Ordering

Moved the "Energy Tariff" navigation tab to the end of the calculator navigation bar, making it the last tab in the calculator module selector alongside Cable & Conduit, Electrical Power, EV Charging, and MTG Hypergeometric.

### Test Coverage

Added and expanded test cases covering:
- Public access verification for calculator, electrical_power, ev_charging, and mtg_hypergeometric routes
- Login requirement enforcement for energy_tariff route
- Navigation ordering (Energy Tariff positioned after MTG Hypergeometric)
- Unit test for `_draws_for_probability_thresholds()` returning `None` values when success_states is zero
- Template rendering of estimated draw counts and "Not reachable" messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->