### PR TITLE
Add storage backend/config options to imager build CLI and artifact metadata

### DIFF
--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -152,6 +152,16 @@ class Command(BaseCommand):
             help="JSON object carrying profile metadata, required artifacts, and rollout fields.",
         )
         build_parser.add_argument(
+            "--storage-backend",
+            default="local",
+            help="Artifact storage backend stub (local, s3, gcs, azure_blob). Local keeps artifacts on the build host.",
+        )
+        build_parser.add_argument(
+            "--storage-options",
+            default="{}",
+            help="JSON object with backend-specific storage options reserved for future external upload support.",
+        )
+        build_parser.add_argument(
             "--recovery-ssh-user",
             default="",
             help=(
@@ -304,6 +314,12 @@ class Command(BaseCommand):
             raise CommandError("--profile-metadata must be valid JSON.") from exc
         if not isinstance(profile_metadata, dict):
             raise CommandError("--profile-metadata must decode to a JSON object.")
+        try:
+            storage_options = json.loads(str(options["storage_options"]))
+        except json.JSONDecodeError as exc:
+            raise CommandError("--storage-options must be valid JSON.") from exc
+        if not isinstance(storage_options, dict):
+            raise CommandError("--storage-options must decode to a JSON object.")
 
         recovery_authorized_keys = self._read_recovery_authorized_keys(
             file_paths=[str(path) for path in options.get("recovery_authorized_key_file", [])],
@@ -370,6 +386,8 @@ class Command(BaseCommand):
                 reserve_hostname_prefix=str(options["reserve_prefix"]),
                 reserve_number=reserve_number,
                 reserve_role=str(options["reserve_role"]),
+                storage_backend=str(options["storage_backend"]),
+                storage_options=storage_options,
             )
         except ImagerBuildError as exc:
             raise CommandError(str(exc)) from exc

--- a/apps/imager/management/commands/imager.py
+++ b/apps/imager/management/commands/imager.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import gettext as _
 
 from apps.imager.models import RaspberryPiImageArtifact
 from apps.imager.reservations import (
@@ -15,6 +16,8 @@ from apps.imager.reservations import (
 from apps.imager.services import (
     DEFAULT_RECOVERY_SSH_USER,
     ImagerBuildError,
+    STORAGE_BACKEND_LOCAL,
+    SUPPORTED_STORAGE_BACKENDS,
     RecoveryAuthorizedKeyError,
     build_rpi4b_image,
     list_block_devices,
@@ -151,10 +154,15 @@ class Command(BaseCommand):
             default="{}",
             help="JSON object carrying profile metadata, required artifacts, and rollout fields.",
         )
+        supported_storage_backends = tuple(sorted(SUPPORTED_STORAGE_BACKENDS))
         build_parser.add_argument(
             "--storage-backend",
-            default="local",
-            help="Artifact storage backend stub (local, s3, gcs, azure_blob). Local keeps artifacts on the build host.",
+            choices=supported_storage_backends,
+            default=STORAGE_BACKEND_LOCAL,
+            help=_(
+                "Artifact storage backend stub (%(supported)s). Local keeps artifacts on the build host."
+            )
+            % {"supported": ", ".join(supported_storage_backends)},
         )
         build_parser.add_argument(
             "--storage-options",

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -355,12 +355,22 @@ def _sanitize_storage_options(storage_options: dict[str, object]) -> dict[str, o
         "secret",
         "token",
     )
+
+    def is_sensitive_key(key: object) -> bool:
+        return any(fragment in str(key).lower() for fragment in sensitive_fragments)
+
+    def sanitize_value(value: object) -> object:
+        if isinstance(value, dict):
+            return {
+                key: "***" if is_sensitive_key(key) else sanitize_value(nested_value)
+                for key, nested_value in value.items()
+            }
+        if isinstance(value, list):
+            return [sanitize_value(item) for item in value]
+        return value
+
     return {
-        key: (
-            "***"
-            if any(fragment in key.lower() for fragment in sensitive_fragments)
-            else value
-        )
+        key: "***" if is_sensitive_key(key) else sanitize_value(value)
         for key, value in storage_options.items()
     }
 

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -340,7 +340,29 @@ class BuildResult:
     build_engine: str
     build_profile: str
     profile_manifest: dict[str, object]
+    storage_backend: str
+    storage_options: dict[str, object]
     reservation: dict[str, object] | None = None
+
+
+def _sanitize_storage_options(storage_options: dict[str, object]) -> dict[str, object]:
+    """Mask sensitive storage configuration values before persisting metadata."""
+
+    sensitive_fragments = (
+        "access_key",
+        "connection_string",
+        "password",
+        "secret",
+        "token",
+    )
+    return {
+        key: (
+            "***"
+            if any(fragment in key.lower() for fragment in sensitive_fragments)
+            else value
+        )
+        for key, value in storage_options.items()
+    }
 
 
 @dataclass
@@ -1937,7 +1959,7 @@ def build_rpi4b_image(
         raise ImagerBuildError(
             "Artifact name must start with an alphanumeric character and use only letters, numbers, dot, underscore, or hyphen."
         )
-    normalized_storage_backend = str(storage_backend).strip().lower() or STORAGE_BACKEND_LOCAL
+    normalized_storage_backend = (storage_backend or "").strip().lower() or STORAGE_BACKEND_LOCAL
     if normalized_storage_backend not in SUPPORTED_STORAGE_BACKENDS:
         supported_backends = ", ".join(sorted(SUPPORTED_STORAGE_BACKENDS))
         raise ImagerBuildError(
@@ -2081,7 +2103,7 @@ def build_rpi4b_image(
                     },
                     "artifact_storage": {
                         "backend": normalized_storage_backend,
-                        "options": normalized_storage_options,
+                        "options": _sanitize_storage_options(normalized_storage_options),
                         "external_upload_configured": normalized_storage_backend != STORAGE_BACKEND_LOCAL,
                         "external_upload_implemented": False,
                     },
@@ -2102,5 +2124,7 @@ def build_rpi4b_image(
         build_engine=build_engine,
         build_profile=profile,
         profile_manifest=profile_manifest,
+        storage_backend=normalized_storage_backend,
+        storage_options=normalized_storage_options,
         reservation=reservation_payload,
     )

--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -42,6 +42,18 @@ from apps.imager.reservations import (
 )
 
 TARGET_RPI4B = "rpi-4b"
+STORAGE_BACKEND_LOCAL = "local"
+STORAGE_BACKEND_S3 = "s3"
+STORAGE_BACKEND_GCS = "gcs"
+STORAGE_BACKEND_AZURE_BLOB = "azure_blob"
+SUPPORTED_STORAGE_BACKENDS = frozenset(
+    {
+        STORAGE_BACKEND_LOCAL,
+        STORAGE_BACKEND_S3,
+        STORAGE_BACKEND_GCS,
+        STORAGE_BACKEND_AZURE_BLOB,
+    }
+)
 DEFAULT_RECOVERY_SSH_USER = "arthe"
 RECOVERY_SSH_USERNAME_PATTERN = re.compile(r"^[a-z_][a-z0-9_-]*$")
 RECOVERY_SSH_FORBIDDEN_USERS = frozenset({"root"})
@@ -1916,6 +1928,8 @@ def build_rpi4b_image(
     reserve_number: int | None = None,
     reserve_role: str = "",
     connect_bootstrap_enabled: bool = False,
+    storage_backend: str = STORAGE_BACKEND_LOCAL,
+    storage_options: dict[str, object] | None = None,
 ) -> BuildResult:
     """Build and register a Raspberry Pi 4B Arthexis image artifact."""
 
@@ -1923,6 +1937,13 @@ def build_rpi4b_image(
         raise ImagerBuildError(
             "Artifact name must start with an alphanumeric character and use only letters, numbers, dot, underscore, or hyphen."
         )
+    normalized_storage_backend = str(storage_backend).strip().lower() or STORAGE_BACKEND_LOCAL
+    if normalized_storage_backend not in SUPPORTED_STORAGE_BACKENDS:
+        supported_backends = ", ".join(sorted(SUPPORTED_STORAGE_BACKENDS))
+        raise ImagerBuildError(
+            f"Unsupported storage backend '{storage_backend}'. Available backends: {supported_backends}."
+        )
+    normalized_storage_options = dict(storage_options or {})
 
     engine = BUILD_ENGINES.get(build_engine)
     if engine is None:
@@ -2057,6 +2078,12 @@ def build_rpi4b_image(
                         if recovery_ssh_access
                         else 0,
                         "explicitly_skipped": bool(customize and skip_recovery_ssh),
+                    },
+                    "artifact_storage": {
+                        "backend": normalized_storage_backend,
+                        "options": normalized_storage_options,
+                        "external_upload_configured": normalized_storage_backend != STORAGE_BACKEND_LOCAL,
+                        "external_upload_implemented": False,
                     },
                 },
                 "build_engine": build_engine,

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -40,6 +40,7 @@ from apps.imager.services import (
     _guestfish_write,
     _render_bootstrap_script,
     _resolve_root_disk_path,
+    _sanitize_storage_options,
     _should_exclude_suite_bundle_path,
     _validate_remote_base_image_url,
     build_rpi4b_image,
@@ -601,6 +602,40 @@ def test_imager_build_command_passes_storage_options_to_backend(mock_build, tmp_
     assert mock_build.call_args.kwargs["storage_options"] == {
         "bucket": "artifacts",
         "access_key": "key",
+    }
+
+
+def test_sanitize_storage_options_masks_nested_secret_values() -> None:
+    """Regression: persisted artifact metadata must not leak nested credentials."""
+
+    assert _sanitize_storage_options(
+        {
+            "bucket": "artifacts",
+            "credentials": {
+                "secret": "cleartext-secret",
+                "profile": {
+                    "access_key": "cleartext-access-key",
+                    "region": "us-east-1",
+                },
+            },
+            "mirrors": [
+                {"token": "cleartext-token", "endpoint": "https://example.invalid"},
+                {"name": "public"},
+            ],
+        }
+    ) == {
+        "bucket": "artifacts",
+        "credentials": {
+            "secret": "***",
+            "profile": {
+                "access_key": "***",
+                "region": "us-east-1",
+            },
+        },
+        "mirrors": [
+            {"token": "***", "endpoint": "https://example.invalid"},
+            {"name": "public"},
+        ],
     }
 
 

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -521,6 +521,90 @@ def test_imager_build_command_rejects_nonpositive_reserve_number(tmp_path: Path)
 
 
 @pytest.mark.django_db
+def test_imager_build_command_rejects_invalid_storage_options_json(tmp_path: Path) -> None:
+    """Regression: --storage-options must be valid JSON."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+
+    with pytest.raises(CommandError, match="--storage-options must be valid JSON."):
+        call_command(
+            "imager",
+            "build",
+            "--name",
+            "bad-storage-options-json",
+            "--base-image-uri",
+            str(output_path),
+            "--skip-recovery-ssh",
+            "--storage-options",
+            "{invalid",
+        )
+
+
+@pytest.mark.django_db
+def test_imager_build_command_rejects_non_object_storage_options_json(tmp_path: Path) -> None:
+    """Regression: --storage-options must decode to a JSON object."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+
+    with pytest.raises(CommandError, match="--storage-options must decode to a JSON object."):
+        call_command(
+            "imager",
+            "build",
+            "--name",
+            "bad-storage-options-type",
+            "--base-image-uri",
+            str(output_path),
+            "--skip-recovery-ssh",
+            "--storage-options",
+            "[1,2,3]",
+        )
+
+
+@pytest.mark.django_db
+@patch("apps.imager.management.commands.imager.build_rpi4b_image")
+def test_imager_build_command_passes_storage_options_to_backend(mock_build, tmp_path: Path) -> None:
+    """Regression: build command should pass parsed storage configuration to the backend."""
+
+    output_path = tmp_path / "artifact.img"
+    output_path.write_bytes(b"pi")
+    mock_build.return_value = type(
+        "BuildResult",
+        (),
+        {
+            "output_path": output_path,
+            "sha256": "abc123",
+            "size_bytes": 2,
+            "download_uri": "",
+            "build_engine": "arthexis-bootstrap",
+            "build_profile": "bootstrap",
+            "profile_manifest": {},
+        },
+    )()
+
+    call_command(
+        "imager",
+        "build",
+        "--name",
+        "good-storage-options",
+        "--base-image-uri",
+        str(output_path),
+        "--skip-recovery-ssh",
+        "--storage-backend",
+        "s3",
+        "--storage-options",
+        '{"bucket":"artifacts","access_key":"key"}',
+    )
+
+    assert mock_build.call_args.kwargs["storage_backend"] == "s3"
+    assert mock_build.call_args.kwargs["storage_options"] == {
+        "bucket": "artifacts",
+        "access_key": "key",
+    }
+
+
+@pytest.mark.django_db
 @patch("apps.imager.management.commands.imager.build_rpi4b_image")
 def test_imager_build_command_reads_recovery_authorized_key_files(mock_build, tmp_path: Path) -> None:
     """Regression: recovery key files should flow into build customization args."""


### PR DESCRIPTION
### Motivation

- Expose configurable artifact storage backend and backend options for image builds so artifacts can be tracked for future external upload support.
- Surface storage configuration in the build metadata to record whether external upload is configured or implemented.

### Description

- Add CLI flags `--storage-backend` and `--storage-options` in `apps/imager/management/commands/imager.py` with JSON parsing/validation for `--storage-options` and pass-through to the build handler. 
- Introduce storage backend constants and `SUPPORTED_STORAGE_BACKENDS` in `apps/imager/services.py` and normalize/validate `storage_backend` and `storage_options` in `build_rpi4b_image` with `local` as the default.
- Attach `artifact_storage` metadata to the build result including `backend`, `options`, `external_upload_configured`, and `external_upload_implemented` (set to `False` for now).

### Testing

- No automated tests were added or executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0295404d1c8326a3fcddcd81e01079)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR exposes configurable artifact storage backend and backend-specific options to the imager build CLI, records the chosen storage configuration in build metadata, and redacts nested secrets in stored options. It prepares the codebase for future external upload support without implementing external upload behavior.

## Changes

### CLI Updates (`apps/imager/management/commands/imager.py`)
- Added `--storage-backend` flag (choices: local, s3, gcs, azure_blob; default: local).
- Added `--storage-options` flag (JSON object string; defaults to `{}`) and validate/parse it; invalid JSON or non-object raises `CommandError`.
- Passes parsed `storage_backend` and decoded `storage_options` through to `build_rpi4b_image`.
- Added import of translation helpers for help text.

### Service Updates (`apps/imager/services.py`)
- New backend constants and allowlist:
  - STORAGE_BACKEND_LOCAL = "local"
  - STORAGE_BACKEND_S3 = "s3"
  - STORAGE_BACKEND_GCS = "gcs"
  - STORAGE_BACKEND_AZURE_BLOB = "azure_blob"
  - SUPPORTED_STORAGE_BACKENDS (frozenset) includes the above.
- build_rpi4b_image signature extended to accept `storage_backend: str = STORAGE_BACKEND_LOCAL` and `storage_options: dict[str, object] | None = None`.
- Normalizes/validates `storage_backend` (lowercase, default to local) and validates against SUPPORTED_STORAGE_BACKENDS (raises ImagerBuildError for unsupported values).
- Coerces `storage_options` to a dict (empty dict if None).
- Added `_sanitize_storage_options` to mask/redact sensitive keys/values (redacts nested secrets) before persisting or logging.
- Persisted artifact storage configuration in build metadata under `artifact_storage` with fields:
  - `backend` (normalized),
  - `options` (sanitized),
  - `external_upload_configured` (true iff backend != `local`),
  - `external_upload_implemented` (hardcoded to `False`).
- Extended BuildResult to include `storage_backend` and `storage_options` fields.

### Tests (`apps/imager/tests/test_imager_command.py`)
- Added CLI regression tests covering:
  - Rejection of invalid JSON for `--storage-options`.
  - Rejection when JSON decodes to a non-object (e.g., array).
  - Acceptance of valid object JSON and ensuring `storage_backend` and decoded `storage_options` are forwarded to build_rpi4b_image.
- Added unit test verifying `_sanitize_storage_options` masks nested secret values.
- Existing imager command metadata-printing and profile forwarding tests remain and were updated to account for new imports/mocks.

## Behavior & Compatibility
- Default behavior unchanged: omitting flags keeps `local` storage and empty options.
- No external upload implementation added; flags and metadata only record configuration and readiness for future implementation.
- Sensitive storage options are sanitized before persistence/logging (commit: "imager: redact nested storage backend secrets").

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7711)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->