### PR TITLE
Dispatch forwarded replies when background task cap is reached

### DIFF
--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -65,12 +65,11 @@ class DispatchMixin:
 
         if len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS:
             logger.warning(
-                "Background forwarding task limit reached for message %s; "
-                "dispatching reply without task tracking.",
+                "Background forwarding task limit reached for message %s (%d active); "
+                "dispatching reply with continued tracking.",
                 message_id,
+                len(background_tasks),
             )
-            create_task(forward_reply(message_id, raw))
-            return
 
         task = create_task(forward_reply(message_id, raw))
         background_tasks.add(task)

--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -65,11 +65,11 @@ class DispatchMixin:
 
         if len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS:
             logger.warning(
-                "Skipping reply forwarding for message %s because %s background "
-                "forwarding tasks are still active.",
+                "Background forwarding task limit reached for message %s; "
+                "dispatching reply without task tracking.",
                 message_id,
-                len(background_tasks),
             )
+            create_task(forward_reply(message_id, raw))
             return
 
         task = create_task(forward_reply(message_id, raw))

--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -63,19 +63,30 @@ class DispatchMixin:
             if done_task.done():
                 background_tasks.discard(done_task)
 
-        if len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS:
+        track_task = len(background_tasks) < MAX_BACKGROUND_FORWARD_REPLY_TASKS
+        if not track_task:
             logger.warning(
                 "Background forwarding task limit reached for message %s (%d active); "
-                "dispatching reply with continued tracking.",
+                "dispatching reply with overflow tracking.",
                 message_id,
                 len(background_tasks),
             )
 
         task = create_task(forward_reply(message_id, raw))
-        background_tasks.add(task)
+        if track_task:
+            background_tasks.add(task)
+        else:
+            overflow_tasks = getattr(self, "_overflow_forward_reply_tasks", None)
+            if overflow_tasks is None:
+                overflow_tasks = set()
+                self._overflow_forward_reply_tasks = overflow_tasks
+            overflow_tasks.add(task)
 
         def _drop_completed(done_task):
             background_tasks.discard(done_task)
+            overflow_tasks = getattr(self, "_overflow_forward_reply_tasks", None)
+            if overflow_tasks is not None:
+                overflow_tasks.discard(done_task)
             try:
                 done_task.result()
             except CancelledError:

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -3001,8 +3001,8 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
 
     await asyncio.wait_for(all_started.wait(), timeout=0.5)
     assert calls == 2
-    assert len(consumer._background_forward_reply_tasks) == 1
-    assert "dispatching reply without task tracking" in caplog.text
+    assert len(consumer._background_forward_reply_tasks) == 2
+    assert "dispatching reply with continued tracking" in caplog.text
 
     tasks = list(consumer._background_forward_reply_tasks)
     release.set()

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -2983,11 +2983,14 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
     started = asyncio.Event()
     release = asyncio.Event()
     calls = 0
+    all_started = asyncio.Event()
 
     async def _slow_forward_reply(*_args):
         nonlocal calls
         calls += 1
         started.set()
+        if calls >= 2:
+            all_started.set()
         await release.wait()
 
     consumer._dispatch_forward_reply(_slow_forward_reply, "msg-one", "[3]")
@@ -2996,9 +2999,10 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
     with caplog.at_level("WARNING", logger=dispatch_module.logger.name):
         consumer._dispatch_forward_reply(_slow_forward_reply, "msg-two", "[3]")
 
-    assert calls == 1
+    await asyncio.wait_for(all_started.wait(), timeout=0.5)
+    assert calls == 2
     assert len(consumer._background_forward_reply_tasks) == 1
-    assert "Skipping reply forwarding for message msg-two" in caplog.text
+    assert "dispatching reply without task tracking" in caplog.text
 
     tasks = list(consumer._background_forward_reply_tasks)
     release.set()

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -3001,10 +3001,11 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
 
     await asyncio.wait_for(all_started.wait(), timeout=0.5)
     assert calls == 2
-    assert len(consumer._background_forward_reply_tasks) == 2
-    assert "dispatching reply with continued tracking" in caplog.text
+    assert len(consumer._background_forward_reply_tasks) == 1
+    assert len(consumer._overflow_forward_reply_tasks) == 1
+    assert "dispatching reply with overflow tracking" in caplog.text
 
-    tasks = list(consumer._background_forward_reply_tasks)
+    tasks = list(consumer._background_forward_reply_tasks | consumer._overflow_forward_reply_tasks)
     release.set()
     await asyncio.gather(*tasks)
 


### PR DESCRIPTION
### Motivation
- A background-task fanout limit caused forwarded reply forwarding to be skipped entirely, which left entries in `pending_call_ids` and silently dropped command results when the forwarding peer was slow or stalled.
- The intent is to avoid silent result loss and unbounded per-session pending ID growth while still bounding tracked background tasks.

### Description
- Change `_dispatch_forward_reply` to still call `create_task(forward_reply(message_id, raw))` when the tracked task cap is reached, but avoid adding the overflow task to the tracked `background_tasks` set so tracking remains bounded.
- Adjust the warning text to reflect the fallback behavior and avoid implying the reply was dropped. 
- Update the unit test `test_forward_reply_dispatch_limits_background_task_fanout` to assert the overflow reply executes and to expect the new log message.
- Files changed: `apps/ocpp/consumers/base/dispatch.py` and `apps/ocpp/tests/test_ocpp_handlers.py`.

### Testing
- Attempted to run ` .venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp_handlers.py`, but the container lacks the repository virtualenv so the command could not be executed and no tests ran.
- Attempted to bootstrap the environment with `./install.sh`, but it failed because `redis-server` is not installed so `.venv` could not be created and tests could not be executed.
- The change is minimal and covered by the updated test case in `apps/ocpp/tests/test_ocpp_handlers.py`, which should pass in a properly provisioned developer or CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f82b04908326811b94bc8b120e54)