### PR TITLE
Add LCD summary chat command

### DIFF
--- a/apps/summary/management/commands/chat.py
+++ b/apps/summary/management/commands/chat.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.summary.services import ensure_local_model, get_summary_config
+from apps.tasks.tasks import LocalLLMSummarizer
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are the local Arthexis LCD summary model running in a management "
+    "command smoke test. Answer the operator's latest message concisely."
+)
+
+
+def build_chat_prompt(
+    history: list[tuple[str, str]], *, system_prompt: str = DEFAULT_SYSTEM_PROMPT
+) -> str:
+    """Build a prompt that works for both chat-style and LCD-summary adapters."""
+
+    transcript_lines = [system_prompt.strip(), "", "CHAT TRANSCRIPT:"]
+    log_lines = ["LOGS:"]
+    for role, message in history:
+        clean_message = " ".join(str(message or "").split())
+        if not clean_message:
+            continue
+        transcript_lines.append(f"{role}: {clean_message}")
+        log_lines.append(clean_message)
+    transcript_lines.append("assistant:")
+    return "\n".join([*transcript_lines, "", *log_lines, ""])
+
+
+class Command(BaseCommand):
+    """Run a small chat loop against the LCD summary local LLM adapter."""
+
+    help = "Chat with the local LLM adapter used by LCD summary generation."
+
+    def add_arguments(self, parser) -> None:
+        """Register command-line flags."""
+
+        parser.add_argument(
+            "-m",
+            "--message",
+            action="append",
+            default=None,
+            help=(
+                "Send a message and exit. Repeat to send a short transcript in "
+                "one command invocation."
+            ),
+        )
+        parser.add_argument(
+            "--system-prompt",
+            default=DEFAULT_SYSTEM_PROMPT,
+            help="System instruction prepended to each chat prompt.",
+        )
+        parser.add_argument(
+            "--raw",
+            action="store_true",
+            help="Print only model replies, without status lines or prompts.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        """Run one-shot messages or an interactive chat session."""
+
+        messages = [
+            text
+            for message in (options.get("message") or [])
+            if (text := str(message or "").strip())
+        ]
+        raw: bool = bool(options["raw"])
+        if raw and not messages:
+            raise CommandError("--raw requires at least one --message.")
+
+        config = get_summary_config()
+        model_path = ensure_local_model(config)
+        summarizer = LocalLLMSummarizer()
+        system_prompt: str = options["system_prompt"]
+
+        if messages:
+            self._run_messages(
+                messages,
+                summarizer=summarizer,
+                model_path=model_path,
+                system_prompt=system_prompt,
+                raw=raw,
+            )
+            return
+
+        self._run_interactive(
+            summarizer=summarizer,
+            model_path=model_path,
+            system_prompt=system_prompt,
+        )
+
+    def _run_messages(
+        self,
+        messages: list[str],
+        *,
+        summarizer: LocalLLMSummarizer,
+        model_path: Path,
+        system_prompt: str,
+        raw: bool,
+    ) -> None:
+        history: list[tuple[str, str]] = []
+        if not raw:
+            self._write_header(model_path)
+
+        for message in messages:
+            text = str(message or "").strip()
+            history.append(("operator", text))
+            reply = summarizer.summarize(
+                build_chat_prompt(history, system_prompt=system_prompt)
+            )
+            history.append(("assistant", reply))
+            if raw:
+                self.stdout.write(reply)
+            else:
+                self.stdout.write(f"operator> {text}")
+                self.stdout.write("assistant>")
+                self.stdout.write(reply)
+
+    def _run_interactive(
+        self,
+        *,
+        summarizer: LocalLLMSummarizer,
+        model_path: Path,
+        system_prompt: str,
+    ) -> None:
+        self._write_header(model_path)
+        self.stdout.write("Type :quit to exit, :reset to clear chat history.")
+        history: list[tuple[str, str]] = []
+
+        while True:
+            try:
+                message = input("operator> ")
+            except (EOFError, KeyboardInterrupt):
+                self.stdout.write("")
+                return
+            text = message.strip()
+            if not text:
+                continue
+            if text in {":q", ":quit", "quit", "exit"}:
+                return
+            if text == ":reset":
+                history.clear()
+                self.stdout.write("History reset.")
+                continue
+
+            history.append(("operator", text))
+            reply = summarizer.summarize(
+                build_chat_prompt(history, system_prompt=system_prompt)
+            )
+            history.append(("assistant", reply))
+            self.stdout.write("assistant>")
+            self.stdout.write(reply)
+
+    def _write_header(self, model_path: Path) -> None:
+        self.stdout.write(self.style.MIGRATE_HEADING("Local LLM Chat"))
+        self.stdout.write(f"Backend: {LocalLLMSummarizer.__name__}")
+        self.stdout.write(f"Model path: {model_path}")

--- a/apps/summary/tests/test_chat_command.py
+++ b/apps/summary/tests/test_chat_command.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.summary.management.commands import chat as chat_command
+
+
+class FakeConfig:
+    pass
+
+
+class FakeSummarizer:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def summarize(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return f"reply-{len(self.prompts)}"
+
+
+def test_chat_command_sends_one_shot_message_through_summary_summarizer(
+    monkeypatch, tmp_path
+) -> None:
+    fake_summarizer = FakeSummarizer()
+    monkeypatch.setattr(chat_command, "get_summary_config", lambda: FakeConfig())
+    monkeypatch.setattr(chat_command, "ensure_local_model", lambda config: tmp_path)
+    monkeypatch.setattr(chat_command, "LocalLLMSummarizer", lambda: fake_summarizer)
+
+    stdout = StringIO()
+    call_command("chat", message=["status?"], raw=True, stdout=stdout)
+
+    assert stdout.getvalue().strip() == "reply-1"
+    assert "CHAT TRANSCRIPT:" in fake_summarizer.prompts[0]
+    assert "operator: status?" in fake_summarizer.prompts[0]
+    assert "LOGS:\nstatus?" in fake_summarizer.prompts[0]
+
+
+def test_chat_command_reuses_history_for_repeated_messages(monkeypatch, tmp_path) -> None:
+    fake_summarizer = FakeSummarizer()
+    monkeypatch.setattr(chat_command, "get_summary_config", lambda: FakeConfig())
+    monkeypatch.setattr(chat_command, "ensure_local_model", lambda config: tmp_path)
+    monkeypatch.setattr(chat_command, "LocalLLMSummarizer", lambda: fake_summarizer)
+
+    stdout = StringIO()
+    call_command("chat", message=["first", "second"], raw=True, stdout=stdout)
+
+    assert stdout.getvalue().splitlines() == ["reply-1", "reply-2"]
+    assert "operator: first" in fake_summarizer.prompts[1]
+    assert "assistant: reply-1" in fake_summarizer.prompts[1]
+    assert "operator: second" in fake_summarizer.prompts[1]
+
+
+def test_chat_command_raw_requires_message_before_model_setup(monkeypatch) -> None:
+    def fail_model_setup() -> None:
+        raise AssertionError("raw validation should run before model setup")
+
+    monkeypatch.setattr(chat_command, "get_summary_config", fail_model_setup)
+
+    try:
+        call_command("chat", raw=True)
+    except CommandError as exc:
+        assert "--raw requires at least one --message" in str(exc)
+    else:
+        raise AssertionError("Expected CommandError")


### PR DESCRIPTION
## Summary
- add `manage.py chat` for one-shot or interactive probing of the LCD summary local LLM adapter
- reuse summary model setup via `get_summary_config()` / `ensure_local_model()` and `LocalLLMSummarizer`
- add focused command tests for raw output, transcript history, and validation before model setup

## Verification
- `./.venv/bin/python -m pytest apps/summary/tests/test_chat_command.py apps/summary/tests/test_services.py`
- `./.venv/bin/python manage.py chat --message 'ERR demo failure' --raw`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary: Add LCD summary chat command

This pull request introduces a new Django management command `manage.py chat` that provides one-shot and interactive access to the LCD summary local LLM adapter, enabling smoke testing and exploration of the model.

### Key Changes

**New Command Implementation** (`apps/summary/management/commands/chat.py`)
- Defines a `build_chat_prompt()` helper that constructs prompts with both a "CHAT TRANSCRIPT" section and a "LOGS" section from accumulated message history, making it compatible with both chat-style and LCD-summary adapters
- Implements the `Command` class with CLI options:
  - `-m/--message`: One or more messages to send (repeatable for multi-turn conversations)
  - `--system-prompt`: Custom system instruction (defaults to a focused smoke-test prompt)
  - `--raw`: Output only model replies without formatting
- Provides two execution modes:
  - **One-shot mode** (`_run_messages()`): Processes messages sequentially, building transcript history across multiple invocations and maintaining conversation context
  - **Interactive mode** (`_run_interactive()`): Starts a REPL-style loop with `:quit`/`:q`/`quit`/`exit` to exit and `:reset` to clear history
- Integrates with existing infrastructure via `get_summary_config()`, `ensure_local_model()`, and `LocalLLMSummarizer`
- Validates early (before model setup) that `--raw` mode requires at least one message

**Test Suite** (`apps/summary/tests/test_chat_command.py`)
- `test_chat_command_sends_one_shot_message_through_summary_summarizer`: Verifies single message flow through the summarizer and validates prompt structure contains expected sections and message text
- `test_chat_command_reuses_history_for_repeated_messages`: Confirms conversation history is maintained across multiple messages in one invocation, with prior assistant responses included in subsequent prompts
- `test_chat_command_raw_requires_message_before_model_setup`: Validates that input validation occurs before model initialization, ensuring resources are not loaded unnecessarily

The implementation is lean and focused, with tests targeting only the stated objectives without over-engineering for future scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->