### PR TITLE
Add Arthexis notebook client (Node, Charger) and unit tests

### DIFF
--- a/apps/core/tests/test_arthexis_notebook.py
+++ b/apps/core/tests/test_arthexis_notebook.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from arthexis.notebook import ArthexisNotebookError, Node
+
+
+class _Response:
+    def __init__(self, *, text: str = "", payload=None, status_code: int = 200):
+        self.text = text
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_node_login_sets_authenticated_session():
+    session = requests.Session()
+    session.get = Mock(
+        return_value=_Response(
+            text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
+        )
+    )
+
+    def _fake_post(*args, **kwargs):
+        session.cookies.set("sessionid", "abc123")
+        return _Response()
+
+    session.post = Mock(side_effect=_fake_post)
+
+    node = Node("https://example.com", session=session)
+    node.login("user", "pass")
+
+    assert node.is_authenticated is True
+
+
+def test_chargers_returns_typed_wrappers():
+    session = requests.Session()
+    session.get = Mock(
+        return_value=_Response(
+            payload={"chargers": [{"charger_id": "SIM-CP-1", "status": "Charging"}]}
+        )
+    )
+
+    chargers = Node("https://example.com", session=session).chargers()
+
+    assert len(chargers) == 1
+    assert chargers[0].charger_id == "SIM-CP-1"
+    assert chargers[0].status == "Charging"
+
+
+def test_login_raises_when_csrf_token_missing():
+    session = requests.Session()
+    session.get = Mock(return_value=_Response(text="<html></html>"))
+    node = Node("https://example.com", session=session)
+
+    with pytest.raises(ArthexisNotebookError):
+        node.login("user", "pass")

--- a/apps/core/tests/test_arthexis_notebook.py
+++ b/apps/core/tests/test_arthexis_notebook.py
@@ -19,15 +19,65 @@ class _Response:
             raise requests.HTTPError(f"HTTP {self.status_code}")
 
     def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
         return self._payload
+
+
+def test_node_login_uses_admin_path_and_verifies_session():
+    session = requests.Session()
+    session.get = Mock(
+        side_effect=[
+            _Response(
+                text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
+            ),
+            _Response(),
+        ]
+    )
+
+    session.post = Mock(return_value=_Response())
+
+    node = Node("https://example.com", session=session, admin_path="control-panel/")
+    node.login("user", "pass")
+
+    assert node.is_authenticated is False
+    session.get.assert_any_call("https://example.com/control-panel/login/", timeout=30.0)
+    session.get.assert_any_call(
+        "https://example.com/control-panel/",
+        timeout=30.0,
+        allow_redirects=False,
+    )
+    session.post.assert_called_once()
+    assert session.post.call_args.kwargs["data"]["next"] == "/control-panel/"
+
+
+def test_login_rejects_stale_session_cookie_after_failed_auth_check():
+    session = requests.Session()
+    session.cookies.set("sessionid", "stale")
+    session.get = Mock(
+        side_effect=[
+            _Response(
+                text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
+            ),
+            _Response(status_code=302),
+        ]
+    )
+    session.post = Mock(return_value=_Response())
+    node = Node("https://example.com", session=session)
+
+    with pytest.raises(ArthexisNotebookError, match="Login failed"):
+        node.login("user", "bad-password")
 
 
 def test_node_login_sets_authenticated_session():
     session = requests.Session()
     session.get = Mock(
-        return_value=_Response(
-            text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
-        )
+        side_effect=[
+            _Response(
+                text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
+            ),
+            _Response(),
+        ]
     )
 
     def _fake_post(*args, **kwargs):
@@ -40,6 +90,33 @@ def test_node_login_sets_authenticated_session():
     node.login("user", "pass")
 
     assert node.is_authenticated is True
+
+
+def test_extract_csrf_token_handles_attribute_order_and_quotes():
+    html = (
+        "<form>"
+        "<input value='token123' class='x' name='csrfmiddlewaretoken'>"
+        "</form>"
+    )
+
+    assert Node._extract_csrf_token(html) == "token123"
+
+
+def test_extract_csrf_token_rejects_unexpected_characters():
+    html = '<input name="csrfmiddlewaretoken" value="token-123">'
+
+    assert Node._extract_csrf_token(html) is None
+
+
+def test_login_wraps_csrf_fetch_errors():
+    session = requests.Session()
+    session.get = Mock(return_value=_Response(status_code=500))
+    session.post = Mock()
+    node = Node("https://example.com", session=session)
+
+    with pytest.raises(ArthexisNotebookError, match="admin login page"):
+        node.login("user", "pass")
+    session.post.assert_not_called()
 
 
 def test_chargers_returns_typed_wrappers():
