### PR TITLE
Gate release readiness on current install health

### DIFF
--- a/.github/workflows/install-health.yml
+++ b/.github/workflows/install-health.yml
@@ -221,7 +221,7 @@ jobs:
             pytest-junit.xml
           if-no-files-found: warn
   notify_failure:
-    if: ${{ always() && needs.install.result == 'failure' }}
+    if: ${{ always() && needs.install.result == 'failure' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     needs:
       - install
     runs-on: ubuntu-latest

--- a/.github/workflows/install-health.yml
+++ b/.github/workflows/install-health.yml
@@ -10,13 +10,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
+  push: {}
   workflow_dispatch:
 
 jobs:
   install:
+    if: ${{ github.event_name != 'push' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     name: install (${{ matrix.os_flavor }}, ${{ matrix.db_backend }})
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/install-hourly.yml
+++ b/.github/workflows/install-hourly.yml
@@ -10,8 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 * * * *'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -215,7 +216,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: install-hourly-pytest-results-${{ matrix.os_flavor }}-${{ matrix.db_backend }}
+          name: install-health-pytest-results-${{ matrix.os_flavor }}-${{ matrix.db_backend }}
           path: |
             pytest.log
             pytest-junit.xml
@@ -288,7 +289,7 @@ jobs:
             const body = [
               marker,
               '',
-              'The hourly **Install Health Check** workflow failed.',
+              'The **Install Health Check** workflow failed.',
               '',
               `- Workflow run: ${runUrl}`,
               `- Workflow run API: ${runApiUrl}`,
@@ -345,7 +346,7 @@ jobs:
             core.info(`Created issue #${created.data.number}.`);
 
   notify_recovery:
-    if: ${{ always() && needs.install.result == 'success' && github.event_name == 'schedule' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    if: ${{ always() && needs.install.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     needs:
       - install
     runs-on: ubuntu-latest

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -85,6 +85,7 @@ jobs:
       actions: read
       contents: read
       issues: read
+      security-events: read
     outputs:
       should_run: ${{ steps.evaluate.outputs.should_run }}
       skip_reason: ${{ steps.evaluate.outputs.skip_reason }}
@@ -103,6 +104,7 @@ jobs:
             const blockers = [];
             const fullDayMillis = 24 * 60 * 60 * 1000;
             const releaseCutoffMillis = 3 * fullDayMillis;
+            const securityScanQuietMillis = 2 * 60 * 60 * 1000;
             let shouldRun = true;
             let skipReason = '';
 
@@ -160,6 +162,41 @@ jobs:
                 branch: defaultBranch,
               });
               const defaultBranchSha = defaultBranchData?.commit?.sha || context.sha;
+              const defaultBranchCommitDate =
+                defaultBranchData?.commit?.commit?.committer?.date
+                || defaultBranchData?.commit?.commit?.author?.date;
+
+              if (defaultBranchCommitDate) {
+                const commitTime = Date.parse(defaultBranchCommitDate);
+                const quietUntil = new Date(commitTime + securityScanQuietMillis);
+                const quietAgeMillis = Date.now() - commitTime;
+                if (quietAgeMillis < securityScanQuietMillis) {
+                  blockers.push(`Security scan settling period has not elapsed for current ${defaultBranch} commit ${defaultBranchSha}; wait until ${quietUntil.toISOString()}.`);
+                }
+              } else {
+                blockers.push(`Unable to verify ${defaultBranch} commit time before security scan readiness.`);
+              }
+
+              try {
+                const codeScanningAlerts = await github.paginate(github.rest.codeScanning.listAlertsForRepo, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  per_page: 100,
+                });
+
+                if (codeScanningAlerts.length) {
+                  const preview = codeScanningAlerts.slice(0, 5).map((alert) => {
+                    const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
+                    const rule = alert.rule?.id || alert.rule?.name || `alert ${alert.number}`;
+                    return `${severity}:${rule}${alert.html_url ? ` (${alert.html_url})` : ''}`;
+                  }).join('; ');
+                  const suffix = codeScanningAlerts.length > 5 ? `; and ${codeScanningAlerts.length - 5} more` : '';
+                  blockers.push(`Open GitHub code scanning security findings: ${codeScanningAlerts.length}. ${preview}${suffix}`);
+                }
+              } catch (error) {
+                blockers.push(`Unable to verify GitHub code scanning alerts before release readiness: ${error.message}`);
+              }
 
               const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
                 owner: context.repo.owner,
@@ -484,7 +521,7 @@ jobs:
               echo 'summary_markdown<<EOF'
               echo '### Simulation result'
               echo ''
-              echo '- ⏭️ Release simulation was skipped because install/upgrade blockers are open.'
+              echo '- ⏭️ Release simulation was skipped because release readiness blockers are open.'
               echo 'EOF'
               echo 'simulated_ok=false'
             } >> "$GITHUB_OUTPUT"
@@ -529,7 +566,7 @@ jobs:
               ? '❌ Do not release yet. Resolve blockers and wait for the next simulator run.'
               : simulatedOk
                 ? '✅ Recommendation: release can proceed once maintainers approve authorization.'
-                : '⚠️ No install/upgrade blockers were found, but release simulation did not complete.';
+                : '⚠️ No release readiness blockers were found, but release simulation did not complete.';
 
             const body = [
               marker,
@@ -541,11 +578,11 @@ jobs:
               `- Commit: ${context.sha}`,
               `- Event: ${context.eventName}`,
               '',
-              '## Install/upgrade blockers',
+              '## Release readiness blockers',
               blockerSection,
               '',
               canSimulate ? '## Release simulation' : '## Release simulation',
-              canSimulate ? simulationSummary : '- Skipped because install/upgrade blockers are currently open.',
+              canSimulate ? simulationSummary : '- Skipped because release readiness blockers are currently open.',
               '',
               '## Recommendation',
               recommendation,

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -4,9 +4,7 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  push: {}
 
 concurrency:
   group: release-simulator-${{ github.ref }}
@@ -16,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  mark_outdated_on_main_change:
+  mark_outdated_on_default_branch_change:
     if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     permissions:
@@ -29,6 +27,7 @@ jobs:
           script: |
             const title = 'Release Readiness Report';
             const marker = '<!-- release-readiness-report -->';
+            const defaultBranch = context.payload.repository?.default_branch || 'default branch';
             const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -62,9 +61,9 @@ jobs:
               repo: context.repo.repo,
               issue_number: existing.number,
               body: [
-                'Marking this report as outdated because `main` changed.',
+                `Marking this report as outdated because \`${defaultBranch}\` changed.`,
                 '',
-                `- New main commit: ${context.sha}`,
+                `- New default-branch commit: ${context.sha}`,
                 `- Push event: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
                 '',
                 'A fresh release readiness report will be created on the next scheduled simulator run.'
@@ -162,19 +161,27 @@ jobs:
                 branch: defaultBranch,
               });
               const defaultBranchSha = defaultBranchData?.commit?.sha || context.sha;
-              const defaultBranchCommitDate =
-                defaultBranchData?.commit?.commit?.committer?.date
-                || defaultBranchData?.commit?.commit?.author?.date;
+              const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: defaultBranch,
+                per_page: 100,
+              });
 
-              if (defaultBranchCommitDate) {
-                const commitTime = Date.parse(defaultBranchCommitDate);
-                const quietUntil = new Date(commitTime + securityScanQuietMillis);
-                const quietAgeMillis = Date.now() - commitTime;
+              const defaultBranchHeadPushRuns = ciRuns
+                .filter((run) => run.head_sha === defaultBranchSha && run.event === 'push' && run.created_at)
+                .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+              const defaultBranchAdvancedAt = defaultBranchHeadPushRuns[0]?.created_at;
+
+              if (defaultBranchAdvancedAt) {
+                const advancedTime = Date.parse(defaultBranchAdvancedAt);
+                const quietUntil = new Date(advancedTime + securityScanQuietMillis);
+                const quietAgeMillis = Date.now() - advancedTime;
                 if (quietAgeMillis < securityScanQuietMillis) {
-                  blockers.push(`Security scan settling period has not elapsed for current ${defaultBranch} commit ${defaultBranchSha}; wait until ${quietUntil.toISOString()}.`);
+                  blockers.push(`Security scan settling period has not elapsed since ${defaultBranch} advanced to commit ${defaultBranchSha}; wait until ${quietUntil.toISOString()}.`);
                 }
               } else {
-                blockers.push(`Unable to verify ${defaultBranch} commit time before security scan readiness.`);
+                blockers.push(`Unable to verify when ${defaultBranch} advanced to commit ${defaultBranchSha} before security scan readiness.`);
               }
 
               try {
@@ -197,13 +204,6 @@ jobs:
               } catch (error) {
                 blockers.push(`Unable to verify GitHub code scanning alerts before release readiness: ${error.message}`);
               }
-
-              const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: defaultBranch,
-                per_page: 100,
-              });
 
               const installHealthRunsForHead = ciRuns
                 .filter((run) => run.name === 'Install Health Check' && run.head_sha === defaultBranchSha)

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -154,12 +154,32 @@ jobs:
                 blockers.push(`Open install failure issue: #${installFailureIssue.number}`);
               }
 
+              const { data: defaultBranchData } = await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: defaultBranch,
+              });
+              const defaultBranchSha = defaultBranchData?.commit?.sha || context.sha;
+
               const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 branch: defaultBranch,
                 per_page: 100,
               });
+
+              const installHealthRunsForHead = ciRuns
+                .filter((run) => run.name === 'Install Health Check' && run.head_sha === defaultBranchSha)
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              const latestInstallHealthRun = installHealthRunsForHead[0];
+
+              if (!latestInstallHealthRun) {
+                blockers.push(`Install Health Check has not run for current ${defaultBranch} commit ${defaultBranchSha}.`);
+              } else if (latestInstallHealthRun.status !== 'completed') {
+                blockers.push(`Install Health Check for current ${defaultBranch} commit ${defaultBranchSha} is ${latestInstallHealthRun.status}: ${latestInstallHealthRun.html_url}`);
+              } else if (latestInstallHealthRun.conclusion !== 'success') {
+                blockers.push(`Install Health Check for current ${defaultBranch} commit ${defaultBranchSha} completed with ${latestInstallHealthRun.conclusion}: ${latestInstallHealthRun.html_url}`);
+              }
 
               const latestCiRun = ciRuns
                 .filter((run) => run.name === 'Upgrade Gate')

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -563,6 +563,24 @@ def test_release_simulator_requires_current_main_install_health_success() -> Non
     assert "Install Health Check has not run for current" in script
 
 
+def test_release_simulator_requires_security_scan_settling_and_clear_alerts() -> None:
+    workflow = _workflow_data("release-simulator.yml")
+    evaluate_job = workflow["jobs"]["evaluate"]
+    evaluate_step = _workflow_step(
+        evaluate_job, "Evaluate release blockers from install/upgrade pipeline state"
+    )
+    script = evaluate_step["with"]["script"]
+
+    assert evaluate_job["permissions"]["security-events"] == "read"
+    assert "securityScanQuietMillis = 2 * 60 * 60 * 1000" in script
+    assert "defaultBranchCommitDate" in script
+    assert "Security scan settling period has not elapsed" in script
+    assert "github.rest.codeScanning.listAlertsForRepo" in script
+    assert "state: 'open'" in script
+    assert "Open GitHub code scanning security findings" in script
+    assert "Unable to verify GitHub code scanning alerts" in script
+
+
 @pytest.mark.django_db
 def test_step_record_publish_metadata_records_github_release_url(
     monkeypatch, tmp_path: Path

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -527,6 +527,42 @@ def test_tag_from_version_workflow_creates_release_tag_and_dispatches_publish() 
     assert 'gh workflow run publish.yml --ref "$tag" -f release_tag="$tag"' in dispatch_run
 
 
+def test_install_health_workflow_runs_on_main_push_not_schedule() -> None:
+    workflow = _workflow_data("install-hourly.yml")
+    on_section = _workflow_on(workflow)
+
+    assert "schedule" not in on_section
+    assert on_section["push"]["branches"] == ["main"]
+    assert "workflow_dispatch" in on_section
+
+    install_job = workflow["jobs"]["install"]
+    upload_step = _workflow_step(install_job, "Upload pytest log")
+    assert upload_step["with"]["name"].startswith("install-health-pytest-results-")
+
+    notify_recovery = workflow["jobs"]["notify_recovery"]
+    assert "github.event_name == 'schedule'" not in notify_recovery["if"]
+    assert (
+        "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)"
+        in notify_recovery["if"]
+    )
+
+
+def test_release_simulator_requires_current_main_install_health_success() -> None:
+    workflow = _workflow_data("release-simulator.yml")
+    evaluate_job = workflow["jobs"]["evaluate"]
+    evaluate_step = _workflow_step(
+        evaluate_job, "Evaluate release blockers from install/upgrade pipeline state"
+    )
+    script = evaluate_step["with"]["script"]
+
+    assert "github.rest.repos.getBranch" in script
+    assert "defaultBranchSha" in script
+    assert "run.name === 'Install Health Check'" in script
+    assert "run.head_sha === defaultBranchSha" in script
+    assert "latestInstallHealthRun.conclusion !== 'success'" in script
+    assert "Install Health Check has not run for current" in script
+
+
 @pytest.mark.django_db
 def test_step_record_publish_metadata_records_github_release_url(
     monkeypatch, tmp_path: Path

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -527,15 +527,19 @@ def test_tag_from_version_workflow_creates_release_tag_and_dispatches_publish() 
     assert 'gh workflow run publish.yml --ref "$tag" -f release_tag="$tag"' in dispatch_run
 
 
-def test_install_health_workflow_runs_on_main_push_not_schedule() -> None:
-    workflow = _workflow_data("install-hourly.yml")
+def test_install_health_workflow_runs_on_default_branch_push_not_schedule() -> None:
+    workflow = _workflow_data("install-health.yml")
     on_section = _workflow_on(workflow)
 
     assert "schedule" not in on_section
-    assert on_section["push"]["branches"] == ["main"]
+    assert on_section["push"] == {}
     assert "workflow_dispatch" in on_section
 
     install_job = workflow["jobs"]["install"]
+    assert (
+        "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)"
+        in install_job["if"]
+    )
     upload_step = _workflow_step(install_job, "Upload pytest log")
     assert upload_step["with"]["name"].startswith("install-health-pytest-results-")
 
@@ -557,6 +561,7 @@ def test_release_simulator_requires_current_main_install_health_success() -> Non
 
     assert "github.rest.repos.getBranch" in script
     assert "defaultBranchSha" in script
+    assert "const ciRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo" in script
     assert "run.name === 'Install Health Check'" in script
     assert "run.head_sha === defaultBranchSha" in script
     assert "latestInstallHealthRun.conclusion !== 'success'" in script
@@ -573,8 +578,10 @@ def test_release_simulator_requires_security_scan_settling_and_clear_alerts() ->
 
     assert evaluate_job["permissions"]["security-events"] == "read"
     assert "securityScanQuietMillis = 2 * 60 * 60 * 1000" in script
-    assert "defaultBranchCommitDate" in script
-    assert "Security scan settling period has not elapsed" in script
+    assert "run.event === 'push'" in script
+    assert "defaultBranchAdvancedAt" in script
+    assert "Security scan settling period has not elapsed since" in script
+    assert "Unable to verify when" in script
     assert "github.rest.codeScanning.listAlertsForRepo" in script
     assert "state: 'open'" in script
     assert "Open GitHub code scanning security findings" in script

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -550,6 +550,12 @@ def test_install_health_workflow_runs_on_default_branch_push_not_schedule() -> N
         in notify_recovery["if"]
     )
 
+    notify_failure = workflow["jobs"]["notify_failure"]
+    assert (
+        "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)"
+        in notify_failure["if"]
+    )
+
 
 def test_release_simulator_requires_current_main_install_health_success() -> None:
     workflow = _workflow_data("release-simulator.yml")

--- a/docs/development/package-release-process.md
+++ b/docs/development/package-release-process.md
@@ -40,6 +40,7 @@ flowchart TD
 - The same step sequence is executed by the headless scheduler through `run_headless_publish`, which builds a `NodeWorkflow` from `PUBLISH_STEPS` and writes progress logs under `LOG_DIR`.
 - Dry-run mode exercises build and publish commands against Test PyPI, restoring `VERSION` and `pyproject.toml` afterward to avoid polluting the working tree.
 - Repository hygiene safeguards (dirty checks, syncs against `origin/main`, and build stale detection) ensure releases restart when source changes appear mid-run.
+- The automated release readiness report waits at least two hours after the latest `main` commit and requires zero open GitHub code-scanning alerts before it can recommend release simulation.
 - Release tags are automatic release output. Do not create the publish tag by hand during the normal path; let the release workflow or `tag-from-version.yml` create `vVERSION` from the reviewed `VERSION` on `main`.
 
 ## Publish with PyPI Trusted Publishers (OIDC)

--- a/docs/development/testing/test-suite-notes.md
+++ b/docs/development/testing/test-suite-notes.md
@@ -6,7 +6,7 @@ This document tracks focused test-suite decisions that are too specific for `tes
 
 - The env refresh integration test was retired because CI and local workflows already run environment refresh before test execution, so failures now surface earlier.
 - Document rendering integration coverage moved to higher-level doc generation checks and manual QA for end-to-end output, while unit coverage retains HTML escaping checks for plain text.
-- 2026-04-18: Removed `critical` marker usage and the PR marker-only workflow so both PR validation and `install-hourly.yml` now run the full default pytest suite without marker exclusions.
+- 2026-04-18: Removed `critical` marker usage and the PR marker-only workflow so both PR validation and the Install Health Check workflow run the full default pytest suite without marker exclusions.
 
 ## Marker change ledger
 


### PR DESCRIPTION
## Summary
- run Install Health Check on pushes to main instead of hourly schedule
- require a completed successful Install Health Check for the current default-branch SHA before release readiness can simulate/proceed
- update workflow regression coverage and stale install-health wording

## Validation
- .\.venv\Scripts\python.exe manage.py test run -- apps/core/tests/reports/test_release_publish_regressions.py
- .\.venv\Scripts\python.exe manage.py check --fail-level ERROR
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR gates the automated release readiness check on a successful and current Install Health Check workflow run for the repository default branch commit SHA. The Install Health Check workflow changes from a scheduled hourly cadence to event-driven runs (push and workflow_dispatch), with push executions limited to the repository default branch so that release readiness evaluations verify the most recent default-branch state.

## Workflow Changes

### Install Health Check (`.github/workflows/install-health.yml`)
- Trigger changed from cron to event-based: now fires on push and workflow_dispatch.
- The `install` job is guarded so push-triggered runs only execute for the repository default branch (`if: github.event_name != 'push' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)`).
- Pytest artifact upload name changed to the `install-health-pytest-results-...` prefix.
- `notify_failure` and recovery notification logic now gate on the default branch for push-based runs and remove "hourly" wording in failure messaging.

### Release Simulator (`.github/workflows/release-simulator.yml`)
- `mark_outdated_on_default_branch_change` now triggers on pushes but only runs when the push targets the repository default branch; the job dynamically references the repository default branch rather than hardcoding `main`.
- The simulator still has a scheduled trigger (cron) and workflow_dispatch; its `evaluate` job is skipped for push events (runs on schedule/dispatch).
- `evaluate` job permissions expanded to include `security-events: read`.
- Blocker determination expanded to use the computed default-branch commit SHA and to add blockers for:
  - Security-scan settling window (2 hours) not yet elapsed or unverified.
  - Any open GitHub code-scanning alerts.
  - Missing, non-completed, or non-successful Install Health Check workflow runs for the exact default-branch commit SHA.
- Existing upgrade-gate/CI failure checks remain; the report text was standardized to use “Release readiness blockers”.

## Tests
Added regression tests in apps/core/tests/reports/test_release_publish_regressions.py that assert workflow structure and evaluator script contents:
- test_install_health_workflow_runs_on_default_branch_push_not_schedule(): verifies install-health has no schedule trigger, includes workflow_dispatch, gates install job on the default-branch ref, and updates artifact naming/notification gating.
- test_release_simulator_requires_current_main_install_health_success(): verifies the release-simulator evaluate script discovers the default branch via the GitHub API, computes defaultBranchSha, compares workflow run head_sha, and blocks when the Install Health Check run for that SHA is missing/incomplete/unsuccessful.
- test_release_simulator_requires_security_scan_settling_and_clear_alerts(): verifies evaluate includes security-events read permission, security-scan settling window logic, and code-scanning alert listing/verification.

## Documentation
- docs/development/testing/test-suite-notes.md: records that `critical` marker usage and a PR-marker-only workflow were removed so both PR validation and Install Health Check run the full default pytest suite.
- docs/development/package-release-process.md: documents that the automated release readiness report waits (via a 2-hour security-scan quiet window) after the latest default-branch commit and requires zero open GitHub code-scanning alerts before recommending release simulation.

## Validation
Included validation commands in the PR description (Django tests, manage.py check, git diff --check) and the added tests exercise the YAML/embedded script structure to prevent regressions.

Lines changed: +67/-10 (workflows and tests). Estimated review effort: High (workflow logic) / Medium (tests) / Low (docs).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7718)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->