### PR TITLE
AP portal trusted device allowlist

### DIFF
--- a/config/settings/security.py
+++ b/config/settings/security.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = [
     "10.42.0.0/16",
     "192.168.129.10",
     "192.168.0.0/16",
+    "arthexis.net",
     "arthexis.com",
     "www.arthexis.com",
     "m.arthexis.com",

--- a/docs/operations/ap-portal.md
+++ b/docs/operations/ap-portal.md
@@ -55,6 +55,24 @@ script looks for `/etc/letsencrypt/live/arthexis.net/fullchain.pem` and
 port 443 nginx server block; override `DEFAULT_CERT_PATH` and `DEFAULT_KEY_PATH`
 only when a gateway uses a different certificate location.
 
+Certbot can install that certificate, but ACME validation must be able to prove
+control of the public `arthexis.net` name. HTTP-01 validation only works when
+public DNS for `arthexis.net` resolves to this gateway and inbound port 80
+reaches nginx here. Split local DNS is not enough; clients may resolve
+`arthexis.net` locally, but Let's Encrypt still follows public DNS. When public
+DNS points elsewhere, use DNS-01 with configured DNS provider credentials instead
+of the nginx authenticator. A safe HTTP-01 readiness check is:
+
+```bash
+sudo certbot certonly --nginx --dry-run --non-interactive \
+  --agree-tos --register-unsafely-without-email -d arthexis.net
+```
+
+The AP setup writes `server_name arthexis.net _;` by default so certbot's nginx
+plugin can match the local server block once the public validation path is
+correct. Override `SERVER_NAMES` only when the gateway serves a different local
+hostname set.
+
 ## Gateway Recovery
 
 On the gateway device:

--- a/docs/operations/ap-portal.md
+++ b/docs/operations/ap-portal.md
@@ -29,12 +29,31 @@ the portal synchronize nftables authorization rules. In this local-only mode,
 loopback clients use a deterministic development MAC (`02:00:00:00:00:01`) so
 the consent flow can be previewed from a browser without an AP neighbor table.
 Authorized clients wait three seconds on the portal status message, then redirect
-to the AP guest gallery at `http://10.42.0.1:8888/gallery/ap/` by default. Override
-`--suite-login-scheme`, `--suite-login-host`, `--suite-login-port`, or
+to the AP guest gallery at `http://arthexis.net:8888/gallery/ap/` by default.
+Override `--suite-login-scheme`, `--suite-login-host`, `--suite-login-port`, or
 `--suite-login-path` only for gateways that use a different AP-side suite
 address. Override `--authorized-redirect-delay-ms` when authorized clients
 should wait for a different interval; the default is `3000` ms, and `0` redirects
 immediately.
+
+Devices that should skip AP registration can be placed in
+`.state/ap_portal/trusted_macs.txt`, one MAC address per line. Lines may include
+comments or a short label after the MAC, for example:
+
+```text
+2c:cc:44:4d:1a:c5 ps4
+# aa:bb:cc:dd:ee:ff reserved
+```
+
+Trusted devices are treated as authorized for the portal and nftables sync, but
+they are kept separate from `authorized_macs.txt` so consent-backed
+authorizations remain distinguishable from local operator allow-list entries.
+
+Local HTTPS requires a certificate that is valid for `arthexis.net`. The setup
+script looks for `/etc/letsencrypt/live/arthexis.net/fullchain.pem` and
+`/etc/letsencrypt/live/arthexis.net/privkey.pem` by default before adding a
+port 443 nginx server block; override `DEFAULT_CERT_PATH` and `DEFAULT_KEY_PATH`
+only when a gateway uses a different certificate location.
 
 ## Gateway Recovery
 

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -26,11 +26,12 @@ DEFAULT_SOURCE_URL = (
     "https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py"
 )
 DEFAULT_SUITE_LOGIN_SCHEME = "http"
-DEFAULT_SUITE_LOGIN_HOST = "10.42.0.1"
+DEFAULT_SUITE_LOGIN_HOST = "arthexis.net"
 DEFAULT_SUITE_LOGIN_PORT = 8888
 DEFAULT_SUITE_LOGIN_PATH = "/gallery/ap/"
 DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS = 3000
 AUTHORIZED_MACS_PATH = DEFAULT_STATE_DIR / "authorized_macs.txt"
+TRUSTED_MACS_PATH = DEFAULT_STATE_DIR / "trusted_macs.txt"
 CONSENTS_PATH = DEFAULT_STATE_DIR / "consents.jsonl"
 ACTIVITY_PATH = DEFAULT_STATE_DIR / "activity.jsonl"
 NFT_TABLE_NAME = "arthexis_ap_portal"
@@ -86,6 +87,7 @@ class PortalConfig:
     assets_dir: Path
     state_dir: Path
     authorized_macs_path: Path
+    trusted_macs_path: Path
     consents_path: Path
     activity_path: Path
     source_url: str
@@ -316,13 +318,16 @@ class ActivityRecorder:
     def client_summary(self, limit: int = 100) -> list[dict[str, Any]]:
         clients: dict[str, dict[str, Any]] = {}
         authorized = _read_authorized_macs(self.config.authorized_macs_path)
+        trusted = _read_trusted_macs(self.config.trusted_macs_path)
+        effective_authorized = authorized | trusted
 
-        for mac in authorized:
+        for mac in effective_authorized:
             clients.setdefault(
                 mac,
                 {
                     "mac_address": mac,
                     "authorized": True,
+                    "trusted_device": mac in trusted,
                     "event_count": 0,
                 },
             )
@@ -332,7 +337,8 @@ class ActivityRecorder:
             if not mac:
                 continue
             entry = clients.setdefault(mac, {"mac_address": mac, "event_count": 0})
-            entry["authorized"] = mac in authorized
+            entry["authorized"] = mac in effective_authorized
+            entry["trusted_device"] = mac in trusted
             entry["email"] = consent.get("email")
             entry["accepted_at"] = consent.get("accepted_at")
             entry["last_ip_address"] = consent.get("ip_address")
@@ -348,7 +354,9 @@ class ActivityRecorder:
             entry["last_event_at"] = event.get("observed_at")
             entry["last_event_type"] = event.get("event_type")
             entry["event_count"] = int(entry.get("event_count") or 0) + 1
-            entry.setdefault("authorized", key in authorized)
+            entry.setdefault("authorized", key in effective_authorized)
+            if mac:
+                entry.setdefault("trusted_device", mac in trusted)
 
         return sorted(
             clients.values(),
@@ -360,13 +368,25 @@ class ActivityRecorder:
 
 
 def _read_authorized_macs(path: Path) -> set[str]:
+    return _read_mac_allowlist(path)
+
+
+def _read_trusted_macs(path: Path) -> set[str]:
+    return _read_mac_allowlist(path)
+
+
+def _read_mac_allowlist(path: Path) -> set[str]:
     if not path.exists():
         return set()
-    return {
-        _normalize_mac(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    }
+    macs = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        if not line:
+            continue
+        token = line.split(maxsplit=1)[0]
+        if MAC_RE.fullmatch(token):
+            macs.add(_normalize_mac(token))
+    return macs
 
 
 def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
@@ -403,8 +423,18 @@ class PortalState:
         self._firewall = FirewallManager()
         self.activity = ActivityRecorder(config)
         self._authorized = _read_authorized_macs(self.config.authorized_macs_path)
+        self._trusted = _read_trusted_macs(self.config.trusted_macs_path)
         if self.config.sync_firewall:
-            self._firewall.sync(self._authorized)
+            self._firewall.sync(self._effective_authorized_macs())
+
+    def _effective_authorized_macs(self) -> set[str]:
+        return self._authorized | self._trusted
+
+    def _authorization_for_mac(self, mac_address: str | None) -> tuple[bool, bool]:
+        if not mac_address:
+            return False, False
+        trusted = mac_address in self._trusted
+        return mac_address in self._authorized or trusted, trusted
 
     def status_for_request(
         self,
@@ -416,19 +446,21 @@ class PortalState:
     ) -> dict[str, Any]:
         mac_address = self.resolve_mac(ip_address)
         with self._lock:
-            authorized = bool(mac_address and mac_address in self._authorized)
+            authorized, trusted = self._authorization_for_mac(mac_address)
         authorized_redirect_url = self.suite_login_url(host) if authorized else ""
         self.activity.record(
             "status_check",
             ip_address=ip_address,
             mac_address=mac_address,
             authorized=authorized,
+            trusted_device=trusted,
             user_agent=user_agent,
             path=path,
             host=host,
         )
         return {
             "authorized": authorized,
+            "trusted_device": trusted,
             "mac_address": mac_address,
             "authorized_redirect_url": authorized_redirect_url,
             "redirect_delay_ms": self.config.authorized_redirect_delay_ms,
@@ -440,6 +472,7 @@ class PortalState:
                 "activity_log": str(self.config.activity_path),
                 "consent_log": str(self.config.consents_path),
                 "authorized_macs": str(self.config.authorized_macs_path),
+                "trusted_macs": str(self.config.trusted_macs_path),
             },
         }
 
@@ -454,18 +487,30 @@ class PortalState:
         referer: str,
     ) -> None:
         mac_address = self.resolve_mac(ip_address)
-        authorized = bool(mac_address and mac_address in self._authorized)
+        with self._lock:
+            authorized, trusted = self._authorization_for_mac(mac_address)
         self.activity.record(
             "request",
             ip_address=ip_address,
             mac_address=mac_address,
             authorized=authorized,
+            trusted_device=trusted,
             user_agent=user_agent,
             method=method,
             path=path,
             host=host,
             referer=referer,
         )
+
+    def authorized_redirect_for_request(
+        self, *, ip_address: str | None, host: str
+    ) -> str:
+        mac_address = self.resolve_mac(ip_address)
+        with self._lock:
+            authorized, _trusted = self._authorization_for_mac(mac_address)
+        if not authorized:
+            return ""
+        return self.suite_login_url(host)
 
     def suite_login_url(self, host: str) -> str:
         return _suite_login_url(
@@ -514,14 +559,14 @@ class PortalState:
         }
 
         with self._lock:
-            already_authorized = mac_address in self._authorized
+            already_authorized, trusted = self._authorization_for_mac(mac_address)
             if not already_authorized:
                 previous_authorized = set(self._authorized)
                 authorized_file_existed = self.config.authorized_macs_path.exists()
                 next_authorized = set(self._authorized)
                 next_authorized.add(mac_address)
                 if self.config.sync_firewall:
-                    self._firewall.sync(next_authorized)
+                    self._firewall.sync(next_authorized | self._trusted)
                 consent_rollback_position = self._consent_log_position()
                 try:
                     self._write_authorized_macs(next_authorized)
@@ -532,6 +577,7 @@ class PortalState:
                         mac_address=mac_address,
                         email=normalized_email,
                         already_authorized=already_authorized,
+                        trusted_device=trusted,
                         user_agent=user_agent,
                         host=host,
                     )
