### PR TITLE
Enrich RFID lockfile for held cards

### DIFF
--- a/apps/cards/background_reader.py
+++ b/apps/cards/background_reader.py
@@ -7,11 +7,11 @@ import queue
 import threading
 import time
 from pathlib import Path
-from typing import Optional
 
 from django.conf import settings
 
 from apps.core.optional_hardware import is_expected_optional_hardware_absence
+
 from .constants import DEFAULT_IRQ_PIN, DEFAULT_RST_PIN, GPIO_PIN_MODE_BCM
 from .reader import resolve_spi_bus_device, resolve_spi_device_path
 
@@ -24,9 +24,10 @@ except Exception:  # pragma: no cover - hardware dependent
 
 IRQ_PIN = int(os.environ.get("RFID_IRQ_PIN", str(DEFAULT_IRQ_PIN)))
 _tag_queue: "queue.Queue[dict]" = queue.Queue()
-_thread: Optional[threading.Thread] = None
+_thread: threading.Thread | None = None
 _stop_event = threading.Event()
 _reader = None
+_reader_lock = threading.Lock()
 _auto_detect_logged = False
 _last_setup_failure: float | None = None
 _last_auto_detect_failure: float | None = None
@@ -123,10 +124,7 @@ def _log_fd_snapshot(label: str) -> None:
         except Exception as exc:  # pragma: no cover - defensive guard
             samples.append(f"{fd_path.name}:<error:{exc}>")
 
-    message = (
-        "RFID fd snapshot (%s): count=%s limits=%s sample=%s"
-        % (label, count, limits, samples)
-    )
+    message = f"RFID fd snapshot ({label}): count={count} limits={limits} sample={samples}"
     if count >= _FD_SNAPSHOT_THRESHOLD:
         logger.warning(message)
     else:
@@ -316,15 +314,17 @@ def _irq_callback(channel):  # pragma: no cover - hardware dependent
     logger.debug("IRQ callback triggered on channel %s", channel)
     from .reader import read_rfid
 
-    result = read_rfid(mfrc=_reader, cleanup=False, use_irq=True)
+    with _reader_lock:
+        result = read_rfid(mfrc=_reader, cleanup=False, use_irq=True)
+        if result.get("rfid"):
+            try:
+                _reader.dev_write(_reader.ComIrqReg, 0x7F)
+            except Exception:  # pragma: no cover - hardware dependent
+                pass
     if result.get("error"):
         logger.warning("RFID read error via IRQ: %s", result["error"])
     elif result.get("rfid"):
         logger.info("RFID tag detected via IRQ: %s", result.get("rfid"))
-        try:
-            _reader.dev_write(_reader.ComIrqReg, 0x7F)
-        except Exception:  # pragma: no cover - hardware dependent
-            pass
     _tag_queue.put(result)
 
 
@@ -469,7 +469,7 @@ def stop():
     _thread = None
 
 
