### PR TITLE
Add controller/gamepad mappings and zoom behavior; wire feedback open/close events

### DIFF
--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -1016,6 +1016,12 @@ html[data-bs-theme='dark'] .funding-banner {
   transition: var(--controller-zoom-transition);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .controller-mode body {
+    transition: none;
+  }
+}
+
 @media (max-width: 575.98px) {
   .funding-banner {
     align-items: flex-start;

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -1005,6 +1005,17 @@ html[data-bs-theme='dark'] .funding-banner {
   --funding-banner-mark: rgba(var(--bs-emphasis-color-rgb), 0.75);
 }
 
+:root {
+  --controller-zoom-origin-default-x: var(--bs-controller-zoom-origin-x, 50%);
+  --controller-zoom-origin-default-y: var(--bs-controller-zoom-origin-y, 50%);
+  --controller-zoom-scale: var(--bs-controller-zoom-scale, 1.08);
+  --controller-zoom-transition: var(--bs-controller-zoom-transition, transform 0.15s ease-out);
+}
+
+.controller-mode body {
+  transition: var(--controller-zoom-transition);
+}
+
 @media (max-width: 575.98px) {
   .funding-banner {
     align-items: flex-start;
@@ -1015,6 +1026,8 @@ html[data-bs-theme='dark'] .funding-banner {
 
 
 .controller-zoom-active body {
-  transform: scale(1.08);
-  transform-origin: var(--controller-zoom-origin-x, 50%) var(--controller-zoom-origin-y, 50%);
+  transform: scale(var(--controller-zoom-scale));
+  transform-origin:
+    var(--controller-zoom-origin-x, var(--controller-zoom-origin-default-x))
+    var(--controller-zoom-origin-y, var(--controller-zoom-origin-default-y));
 }

--- a/apps/sites/static/pages/css/base.css
+++ b/apps/sites/static/pages/css/base.css
@@ -1012,3 +1012,9 @@ html[data-bs-theme='dark'] .funding-banner {
   }
 
 }
+
+
+.controller-zoom-active body {
+  transform: scale(1.08);
+  transform-origin: var(--controller-zoom-origin-x, 50%) var(--controller-zoom-origin-y, 50%);
+}

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -493,19 +493,57 @@ const setupControllerButtonMappings = () => {
     nodes[nextIndex].focus();
   };
 
+  const getActiveGamepad = () => Array.from(navigator.getGamepads() || []).find(gamepad => gamepad && gamepad.buttons);
+
+  const clearPressedState = () => {
+    if (pressedButtons.has(L2_BUTTON_INDEX)) {
+      releaseZoom();
+    }
+    pressedButtons.clear();
+  };
+
+  const startPolling = () => {
+    if (!animationFrameId) {
+      animationFrameId = window.requestAnimationFrame(pollGamepad);
+    }
+  };
+
+  const stopPolling = () => {
+    if (animationFrameId) {
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = null;
+    }
+  };
+
+  const getFocusableTarget = target => {
+    if (!target) {
+      return null;
+    }
+    if (target.closest) {
+      return target.closest(focusSelector);
+    }
+    if (target.matches && target.matches(focusSelector)) {
+      return target;
+    }
+    return null;
+  };
+
   const dispatchFeedbackToggle = () => {
     document.dispatchEvent(new Event('pages:feedback-toggle'));
   };
 
   const applyZoomAroundCursor = () => {
     document.documentElement.classList.add('controller-zoom-active');
-    document.documentElement.style.setProperty('--controller-zoom-origin-x', `${lastPointerX}px`);
-    document.documentElement.style.setProperty('--controller-zoom-origin-y', `${lastPointerY}px`);
+    const originX = lastPointerX + (window.scrollX || window.pageXOffset || 0);
+    const originY = lastPointerY + (window.scrollY || window.pageYOffset || 0);
+    document.documentElement.style.setProperty('--controller-zoom-origin-x', `${originX}px`);
+    document.documentElement.style.setProperty('--controller-zoom-origin-y', `${originY}px`);
     const target = document.elementFromPoint(lastPointerX, lastPointerY);
     if (target) {
       target.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: lastPointerX, clientY: lastPointerY }));
-      if (target.focus && target.matches && target.matches(focusSelector)) {
-        target.focus();
+      const focusable = getFocusableTarget(target);
+      if (focusable && focusable.focus) {
+        focusable.focus();
       }
     }
   };
@@ -538,33 +576,44 @@ const setupControllerButtonMappings = () => {
   };
 
   const pollGamepad = () => {
-    const gamepads = navigator.getGamepads();
-    const gamepad = gamepads && gamepads[0];
-    if (gamepad && gamepad.buttons) {
-      gamepad.buttons.forEach((button, index) => {
-        if (button.pressed) {
-          if (!pressedButtons.has(index)) {
-            pressedButtons.add(index);
-            handleButtonPress(index);
-          }
-          return;
-        }
-        if (pressedButtons.has(index)) {
-          pressedButtons.delete(index);
-          if (index === L2_BUTTON_INDEX) {
-            releaseZoom();
-          }
-        }
-      });
+    const gamepad = getActiveGamepad();
+    const buttons = gamepad && gamepad.buttons ? Array.from(gamepad.buttons) : [];
+    if (!buttons.length) {
+      clearPressedState();
+      animationFrameId = null;
+      return;
     }
+
+    buttons.forEach((button, index) => {
+      if (button.pressed) {
+        if (!pressedButtons.has(index)) {
+          pressedButtons.add(index);
+          handleButtonPress(index);
+        }
+        return;
+      }
+      if (pressedButtons.has(index)) {
+        pressedButtons.delete(index);
+        if (index === L2_BUTTON_INDEX) {
+          releaseZoom();
+        }
+      }
+    });
     animationFrameId = window.requestAnimationFrame(pollGamepad);
   };
 
-  pollGamepad();
-  window.addEventListener('beforeunload', () => {
-    if (animationFrameId) {
-      window.cancelAnimationFrame(animationFrameId);
+  if (getActiveGamepad()) {
+    startPolling();
+  }
+  window.addEventListener('gamepadconnected', startPolling);
+  window.addEventListener('gamepaddisconnected', () => {
+    if (!getActiveGamepad()) {
+      clearPressedState();
+      stopPolling();
     }
+  });
+  window.addEventListener('beforeunload', () => {
+    stopPolling();
     releaseZoom();
   });
 };

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -456,6 +456,119 @@ const setupFundingBannerDismissal = () => {
   });
 };
 
+
+const setupControllerButtonMappings = () => {
+  if (!document.documentElement.classList.contains('controller-mode') || !navigator.getGamepads) {
+    return;
+  }
+
+  const L2_BUTTON_INDEX = 6;
+  const L1_BUTTON_INDEX = 4;
+  const R1_BUTTON_INDEX = 5;
+  const R2_BUTTON_INDEX = 7;
+  const pressedButtons = new Set();
+  let animationFrameId = null;
+  let lastPointerX = Math.round(window.innerWidth / 2);
+  let lastPointerY = Math.round(window.innerHeight / 2);
+
+  const focusSelector = '.navbar-nav .nav-link, .toolbar .btn, .toolbar a.btn';
+  const modulePillSelector = '.navbar-nav .nav-link';
+  const toolbarSelector = '#theme-toggle, .user-info-trigger';
+
+  const getVisibleElements = selector => Array.from(document.querySelectorAll(selector)).filter(node => {
+    if (!node || node.disabled) {
+      return false;
+    }
+    const style = window.getComputedStyle(node);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+  });
+
+  const cycleFocus = (selector, direction) => {
+    const nodes = getVisibleElements(selector);
+    if (!nodes.length) {
+      return;
+    }
+    const currentIndex = nodes.indexOf(document.activeElement);
+    const nextIndex = currentIndex < 0 ? 0 : (currentIndex + direction + nodes.length) % nodes.length;
+    nodes[nextIndex].focus();
+  };
+
+  const dispatchFeedbackToggle = () => {
+    document.dispatchEvent(new Event('pages:feedback-toggle'));
+  };
+
+  const applyZoomAroundCursor = () => {
+    document.documentElement.classList.add('controller-zoom-active');
+    document.documentElement.style.setProperty('--controller-zoom-origin-x', `${lastPointerX}px`);
+    document.documentElement.style.setProperty('--controller-zoom-origin-y', `${lastPointerY}px`);
+    const target = document.elementFromPoint(lastPointerX, lastPointerY);
+    if (target) {
+      target.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: lastPointerX, clientY: lastPointerY }));
+      if (target.focus && target.matches && target.matches(focusSelector)) {
+        target.focus();
+      }
+    }
+  };
+
+  const releaseZoom = () => {
+    document.documentElement.classList.remove('controller-zoom-active');
+  };
+
+  document.addEventListener('mousemove', event => {
+    lastPointerX = event.clientX;
+    lastPointerY = event.clientY;
+  });
+
+  const handleButtonPress = buttonIndex => {
+    if (buttonIndex === R2_BUTTON_INDEX) {
+      dispatchFeedbackToggle();
+      return;
+    }
+    if (buttonIndex === R1_BUTTON_INDEX) {
+      cycleFocus(toolbarSelector, 1);
+      return;
+    }
+    if (buttonIndex === L1_BUTTON_INDEX) {
+      cycleFocus(modulePillSelector, 1);
+      return;
+    }
+    if (buttonIndex === L2_BUTTON_INDEX) {
+      applyZoomAroundCursor();
+    }
+  };
+
+  const pollGamepad = () => {
+    const gamepads = navigator.getGamepads();
+    const gamepad = gamepads && gamepads[0];
+    if (gamepad && gamepad.buttons) {
+      gamepad.buttons.forEach((button, index) => {
+        if (button.pressed) {
+          if (!pressedButtons.has(index)) {
+            pressedButtons.add(index);
+            handleButtonPress(index);
+          }
+          return;
+        }
+        if (pressedButtons.has(index)) {
+          pressedButtons.delete(index);
+          if (index === L2_BUTTON_INDEX) {
+            releaseZoom();
+          }
+        }
+      });
+    }
+    animationFrameId = window.requestAnimationFrame(pollGamepad);
+  };
+
+  pollGamepad();
+  window.addEventListener('beforeunload', () => {
+    if (animationFrameId) {
+      window.cancelAnimationFrame(animationFrameId);
+    }
+    releaseZoom();
+  });
+};
+
 setupControllerMode();
 applySiteThemeVariables();
 setupThemeToggle();
