### PR TITLE
security: prevent regex backtracking in diagnostics redaction

### DIFF
--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -24,8 +24,8 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r")\b"
     r"[\"']?\s*[:=]\s*"
     r")"
-    r"(?:(?P<quote>[\"'])(?P<quoted_value>(?:\\.|(?!(?P=quote)(?=$|[\s,;}\]])).)*)"
-    r"(?P=quote)|(?P<unquoted_value>(?:[A-Za-z0-9._~+/=:@%!-]|\\+[\"']|\\+)+))",
+    r"(?:\"[^\"\\]*(?:\\.[^\"\\]*)*\"|\'[^\'\\]*(?:\\.[^\'\\]*)*\'"
+    r"|(?P<unquoted_value>(?:[A-Za-z0-9._~+/=:@%!-]|\\+[\"']|\\+)+))",
     re.IGNORECASE,
 )
 SECRET_EXPOSURE_PATTERN = re.compile(
@@ -159,7 +159,8 @@ def redact_sensitive_text(text: str) -> str:
     """Return ``text`` with obvious credential material replaced for reports."""
 
     def _replace_assignment(match: re.Match[str]) -> str:
-        quote = match.group("quote") or ""
+        value = match.group(0)[len(match.group("prefix")) :]
+        quote = value[:1] if value[:1] in {'"', "'"} else ""
         return f"{match.group('prefix')}{quote}[redacted]{quote}"
 
     redacted = PRIVATE_KEY_BLOCK_PATTERN.sub("[redacted private key]", text)

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -24,9 +24,9 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r")\b"
     r"[\"']?\s*[:=]\s*"
     r")"
-    r"(?:\"(?P<double_quoted_value>[^\"\\]*(?:\\.[^\"\\]*)*)\""
-    r"|\'(?P<single_quoted_value>[^\'\\]*(?:\\.[^\'\\]*)*)\'"
-    r"|[A-Za-z0-9._~+/=:@%!-]+)",
+    r"(?:\"(?P<double_quoted_value>[^\r\n]*)\""
+    r"|\'(?P<single_quoted_value>[^\r\n]*)\'"
+    r"|(?P<unquoted_value>[^\s;,]+))",
     re.IGNORECASE,
 )
 SECRET_EXPOSURE_PATTERN = re.compile(

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -24,8 +24,9 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r")\b"
     r"[\"']?\s*[:=]\s*"
     r")"
-    r"(?:\"[^\"\\]*(?:\\.[^\"\\]*)*\"|\'[^\'\\]*(?:\\.[^\'\\]*)*\'"
-    r"|(?P<unquoted_value>(?:[A-Za-z0-9._~+/=:@%!-]|\\+[\"']|\\+)+))",
+    r"(?:\"(?P<double_quoted_value>[^\"\\]*(?:\\.[^\"\\]*)*)\""
+    r"|\'(?P<single_quoted_value>[^\'\\]*(?:\\.[^\'\\]*)*)\'"
+    r"|[A-Za-z0-9._~+/=:@%!-]+)",
     re.IGNORECASE,
 )
 SECRET_EXPOSURE_PATTERN = re.compile(
@@ -159,8 +160,12 @@ def redact_sensitive_text(text: str) -> str:
     """Return ``text`` with obvious credential material replaced for reports."""
 
     def _replace_assignment(match: re.Match[str]) -> str:
-        value = match.group(0)[len(match.group("prefix")) :]
-        quote = value[:1] if value[:1] in {'"', "'"} else ""
+        if match.group("double_quoted_value") is not None:
+            quote = '"'
+        elif match.group("single_quoted_value") is not None:
+            quote = "'"
+        else:
+            quote = ""
         return f"{match.group('prefix')}{quote}[redacted]{quote}"
 
     redacted = PRIVATE_KEY_BLOCK_PATTERN.sub("[redacted private key]", text)

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -336,6 +336,12 @@ def test_redact_sensitive_text_handles_pem_variants_and_quoted_values():
     assert "db_password=[redacted]" in redacted
     assert "api_key=[redacted]" in redacted
 
+def test_redact_sensitive_text_handles_unterminated_quoted_backslash_sequence():
+    text = 'password="' + ('\\' * 64)
+
+    redacted = redact_sensitive_text(text)
+
+    assert redacted == text
 
 def test_redact_analysis_payload_preserves_tuple_type():
     redacted = redact_analysis_payload(("password=hunter2", "ok"))


### PR DESCRIPTION
### Motivation

- A newly introduced regex used for secret redaction could exhibit catastrophic backtracking on crafted inputs (unterminated quoted values with many backslashes), allowing a CPU denial-of-service during `manage.py diagnostics analyze`.
- The vulnerable pattern lived in `apps/users/error_report_analysis.py` and was applied to attacker-controlled strings from error-report package metadata, making the issue exploitable by a malicious diagnostics zip.

### Description

- Rewrote the quoted-value branch of `SECRET_ASSIGNMENT_PATTERN` to use deterministic single-quoted and double-quoted alternatives that do not contain ambiguous nested quantifiers and therefore avoid catastrophic backtracking. 
- Adjusted the replacement logic in `redact_sensitive_text` to infer the quote character from the matched value slice instead of depending on the removed `quote` capture group, preserving existing redaction output formatting. 
- Added a regression test `test_redact_sensitive_text_handles_unterminated_quoted_backslash_sequence` in `apps/users/tests/test_error_report_analysis.py` that covers an unterminated quoted secret assignment followed by many backslashes to ensure the redaction completes safely. 

### Testing

- Ran `python3 -m py_compile apps/users/error_report_analysis.py` which succeeded. 
- Added a unit test covering the ReDoS case in `apps.users.tests.test_error_report_analysis`; a full test run via the repository test entrypoint was not executed in this environment because the project's virtual environment was not present. 
- Recommend running `.venv/bin/python manage.py test run -- apps.users.tests.test_error_report_analysis` in CI or a developer environment to validate the new test and full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f82b00b48326b01ec560d01b5897)