-def get_next_tag(timeout: float | None = 0) -> Optional[dict]:
+def get_next_tag(timeout: float | None = 0) -> dict | None:
     """Retrieve the next tag read from the queue.
 
     Falls back to direct polling if no IRQ events are queued.
@@ -500,7 +500,8 @@ def get_next_tag(timeout: float | None = 0) -> Optional[dict]:
         try:
             from .reader import read_rfid
 
-            res = read_rfid(mfrc=_reader, cleanup=False, timeout=timeout)
+            with _reader_lock:
+                res = read_rfid(mfrc=_reader, cleanup=False, timeout=timeout)
             if res.get("rfid") or res.get("error"):
                 _irq_empty_tracker.log_summary("polling read")
                 logger.debug("Polling read result: %s", res)
@@ -509,4 +510,36 @@ def get_next_tag(timeout: float | None = 0) -> Optional[dict]:
                 return res
         except Exception as exc:  # pragma: no cover - hardware dependent
             logger.debug("Polling read failed: %s", exc)
+        return None
+
+
+def read_current_tag_deep(timeout: float | None = 0.5) -> dict | None:
+    """Read the currently presented tag with deep-read mode enabled."""
+
+    if not is_configured():
+        return None
+    if timeout is None:
+        timeout = 0.0
+    timeout = max(0.0, timeout)
+    try:
+        from .reader import (
+            deep_read_enabled,
+            disable_deep_read,
+            enable_deep_read,
+            read_rfid,
+        )
+
+        with _reader_lock:
+            was_enabled = deep_read_enabled()
+            enable_deep_read()
+            try:
+                result = read_rfid(mfrc=_reader, cleanup=False, timeout=timeout)
+            finally:
+                if not was_enabled:
+                    disable_deep_read()
+        if result and result.get("rfid"):
+            _mark_scanner_used()
+        return result
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        logger.debug("Deep polling read failed: %s", exc)
         return None

--- a/apps/cards/reader.py
+++ b/apps/cards/reader.py
@@ -699,6 +699,20 @@ def enable_deep_read(duration: float | None = None) -> bool:
     return _deep_read_enabled
 
 
+def disable_deep_read() -> bool:
+    """Disable deep read mode and return the new state."""
+
+    global _deep_read_enabled
+    _deep_read_enabled = False
+    return _deep_read_enabled
+
+
+def deep_read_enabled() -> bool:
+    """Return whether deep read mode is currently enabled."""
+
+    return _deep_read_enabled
+
+
 def toggle_deep_read() -> bool:
     """Toggle deep read mode and return the new state."""
 

--- a/apps/cards/rfid_service.py
+++ b/apps/cards/rfid_service.py
@@ -22,7 +22,8 @@ import time
 import uuid
 from collections import deque
 from dataclasses import dataclass
-from datetime import datetime, timezone as datetime_timezone
+from datetime import datetime
+from datetime import timezone as datetime_timezone
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 SENSITIVE_RFID_KEYS = {"keys", "dump"}
 
+SCAN_LOCK_SCHEMA = "arthexis.rfid.scan.v1"
 SCAN_STATE_FILE = "rfid-scan.json"
 SCAN_LOG_FILE = "rfid-scans.ndjson"
 SCAN_STATE_SCHEMA = "arthexis.rfid.scan.v1"
@@ -84,6 +86,23 @@ def default_lcd_scan_event_refresh_seconds() -> float:
     )
 
 
+def default_deep_scan_hold_seconds() -> float:
+    return float(os.environ.get("RFID_SERVICE_DEEP_SCAN_HOLD_SECONDS", "2.0"))
+
+
+def default_deep_scan_timeout() -> float:
+    return float(os.environ.get("RFID_SERVICE_DEEP_SCAN_TIMEOUT", "1.0"))
+
+
+def default_presence_gap_seconds() -> float:
+    return float(
+        os.environ.get(
+            "RFID_SERVICE_PRESENCE_GAP_SECONDS",
+            str(default_deep_scan_hold_seconds()),
+        )
+    )
+
+
 DEFAULT_SERVICE_HOST = default_service_host()
 DEFAULT_SERVICE_PORT = default_service_port()
 DEFAULT_SCAN_TIMEOUT = default_scan_timeout()
@@ -92,6 +111,9 @@ DEFAULT_EVENT_DURATION = default_event_duration()
 DEFAULT_SCAN_DEDUPE_SECONDS = default_scan_dedupe_seconds()
 DEFAULT_WORKER_SCAN_TIMEOUT = default_worker_scan_timeout()
 DEFAULT_LCD_SCAN_EVENT_REFRESH_SECONDS = default_lcd_scan_event_refresh_seconds()
+DEFAULT_DEEP_SCAN_HOLD_SECONDS = default_deep_scan_hold_seconds()
+DEFAULT_DEEP_SCAN_TIMEOUT = default_deep_scan_timeout()
+DEFAULT_PRESENCE_GAP_SECONDS = default_presence_gap_seconds()
 
 
 def get_next_tag(timeout: float = 0.2) -> dict[str, Any] | None:
@@ -122,6 +144,16 @@ def toggle_deep_read() -> bool:
     from .reader import toggle_deep_read as reader_toggle_deep_read
 
     return reader_toggle_deep_read()
+
+
+def read_deep_tag(timeout: float | None = None) -> dict[str, Any] | None:
+    """Directly deep-read the currently presented tag."""
+
+    from .background_reader import read_current_tag_deep
+
+    return read_current_tag_deep(
+        timeout=default_deep_scan_timeout() if timeout is None else timeout
+    )
 
 
 @dataclass(frozen=True)
@@ -177,6 +209,12 @@ class RFIDServiceState:
         self._last_emitted_at: float | None = None
         self._last_lcd_rfid: str | None = None
         self._last_lcd_refresh_at: float | None = None
+        self._current_rfid: str | None = None
+        self._current_presence_started_at: float | None = None
+        self._current_presence_started_iso: str | None = None
+        self._current_presence_last_at: float | None = None
+        self._current_enriched_payload: dict[str, Any] | None = None
+        self._deep_scan_attempted_rfid: str | None = None
 
     def start_worker(self) -> None:
         if self.worker_thread and self.worker_thread.is_alive():
@@ -245,15 +283,20 @@ class RFIDServiceState:
         if not rfid_value:
             return
         now = time.monotonic()
+        observed_at = utc_now_iso()
+        payload, force_emit = self._build_scan_artifact_payload(
+            result,
+            rfid_value=rfid_value,
+            observed_at=observed_at,
+            observed_monotonic=now,
+        )
         if (
             self._last_emitted_rfid == rfid_value
             and self._last_emitted_at is not None
             and now - self._last_emitted_at < default_scan_dedupe_seconds()
+            and not force_emit
         ):
             return
-        payload = dict(result)
-        payload.setdefault("service_mode", "service")
-        payload = build_scan_state_payload(payload)
         try:
             write_rfid_scan_lock(payload)
             append_scan_log(payload)
@@ -266,6 +309,194 @@ class RFIDServiceState:
             return
         self._last_emitted_rfid = rfid_value
         self._last_emitted_at = now
+
+    def _build_scan_artifact_payload(
+        self,
+        result: dict[str, Any],
+        *,
+        rfid_value: str,
+        observed_at: str,
+        observed_monotonic: float,
+    ) -> tuple[dict[str, Any], bool]:
+        """Return the lock/log payload for this scan plus whether to bypass dedupe."""
+
+        if self._should_start_presence(
+            rfid_value=rfid_value,
+            observed_monotonic=observed_monotonic,
+        ):
+            self._start_presence(
+                rfid_value=rfid_value,
+                observed_at=observed_at,
+                observed_monotonic=observed_monotonic,
+            )
+
+        base_payload = dict(result)
+        base_payload["rfid"] = rfid_value
+        base_payload.setdefault("service_mode", "service")
+        base_payload["scanned_at"] = observed_at
+        self._stamp_presence(
+            base_payload,
+            observed_at=observed_at,
+            observed_monotonic=observed_monotonic,
+        )
+
+        if has_deep_scan_data(base_payload):
+            force_emit = self._current_enriched_payload is None or not has_deep_scan_data(
+                self._current_enriched_payload
+            )
+            self._current_enriched_payload = dict(base_payload)
+            return base_payload, force_emit
+
+        force_emit = False
+        if self._current_enriched_payload is None and self._should_deep_scan(
+            rfid_value=rfid_value,
+            observed_monotonic=observed_monotonic,
+        ):
+            deep_payload = self._attempt_deep_scan(
+                rfid_value=rfid_value,
+                observed_at=observed_at,
+                observed_monotonic=observed_monotonic,
+            )
+            if deep_payload:
+                base_payload = merge_deep_scan_payload(base_payload, deep_payload)
+                self._stamp_presence(
+                    base_payload,
+                    observed_at=observed_at,
+                    observed_monotonic=observed_monotonic,
+                )
+                if has_deep_scan_data(base_payload):
+                    self._current_enriched_payload = dict(base_payload)
+            force_emit = True
+
+        if self._current_enriched_payload is None:
+            return base_payload, force_emit
+
+        enriched_payload = dict(self._current_enriched_payload)
+        for key, value in base_payload.items():
+            if key in SENSITIVE_RFID_KEYS or key == "deep_read":
+                continue
+            enriched_payload[key] = value
+        self._stamp_presence(
+            enriched_payload,
+            observed_at=observed_at,
+            observed_monotonic=observed_monotonic,
+        )
+        self._current_enriched_payload = dict(enriched_payload)
+        return enriched_payload, force_emit
+
+    def _should_start_presence(
+        self,
+        *,
+        rfid_value: str,
+        observed_monotonic: float,
+    ) -> bool:
+        """Return whether this observation starts a new physical presence."""
+
+        if self._current_rfid != rfid_value:
+            return True
+        last_seen = self._current_presence_last_at
+        if last_seen is None:
+            return self._current_presence_started_at is None
+        return observed_monotonic - last_seen > default_presence_gap_seconds()
+
+    def _start_presence(
+        self,
+        *,
+        rfid_value: str,
+        observed_at: str,
+        observed_monotonic: float,
+    ) -> None:
+        self._current_rfid = rfid_value
+        self._current_presence_started_at = observed_monotonic
+        self._current_presence_started_iso = observed_at
+        self._current_presence_last_at = None
+        self._current_enriched_payload = None
+        self._deep_scan_attempted_rfid = None
+
+    def _stamp_presence(
+        self,
+        payload: dict[str, Any],
+        *,
+        observed_at: str,
+        observed_monotonic: float,
+    ) -> None:
+        """Add held-card presence timestamps to an emitted scan payload."""
+
+        started_at = self._current_presence_started_at
+        if started_at is None:
+            started_at = observed_monotonic
+            self._current_presence_started_at = started_at
+        started_iso = self._current_presence_started_iso or observed_at
+        self._current_presence_started_iso = started_iso
+        payload["first_presence_at"] = started_iso
+        payload["last_presence_at"] = observed_at
+        payload["presence_duration_seconds"] = round(
+            max(0.0, observed_monotonic - started_at),
+            3,
+        )
+        self._current_presence_last_at = observed_monotonic
+
+    def _should_deep_scan(
+        self,
+        *,
+        rfid_value: str,
+        observed_monotonic: float,
+    ) -> bool:
+        """Return whether this card has been held long enough for auto deep-read."""
+
+        if self._deep_scan_attempted_rfid == rfid_value:
+            return False
+        started_at = self._current_presence_started_at
+        if started_at is None:
+            return False
+        return observed_monotonic - started_at >= default_deep_scan_hold_seconds()
+
+    def _attempt_deep_scan(
+        self,
+        *,
+        rfid_value: str,
+        observed_at: str,
+        observed_monotonic: float,
+    ) -> dict[str, Any] | None:
+        """Try one automatic deep read for a held card."""
+
+        self._deep_scan_attempted_rfid = rfid_value
+        deep_payload = read_deep_tag(timeout=default_deep_scan_timeout())
+        if not deep_payload:
+            return {
+                "deep_scan": {
+                    "automatic": True,
+                    "attempted_at": observed_at,
+                    "status": "no-card",
+                }
+            }
+
+        deep_rfid = str(deep_payload.get("rfid", "") or "").strip().upper()
+        if deep_rfid != rfid_value:
+            return {
+                "deep_scan": {
+                    "automatic": True,
+                    "attempted_at": observed_at,
+                    "status": "rfid-mismatch",
+                    "rfid": deep_rfid or None,
+                }
+            }
+
+        payload = dict(deep_payload)
+        payload["rfid"] = rfid_value
+        payload.setdefault("service_mode", "service")
+        payload["scanned_at"] = observed_at
+        payload["deep_scan"] = {
+            "automatic": True,
+            "attempted_at": observed_at,
+            "status": "ok" if has_deep_scan_data(payload) else "no-deep-data",
+        }
+        self._stamp_presence(
+            payload,
+            observed_at=observed_at,
+            observed_monotonic=observed_monotonic,
+        )
+        return payload
 
     def status(self) -> ServiceStatus:
         queue_depth, _last_scan, last_scan_at = self.queue.status()
@@ -436,6 +667,57 @@ def format_lcd_scan_event(result: dict[str, Any]) -> tuple[str, str]:
     return subject, body
 
 
+def utc_now_iso() -> str:
+    return datetime.now(datetime_timezone.utc).isoformat()
+
+
+def has_deep_scan_data(payload: dict[str, Any]) -> bool:
+    """Return whether a scanner payload contains enriched tag data."""
+
+    return bool(payload.get("deep_read") or payload.get("dump") or payload.get("keys"))
+
+
+def merge_deep_scan_payload(
+    base_payload: dict[str, Any],
+    deep_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge automatic deep-read fields into a normal scan payload."""
+
+    merged = dict(base_payload)
+    for key, value in deep_payload.items():
+        if key in {"rfid", "service_mode"}:
+            continue
+        merged[key] = value
+    return merged
+
+
+def normalize_scan_lock_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a stable latest-scan lockfile payload."""
+
+    normalized = dict(payload)
+    now = utc_now_iso()
+    normalized.setdefault("schema", SCAN_LOCK_SCHEMA)
+    normalized.setdefault("written_at", now)
+    normalized.setdefault("scanned_at", now)
+    rfid_value = str(normalized.get("rfid", "") or "").strip().upper()
+    if rfid_value:
+        normalized["rfid"] = rfid_value
+        normalized.setdefault(
+            "last_presence_at",
+            normalized.get("scanned_at") or now,
+        )
+    return normalized
+
+
+def normalize_scan_log_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the append-only ingest payload without lockfile-only deep data."""
+
+    normalized = normalize_scan_lock_payload(payload)
+    for key in SENSITIVE_RFID_KEYS:
+        normalized.pop(key, None)
+    return normalized
+
+
 def rfid_service_lock_path(base_dir: Path | None = None) -> Path:
     return get_lock_dir(base_dir) / "rfid-service.lck"
 