@@ -57,6 +134,19 @@ def test_chargers_returns_typed_wrappers():
     assert chargers[0].status == "Charging"
 
 
+def test_charger_encodes_reserved_path_characters():
+    session = requests.Session()
+    session.get = Mock(return_value=_Response(payload={"charger_id": "CP/1 ?#"}))
+
+    charger = Node("https://example.com", session=session).charger("CP/1 ?#")
+
+    assert charger.charger_id == "CP/1 ?#"
+    session.get.assert_called_once_with(
+        "https://example.com/ocpp/chargers/CP%2F1%20%3F%23/",
+        timeout=30.0,
+    )
+
+
 def test_login_raises_when_csrf_token_missing():
     session = requests.Session()
     session.get = Mock(return_value=_Response(text="<html></html>"))
@@ -64,3 +154,17 @@ def test_login_raises_when_csrf_token_missing():
 
     with pytest.raises(ArthexisNotebookError):
         node.login("user", "pass")
+
+
+def test_get_json_wraps_http_and_json_errors():
+    session = requests.Session()
+    session.get = Mock(return_value=_Response(status_code=500))
+    node = Node("https://example.com", session=session)
+
+    with pytest.raises(ArthexisNotebookError, match="Request failed"):
+        node.chargers()
+
+    session.get = Mock(return_value=_Response(payload=ValueError("bad json")))
+
+    with pytest.raises(ArthexisNotebookError, match="Invalid JSON"):
+        node.chargers()

--- a/apps/core/tests/test_arthexis_notebook.py
+++ b/apps/core/tests/test_arthexis_notebook.py
@@ -92,6 +92,33 @@ def test_node_login_sets_authenticated_session():
     assert node.is_authenticated is True
 
 
+def test_is_authenticated_uses_configured_session_cookie_name():
+    session = requests.Session()
+    session.cookies.set("customsession", "abc123")
+
+    node = Node(
+        "https://example.com",
+        session=session,
+        session_cookie_name="customsession",
+    )
+
+    assert node.is_authenticated is True
+
+
+def test_login_wraps_post_request_errors():
+    session = requests.Session()
+    session.get = Mock(
+        return_value=_Response(
+            text='<form><input name="csrfmiddlewaretoken" value="token123"/></form>'
+        )
+    )
+    session.post = Mock(side_effect=requests.Timeout("slow network"))
+    node = Node("https://example.com", session=session)
+
+    with pytest.raises(ArthexisNotebookError, match="Login request failed"):
+        node.login("user", "pass")
+
+
 def test_extract_csrf_token_handles_attribute_order_and_quotes():
     html = (
         "<form>"

--- a/arthexis/notebook.py
+++ b/arthexis/notebook.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 
+from django.conf import settings
 import requests
+
+from config.admin_urls import normalize_admin_url_path
+
+
+CSRF_TOKEN_PATTERN = re.compile(
+    r"<input\b"
+    r"(?=[^>]*\bname=[\"']csrfmiddlewaretoken[\"'])"
+    r"(?=[^>]*\bvalue=[\"'](?P<token>[A-Za-z0-9]+)[\"'])"
+    r"[^>]*>",
+    re.IGNORECASE,
+)
+DEFAULT_ADMIN_URL_PATH = "admin/"
 
 
 class ArthexisNotebookError(RuntimeError):
@@ -42,13 +57,15 @@ class Node:
         *,
         session: requests.Session | None = None,
         timeout: float = 30.0,
+        admin_path: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session = session or requests.Session()
         self.timeout = timeout
+        self.admin_path = normalize_admin_url_path(admin_path or _default_admin_url_path())
 
     def login(self, username: str, password: str) -> None:
-        login_url = f"{self.base_url}/admin/login/"
+        login_url = self._absolute_url(f"/{self.admin_path}login/")
         csrf = self._fetch_login_csrf(login_url)
         response = self.session.post(
             login_url,
@@ -56,13 +73,16 @@ class Node:
                 "username": username,
                 "password": password,
                 "csrfmiddlewaretoken": csrf,
-                "next": "/admin/",
+                "next": f"/{self.admin_path}",
             },
             headers={"Referer": login_url},
             timeout=self.timeout,
         )
-        response.raise_for_status()
-        if not self.is_authenticated:
+        try:
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise ArthexisNotebookError("Login request failed.") from exc
+        if not self._admin_session_is_authenticated():
             raise ArthexisNotebookError("Login failed: invalid credentials or CSRF flow.")
 
     @property
