### PR TITLE
Guard OCPP 2.0.1 coverage against stubs

### DIFF
--- a/apps/ocpp/coverage201.json
+++ b/apps/ocpp/coverage201.json
@@ -230,6 +230,11 @@
       "UpdateFirmware"
     ]
   },
+  "missing": {
+    "cp_to_csms": [],
+    "csms_to_cp": [],
+    "overall": []
+  },
   "spec": {
     "cp_to_csms": [
       "Authorize",
@@ -300,5 +305,6 @@
       "UnpublishFirmware",
       "UpdateFirmware"
     ]
-  }
+  },
+  "stubbed": []
 }

--- a/apps/ocpp/management/coverage_ocpp201_impl.py
+++ b/apps/ocpp/management/coverage_ocpp201_impl.py
@@ -1,5 +1,6 @@
 import ast
 import json
+from collections.abc import Iterator
 from pathlib import Path
 
 from apps.ocpp.management.coverage_ocpp16_impl import (
@@ -8,6 +9,9 @@ from apps.ocpp.management.coverage_ocpp16_impl import (
 )
 from apps.protocols.services import load_protocol_spec_from_file, spec_path
 from utils.coverage import coverage_color, render_badge
+
+DIRECTION_NAMES = {"cp_to_csms": "cp_to_csms", "csms_to_cp": "csms_to_cp"}
+DIRECTION_ATTRIBUTES = {"CP_TO_CSMS": "cp_to_csms", "CSMS_TO_CP": "csms_to_cp"}
 
 
 def _load_spec() -> dict[str, list[str]]:
@@ -33,49 +37,61 @@ def _is_not_implemented_stub(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
     return False
 
 
+def _extract_constant_str(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_protocol_call_func(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "protocol_call"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "protocol_call"
+    return False
+
+
+def _normalize_direction(node: ast.AST) -> str | None:
+    constant_value = _extract_constant_str(node)
+    if constant_value in DIRECTION_NAMES:
+        return DIRECTION_NAMES[constant_value]
+    if isinstance(node, ast.Attribute):
+        return DIRECTION_ATTRIBUTES.get(node.attr)
+    return None
+
+
 def _protocol_call_details(
     decorator: ast.expr, protocol_slug: str
 ) -> tuple[str, str] | None:
     if not isinstance(decorator, ast.Call):
         return None
-    func = decorator.func
-    is_protocol_call = (
-        isinstance(func, ast.Name) and func.id == "protocol_call"
-    ) or (
-        isinstance(func, ast.Attribute) and func.attr == "protocol_call"
-    )
-    if not is_protocol_call or len(decorator.args) < 3:
+    if not _is_protocol_call_func(decorator.func) or len(decorator.args) < 3:
         return None
-    slug_arg = decorator.args[0]
-    direction_arg = decorator.args[1]
-    action_arg = decorator.args[2]
-    if not (
-        isinstance(slug_arg, ast.Constant)
-        and isinstance(slug_arg.value, str)
-        and slug_arg.value == protocol_slug
-    ):
+    slug = _extract_constant_str(decorator.args[0])
+    direction = _normalize_direction(decorator.args[1])
+    action = _extract_constant_str(decorator.args[2])
+    if slug != protocol_slug or direction is None or action is None:
         return None
-    if not (
-        isinstance(action_arg, ast.Constant) and isinstance(action_arg.value, str)
-    ):
-        return None
-    if (
-        isinstance(direction_arg, ast.Constant)
-        and direction_arg.value == "cp_to_csms"
-    ) or (
-        isinstance(direction_arg, ast.Attribute)
-        and direction_arg.attr == "CP_TO_CSMS"
-    ):
-        return "cp_to_csms", action_arg.value
-    if (
-        isinstance(direction_arg, ast.Constant)
-        and direction_arg.value == "csms_to_cp"
-    ) or (
-        isinstance(direction_arg, ast.Attribute)
-        and direction_arg.attr == "CSMS_TO_CP"
-    ):
-        return "csms_to_cp", action_arg.value
-    return None
+    return direction, action
+
+
+def _iter_decorated_actions(
+    app_dir: Path, protocol_slug: str
+) -> Iterator[tuple[str, str, ast.FunctionDef | ast.AsyncFunctionDef, Path, bool]]:
+    for path in app_dir.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            is_stub = _is_not_implemented_stub(node)
+            for decorator in node.decorator_list:
+                details = _protocol_call_details(decorator, protocol_slug)
+                if details is None:
+                    continue
+                direction, action = details
+                yield direction, action, node, path, is_stub
 
 
 def _collect_stub_decorated_actions(
@@ -84,29 +100,20 @@ def _collect_stub_decorated_actions(
     """Collect protocol actions still mapped directly to NotImplementedError stubs."""
 
     stubs: list[dict[str, object]] = []
-    for path in app_dir.rglob("*.py"):
-        if "tests" in path.parts:
+    for direction, action, node, path, is_stub in _iter_decorated_actions(
+        app_dir, protocol_slug
+    ):
+        if not is_stub:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            if not _is_not_implemented_stub(node):
-                continue
-            for decorator in node.decorator_list:
-                details = _protocol_call_details(decorator, protocol_slug)
-                if details is None:
-                    continue
-                direction, action = details
-                stubs.append(
-                    {
-                        "action": action,
-                        "direction": direction,
-                        "function": node.name,
-                        "line": node.lineno,
-                        "path": path.relative_to(app_dir).as_posix(),
-                    }
-                )
+        stubs.append(
+            {
+                "action": action,
+                "direction": direction,
+                "function": node.name,
+                "line": node.lineno,
+                "path": path.relative_to(app_dir).as_posix(),
+            }
+        )
     return sorted(
         stubs,
         key=lambda stub: (
@@ -124,24 +131,15 @@ def _collect_real_decorated_actions(app_dir: Path, protocol_slug: str) -> tuple[
     cp_to_csms: set[str] = set()
     csms_to_cp: set[str] = set()
 
-    for path in app_dir.rglob("*.py"):
-        if "tests" in path.parts:
+    for direction, action, _node, _path, is_stub in _iter_decorated_actions(
+        app_dir, protocol_slug
+    ):
+        if is_stub:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            if _is_not_implemented_stub(node):
-                continue
-            for decorator in node.decorator_list:
-                details = _protocol_call_details(decorator, protocol_slug)
-                if details is None:
-                    continue
-                direction, action = details
-                if direction == "cp_to_csms":
-                    cp_to_csms.add(action)
-                elif direction == "csms_to_cp":
-                    csms_to_cp.add(action)
+        if direction == "cp_to_csms":
+            cp_to_csms.add(action)
+        elif direction == "csms_to_cp":
+            csms_to_cp.add(action)
     return cp_to_csms, csms_to_cp
 
 

--- a/apps/ocpp/management/coverage_ocpp201_impl.py
+++ b/apps/ocpp/management/coverage_ocpp201_impl.py
@@ -33,6 +33,91 @@ def _is_not_implemented_stub(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
     return False
 
 
+def _protocol_call_details(
+    decorator: ast.expr, protocol_slug: str
+) -> tuple[str, str] | None:
+    if not isinstance(decorator, ast.Call):
+        return None
+    func = decorator.func
+    is_protocol_call = (
+        isinstance(func, ast.Name) and func.id == "protocol_call"
+    ) or (
+        isinstance(func, ast.Attribute) and func.attr == "protocol_call"
+    )
+    if not is_protocol_call or len(decorator.args) < 3:
+        return None
+    slug_arg = decorator.args[0]
+    direction_arg = decorator.args[1]
+    action_arg = decorator.args[2]
+    if not (
+        isinstance(slug_arg, ast.Constant)
+        and isinstance(slug_arg.value, str)
+        and slug_arg.value == protocol_slug
+    ):
+        return None
+    if not (
+        isinstance(action_arg, ast.Constant) and isinstance(action_arg.value, str)
+    ):
+        return None
+    if (
+        isinstance(direction_arg, ast.Constant)
+        and direction_arg.value == "cp_to_csms"
+    ) or (
+        isinstance(direction_arg, ast.Attribute)
+        and direction_arg.attr == "CP_TO_CSMS"
+    ):
+        return "cp_to_csms", action_arg.value
+    if (
+        isinstance(direction_arg, ast.Constant)
+        and direction_arg.value == "csms_to_cp"
+    ) or (
+        isinstance(direction_arg, ast.Attribute)
+        and direction_arg.attr == "CSMS_TO_CP"
+    ):
+        return "csms_to_cp", action_arg.value
+    return None
+
+
+def _collect_stub_decorated_actions(
+    app_dir: Path, protocol_slug: str
+) -> list[dict[str, object]]:
+    """Collect protocol actions still mapped directly to NotImplementedError stubs."""
+
+    stubs: list[dict[str, object]] = []
+    for path in app_dir.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _is_not_implemented_stub(node):
+                continue
+            for decorator in node.decorator_list:
+                details = _protocol_call_details(decorator, protocol_slug)
+                if details is None:
+                    continue
+                direction, action = details
+                stubs.append(
+                    {
+                        "action": action,
+                        "direction": direction,
+                        "function": node.name,
+                        "line": node.lineno,
+                        "path": path.relative_to(app_dir).as_posix(),
+                    }
+                )
+    return sorted(
+        stubs,
+        key=lambda stub: (
+            str(stub["direction"]),
+            str(stub["action"]),
+            str(stub["path"]),
+            str(stub["function"]),
+        ),
+    )
+
+
 def _collect_real_decorated_actions(app_dir: Path, protocol_slug: str) -> tuple[set[str], set[str]]:
     """Collect protocol actions mapped to non-stub handlers for the target protocol."""
 
@@ -49,45 +134,14 @@ def _collect_real_decorated_actions(app_dir: Path, protocol_slug: str) -> tuple[
             if _is_not_implemented_stub(node):
                 continue
             for decorator in node.decorator_list:
-                if not isinstance(decorator, ast.Call):
+                details = _protocol_call_details(decorator, protocol_slug)
+                if details is None:
                     continue
-                func = decorator.func
-                is_protocol_call = (
-                    isinstance(func, ast.Name) and func.id == "protocol_call"
-                ) or (
-                    isinstance(func, ast.Attribute) and func.attr == "protocol_call"
-                )
-                if not is_protocol_call or len(decorator.args) < 3:
-                    continue
-                slug_arg = decorator.args[0]
-                direction_arg = decorator.args[1]
-                action_arg = decorator.args[2]
-                if not (
-                    isinstance(slug_arg, ast.Constant)
-                    and isinstance(slug_arg.value, str)
-                    and slug_arg.value == protocol_slug
-                ):
-                    continue
-                if not (
-                    isinstance(action_arg, ast.Constant) and isinstance(action_arg.value, str)
-                ):
-                    continue
-                if (
-                    isinstance(direction_arg, ast.Constant)
-                    and direction_arg.value == "cp_to_csms"
-                ) or (
-                    isinstance(direction_arg, ast.Attribute)
-                    and direction_arg.attr == "CP_TO_CSMS"
-                ):
-                    cp_to_csms.add(action_arg.value)
-                elif (
-                    isinstance(direction_arg, ast.Constant)
-                    and direction_arg.value == "csms_to_cp"
-                ) or (
-                    isinstance(direction_arg, ast.Attribute)
-                    and direction_arg.attr == "CSMS_TO_CP"
-                ):
-                    csms_to_cp.add(action_arg.value)
+                direction, action = details
+                if direction == "cp_to_csms":
+                    cp_to_csms.add(action)
+                elif direction == "csms_to_cp":
+                    csms_to_cp.add(action)
     return cp_to_csms, csms_to_cp
 
 
@@ -105,6 +159,9 @@ def run_coverage_ocpp201(*, badge_path=None, json_path=None, stdout=None, stderr
     spec_csms_to_cp = set(spec["csms_to_cp"])
     cp_to_csms_coverage = sorted(spec_cp_to_csms & implemented_cp_to_csms)
     csms_to_cp_coverage = sorted(spec_csms_to_cp & implemented_csms_to_cp)
+    missing_cp_to_csms = sorted(spec_cp_to_csms - implemented_cp_to_csms)
+    missing_csms_to_cp = sorted(spec_csms_to_cp - implemented_csms_to_cp)
+    stubbed_actions = _collect_stub_decorated_actions(app_dir, "ocpp201")
     cp_to_csms_percentage = len(cp_to_csms_coverage) / len(spec_cp_to_csms) * 100 if spec_cp_to_csms else 0.0
     csms_to_cp_percentage = len(csms_to_cp_coverage) / len(spec_csms_to_cp) * 100 if spec_csms_to_cp else 0.0
     overall_spec = spec_cp_to_csms | spec_csms_to_cp
@@ -116,6 +173,11 @@ def run_coverage_ocpp201(*, badge_path=None, json_path=None, stdout=None, stderr
         "implemented": {
             "cp_to_csms": sorted(implemented_cp_to_csms),
             "csms_to_cp": sorted(implemented_csms_to_cp),
+        },
+        "missing": {
+            "cp_to_csms": missing_cp_to_csms,
+            "csms_to_cp": missing_csms_to_cp,
+            "overall": sorted(set(missing_cp_to_csms) | set(missing_csms_to_cp)),
         },
         "coverage": {
             "cp_to_csms": {
@@ -137,6 +199,7 @@ def run_coverage_ocpp201(*, badge_path=None, json_path=None, stdout=None, stderr
                 "percent": round(overall_percentage, 2),
             },
         },
+        "stubbed": stubbed_actions,
     }
     output = json.dumps(summary, indent=2, sort_keys=True)
     if stdout:
@@ -158,5 +221,7 @@ def run_coverage_ocpp201(*, badge_path=None, json_path=None, stdout=None, stderr
     if overall_percentage < 100 and stderr:
         stderr.write("OCPP 2.0.1 coverage is incomplete; consider adding more handlers.")
         stderr.write(f"Currently supporting {len(overall_coverage)} of {len(overall_spec)} operations.")
+    if stubbed_actions and stderr:
+        stderr.write("OCPP 2.0.1 decorated handlers still contain NotImplementedError stubs.")
     if stdout:
         stdout.write("Command completed without failure.")

--- a/apps/ocpp/management/coverage_ocpp201_impl.py
+++ b/apps/ocpp/management/coverage_ocpp201_impl.py
@@ -233,9 +233,11 @@ def run_coverage_ocpp201(*, badge_path=None, json_path=None, stdout=None, stderr
         encoding="utf-8",
     )
     if overall_percentage < 100 and stderr:
-        stderr.write("OCPP 2.0.1 coverage is incomplete; consider adding more handlers.")
-        stderr.write(f"Currently supporting {len(overall_coverage)} of {len(overall_spec)} operations.")
+        stderr.write("OCPP 2.0.1 coverage is incomplete; consider adding more handlers.\n")
+        stderr.write(
+            f"Currently supporting {len(overall_coverage)} of {len(overall_spec)} operations.\n"
+        )
     if stubbed_actions and stderr:
-        stderr.write("OCPP 2.0.1 decorated handlers still contain NotImplementedError stubs.")
+        stderr.write("OCPP 2.0.1 decorated handlers still contain NotImplementedError stubs.\n")
     if stdout:
         stdout.write("Command completed without failure.")

--- a/apps/ocpp/management/coverage_ocpp201_impl.py
+++ b/apps/ocpp/management/coverage_ocpp201_impl.py
@@ -60,16 +60,32 @@ def _normalize_direction(node: ast.AST) -> str | None:
     return None
 
 
+def _decorator_argument(
+    decorator: ast.Call, index: int, keyword: str
+) -> ast.AST | None:
+    if len(decorator.args) > index:
+        return decorator.args[index]
+    return next(
+        (kw.value for kw in decorator.keywords if kw.arg == keyword),
+        None,
+    )
+
+
 def _protocol_call_details(
     decorator: ast.expr, protocol_slug: str
 ) -> tuple[str, str] | None:
     if not isinstance(decorator, ast.Call):
         return None
-    if not _is_protocol_call_func(decorator.func) or len(decorator.args) < 3:
+    if not _is_protocol_call_func(decorator.func):
         return None
-    slug = _extract_constant_str(decorator.args[0])
-    direction = _normalize_direction(decorator.args[1])
-    action = _extract_constant_str(decorator.args[2])
+    slug_arg = _decorator_argument(decorator, 0, "protocol_slug")
+    direction_arg = _decorator_argument(decorator, 1, "direction")
+    action_arg = _decorator_argument(decorator, 2, "call_name")
+    if slug_arg is None or direction_arg is None or action_arg is None:
+        return None
+    slug = _extract_constant_str(slug_arg)
+    direction = _normalize_direction(direction_arg)
+    action = _extract_constant_str(action_arg)
     if slug != protocol_slug or direction is None or action is None:
         return None
     return direction, action

--- a/apps/ocpp/tests/test_ocpp201_actions.py
+++ b/apps/ocpp/tests/test_ocpp201_actions.py
@@ -8,7 +8,10 @@ from apps.ocpp.consumers.csms.consumer import CSMSConsumer
 from apps.ocpp.consumers.csms.dispatch import build_action_registry
 from apps.ocpp.management import coverage_ocpp201_impl, coverage_ocpp21_impl
 from apps.ocpp.management.coverage_ocpp21_impl import run_coverage_ocpp21
-from apps.ocpp.management.coverage_ocpp201_impl import _collect_real_decorated_actions
+from apps.ocpp.management.coverage_ocpp201_impl import (
+    _collect_real_decorated_actions,
+    _collect_stub_decorated_actions,
+)
 from apps.ocpp.models import (
     Charger,
 )
@@ -466,6 +469,63 @@ def from_tests():
     assert "StubByBody" not in csms_to_cp
 
 
+def test_collect_stub_decorated_actions_reports_protocol_stubs(tmp_path):
+    app_dir = tmp_path / "apps" / "ocpp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "handlers.py").write_text(
+        """
+from apps.protocols.decorators import protocol_call
+from apps.protocols.models import ProtocolCall as ProtocolCallModel
+
+@protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "StubByBody")
+def stub_by_body():
+    raise NotImplementedError("todo")
+
+@protocol_call("ocpp201", ProtocolCallModel.CSMS_TO_CP, "RealAction")
+def real_action():
+    return {}
+
+@protocol_call("ocpp21", ProtocolCallModel.CP_TO_CSMS, "OtherProtocolStub")
+def other_protocol_stub():
+    raise NotImplementedError("todo")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    tests_dir = app_dir / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_handlers.py").write_text(
+        """
+from apps.protocols.decorators import protocol_call
+from apps.protocols.models import ProtocolCall as ProtocolCallModel
+
+@protocol_call("ocpp201", ProtocolCallModel.CP_TO_CSMS, "TestStub")
+def test_stub():
+    raise NotImplementedError("todo")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stubs = _collect_stub_decorated_actions(app_dir, "ocpp201")
+
+    assert stubs == [
+        {
+            "action": "StubByBody",
+            "direction": "cp_to_csms",
+            "function": "stub_by_body",
+            "line": 5,
+            "path": "handlers.py",
+        }
+    ]
+
+
+def test_ocpp201_has_no_decorated_not_implemented_stubs():
+    app_dir = Path(__file__).resolve().parents[1]
+
+    assert _collect_stub_decorated_actions(app_dir, "ocpp201") == []
+
+
 def test_run_coverage_ocpp21_keeps_shared_ocpp201_handlers(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "apps.ocpp.management.coverage_ocpp21_impl._load_spec",
@@ -526,6 +586,8 @@ def test_run_coverage_ocpp201_keeps_decorator_only_cp_to_csms(monkeypatch, tmp_p
     report = json.loads(json_path.read_text(encoding="utf-8"))
 
     assert report["implemented"]["cp_to_csms"] == ["Heartbeat"]
+    assert report["missing"] == {"cp_to_csms": [], "csms_to_cp": [], "overall": []}
+    assert report["stubbed"] == []
     assert report["coverage"]["cp_to_csms"]["supported"] == ["Heartbeat"]
 
 

--- a/apps/ocpp/tests/test_ocpp201_actions.py
+++ b/apps/ocpp/tests/test_ocpp201_actions.py
@@ -481,6 +481,14 @@ from apps.protocols.models import ProtocolCall as ProtocolCallModel
 def stub_by_body():
     raise NotImplementedError("todo")
 
+@protocol_call(
+    protocol_slug="ocpp201",
+    direction=ProtocolCallModel.CSMS_TO_CP,
+    call_name="KeywordStub",
+)
+def keyword_stub():
+    raise NotImplementedError("todo")
+
 @protocol_call("ocpp201", ProtocolCallModel.CSMS_TO_CP, "RealAction")
 def real_action():
     return {}
@@ -515,6 +523,13 @@ def test_stub():
             "direction": "cp_to_csms",
             "function": "stub_by_body",
             "line": 5,
+            "path": "handlers.py",
+        },
+        {
+            "action": "KeywordStub",
+            "direction": "csms_to_cp",
+            "function": "keyword_stub",
+            "line": 13,
             "path": "handlers.py",
         }
     ]


### PR DESCRIPTION
### Summary
- Add explicit OCPP 2.0.1 coverage fields for missing and stubbed protocol actions.
- Add AST-based detection for protocol-decorated handlers that still raise `NotImplementedError`.
- Add regression coverage proving no current `ocpp201` protocol handler is still a stub, and regenerate `apps/ocpp/coverage201.json` with `missing: []` and `stubbed: []`.

Closes #7705

### Testing
- `git diff --check`
- `.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.venv\Scripts\python.exe manage.py ocpp coverage --version 2.0.1 --json-path apps/ocpp/coverage201.json --badge-path media/ocpp201_coverage.svg`
- `.venv\Scripts\python.exe manage.py test run -- apps/ocpp/tests/test_ocpp201_actions.py` (54 passed)
- `.venv\Scripts\python.exe manage.py test run -- apps/ocpp/tests/test_ocpp_command.py` (5 passed)

### Notes
- `.venv\Scripts\python.exe manage.py test run -- apps/ocpp/tests` is blocked on Windows during collection by `socketserver.UnixStreamServer` imports in `apps/ocpp/tests/test_ocpp_reconnect.py` and `apps/ocpp/tests/test_websocket_creation.py`; this is outside the coverage change and the focused OCPP 2.0.1/command suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request adds explicit OCPP 2.0.1 coverage tracking for missing and stubbed protocol actions by implementing AST-based detection for handler functions that raise NotImplementedError, supports keyword-style protocol decorators, regenerates the coverage report with new fields, and introduces a regression check to prevent future stubbed handlers in the ocpp201 protocol.

## Key Changes

### Coverage Data Structure Update
- Regenerated apps/ocpp/coverage201.json to include a top-level `missing` object with per-direction arrays (`cp_to_csms`, `csms_to_cp`, `overall`) and a top-level `stubbed` array. Both are empty after regeneration.

### AST-Based Stub Detection & Coverage Generation
- Added AST helpers and utilities to parse `protocol_call` decorators (including keyword-style decorators), normalize direction values, and extract (direction, action) details targeted at the ocpp201 protocol.
- Detection pipeline collects decorated handlers that are implemented (non-stub) and decorated handlers that raise NotImplementedError (stubs).
- Updated run_coverage_ocpp201(...) to compute per-direction missing operations (set differences vs implemented actions), populate `missing.overall`, include `stubbed` entries in the generated JSON, and emit a stderr warning when stubbed handlers are found.
- Introduced constants and helper functions (DIRECTION_NAMES, DIRECTION_ATTRIBUTES, _extract_constant_str, _is_protocol_call_func, _normalize_direction, _protocol_call_details, _iter_decorated_actions, _collect_stub_decorated_actions) to support AST parsing and decorator normalization.

### Tests
- Added test_collect_stub_decorated_actions_reports_protocol_stubs() to verify the stub collector reports only expected ocpp201 decorator-based NotImplementedError stubs and excludes other-protocol stubs, implemented handlers, and items under tests/.
- Added test_ocpp201_has_no_decorated_not_implemented_stubs() asserting the repository’s ocpp201 app has no decorated NotImplementedError stubs.
- Tightened existing coverage assertions in apps/ocpp/tests/test_ocpp201_actions.py to require `missing.cp_to_csms`, `missing.csms_to_cp`, and `missing.overall` be empty and `stubbed` be an empty list (regression check).

## Files Changed (high level)
- apps/ocpp/coverage201.json — regenerated with `missing` and `stubbed` sections (empty).
- apps/ocpp/management/coverage_ocpp201_impl.py — added AST-driven detection, support for keyword decorators, new helpers/constants, stub collection, and extended JSON output.
- apps/ocpp/tests/test_ocpp201_actions.py — added tests and tightened assertions.

## Testing Performed
- git diff --check
- Django system checks (manage.py check --fail-level ERROR)
- manage.py ocpp coverage --version 2.0.1 --json-path apps/ocpp/coverage201.json --badge-path media/ocpp201_coverage.svg (produced regenerated JSON and badge)
- Unit tests: apps/ocpp/tests/test_ocpp201_actions.py (54 passed) and apps/ocpp/tests/test_ocpp_command.py (5 passed)
- Note: running the full apps/ocpp test suite on Windows is blocked during collection by socketserver.UnixStreamServer imports in two tests; this PR focuses on ocpp201 and command suites which passed.

## Issues
- Closes issue #7705

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7715)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->