@@ -455,13 +737,7 @@ def rfid_scan_log_path(base_dir: Path | None = None) -> Path:
 def build_scan_state_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Return normalized latest-scan state for local lockfile consumers."""
 
-    state = dict(payload)
-    state["schema"] = SCAN_STATE_SCHEMA
-    rfid_value = str(state.get("rfid") or "").strip().upper()
-    if rfid_value:
-        state["rfid"] = rfid_value
-    state.setdefault("scanned_at", datetime.now(datetime_timezone.utc).isoformat())
-    return state
+    return normalize_scan_lock_payload(payload)
 
 
 def write_rfid_scan_lock(payload: dict[str, Any], *, base_dir: Path | None = None) -> None:
@@ -488,8 +764,9 @@ def write_rfid_scan_lock(payload: dict[str, Any], *, base_dir: Path | None = Non
 def append_scan_log(payload: dict[str, Any], *, base_dir: Path | None = None) -> None:
     log_path = rfid_scan_log_path(base_dir)
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    normalized_payload = normalize_scan_log_payload(payload)
     with log_path.open("a", encoding="utf-8") as log_file:
-        log_file.write(json.dumps(payload, sort_keys=True))
+        log_file.write(json.dumps(normalized_payload, sort_keys=True))
         log_file.write("\n")
 
 
@@ -520,7 +797,7 @@ def request_service(
             sock.sendto(message, (endpoint.host, endpoint.port))
             resp_bytes, _addr = sock.recvfrom(65535)
             response = json.loads(resp_bytes.decode("utf-8"))
-        except (socket.timeout, OSError, json.JSONDecodeError, UnicodeDecodeError):
+        except (TimeoutError, OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None
     if not isinstance(response, dict):
         return None

--- a/apps/cards/tests/test_rfid_service_runtime.py
+++ b/apps/cards/tests/test_rfid_service_runtime.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 import json
+import queue
 from types import SimpleNamespace
 
-from apps.cards import rfid_service
-from apps.cards import reader
-from apps.cards import scanner
+from apps.cards import background_reader, reader, rfid_service, scanner
+
+
+class _RecordingLock:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.held = False
+
+    def __enter__(self):
+        self.events.append("enter")
+        self.held = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.held = False
+        self.events.append("exit")
+        return False
 
 
 def test_rfid_service_module_main_invokes_runner(monkeypatch):
@@ -114,18 +129,14 @@ def test_emit_scan_artifacts_uses_shared_payload_timestamp(settings, tmp_path, m
     settings.BASE_DIR = tmp_path
     appended: list[dict[str, object]] = []
     timestamp = "2026-04-24T22:00:00+00:00"
-    original_build_scan_state_payload = rfid_service.build_scan_state_payload
 
-    def build_with_timestamp(payload):
-        state = original_build_scan_state_payload(payload)
-        state["scanned_at"] = timestamp
-        return state
-
-    monkeypatch.setattr(rfid_service, "build_scan_state_payload", build_with_timestamp)
+    monkeypatch.setattr(rfid_service, "utc_now_iso", lambda: timestamp)
     monkeypatch.setattr(
         rfid_service,
         "append_scan_log",
-        lambda payload: appended.append(dict(payload)),
+        lambda payload: appended.append(
+            rfid_service.normalize_scan_log_payload(payload)
+        ),
     )
 
     state = rfid_service.RFIDServiceState()
@@ -330,3 +341,342 @@ def test_scan_sources_no_irq_returns_direct_empty_result(monkeypatch):
     result = scanner.scan_sources(timeout=0.5, no_irq=True)
 
     assert result == {"rfid": None, "label_id": None}
+
+
+def _read_latest_scan_lock(base_dir):
+    lock_path = base_dir / ".locks" / "rfid-scan.json"
+    return json.loads(lock_path.read_text(encoding="utf-8"))
+
+
+def _read_scan_log_entries(base_dir):
+    log_path = base_dir / "logs" / "rfid-scans.ndjson"
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_rfid_service_auto_deep_scans_held_card_and_preserves_enrichment(
+    monkeypatch,
+    settings,
+    tmp_path,
+):
+    """Holding the same card should enrich the latest-scan lockfile once."""
+
+    settings.BASE_DIR = str(tmp_path)
+    monkeypatch.setattr(settings, "LOG_DIR", str(tmp_path / "logs"), raising=False)
+    clock = {"now": 100.0}
+    deep_calls: list[float] = []
+
+    monkeypatch.setattr(rfid_service.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(rfid_service, "default_scan_dedupe_seconds", lambda: 0.0)
+    monkeypatch.setattr(rfid_service, "default_deep_scan_hold_seconds", lambda: 2.0)
+    monkeypatch.setattr(rfid_service, "default_deep_scan_timeout", lambda: 0.1)
+
+    def fake_read_deep_tag(timeout):
+        deep_calls.append(timeout)
+        return {
+            "rfid": "abcd1234",
+            "label_id": "alpha",
+            "deep_read": True,
+            "keys": {"a": "FFFFFFFFFFFF", "a_verified": True},
+            "dump": [{"block": 0, "data": [1, 2, 3]}],
+        }
+
+    monkeypatch.setattr(rfid_service, "read_deep_tag", fake_read_deep_tag)
+
+    state = rfid_service.RFIDServiceState()
+    state._emit_scan_artifacts({"rfid": "abcd1234", "label_id": "alpha"})
+    first_payload = _read_latest_scan_lock(tmp_path)
+
+    assert first_payload["schema"] == rfid_service.SCAN_LOCK_SCHEMA
+    assert first_payload["rfid"] == "ABCD1234"
+    assert first_payload["presence_duration_seconds"] == 0.0
+    assert "dump" not in first_payload
+    assert deep_calls == []
+
+    clock["now"] = 101.5
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+    assert deep_calls == []
+
+    clock["now"] = 102.1
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+    enriched_payload = _read_latest_scan_lock(tmp_path)
+
+    assert deep_calls == [0.1]
+    assert enriched_payload["deep_read"] is True
+    assert enriched_payload["keys"] == {"a": "FFFFFFFFFFFF", "a_verified": True}
+    assert enriched_payload["dump"] == [{"block": 0, "data": [1, 2, 3]}]
+    assert enriched_payload["deep_scan"]["automatic"] is True
+    assert enriched_payload["deep_scan"]["status"] == "ok"
+    assert enriched_payload["presence_duration_seconds"] == 2.1
+    assert enriched_payload["last_presence_at"]
+    enriched_log_payload = _read_scan_log_entries(tmp_path)[-1]
+    assert enriched_log_payload["deep_scan"]["status"] == "ok"
+    assert "keys" not in enriched_log_payload
+    assert "dump" not in enriched_log_payload
+
+    clock["now"] = 103.5
+    state._emit_scan_artifacts(
+        {"rfid": "ABCD1234", "label_id": "alpha", "allowed": True}
+    )
+    retained_payload = _read_latest_scan_lock(tmp_path)
+
+    assert deep_calls == [0.1]
+    assert retained_payload["dump"] == [{"block": 0, "data": [1, 2, 3]}]
+    assert retained_payload["allowed"] is True
+    assert retained_payload["presence_duration_seconds"] == 3.5
+
+    clock["now"] = 104.6
+    state._emit_scan_artifacts({"rfid": "BEEF0001", "label_id": "beta"})
+    different_card_payload = _read_latest_scan_lock(tmp_path)
+
+    assert different_card_payload["rfid"] == "BEEF0001"
+    assert different_card_payload["presence_duration_seconds"] == 0.0
+    assert "dump" not in different_card_payload
+
+
+def test_rfid_service_resets_presence_when_same_card_returns_after_gap(
+    monkeypatch,
+    settings,
+    tmp_path,
+):
+    settings.BASE_DIR = str(tmp_path)
+    monkeypatch.setattr(settings, "LOG_DIR", str(tmp_path / "logs"), raising=False)
+    clock = {"now": 100.0}
+    deep_calls: list[float] = []
+
+    monkeypatch.setattr(rfid_service.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(rfid_service, "default_scan_dedupe_seconds", lambda: 0.0)
+    monkeypatch.setattr(rfid_service, "default_deep_scan_hold_seconds", lambda: 2.0)
+    monkeypatch.setattr(rfid_service, "default_deep_scan_timeout", lambda: 0.1)
+    monkeypatch.setattr(rfid_service, "default_presence_gap_seconds", lambda: 2.0)
+
+    def fake_read_deep_tag(timeout):
+        deep_calls.append(timeout)
+        return {
+            "rfid": "abcd1234",
+            "deep_read": True,
+            "dump": [{"block": 0, "data": [1, 2, 3]}],
+        }
+
+    monkeypatch.setattr(rfid_service, "read_deep_tag", fake_read_deep_tag)
+
+    state = rfid_service.RFIDServiceState()
+    state._emit_scan_artifacts({"rfid": "abcd1234", "label_id": "alpha"})
+
+    clock["now"] = 101.0
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+
+    clock["now"] = 104.5
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+    returned_payload = _read_latest_scan_lock(tmp_path)
+
+    assert returned_payload["presence_duration_seconds"] == 0.0
+    assert "dump" not in returned_payload
+    assert deep_calls == []
+
+    clock["now"] = 105.5
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+    held_again_payload = _read_latest_scan_lock(tmp_path)
+
+    assert held_again_payload["presence_duration_seconds"] == 1.0
+    assert "dump" not in held_again_payload
+
+    clock["now"] = 106.6
+    state._emit_scan_artifacts({"rfid": "ABCD1234", "label_id": "alpha"})
+    enriched_payload = _read_latest_scan_lock(tmp_path)
+
+    assert deep_calls == [0.1]
+    assert enriched_payload["presence_duration_seconds"] == 2.1
+    assert enriched_payload["deep_scan"]["status"] == "ok"
+
+
+def test_rfid_service_dedupes_repeated_deep_read_payloads(
+    monkeypatch,
+    settings,
+    tmp_path,
+):
+    settings.BASE_DIR = str(tmp_path)
+    monkeypatch.setattr(settings, "LOG_DIR", str(tmp_path / "logs"), raising=False)
+    clock = {"now": 100.0}
+    deep_payload = {
+        "rfid": "abcd1234",
+        "label_id": "alpha",
+        "deep_read": True,
+        "dump": [{"block": 0, "data": [1, 2, 3]}],
+    }
+
+    monkeypatch.setattr(rfid_service.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(rfid_service, "default_scan_dedupe_seconds", lambda: 1.0)
+
+    state = rfid_service.RFIDServiceState()
+    state._emit_scan_artifacts({"rfid": "abcd1234", "label_id": "alpha"})
+    assert len(_read_scan_log_entries(tmp_path)) == 1
+
+    clock["now"] = 100.1
+    state._emit_scan_artifacts(deep_payload)
+    assert len(_read_scan_log_entries(tmp_path)) == 2
+
+    clock["now"] = 100.2
+    state._emit_scan_artifacts(deep_payload)
+    assert len(_read_scan_log_entries(tmp_path)) == 2
+
+    clock["now"] = 101.2
+    state._emit_scan_artifacts(deep_payload)
+    assert len(_read_scan_log_entries(tmp_path)) == 3
+
+
+def test_background_reader_deep_read_uses_direct_reader_and_restores_state(
+    monkeypatch,
+):
+    """Automatic deep reads should not drain a stale fast-read queue entry."""
+
+    sentinel_reader = object()
+    reader_lock = _RecordingLock()
+    deep_state = {"enabled": False}
+    read_calls = []
+    usage_marks = []
+
+    monkeypatch.setattr(background_reader, "is_configured", lambda: True)
+    monkeypatch.setattr(background_reader, "_reader", sentinel_reader)
+    monkeypatch.setattr(background_reader, "_reader_lock", reader_lock)
+    monkeypatch.setattr(reader, "deep_read_enabled", lambda: deep_state["enabled"])
+
+    def fake_enable_deep_read():
+        deep_state["enabled"] = True
+        return True
+
+    def fake_disable_deep_read():
+        deep_state["enabled"] = False
+        return False
+
+    def fake_read_rfid(*, mfrc=None, cleanup=True, timeout=1.0, **kwargs):
+        read_calls.append(
+            {
+                "mfrc": mfrc,
+                "cleanup": cleanup,
+                "timeout": timeout,
+                "deep_enabled": deep_state["enabled"],
+                "lock_held": reader_lock.held,
+            }
+        )
+        return {"rfid": "ABCD1234"}
+
+    monkeypatch.setattr(reader, "enable_deep_read", fake_enable_deep_read)
+    monkeypatch.setattr(reader, "disable_deep_read", fake_disable_deep_read)
+    monkeypatch.setattr(reader, "read_rfid", fake_read_rfid)
+    monkeypatch.setattr(
+        background_reader,
+        "_mark_scanner_used",
+        lambda: usage_marks.append("used"),
+    )
+
+    result = background_reader.read_current_tag_deep(timeout=0.25)
+
+    assert result == {"rfid": "ABCD1234"}
+    assert read_calls == [
+        {
+            "mfrc": sentinel_reader,
+            "cleanup": False,
+            "timeout": 0.25,
+            "deep_enabled": True,
+            "lock_held": True,
+        }
+    ]
+    assert deep_state["enabled"] is False
+    assert usage_marks == ["used"]
+    assert reader_lock.events == ["enter", "exit"]
+
+
+def test_background_reader_polling_read_uses_reader_lock(monkeypatch):
+    sentinel_reader = object()
+    reader_lock = _RecordingLock()
+    read_calls = []
+    usage_marks = []
+
+    monkeypatch.setattr(background_reader, "is_configured", lambda: True)
+    monkeypatch.setattr(background_reader, "_reader", sentinel_reader)
+    monkeypatch.setattr(background_reader, "_reader_lock", reader_lock)
+    monkeypatch.setattr(background_reader, "_tag_queue", queue.Queue())
+    monkeypatch.setattr(
+        background_reader,
+        "_mark_scanner_used",
+        lambda: usage_marks.append("used"),
+    )
+
+    def fake_read_rfid(*, mfrc=None, cleanup=True, timeout=1.0, **kwargs):
+        read_calls.append(
+            {
+                "mfrc": mfrc,
+                "cleanup": cleanup,
+                "timeout": timeout,
+                "lock_held": reader_lock.held,
+            }
+        )
+        return {"rfid": "ABCD1234"}
+
+    monkeypatch.setattr(reader, "read_rfid", fake_read_rfid)
+
+    result = background_reader.get_next_tag(timeout=0.0)
+
+    assert result == {"rfid": "ABCD1234"}
+    assert read_calls == [
+        {
+            "mfrc": sentinel_reader,
+            "cleanup": False,
+            "timeout": 0.0,
+            "lock_held": True,
+        }
+    ]
+    assert usage_marks == ["used"]
+    assert reader_lock.events == ["enter", "exit"]
+
+
+def test_background_reader_irq_callback_uses_reader_lock(monkeypatch):
+    reader_lock = _RecordingLock()
+    read_calls = []
+
+    class DummyReader:
+        ComIrqReg = 0x04
+
+        def __init__(self) -> None:
+            self.writes: list[tuple[int, int, bool]] = []
+
+        def dev_write(self, register, value):
+            self.writes.append((register, value, reader_lock.held))
+
+    dummy_reader = DummyReader()
+    tag_queue = queue.Queue()
+
+    monkeypatch.setattr(background_reader, "_reader", dummy_reader)
+    monkeypatch.setattr(background_reader, "_reader_lock", reader_lock)
+    monkeypatch.setattr(background_reader, "_tag_queue", tag_queue)
+
+    def fake_read_rfid(*, mfrc=None, cleanup=True, use_irq=False, **kwargs):
+        read_calls.append(
+            {
+                "mfrc": mfrc,
+                "cleanup": cleanup,
+                "use_irq": use_irq,
+                "lock_held": reader_lock.held,
+            }
+        )
+        return {"rfid": "ABCD1234"}
+
+    monkeypatch.setattr(reader, "read_rfid", fake_read_rfid)
+
+    background_reader._irq_callback(22)
+
+    assert tag_queue.get_nowait() == {"rfid": "ABCD1234"}
+    assert read_calls == [
+        {
+            "mfrc": dummy_reader,
+            "cleanup": False,
+            "use_irq": True,
+            "lock_held": True,
+        }
+    ]
+    assert dummy_reader.writes == [(dummy_reader.ComIrqReg, 0x7F, True)]
+    assert reader_lock.events == ["enter", "exit"]

--- a/docs/services/rfid-scanner-service.md
+++ b/docs/services/rfid-scanner-service.md
@@ -6,8 +6,20 @@ The RFID scanner service runs a lightweight background reader for local hardware
 ## What it does
 - Reads RFID tags from attached hardware in a background worker.
 - Writes non-repeated scans to `.locks/rfid-scan.json` and `logs/rfid-scans.ndjson`.
+- Adds `last_presence_at` and presence duration fields to the latest-scan lock file so local consumers can ignore cards that have not been physically observed recently.
+- Attempts one automatic deep read when the same card remains on the reader for more than two seconds, then keeps the enriched lock-file payload until a different card is scanned.
 - Lets Django ingest those artifacts into RFID Attempts for web/API consumers.
 - Exposes health checks (ping) and deep-read toggles for diagnostics.
+
+## Latest-scan lock file
+The service writes `.locks/rfid-scan.json` with schema `arthexis.rfid.scan.v1`. A normal fast scan includes the RFID, scan time, first and last physical presence timestamps, and presence duration.
+
+When automatic deep-read succeeds, the lock file keeps the returned `keys`, `dump`, and `deep_read` fields for that same card even if later fast reads only refresh its presence. Scanning a different card replaces the enriched payload.
+
+Automatic deep-read timing can be tuned with:
+- `RFID_SERVICE_DEEP_SCAN_HOLD_SECONDS` (default `2.0`)
+- `RFID_SERVICE_DEEP_SCAN_TIMEOUT` (default `1.0`)
+- `RFID_SERVICE_PRESENCE_GAP_SECONDS` (default: same as the hold threshold)
 
 ## Enable
 1. Enable the RFID service lock (installer or configurator):


### PR DESCRIPTION
## Summary
- add held-card tracking to the RFID service latest-scan lockfile, including first/last presence timestamps and presence duration
- automatically perform one direct deep-read attempt after the same card has stayed present past the hold threshold, preserving enriched lockfile data until another RFID is scanned
- reset same-RFID presence tracking after a configurable observation gap so returned cards start a fresh hold window
- keep dedupe active for repeated deep-read payloads while still force-emitting the first enrichment
- keep raw deep-read keys/dumps out of the append-only ingest log while documenting the new lockfile fields and tuning env vars
- serialize MFRC522 reader access across IRQ, polling, and automatic deep-read paths

## Verification
- `.venv\Scripts\python.exe -m ruff check apps\cards\background_reader.py apps\cards\reader.py apps\cards\rfid_service.py apps\cards\tests\test_rfid_service_runtime.py`
- `.venv\Scripts\python.exe -m ruff check apps\cards\rfid_service.py apps\cards\tests\test_rfid_service_runtime.py` (post-review fixes)
- `.venv\Scripts\python.exe manage.py check --fail-level ERROR`
- `.venv\Scripts\python.exe manage.py test run -- apps/cards/tests/test_rfid_service_runtime.py` (19 passed after dedupe fix)
- `.venv\Scripts\python.exe manage.py test run -- apps/cards/tests` (101 passed before final review fix)
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enriches the RFID latest-scan lockfile with held-card tracking and automatic one-time deep-read enrichment. The service records first and last presence timestamps and presence_duration_seconds for the currently held card; when the same card remains present past a configurable hold threshold (default 2s) the service performs a single automatic direct deep-read attempt and preserves the enriched lockfile payload until a different RFID is scanned. Raw deep-read keys/dumps are explicitly excluded from the append-only NDJSON ingest log.

## Key Changes

Background reader (concurrency & deep-read API)
- Serialize MFRC522 hardware access across IRQ callback, polling fallback, and automatic deep-read paths using a new _reader_lock.
- Tightened typing (threading.Thread | None, float | None, dict | None).
- Added public helper read_current_tag_deep(timeout: float | None = 0.5) that temporarily enables deep-read mode, performs a locked direct read, and restores prior state.

Reader module (deep-read state control)
- Added disable_deep_read() and deep_read_enabled() to complement existing enable/toggle helpers.

RFID service (held-card tracking, payload normalization, and deep-scan workflow)
- Added per-card presence tracking (first/last presence timestamps, presence_duration_seconds, and one-time deep-scan attempt flag) in RFIDServiceState.
- Automatic deep-read: after presence exceeds DEFAULT_DEEP_SCAN_HOLD_SECONDS (default 2.0s) perform one direct deep-read with DEFAULT_DEEP_SCAN_TIMEOUT (default 0.5s).
- New SCAN_LOCK_SCHEMA (arthexis.rfid.scan.v1) and helpers: utc_now_iso(), has_deep_scan_data(), merge_deep_scan_payload(), normalize_scan_lock_payload(), normalize_scan_log_payload(), build_scan_state_payload(), and read_deep_tag().
- Normalized emission pipeline: lockfile payloads are enriched with deep-read data and presence timing; append-only NDJSON log payloads are normalized and stripped of sensitive raw keys/dumps.
- Reset same-RFID presence tracking after a configurable observation gap (DEFAULT_PRESENCE_GAP_SECONDS; defaults to the hold threshold) so returned cards start a fresh hold window.
- Broadened request_service() error handling to catch TimeoutError.

Documentation
- Expanded rfid-scanner-service.md with the latest-scan lockfile schema (arthexis.rfid.scan.v1), semantics for presence timestamps and duration, the one-time automatic deep-read behavior, and environment variable tuning (RFID_SERVICE_DEEP_SCAN_HOLD_SECONDS, RFID_SERVICE_DEEP_SCAN_TIMEOUT, RFID_SERVICE_PRESENCE_GAP_SECONDS).

## Testing

- New runtime tests and unit tests validate:
  - Held-card enrichment: one-time deep read after hold threshold, presence_duration_seconds progression, and preservation of enrichment until a different card is scanned.
  - Presence reset when the same card returns after the configured gap.
  - Deduping repeated deep-read payload emissions within a dedupe window.
  - Reader lock serialization across IRQ, polling, and deep-read flows.
  - Deep-read state enable/restore behavior and NDJSON/log normalization (no raw keys/dumps).
- Test helpers added: on-disk readers for lockfile and NDJSON log inspection and a _RecordingLock to assert lock enter/exit ordering.
- Verification performed: ruff checks on modified files; manage.py check --fail-level ERROR; unit tests: runtime test (18 passed after rebase) and broader app tests (101 passed before final rebase); git diff --check.

## Verification / Smoke test notes

Contributor hardware smoke test:
- Temporarily stopped/restarted rfid-arthexis.service to gain reader access; prototype run used system venv for mfrc522 dependency.
- Fast read detected CLASSIC card ID DC476D46B0.
- Deep-read succeeded (deep_read: true) producing a 64-block dump.
- latest-lockfile preserved enriched deep data with schema, last_presence_at, and presence_duration_seconds.
- NDJSON scan log retained scan metadata but did not include raw keys/dumps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7735)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->