### PR TITLE
Harden PR oversight tooling

### DIFF
--- a/apps/repos/management/commands/pr_oversee.py
+++ b/apps/repos/management/commands/pr_oversee.py
@@ -14,6 +14,7 @@ from apps.repos.pr_oversee import (
     PullRequestOverseer,
     default_patchwork_dir,
     patchwork_worktree_path,
+    review_reply_summary,
 )
 
 
@@ -68,6 +69,11 @@ class Command(BaseCommand):
         checkout_parser.add_argument(
             "--branch", default="", help="Optional local branch name."
         )
+        checkout_parser.add_argument(
+            "--no-link-venv",
+            action="store_true",
+            help="Do not link the current checkout .venv into the PR worktree.",
+        )
 
         test_plan_parser = subparsers.add_parser(
             "test-plan", help="Map changed files to test commands."
@@ -90,6 +96,33 @@ class Command(BaseCommand):
             help="Find duplicate or superseded dependency PR groups.",
         )
         dedupe_parser.add_argument("--limit", type=int, default=80)
+
+        advance_parser = subparsers.add_parser(
+            "advance",
+            help="Prioritize and optionally advance open pull requests.",
+        )
+        advance_parser.add_argument("--limit", type=int, default=80)
+        advance_parser.add_argument("--include-drafts", action="store_true")
+        advance_parser.add_argument("--require-approval", action="store_true")
+        advance_parser.add_argument("--allow-pending", action="store_true")
+        advance_parser.add_argument(
+            "--ready-drafts",
+            action="store_true",
+            help="Plan or mark otherwise-ready drafts as ready for review.",
+        )
+        advance_parser.add_argument(
+            "--merge", action="store_true", help="Plan or merge ready PRs."
+        )
+        advance_parser.add_argument(
+            "--method", choices=["squash", "merge", "rebase"], default="squash"
+        )
+        advance_parser.add_argument("--delete-branch", action="store_true")
+        advance_parser.add_argument("--admin", action="store_true")
+        advance_parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Required to mark drafts ready or merge PRs.",
+        )
 
         merge_parser = subparsers.add_parser("merge", help="Gate and merge a PR.")
         self._add_pr_arg(merge_parser)
@@ -136,6 +169,23 @@ class Command(BaseCommand):
             "--write",
             action="store_true",
             help="Required to remove patchwork worktrees.",
+        )
+
+        reply_summary_parser = subparsers.add_parser(
+            "reply-summary", help="Build a terse PR review reply body."
+        )
+        reply_summary_parser.add_argument("--commit", default="")
+        reply_summary_parser.add_argument(
+            "--change", action="append", default=[], help="Change summary bullet."
+        )
+        reply_summary_parser.add_argument(
+            "--validation",
+            action="append",
+            default=[],
+            help="Validation summary bullet.",
+        )
+        reply_summary_parser.add_argument(
+            "--note", action="append", default=[], help="Optional note bullet."
         )
 
         monitor_parser = subparsers.add_parser(
@@ -231,6 +281,7 @@ class Command(BaseCommand):
                 number,
                 worktree=worktree,
                 branch=str(options.get("branch") or ""),
+                link_venv=not bool(options.get("no_link_venv")),
             )
         if action == "test-plan":
             return overseer.test_plan(number)
@@ -238,6 +289,19 @@ class Command(BaseCommand):
             return overseer.ci_failures(number, include_logs=bool(options.get("logs")))
         if action == "dependency-dedupe":
             return overseer.dependency_dedupe(limit=int(options.get("limit") or 80))
+        if action == "advance":
+            return overseer.advance(
+                limit=int(options.get("limit") or 80),
+                include_drafts=bool(options.get("include_drafts")),
+                require_approval=bool(options.get("require_approval")),
+                allow_pending=bool(options.get("allow_pending")),
+                ready_drafts=bool(options.get("ready_drafts")),
+                merge=bool(options.get("merge")),
+                method=str(options.get("method") or "squash"),
+                delete_branch=bool(options.get("delete_branch")),
+                admin=bool(options.get("admin")),
+                write=bool(options.get("write")),
+            )
         if action == "merge":
             if not options.get("write"):
                 gate = overseer.gate(
@@ -314,6 +378,13 @@ class Command(BaseCommand):
                 expected_head_sha=str(options.get("expected_head_sha") or ""),
                 admin=bool(options.get("admin")),
                 write=bool(options.get("write")),
+            )
+        if action == "reply-summary":
+            return review_reply_summary(
+                commit=str(options.get("commit") or ""),
+                changes=[str(item) for item in options.get("change") or []],
+                validations=[str(item) for item in options.get("validation") or []],
+                notes=[str(item) for item in options.get("note") or []],
             )
         raise CommandError(f"Unsupported action: {action}")
 
@@ -409,6 +480,10 @@ class Command(BaseCommand):
             self.stdout.write(f"monitor={result.get('status')}")
             for reason in result.get("manualDecisionReasons") or []:
                 self.stdout.write(f"manual={reason}")
+            return
+
+        if "body" in result:
+            self.stdout.write(str(result.get("body") or "").rstrip())
             return
 
         self.stdout.write(json.dumps(result, indent=2, sort_keys=True))

--- a/apps/repos/pr_oversee.py
+++ b/apps/repos/pr_oversee.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
+import shutil
+import stat
 import subprocess
 import sys
 import time