@@ -466,4 +579,5 @@ setupLanguageSelect();
 setupShareModal();
 setupSiteHighlightDismissal();
 setupFundingBannerDismissal();
+setupControllerButtonMappings();
 window.addEventListener('load', syncDebugToolbarTheme);

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -458,7 +458,7 @@ const setupFundingBannerDismissal = () => {
 
 
 const setupControllerButtonMappings = () => {
-  if (!document.documentElement.classList.contains('controller-mode') || !navigator.getGamepads) {
+  if (!document.documentElement.classList.contains('controller-mode') || (!navigator.getGamepads && !navigator.webkitGetGamepads)) {
     return;
   }
 
@@ -474,6 +474,13 @@ const setupControllerButtonMappings = () => {
   const focusSelector = '.navbar-nav .nav-link, .toolbar .btn, .toolbar a.btn';
   const modulePillSelector = '.navbar-nav .nav-link';
   const toolbarSelector = '#theme-toggle, .user-info-trigger';
+
+  const getGamepads = () => {
+    if (navigator.getGamepads) {
+      return navigator.getGamepads();
+    }
+    return navigator.webkitGetGamepads();
+  };
 
   const getVisibleElements = selector => Array.from(document.querySelectorAll(selector)).filter(node => {
     if (!node || node.disabled) {
@@ -493,7 +500,7 @@ const setupControllerButtonMappings = () => {
     nodes[nextIndex].focus();
   };
 
-  const getActiveGamepad = () => Array.from(navigator.getGamepads() || []).find(gamepad => gamepad && gamepad.buttons);
+  const getActiveGamepad = () => Array.from(getGamepads() || []).find(gamepad => gamepad && gamepad.buttons);
 
   const clearPressedState = () => {
     if (pressedButtons.has(L2_BUTTON_INDEX)) {
@@ -537,6 +544,31 @@ const setupControllerButtonMappings = () => {
     return event;
   };
 
+  const createMouseMoveEvent = (clientX, clientY) => {
+    if (typeof MouseEvent === 'function') {
+      return new MouseEvent('mousemove', { bubbles: true, clientX, clientY });
+    }
+    const event = document.createEvent('MouseEvent');
+    event.initMouseEvent(
+      'mousemove',
+      true,
+      false,
+      window,
+      0,
+      clientX,
+      clientY,
+      clientX,
+      clientY,
+      false,
+      false,
+      false,
+      false,
+      0,
+      null
+    );
+    return event;
+  };
+
   const dispatchFeedbackToggle = () => {
     document.dispatchEvent(createBubblingEvent('pages:feedback-toggle'));
   };
@@ -549,7 +581,7 @@ const setupControllerButtonMappings = () => {
     document.documentElement.style.setProperty('--controller-zoom-origin-y', `${originY}px`);
     const target = document.elementFromPoint(lastPointerX, lastPointerY);
     if (target) {
-      target.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: lastPointerX, clientY: lastPointerY }));
+      target.dispatchEvent(createMouseMoveEvent(lastPointerX, lastPointerY));
       const focusable = getFocusableTarget(target);
       if (focusable && focusable.focus) {
         focusable.focus();
@@ -584,6 +616,17 @@ const setupControllerButtonMappings = () => {
     }
   };
 
+  const isButtonPressed = button => {
+    if (typeof button === 'number') {
+      return button >= 0.5;
+    }
+    if (!button) {
+      return false;
+    }
+    const value = typeof button.value === 'number' ? button.value : 0;
+    return button.pressed === true || value >= 0.5;
+  };
+
   const pollGamepad = () => {
     const gamepad = getActiveGamepad();
     const buttons = gamepad && gamepad.buttons ? Array.from(gamepad.buttons) : [];
@@ -594,7 +637,7 @@ const setupControllerButtonMappings = () => {
     }
 
     buttons.forEach((button, index) => {
-      if (button.pressed) {
+      if (isButtonPressed(button)) {
         if (!pressedButtons.has(index)) {
           pressedButtons.add(index);
           handleButtonPress(index);

--- a/apps/sites/static/pages/js/base.js
+++ b/apps/sites/static/pages/js/base.js
@@ -528,8 +528,17 @@ const setupControllerButtonMappings = () => {
     return null;
   };
 
+  const createBubblingEvent = eventName => {
+    if (typeof Event === 'function') {
+      return new Event(eventName, { bubbles: true });
+    }
+    const event = document.createEvent('Event');
+    event.initEvent(eventName, true, false);
+    return event;
+  };
+
   const dispatchFeedbackToggle = () => {
-    document.dispatchEvent(new Event('pages:feedback-toggle'));
+    document.dispatchEvent(createBubblingEvent('pages:feedback-toggle'));
   };
 
   const applyZoomAroundCursor = () => {

--- a/apps/sites/static/pages/js/user_story_feedback.js
+++ b/apps/sites/static/pages/js/user_story_feedback.js
@@ -1,5 +1,8 @@
 (() => {
   const DIALOG_OPENED_EVENT = 'pages:dialog-opened';
+  const FEEDBACK_TOGGLE_EVENT = 'pages:feedback-toggle';
+  const FEEDBACK_OPEN_EVENT = 'pages:feedback-open';
+  const FEEDBACK_CLOSE_EVENT = 'pages:feedback-close';
 
   const toggle = document.getElementById('user-story-toggle');
   const overlay = document.getElementById('user-story-overlay');
@@ -382,6 +385,23 @@
     if (event.key === 'Escape' && !overlay.hasAttribute('hidden')) {
       closeOverlay();
     }
+  });
+
+
+  document.addEventListener(FEEDBACK_TOGGLE_EVENT, () => {
+    if (overlay.hasAttribute('hidden')) {
+      openOverlay();
+      return;
+    }
+    closeOverlay();
+  });
+
+  document.addEventListener(FEEDBACK_OPEN_EVENT, () => {
+    openOverlay();
+  });
+
+  document.addEventListener(FEEDBACK_CLOSE_EVENT, () => {
+    closeOverlay();
   });
 
   document.addEventListener(DIALOG_OPENED_EVENT, event => {

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -33,8 +33,13 @@ def test_controller_gamepad_polling_handles_connected_slots_and_disconnects():
     script = BASE_JS.read_text(encoding="utf-8")
 
     assert "getActiveGamepad" in script
-    assert "Array.from(navigator.getGamepads() || []).find(gamepad => gamepad && gamepad.buttons)" in script
+    assert "!navigator.getGamepads && !navigator.webkitGetGamepads" in script
+    assert "return navigator.webkitGetGamepads();" in script
+    assert "Array.from(getGamepads() || []).find(gamepad => gamepad && gamepad.buttons)" in script
     assert "Array.from(gamepad.buttons)" in script
+    assert "isButtonPressed(button)" in script
+    assert "typeof button === 'number'" in script
+    assert "typeof button.value === 'number'" in script
     assert "clearPressedState();" in script
     assert "pressedButtons.clear();" in script
     assert "gamepadconnected" in script
@@ -57,6 +62,9 @@ def test_controller_zoom_uses_document_origin_focus_closest_and_tokens():
     assert "transition: none;" in css
     assert "createBubblingEvent('pages:feedback-toggle')" in script
     assert "document.createEvent('Event')" in script
+    assert "createMouseMoveEvent(lastPointerX, lastPointerY)" in script
+    assert "document.createEvent('MouseEvent')" in script
+    assert ".initMouseEvent(" in script
 
 
 def test_docs_reader_has_controller_safe_full_document_and_reload_paths():

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -29,6 +29,32 @@ def test_controller_mode_adds_large_targets_and_legacy_focus_fallbacks():
     assert ":focus-visible" in css
 
 
+def test_controller_gamepad_polling_handles_connected_slots_and_disconnects():
+    script = BASE_JS.read_text(encoding="utf-8")
+
+    assert "getActiveGamepad" in script
+    assert "Array.from(navigator.getGamepads() || []).find(gamepad => gamepad && gamepad.buttons)" in script
+    assert "Array.from(gamepad.buttons)" in script
+    assert "clearPressedState();" in script
+    assert "pressedButtons.clear();" in script
+    assert "gamepadconnected" in script
+    assert "gamepaddisconnected" in script
+
+
+def test_controller_zoom_uses_document_origin_focus_closest_and_tokens():
+    css = BASE_CSS.read_text(encoding="utf-8")
+    script = BASE_JS.read_text(encoding="utf-8")
+
+    assert "lastPointerX + (window.scrollX || window.pageXOffset || 0)" in script
+    assert "lastPointerY + (window.scrollY || window.pageYOffset || 0)" in script
+    assert "target.closest(focusSelector)" in script
+    assert "--controller-zoom-scale" in css
+    assert "--controller-zoom-origin-default-x" in css
+    assert "--controller-zoom-transition" in css
+    assert "transform: scale(var(--controller-zoom-scale));" in css
+    assert ".controller-mode body" in css
+
+
 def test_docs_reader_has_controller_safe_full_document_and_reload_paths():
     template = DOCS_README_TEMPLATE.read_text(encoding="utf-8")
 

--- a/apps/sites/tests/test_public_controller_mode.py
+++ b/apps/sites/tests/test_public_controller_mode.py
@@ -53,6 +53,10 @@ def test_controller_zoom_uses_document_origin_focus_closest_and_tokens():
     assert "--controller-zoom-transition" in css
     assert "transform: scale(var(--controller-zoom-scale));" in css
     assert ".controller-mode body" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
+    assert "transition: none;" in css
+    assert "createBubblingEvent('pages:feedback-toggle')" in script
+    assert "document.createEvent('Event')" in script
 
 
 def test_docs_reader_has_controller_safe_full_document_and_reload_paths():


### PR DESCRIPTION
### Motivation

- Add first-class controller (gamepad) support for the site in `controller-mode`, enabling navigation and feedback toggling via common gamepad buttons.
- Provide a temporary zoom/focus affordance when a trigger button is held to help aim the pointer with a controller.
- Allow the feedback overlay to be opened/closed from the controller code via events.

### Description

- Add CSS rules for `.controller-zoom-active` to scale the page and use `--controller-zoom-origin-x`/`--controller-zoom-origin-y` as the transform origin. 
- Implement `setupControllerButtonMappings()` in `apps/sites/static/pages/js/base.js` which polls `navigator.getGamepads()`, maps L2/L1/R1/R2 button indices to actions (L2: hold-to-zoom, L1: cycle module pills, R1: cycle toolbar controls, R2: dispatch `pages:feedback-toggle`), focuses elements under cursor, dispatches mouse `mousemove` events, and cleans up on `beforeunload`.
- Call `setupControllerButtonMappings()` during site initialization in `base.js`.
- In `apps/sites/static/pages/js/user_story_feedback.js` add event constants and listeners for `pages:feedback-toggle`, `pages:feedback-open`, and `pages:feedback-close` to open or close the feedback overlay programmatically.

### Testing

- Ran the project's JavaScript linting and static checks against the modified files and they passed. 
- Executed the existing JS unit test suite locally and all tests passed. 
- Verified the new code registers and cleans up the animation frame loop without errors in a browser dev session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a66fdf748326b759c831452976c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Controller and Gamepad Support

This PR adds first-class controller/gamepad support to enable navigation and feedback control via common gamepad buttons, and a temporary zoom/focus affordance while a trigger is held.

### Changes

**CSS** (`apps/sites/static/pages/css/base.css`)
- Added controller zoom styling and CSS custom properties:
  - New variables: `--controller-zoom-origin-default-x`, `--controller-zoom-origin-default-y`, `--controller-zoom-scale`, `--controller-zoom-transition`.
  - `.controller-mode body` transition using `--controller-zoom-transition`, with a `prefers-reduced-motion: reduce` override that disables the transition.
  - `.controller-zoom-active body` applies `transform: scale(var(--controller-zoom-scale))` and sets `transform-origin` from `--controller-zoom-origin-x` / `--controller-zoom-origin-y` (falling back to the declared origin defaults).

**JavaScript** (`apps/sites/static/pages/js/base.js`)
- Added `setupControllerButtonMappings()` and invoke it during site initialization.
  - Polls `navigator.getGamepads()` using a requestAnimationFrame loop when a gamepad is present; hooks `gamepadconnected`/`gamepaddisconnected` and cleans up on `beforeunload`.
  - Edge-detects button presses via an internal pressed-state Set and maps buttons to actions:
    - L2 (trigger): hold-to-zoom — adds `.controller-zoom-active`, sets `--controller-zoom-origin-x`/`--controller-zoom-origin-y` from the last tracked pointer position (accounting for scroll), dispatches a synthetic bubbled `mousemove` at that point, and focuses the nearest focusable element matching the focus selector.
    - L1 / R1: cycle focus forward through visible/enabled module pills and toolbar controls respectively, skipping hidden/inactive nodes and using `document.activeElement` to determine the next item.
    - R2: dispatches a bubbled `pages:feedback-toggle` event.
  - Tracks last pointer coordinates via real `mousemove` events; registers/tears down the animation-frame polling loop appropriately.

**Feedback Overlay** (`apps/sites/static/pages/js/user_story_feedback.js`)
- Added event name constants `pages:feedback-toggle`, `pages:feedback-open`, `pages:feedback-close` and document-level listeners that reuse existing `openOverlay()` / `closeOverlay()` logic so the overlay can be toggled/opened/closed programmatically (e.g., from controller code).

**Tests** (`apps/sites/tests/test_public_controller_mode.py`)
- Added two pytest string-assertion tests:
  - `test_controller_gamepad_polling_handles_connected_slots_and_disconnects()` — verifies gamepad polling, connected/disconnected wiring, iteration over gamepad buttons, numeric/value checks for buttons, pressed-state clearing, and disconnect handling.
  - `test_controller_zoom_uses_document_origin_focus_closest_and_tokens()` — verifies zoom origin calculations (pointer + scroll), CSS variable usage for scale/transform-origin, reduced-motion transition override, focus targeting via `target.closest(focusSelector)`, and construction/dispatch of the feedback-toggle and synthetic mousemove events.

### Testing & Validation
- JS linting and static checks passed.
- Existing JS unit tests passed locally; new tests added.
- Verified the requestAnimationFrame polling loop registers and cleans up without errors in a browser dev session.

Commit notes include robustness-focused changes to controller feedback interactions ("Harden controller feedback interactions").

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7731)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->