@@ -552,7 +598,7 @@ class PortalState:
                             rollback_error = exc
                     try:
                         if self.config.sync_firewall:
-                            self._firewall.sync(previous_authorized)
+                            self._firewall.sync(previous_authorized | self._trusted)
                     except FirewallSyncError as exc:
                         if rollback_error is not None:
                             exc.add_note(f"file rollback failed: {rollback_error}")
@@ -571,6 +617,7 @@ class PortalState:
                         mac_address=mac_address,
                         email=normalized_email,
                         already_authorized=already_authorized,
+                        trusted_device=trusted,
                         user_agent=user_agent,
                         host=host,
                     )
@@ -581,6 +628,7 @@ class PortalState:
         return {
             "authorized": True,
             "already_authorized": already_authorized,
+            "trusted_device": trusted,
             "mac_address": mac_address,
             "monitoring_notice": MONITORING_NOTICE,
             "source_code_url": self.config.source_url,
@@ -697,6 +745,8 @@ class PortalApplication:
                     return
 
                 if request_path in {"", "/"}:
+                    if self._redirect_authorized_request(request_path):
+                        return
                     self._serve_portal_page(request_path or "/")
                     return
                 if request_path.startswith("/api/"):
@@ -704,6 +754,8 @@ class PortalApplication:
                     self.send_error(HTTPStatus.NOT_FOUND)
                     return
                 if request_path in CAPTIVE_PORTAL_PROBE_PATHS:
+                    if self._redirect_authorized_request(request_path):
+                        return
                     self._serve_portal_page(request_path)
                     return
                 asset_name = request_path.lstrip("/")
@@ -715,6 +767,8 @@ class PortalApplication:
                         self._record_request(request_path)
                         if not self._serve_asset(asset_name):
                             self.send_error(HTTPStatus.NOT_FOUND)
+                        return
+                    if self._redirect_authorized_request(request_path):
                         return
                     self._serve_portal_page(request_path)
                     return
@@ -784,6 +838,20 @@ class PortalApplication:
                     referer=self.headers.get("Referer", ""),
                 )
 
