### PR TITLE
Fix duplicate release tag creation log entry

### DIFF
--- a/apps/release/publishing/pipeline.py
+++ b/apps/release/publishing/pipeline.py
@@ -980,7 +980,6 @@ def _ensure_release_tag(release: PackageRelease, log_path: Path) -> str:
                 ["git", "tag", "-a", tag_name, "-m", f"Release {tag_name}"],
                 check=True,
             )
-            _append_log(log_path, f"Created git tag {tag_name}")
         except subprocess.CalledProcessError as exc:
             detail = _format_subprocess_error(exc).lower()
             if "committer identity unknown" not in detail:


### PR DESCRIPTION
### Motivation
- Remove a duplicated log entry when creating an annotated git tag in `_ensure_release_tag`, which caused the same `Created git tag <tag>` message to be recorded twice on the normal success path.

### Description
- Delete the redundant `_append_log(log_path, f"Created git tag {tag_name}")` inside the `try` block in `apps/release/publishing/pipeline.py` so the single unconditional append after the `try/except` is the sole success message, preserving the lightweight-tag fallback and existing-tag flows.

### Testing
- Could not run the repository-standard test entrypoint due to missing `.venv` and `redis-server` required by `./install.sh`; instead ran targeted tests with `pytest` and the following passed: `pytest -q apps/core/tests/reports/test_release_publish_regressions.py -k ensure_release_tag_uses_git_adapter_for_tag_creation` and `pytest -q apps/core/tests/reports/test_release_publish_regressions.py -k 'ensure_release_tag_falls_back_to_lightweight_without_git_identity or ensure_release_tag_uses_git_adapter_for_tag_creation'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051d78cf2c8326bf8c2ace012aea3b)