### PR TITLE
Run release readiness hourly and require 2-hour settle window; block on non-enhancement issues & open PRs

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -2,7 +2,7 @@ name: Release Simulator
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '15 * * * *'
   workflow_dispatch:
   push: {}
 
@@ -104,6 +104,7 @@ jobs:
             const fullDayMillis = 24 * 60 * 60 * 1000;
             const releaseCutoffMillis = 3 * fullDayMillis;
             const securityScanQuietMillis = 2 * 60 * 60 * 1000;
+            const blockingIssueLabel = "enhancement";
             let shouldRun = true;
             let skipReason = '';
 
@@ -153,6 +154,39 @@ jobs:
               const installFailureIssue = openIssues.find((issue) => issue.title === installIssueTitle && issue.body?.includes(installMarker));
               if (installFailureIssue) {
                 blockers.push(`Open install failure issue: #${installFailureIssue.number}`);
+              }
+
+              const openBlockingIssues = openIssues.filter((issue) => {
+                if (issue.pull_request) {
+                  return false;
+                }
+                const labels = Array.isArray(issue.labels) ? issue.labels : [];
+                return !labels.some((label) => (label?.name || '').toLowerCase() === blockingIssueLabel);
+              });
+              if (openBlockingIssues.length) {
+                const issueList = openBlockingIssues
+                  .slice(0, 10)
+                  .map((issue) => `#${issue.number}`)
+                  .join(', ');
+                const moreCount = openBlockingIssues.length - 10;
+                const moreSuffix = moreCount > 0 ? `, and ${moreCount} more` : '';
+                blockers.push(`Open non-enhancement issues: ${issueList}${moreSuffix}.`);
+              }
+
+              const openPullRequests = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              if (openPullRequests.length) {
+                const pullList = openPullRequests
+                  .slice(0, 10)
+                  .map((pull) => `#${pull.number}`)
+                  .join(', ');
+                const moreCount = openPullRequests.length - 10;
+                const moreSuffix = moreCount > 0 ? `, and ${moreCount} more` : '';
+                blockers.push(`Open pull requests: ${pullList}${moreSuffix}.`);
               }
 
               const { data: defaultBranchData } = await github.rest.repos.getBranch({
@@ -571,7 +605,7 @@ jobs:
             const body = [
               marker,
               '',
-              'Automated release readiness report. Scheduled every 6 hours for 4 release windows per day.',
+              'Automated release readiness report. Runs hourly and only proceeds after the default branch has remained unchanged for at least two hours.',
               '',
               `- Workflow run: ${runUrl}`,
               `- Ref: ${context.ref}`,

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -84,6 +84,7 @@ jobs:
       actions: read
       contents: read
       issues: read
+      pull-requests: read
       security-events: read
     outputs:
       should_run: ${{ steps.evaluate.outputs.should_run }}
@@ -99,6 +100,8 @@ jobs:
           script: |
             const installIssueTitle = 'Install health check is failing';
             const installMarker = '<!-- install-health-check-failure -->';
+            const releaseReadinessReportTitle = 'Release Readiness Report';
+            const releaseReadinessReportMarker = '<!-- release-readiness-report -->';
             const defaultBranch = context.payload.repository.default_branch;
             const blockers = [];
             const fullDayMillis = 24 * 60 * 60 * 1000;
@@ -158,6 +161,9 @@ jobs:
 
               const openBlockingIssues = openIssues.filter((issue) => {
                 if (issue.pull_request) {
+                  return false;
+                }
+                if (issue.title === releaseReadinessReportTitle && issue.body?.includes(releaseReadinessReportMarker)) {
                   return false;
                 }
                 const labels = Array.isArray(issue.labels) ? issue.labels : [];

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -722,6 +722,22 @@ def test_release_simulator_requires_security_scan_settling_and_clear_alerts() ->
     assert "Unable to verify GitHub code scanning alerts" in script
 
 
+def test_release_simulator_pr_and_issue_blockers_have_required_permissions() -> None:
+    workflow = _workflow_data("release-simulator.yml")
+    evaluate_job = workflow["jobs"]["evaluate"]
+    evaluate_step = _workflow_step(
+        evaluate_job, "Evaluate release blockers from install/upgrade pipeline state"
+    )
+    script = evaluate_step["with"]["script"]
+
+    assert evaluate_job["permissions"]["pull-requests"] == "read"
+    assert "github.rest.pulls.list" in script
+    assert "releaseReadinessReportTitle = 'Release Readiness Report'" in script
+    assert "releaseReadinessReportMarker = '<!-- release-readiness-report -->'" in script
+    assert "issue.title === releaseReadinessReportTitle" in script
+    assert "issue.body?.includes(releaseReadinessReportMarker)" in script
+
+
 @pytest.mark.django_db
 def test_step_record_publish_metadata_records_github_release_url(
     monkeypatch, tmp_path: Path


### PR DESCRIPTION
### Motivation
- Replace the multi-window scheduled runs with a settle-window-driven flow so readiness checks only proceed at least two hours after the default branch last advanced and other repo blockers are clear.
- Surface open non-enhancement issues and open pull requests as explicit readiness blockers to avoid running simulations while the repo still has active work or unresolved issues.

### Description
- Change the cron in `.github/workflows/release-simulator.yml` from `cron: '0 */6 * * *'` to `cron: '15 * * * *'` so the workflow evaluates readiness hourly.
- Add a `blockingIssueLabel = "enhancement"` constant and a filter that treats any open issue without that label (and not a PR) as a blocker, and add an explicit check for open pull requests returned as blockers.
- Keep the existing two-hour quiet/settle window implemented via `securityScanQuietMillis = 2 * 60 * 60 * 1000` to ensure checks only run after the default branch has remained unchanged for at least two hours, and update the readiness report wording to describe the new behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b283d2488326b872971064b3a113)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to Release Simulator Workflow

### Schedule Change
Updated the workflow cron schedule from `0 */6 * * *` (every 6 hours) to `15 * * * *` (every hour at minute 15), enabling hourly release readiness evaluation.

### Release Blocker Detection Enhancements
Added explicit blocking rules for release readiness checks:

- **Issue filtering**: Introduced `blockingIssueLabel = "enhancement"` constant; any open issue without the "enhancement" label (and not a PR) is treated as a release blocker. The workflow ignores the simulator's own "Release Readiness Report" issue (by title + marker).
- **Open PR blocking**: Added detection for open pull requests as blockers and reports them separately.
- **Blocker reporting**: Both non-enhancement issues and open pull requests are listed in the report with up to 10 items shown per category and an "and N more" suffix if applicable.
- **Install failure check**: Retains check for a specific install failure issue marker and reports it as a blocker.

### Permissions
The `evaluate` job now requests `pull-requests: read` (in addition to existing permissions) to allow querying open PRs.

### Quiet/Settle Window Retention
Kept the two-hour settle window via `securityScanQuietMillis = 2 * 60 * 60 * 1000`; readiness checks only proceed after the default branch has been unchanged for at least two hours. If the default branch advanced within that window, the report will list the required wait-until time as a blocker.

### Report Description Update
Updated the generated "Release Readiness Report" wording to reflect the new hourly cadence and the two-hour quiet requirement.

### Tests
Added test `test_release_simulator_pr_and_issue_blockers_have_required_permissions` in apps/core/tests/reports/test_release_publish_regressions.py which:
- Loads the `release-simulator.yml` workflow,
- Asserts the `evaluate` job grants `pull-requests: read` permission,
- Asserts the workflow script includes logic to list open PRs and to detect/ignore the release readiness report marker in issues.

### Impact
The workflow evaluates readiness more frequently (hourly at :15) but preserves a mandatory 2-hour stability window and now blocks on open non-enhancement issues and any open pull requests, improving responsiveness while maintaining stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7732)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->