### PR TITLE
Fix stale PR approval bypass by using PR updated timestamp

### DIFF
--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -623,25 +623,23 @@ def _reaction_approval(
     return None
 
 
-def _head_commit_timestamp(commit_payload: Mapping[str, object]):
+def _pull_request_last_updated_at(pull_request: Mapping[str, object]):
     try:
-        commit = commit_payload.get("commit") or {}
-        committer = commit.get("committer") or {}
-        authored = commit.get("author") or {}
+        updated_at = pull_request.get("updated_at")
     except AttributeError:
         return None
-    return _parse_github_datetime(committer.get("date") or authored.get("date"))
+    return _parse_github_datetime(updated_at)
 
 
 def _approval_covers_head(
     approval: Mapping[str, object],
-    commit_payload: Mapping[str, object],
+    pull_request: Mapping[str, object],
 ) -> bool:
     approved_at = approval.get("approved_at")
-    committed_at = _head_commit_timestamp(commit_payload)
-    if approved_at is None or committed_at is None:
+    last_updated_at = _pull_request_last_updated_at(pull_request)
+    if approved_at is None or last_updated_at is None:
         return False
-    return approved_at >= committed_at
+    return approved_at >= last_updated_at
 
 
 def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
@@ -855,15 +853,10 @@ def sync_monitor_items(*, token: str | None = None, now=None) -> dict[str, Any]:
                     head_sha = ""
                 if not head_sha:
                     continue
-                if task.require_approval_reaction:
-                    commit_payload = github_service.fetch_commit(
-                        token=token,
-                        owner=task.repository.owner,
-                        name=task.repository.name,
-                        sha=head_sha,
-                    )
-                    if not _approval_covers_head(approval, commit_payload):
-                        continue
+                if task.require_approval_reaction and not _approval_covers_head(
+                    approval, pull_request
+                ):
+                    continue
                 item = _upsert_monitor_item(
                     task,
                     pull_request,

--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -623,23 +623,49 @@ def _reaction_approval(
     return None
 
 
-def _pull_request_last_updated_at(pull_request: Mapping[str, object]):
-    try:
-        updated_at = pull_request.get("updated_at")
-    except AttributeError:
+def _pull_request_head_commit_timestamp(
+    *,
+    token: str,
+    task: GitHubMonitorTask,
+    pull_request: Mapping[str, object],
+):
+    if not isinstance(pull_request, Mapping):
         return None
-    return _parse_github_datetime(updated_at)
+    try:
+        head_sha = str((pull_request.get("head") or {}).get("sha") or "").strip()
+    except (AttributeError, TypeError):
+        head_sha = ""
+    if not head_sha:
+        return None
+    commit = github_service.fetch_commit(
+        token=token,
+        owner=task.repository.owner,
+        name=task.repository.name,
+        sha=head_sha,
+    )
+    try:
+        committed_at = ((commit.get("commit") or {}).get("author") or {}).get("date")
+    except (AttributeError, TypeError):
+        committed_at = None
+    return _parse_github_datetime(committed_at)
 
 
 def _approval_covers_head(
+    *,
+    token: str,
+    task: GitHubMonitorTask,
     approval: Mapping[str, object],
     pull_request: Mapping[str, object],
 ) -> bool:
     approved_at = approval.get("approved_at")
-    last_updated_at = _pull_request_last_updated_at(pull_request)
-    if approved_at is None or last_updated_at is None:
+    head_commit_timestamp = _pull_request_head_commit_timestamp(
+        token=token,
+        task=task,
+        pull_request=pull_request,
+    )
+    if approved_at is None or head_commit_timestamp is None:
         return False
-    return approved_at >= last_updated_at
+    return approved_at >= head_commit_timestamp
 
 
 def _issue_matches(task: GitHubMonitorTask, item: Mapping[str, object]) -> bool:
@@ -854,7 +880,10 @@ def sync_monitor_items(*, token: str | None = None, now=None) -> dict[str, Any]:
                 if not head_sha:
                     continue
                 if task.require_approval_reaction and not _approval_covers_head(
-                    approval, pull_request
+                    token=token,
+                    task=task,
+                    approval=approval,
+                    pull_request=pull_request,
                 ):
                     continue
                 item = _upsert_monitor_item(

--- a/apps/repos/github_monitor.py
+++ b/apps/repos/github_monitor.py
@@ -623,46 +623,19 @@ def _reaction_approval(
     return None
 
 
-def _pull_request_head_commit_timestamp(
-    *,
-    token: str,
-    task: GitHubMonitorTask,
-    pull_request: Mapping[str, object],
-):
+def _pull_request_last_updated_at(pull_request: Mapping[str, object]):
     if not isinstance(pull_request, Mapping):
         return None
-    try:
-        head_sha = str((pull_request.get("head") or {}).get("sha") or "").strip()
-    except (AttributeError, TypeError):
-        head_sha = ""
-    if not head_sha:
-        return None
-    commit = github_service.fetch_commit(
-        token=token,
-        owner=task.repository.owner,
-        name=task.repository.name,
-        sha=head_sha,
-    )
-    try:
-        committed_at = ((commit.get("commit") or {}).get("author") or {}).get("date")
-    except (AttributeError, TypeError):
-        committed_at = None
-    return _parse_github_datetime(committed_at)
+    return _parse_github_datetime(pull_request.get("updated_at"))
 
 
 def _approval_covers_head(
     *,
-    token: str,
-    task: GitHubMonitorTask,
     approval: Mapping[str, object],
     pull_request: Mapping[str, object],
 ) -> bool:
     approved_at = approval.get("approved_at")
-    head_commit_timestamp = _pull_request_head_commit_timestamp(
-        token=token,
-        task=task,
-        pull_request=pull_request,
-    )
+    head_commit_timestamp = _pull_request_last_updated_at(pull_request)
     if approved_at is None or head_commit_timestamp is None:
         return False
     return approved_at >= head_commit_timestamp
@@ -880,8 +853,6 @@ def sync_monitor_items(*, token: str | None = None, now=None) -> dict[str, Any]:
                 if not head_sha:
                     continue
                 if task.require_approval_reaction and not _approval_covers_head(
-                    token=token,
-                    task=task,
                     approval=approval,
                     pull_request=pull_request,
                 ):

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -52,6 +52,7 @@ def _issue(number: int, title: str, marker: str) -> dict[str, object]:
 def _pull_request(
     number: int,
     head_sha: str = "abc123",
+    updated_at: str = "2026-05-07T16:00:00Z",
 ) -> dict[str, object]:
     return {
         "number": number,
@@ -62,6 +63,7 @@ def _pull_request(
         "draft": False,
         "head": {"sha": head_sha},
         "labels": [{"name": "ready"}],
+        "updated_at": updated_at,
     }
 
 
@@ -261,11 +263,6 @@ def test_sync_monitor_items_queues_pr_approved_by_configured_reaction(monkeypatc
         "fetch_issue_reactions",
         lambda **_: reactions,
     )
-    monkeypatch.setattr(
-        github_monitor.github_service,
-        "fetch_commit",
-        lambda **_: {"commit": {"author": {"date": "2026-05-07T16:00:00Z"}}},
-    )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
 
@@ -300,11 +297,6 @@ def test_sync_monitor_items_rejects_pr_without_configured_reaction(monkeypatch):
         "fetch_issue_reactions",
         lambda **_: [{"content": "+1", "user": {"login": "someone-else"}}],
     )
-    monkeypatch.setattr(
-        github_monitor.github_service,
-        "fetch_commit",
-        lambda **_: {"commit": {"author": {"date": "2026-05-07T16:00:00Z"}}},
-    )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
 
@@ -319,7 +311,7 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
     monkeypatch.setattr(
         github_monitor.github_service,
         "fetch_repository_pull_requests",
-        lambda **_: [_pull_request(94, head_sha="newsha")],
+        lambda **_: [_pull_request(94, head_sha="newsha", updated_at="2026-05-07T18:00:00Z")],
     )
     monkeypatch.setattr(
         github_monitor.github_service,
@@ -331,11 +323,6 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
                 "created_at": "2026-05-07T17:00:00Z",
             }
         ],
-    )
-    monkeypatch.setattr(
-        github_monitor.github_service,
-        "fetch_commit",
-        lambda **_: {"commit": {"author": {"date": "2026-05-07T18:00:00Z"}}},
     )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -52,7 +52,6 @@ def _issue(number: int, title: str, marker: str) -> dict[str, object]:
 def _pull_request(
     number: int,
     head_sha: str = "abc123",
-    updated_at: str = "2026-05-07T16:00:00Z",
 ) -> dict[str, object]:
     return {
         "number": number,
@@ -62,7 +61,6 @@ def _pull_request(
         "html_url": f"https://github.example/pulls/{number}",
         "draft": False,
         "head": {"sha": head_sha},
-        "updated_at": updated_at,
         "labels": [{"name": "ready"}],
     }
 
@@ -263,6 +261,11 @@ def test_sync_monitor_items_queues_pr_approved_by_configured_reaction(monkeypatc
         "fetch_issue_reactions",
         lambda **_: reactions,
     )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_commit",
+        lambda **_: {"commit": {"author": {"date": "2026-05-07T16:00:00Z"}}},
+    )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
 
@@ -297,6 +300,11 @@ def test_sync_monitor_items_rejects_pr_without_configured_reaction(monkeypatch):
         "fetch_issue_reactions",
         lambda **_: [{"content": "+1", "user": {"login": "someone-else"}}],
     )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_commit",
+        lambda **_: {"commit": {"author": {"date": "2026-05-07T16:00:00Z"}}},
+    )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
 
@@ -311,9 +319,7 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
     monkeypatch.setattr(
         github_monitor.github_service,
         "fetch_repository_pull_requests",
-        lambda **_: [
-            _pull_request(94, head_sha="newsha", updated_at="2026-05-07T18:00:00Z")
-        ],
+        lambda **_: [_pull_request(94, head_sha="newsha")],
     )
     monkeypatch.setattr(
         github_monitor.github_service,
@@ -325,6 +331,11 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
                 "created_at": "2026-05-07T17:00:00Z",
             }
         ],
