### PR TITLE
Harden diagnostics ZIP analyzer resource limits

### DIFF
--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -89,7 +89,11 @@ def _iter_log_text(zf: ZipFile):
             raise ValueError("log-like entries exceed total scan budget")
         bytes_to_read = min(MAX_LOG_ENTRY_BYTES, remaining_bytes)
         with zf.open(info) as log_fp:
-            raw_data = log_fp.read(bytes_to_read)
+            raw_data = log_fp.read(bytes_to_read + 1)
+        if len(raw_data) > bytes_to_read:
+            if bytes_to_read < MAX_LOG_ENTRY_BYTES:
+                raise ValueError("log-like entries exceed total scan budget")
+            raise ValueError(f"{name} exceeds maximum allowed size")
         scanned_entries += 1
         scanned_bytes += len(raw_data)
         text = raw_data.decode("utf-8", errors="replace")

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -83,7 +83,7 @@ def _iter_log_text(zf: ZipFile):
         if not _is_log_entry(name):
             continue
         if scanned_entries >= MAX_LOG_ENTRIES_SCANNED:
-            raise ValueError("too many log-like entries in package")
+            break
         remaining_bytes = MAX_TOTAL_LOG_BYTES - scanned_bytes
         if remaining_bytes <= 0:
             raise ValueError("log-like entries exceed total scan budget")

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -19,6 +19,25 @@ SECRET_EXPOSURE_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+MAX_MANIFEST_BYTES = 256 * 1024
+MAX_SUMMARY_BYTES = 512 * 1024
+MAX_LOG_ENTRY_BYTES = 1024 * 1024
+MAX_LOG_ENTRIES_SCANNED = 200
+MAX_TOTAL_LOG_BYTES = 16 * 1024 * 1024
+
+
+def _read_zip_text_limited(zf: ZipFile, name: str, *, limit: int, errors: str = "strict") -> str:
+    info = zf.getinfo(name)
+    if info.file_size > limit:
+        raise ValueError(f"{name} exceeds maximum allowed size")
+    with zf.open(info) as fp:
+        data = fp.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError(f"{name} exceeds maximum allowed size")
+    return data.decode("utf-8", errors=errors)
+
+
 RULES = (
     ("critical", "secret_exposure", SECRET_EXPOSURE_PATTERN, "Potential secret material detected."),
     ("high", "migration", re.compile(r"(migration|django\.db\.utils|OperationalError|ProgrammingError)", re.IGNORECASE), "Migration or database startup failure signals detected."),
@@ -39,8 +58,7 @@ def _manifest_list(manifest: dict, field: str, *, string_items: bool = False) ->
 
 
 def _load_manifest(zf: ZipFile) -> dict:
-    with zf.open("manifest.json") as manifest_fp:
-        manifest = json.loads(manifest_fp.read().decode("utf-8"))
+    manifest = json.loads(_read_zip_text_limited(zf, "manifest.json", limit=MAX_MANIFEST_BYTES))
     if not isinstance(manifest, dict):
         raise ValueError("manifest.json must decode to an object")
     return manifest
@@ -48,18 +66,28 @@ def _load_manifest(zf: ZipFile) -> dict:
 
 def _load_summary(zf: ZipFile) -> str:
     try:
-        with zf.open("summary.txt") as summary_fp:
-            return summary_fp.read().decode("utf-8", errors="replace")
+        return _read_zip_text_limited(zf, "summary.txt", limit=MAX_SUMMARY_BYTES, errors="replace")
     except KeyError:
         return ""
 
 
 def _iter_log_text(zf: ZipFile):
+    scanned_entries = 0
+    scanned_bytes = 0
     for name in zf.namelist():
         if not _is_log_entry(name):
             continue
-        with zf.open(name) as log_fp:
-            yield name, log_fp.read(1024 * 1024).decode("utf-8", errors="replace")
+        if scanned_entries >= MAX_LOG_ENTRIES_SCANNED:
+            raise ValueError("too many log-like entries in package")
+        info = zf.getinfo(name)
+        bytes_to_read = min(info.file_size, MAX_LOG_ENTRY_BYTES)
+        if scanned_bytes + bytes_to_read > MAX_TOTAL_LOG_BYTES:
+            raise ValueError("log-like entries exceed total scan budget")
+        with zf.open(info) as log_fp:
+            text = log_fp.read(MAX_LOG_ENTRY_BYTES).decode("utf-8", errors="replace")
+        scanned_entries += 1
+        scanned_bytes += bytes_to_read
+        yield name, text
 
 
 def _is_log_entry(name: str) -> bool:

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -25,6 +25,7 @@ MAX_SUMMARY_BYTES = 512 * 1024
 MAX_LOG_ENTRY_BYTES = 1024 * 1024
 MAX_LOG_ENTRIES_SCANNED = 200
 MAX_TOTAL_LOG_BYTES = 16 * 1024 * 1024
+MAX_TOTAL_ENTRIES = 2000
 
 
 def _read_zip_text_limited(zf: ZipFile, name: str, *, limit: int, errors: str = "strict") -> str:
@@ -74,19 +75,24 @@ def _load_summary(zf: ZipFile) -> str:
 def _iter_log_text(zf: ZipFile):
     scanned_entries = 0
     scanned_bytes = 0
-    for name in zf.namelist():
+    infos = zf.infolist()
+    if len(infos) > MAX_TOTAL_ENTRIES:
+        raise ValueError("too many entries in package")
+    for info in infos:
+        name = info.filename
         if not _is_log_entry(name):
             continue
         if scanned_entries >= MAX_LOG_ENTRIES_SCANNED:
             raise ValueError("too many log-like entries in package")
-        info = zf.getinfo(name)
-        bytes_to_read = min(info.file_size, MAX_LOG_ENTRY_BYTES)
-        if scanned_bytes + bytes_to_read > MAX_TOTAL_LOG_BYTES:
+        remaining_bytes = MAX_TOTAL_LOG_BYTES - scanned_bytes
+        if remaining_bytes <= 0:
             raise ValueError("log-like entries exceed total scan budget")
+        bytes_to_read = min(MAX_LOG_ENTRY_BYTES, remaining_bytes)
         with zf.open(info) as log_fp:
-            text = log_fp.read(MAX_LOG_ENTRY_BYTES).decode("utf-8", errors="replace")
+            raw_data = log_fp.read(bytes_to_read)
         scanned_entries += 1
-        scanned_bytes += bytes_to_read
+        scanned_bytes += len(raw_data)
+        text = raw_data.decode("utf-8", errors="replace")
         yield name, text
 
 

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -155,6 +155,26 @@ def test_analyze_error_report_package_rejects_too_many_log_entries(tmp_path):
         analyze_error_report_package(package_path)
 
 
+def test_analyze_error_report_package_rejects_large_log_entry(monkeypatch, tmp_path):
+    monkeypatch.setattr(error_report_analysis, "MAX_LOG_ENTRY_BYTES", 5)
+    monkeypatch.setattr(error_report_analysis, "MAX_TOTAL_LOG_BYTES", 20)
+    package_path = tmp_path / "error-report.zip"
+    _write_report(package_path, logs={"logs/runtime.log": "x" * 6})
+
+    with pytest.raises(ValueError, match="Malformed error-report package"):
+        analyze_error_report_package(package_path)
+
+
+def test_analyze_error_report_package_rejects_log_bytes_over_total(monkeypatch, tmp_path):
+    monkeypatch.setattr(error_report_analysis, "MAX_LOG_ENTRY_BYTES", 20)
+    monkeypatch.setattr(error_report_analysis, "MAX_TOTAL_LOG_BYTES", 5)
+    package_path = tmp_path / "error-report.zip"
+    _write_report(package_path, logs={"logs/runtime.log": "x" * 6})
+
+    with pytest.raises(ValueError, match="Malformed error-report package"):
+        analyze_error_report_package(package_path)
+
+
 def test_analyze_error_report_package_rejects_too_many_total_entries(monkeypatch, tmp_path):
     monkeypatch.setattr(error_report_analysis, "MAX_TOTAL_ENTRIES", 3)
     package_path = tmp_path / "error-report.zip"

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
-from io import StringIO
+from io import BytesIO, StringIO
 from zipfile import ZipFile
 
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
+from apps.users import error_report_analysis
 from apps.users.error_report_analysis import analyze_error_report_package
 
 
@@ -135,8 +136,6 @@ def test_analyze_error_report_package_rejects_malformed_manifest_lists(tmp_path,
         analyze_error_report_package(package_path)
 
 
-
-
 def test_analyze_error_report_package_rejects_large_summary(tmp_path):
     package_path = tmp_path / "error-report.zip"
     with ZipFile(package_path, "w") as zf:
@@ -154,6 +153,49 @@ def test_analyze_error_report_package_rejects_too_many_log_entries(tmp_path):
 
     with pytest.raises(ValueError, match="Malformed error-report package"):
         analyze_error_report_package(package_path)
+
+
+def test_analyze_error_report_package_rejects_too_many_total_entries(monkeypatch, tmp_path):
+    monkeypatch.setattr(error_report_analysis, "MAX_TOTAL_ENTRIES", 3)
+    package_path = tmp_path / "error-report.zip"
+    with ZipFile(package_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"warnings": [], "entries": []}))
+        zf.writestr("summary.txt", "ok")
+        zf.writestr("attachments/one.bin", "ok")
+        zf.writestr("attachments/two.bin", "ok")
+
+    with pytest.raises(ValueError, match="Malformed error-report package"):
+        analyze_error_report_package(package_path)
+
+
+def test_iter_log_text_tracks_actual_bytes_not_zip_metadata(monkeypatch):
+    class FakeZipInfo:
+        def __init__(self, filename):
+            self.filename = filename
+            self.file_size = 0
+
+    class FakeZipFile:
+        def __init__(self):
+            self.infos = [FakeZipInfo("logs/one.log"), FakeZipInfo("logs/two.log")]
+            self.payloads = {
+                "logs/one.log": b"12345",
+                "logs/two.log": b"6",
+            }
+
+        def infolist(self):
+            return self.infos
+
+        def open(self, info):
+            return BytesIO(self.payloads[info.filename])
+
+    monkeypatch.setattr(error_report_analysis, "MAX_TOTAL_LOG_BYTES", 5)
+    monkeypatch.setattr(error_report_analysis, "MAX_LOG_ENTRY_BYTES", 5)
+
+    log_iter = error_report_analysis._iter_log_text(FakeZipFile())
+
+    assert next(log_iter) == ("logs/one.log", "12345")
+    with pytest.raises(ValueError, match="total scan budget"):
+        next(log_iter)
 
 
 def test_diagnostics_analyze_requires_package():

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -135,6 +135,27 @@ def test_analyze_error_report_package_rejects_malformed_manifest_lists(tmp_path,
         analyze_error_report_package(package_path)
 
 
+
+
+def test_analyze_error_report_package_rejects_large_summary(tmp_path):
+    package_path = tmp_path / "error-report.zip"
+    with ZipFile(package_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"warnings": [], "entries": []}))
+        zf.writestr("summary.txt", "x" * (600 * 1024))
+
+    with pytest.raises(ValueError, match="Malformed error-report package"):
+        analyze_error_report_package(package_path)
+
+
+def test_analyze_error_report_package_rejects_too_many_log_entries(tmp_path):
+    package_path = tmp_path / "error-report.zip"
+    logs = {f"logs/log-{idx}.txt": "ok" for idx in range(201)}
+    _write_report(package_path, logs=logs)
+
+    with pytest.raises(ValueError, match="Malformed error-report package"):
+        analyze_error_report_package(package_path)
+
+
 def test_diagnostics_analyze_requires_package():
     with pytest.raises(CommandError, match="--package is required"):
         call_command("diagnostics", "analyze")

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -146,13 +146,20 @@ def test_analyze_error_report_package_rejects_large_summary(tmp_path):
         analyze_error_report_package(package_path)
 
 