@@ -104,6 +107,100 @@ def _status_is_patchwork_noise(lines: Iterable[str]) -> bool:
     )
 
 
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = getattr(path.lstat(), "st_file_attributes", 0)
+    except OSError:
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+
+
+def _remove_owned_path(path: Path) -> None:
+    if path.is_symlink():
+        path.unlink()
+        return
+    if _is_reparse_point(path):
+        if path.is_dir():
+            path.rmdir()
+        else:
+            path.unlink()
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+        return
+    path.unlink(missing_ok=True)
+
+
+def _local_venv_link(source: Path, target: Path) -> dict[str, Any]:
+    if target.exists() or target.is_symlink():
+        return {
+            "linked": False,
+            "reason": "target-exists",
+            "source": str(source),
+            "target": str(target),
+        }
+    if not source.exists():
+        return {
+            "linked": False,
+            "reason": "source-missing",
+            "source": str(source),
+            "target": str(target),
+        }
+
+    resolved_source = source.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if os.name == "nt":
+            completed = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(target), str(resolved_source)],
+                check=False,
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                text=True,
+            )
+            if completed.returncode != 0:
+                return {
+                    "linked": False,
+                    "reason": "junction-failed",
+                    "source": str(resolved_source),
+                    "target": str(target),
+                    "stderr": completed.stderr.strip(),
+                    "stdout": completed.stdout.strip(),
+                }
+            kind = "junction"
+        else:
+            target.symlink_to(resolved_source, target_is_directory=True)
+            kind = "symlink"
+    except OSError as exc:
+        return {
+            "linked": False,
+            "reason": "link-failed",
+            "source": str(resolved_source),
+            "target": str(target),
+            "error": str(exc),
+        }
+    return {
+        "linked": True,
+        "kind": kind,
+        "source": str(resolved_source),
+        "target": str(target),
+    }
+
+
+def _git_worktree_missing_error(*results: Any) -> bool:
+    message = " ".join(f"{result.stdout} {result.stderr}".lower() for result in results)
+    return any(
+        marker in message
+        for marker in (
+            "not a working tree",
+            "not a git repository",
+            "is not a working tree",
+            "does not exist",
+        )
+    )
+
+
 class PullRequestOverseeError(RuntimeError):
     """Raised when PR oversight cannot complete deterministically."""
 
@@ -185,27 +282,67 @@ def _check_name(check: Mapping[str, Any]) -> str:
     )
 
 
+def _check_group_key(check: Mapping[str, Any]) -> tuple[str, str, str]:
+    app = _coerce_mapping(check.get("app"))
+    return (
+        _check_name(check),
+        str(check.get("workflowName") or check.get("workflow") or ""),
+        str(app.get("name") or ""),
+    )
+
+
+def _check_order_key(check: Mapping[str, Any], index: int) -> tuple[int, str]:
+    for key in ("completedAt", "startedAt", "updatedAt", "createdAt"):
+        value = str(check.get(key) or "")
+        if value and not value.startswith("0001-"):
+            return 1, value
+    return 0, f"{index:08d}"
+
+
+def _check_entry(check: Mapping[str, Any]) -> dict[str, str]:
+    name = _check_name(check)
+    conclusion = str(check.get("conclusion") or "").upper()
+    status = str(check.get("status") or "").upper()
+    state = str(check.get("state") or "").upper()
+    return {
+        "name": name,
+        "status": status,
+        "state": state,
+        "conclusion": conclusion,
+        "value": conclusion or state or status or "UNKNOWN",
+        "detailsUrl": str(
+            check.get("detailsUrl") or check.get("targetUrl") or check.get("link") or ""
+        ),
+    }
+
+
 def check_rollup_state(pr: Mapping[str, Any]) -> dict[str, list[dict[str, str]]]:
     """Classify status check rollup entries as failing, pending, or passing."""
+
+    latest: dict[
+        tuple[str, str, str], tuple[tuple[int, str], int, Mapping[str, Any]]
+    ] = {}
+    superseded: list[dict[str, str]] = []
+    for index, raw_check in enumerate(_coerce_list(pr.get("statusCheckRollup"))):
+        check = _coerce_mapping(raw_check)
+        key = _check_group_key(check)
+        order = _check_order_key(check, index)
+        previous = latest.get(key)
+        if previous is None or order >= previous[0]:
+            if previous is not None:
+                superseded.append(_check_entry(previous[2]))
+            latest[key] = (order, index, check)
+        else:
+            superseded.append(_check_entry(check))
 
     failing: list[dict[str, str]] = []
     pending: list[dict[str, str]] = []
     passing: list[dict[str, str]] = []
-    for raw_check in _coerce_list(pr.get("statusCheckRollup")):
-        check = _coerce_mapping(raw_check)
-        name = _check_name(check)
-        conclusion = str(check.get("conclusion") or "").upper()
-        status = str(check.get("status") or "").upper()
-        state = str(check.get("state") or "").upper()
-        value = conclusion or state or status or "UNKNOWN"
-        entry = {
-            "name": name,
-            "status": status,
-            "state": state,
-            "conclusion": conclusion,
-            "value": value,
-            "detailsUrl": str(check.get("detailsUrl") or check.get("link") or ""),
-        }
+    for _order, _index, check in sorted(latest.values(), key=lambda item: item[1]):
+        entry = _check_entry(check)
+        conclusion = entry["conclusion"]
+        status = entry["status"]
+        state = entry["state"]
         if conclusion in BAD_CHECKS or state in BAD_CHECKS:
             failing.append(entry)
         elif conclusion and conclusion not in GOOD_CHECKS:
@@ -222,7 +359,12 @@ def check_rollup_state(pr: Mapping[str, Any]) -> dict[str, list[dict[str, str]]]
                 failing.append(entry)
         else:
             passing.append(entry)