@@ -74,12 +94,15 @@ class Node:
         return [Charger(item) for item in payload.get("chargers", [])]
 
     def charger(self, charger_id: str) -> Charger:
-        payload = self._get_json(f"/ocpp/chargers/{charger_id}/")
+        payload = self._get_json(f"/ocpp/chargers/{quote(charger_id, safe='')}/")
         return Charger(payload)
 
     def _fetch_login_csrf(self, login_url: str) -> str:
-        response = self.session.get(login_url, timeout=self.timeout)
-        response.raise_for_status()
+        try:
+            response = self.session.get(login_url, timeout=self.timeout)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise ArthexisNotebookError("Could not fetch admin login page.") from exc
         token = self._extract_csrf_token(response.text)
         if not token:
             raise ArthexisNotebookError("Could not find csrfmiddlewaretoken on admin login page.")
@@ -87,30 +110,42 @@ class Node:
 
     @staticmethod
     def _extract_csrf_token(html: str) -> str | None:
-        marker = 'name="csrfmiddlewaretoken"'
-        marker_index = html.find(marker)
-        if marker_index < 0:
-            return None
-
-        value_marker = 'value="'
-        value_start = html.find(value_marker, marker_index)
-        if value_start < 0:
-            return None
-
-        value_start += len(value_marker)
-        value_end = html.find('"', value_start)
-        if value_end < 0:
-            return None
-
-        return html[value_start:value_end]
+        match = CSRF_TOKEN_PATTERN.search(html)
+        return match.group("token") if match else None
 
     def _get_json(self, path: str) -> dict[str, Any]:
-        response = self.session.get(f"{self.base_url}{path}", timeout=self.timeout)
-        response.raise_for_status()
-        data = response.json()
+        try:
+            response = self.session.get(self._absolute_url(path), timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+        except requests.RequestException as exc:
+            raise ArthexisNotebookError(f"Request failed for {path!r}.") from exc
+        except ValueError as exc:
+            raise ArthexisNotebookError(f"Invalid JSON response for {path!r}.") from exc
         if not isinstance(data, dict):
             raise ArthexisNotebookError("Unexpected API response; expected JSON object.")
         return data
+
+    def _admin_session_is_authenticated(self) -> bool:
+        try:
+            response = self.session.get(
+                self._absolute_url(f"/{self.admin_path}"),
+                timeout=self.timeout,
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            return False
+        return not 300 <= response.status_code < 400
+
+    def _absolute_url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+
+def _default_admin_url_path() -> str:
+    if settings.configured:
+        return str(getattr(settings, "ADMIN_URL_PATH", DEFAULT_ADMIN_URL_PATH))
+    return DEFAULT_ADMIN_URL_PATH
 
 
 __all__ = ["ArthexisNotebookError", "Charger", "Node"]

--- a/arthexis/notebook.py
+++ b/arthexis/notebook.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+class ArthexisNotebookError(RuntimeError):
+    """Raised when notebook helper operations fail."""
+
+
+@dataclass(frozen=True)
+class Charger:
+    """Typed wrapper around a charger payload returned by Arthexis APIs."""
+
+    payload: dict[str, Any]
+
+    @property
+    def charger_id(self) -> str | None:
+        return self.payload.get("charger_id")
+
+    @property
+    def status(self) -> str | None:
+        return self.payload.get("status")
+
+    @property
+    def connected(self) -> bool | None:
+        return self.payload.get("connected")
+
+    @property
+    def transaction(self) -> dict[str, Any] | None:
+        return self.payload.get("transaction")
+
+
+class Node:
+    """Notebook-friendly client for querying a live Arthexis node."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        session: requests.Session | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+        self.timeout = timeout
+
+    def login(self, username: str, password: str) -> None:
+        login_url = f"{self.base_url}/admin/login/"
+        csrf = self._fetch_login_csrf(login_url)
+        response = self.session.post(
+            login_url,
+            data={
+                "username": username,
+                "password": password,
+                "csrfmiddlewaretoken": csrf,
+                "next": "/admin/",
+            },
+            headers={"Referer": login_url},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        if not self.is_authenticated:
+            raise ArthexisNotebookError("Login failed: invalid credentials or CSRF flow.")
+
+    @property
+    def is_authenticated(self) -> bool:
+        return "sessionid" in self.session.cookies
+
+    def chargers(self) -> list[Charger]:
+        payload = self._get_json("/ocpp/chargers/")
+        return [Charger(item) for item in payload.get("chargers", [])]
+
+    def charger(self, charger_id: str) -> Charger:
+        payload = self._get_json(f"/ocpp/chargers/{charger_id}/")
+        return Charger(payload)
+
+    def _fetch_login_csrf(self, login_url: str) -> str:
+        response = self.session.get(login_url, timeout=self.timeout)
+        response.raise_for_status()
+        token = self._extract_csrf_token(response.text)
+        if not token:
+            raise ArthexisNotebookError("Could not find csrfmiddlewaretoken on admin login page.")
+        return token
+
+    @staticmethod
+    def _extract_csrf_token(html: str) -> str | None:
+        marker = 'name="csrfmiddlewaretoken"'
+        marker_index = html.find(marker)
+        if marker_index < 0:
+            return None
+
+        value_marker = 'value="'
+        value_start = html.find(value_marker, marker_index)
+        if value_start < 0:
+            return None
+
+        value_start += len(value_marker)
+        value_end = html.find('"', value_start)
+        if value_end < 0:
+            return None
+
+        return html[value_start:value_end]
+
+    def _get_json(self, path: str) -> dict[str, Any]:
+        response = self.session.get(f"{self.base_url}{path}", timeout=self.timeout)
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            raise ArthexisNotebookError("Unexpected API response; expected JSON object.")
+        return data
+
+
+__all__ = ["ArthexisNotebookError", "Charger", "Node"]

--- a/arthexis/notebook.py
+++ b/arthexis/notebook.py
@@ -19,6 +19,7 @@ CSRF_TOKEN_PATTERN = re.compile(
     re.IGNORECASE,
 )
 DEFAULT_ADMIN_URL_PATH = "admin/"
+DEFAULT_SESSION_COOKIE_NAME = "sessionid"
 
 
 class ArthexisNotebookError(RuntimeError):
@@ -58,27 +59,29 @@ class Node:
         session: requests.Session | None = None,
         timeout: float = 30.0,
         admin_path: str | None = None,
+        session_cookie_name: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session = session or requests.Session()
         self.timeout = timeout
         self.admin_path = normalize_admin_url_path(admin_path or _default_admin_url_path())
+        self.session_cookie_name = session_cookie_name or _default_session_cookie_name()
 
     def login(self, username: str, password: str) -> None:
         login_url = self._absolute_url(f"/{self.admin_path}login/")
         csrf = self._fetch_login_csrf(login_url)
-        response = self.session.post(
-            login_url,
-            data={
-                "username": username,
-                "password": password,
-                "csrfmiddlewaretoken": csrf,
-                "next": f"/{self.admin_path}",
-            },
-            headers={"Referer": login_url},
-            timeout=self.timeout,
-        )
         try:
+            response = self.session.post(
+                login_url,
+                data={
+                    "username": username,
+                    "password": password,
+                    "csrfmiddlewaretoken": csrf,
+                    "next": f"/{self.admin_path}",
+                },
+                headers={"Referer": login_url},
+                timeout=self.timeout,
+            )
             response.raise_for_status()
         except requests.RequestException as exc:
             raise ArthexisNotebookError("Login request failed.") from exc
@@ -87,7 +90,7 @@ class Node:
 
     @property
     def is_authenticated(self) -> bool:
-        return "sessionid" in self.session.cookies
+        return self.session_cookie_name in self.session.cookies
 
     def chargers(self) -> list[Charger]:
         payload = self._get_json("/ocpp/chargers/")
@@ -146,6 +149,12 @@ def _default_admin_url_path() -> str:
     if settings.configured:
         return str(getattr(settings, "ADMIN_URL_PATH", DEFAULT_ADMIN_URL_PATH))
     return DEFAULT_ADMIN_URL_PATH
+
+
+def _default_session_cookie_name() -> str:
+    if settings.configured:
+        return str(getattr(settings, "SESSION_COOKIE_NAME", DEFAULT_SESSION_COOKIE_NAME))
+    return DEFAULT_SESSION_COOKIE_NAME
 
 
 __all__ = ["ArthexisNotebookError", "Charger", "Node"]


### PR DESCRIPTION
### Motivation

- Provide a lightweight, notebook-friendly client to query a live Arthexis node and simplify interactive workflows by exposing typed wrappers for charger payloads and login helpers.
- Handle CSRF-protected admin login flows programmatically and surface clear errors when the flow fails.
- Enable basic unit coverage for the notebook helpers to prevent regressions.

### Description

- Add `arthexis/notebook.py` which defines `ArthexisNotebookError`, a frozen `Charger` dataclass with typed accessors, and a `Node` client that implements `login`, `is_authenticated`, `chargers`, and `charger` methods along with internal helpers `_fetch_login_csrf`, `_extract_csrf_token`, and `_get_json`.
- Implement a simple HTML CSRF token extractor using string searches and raise `ArthexisNotebookError` on unexpected responses or missing tokens.
- Export the new API via `__all__` and add `apps/core/tests/test_arthexis_notebook.py` with unit tests that mock `requests.Session` to validate login behavior and charger parsing.

### Testing

- Ran the unit tests in `apps/core/tests/test_arthexis_notebook.py` via `pytest`, which exercise login success (session cookie set), charger list parsing into `Charger` objects, and the error path when the CSRF token is missing; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03489629bc8326bc38bf0791aaf95a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Notebook Client for Arthexis Node

This PR adds a lightweight Python client for interactive access to a live Arthexis node with programmatic handling of the CSRF-protected admin login flow, typed wrappers for charger payloads, and unit tests to prevent regressions.

### Implementation Details

arthexis/notebook.py
- ArthexisNotebookError: RuntimeError subclass for notebook helper failures.
- Charger: frozen dataclass wrapping a charger API payload with typed accessors: charger_id, status, connected, transaction.
- Node: session-based client for node admin/API interaction:
  - Constructor: base_url, optional requests.Session, timeout, admin_path (normalized via config.admin_urls.normalize_admin_url_path or Django settings fallback), session_cookie_name (from settings fallback).
  - login(username, password): performs CSRF-protected admin login by:
    - GET the admin login page and extract csrfmiddlewaretoken using CSRF_TOKEN_PATTERN (restricts token to A–Z, a–z, 0–9),
    - POSTing credentials + token + next URL with Referer,
    - validating authentication with a follow-up GET to the admin root using allow_redirects=False and treating any 3xx as unauthenticated.
    - Network/HTTP failures raise ArthexisNotebookError with clear messages.
  - is_authenticated property: checks for configured session cookie name in the session's cookies.
  - chargers(): fetches /ocpp/chargers/, ensures JSON object response, and returns list[Charger].
  - charger(charger_id): URL-encodes reserved characters and fetches /ocpp/chargers/<id>/, returning Charger.
  - Internal helpers:
    - _fetch_login_csrf(login_url): GET + extract token, raises ArthexisNotebookError on failures or missing token.
    - _extract_csrf_token(html): static extraction using CSRF_TOKEN_PATTERN.
    - _get_json(path): GET absolute URL, raise ArthexisNotebookError on HTTP or JSON errors, ensures result is a dict.
  - Exports: __all__ = ["ArthexisNotebookError", "Charger", "Node"].

apps/core/tests/test_arthexis_notebook.py
- Adds a module-local _Response helper to mock requests responses (text, json payload, status_code, raise_for_status).
- Unit tests covering:
  - admin-path login flow and that POST includes "next" (test_node_login_uses_admin_path_and_verifies_session)
  - rejecting stale session cookie when admin auth check indicates redirect (test_login_rejects_stale_session_cookie_after_failed_auth_check)
  - login setting session cookie -> is_authenticated True (test_node_login_sets_authenticated_session)
  - is_authenticated honoring configured session_cookie_name (test_is_authenticated_uses_configured_session_cookie_name)
  - wrapping of POST request errors into ArthexisNotebookError (test_login_wraps_post_request_errors)
  - CSRF extraction handling attribute order and quote styles (test_extract_csrf_token_handles_attribute_order_and_quotes)
  - rejecting CSRF tokens with unexpected characters (test_extract_csrf_token_rejects_unexpected_characters)
  - wrapping CSRF fetch HTTP failures into ArthexisNotebookError and ensuring no POST occurs (test_login_wraps_csrf_fetch_errors)
  - chargers() returns typed Charger wrappers from API JSON (test_chargers_returns_typed_wrappers)
  - charger() URL-encodes reserved path characters when calling the endpoint (test_charger_encodes_reserved_path_characters)
  - login() raises when CSRF token missing (test_login_raises_when_csrf_token_missing)
  - _get_json() error wrapping for HTTP and JSON failures (test_get_json_wraps_http_and_json_errors)

Testing
- The new unit tests mock requests.Session to validate the login flow, CSRF extraction, charger fetching, and error paths; they exercise the error-wrapping and behavior described above.

Commit note
- Commit message indicates hardening/normalization of login/session failure handling in the Node client.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7724)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->