+    )
+    monkeypatch.setattr(
+        github_monitor.github_service,
+        "fetch_commit",
+        lambda **_: {"commit": {"author": {"date": "2026-05-07T18:00:00Z"}}},
     )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())

--- a/apps/repos/tests/test_gh_monitor.py
+++ b/apps/repos/tests/test_gh_monitor.py
@@ -49,7 +49,11 @@ def _issue(number: int, title: str, marker: str) -> dict[str, object]:
     }
 
 
-def _pull_request(number: int, head_sha: str = "abc123") -> dict[str, object]:
+def _pull_request(
+    number: int,
+    head_sha: str = "abc123",
+    updated_at: str = "2026-05-07T16:00:00Z",
+) -> dict[str, object]:
     return {
         "number": number,
         "title": f"PR {number}",
@@ -58,12 +62,9 @@ def _pull_request(number: int, head_sha: str = "abc123") -> dict[str, object]:
         "html_url": f"https://github.example/pulls/{number}",
         "draft": False,
         "head": {"sha": head_sha},
+        "updated_at": updated_at,
         "labels": [{"name": "ready"}],
     }
-
-
-def _commit(date: str = "2026-05-07T16:00:00Z") -> dict[str, object]:
-    return {"commit": {"committer": {"date": date}}}
 
 
 @pytest.mark.django_db
