### PR TITLE
docs(agents): remove branch naming guideline from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,20 +294,6 @@ When issue and PR workflows overlap:
 
 ---
 
-## Branch Naming
-
-Branch names must include the **affected apps**.
-
-Example:
-
-```
-billing-auth-fix-login
-charging-station-admin-ui
-users-permissions-regression
-```
-
----
-
 ## Code Review Handling
 
 When a PR review requests a bug fix:


### PR DESCRIPTION
### Motivation
- Remove the explicit Branch Naming guideline from the agents instructions so branch naming is no longer mandated in the `AGENTS.md` Pull Requests section.

### Description
- Deleted the "Branch Naming" subsection from `AGENTS.md` (documentation-only change) and committed the update.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029f8067d48326b68d9595656e9ada)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes the explicit "Branch Naming" guideline section from `AGENTS.md`. The documentation-only change eliminates the subsection heading, explanatory text, and examples that previously mandated branch naming conventions in the Pull Requests section, allowing the document to flow directly from preceding PR-related content to the "Code Review Handling" section.

## Changes

- **AGENTS.md**: Removed the "Branch Naming" subsection (14 lines deleted)

## Testing

No tests required or affected—this is a documentation-only change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7714)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->