### PR TITLE
Decouple OCPP forward-reply dispatch from charger response handling

### DIFF
--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -1,7 +1,7 @@
 import base64
-import contextlib
 import json
-from asyncio import create_task
+import logging
+from asyncio import CancelledError, create_task
 from functools import cached_property
 
 from ... import store
@@ -9,6 +9,10 @@ from ...call_error_handlers import dispatch_call_error
 from ...call_result_handlers import dispatch_call_result
 from ...models import Charger
 from .routing import ActionRouter
+
+
+logger = logging.getLogger(__name__)
+MAX_BACKGROUND_FORWARD_REPLY_TASKS = 32
 
 
 class DispatchMixin:
@@ -50,17 +54,35 @@ class DispatchMixin:
 
     def _dispatch_forward_reply(self, forward_reply, message_id: str, raw: str) -> None:
         """Send forwarding replies without blocking charger message handling."""
-        task = create_task(forward_reply(message_id, raw))
         background_tasks = getattr(self, "_background_forward_reply_tasks", None)
         if background_tasks is None:
             background_tasks = set()
             self._background_forward_reply_tasks = background_tasks
+
+        for done_task in tuple(background_tasks):
+            if done_task.done():
+                background_tasks.discard(done_task)
+
+        if len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS:
+            logger.warning(
+                "Skipping reply forwarding for message %s because %s background "
+                "forwarding tasks are still active.",
+                message_id,
+                len(background_tasks),
+            )
+            return
+
+        task = create_task(forward_reply(message_id, raw))
         background_tasks.add(task)
 
         def _drop_completed(done_task):
             background_tasks.discard(done_task)
-            with contextlib.suppress(Exception):
+            try:
                 done_task.result()
+            except CancelledError:
+                logger.debug("Reply forwarding task cancelled for message %s.", message_id)
+            except Exception:
+                logger.exception("Reply forwarding failed for message %s.", message_id)
 
         task.add_done_callback(_drop_completed)
 

--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -1,5 +1,7 @@
 import base64
+import contextlib
 import json
+from asyncio import create_task
 from functools import cached_property
 
 from ... import store
@@ -45,6 +47,22 @@ class DispatchMixin:
         if raw is None and bytes_data is not None:
             raw = base64.b64encode(bytes_data).decode("ascii")
         return raw
+
+    def _dispatch_forward_reply(self, forward_reply, message_id: str, raw: str) -> None:
+        """Send forwarding replies without blocking charger message handling."""
+        task = create_task(forward_reply(message_id, raw))
+        background_tasks = getattr(self, "_background_forward_reply_tasks", None)
+        if background_tasks is None:
+            background_tasks = set()
+            self._background_forward_reply_tasks = background_tasks
+        background_tasks.add(task)
+
+        def _drop_completed(done_task):
+            background_tasks.discard(done_task)
+            with contextlib.suppress(Exception):
+                done_task.result()
+
+        task.add_done_callback(_drop_completed)
 
     def _parse_message(self, raw: str):
         try:
@@ -124,7 +142,7 @@ class DispatchMixin:
         )
         forward_reply = getattr(self, "_forward_charge_point_reply", None)
         if callable(forward_reply) and raw is not None:
-            await forward_reply(message_id, raw)
+            self._dispatch_forward_reply(forward_reply, message_id, raw)
         if handled:
             return
         store.record_pending_call_result(
@@ -164,7 +182,7 @@ class DispatchMixin:
         )
         forward_reply = getattr(self, "_forward_charge_point_reply", None)
         if callable(forward_reply) and raw is not None:
-            await forward_reply(message_id, raw)
+            self._dispatch_forward_reply(forward_reply, message_id, raw)
         if handled:
             return
         store.record_pending_call_result(

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime
 from datetime import timezone as dt_timezone
@@ -2947,3 +2948,28 @@ async def test_reservation_status_update_ignored_for_other_connector():
     assert updated.evcs_confirmed is False
     assert updated.evcs_confirmed_at is None
     assert not store.connector_release_notifications
+
+
+@pytest.mark.anyio
+async def test_call_result_forwarding_does_not_block_response_handling():
+    _reset_pending_calls()
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    consumer.store_key = "CP-BG-FWD"
+    consumer.charger_id = consumer.store_key
+    message_id = "msg-bg-forward"
+    store.register_pending_call(
+        message_id,
+        {"action": "Heartbeat", "charger_id": consumer.charger_id, "log_key": consumer.store_key},
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_forward_reply(*_args):
+        started.set()
+        await release.wait()
+
+    consumer._forward_charge_point_reply = _slow_forward_reply
+    await consumer._handle_call_result(message_id, {"status": "Accepted"}, raw='[3,"msg-bg-forward",{}]')
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+    assert message_id not in store.pending_calls
+    release.set()

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -22,6 +22,7 @@ from apps.ocpp.call_result_handlers.transactions import (
 )
 from apps.ocpp.consumers import CSMSConsumer
 from apps.ocpp.consumers import base as consumers_base
+from apps.ocpp.consumers.base import dispatch as dispatch_module
 from apps.ocpp.models import (
     CertificateOperation,
     CertificateRequest,
@@ -2973,3 +2974,69 @@ async def test_call_result_forwarding_does_not_block_response_handling():
     await asyncio.wait_for(started.wait(), timeout=0.5)
     assert message_id not in store.pending_calls
     release.set()
+
+
+@pytest.mark.anyio
+async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch, caplog):
+    monkeypatch.setattr(dispatch_module, "MAX_BACKGROUND_FORWARD_REPLY_TASKS", 1)
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _slow_forward_reply(*_args):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    consumer._dispatch_forward_reply(_slow_forward_reply, "msg-one", "[3]")
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    with caplog.at_level("WARNING", logger=dispatch_module.logger.name):
+        consumer._dispatch_forward_reply(_slow_forward_reply, "msg-two", "[3]")
+
+    assert calls == 1
+    assert len(consumer._background_forward_reply_tasks) == 1
+    assert "Skipping reply forwarding for message msg-two" in caplog.text
+
+    tasks = list(consumer._background_forward_reply_tasks)
+    release.set()
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.anyio
+async def test_forward_reply_dispatch_logs_failures(caplog):
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+
+    async def _failing_forward_reply(*_args):
+        raise OSError("forwarding offline")
+
+    with caplog.at_level("ERROR", logger=dispatch_module.logger.name):
+        consumer._dispatch_forward_reply(_failing_forward_reply, "msg-fail", "[3]")
+        for _ in range(5):
+            if not getattr(consumer, "_background_forward_reply_tasks", set()):
+                break
+            await asyncio.sleep(0)
+
+    assert any(
+        "Reply forwarding failed for message msg-fail" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_forward_reply_dispatch_drains_cancelled_tasks():
+    consumer = CSMSConsumer(scope={}, receive=None, send=None)
+    release = asyncio.Event()
+
+    async def _waiting_forward_reply(*_args):
+        await release.wait()
+
+    consumer._dispatch_forward_reply(_waiting_forward_reply, "msg-cancel", "[3]")
+    task = next(iter(consumer._background_forward_reply_tasks))
+    task.cancel()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert consumer._background_forward_reply_tasks == set()


### PR DESCRIPTION
### Motivation

- Forwarding of OCPP call-results/replies was performed inline on the charger response path which could delay or block the main response loop if forwarding I/O was slow, contributing to charger disconnects.

### Description

- Add `_dispatch_forward_reply` to `DispatchMixin` to schedule reply-forwarding using `asyncio.create_task` and to safely drain exceptions with `contextlib.suppress` so forwarding does not block the consumer loop.
- Replace inline `await _forward_charge_point_reply(...)` calls in `_handle_call_result` and `_handle_call_error` with `self._dispatch_forward_reply(...)` so forwarding runs in background tasks.
- Import `contextlib` and `create_task` and keep per-instance tracking of background forward-reply tasks to avoid silent failures.
- Add a regression test `test_call_result_forwarding_does_not_block_response_handling` in `apps/ocpp/tests/test_ocpp_handlers.py` that proves pending-call handling completes even when reply forwarding is deliberately slow.

### Testing

- Ran the targeted test file with the repo test runner: `.venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp_handlers.py -k call_result_forwarding_does_not_block_response_handling` and the test selection executed successfully.
- The test run reported `1 passed, 67 deselected` for the selected test, demonstrating the fix prevents forwarding from blocking response handling.
- Environment preparations (`./install.sh --terminal` and `./env-refresh.sh --deps-only`) were performed as part of the validation before running the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034db895e48326a7fd003a926d985c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Decouple OCPP forward-reply dispatch from charger response handling

### Problem
Forwarding of OCPP call-results/replies was performed inline on the charger response path, which could delay or block the main response loop and contribute to charger disconnects when forwarding I/O was slow.

### Solution
Refactored `DispatchMixin` to schedule reply-forwarding asynchronously instead of awaiting it directly in the response handling path, ensuring forwarding runs in background tasks and cannot block pending-call handling.

### Changes
- **`apps/ocpp/consumers/base/dispatch.py`**
  - Added `DispatchMixin._dispatch_forward_reply(self, forward_reply, message_id: str, raw: str) -> None`.
  - `_dispatch_forward_reply` schedules forwarding via `asyncio.create_task`, maintains a per-instance set of in-flight forward-reply tasks, prunes completed tasks, enforces a maximum concurrent background-forwarding limit (`MAX_BACKGROUND_FORWARD_REPLY_TASKS`), and ensures exceptions from forwarding tasks are safely handled (logged and suppressed) so they do not propagate into the consumer loop.
  - Replaced inline `await _forward_charge_point_reply(...)` calls in `_handle_call_result` and `_handle_call_error` with `self._dispatch_forward_reply(...)` so forwarding runs in background tasks and does not block response handling.

- **`apps/ocpp/tests/test_ocpp_handlers.py`**
  - Added regression test `test_call_result_forwarding_does_not_block_response_handling` proving pending-call handling completes promptly even when reply forwarding is deliberately slow.
  - Added tests covering background-task fanout limit, logging when the forwarder raises, and proper draining/removal of cancelled background tasks from the tracked set.

### Testing
- Ran targeted tests: 1 passed (the new regression test), 67 deselected.
- Environment preparation scripts executed prior to testing.

### Metadata
- Commit message indicates binding/tracking of forward-reply background tasks to avoid silent failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7725)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->