+            def _redirect_authorized_request(self, path: str) -> bool:
+                redirect_url = app.state.authorized_redirect_for_request(
+                    ip_address=self._client_ip(),
+                    host=self.headers.get("Host", ""),
+                )
+                if not redirect_url:
+                    return False
+                self._record_request(path)
+                self.send_response(HTTPStatus.FOUND)
+                self.send_header("Location", redirect_url)
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                return True
+
             def _serve_portal_page(self, path: str) -> None:
                 self._record_request(path)
                 if not self._serve_asset("index.html"):
@@ -840,6 +908,11 @@ class PortalApplication:
 def build_config(args: argparse.Namespace) -> PortalConfig:
     state_dir = Path(args.state_dir).expanduser().resolve()
     assets_dir = Path(args.assets_dir).expanduser().resolve()
+    trusted_macs_path = (
+        Path(args.trusted_macs_path).expanduser().resolve()
+        if args.trusted_macs_path
+        else state_dir / "trusted_macs.txt"
+    )
     source_url = (
         args.source_url
         or os.environ.get("ARTHEXIS_AP_SOURCE_URL")
@@ -860,6 +933,7 @@ def build_config(args: argparse.Namespace) -> PortalConfig:
         assets_dir=assets_dir,
         state_dir=state_dir,
         authorized_macs_path=state_dir / "authorized_macs.txt",
+        trusted_macs_path=trusted_macs_path,
         consents_path=state_dir / "consents.jsonl",
         activity_path=state_dir / "activity.jsonl",
         source_url=source_url,
@@ -881,6 +955,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=9080)
     parser.add_argument("--assets-dir", default=str(ASSETS_DIR))
     parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    parser.add_argument("--trusted-macs-path", default="")
     parser.add_argument("--source-url", default="")
     parser.add_argument("--suite-login-scheme", default=DEFAULT_SUITE_LOGIN_SCHEME)
     parser.add_argument("--suite-login-host", default=DEFAULT_SUITE_LOGIN_HOST)

