### PR TITLE
Handle release tag creation when git tagger identity is missing

### DIFF
--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -212,6 +212,46 @@ def test_ensure_release_tag_uses_git_adapter_for_tag_creation(
     ) in adapter.calls
 
 
+def test_ensure_release_tag_falls_back_to_lightweight_without_git_identity(
+    monkeypatch, tmp_path: Path
+) -> None:
+    class FakeGitAdapter:
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[str], bool]] = []
+
+        def run(self, args, *, check=True, input_text=None, timeout=None):
+            self.calls.append((list(args), check))
+            if args[:5] == ["git", "tag", "-a", "v1.2.3", "-m"]:
+                raise subprocess.CalledProcessError(
+                    returncode=128,
+                    cmd=args,
+                    stderr="Committer identity unknown",
+                )
+            stdout = ""
+            returncode = 0
+            if args[:2] == ["git", "show"]:
+                stdout = "1.2.3\n"
+            elif args[:4] == ["git", "rev-parse", "--verify", "-q"]:
+                returncode = 1
+            return subprocess.CompletedProcess(
+                args,
+                returncode,
+                stdout=stdout,
+                stderr="",
+            )
+
+    adapter = FakeGitAdapter()
+    monkeypatch.setattr(pipeline, "GIT_ADAPTER", adapter)
+    monkeypatch.setattr(pipeline.release_uploader, "_push_tag", lambda _tag: None)
+
+    tag_name = pipeline._ensure_release_tag(
+        SimpleNamespace(version="1.2.3"), tmp_path / "publish.log"
+    )
+
+    assert tag_name == "v1.2.3"
+    assert (["git", "tag", "v1.2.3"], True) in adapter.calls
+
+
 def test_release_progress_uses_mutated_context_for_advance(monkeypatch, tmp_path: Path):
     class DummyRelease:
         pk = 1

--- a/apps/release/publishing/pipeline.py
+++ b/apps/release/publishing/pipeline.py
@@ -975,10 +975,20 @@ def _ensure_release_tag(release: PackageRelease, log_path: Path) -> str:
         check=False,
     )
     if exists.returncode != 0:
-        GIT_ADAPTER.run(
-            ["git", "tag", "-a", tag_name, "-m", f"Release {tag_name}"],
-            check=True,
-        )
+        try:
+            GIT_ADAPTER.run(
+                ["git", "tag", "-a", tag_name, "-m", f"Release {tag_name}"],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            detail = (getattr(exc, "stderr", "") or getattr(exc, "stdout", "")).lower()
+            if "committer identity unknown" not in detail:
+                raise
+            GIT_ADAPTER.run(["git", "tag", tag_name], check=True)
+            _append_log(
+                log_path,
+                f"Created lightweight git tag {tag_name} because git tagger identity is unavailable",
+            )
         _append_log(log_path, f"Created git tag {tag_name}")
     else:
         _append_log(log_path, f"Git tag {tag_name} already exists")

--- a/apps/release/publishing/pipeline.py
+++ b/apps/release/publishing/pipeline.py
@@ -980,8 +980,9 @@ def _ensure_release_tag(release: PackageRelease, log_path: Path) -> str:
                 ["git", "tag", "-a", tag_name, "-m", f"Release {tag_name}"],
                 check=True,
             )
+            _append_log(log_path, f"Created git tag {tag_name}")
         except subprocess.CalledProcessError as exc:
-            detail = (getattr(exc, "stderr", "") or getattr(exc, "stdout", "")).lower()
+            detail = _format_subprocess_error(exc).lower()
             if "committer identity unknown" not in detail:
                 raise
             GIT_ADAPTER.run(["git", "tag", tag_name], check=True)


### PR DESCRIPTION
### Motivation
- Annotated tag creation (`git tag -a`) can fail in minimally configured release environments that lack a local Git tagger identity (`user.name`/`user.email`), causing the publish step to abort. 
- The intent is to preserve annotated tags when possible while restoring publish availability by falling back to a lightweight tag when Git reports a missing tagger identity.

### Description
- Update `_ensure_release_tag` in `apps/release/publishing/pipeline.py` to attempt an annotated tag first and catch `subprocess.CalledProcessError`; when the error output contains `Committer identity unknown` the code falls back to creating a lightweight tag with `git tag vVERSION` and logs the fallback. 
- Preserve existing version-guard checks (`_ensure_git_ref_version_matches_release`) and the `_push_tag` behavior unchanged. 
- Add a regression test `test_ensure_release_tag_falls_back_to_lightweight_without_git_identity` in `apps/core/tests/reports/test_release_publish_regressions.py` that simulates the annotated-tag failure and verifies the fallback to a lightweight tag.

### Testing
- Added the unit test `apps/core/tests/reports/test_release_publish_regressions.py::test_ensure_release_tag_falls_back_to_lightweight_without_git_identity` but tests were not executed due to local environment limitations. 
- Attempted to run `.venv/bin/python manage.py test run -- apps.core.tests.reports.test_release_publish_regressions` but the test runner is unavailable because `.venv/bin/python` is not present in this environment. 
- Attempted bootstrap with `./install.sh` to create the venv, but the script failed because `redis-server` is required by the environment and is not installed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f82b46708326b6183e778340fbba)