### PR TITLE
Fix RFID public login scanner polling

### DIFF
--- a/apps/cards/models/rfid_attempt.py
+++ b/apps/cards/models/rfid_attempt.py
@@ -107,6 +107,15 @@ class RFIDAttempt(Entity):
             elif normalized_status == cls.Status.REJECTED:
                 authenticated = False
         label_id = payload.get("label_id")
+        if label_id:
+            try:
+                label_id = int(label_id)
+            except (TypeError, ValueError):
+                label_id = None
+        if label_id:
+            label_model = cls._meta.get_field("label").remote_field.model
+            if not label_model.objects.filter(pk=label_id).exists():
+                label_id = None
         allowed_value = payload.get("allowed") if "allowed" in payload else None
         return cls.objects.create(
             rfid=rfid_value,

--- a/apps/cards/models/rfid_attempt.py
+++ b/apps/cards/models/rfid_attempt.py
@@ -106,13 +106,16 @@ class RFIDAttempt(Entity):
                 authenticated = True
             elif normalized_status == cls.Status.REJECTED:
                 authenticated = False
-        label_id = payload.get("label_id")
-        if label_id:
-            try:
-                label_id = int(label_id)
-            except (TypeError, ValueError):
-                label_id = None
-        if label_id:
+        raw_label_id = payload.get("label_id")
+        try:
+            label_id = (
+                int(raw_label_id)
+                if raw_label_id not in (None, "")
+                else None
+            )
+        except (TypeError, ValueError):
+            label_id = None
+        if label_id is not None:
             label_model = cls._meta.get_field("label").remote_field.model
             if not label_model.objects.filter(pk=label_id).exists():
                 label_id = None

--- a/apps/cards/tests/test_scan_next_access.py
+++ b/apps/cards/tests/test_scan_next_access.py
@@ -82,6 +82,30 @@ def test_scan_next_allows_anonymous_get_for_control_role(monkeypatch):
     assert json.loads(get_response.content)["rfid"] == "SCAN_NEXT"
 
 
+def test_scan_next_allows_anonymous_json_get_for_control_role(monkeypatch):
+    node = _make_node("Control")
+    monkeypatch.setattr(views.Node, "get_local", lambda: node)
+    RFIDAttempt.objects.create(
+        rfid="SCAN_NEXT_JSON",
+        status=RFIDAttempt.Status.SCANNED,
+        source=RFIDAttempt.Source.SERVICE,
+        payload={"rfid": "SCAN_NEXT_JSON"},
+    )
+
+    factory = RequestFactory()
+    get_request = factory.get(
+        reverse("rfid-scan-next"),
+        HTTP_ACCEPT="application/json",
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    get_request.user = AnonymousUser()
+
+    get_response = views.scan_next(get_request)
+
+    assert get_response.status_code == 200
+    assert json.loads(get_response.content)["rfid"] == "SCAN_NEXT_JSON"
+
+
 def test_scan_next_blocks_anonymous_post_for_control_role(monkeypatch):
     node = _make_node("Control")
     monkeypatch.setattr(views.Node, "get_local", lambda: node)

--- a/apps/cards/tests/test_scanner_service_ingest.py
+++ b/apps/cards/tests/test_scanner_service_ingest.py
@@ -107,3 +107,30 @@ def test_ingest_service_scans_ignores_stale_label_id(
     assert attempt.rfid == "ABCD1234"
     assert attempt.label_id is None
     assert attempt.payload["label_id"] == 999
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("label_id", ["", 0, "0", "not-int"])
+def test_ingest_service_scans_normalizes_invalid_label_id(
+    monkeypatch, settings, tmp_path, label_id
+):
+    settings.BASE_DIR = str(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "LOG_DIR", str(log_dir), raising=False)
+
+    log_file = log_dir / "rfid-scans.ndjson"
+    payload = {
+        "rfid": "ABCD1234",
+        "label_id": label_id,
+        "service_mode": "service",
+    }
+    log_file.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    processed = ingest_service_scans()
+
+    assert processed == 1
+    attempt = RFIDAttempt.objects.get()
+    assert attempt.rfid == "ABCD1234"
+    assert attempt.label_id is None
+    assert attempt.payload["label_id"] == label_id

--- a/apps/cards/tests/test_scanner_service_ingest.py
+++ b/apps/cards/tests/test_scanner_service_ingest.py
@@ -85,3 +85,25 @@ def test_ingest_service_scans_honors_legacy_integer_offset(
     assert RFIDAttempt.objects.count() == 1
     assert RFIDAttempt.objects.filter(rfid="ABCD1234").count() == 0
     assert RFIDAttempt.objects.filter(rfid="FEDC4321").count() == 1
+
+
+@pytest.mark.django_db
+def test_ingest_service_scans_ignores_stale_label_id(
+    monkeypatch, settings, tmp_path
+):
+    settings.BASE_DIR = str(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "LOG_DIR", str(log_dir), raising=False)
+
+    log_file = log_dir / "rfid-scans.ndjson"
+    payload = {"rfid": "ABCD1234", "label_id": 999, "service_mode": "service"}
+    log_file.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    processed = ingest_service_scans()
+
+    assert processed == 1
+    attempt = RFIDAttempt.objects.get()
+    assert attempt.rfid == "ABCD1234"
+    assert attempt.label_id is None
+    assert attempt.payload["label_id"] == 999

--- a/apps/cards/views.py
+++ b/apps/cards/views.py
@@ -59,9 +59,7 @@ def scan_next(request):
     role_name = getattr(getattr(node, "role", None), "name", None)
     user = request.user
     wants_json = _request_wants_json(request) or request.method == "POST"
-    allow_anonymous_get = (
-        role_name == "Control" and request.method == "GET" and not wants_json
-    )
+    allow_anonymous_get = role_name == "Control" and request.method == "GET"
     if not user.is_authenticated and not allow_anonymous_get:
         if wants_json:
             return JsonResponse({"error": "Authentication required"}, status=401)


### PR DESCRIPTION
## Summary
- allow Control-node public RFID login polling to request JSON from `/cards/scan/next/`
- ignore stale scanner-log `label_id` values when the referenced RFID row no longer exists
- add regression coverage for anonymous JSON scanner polling and stale service-log ingestion

## Verification
- `.venv/bin/python -m pytest apps/cards/tests/test_scan_next_access.py apps/cards/tests/test_scanner_service_ingest.py`

Closes #7726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix RFID public login scanner polling

### Problem
The public RFID login page on Control nodes failed when polling the scanner endpoint (`/cards/scan/next/`) with JSON requests, returning `401 Authentication required`. Additionally, stale RFID scan log entries containing invalid or outdated `label_id` references caused foreign-key integrity errors that prevented processing of subsequent scans.

### Solution

**View Layer**
- Modified `scan_next` view to allow anonymous `GET` requests on Control nodes regardless of whether the client accepts JSON, removing the previous restriction that blocked JSON requests from anonymous users.

**Model Layer**
- Updated `RFIDAttempt.record_attempt` to normalize `label_id` values by safely parsing them as integers, handling invalid inputs (`None`, empty strings, non-integer values) by setting them to `None`.
- Added validation to check that a parsed `label_id` references an existing label row in the remote model; if the reference is stale or broken, the field is cleared to `None` before creating the attempt record.

### Testing
- Added test for anonymous JSON GET requests to the scan endpoint when node role is Control, verifying a `200` response with expected RFID data.
- Added tests for `label_id` handling during NDJSON service log ingestion:
  - Stale `label_id` values are ignored (cleared to `None`) while preserving the original value in the attempt's payload
  - Multiple invalid `label_id` formats (empty string, invalid numbers, non-integer strings) are handled consistently without blocking log ingestion

### Impact
Enables public RFID scanner polling on Control nodes over JSON (supporting modern browser polling patterns) while gracefully handling legacy or corrupted scan log data during ingestion without service interruption.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->