### PR TITLE
Handle decimal.Overflow in EV charging calculator

### DIFF
--- a/apps/awg/templates/awg/ev_charging_calculator.html
+++ b/apps/awg/templates/awg/ev_charging_calculator.html
@@ -10,7 +10,7 @@
   <div class="row g-3">
     <div class="col-md-4">
       <label class="form-label" for="battery_kwh">{% trans "Battery Capacity (kWh)" %}</label>
-      <input id="battery_kwh" name="battery_kwh" type="number" step="0.01" min="0.01" class="form-control" value="{{ form.battery_kwh }}" required>
+      <input id="battery_kwh" name="battery_kwh" type="number" step="0.01" min="0.01" max="1000000000" class="form-control" value="{{ form.battery_kwh }}" required>
     </div>
     <div class="col-md-4">
       <label class="form-label" for="start_soc">{% trans "Start SOC (%)" %}</label>
@@ -22,7 +22,7 @@
     </div>
     <div class="col-md-4">
       <label class="form-label" for="charger_power_kw">{% trans "Charger Power (kW)" %}</label>
-      <input id="charger_power_kw" name="charger_power_kw" type="number" step="0.01" min="0.01" class="form-control" value="{{ form.charger_power_kw }}" required>
+      <input id="charger_power_kw" name="charger_power_kw" type="number" step="0.01" min="0.01" max="1000000000" class="form-control" value="{{ form.charger_power_kw }}" required>
     </div>
     <div class="col-md-4">
       <label class="form-label" for="charging_efficiency">{% trans "Charging Efficiency (0-1)" %}</label>

--- a/apps/awg/tests/test_hypergeometric_calculator.py
+++ b/apps/awg/tests/test_hypergeometric_calculator.py
@@ -219,7 +219,7 @@ def test_public_calculators_accessible_without_login(db):
     assert client.get(reverse("awg:mtg_hypergeometric")).status_code == 200
 
 
-def test_ev_charging_calculator_handles_decimal_overflow_input(db):
+def test_ev_charging_calculator_rejects_excessive_battery_capacity(db):
     response = Client().post(
         reverse("awg:ev_charging"),
         data={
@@ -233,7 +233,26 @@ def test_ev_charging_calculator_handles_decimal_overflow_input(db):
 
     assert response.status_code == 200
     assert (
-        "Unable to calculate EV charging totals for the provided values."
+        "Battery capacity and charger power are too large to calculate safely."
+        in response.content.decode()
+    )
+
+
+def test_ev_charging_calculator_rejects_excessive_charger_power(db):
+    response = Client().post(
+        reverse("awg:ev_charging"),
+        data={
+            "battery_kwh": "50",
+            "start_soc": "0",
+            "target_soc": "50",
+            "charger_power_kw": "1e999999999",
+            "charging_efficiency": "0.9",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        "Battery capacity and charger power are too large to calculate safely."
         in response.content.decode()
     )
 

--- a/apps/awg/tests/test_hypergeometric_calculator.py
+++ b/apps/awg/tests/test_hypergeometric_calculator.py
@@ -219,6 +219,25 @@ def test_public_calculators_accessible_without_login(db):
     assert client.get(reverse("awg:mtg_hypergeometric")).status_code == 200
 
 
+def test_ev_charging_calculator_handles_decimal_overflow_input(db):
+    response = Client().post(
+        reverse("awg:ev_charging"),
+        data={
+            "battery_kwh": "1e999999999",
+            "start_soc": "0",
+            "target_soc": "50",
+            "charger_power_kw": "1",
+            "charging_efficiency": "0.9",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        "Unable to calculate EV charging totals for the provided values."
+        in response.content.decode()
+    )
+
+
 def test_energy_tariff_requires_login(db):
     response = Client().get(reverse("awg:energy_tariff"))
 

--- a/apps/awg/views/reports.py
+++ b/apps/awg/views/reports.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation, Overflow
 from math import comb
 from typing import Optional
 
@@ -906,7 +906,7 @@ def ev_charging_calculator(request):
                     charging_efficiency=values["charging_efficiency"],
                     tariff_mxn_kwh=values.get("tariff_mxn_kwh"),
                 )
-            except (InvalidOperation, ZeroDivisionError):
+            except (InvalidOperation, Overflow, ZeroDivisionError):
                 context["error"] = _(
                     "Unable to calculate EV charging totals for the provided values."
                 )

--- a/apps/awg/views/reports.py
+++ b/apps/awg/views/reports.py
@@ -882,6 +882,13 @@ def ev_charging_calculator(request):
                 error = _("Battery capacity must be greater than zero.")
             elif values["charger_power_kw"] <= 0:
                 error = _("Charger power must be greater than zero.")
+            elif (
+                values["battery_kwh"] > MAX_POWER_CALCULATOR_INPUT
+                or values["charger_power_kw"] > MAX_POWER_CALCULATOR_INPUT
+            ):
+                error = _(
+                    "Battery capacity and charger power are too large to calculate safely."
+                )
             elif values["start_soc"] < 0 or values["target_soc"] > 100:
                 error = _("State of charge must stay between 0 and 100 percent.")
             elif values["target_soc"] <= values["start_soc"]:


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated requests from causing unhandled `decimal.Overflow` exceptions in the EV charging calculator that result in 500 errors by ensuring overflow conditions are handled at the view layer.

### Description

- Import `Overflow` from `decimal` and include it in the exception tuple caught around `_calculate_ev_charging_totals` in `apps/awg/views/reports.py` so overflow during Decimal arithmetic is reported as a user-facing error.
- Add a regression test `test_ev_charging_calculator_handles_decimal_overflow_input` in `apps/awg/tests/test_hypergeometric_calculator.py` that posts a very large exponent payload (`battery_kwh=1e999999999`) to `reverse("awg:ev_charging")` and asserts the view responds with the handled error message.
- Keep the fix minimal to preserve existing behavior while closing the availability crash path.

### Testing

- Added an automated regression test `test_ev_charging_calculator_handles_decimal_overflow_input` under `apps.awg.tests.test_hypergeometric_calculator`; the test is present in the tree but was not executed locally due to environment constraints.
- Attempts to run the test suite with `.venv/bin/python manage.py test run -- apps.awg.tests.test_hypergeometric_calculator` failed because the repository virtual environment was not present in the container.
- Attempts to bootstrap the environment with `./install.sh` failed in this container because `redis-server` is required but not installed, and `./command.sh test run ...` likewise failed due to the missing virtual environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f2aab7348326a8a9b962b5abc698)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds handling for `decimal.Overflow` exceptions in the EV charging calculator to prevent unhandled exceptions from causing 500 errors when processing extreme input values.

## Changes

**apps/awg/views/reports.py**
- Added `Overflow` to the decimal module imports
- Expanded the exception handler in the `ev_charging_calculator` view to catch `Overflow` alongside existing `InvalidOperation` and `ZeroDivisionError` exceptions when calculating charging totals
- Overflow conditions now render the same user-facing error message as other calculation failures

**apps/awg/tests/test_hypergeometric_calculator.py**
- Added regression test `test_ev_charging_calculator_handles_decimal_overflow_input` that posts an extremely large exponent value (`battery_kwh=1e999999999`) to the EV charging endpoint
- Verifies the response returns HTTP 200 with the appropriate error message displayed to the user, confirming overflow is handled gracefully rather than causing a 500 error

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7708)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->