### PR TITLE
Add 'open' and 'strict' RFID actions to charger management command

### DIFF
--- a/apps/ocpp/management/commands/chargers.py
+++ b/apps/ocpp/management/commands/chargers.py
@@ -166,6 +166,28 @@ class Command(BaseCommand):
                 )
             )
             return
+        if mode == 'open':
+            updated = queryset.update(
+                authorization_policy=Charger.AuthorizationPolicy.OPEN,
+                require_rfid=False,
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Set authorization policy to open on {updated} charger(s).'
+                )
+            )
+            return
+        if mode == 'strict':
+            updated = queryset.update(
+                authorization_policy=Charger.AuthorizationPolicy.STRICT,
+                require_rfid=True,
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Set authorization policy to strict on {updated} charger(s).'
+                )
+            )
+            return
         if mode == 'push':
             sent = self._send_local_rfid_list(chargers)
             self.stdout.write(

--- a/apps/ocpp/management/commands/chargers_cmd/args.py
+++ b/apps/ocpp/management/commands/chargers_cmd/args.py
@@ -164,7 +164,7 @@ def build_chargers_parser(parser: argparse.ArgumentParser) -> None:
         help='Manage RFID requirements and local lists.',
         description='Manage RFID requirements and local lists.',
     )
-    rfid_parser.add_argument('rfid_action', choices=['on', 'off', 'push', 'lock'])
+    rfid_parser.add_argument('rfid_action', choices=['on', 'off', 'open', 'strict', 'push', 'lock'])
 
     auth_parser = subparsers.add_parser(
         'auth',

--- a/apps/ocpp/tests/test_chargers_command.py
+++ b/apps/ocpp/tests/test_chargers_command.py
@@ -424,6 +424,39 @@ class ChargersCommandTests(TestCase):
         frame = json.loads(ws.messages[0])
         self.assertEqual(frame[2], "SendLocalList")
 
+
+    def test_rfid_open_sets_open_policy_and_disables_requirement(self) -> None:
+        """RFID open mode sets insecure compatibility auth policy per charger."""
+
+        charger = Charger.objects.create(
+            charger_id="CLI-RFID-OPEN-1",
+            connector_id=1,
+            authorization_policy=Charger.AuthorizationPolicy.STRICT,
+            require_rfid=True,
+        )
+
+        call_command("charger", "rfid", "open", "--sn", charger.charger_id, "--cp", "A")
+
+        charger.refresh_from_db()
+        self.assertEqual(charger.authorization_policy, Charger.AuthorizationPolicy.OPEN)
+        self.assertFalse(charger.require_rfid)
+
+    def test_rfid_strict_sets_strict_policy_and_enables_requirement(self) -> None:
+        """RFID strict mode leaves open mode and restores RFID requirement."""
+
+        charger = Charger.objects.create(
+            charger_id="CLI-RFID-STRICT-1",
+            connector_id=1,
+            authorization_policy=Charger.AuthorizationPolicy.OPEN,
+            require_rfid=False,
+        )
+
+        call_command("charger", "rfid", "strict", "--sn", charger.charger_id, "--cp", "A")
+
+        charger.refresh_from_db()
+        self.assertEqual(charger.authorization_policy, Charger.AuthorizationPolicy.STRICT)
+        self.assertTrue(charger.require_rfid)
+
     def test_rfid_lockdown_cannot_be_combined_with_send_local_rfids(self) -> None:
         """Lockdown rejects duplicate list-send intent on the same command call."""
 


### PR DESCRIPTION
### Motivation

- Provide explicit CLI controls to switch charger RFID authorization policies between open and strict modes and keep the `require_rfid` flag consistent with the selected policy.

### Description

- Added `open` and `strict` options to the `rfid` subcommand parser in `apps.ocpp.management.commands.chargers_cmd.args` by extending the `rfid_action` choices to include `open` and `strict`.
- Implemented handling for `open` and `strict` in the `chargers` management command (`apps.ocpp.management.commands.chargers`) to update `authorization_policy` to `Charger.AuthorizationPolicy.OPEN`/`STRICT` and to toggle `require_rfid` accordingly.
- Kept existing behavior for `on`, `off`, `push`, and `lock` actions and updated success messages for the new modes.
- Added unit tests in `apps.ocpp.tests.test_chargers_command` to verify that `rfid open` sets the open policy and disables `require_rfid`, and that `rfid strict` sets the strict policy and enables `require_rfid`.

### Testing

- Ran the `apps.ocpp.tests.test_chargers_command` Django unit tests, including the new `test_rfid_open_sets_open_policy_and_disables_requirement` and `test_rfid_strict_sets_strict_policy_and_enables_requirement` tests, and they passed.
- Existing chargers command tests (including RFID `lock` and list-send behavior) were also executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2b8be1e883269f52e7c8d8fba6d8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends the charger management command with two new RFID authorization policy modes: `open` and `strict`.

## Changes

**Command handler** (`apps/ocpp/management/commands/chargers.py`):
- Added handling for `open` mode: sets `authorization_policy` to `OPEN` and disables `require_rfid`
- Added handling for `strict` mode: sets `authorization_policy` to `STRICT` and enables `require_rfid`
- Both modes print a success message confirming the policy change and number of affected chargers
- Early return prevents fallthrough to existing `push`/`lock` logic

**CLI argument definition** (`apps/ocpp/management/commands/chargers_cmd/args.py`):
- Extended `rfid_action` choices from `['on', 'off', 'push', 'lock']` to `['on', 'off', 'open', 'strict', 'push', 'lock']`

**Tests** (`apps/ocpp/tests/test_chargers_command.py`):
- Added test for `rfid open`: verifies `authorization_policy` is set to `OPEN` and `require_rfid` is disabled
- Added test for `rfid strict`: verifies `authorization_policy` is set to `STRICT` and `require_rfid` is enabled
- Both tests confirm the database state is updated

## Impact

- Existing RFID actions (`on`, `off`, `push`, `lock`) remain unchanged
- Provides CLI controls to switch between open and strict RFID authorization policies
- Keeps `require_rfid` flag consistent with the selected policy
- All tests pass, including existing chargers command tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->