@@ -262,11 +263,6 @@ def test_sync_monitor_items_queues_pr_approved_by_configured_reaction(monkeypatc
         "fetch_issue_reactions",
         lambda **_: reactions,
     )
-    monkeypatch.setattr(
-        github_monitor.github_service,
-        "fetch_commit",
-        lambda **_: _commit(),
-    )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())
 
@@ -315,7 +311,9 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
     monkeypatch.setattr(
         github_monitor.github_service,
         "fetch_repository_pull_requests",
-        lambda **_: [_pull_request(94, head_sha="newsha")],
+        lambda **_: [
+            _pull_request(94, head_sha="newsha", updated_at="2026-05-07T18:00:00Z")
+        ],
     )
     monkeypatch.setattr(
         github_monitor.github_service,
@@ -327,11 +325,6 @@ def test_sync_monitor_items_rejects_pr_approval_older_than_head(monkeypatch):
                 "created_at": "2026-05-07T17:00:00Z",
             }
         ],
-    )
-    monkeypatch.setattr(
-        github_monitor.github_service,
-        "fetch_commit",
-        lambda **_: _commit("2026-05-07T18:00:00Z"),
     )
 
     result = github_monitor.sync_monitor_items(token="token", now=timezone.now())


### PR DESCRIPTION
### Motivation
- The approval freshness check used Git commit metadata (`commit.author/committer.date`) which is attacker-controllable and allowed a stale trusted reaction to be reused after a force-push with backdated commit timestamps. 
- The goal is to ensure approvals are validated against an immutable GitHub event timestamp to prevent authorization bypass without changing the approval UX.

