### PR TITLE
Tone down sponsorship emphasis in license sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,6 @@ If you decide to use our suite for your energy projects, you may contact us at [
 
 ## License and Support
 
-Arthexis is distributed under the Arthexis Reciprocity General License 1.0. Contributions through code, documentation, reviews, and maintenance all help keep the project healthy.
+Arthexis is distributed under the Arthexis Reciprocity General License 1.0. Contributions through code, documentation, reviews, and maintenance are all recognized as valid forms of contribution that help keep the project healthy.
 
-If Arthexis helps your team, please review the license terms in [`LICENSE`](https://github.com/arthexis/arthexis/blob/main/LICENSE) and support the maintainers of the libraries, frameworks, and infrastructure projects that make this suite possible.
+If Arthexis helps your team, please review the license terms in [LICENSE](LICENSE) and support the maintainers of the libraries, frameworks, and infrastructure projects that make this suite possible.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Arthexis Constellation is actively maintained with documented release notes and 
 
 If you decide to use our suite for your energy projects, you may contact us at [tecnologia@gelectriic.com](mailto:tecnologia@gelectriic.com) or visit our [web page](https://www.gelectriic.com/) for professional services and commercial support.
 
-## License and Sponsorship
+## License and Support
 
-Arthexis is distributed under the Arthexis Reciprocity General License 1.0. In addition to code, docs, reviews, and maintenance, we also consider sponsoring Arthexis and doing paid or volunteer work for the open-source dependencies we rely on to be a valid and important form of contribution.
+Arthexis is distributed under the Arthexis Reciprocity General License 1.0. Contributions through code, documentation, reviews, and maintenance all help keep the project healthy.
 
-If Arthexis helps your team, please review the license terms in [`LICENSE`](https://github.com/arthexis/arthexis/blob/main/LICENSE) and consider sponsoring or directly supporting the maintainers of the libraries, frameworks, and infrastructure projects that make this suite possible. Supporting those dependencies helps keep the whole Arthexis ecosystem healthy.
+If Arthexis helps your team, please review the license terms in [`LICENSE`](https://github.com/arthexis/arthexis/blob/main/LICENSE) and support the maintainers of the libraries, frameworks, and infrastructure projects that make this suite possible.

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,6 @@ For targeted notes about notable test-suite decisions and historical changes, se
 
 ## License and Support
 
-Arthexis is released under the Arthexis Reciprocity General License 1.0. Test fixes, maintenance, and documentation updates are all valuable contributions to this stack.
+Arthexis is distributed under the Arthexis Reciprocity General License 1.0. Test fixes, maintenance, and documentation updates are all recognized as valid forms of contribution to this stack.
 
 Please review the repository [`LICENSE`](../LICENSE) and support the maintainers of the dependencies that make this suite and its automated testing possible.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,8 +13,8 @@ For targeted notes about notable test-suite decisions and historical changes, se
 - [Test Suite Notes](../docs/development/testing/test-suite-notes.md)
 - [Command Matrix](../docs/development/command-matrix.md)
 
-## License and Sponsorship
+## License and Support
 
-Arthexis is released under the Arthexis Reciprocity General License 1.0. In addition to test fixes and maintenance, we consider sponsoring Arthexis and doing paid or volunteer work for the open-source dependencies that support this test stack to be a valid and important contribution.
+Arthexis is released under the Arthexis Reciprocity General License 1.0. Test fixes, maintenance, and documentation updates are all valuable contributions to this stack.
 
-Please review the repository [`LICENSE`](../LICENSE) and consider supporting the maintainers of the dependencies that make this suite and its automated testing possible.
+Please review the repository [`LICENSE`](../LICENSE) and support the maintainers of the dependencies that make this suite and its automated testing possible.


### PR DESCRIPTION
### Motivation
- Reduce sponsorship-focused language in top-level documentation to emphasize broader contribution and support options while keeping guidance to review licensing and support maintainers.

### Description
- Rename `License and Sponsorship` to `License and Support` and reword the explanatory paragraphs in `README.md` and `tests/README.md` to remove explicit sponsorship solicitation while preserving guidance to review `LICENSE` and support maintainers.

### Testing
- Ran lightweight verification commands (`git diff -- README.md tests/README.md` and `nl -ba README.md | sed -n '144,160p'` / `nl -ba tests/README.md | sed -n '10,24p'`) and confirmed the expected text changes; no unit or integration test suite run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b3a05988326a11cc8ecb07ac441)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Tone down sponsorship emphasis in license sections

### Changes
Updated the final section headers in README.md and tests/README.md from "License and Sponsorship" to "License and Support". Rewrote the explanatory paragraphs in both files to remove explicit sponsorship solicitation while preserving guidance to review the LICENSE file and to support maintainers of dependent libraries, frameworks, and infrastructure.

### Impact
- **README.md**: Section retitled and explanatory text revised to de-emphasize invitations to sponsor Arthexis and references to paid/volunteer work for dependency maintainers (+3/-3 lines)
- **tests/README.md**: Section retitled and contribution/support wording adjusted while preserving the Arthexis Reciprocity General License reference and the link to ../LICENSE (+3/-3 lines)

### Scope
Documentation-only change; no code, exported/public API, or test-suite changes. Lightweight text-verification commands were used to confirm the edits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7717)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->