### PR TITLE
[codex] Fix async OCPP forwarding wrapper

### DIFF
--- a/apps/ocpp/consumers/csms/transport.py
+++ b/apps/ocpp/consumers/csms/transport.py
@@ -197,9 +197,13 @@ class CSMSTransportMixin:
         if allowed is not None and action not in allowed:
             return
 
-        wrapped_payload = self._wrap_forwarding_payload(charger, raw, direction="cp_to_csms")
         forwarded = False
         try:
+            wrapped_payload = await self._wrap_forwarding_payload(
+                charger,
+                raw,
+                direction="cp_to_csms",
+            )
             forwarded = await self._send_or_buffer_cp_payload(
                 session=session,
                 action=action,
@@ -241,14 +245,15 @@ class CSMSTransportMixin:
             if allowed is not None and action not in allowed:
                 return
             try:
+                wrapped_payload = await self._wrap_forwarding_payload(
+                    charger,
+                    raw,
+                    direction="cp_to_csms",
+                )
                 forwarded = await self._send_or_buffer_cp_payload(
                     session=session,
                     action=action,
-                    wrapped_payload=self._wrap_forwarding_payload(
-                        charger,
-                        raw,
-                        direction="cp_to_csms",
-                    ),
+                    wrapped_payload=wrapped_payload,
                 )
             except Exception as retry_exc:  # pragma: no cover
                 logger.warning(
@@ -299,9 +304,12 @@ class CSMSTransportMixin:
                 return
             session.pending_call_ids.discard(message_id)
         try:
-            await sync_to_async(session.connection.send)(
-                self._wrap_forwarding_payload(charger, raw, direction="cp_to_csms_reply")
+            wrapped_payload = await self._wrap_forwarding_payload(
+                charger,
+                raw,
+                direction="cp_to_csms_reply",
             )
+            await sync_to_async(session.connection.send)(wrapped_payload)
         except Exception as exc:  # pragma: no cover
             logger.warning(
                 "Failed to forward reply %s for charger %s via %s: %s",
@@ -312,7 +320,7 @@ class CSMSTransportMixin:
             )
             forwarder.remove_session(charger.pk)
 
-    def _wrap_forwarding_payload(self, charger, raw: str, *, direction: str) -> str:
+    async def _wrap_forwarding_payload(self, charger, raw: str, *, direction: str) -> str:
         """Wrap OCPP message with route metadata for forwarding channels."""
         try:
             payload = json.loads(raw)
@@ -320,7 +328,7 @@ class CSMSTransportMixin:
             return raw
         if not isinstance(payload, list):
             return raw
-        local_node = Node.get_local()
+        local_node = await database_sync_to_async(Node.get_local)()
         meta: dict[str, object] = {
             "charger_id": getattr(charger, "charger_id", None),
             "connector_id": getattr(charger, "connector_id", None),

--- a/apps/ocpp/consumers/csms/transport.py
+++ b/apps/ocpp/consumers/csms/transport.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 class CSMSTransportMixin:
     """Provide forwarding transport helpers for CSMSConsumer."""
 
+    _FORWARDING_LOCAL_NODE_UNSET = object()
+
     @staticmethod
     def _forwarding_interval_seconds(session) -> float:
         interval = getattr(session, "forwarding_interval_seconds", 0.0) or 0.0
@@ -328,7 +330,7 @@ class CSMSTransportMixin:
             return raw
         if not isinstance(payload, list):
             return raw
-        local_node = await database_sync_to_async(Node.get_local)()
+        local_node = await self._get_local_node_for_forwarding()
         meta: dict[str, object] = {
             "charger_id": getattr(charger, "charger_id", None),
             "connector_id": getattr(charger, "connector_id", None),
@@ -337,6 +339,17 @@ class CSMSTransportMixin:
         if local_node and getattr(local_node, "uuid", None):
             meta["route"] = [str(local_node.uuid)]
         return json.dumps({"ocpp": payload, "meta": meta})
+
+    async def _get_local_node_for_forwarding(self):
+        cached_local_node = getattr(
+            self,
+            "_forwarding_local_node",
+            self._FORWARDING_LOCAL_NODE_UNSET,
+        )
+        if cached_local_node is self._FORWARDING_LOCAL_NODE_UNSET:
+            cached_local_node = await database_sync_to_async(Node.get_local)()
+            self._forwarding_local_node = cached_local_node
+        return cached_local_node
 
     @staticmethod
     def _cancel_scheduled_cp_flush(session) -> None:

--- a/apps/ocpp/tests/test_transport_forwarding.py
+++ b/apps/ocpp/tests/test_transport_forwarding.py
@@ -89,6 +89,32 @@ async def test_forwarding_payload_local_node_lookup_stays_outside_event_loop(mon
 
 
 @pytest.mark.anyio
+async def test_forwarding_payload_reuses_cached_local_node_lookup(monkeypatch):
+    """Forwarding should cache local-node lookup per transport instance."""
+
+    transport = DummyTransport()
+    charger = SimpleNamespace(pk=10, charger_id="CP-10", connector_id=1)
+    local_node = SimpleNamespace(uuid="00000000-0000-4000-8000-000000000011")
+    get_local = Mock(return_value=local_node)
+    monkeypatch.setattr("apps.ocpp.consumers.csms.transport.Node.get_local", get_local)
+
+    wrapped_first = await transport._wrap_forwarding_payload(
+        charger,
+        '[2,"msg-1","Heartbeat",{}]',
+        direction="cp_to_csms",
+    )
+    wrapped_second = await transport._wrap_forwarding_payload(
+        charger,
+        '[2,"msg-2","Heartbeat",{}]',
+        direction="cp_to_csms",
+    )
+
+    assert get_local.call_count == 1
+    assert json.loads(wrapped_first)["meta"]["route"] == [str(local_node.uuid)]
+    assert json.loads(wrapped_second)["meta"]["route"] == [str(local_node.uuid)]
+
+
+@pytest.mark.anyio
 async def test_forward_charge_point_reply_noops_for_non_pending_message_id(monkeypatch):
     """Replies not tracked as pending should not be forwarded or mutated."""
 

--- a/apps/ocpp/tests/test_transport_forwarding.py
+++ b/apps/ocpp/tests/test_transport_forwarding.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from asyncio import sleep
+from asyncio import get_running_loop, sleep
 from datetime import timedelta
 from threading import Lock
 from types import SimpleNamespace
@@ -60,6 +60,32 @@ async def test_forward_charge_point_reply_sends_and_clears_pending_id(monkeypatc
     wrapped = json.loads(forwarded_message)
     assert wrapped["meta"]["direction"] == "cp_to_csms_reply"
     assert "msg-1" not in session.pending_call_ids
+
+
+@pytest.mark.anyio
+async def test_forwarding_payload_local_node_lookup_stays_outside_event_loop(monkeypatch):
+    """Route metadata lookup should not run synchronous ORM work in the async loop."""
+
+    transport = DummyTransport()
+    charger = SimpleNamespace(pk=10, charger_id="CP-10", connector_id=1)
+
+    def get_local_node():
+        try:
+            get_running_loop()
+        except RuntimeError:
+            return SimpleNamespace(uuid="00000000-0000-4000-8000-000000000010")
+        raise AssertionError("Node.get_local was called in the event loop")
+
+    monkeypatch.setattr("apps.ocpp.consumers.csms.transport.Node.get_local", get_local_node)
+
+    wrapped = await transport._wrap_forwarding_payload(
+        charger,
+        '[2,"msg-1","Heartbeat",{}]',
+        direction="cp_to_csms",
+    )
+
+    payload = json.loads(wrapped)
+    assert payload["meta"]["route"] == ["00000000-0000-4000-8000-000000000010"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fix OCPP charge-point forwarding so forwarding metadata wrapping is safe in the async websocket receive path.

## Root Cause

The CSMS consumer sends the local OCPP response and then forwards the inbound charge-point message. The forwarding wrapper called `Node.get_local()` synchronously from the async receive flow, which can raise Django `SynchronousOnlyOperation` and tear down the local charger websocket after the local reply has already been sent.

## Changes

- Make `_wrap_forwarding_payload` async and run `Node.get_local()` through `database_sync_to_async`.
- Move payload wrapping into the existing forwarding exception handling for charge-point messages and replies.
- Add a regression test that fails if local-node lookup runs in the event loop.

## Validation

- `/home/arthe/arthexis/.venv/bin/python -m pytest apps/ocpp/tests/test_transport_forwarding.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixed OCPP charge-point forwarding to ensure forwarding metadata wrapping is safe when called from the asynchronous websocket receive path. Previously, the synchronous `Node.get_local()` call from within the async receive flow could raise `Django.SynchronousOnlyOperation` and tear down the local charger websocket.

## Changes

### apps/ocpp/consumers/csms/transport.py
Updated `CSMSTransportMixin` to convert forwarding payload wrapping to asynchronous logic:

- Changed `_wrap_forwarding_payload` from a synchronous method to an async method
- Added `_get_local_node_for_forwarding` helper method that performs cached `Node.get_local()` lookup using `database_sync_to_async` to safely access the database from the async context
- Introduced `_FORWARDING_LOCAL_NODE_UNSET` sentinel object to support caching of the resolved local node on the instance
- Updated all call sites to `await` the async `_wrap_forwarding_payload` calls before sending forwarding payloads

The wrapping behavior itself remains unchanged: raw payloads with JSON parsing failures or non-list JSON are returned unchanged, while list payloads are wrapped with `charger_id`, `connector_id`, `direction`, and `route` (when local node UUID is available) metadata.

### apps/ocpp/tests/test_transport_forwarding.py
Added test coverage for async-safety:

- Added regression test ensuring `Node.get_local()` is performed outside the running event loop (fails if invoked from within event loop)
- Added test verifying that local-node lookup results are cached and reused across multiple forwarding payload wraps on the same transport instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->