### PR TITLE
Disable default RFID auto-initialization for unknown cards

### DIFF
--- a/apps/cards/rfid_service.py
+++ b/apps/cards/rfid_service.py
@@ -96,7 +96,7 @@ def default_deep_scan_timeout() -> float:
 
 
 def default_auto_initialize_unknown() -> bool:
-    return os.environ.get("RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN", "1").lower() not in {
+    return os.environ.get("RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN", "0").lower() not in {
         "0",
         "false",
         "no",

--- a/apps/cards/tests/test_rfid_service_runtime.py
+++ b/apps/cards/tests/test_rfid_service_runtime.py
@@ -125,6 +125,14 @@ def test_write_rfid_scan_lock_uses_uuid_temp_name(settings, tmp_path, monkeypatc
     ]
 
 
+def test_default_auto_initialize_unknown_is_opt_in(monkeypatch):
+    monkeypatch.delenv("RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN", raising=False)
+    assert rfid_service.default_auto_initialize_unknown() is False
+
+    monkeypatch.setenv("RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN", "true")
+    assert rfid_service.default_auto_initialize_unknown() is True
+
+
 def test_emit_scan_artifacts_uses_shared_payload_timestamp(settings, tmp_path, monkeypatch):
     settings.BASE_DIR = tmp_path
     appended: list[dict[str, object]] = []


### PR DESCRIPTION
### Motivation
- Prevent background held-card deep scans from performing destructive initialization/re-keying by making automatic unknown-card initialization opt-in rather than enabled by default.

### Description
- Change `default_auto_initialize_unknown()` to use a default of `"0"` so `RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN` must be explicitly set to enable auto-initialization.
- Add `test_default_auto_initialize_unknown_is_opt_in` in `apps/cards/tests/test_rfid_service_runtime.py` to assert the function returns `False` when the env var is unset and `True` when set to `"true"`.

### Testing
- Ran `python3 -m compileall apps/cards/rfid_service.py apps/cards/tests/test_rfid_service_runtime.py` successfully to verify syntax.
- Attempted to run the repository test target with `.venv/bin/python manage.py test run -- apps/cards/tests/test_rfid_service_runtime.py` but the environment lacks `.venv` and `./install.sh` is blocked due to missing system `redis-server`, so the full test suite could not be executed here.
- Changes committed under message `Disable RFID auto-initialization by default` and prepared for PR submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05170046d083268717f0ed331677d6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Modified the default behavior of RFID auto-initialization for unknown cards by changing the environment variable fallback from enabled-by-default to disabled-by-default.

## Changes

**apps/cards/rfid_service.py**
- Changed the default fallback value in `default_auto_initialize_unknown()` from `"1"` to `"0"`, making automatic initialization of unknown RFID cards opt-in by requiring `RFID_SERVICE_AUTO_INITIALIZE_UNKNOWN` to be explicitly set to enable the feature

**apps/cards/tests/test_rfid_service_runtime.py**
- Added `test_default_auto_initialize_unknown_is_opt_in` to verify that `default_auto_initialize_unknown()` returns `False` when the environment variable is unset and `True` when set to `"true"`

## Motivation

Prevents background held-card deep scans from performing destructive initialization or re-keying operations on unknown cards unless explicitly enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7749)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->