-    return {"failing": failing, "pending": pending, "passing": passing}
+    return {
+        "failing": failing,
+        "pending": pending,
+        "passing": passing,
+        "superseded": superseded,
+    }
 
 
 def readiness_gate(
@@ -543,6 +685,38 @@ def hygiene_report(pr: Mapping[str, Any], files: Iterable[str]) -> dict[str, Any
     }
 
 
+def review_reply_summary(
+    *,
+    commit: str = "",
+    changes: Iterable[str] = (),
+    validations: Iterable[str] = (),
+    notes: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build a terse review-thread reply body from structured inputs."""
+
+    cleaned_changes = [item.strip() for item in changes if item.strip()]
+    cleaned_validations = [item.strip() for item in validations if item.strip()]
+    cleaned_notes = [item.strip() for item in notes if item.strip()]
+    short_commit = commit.strip()[:12]
+    lines = [f"Addressed in {short_commit}." if short_commit else "Addressed."]
+    if cleaned_changes:
+        lines.extend(["", "Changes:"])
+        lines.extend(f"- {item}" for item in cleaned_changes)
+    if cleaned_validations:
+        lines.extend(["", "Validation:"])
+        lines.extend(f"- {item}" for item in cleaned_validations)
+    if cleaned_notes:
+        lines.extend(["", "Notes:"])
+        lines.extend(f"- {item}" for item in cleaned_notes)
+    return {
+        "commit": short_commit,
+        "changes": cleaned_changes,
+        "validations": cleaned_validations,
+        "notes": cleaned_notes,
+        "body": "\n".join(lines).strip() + "\n",
+    }
+
+
 class PullRequestOverseer:
     """Command-backed deterministic PR oversight surface."""
 
@@ -851,12 +1025,406 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
     def dependency_dedupe(self, *, limit: int = 80) -> dict[str, Any]:
         return dependency_duplicates(self.list_open_prs(limit=limit))
 
+    def advance(
+        self,
+        *,
+        limit: int = 80,
+        include_drafts: bool = False,
+        require_approval: bool = False,
+        allow_pending: bool = False,
+        ready_drafts: bool = False,
+        merge: bool = False,
+        method: str = "squash",
+        delete_branch: bool = False,
+        admin: bool = False,
+        write: bool = False,
+    ) -> dict[str, Any]:
+        """Summarize and optionally advance open PRs by deterministic gates."""
+
+        selection = self.select_candidates(limit=limit, include_drafts=include_drafts)
+        items: list[dict[str, Any]] = []
+        action_plans: list[dict[str, Any]] = []
+        for candidate in _coerce_list(selection.get("candidates")):
+            assessment = self.assess_pr(
+                int(_coerce_mapping(candidate).get("number") or 0),
+                require_approval=require_approval,
+                allow_pending=allow_pending,
+                ready_drafts=ready_drafts,
+                merge=merge,
+                method=method,
+                delete_branch=delete_branch,
+                admin=admin,
+                write=write,
+            )
+            items.append(_coerce_mapping(assessment.get("item")))
+            action_plans.extend(_coerce_list(assessment.get("actions")))
+
+        ordered = sorted(
+            items,
+            key=lambda item: (
+                int(item["priority"]) if "priority" in item else 99,
+                str(item.get("updatedAt") or ""),
+                int(item.get("number") or 0),
+            ),
+        )
+        return {
+            "repo": self.repo,
+            "limit": limit,
+            "includeDrafts": include_drafts,
+            "write": write,
+            "openCount": len(_coerce_list(selection.get("summaries"))),
+            "consideredCount": len(items),
+            "skipped": _coerce_list(selection.get("skipped")),
+            "topSuggestions": ordered[:3],
+            "items": ordered,
+            "actions": self.execute_actions(action_plans) if write else [],
+        }
+
+    def select_candidates(self, *, limit: int, include_drafts: bool) -> dict[str, Any]:
+        if limit <= 0:
+            raise PullRequestOverseeError("limit must be positive")
+        summaries = self.list_open_prs(limit=limit)
+        candidates: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        for summary in summaries:
+            number = int(summary.get("number") or 0)
+            if not number:
+                continue
+            if summary.get("isDraft") and not include_drafts:
+                skipped.append(
+                    {
+                        "number": number,
+                        "title": summary.get("title"),
+                        "reason": "draft",
+                    }
+                )
+                continue
+            candidates.append({"number": number, "summary": summary})
+        return {
+            "summaries": summaries,
+            "candidates": candidates,
+            "skipped": skipped,
+        }
+
+    def assess_pr(
+        self,
+        number: int,
+        *,
+        require_approval: bool,
+        allow_pending: bool,
+        ready_drafts: bool,
+        merge: bool,
+        method: str,
+        delete_branch: bool,
+        admin: bool,
+        write: bool,
+    ) -> dict[str, Any]:
+        inspection = self.inspect(
+            number,
+            require_approval=require_approval,
+            allow_pending=allow_pending,
+        )
+        pr = inspection["pullRequest"]
+        gate = inspection["readiness"]
+        files = self.changed_files(number)
+        hygiene = hygiene_report(pr, files)
+        item = self._advance_item(pr, gate, hygiene)
+        item["suggestedCommand"] = self._advance_suggested_command(
+            number,
+            gate=gate,
+            ready_to_merge=bool(item["readyToMerge"]),
+            can_mark_ready=bool(item["canMarkReady"]),
+            blockers=[str(blocker) for blocker in item["blockers"]],
+            require_approval=require_approval,
+            allow_pending=allow_pending,
+            delete_branch=delete_branch,
+            admin=admin,
+        )
+        action_plan = self._advance_action_plan(
+            item,
+            gate=gate,
+            ready_drafts=ready_drafts,
+            merge=merge,
+            method=method,
+            delete_branch=delete_branch,
+            require_approval=require_approval,
+            allow_pending=allow_pending,
+            admin=admin,
+        )
+        actions = []
+        if action_plan:
+            item["plannedAction"] = action_plan["commandText"]
+            if write:
+                actions.append(action_plan)
+        return {"item": item, "actions": actions}
+
+    def execute_actions(
+        self, actions_list: Iterable[Mapping[str, Any]]
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        for action_plan in actions_list:
+            action = str(action_plan.get("action") or "")
+            number = int(action_plan.get("number") or 0)
+            try:
+                if action == "mark-ready":
+                    results.append(
+                        {
+                            "action": action,
+                            "number": number,
+                            "stdout": self.gh_text(
+                                [str(part) for part in action_plan["command"]]
+                            ),
+                        }
+                    )
+                elif action == "merge":
+                    results.append(
+                        {
+                            "action": action,
+                            "number": number,
+                            "result": self.merge(
+                                number,
+                                method=str(action_plan.get("method") or "squash"),
+                                delete_branch=bool(action_plan.get("deleteBranch")),
+                                require_approval=bool(
+                                    action_plan.get("requireApproval")
+                                ),
+                                expected_head_sha=str(
+                                    action_plan.get("expectedHeadSha") or ""
+                                ),
+                                allow_pending=bool(action_plan.get("allowPending")),
+                                admin=bool(action_plan.get("admin")),
+                            ),
+                        }
+                    )
+                else:
+                    results.append(
+                        {
+                            "action": action or "unknown",
+                            "number": number,
+                            "error": "unsupported-action",
+                        }
+                    )
+            except PullRequestOverseeError as exc:
+                results.append(
+                    {
+                        "action": action,
+                        "number": number,
+                        "error": str(exc),
+                    }
+                )
+        return results
+
+    def _advance_action_plan(
+        self,
+        item: Mapping[str, Any],
+        *,
+        gate: Mapping[str, Any],
+        ready_drafts: bool,
+        merge: bool,
+        method: str,
+        delete_branch: bool,
+        require_approval: bool,
+        allow_pending: bool,
+        admin: bool,
+    ) -> dict[str, Any] | None:
+        number = int(item.get("number") or 0)
+        if item.get("canMarkReady") and ready_drafts:
+            command = ["pr", "ready", str(number), "--repo", self.repo]
+            return {
+                "action": "mark-ready",
+                "number": number,
+                "command": command,
+                "commandText": self._quoted_command(["gh", *command]),
+            }
+        if item.get("readyToMerge") and merge:
+            expected_head_sha = str(gate.get("headRefOid") or "")
+            return {
+                "action": "merge",
+                "number": number,
+                "method": method,
+                "deleteBranch": delete_branch,
+                "requireApproval": require_approval,
+                "expectedHeadSha": expected_head_sha,
+                "allowPending": allow_pending,
+                "admin": admin,
+                "commandText": self._merge_command_text(
+                    number,
+                    method=method,
+                    expected_head_sha=expected_head_sha,
+                    delete_branch=delete_branch,
+                    admin=admin,
+                ),
+            }
+        return None
+
+    def _quoted_command(self, command: Iterable[object]) -> str:
+        parts = [str(part) for part in command]
+        if os.name == "nt":
+            return subprocess.list2cmdline(parts)
+        return shlex.join(parts)
+
+    def _manage_pr_oversee_command(self, *args: object) -> str:
+        return self._quoted_command(
+            [sys.executable, "manage.py", "pr_oversee", "--repo", self.repo, *args]
+        )
+
+    def _merge_command_text(
+        self,
+        number: int,
+        *,
+        method: str,
+        expected_head_sha: str,
+        delete_branch: bool,
+        admin: bool,
+    ) -> str:
+        command = ["gh", "pr", "merge", str(number), "--repo", self.repo, f"--{method}"]
+        if expected_head_sha:
+            command.extend(["--match-head-commit", expected_head_sha])
+        if delete_branch:
+            command.append("--delete-branch")
+        if admin:
+            command.append("--admin")
+        return self._quoted_command(command)
+
+    def _advance_item(
+        self,
+        pr: Mapping[str, Any],
+        gate: Mapping[str, Any],
+        hygiene: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        number = int(pr.get("number") or 0)
+        blockers = [str(item) for item in _coerce_list(gate.get("blockers"))]
+        non_draft_blockers = [item for item in blockers if item != "draft"]
+        is_draft = bool(pr.get("isDraft"))
+        hygiene_ok = bool(hygiene.get("ok"))
+        ready_to_merge = bool(gate.get("ready")) and hygiene_ok and not is_draft
+        can_mark_ready = is_draft and not non_draft_blockers and hygiene_ok
+        priority = self._advance_priority(
+            blockers=blockers,
+            hygiene_ok=hygiene_ok,
+            ready_to_merge=ready_to_merge,
+            can_mark_ready=can_mark_ready,
+            is_draft=is_draft,
+        )
+        return {
+            "number": number,
+            "title": pr.get("title"),
+            "url": pr.get("url"),
+            "author": _author_login(pr),
+            "headRefName": pr.get("headRefName"),
+            "headRefOid": pr.get("headRefOid"),
+            "isDraft": is_draft,
+            "updatedAt": pr.get("updatedAt"),
+            "priority": priority,
+            "status": self._advance_status(
+                blockers=blockers,
+                hygiene_ok=hygiene_ok,
+                ready_to_merge=ready_to_merge,
+                can_mark_ready=can_mark_ready,
+            ),
+            "readyToMerge": ready_to_merge,
+            "canMarkReady": can_mark_ready,
+            "blockers": blockers,
+            "warnings": _coerce_list(gate.get("warnings")),
+            "hygiene": hygiene,
+        }
+
+    def _advance_priority(
+        self,
+        *,
+        blockers: list[str],
+        hygiene_ok: bool,
+        ready_to_merge: bool,
+        can_mark_ready: bool,
+        is_draft: bool,
+    ) -> int:
+        if ready_to_merge:
+            return 0
+        if can_mark_ready:
+            return 1
+        if any(
+            blocker.startswith(("review:", "review_threads:")) for blocker in blockers
+        ):
+            return 2
+        if any(blocker.startswith("check:") for blocker in blockers):
+            return 3
+        if any(blocker.startswith("pending:") for blocker in blockers):
+            return 4
+        if any(
+            blocker.startswith(("merge_state:", "mergeable:")) for blocker in blockers
+        ):
+            return 5
+        if is_draft:
+            return 6
+        if not hygiene_ok:
+            return 7
+        return 8
+
+    def _advance_status(
+        self,
+        *,
+        blockers: list[str],
+        hygiene_ok: bool,
+        ready_to_merge: bool,
+        can_mark_ready: bool,
+    ) -> str:
+        if ready_to_merge:
+            return "ready-to-merge"
+        if can_mark_ready:
+            return "draft-ready"
+        if blockers:
+            return "blocked"
+        if not hygiene_ok:
+            return "hygiene-failed"
+        return "needs-review"
+
+    def _advance_suggested_command(
+        self,
+        number: int,
+        *,
+        gate: Mapping[str, Any],
+        ready_to_merge: bool,
+        can_mark_ready: bool,
+        blockers: list[str],
+        require_approval: bool,
+        allow_pending: bool,
+        delete_branch: bool,
+        admin: bool,
+    ) -> str:
+        if ready_to_merge:
+            command = ["monitor", "--pr", str(number), "--merge", "--write"]
+            if delete_branch:
+                command.append("--delete-branch")
+            if require_approval:
+                command.append("--require-approval")
+            if allow_pending:
+                command.append("--allow-pending")
+            if admin:
+                command.append("--admin")
+            if gate.get("headRefOid"):
+                command.extend(["--expected-head-sha", str(gate.get("headRefOid"))])
+            return self._manage_pr_oversee_command(*command)
+        if can_mark_ready:
+            return f"gh pr ready {number} --repo {self.repo}"
+        if any(blocker.startswith(("check:", "pending:")) for blocker in blockers):
+            return self._manage_pr_oversee_command(
+                "ci", "--pr", number, "--failures", "--logs"
+            )
+        if any(
+            blocker.startswith(("review:", "review_threads:")) for blocker in blockers
+        ):
+            return self._manage_pr_oversee_command(
+                "comments", "--pr", number, "--unresolved"
+            )
+        return self._manage_pr_oversee_command("inspect", "--pr", number)
+
     def checkout(
         self,
         number: int,
         *,
         worktree: Path,
         branch: str = "",
+        link_venv: bool = True,
     ) -> dict[str, Any]:
         if worktree.exists():
             raise PullRequestOverseeError(f"Worktree path already exists: {worktree}")
@@ -880,6 +1448,8 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             "baseRefOid": pr.get("baseRefOid"),
             "worktree": str(worktree),
         }
+        if link_venv:
+            metadata["venv"] = _local_venv_link(self.cwd / ".venv", worktree / ".venv")
         metadata_path = worktree / PATCHWORK_METADATA
         try:
             with open(
@@ -928,6 +1498,11 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             "stderr": result.stderr.strip(),
         }
         if result.returncode == 0:
+            residue = self._remove_patchwork_residue(
+                worktree, patchwork_root=patchwork_root
+            )
+            if residue.get("attempted"):
+                action["residue"] = residue
             return action
 
         metadata_exists = (worktree / PATCHWORK_METADATA).exists()
@@ -952,7 +1527,88 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                 "forceStderr": forced.stderr.strip(),
             }
         )
+        if forced.returncode == 0:
+            residue = self._remove_patchwork_residue(
+                worktree, patchwork_root=patchwork_root
+            )
+            if residue.get("attempted"):
+                action["residue"] = residue
+        elif _git_worktree_missing_error(result, forced):
+            local_remove = self._remove_patchwork_residue(
+                worktree, patchwork_root=patchwork_root
+            )
+            action["localRemove"] = local_remove
         return action
+
+    def _remove_patchwork_residue(
+        self,
+        worktree: Path,
+        *,
+        patchwork_root: Path | None = None,
+    ) -> dict[str, Any]:
+        if not worktree.exists():
+            return {"attempted": False, "reason": "missing"}
+        if patchwork_root is not None and not _path_is_relative_to(
+            worktree, patchwork_root
+        ):
+            return {"attempted": False, "reason": "outside-patchwork-root"}
+        try:
+            children = list(worktree.iterdir())
+        except OSError as exc:
+            return {
+                "attempted": False,
+                "reason": "list-failed",
+                "error": str(exc),
+            }
+        metadata = self._read_patchwork_metadata(worktree)
+        blocked_names = [
+            child.name
+            for child in children
+            if not self._is_owned_residue_path(child, metadata)
+        ]
+        residue_names = sorted(child.name for child in children)
+        if blocked_names:
+            return {
+                "attempted": False,
+                "reason": "non-owned-residue",
+                "paths": sorted(blocked_names),
+            }
+        try:
+            for child in children:
+                _remove_owned_path(child)
+            worktree.rmdir()
+        except OSError as exc:
+            return {
+                "attempted": True,
+                "removed": False,
+                "reason": "remove-failed",
+                "error": str(exc),
+                "paths": residue_names,
+            }
+        return {
+            "attempted": True,
+            "removed": not worktree.exists(),
+            "paths": residue_names,
+        }
+
+    def _read_patchwork_metadata(self, worktree: Path) -> dict[str, Any]:
+        try:
+            return _coerce_mapping(
+                json.loads((worktree / PATCHWORK_METADATA).read_text())
+            )
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    def _is_owned_residue_path(self, child: Path, metadata: Mapping[str, Any]) -> bool:
+        if child.name not in PATCHWORK_OWNED_NOISE:
+            return False
+        if child.name != ".venv":
+            return True
+        venv_metadata = _coerce_mapping(metadata.get("venv"))
+        is_link = child.is_symlink() or _is_reparse_point(child)
+        if venv_metadata:
+            return bool(venv_metadata.get("linked")) and is_link
+        return is_link
 
     def sync_worktree(self, number: int, *, worktree: Path) -> dict[str, Any]:
         """Fetch the current PR head and move an existing worktree to it."""
@@ -1207,9 +1863,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
         changed_files_by_head: dict[str, list[str]] = {}
         synced_worktree_head = ""
         dependency_dedupe = (
-            self.dependency_dedupe(limit=dependency_limit)
-            if dependency_limit
-            else {}
+            self.dependency_dedupe(limit=dependency_limit) if dependency_limit else {}
         )
         last_snapshot: dict[str, Any] = {}
         iteration = 0
@@ -1452,9 +2106,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             "gate": gate,
             "hygiene": hygiene_report(pr, files),
             "testPlan": changed_files_to_test_plan(files),
-            "ci": self._ci_failures_from_pr(
-                number, pr, include_logs=include_logs
-            ),
+            "ci": self._ci_failures_from_pr(number, pr, include_logs=include_logs),
             "dependencyDedupe": dependency_dedupe,
         }
 

--- a/apps/repos/tests/test_pr_oversee.py
+++ b/apps/repos/tests/test_pr_oversee.py
@@ -15,12 +15,14 @@ from apps.repos.pr_oversee import (
     CommandResult,
     PullRequestOverseeError,
     PullRequestOverseer,
+    _local_venv_link,
     changed_files_to_test_plan,
     default_patchwork_dir,
     dependency_duplicates,
     hygiene_report,
     patchwork_worktree_path,
     readiness_gate,
+    review_reply_summary,
 )
 
 
@@ -113,6 +115,34 @@ def test_readiness_gate_reports_blockers_for_review_checks_and_threads():
     assert "check:Tests:FAILURE" in result["blockers"]
     assert "pending:CodeQL:IN_PROGRESS" in result["blockers"]
     assert "review_threads:UNRESOLVED:2" in result["blockers"]
+
+
+def test_readiness_gate_ignores_superseded_cancelled_check_runs():
+    result = readiness_gate(
+        _pr_payload(
+            statusCheckRollup=[
+                {
+                    "name": "Upgrade safety gate",
+                    "workflowName": "Upgrade Gate",
+                    "status": "COMPLETED",
+                    "conclusion": "CANCELLED",
+                    "completedAt": "2026-05-12T18:00:00Z",
+                },
+                {
+                    "name": "Upgrade safety gate",
+                    "workflowName": "Upgrade Gate",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "completedAt": "2026-05-12T18:05:00Z",
+                },
+            ],
+        )
+    )
+
+    assert result["ready"] is True
+    assert result["blockers"] == []
+    assert result["checks"]["failing"] == []
+    assert result["checks"]["superseded"][0]["value"] == "CANCELLED"
 
 
 def test_comments_normalizes_unresolved_review_threads():
@@ -333,6 +363,87 @@ def test_dependency_duplicates_groups_versioned_dependabot_branches():
     assert result["django"]["preferred"]["number"] == 2
 
 
+def test_advance_includes_drafts_and_prioritizes_ready_work():
+    runner = FakeRunner(
+        [
+            CommandResult(
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 123,
+                            "title": "Ready PR",
+                            "isDraft": False,
+                        },
+                        {
+                            "number": 124,
+                            "title": "Draft PR",
+                            "isDraft": True,
+                        },
+                    ]
+                ),
+            ),
+            CommandResult(0, json.dumps(_pr_payload(number=123, title="Ready PR"))),
+            CommandResult(0, json.dumps(_review_threads_payload())),
+            CommandResult(0, "apps/repos/pr_oversee.py\n"),
+            CommandResult(
+                0,
+                json.dumps(_pr_payload(number=124, title="Draft PR", isDraft=True)),
+            ),
+            CommandResult(0, json.dumps(_review_threads_payload())),
+            CommandResult(0, "apps/repos/pr_oversee.py\n"),
+        ]
+    )
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
+
+    result = overseer.advance(limit=2, include_drafts=True)
+
+    assert result["consideredCount"] == 2
+    assert [item["number"] for item in result["topSuggestions"]] == [123, 124]
+    assert result["topSuggestions"][0]["readyToMerge"] is True
+    assert result["topSuggestions"][1]["canMarkReady"] is True
+
+
+def test_advance_suggests_ci_for_pending_checks():
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=FakeRunner())
+
+    command = overseer._advance_suggested_command(
+        123,
+        gate={},
+        ready_to_merge=False,
+        can_mark_ready=False,
+        blockers=["pending:Tests:IN_PROGRESS"],
+        require_approval=False,
+        allow_pending=False,
+        delete_branch=False,
+        admin=False,
+    )
+
+    assert command.endswith("ci --pr 123 --failures --logs")
+
+
+def test_advance_merge_suggestion_mirrors_enabled_flags():
+    overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=FakeRunner())
+
+    command = overseer._advance_suggested_command(
+        123,
+        gate={"headRefOid": "head-sha"},
+        ready_to_merge=True,
+        can_mark_ready=False,
+        blockers=[],
+        require_approval=True,
+        allow_pending=True,
+        delete_branch=False,
+        admin=True,
+    )
+
+    assert "--delete-branch" not in command
+    assert "--require-approval" in command
+    assert "--allow-pending" in command
+    assert "--admin" in command
+    assert "--expected-head-sha head-sha" in command
+
+
 def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
     runner = FakeRunner(
         [
@@ -368,6 +479,26 @@ def test_checkout_fetches_pr_head_creates_worktree_and_metadata(tmp_path: Path):
         json.loads((worktree / ".arthexis-pr-oversee.json").read_text())["headRefOid"]
         == "head-sha"
     )
+
+
+def test_checkout_links_current_venv_into_worktree(tmp_path: Path):
+    (tmp_path / ".venv").mkdir()
+    runner = FakeRunner(
+        [
+            CommandResult(0, json.dumps(_pr_payload())),
+            CommandResult(0),
+            CommandResult(0),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+    worktree = tmp_path / "pr-123"
+
+    result = overseer.checkout(123, worktree=worktree, branch="repos-pr-123")
+
+    assert result["venv"]["linked"] is True
+    assert (worktree / ".venv").exists()
 
 
 def test_checkout_does_not_follow_metadata_symlink(tmp_path: Path):
@@ -529,6 +660,60 @@ def test_cleanup_forces_removal_for_owned_patchwork_metadata(tmp_path: Path):
     ]
 
 
+def test_patchwork_remove_prunes_owned_residue_after_missing_worktree_error(
+    tmp_path: Path,
+):
+    patchwork_root = tmp_path / "patchwork"
+    worktree = patchwork_root / "arthexis-arthexis-pr-123"
+    worktree.mkdir(parents=True)
+    venv_source = tmp_path / "venv-source"
+    venv_source.mkdir()
+    venv = _local_venv_link(venv_source, worktree / ".venv")
+    assert venv["linked"] is True
+    (worktree / ".arthexis-pr-oversee.json").write_text(
+        json.dumps({"number": 123, "venv": venv})
+    )
+    runner = FakeRunner(
+        [
+            CommandResult(128, stderr="is not a working tree"),
+            CommandResult(128, stderr="not a git repository"),
+            CommandResult(128, stderr="is not a working tree"),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+
+    result = overseer._remove_worktree(worktree, patchwork_root=patchwork_root)
+
+    assert result["localRemove"]["removed"] is True
+    assert not worktree.exists()
+
+
+def test_patchwork_remove_preserves_real_venv_residue(tmp_path: Path):
+    patchwork_root = tmp_path / "patchwork"
+    worktree = patchwork_root / "arthexis-arthexis-pr-123"
+    worktree.mkdir(parents=True)
+    (worktree / ".arthexis-pr-oversee.json").write_text('{"number": 123}\n')
+    (worktree / ".venv").mkdir()
+    runner = FakeRunner(
+        [
+            CommandResult(128, stderr="is not a working tree"),
+            CommandResult(128, stderr="not a git repository"),
+            CommandResult(128, stderr="is not a working tree"),
+        ]
+    )
+    overseer = PullRequestOverseer(
+        repo="arthexis/arthexis", runner=runner, cwd=tmp_path
+    )
+
+    result = overseer._remove_worktree(worktree, patchwork_root=patchwork_root)
+
+    assert result["localRemove"]["reason"] == "non-owned-residue"
+    assert result["localRemove"]["paths"] == [".venv"]
+    assert (worktree / ".venv").exists()
+
+
 def test_patchwork_remove_respects_git_force_failure(tmp_path: Path):
     patchwork_root = tmp_path / "patchwork"
     worktree = patchwork_root / "arthexis-arthexis-pr-123"
@@ -559,7 +744,9 @@ def test_patchwork_hygiene_marks_merged_worktrees_for_prune(tmp_path: Path):
     (worktree / ".arthexis-pr-oversee.json").write_text(
         json.dumps({"repo": "arthexis/arthexis", "number": 123})
     )
-    runner = FakeRunner([CommandResult(0, json.dumps([{"number": 123, "state": "MERGED"}]))])
+    runner = FakeRunner(
+        [CommandResult(0, json.dumps([{"number": 123, "state": "MERGED"}]))]
+    )
     overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
 
     result = overseer.patchwork_hygiene(root=tmp_path)
@@ -628,6 +815,19 @@ def test_hygiene_detects_missing_migration_and_generated_files():
     assert "model-change:missing-migration" in result["failures"]
     assert "body:missing-summary" in result["warnings"]
     assert "body:missing-validation" in result["warnings"]
+
+
+def test_review_reply_summary_formats_change_and_validation_body():
+    result = review_reply_summary(
+        commit="0123456789abcdef",
+        changes=["Linked patchwork .venv"],
+        validations=["manage.py test run -- apps/repos/tests"],
+    )
+
+    assert result["commit"] == "0123456789ab"
+    assert "Addressed in 0123456789ab." in result["body"]
+    assert "- Linked patchwork .venv" in result["body"]
+    assert "- manage.py test run -- apps/repos/tests" in result["body"]
 
 
 def test_management_command_merge_without_write_reports_plan():
@@ -699,6 +899,49 @@ def test_management_command_checkout_defaults_to_patchwork_dir(tmp_path: Path):
     assert kwargs["worktree"] == tmp_path / "arthexis-arthexis-pr-123"
 
 
+def test_management_command_advance_passes_include_drafts_and_write_flags():
+    fake = PullRequestOverseer(repo="arthexis/arthexis")
+    fake.advance = Mock(
+        return_value={
+            "repo": "arthexis/arthexis",
+            "includeDrafts": True,
+            "topSuggestions": [],
+            "items": [],
+            "actions": [],
+        }
+    )
+    buffer = StringIO()
+
+    with patch(
+        "apps.repos.management.commands.pr_oversee.PullRequestOverseer",
+        return_value=fake,
+    ):
+        call_command(
+            "pr_oversee",
+            "--repo",
+            "arthexis/arthexis",
+            "--json",
+            "advance",
+            "--include-drafts",
+            "--ready-drafts",
+            "--merge",
+            "--write",
+            "--limit",
+            "5",
+            stdout=buffer,
+        )
+
+    payload = json.loads(buffer.getvalue())
+    assert payload["includeDrafts"] is True
+    fake.advance.assert_called_once()
+    _, kwargs = fake.advance.call_args
+    assert kwargs["limit"] == 5
+    assert kwargs["include_drafts"] is True
+    assert kwargs["ready_drafts"] is True
+    assert kwargs["merge"] is True
+    assert kwargs["write"] is True
+
+
 def test_monitor_stops_for_manual_review_blocker():
     runner = FakeRunner(
         [
@@ -731,9 +974,7 @@ def test_monitor_stops_for_manual_review_blocker():
 
 def test_monitor_waits_on_pending_then_merges_and_cleans():
     pending = _pr_payload(
-        statusCheckRollup=[
-            {"name": "Tests", "status": "IN_PROGRESS", "conclusion": ""}
-        ]
+        statusCheckRollup=[{"name": "Tests", "status": "IN_PROGRESS", "conclusion": ""}]
     )
     ready = _pr_payload()
     merged = _pr_payload(state="MERGED")
@@ -854,9 +1095,7 @@ def test_monitor_requires_write_for_run_test_plan():
     overseer = PullRequestOverseer(repo="arthexis/arthexis", runner=runner)
 
     with pytest.raises(PullRequestOverseeError) as exc:
-        overseer.monitor(
-            123, run_test_plan=True, max_iterations=1, dependency_limit=0
-        )
+        overseer.monitor(123, run_test_plan=True, max_iterations=1, dependency_limit=0)
 
     assert (
         str(exc.value)


### PR DESCRIPTION
## Summary
- ignore superseded stale status-check rollup entries when newer runs for the same check exist
- add `pr_oversee advance --include-drafts` with optional draft-ready and merge write actions
- link the current `.venv` into PR worktrees by default and prune suite-owned patchwork residue safely
- add `reply-summary` to generate concise review-thread reply text

## Validation
- `.venv\Scripts\python.exe -m ruff check apps\repos\pr_oversee.py apps\repos\management\commands\pr_oversee.py apps\repos\tests\test_pr_oversee.py`
- `.venv\Scripts\python.exe manage.py test run -- apps/repos/tests/test_pr_oversee.py` (40 passed)
- `.venv\Scripts\python.exe manage.py test run -- apps/repos/tests` (117 passed)
- `.venv\Scripts\python.exe manage.py pr_oversee --repo arthexis/arthexis --json advance --include-drafts --limit 5`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR hardens PR oversight tooling by refining status-check handling, adding an advance workflow for drafts/ready PRs (with optional execution), improving worktree/patchwork cleanup (including default .venv linking), and adding a concise review-reply generator.

## Key Changes

### Core functionality (apps/repos/pr_oversee.py)
- Status-check refinement: `check_rollup_state` now groups and orders status-rollup entries deterministically, produces stable recency keys, marks older runs as `superseded`, and returns `superseded` alongside `failing`, `pending`, and `passing` so stale/cancelled runs don’t block readiness when a newer run exists.
- Advance workflow: `PullRequestOverseer.advance(...)` selects candidate open PRs, assesses gating/hygiene/readiness, assigns priorities/statuses, generates suggested commands and mark-ready/merge command text (OS-safe quoted), and can plan or perform mark-ready/merge actions when `write=True`. Options: `limit`, `include_drafts`, `require_approval`, `allow_pending`, `ready_drafts`, `merge`, `method`, `delete_branch`, `admin`, and `write`.
- Worktree & Patchwork cleanup:
  - `checkout(..., link_venv: bool = True)` links the current `.venv` into created PR worktrees by default (opt-out via `--no-link-venv`).
  - OS-aware helpers detect Windows reparse points and Patchwork-owned residue; `_remove_worktree()` classifies missing/invalid worktree errors and prunes suite-owned residue safely, falling back to local cleanup when appropriate.
- Review reply helper: `review_reply_summary(...)` normalizes structured reply inputs and renders a deterministic, concise multiline `body`.

### CLI (apps/repos/management/commands/pr_oversee.py)
- New/updated subcommands and flags:
  - `advance` — forwards include/ready/merge/write/admin and other options to `PullRequestOverseer.advance`. Adds `--include-drafts` and `--ready-drafts` behaviors and supports `--merge`/`--write` for executing actions.
  - `reply-summary` — emits concise review reply text built from `--commit` plus repeatable `--change`, `--validation`, and `--note` bullets.
  - `checkout` gains `--no-link-venv`.
- Result rendering: when a command result includes a `body` field the command prints plain-text reply bodies (right-stripped) directly instead of the prior JSON/state-keyed formatting.

### Tests (apps/repos/tests/test_pr_oversee.py)
- Added/extended tests validating:
  - Ignoring superseded CANCELLED runs when a newer SUCCESS run exists.
  - `advance` includes `--include-drafts`, prioritizes ready work, and respects `limit`.
  - `advance` suggests CI commands for pending checks (expected `ci --pr <id> --failures --logs` suffix).
  - `.venv` is linked into worktrees on checkout and reported as linked.
  - Patchwork residue pruning after repeated “not a working tree / not a git repository” failures leads to local residue removal.
  - `review_reply_summary` formats changes/validations and truncates commit references correctly.
  - Management command `pr_oversee --json advance` forwards flags (`--include-drafts`, `--ready-drafts`, `--merge`, `--write`, `--limit`) with correct argument names and typed values.

### Alterations to exported/public entities
- Added function: `review_reply_summary(*, commit: str = "", changes: Iterable[str] = (), validations: Iterable[str] = (), notes: Iterable[str] = ()) -> dict[str, Any]`.
- Added method: `PullRequestOverseer.advance(self, *, limit: int = 80, include_drafts: bool = False, require_approval: bool = False, allow_pending: bool = False, ready_drafts: bool = False, merge: bool = False, method: str = "squash", delete_branch: bool = False, admin: bool = False, write: bool = False) -> dict[str, Any]`.
- Updated method signature: `PullRequestOverseer.checkout(..., worktree: Path, branch: str = "", link_venv: bool = True)`.
- No existing public API signatures were removed.

## Validation
- Lint: .venv\Scripts\python.exe -m ruff check apps\repos\pr_oversee.py apps\repos/management/commands/pr_oversee.py apps\repos/tests/test_pr_oversee.py
- Tests:
  - apps/repos/tests/test_pr_oversee.py: 39 passed
  - apps/repos/tests: 116 passed
- Command/demo: `.venv\Scripts\python.exe manage.py pr_oversee --repo arthexis/arthexis --json advance --include-drafts --limit 5`
- Git whitespace check: `git diff --check`

## Notes
- Significant additions in pr_oversee (approx +674/-22) and tests (+246/-7); estimated review effort: Medium–High.
- Changes preserve the original intent and add targeted tests that validate the new behaviors without over-engineering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7730)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->