--- a/scripts/ap_portal_server.py
+++ b/scripts/ap_portal_server.py
@@ -379,13 +379,14 @@ def _read_mac_allowlist(path: Path) -> set[str]:
     if not path.exists():
         return set()
     macs = set()
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.split("#", maxsplit=1)[0].strip()
-        if not line:
-            continue
-        token = line.split(maxsplit=1)[0]
-        if MAC_RE.fullmatch(token):
-            macs.add(_normalize_mac(token))
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.split("#", maxsplit=1)[0].strip()
+            if not line:
+                continue
+            token = line.split(maxsplit=1)[0]
+            if MAC_RE.fullmatch(token):
+                macs.add(_normalize_mac(token))
     return macs
 
 
@@ -485,8 +486,10 @@ class PortalState:
         path: str,
         host: str,
         referer: str,
+        mac_address: str | None = None,
     ) -> None:
-        mac_address = self.resolve_mac(ip_address)
+        if mac_address is None:
+            mac_address = self.resolve_mac(ip_address)
         with self._lock:
             authorized, trusted = self._authorization_for_mac(mac_address)
         self.activity.record(
@@ -503,9 +506,10 @@ class PortalState:
         )
 
     def authorized_redirect_for_request(
-        self, *, ip_address: str | None, host: str
+        self, *, ip_address: str | None, host: str, mac_address: str | None = None
     ) -> str:
-        mac_address = self.resolve_mac(ip_address)
+        if mac_address is None:
+            mac_address = self.resolve_mac(ip_address)
         with self._lock:
             authorized, _trusted = self._authorization_for_mac(mac_address)
         if not authorized:
@@ -828,24 +832,40 @@ class PortalApplication:
                     "X-Forwarded-For"
                 )
 
-            def _record_request(self, path: str) -> None:
+            def _record_request(
+                self,
+                path: str,
+                *,
+                ip_address: str | None = None,
+                mac_address: str | None = None,
+            ) -> None:
+                if ip_address is None:
+                    ip_address = self._client_ip()
                 app.state.record_request(
-                    ip_address=self._client_ip(),
+                    ip_address=ip_address,
                     user_agent=self.headers.get("User-Agent", ""),
                     method=self.command,
                     path=path,
                     host=self.headers.get("Host", ""),
                     referer=self.headers.get("Referer", ""),
+                    mac_address=mac_address,
                 )
 
             def _redirect_authorized_request(self, path: str) -> bool:
+                ip_address = self._client_ip()
+                mac_address = app.state.resolve_mac(ip_address)
                 redirect_url = app.state.authorized_redirect_for_request(
-                    ip_address=self._client_ip(),
+                    ip_address=ip_address,
                     host=self.headers.get("Host", ""),
+                    mac_address=mac_address,
                 )
                 if not redirect_url:
                     return False
-                self._record_request(path)
+                self._record_request(
+                    path,
+                    ip_address=ip_address,
+                    mac_address=mac_address,
+                )
                 self.send_response(HTTPStatus.FOUND)
                 self.send_header("Location", redirect_url)
                 self.send_header("Cache-Control", "no-store")

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -15,6 +15,7 @@ NGINX_BACKUP_RETENTION="${NGINX_BACKUP_RETENTION:-10}"
 DEFAULT_CERT_DOMAIN="${DEFAULT_CERT_DOMAIN:-arthexis.net}"
 DEFAULT_CERT_PATH="${DEFAULT_CERT_PATH:-/etc/letsencrypt/live/$DEFAULT_CERT_DOMAIN/fullchain.pem}"
 DEFAULT_KEY_PATH="${DEFAULT_KEY_PATH:-/etc/letsencrypt/live/$DEFAULT_CERT_DOMAIN/privkey.pem}"
+SERVER_NAMES="${SERVER_NAMES:-arthexis.net _}"
 
 if [[ "${EUID}" -ne 0 ]]; then
     echo "Run as root: sudo $0" >&2
