### PR TITLE
Avoid leaking code-scanning alert metadata in release readiness issues

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -233,13 +233,7 @@ jobs:
                 });
 
                 if (codeScanningAlerts.length) {
-                  const preview = codeScanningAlerts.slice(0, 5).map((alert) => {
-                    const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
-                    const rule = alert.rule?.id || alert.rule?.name || `alert ${alert.number}`;
-                    return `${severity}:${rule}${alert.html_url ? ` (${alert.html_url})` : ''}`;
-                  }).join('; ');
-                  const suffix = codeScanningAlerts.length > 5 ? `; and ${codeScanningAlerts.length - 5} more` : '';
-                  blockers.push(`Open GitHub code scanning security findings: ${codeScanningAlerts.length}. ${preview}${suffix}`);
+                  blockers.push(`Open GitHub code scanning security findings: ${codeScanningAlerts.length}.`);
                 }
               } catch (error) {
                 blockers.push(`Unable to verify GitHub code scanning alerts before release readiness: ${error.message}`);

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -719,6 +719,11 @@ def test_release_simulator_requires_security_scan_settling_and_clear_alerts() ->
     assert "github.rest.codeScanning.listAlertsForRepo" in script
     assert "state: 'open'" in script
     assert "Open GitHub code scanning security findings" in script
+    assert "alert.rule?.security_severity_level" not in script
+    assert "alert.rule?.severity" not in script
+    assert "alert.rule?.id" not in script
+    assert "alert.rule?.name" not in script
+    assert "alert.html_url" not in script
     assert "Unable to verify GitHub code scanning alerts" in script
 
 


### PR DESCRIPTION
### Motivation
- The release simulator enumerated open GitHub code-scanning alerts and inserted detailed alert metadata (severity, rule id/name, and alert URLs) into a public release readiness issue, which can disclose sensitive security findings to issue readers.
- The intent is to keep the readiness gate behavior while preventing information disclosure by limiting what is published to public issues.

### Description
- Updated `.github/workflows/release-simulator.yml` to stop formatting and publishing per-alert metadata and URLs and instead report only the alert count with `Open GitHub code scanning security findings: <count>`.
- Preserved the gating behavior so open alerts still block simulation when present and the workflow still enumerates alerts for internal decisioning.
- Added assertions in `apps/core/tests/reports/test_release_publish_regressions.py` to ensure the sensitive alert fields (`alert.rule?.security_severity_level`, `alert.rule?.severity`, `alert.rule?.id`, `alert.rule?.name`, and `alert.html_url`) are not present in the workflow script anymore.

### Testing
- Attempted to run the targeted test suite with `.venv/bin/python manage.py test run -- apps/core/tests/reports/test_release_publish_regressions.py`, but the workspace lacks `.venv/bin/python`, so the automated test run could not be executed here (test execution blocked by environment constraint).
- Static verification performed by inspecting the updated workflow and test file shows the detailed alert preview was removed and the regression assertions were added, and the change is expected to be validated by CI where `.venv` and the test runner are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f82c2ab48326b403f91bf981ef8f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes sensitive code-scanning alert metadata from the release readiness workflow to prevent information disclosure to issue readers, while preserving the security gating mechanism.

## Changes

**`.github/workflows/release-simulator.yml`**: Modified the "Evaluate release blockers" step to report only the count of open code-scanning alerts instead of enumerating per-alert details. The workflow now adds a blocker message `Open GitHub code scanning security findings: <count>` instead of building a formatted preview containing severity levels, rule IDs, rule names, and alert URLs. Alert enumeration and gating behavior remain unchanged for internal decisioning.

**`apps/core/tests/reports/test_release_publish_regressions.py`**: Added five assertions in `test_release_simulator_requires_security_scan_settling_and_clear_alerts` to verify that sensitive alert fields—`alert.rule?.security_severity_level`, `alert.rule?.severity`, `alert.rule?.id`, `alert.rule?.name`, and `alert.html_url`—are not present in the workflow script, preventing regression of information leakage.

## Impact

- Open alerts continue to block release simulation, maintaining security gates
- Public release readiness issues no longer expose finding details or alert-specific URLs
- CI test assertions provide regression protection against future disclosure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7747)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->