### PR TITLE
Add venv-agnostic `./py` wrapper and document fallback for manage.py

### DIFF
--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -21,6 +21,7 @@ Maintain a **single canonical migrations graph only** under `apps/*/migrations/`
 | Context | Allowed command(s) | Notes |
 | --- | --- | --- |
 | Local QA (app tests) | `.venv/bin/python manage.py test run -- <target>` | Canonical path for app test execution. |
+| Local QA (app tests, venv-agnostic wrapper) | `./py manage.py test run -- <target>` | Falls back between `.venv` and `venv`; prints bootstrap guidance when neither exists. |
 | Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
 | Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
 | PR oversight | `.venv/bin/python manage.py pr_oversee <action> --pr <number>` | Deterministic PR state, gates, comments, test plans, CI failure collection, guarded merge, cleanup, and controlled monitor loops. |

--- a/docs/development/command-matrix.md
+++ b/docs/development/command-matrix.md
@@ -21,7 +21,7 @@ Maintain a **single canonical migrations graph only** under `apps/*/migrations/`
 | Context | Allowed command(s) | Notes |
 | --- | --- | --- |
 | Local QA (app tests) | `.venv/bin/python manage.py test run -- <target>` | Canonical path for app test execution. |
-| Local QA (app tests, venv-agnostic wrapper) | `./py manage.py test run -- <target>` | Falls back between `.venv` and `venv`; prints bootstrap guidance when neither exists. |
+| Local QA (app tests, venv-agnostic wrapper) | `./py manage.py test run -- <target>` or `py.bat manage.py test run -- <target>` | Falls back between `.venv` and `venv` across Unix and Windows layouts; prints bootstrap guidance when neither exists. |
 | Local QA (suite-wide/marker runs) | `.venv/bin/python manage.py test run -- -m "<expr>"` | Keep using the same management entrypoint; pass pytest args after `--`. |
 | Local QA (migration validation) | `.venv/bin/python manage.py migrations check` | Preferred migration guardrail before PRs. |
 | PR oversight | `.venv/bin/python manage.py pr_oversee <action> --pr <number>` | Deterministic PR state, gates, comments, test plans, CI failure collection, guarded merge, cleanup, and controlled monitor loops. |

--- a/py
+++ b/py
@@ -3,20 +3,22 @@ set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-if [[ -x "$BASE_DIR/.venv/bin/python" ]]; then
-  exec "$BASE_DIR/.venv/bin/python" "$@"
-fi
-
-if [[ -x "$BASE_DIR/venv/bin/python" ]]; then
-  exec "$BASE_DIR/venv/bin/python" "$@"
-fi
+for venv_dir in .venv venv; do
+  for python_path in "$venv_dir/bin/python" "$venv_dir/Scripts/python.exe"; do
+    if [[ -x "$BASE_DIR/$python_path" ]]; then
+      exec "$BASE_DIR/$python_path" "$@"
+    fi
+  done
+done
 
 cat >&2 <<'MSG'
 No project virtual environment Python was found.
 
 Expected one of:
   .venv/bin/python
+  .venv/Scripts/python.exe
   venv/bin/python
+  venv/Scripts/python.exe
 
 Bootstrap the environment first:
   ./install.sh

--- a/py
+++ b/py
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ -x "$BASE_DIR/.venv/bin/python" ]]; then
+  exec "$BASE_DIR/.venv/bin/python" "$@"
+fi
+
+if [[ -x "$BASE_DIR/venv/bin/python" ]]; then
+  exec "$BASE_DIR/venv/bin/python" "$@"
+fi
+
+cat >&2 <<'MSG'
+No project virtual environment Python was found.
+
+Expected one of:
+  .venv/bin/python
+  venv/bin/python
+
+Bootstrap the environment first:
+  ./install.sh
+
+Then rerun your command, for example:
+  ./py manage.py test run -- apps/sites
+MSG
+exit 1

--- a/py.bat
+++ b/py.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+set "BASE_DIR=%~dp0"
+
+if exist "%BASE_DIR%.venv\Scripts\python.exe" (
+    "%BASE_DIR%.venv\Scripts\python.exe" %*
+    exit /b %errorlevel%
+)
+
+if exist "%BASE_DIR%venv\Scripts\python.exe" (
+    "%BASE_DIR%venv\Scripts\python.exe" %*
+    exit /b %errorlevel%
+)
+
+echo No project virtual environment Python was found. >&2
+echo. >&2
+echo Expected one of: >&2
+echo   .venv\Scripts\python.exe >&2
+echo   venv\Scripts\python.exe >&2
+echo. >&2
+echo Bootstrap the environment first: >&2
+echo   install.bat >&2
+echo. >&2
+echo Then rerun your command, for example: >&2
+echo   py.bat manage.py test run -- apps/sites >&2
+exit /b 1


### PR DESCRIPTION
### Motivation
- Local test and management command invocations using `.venv/bin/python` fail in fresh checkouts that have not bootstrapped a virtualenv, so provide a small, repo-root wrapper that reliably picks an available venv or prints clear bootstrap guidance.

### Description
- Add an executable `py` wrapper at the repository root that prefers `.venv/bin/python` then `venv/bin/python` and otherwise prints remediation instructions recommending `./install.sh` plus an example `./py manage.py test run -- apps/sites` command.
- Update `docs/development/command-matrix.md` to document `./py manage.py test run -- <target>` as a venv-agnostic alternative while preserving the canonical `.venv/bin/python` guidance.

### Testing
- Ran `bash -n py` to validate the script syntax and it returned without errors.
- Ran `./py manage.py --help` in this environment which exited with code 1 and printed the expected bootstrap guidance because neither `.venv` nor `venv` existed, confirming the fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029a2142d48326866c5233e21a9014)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Added venv-agnostic Python launchers and updated command documentation:

### New executable `py` script (≈29 lines)
- Repository-root POSIX wrapper that prefers:
  1. `.venv/bin/python` (preferred)
  2. `venv/bin/python` (fallback)
  3. Also checks Windows locations (`.venv/Scripts/python.exe`, `venv/Scripts/python.exe`) on mixed environments.
- Uses strict mode (`set -euo pipefail`) and `exec`s the discovered interpreter, forwarding arguments.
- If no interpreter is found, prints multi-line remediation guidance to stderr (listing expected paths, recommending `./install.sh`, and showing an example usage such as `./py manage.py test run -- apps/sites`) and exits with status 1.

### New `py.bat` launcher (Windows)
- Batch entrypoint that checks `%~dp0.venv\Scripts\python.exe` then `%~dp0venv\Scripts\python.exe`, runs the first found interpreter with passed args, or prints bootstrap guidance and exits with code 1.

### Docs: `docs/development/command-matrix.md`
- Added a “Local QA (app tests, venv-agnostic wrapper)” entry documenting `./py manage.py test run -- <target>` (and `py.bat ...` on Windows) as a venv-agnostic alternative while retaining canonical `.venv/bin/python` guidance and noting the bootstrap guidance when neither venv exists.

## Testing
- Validated POSIX script syntax with `bash -n py`.
- Ran `./py manage.py --help` in an environment without `.venv` or `venv`; it exited with code 1 and printed the expected bootstrap guidance, confirming fallback behavior.

## Intent
Fixes failures in fresh checkouts that reference `.venv/bin/python` by providing a repository-root wrapper that selects an available venv or prints clear bootstrap instructions, improving contributor experience without changing exported project APIs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7713)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->