### PR TITLE
imager: redact additional cloud storage credential keys

### DIFF
--- a/apps/imager/services.py
+++ b/apps/imager/services.py
@@ -350,9 +350,12 @@ def _sanitize_storage_options(storage_options: dict[str, object]) -> dict[str, o
 
     sensitive_fragments = (
         "access_key",
+        "account_key",
         "connection_string",
         "password",
+        "private_key",
         "secret",
+        "shared_key",
         "token",
     )
 

--- a/apps/imager/tests/test_imager_command.py
+++ b/apps/imager/tests/test_imager_command.py
@@ -615,7 +615,13 @@ def test_sanitize_storage_options_masks_nested_secret_values() -> None:
                 "secret": "cleartext-secret",
                 "profile": {
                     "access_key": "cleartext-access-key",
+                    "private_key": "cleartext-private-key",
+                    "private_key_id": "cleartext-private-key-id",
                     "region": "us-east-1",
+                },
+                "azure": {
+                    "account_key": "cleartext-account-key",
+                    "shared_key": "cleartext-shared-key",
                 },
             },
             "mirrors": [
@@ -629,7 +635,13 @@ def test_sanitize_storage_options_masks_nested_secret_values() -> None:
             "secret": "***",
             "profile": {
                 "access_key": "***",
+                "private_key": "***",
+                "private_key_id": "***",
                 "region": "us-east-1",
+            },
+            "azure": {
+                "account_key": "***",
+                "shared_key": "***",
             },
         },
         "mirrors": [


### PR DESCRIPTION
### Motivation
- The storage-options metadata sanitizer could persist cloud credentials in cleartext because its denylist omitted common key name fragments used by providers (for example `private_key`, `account_key`, `shared_key`), exposing secrets in artifact `metadata` and via Django admin.

### Description
- Extend the sensitive fragments list in `_sanitize_storage_options()` to include `private_key`, `account_key`, and `shared_key` so keys containing those fragments are masked before being persisted.
- Update `apps/imager/tests/test_imager_command.py::test_sanitize_storage_options_masks_nested_secret_values` to cover nested GCS/Azure-style keys and assert they are masked while non-sensitive fields remain unchanged.

### Testing
- Ran `pytest -q apps/imager/tests/test_imager_command.py -k sanitize_storage_options` and the test passed after the change.
- Attempted repository bootstrap via `./install.sh` but it failed in this environment due to a missing `redis-server`, which is unrelated to the sanitizer fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033a4918e8832694dd1474d8bde9e4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation
The storage-options metadata sanitizer could persist cloud credentials in cleartext because its denylist omitted common key name fragments used by cloud providers (`private_key`, `account_key`, `shared_key`), potentially exposing secrets in artifact metadata and via Django admin.

## Changes
- **apps/imager/services.py**: Extended the sensitive fragment list in `_sanitize_storage_options()` to include `private_key`, `account_key`, and `shared_key` so keys containing those fragments are masked before being persisted.
- **apps/imager/tests/test_imager_command.py**: Updated `test_sanitize_storage_options_masks_nested_secret_values` to cover nested GCS and Azure-style credential keys (`credentials.profile.private_key`, `credentials.profile.private_key_id`, `credentials.azure.account_key`, `credentials.azure.shared_key`) and assert they are masked while non-sensitive fields remain unchanged.

## Testing
Test `apps/imager/tests/test_imager_command.py::test_sanitize_storage_options_masks_nested_secret_values` passes after the changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7720)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->