### Description
- Replace the head-commit timestamp check with a check against the pull request `updated_at` timestamp by adding `_pull_request_last_updated_at()` and making `_approval_covers_head()` compare `approved_at` to the PR `updated_at` value. 
- Remove the extra `fetch_commit()` step during PR monitor sync and perform the freshness check directly against the PR payload being processed. 
- Update `apps/repos/tests/test_gh_monitor.py` fixtures to include `updated_at` in PR payloads and remove now-unnecessary `fetch_commit` test stubs so tests verify stale approvals are rejected when the PR update time is later than the approval time.

### Testing
- Updated unit tests in `apps/repos/tests/test_gh_monitor.py` to exercise the new PR `updated_at`-based logic and validate rejection of stale approvals. 
- An attempt to run the canonical app test command `./.venv/bin/python manage.py test run -- apps/repos/tests/test_gh_monitor.py` in this environment failed because the repository virtualenv (`.venv`) is not present, so automated test execution could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce552a31c832691a3698e5884b2da)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

**apps/repos/github_monitor.py**
- Added `_pull_request_last_updated_at()` helper to extract the immutable PR `updated_at` timestamp from the GitHub PR payload.
- Refactored `_approval_covers_head()` to validate approval freshness by comparing `approved_at` against the PR `updated_at` instead of commit metadata (author/committer dates), preventing backdated commit timestamps from bypassing stale-approval checks.
- Removed the extra inline `fetch_commit()` step during PR monitor sync; the freshness check now operates directly on the PR payload being processed and uses the PR `updated_at` as the authoritative timestamp.
- Adjusted related logic so missing/invalid PR head or commit author date handling no longer allows approvals to be treated as covering the head.

**apps/repos/tests/test_gh_monitor.py**
- Updated the `_pull_request()` test helper to include `updated_at` (default "2026-05-07T16:00:00Z") and added `labels` to mocked PR payloads to better mirror actual GitHub responses.
- Removed the separate `_commit()` test helper and eliminated monkeypatch stubs that previously faked `github_service.fetch_commit()` for approval-related tests.
- Updated tests to exercise the new `updated_at`-based approval-freshness logic, including a test that verifies stale approvals are rejected when the PR's `updated_at` is later than the approval timestamp (e.g., PR `updated_at` 2026-05-07T18:00:00Z vs. approval 2026-05-07T17:00:00Z).

## Impact

Approvals are now validated against the immutable PR `updated_at` event timestamp rather than mutable commit metadata, closing the attack vector where an adversary could force-push commits with backdated timestamps to reuse stale trusted approvals. Tests were updated to validate this behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7706)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->