@@ -109,7 +110,7 @@ install_nginx_site() {
         https_block="$(cat <<EOF
 server {
     listen 443 ssl;
-    server_name _;
+    server_name $SERVER_NAMES;
     ssl_certificate $DEFAULT_CERT_PATH;
     ssl_certificate_key $DEFAULT_KEY_PATH;
     include $BASE_DIR/apps/nginx/options-ssl-nginx.conf;
@@ -129,7 +130,7 @@ EOF
     cat > "$NGINX_SITE" <<EOF
 server {
     listen 80 default_server;
-    server_name _;
+    server_name $SERVER_NAMES;
     add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'" always;
     location / {
         proxy_pass http://127.0.0.1:$PORTAL_PORT;

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -6,13 +6,15 @@ PORTAL_PORT="${PORTAL_PORT:-9080}"
 CURRENT_AP_NAME="${CURRENT_AP_NAME:-arthexis-ap}"
 TARGET_AP_NAME="${TARGET_AP_NAME:-arthexis-1}"
 STATE_DIR="${STATE_DIR:-$BASE_DIR/.state/ap_portal}"
+TRUSTED_MACS_PATH="${TRUSTED_MACS_PATH:-$STATE_DIR/trusted_macs.txt}"
 SOURCE_URL="${SOURCE_URL:-https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py}"
 SERVICE_FILE="/etc/systemd/system/arthexis-ap-portal.service"
 NGINX_SITE="/etc/nginx/sites-enabled/arthexis.conf"
 NGINX_BACKUP_DIR="/etc/nginx/sites-available"
 NGINX_BACKUP_RETENTION="${NGINX_BACKUP_RETENTION:-10}"
-DEFAULT_CERT_PATH="/etc/letsencrypt/live/arthexis.com/fullchain.pem"
-DEFAULT_KEY_PATH="/etc/letsencrypt/live/arthexis.com/privkey.pem"
+DEFAULT_CERT_DOMAIN="${DEFAULT_CERT_DOMAIN:-arthexis.net}"
+DEFAULT_CERT_PATH="${DEFAULT_CERT_PATH:-/etc/letsencrypt/live/$DEFAULT_CERT_DOMAIN/fullchain.pem}"
+DEFAULT_KEY_PATH="${DEFAULT_KEY_PATH:-/etc/letsencrypt/live/$DEFAULT_CERT_DOMAIN/privkey.pem}"
 
 if [[ "${EUID}" -ne 0 ]]; then
     echo "Run as root: sudo $0" >&2
@@ -57,7 +59,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=$BASE_DIR
-ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/scripts/ap_portal_server.py --bind 127.0.0.1 --port $PORTAL_PORT --state-dir $STATE_DIR --source-url $SOURCE_URL
+ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/scripts/ap_portal_server.py --bind 127.0.0.1 --port $PORTAL_PORT --state-dir $STATE_DIR --trusted-macs-path $TRUSTED_MACS_PATH --source-url $SOURCE_URL --suite-login-host arthexis.net
 Restart=always
 RestartSec=2
 

--- a/scripts/setup_ap_portal.sh
+++ b/scripts/setup_ap_portal.sh
@@ -60,7 +60,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=$BASE_DIR
-ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/scripts/ap_portal_server.py --bind 127.0.0.1 --port $PORTAL_PORT --state-dir $STATE_DIR --trusted-macs-path $TRUSTED_MACS_PATH --source-url $SOURCE_URL --suite-login-host arthexis.net
+ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/scripts/ap_portal_server.py --bind 127.0.0.1 --port $PORTAL_PORT --state-dir $STATE_DIR --trusted-macs-path $TRUSTED_MACS_PATH --source-url $SOURCE_URL --suite-login-host $DEFAULT_CERT_DOMAIN
 Restart=always
 RestartSec=2
 

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -30,6 +30,7 @@ def make_config(module, tmp_path):
         assets_dir=tmp_path,
         state_dir=state_dir,
         authorized_macs_path=state_dir / "authorized_macs.txt",
+        trusted_macs_path=state_dir / "trusted_macs.txt",
         consents_path=state_dir / "consents.jsonl",
         activity_path=state_dir / "activity.jsonl",
         source_url="https://github.com/arthexis/arthexis/blob/main/scripts/ap_portal_server.py",
@@ -60,7 +61,7 @@ def test_subscribe_records_consent_activity_and_authorizes_client(tmp_path):
 
     assert result["authorized"] is True
     assert result["mac_address"] == "aa:bb:cc:dd:ee:ff"
-    assert result["redirect_url"] == "http://10.42.0.1:8888/gallery/ap/"
+    assert result["redirect_url"] == "http://arthexis.net:8888/gallery/ap/"
     assert "ARE being monitored" in result["monitoring_notice"]
     assert (
         state.config.authorized_macs_path.read_text(encoding="utf-8")
@@ -146,6 +147,7 @@ def test_subscribe_does_not_persist_authorization_when_firewall_sync_fails(tmp_p
         assets_dir=config.assets_dir,
         state_dir=config.state_dir,
         authorized_macs_path=config.authorized_macs_path,
+        trusted_macs_path=config.trusted_macs_path,
         consents_path=config.consents_path,
         activity_path=config.activity_path,
         source_url=config.source_url,
@@ -183,6 +185,7 @@ def test_subscribe_rolls_back_new_authorization_when_consent_log_fails(tmp_path)
         assets_dir=config.assets_dir,
         state_dir=config.state_dir,
         authorized_macs_path=config.authorized_macs_path,
+        trusted_macs_path=config.trusted_macs_path,
         consents_path=config.consents_path,
         activity_path=config.activity_path,
         source_url=config.source_url,
@@ -222,6 +225,7 @@ def test_subscribe_rolls_back_new_authorization_when_activity_log_fails(tmp_path
         assets_dir=config.assets_dir,
         state_dir=config.state_dir,
         authorized_macs_path=config.authorized_macs_path,
+        trusted_macs_path=config.trusted_macs_path,
         consents_path=config.consents_path,
         activity_path=config.activity_path,
         source_url=config.source_url,
@@ -260,6 +264,7 @@ def test_subscribe_resyncs_firewall_when_file_rollback_fails(tmp_path):
         assets_dir=config.assets_dir,
         state_dir=config.state_dir,
         authorized_macs_path=config.authorized_macs_path,
+        trusted_macs_path=config.trusted_macs_path,
         consents_path=config.consents_path,
         activity_path=config.activity_path,
         source_url=config.source_url,
@@ -299,6 +304,7 @@ def test_subscribe_rolls_back_new_authorization_when_authorized_write_fails(tmp_
         assets_dir=config.assets_dir,
         state_dir=config.state_dir,
         authorized_macs_path=config.authorized_macs_path,
+        trusted_macs_path=config.trusted_macs_path,
         consents_path=config.consents_path,
         activity_path=config.activity_path,
         source_url=config.source_url,
@@ -427,8 +433,55 @@ def test_status_redirects_authorized_client_to_gallery_port(tmp_path):
     )
 
     assert payload["authorized"] is True
-    assert payload["authorized_redirect_url"] == "http://10.42.0.1:8888/gallery/ap/"
+    assert payload["authorized_redirect_url"] == "http://arthexis.net:8888/gallery/ap/"
     assert payload["redirect_delay_ms"] == module.DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS
+
+
+def test_trusted_mac_skips_registration_and_redirects_to_suite(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    config.trusted_macs_path.parent.mkdir(parents=True, exist_ok=True)
+    config.trusted_macs_path.write_text(
+        "# Living room console\nAA:BB:CC:DD:EE:FF ps4\n",
+        encoding="utf-8",
+    )
+    state = module.PortalState(config)
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    payload = state.status_for_request(
+        ip_address="192.168.129.143",
+        user_agent="PlayStation",
+        path="/api/status",
+        host="arthexis.net",
+    )
+
+    assert payload["authorized"] is True
+    assert payload["trusted_device"] is True
+    assert payload["authorized_redirect_url"] == "http://arthexis.net:8888/gallery/ap/"
+    assert not config.authorized_macs_path.exists()
+
+
+def test_trusted_mac_consent_does_not_modify_consent_authorization(tmp_path):
+    module = load_portal_module()
+    config = make_config(module, tmp_path)
+    config.trusted_macs_path.parent.mkdir(parents=True, exist_ok=True)
+    config.trusted_macs_path.write_text("aa:bb:cc:dd:ee:ff ps4\n", encoding="utf-8")
+    state = module.PortalState(config)
+    state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+
+    result = state.subscribe(
+        email="guest@example.com",
+        accept_terms=True,
+        ip_address="192.168.129.143",
+        user_agent="PlayStation",
+        host="arthexis.net",
+    )
+
+    assert result["authorized"] is True
+    assert result["already_authorized"] is True
+    assert result["trusted_device"] is True
+    assert not config.authorized_macs_path.exists()
+    assert "guest@example.com" in config.consents_path.read_text(encoding="utf-8")
 
 
 def test_status_preserves_zero_redirect_delay(tmp_path):
@@ -454,7 +507,7 @@ def test_status_preserves_zero_redirect_delay(tmp_path):
     assert payload["redirect_delay_ms"] == 0
 
 
-def test_suite_login_redirect_defaults_to_gateway_host():
+def test_suite_login_redirect_defaults_to_local_hostname():
     module = load_portal_module()
 
     assert (
@@ -465,7 +518,7 @@ def test_suite_login_redirect_defaults_to_gateway_host():
             port=8888,
             path=module.DEFAULT_SUITE_LOGIN_PATH,
         )
-        == "http://10.42.0.1:8888/gallery/ap/"
+        == "http://arthexis.net:8888/gallery/ap/"
     )
 
 
@@ -726,6 +779,7 @@ def test_skip_firewall_sync_defaults_loopback_to_development_mac(tmp_path):
         suite_login_port=module.DEFAULT_SUITE_LOGIN_PORT,
         suite_login_path=module.DEFAULT_SUITE_LOGIN_PATH,
         authorized_redirect_delay_ms=module.DEFAULT_AUTHORIZED_REDIRECT_DELAY_MS,
+        trusted_macs_path="",
         skip_firewall_sync=True,
         local_development_mac="",
     )
@@ -735,6 +789,7 @@ def test_skip_firewall_sync_defaults_loopback_to_development_mac(tmp_path):
 
     assert config.sync_firewall is False
     assert config.local_development_mac == module.LOCAL_DEVELOPMENT_MAC
+    assert config.trusted_macs_path == tmp_path / "state" / "trusted_macs.txt"
     assert state.resolve_mac("127.0.0.1") == module.LOCAL_DEVELOPMENT_MAC
 
 
@@ -772,6 +827,34 @@ def _exercise_get(handler_class, path: str, *, asset_exists: bool = True):
     handler.do_GET()
 
     return SimpleNamespace(recorded=recorded, served=served, errors=errors)
+
+
+def test_get_authorized_client_redirects_before_portal_page(tmp_path):
+    module = load_portal_module()
+    app = module.PortalApplication(make_config(module, tmp_path))
+    app.state.authorized_redirect_for_request = (
+        lambda **_kwargs: "http://arthexis.net:8888/gallery/ap/"
+    )
+    handler_class = app.handler_class()
+    handler = object.__new__(handler_class)
+    handler.path = "/"
+    handler.command = "GET"
+    handler.headers = {}
+    handler.client_address = ("192.168.129.143", 12345)
+    responses = []
+    headers = []
+    handler._record_request = lambda path: responses.append(("record", path))
+    handler._serve_asset = lambda _name: responses.append(("asset", _name)) or True
+    handler.send_response = lambda status: responses.append(("status", status))
+    handler.send_header = lambda key, value: headers.append((key, value))
+    handler.end_headers = lambda: responses.append(("end", None))
+
+    handler.do_GET()
+
+    assert ("record", "/") in responses
+    assert ("status", module.HTTPStatus.FOUND) in responses
+    assert ("Location", "http://arthexis.net:8888/gallery/ap/") in headers
+    assert not any(item[0] == "asset" for item in responses)
 
 
 def test_get_probe_path_returns_portal_page(tmp_path):

--- a/tests/test_ap_portal_server.py
+++ b/tests/test_ap_portal_server.py
@@ -46,6 +46,13 @@ def test_monitoring_notice_is_explicit_and_points_to_source():
     assert module.DEFAULT_SOURCE_URL.endswith("/scripts/ap_portal_server.py")
 
 
+def test_setup_script_uses_configured_cert_domain_for_suite_login_host():
+    script = (SCRIPT_PATH.parent / "setup_ap_portal.sh").read_text(encoding="utf-8")
+
+    assert "--suite-login-host $DEFAULT_CERT_DOMAIN" in script
+    assert "--suite-login-host arthexis.net" not in script
+
+
 def test_subscribe_records_consent_activity_and_authorizes_client(tmp_path):
     module = load_portal_module()
     state = module.PortalState(make_config(module, tmp_path))
@@ -843,7 +850,10 @@ def test_get_authorized_client_redirects_before_portal_page(tmp_path):
     handler.client_address = ("192.168.129.143", 12345)
     responses = []
     headers = []
-    handler._record_request = lambda path: responses.append(("record", path))
+    app.state.resolve_mac = lambda _ip: "aa:bb:cc:dd:ee:ff"
+    handler._record_request = lambda path, **_kwargs: responses.append(
+        ("record", path)
+    )
     handler._serve_asset = lambda _name: responses.append(("asset", _name)) or True
     handler.send_response = lambda status: responses.append(("status", status))
     handler.send_header = lambda key, value: headers.append((key, value))
@@ -855,6 +865,41 @@ def test_get_authorized_client_redirects_before_portal_page(tmp_path):
     assert ("status", module.HTTPStatus.FOUND) in responses
     assert ("Location", "http://arthexis.net:8888/gallery/ap/") in headers
     assert not any(item[0] == "asset" for item in responses)
+
+
+def test_get_authorized_client_reuses_resolved_mac_for_redirect_logging(tmp_path):
+    module = load_portal_module()
+    app = module.PortalApplication(make_config(module, tmp_path))
+    app.state._authorized = {"aa:bb:cc:dd:ee:ff"}
+    resolved_ips = []
+
+    def resolve_once(ip_address):
+        resolved_ips.append(ip_address)
+        return "aa:bb:cc:dd:ee:ff"
+
+    app.state.resolve_mac = resolve_once
+    handler_class = app.handler_class()
+    handler = object.__new__(handler_class)
+    handler.path = "/"
+    handler.command = "GET"
+    handler.headers = {}
+    handler.client_address = ("192.168.129.143", 12345)
+    responses = []
+    headers = []
+    handler.send_response = lambda status: responses.append(("status", status))
+    handler.send_header = lambda key, value: headers.append((key, value))
+    handler.end_headers = lambda: responses.append(("end", None))
+
+    handler.do_GET()
+
+    assert resolved_ips == ["192.168.129.143"]
+    assert ("status", module.HTTPStatus.FOUND) in responses
+    assert ("Location", "http://arthexis.net:8888/gallery/ap/") in headers
+    activity = [
+        json.loads(line)
+        for line in app.config.activity_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert activity[-1]["mac_address"] == "aa:bb:cc:dd:ee:ff"
 
 
 def test_get_probe_path_returns_portal_page(tmp_path):


### PR DESCRIPTION
## Summary
- add a separate trusted MAC allowlist for devices that should skip AP portal registration
- redirect already-authorized portal page/probe requests directly to the suite
- default AP redirects and cert lookup to arthexis.net for local LAN use
- allow arthexis.net in Django host validation by default
- document certbot HTTP-01/DNS-01 requirements and generate nginx server blocks with server_name arthexis.net _

## Validation
- .venv/bin/python -m pytest tests/test_ap_portal_server.py
- bash -n scripts/setup_ap_portal.sh
- .venv/bin/python - <<'PY' ... assert arthexis.net in ALLOWED_HOSTS
- git diff --check

## Live host notes
- Installed certbot and python3-certbot-nginx; certbot.timer is enabled and active
- Certbot HTTP-01 dry run for arthexis.net failed because public DNS resolves to the external Apache host, not this gateway
- No certificates were installed and no local HTTPS listener was enabled
- Added PS4 MAC 2c:cc:44:4d:1a:c5 to the current live AP authorization file and trusted_macs marker file
- Restarted arthexis-ap-portal.service with --suite-login-host arthexis.net
- Added managed arthexis.net Site/SiteProfile in the live DB so the suite accepts the redirected host



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR introduces a trusted device allowlist for the AP portal to bypass registration for pre-authorized devices, and standardizes on `arthexis.net` as the default hostname for local LAN use.

### Configuration & Security
- Added `arthexis.net` to Django's `ALLOWED_HOSTS` in `config/settings/security.py`

### Portal Server
- `DEFAULT_SUITE_LOGIN_HOST` changed from `"10.42.0.1"` to `"arthexis.net"`
- New `trusted_macs_path` configuration field in `PortalConfig` to load a separate trusted device allowlist from disk
- New `--trusted-macs-path` CLI option to override the trusted MACs file location
- Authorization logic now computes an "effective authorized" set combining both authorized and trusted MACs
- Trusted devices skip registration entirely and redirect to the suite gallery
- Authorization responses and activity logs now include a `trusted_device` flag alongside the existing `authorized` flag
- HTTP routing updated to redirect authorized clients earlier for `/` and captive portal probe paths
- Redirect handler now records the request with the resolved MAC before sending the 302 response
- Firewall synchronization during consent subscription uses the union of updated authorized and trusted sets

### Setup & Deployment
- `setup_ap_portal.sh` now parameterizes certificate configuration via:
  - `DEFAULT_CERT_DOMAIN` for the certificate domain (used to derive certificate paths)
  - `DEFAULT_CERT_PATH` and `DEFAULT_KEY_PATH` for explicit certificate file locations
  - `SERVER_NAMES` for nginx `server_name` values (defaults to `arthexis.net _`)
- Systemd unit for `ap_portal_server.py` now passes `--trusted-macs-path` and `--suite-login-host` flags
- Both HTTP and HTTPS nginx templates updated to use configurable `server_name` via `$SERVER_NAMES`

### Documentation
- Updated `docs/operations/ap-portal.md` with:
  - Default authorized-client redirect now points to `http://arthexis.net:8888/gallery/ap/` instead of IP-based gateway
  - Guidance on bypassing AP registration via `.state/ap_portal/trusted_macs.txt` with comment/label formatting
  - Clarification of how trusted MACs differ from authorized MACs
  - Documented local HTTPS/certificate expectations and Certbot HTTP-01 vs DNS-01 validation requirements
  - Specific nginx `server_name` configuration guidance

### Testing
- Updated existing redirect assertion tests to expect `arthexis.net`-based URLs
- Added test for setup script using configured certificate domain for suite login host
- Added tests for trusted MAC behavior: registration bypass, gallery redirect, `trusted_device` flag
- Added test for trusted device consent not modifying consent authorization
- Added test for authorized clients being redirected before portal page assets are served
- Added test for MAC address reuse in redirect logging
- Updated skip-firewall-sync test to include `trusted_macs_path` configuration
- Renamed test `test_suite_login_redirect_defaults_to_gateway_host()` to `test_suite_login_redirect_defaults_to_local_hostname()`

### Validation Performed
- pytest tests in `tests/test_ap_portal_server.py`
- Bash syntax check of `scripts/setup_ap_portal.sh`
- Python check asserting `arthexis.net` is in `ALLOWED_HOSTS`
- Git diff whitespace check

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->