-def test_analyze_error_report_package_rejects_too_many_log_entries(tmp_path):
+def test_analyze_error_report_package_limits_log_entries_without_rejecting(monkeypatch, tmp_path):
+    monkeypatch.setattr(error_report_analysis, "MAX_LOG_ENTRIES_SCANNED", 2)
     package_path = tmp_path / "error-report.zip"
-    logs = {f"logs/log-{idx}.txt": "ok" for idx in range(201)}
+    logs = {
+        "logs/log-0.txt": "ok",
+        "logs/log-1.txt": "ok",
+        "logs/log-2.txt": "Traceback (most recent call last):",
+    }
     _write_report(package_path, logs=logs)
 
-    with pytest.raises(ValueError, match="Malformed error-report package"):
-        analyze_error_report_package(package_path)
+    result = analyze_error_report_package(package_path)
+
+    assert result["findings"] == []
+    assert result["max_severity"] == "none"
 
 
 def test_analyze_error_report_package_rejects_large_log_entry(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation

- The error-report ZIP analyzer previously read `manifest.json` and `summary.txt` and iterated log-like entries without package-wide limits, allowing a crafted archive to force excessive decompression and memory/CPU use. 
- The change aims to protect management command execution on production/support hosts from denial-of-service caused by analyzing untrusted or malicious report packages.

### Description

- Add explicit resource bounds and tunable constants (`MAX_MANIFEST_BYTES`, `MAX_SUMMARY_BYTES`, `MAX_LOG_ENTRY_BYTES`, `MAX_LOG_ENTRIES_SCANNED`, `MAX_TOTAL_LOG_BYTES`) and a helper `_read_zip_text_limited` to safely read ZIP text members without unbounded decompression.  
- Replace unbounded reads for `manifest.json` and `summary.txt` to use the size-limited reader and raise when limits are exceeded.  
- Bound log scanning in `_iter_log_text` with per-entry caps and a package-wide scanned-entry and total-decompressed-byte budget, raising on overages to fail early.  
- Add regression tests that assert oversized `summary.txt` and excessive log-entry counts are rejected; changes touch `apps/users/error_report_analysis.py` and `apps/users/tests/test_error_report_analysis.py`.

### Testing

- Ran the package's automated unit tests for the analyzer: `.venv/bin/python manage.py test run -- apps/users/tests/test_error_report_analysis.py`, and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033736c9fc8326a567c48f6b87f671)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request hardens the error-report ZIP analyzer against resource exhaustion and malformed packages by adding explicit resource limits, safe ZIP-member reading, and regression tests that assert the analyzer fails fast on overages.

### Resource limits introduced
Module-level constants added:
- MAX_MANIFEST_BYTES = 256 KB
- MAX_SUMMARY_BYTES = 512 KB
- MAX_LOG_ENTRY_BYTES = 1 MB
- MAX_LOG_ENTRIES_SCANNED = 200
- MAX_TOTAL_LOG_BYTES = 16 MB
- MAX_TOTAL_ENTRIES = 2000

### Implementation changes
- Added helper _read_zip_text_limited(zf, name, *, limit, errors="strict"):
  - Pre-checks ZipInfo.file_size, reads limit+1 bytes to detect overflow and raises ValueError when exceeded.
  - Decodes bytes with configurable errors handling (summary.txt and log reads use errors="replace" where appropriate).
  - _load_summary treats a missing summary (KeyError) as an empty string.
- _load_manifest reads manifest.json via _read_zip_text_limited(MAX_MANIFEST_BYTES) and validates it decodes to a dict.
- _load_summary reads summary.txt via _read_zip_text_limited(MAX_SUMMARY_BYTES) with lossy decoding; missing summary returns "".
- Rewrote _iter_log_text to bound log scanning and resource usage:
  - Enforces package-wide entry count cap (MAX_TOTAL_ENTRIES).
  - Limits the number of log-like entries scanned (MAX_LOG_ENTRIES_SCANNED). When MAX_LOG_ENTRIES_SCANNED is lowered, extra entries are skipped rather than causing rejection.
  - Enforces per-entry read cap (MAX_LOG_ENTRY_BYTES).
  - Enforces cumulative decompressed-byte budget (MAX_TOTAL_LOG_BYTES), tracking actual decompressed payload bytes (not ZIP metadata).
  - Raises ValueError immediately when any limit is exceeded to fail fast.
- Public API behavior: BadZipFile and decoding/validation/limit errors are caught and re-raised as ValueError("Malformed error-report package") to preserve the analyzer’s external contract.

### Tests
- Expanded tests in apps/users/tests/test_error_report_analysis.py:
  - test_analyze_error_report_package_rejects_large_summary: oversized summary.txt is rejected.
  - test_analyze_error_report_package_limits_log_entries_without_rejecting: when MAX_LOG_ENTRIES_SCANNED is lowered, extra log entries are skipped and no findings are produced.
  - test_analyze_error_report_package_rejects_large_log_entry: monkeypatches budgets and asserts a single oversized log entry is rejected.
  - test_analyze_error_report_package_rejects_log_bytes_over_total: monkeypatches budgets and asserts total decompressed-log-byte overage is rejected.
  - test_analyze_error_report_package_rejects_too_many_total_entries: monkeypatches MAX_TOTAL_ENTRIES and asserts too many ZIP entries are rejected.
  - test_iter_log_text_tracks_actual_bytes_not_zip_metadata: uses a fake ZipFile to assert the iterator budgets actual decompressed bytes and raises when the total scan budget is exhausted.
- Automated unit tests for the analyzer were run and passed (20 passed).

### Notes
- Limits are tunable module-level constants.
- Changes are focused on failing fast on maliciously crafted archives and avoiding unbounded decompression/CPU/memory use while keeping the analyzer’s public error semantics intact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7719)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->