### PR TITLE
Add propose prompt hook wrapper

### DIFF
--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -868,10 +868,6 @@ def _merge_message_batches(
     return merged, changed
 
 
-def _split_windows_command_line(value: str) -> list[str]:
-    return [part.strip("\"") for part in shlex.split(value, posix=False)]
-
-
 def launch_codex_secretary_terminal(
     prompt: str,
     *,
@@ -880,13 +876,15 @@ def launch_codex_secretary_terminal(
 ) -> str:
     from django.conf import settings
 
+    from apps.skills.codex_wrapper import build_codex_command, prepare_codex_prompt
     from apps.terminals.tasks import launch_command_in_terminal
 
-    if sys.platform == "win32":
-        command = _split_windows_command_line(codex_command.strip() or "codex")
-        command.append(prompt)
-    else:
-        command = [*shlex.split(codex_command or "codex"), prompt]
+    guarded_prompt = prepare_codex_prompt(
+        prompt,
+        source="whatsapp",
+        metadata={"terminal_title": terminal_title},
+    )
+    command = build_codex_command(guarded_prompt, codex_command=codex_command)
     launch_path = launch_command_in_terminal(
         command,
         title=terminal_title,

--- a/apps/meta/services.py
+++ b/apps/meta/services.py
@@ -1501,9 +1501,13 @@ def listen_for_whatsapp_secretary_requests(
                             terminal_title=terminal_title,
                         )
                     )
-                    detail = launcher(prompt)
-                    launched = True
-                    status = "launched"
+                    try:
+                        detail = launcher(prompt)
+                        launched = True
+                        status = "launched"
+                    except Exception as exc:  # noqa: BLE001
+                        status = "blocked"
+                        detail = f"Secretary launch blocked: {exc}"
             _write_cursor(cursor_file, cursor_key, pending[-1].fingerprint)
             result = WhatsAppSecretaryListenResult(
                 status=status,

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -555,7 +555,7 @@ def test_secretary_listener_ignores_and_advances_untriggered_batch(tmp_path):
     assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "a"
 
 
-def test_secretary_listener_keeps_cursor_when_launch_fails(tmp_path):
+def test_secretary_listener_advances_cursor_when_launch_is_blocked(tmp_path):
     profile_dir = tmp_path / "profile-a"
     message = WhatsAppWebMessage(
         fingerprint="a",
@@ -582,23 +582,25 @@ def test_secretary_listener_keeps_cursor_when_launch_fails(tmp_path):
     def fail_launch(prompt):
         raise RuntimeError(f"launch failed for {prompt[:10]}")
 
-    with pytest.raises(RuntimeError, match="launch failed"):
-        listen_for_whatsapp_secretary_requests(
-            phone="5551234567",
-            idle_after_seconds=0,
-            daemon_poll_seconds=60,
-            quiet_window_seconds=60,
-            max_batches=1,
-            read_messages=fake_read_messages,
-            launch_callback=fail_launch,
-            monotonic=lambda: now["value"],
-            sleep=lambda seconds: now.update(value=now["value"] + seconds),
-            idle_seconds=lambda: 999,
-            authorized_phones={"525551234567"},
-        )
+    results = listen_for_whatsapp_secretary_requests(
+        phone="5551234567",
+        idle_after_seconds=0,
+        daemon_poll_seconds=60,
+        quiet_window_seconds=60,
+        max_batches=1,
+        read_messages=fake_read_messages,
+        launch_callback=fail_launch,
+        monotonic=lambda: now["value"],
+        sleep=lambda seconds: now.update(value=now["value"] + seconds),
+        idle_seconds=lambda: 999,
+        authorized_phones={"525551234567"},
+    )
 
     cursor_key = cursor_key_for_profile("525551234567", profile_dir)
-    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == ""
+    assert results[-1].status == "blocked"
+    assert results[-1].launched is False
+    assert "blocked" in results[-1].detail.lower()
+    assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == "a"
 
 
 @pytest.mark.django_db

--- a/apps/meta/tests/test_whatsapp.py
+++ b/apps/meta/tests/test_whatsapp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 import sys
 from io import StringIO
 from pathlib import Path
@@ -16,13 +17,13 @@ from apps.meta import models as meta_models
 from apps.meta.management.commands import whatsapp as whatsapp_command
 from apps.meta.models import WhatsAppSecretaryAuthorizedPhone
 from apps.meta.services import (
+    WhatsAppSecretaryAuthorizationUnavailable,
     WhatsAppSecretaryListenResult,
     WhatsAppWebLoginResult,
     WhatsAppWebLoginStatus,
     WhatsAppWebMessage,
     WhatsAppWebReadResult,
     WhatsAppWebSendResult,
-    WhatsAppSecretaryAuthorizationUnavailable,
     _is_whatsapp_web_url,
     _read_cursor,
     _systemd_quote,
@@ -42,6 +43,7 @@ from apps.meta.services import (
     registered_whatsapp_secretary_phones,
     secretary_request_text_from_messages,
 )
+from apps.skills.models import Hook
 
 
 class FakeLocator:
@@ -599,6 +601,7 @@ def test_secretary_listener_keeps_cursor_when_launch_fails(tmp_path):
     assert _read_cursor(cursor_file_for_profile(profile_dir), cursor_key) == ""
 
 
+@pytest.mark.django_db
 def test_secretary_launcher_preserves_windows_codex_path(monkeypatch, tmp_path):
     captured = {}
 
@@ -626,6 +629,44 @@ def test_secretary_launcher_preserves_windows_codex_path(monkeypatch, tmp_path):
     ]
     assert captured["kwargs"]["state_key"] == "whatsapp-secretary"
     assert "terminal.pid" in detail
+
+
+@pytest.mark.django_db
+def test_secretary_launcher_applies_before_prompt_rewrite(monkeypatch, tmp_path):
+    captured = {}
+    Hook.objects.create(
+        slug="rewrite-prompt",
+        title="Rewrite prompt",
+        event=Hook.Event.BEFORE_PROMPT,
+        command="rewrite-hook",
+    )
+
+    def fake_run(command, **kwargs):
+        del command, kwargs
+        return subprocess.CompletedProcess(
+            ["rewrite-hook"],
+            0,
+            stdout=json.dumps(
+                {"decision": "rewrite", "prompt": "rewritten secretary prompt"}
+            ),
+            stderr="",
+        )
+
+    def fake_launch_command_in_terminal(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return tmp_path / "terminal.pid"
+
+    monkeypatch.setattr("apps.meta.services.sys.platform", "win32")
+    monkeypatch.setattr("apps.skills.prompt_hooks.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "apps.terminals.tasks.launch_command_in_terminal",
+        fake_launch_command_in_terminal,
+    )
+
+    launch_codex_secretary_terminal("secretary prompt")
+
+    assert captured["command"] == ["codex", "rewritten secretary prompt"]
 
 
 def test_whatsapp_login_command_outputs_json(monkeypatch, tmp_path):

--- a/apps/skills/codex_wrapper.py
+++ b/apps/skills/codex_wrapper.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from django.conf import settings
+
+from apps.skills.prompt_hooks import (
+    PromptGuardBlocked,
+    PromptGuardOutcome,
+    require_prompt_allowed,
+    run_before_prompt_hooks,
+    split_command_line,
+)
+
+
+@dataclass(frozen=True)
+class CodexWrapperResult:
+    guard: PromptGuardOutcome
+    command: list[str]
+    launched: bool
+    return_code: int | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["guard"] = self.guard.as_dict()
+        return payload
+
+
+def build_codex_command(prompt: str, *, codex_command: str = "codex") -> list[str]:
+    command = split_command_line(codex_command.strip() or "codex")
+    command.append(prompt)
+    return command
+
+
+def prepare_codex_prompt(
+    prompt: str,
+    *,
+    source: str = "cli",
+    metadata: Mapping[str, object] | None = None,
+    fail_open: bool = False,
+) -> str:
+    outcome = require_prompt_allowed(
+        prompt,
+        source=source,
+        metadata=metadata,
+        fail_open=fail_open,
+    )
+    return outcome.prompt
+
+
+def run_codex_with_prompt_hooks(
+    prompt: str,
+    *,
+    codex_command: str = "codex",
+    source: str = "cli",
+    metadata: Mapping[str, object] | None = None,
+    fail_open: bool = False,
+    dry_run: bool = False,
+    cwd: Path | str | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> CodexWrapperResult:
+    runner = runner or subprocess.run
+    guard = run_before_prompt_hooks(
+        prompt,
+        source=source,
+        metadata=metadata,
+        fail_open=fail_open,
+        runner=runner,
+    )
+    command = build_codex_command(guard.prompt, codex_command=codex_command)
+    if not guard.should_launch or dry_run:
+        return CodexWrapperResult(
+            guard=guard,
+            command=command,
+            launched=False,
+        )
+
+    completed = runner(
+        command,
+        cwd=str(cwd or settings.BASE_DIR),
+        env=dict(os.environ),
+        check=False,
+    )
+    return CodexWrapperResult(
+        guard=guard,
+        command=command,
+        launched=True,
+        return_code=completed.returncode,
+    )
+
+
+__all__ = [
+    "CodexWrapperResult",
+    "PromptGuardBlocked",
+    "build_codex_command",
+    "prepare_codex_prompt",
+    "run_codex_with_prompt_hooks",
+]

--- a/apps/skills/management/commands/propose.py
+++ b/apps/skills/management/commands/propose.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.skills.codex_wrapper import run_codex_with_prompt_hooks
+
+
+class Command(BaseCommand):
+    help = "Run before_prompt hooks and then launch Codex with the allowed prompt."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "prompt_args",
+            nargs="*",
+            help="Prompt text. Use --prompt, --prompt-file, or --stdin for explicit input.",
+        )
+        parser.add_argument("--prompt", help="Prompt text to guard and pass to Codex.")
+        parser.add_argument("--prompt-file", help="Read prompt text from a UTF-8 file.")
+        parser.add_argument("--stdin", action="store_true", help="Read prompt text from stdin.")
+        parser.add_argument(
+            "--codex-command",
+            default="codex",
+            help="Codex executable command. Default: codex.",
+        )
+        parser.add_argument(
+            "--source",
+            default="cli",
+            help="Prompt source label passed to before_prompt hooks. Default: cli.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run hooks and report the decision without launching Codex.",
+        )
+        parser.add_argument(
+            "--fail-open",
+            action="store_true",
+            help="Continue when a before_prompt hook errors. Default: fail closed.",
+        )
+        parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+    def handle(self, *args, **options):
+        prompt = self._read_prompt(options)
+        result = run_codex_with_prompt_hooks(
+            prompt,
+            codex_command=options["codex_command"],
+            source=options["source"],
+            fail_open=options["fail_open"],
+            dry_run=options["dry_run"],
+        )
+
+        if options["json"]:
+            self.stdout.write(json.dumps(result.as_dict(), indent=2))
+        elif options["dry_run"] or not result.guard.should_launch:
+            self._write_text_result(result)
+
+        if not result.guard.should_launch and not options["dry_run"]:
+            raise CommandError(result.guard.reason or "Prompt refused by before_prompt hooks.")
+        if result.return_code not in {None, 0}:
+            raise CommandError(f"Codex exited with status {result.return_code}.")
+        return None
+
+    def _read_prompt(self, options) -> str:
+        sources = [
+            bool(options["prompt_args"]),
+            options["prompt"] is not None,
+            options["prompt_file"] is not None,
+            bool(options["stdin"]),
+        ]
+        if sum(sources) != 1:
+            raise CommandError("Provide exactly one prompt source.")
+        if options["prompt_args"]:
+            return " ".join(options["prompt_args"])
+        if options["prompt"] is not None:
+            return options["prompt"]
+        if options["prompt_file"] is not None:
+            return Path(options["prompt_file"]).read_text(encoding="utf-8")
+        return sys.stdin.read()
+
+    def _write_text_result(self, result) -> None:
+        self.stdout.write(f"status={result.guard.status}")
+        self.stdout.write(f"should_launch={str(result.guard.should_launch).lower()}")
+        self.stdout.write(f"hooks={len(result.guard.hooks)}")
+        if result.guard.refused_by:
+            self.stdout.write(f"refused_by={result.guard.refused_by}")
+        if result.guard.reason:
+            self.stdout.write(f"reason={result.guard.reason}")
+        if result.guard.status == "rewrite":
+            self.stdout.write("prompt:")
+            self.stdout.write(result.guard.prompt)

--- a/apps/skills/management/commands/propose.py
+++ b/apps/skills/management/commands/propose.py
@@ -78,7 +78,11 @@ class Command(BaseCommand):
         if options["prompt"] is not None:
             return options["prompt"]
         if options["prompt_file"] is not None:
-            return Path(options["prompt_file"]).read_text(encoding="utf-8")
+            prompt_file = options["prompt_file"]
+            try:
+                return Path(prompt_file).read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                raise CommandError(f"Unable to read prompt file: {prompt_file}: {exc}") from exc
         return sys.stdin.read()
 
     def _write_text_result(self, result) -> None:

--- a/apps/skills/prompt_hooks.py
+++ b/apps/skills/prompt_hooks.py
@@ -22,7 +22,7 @@ REWRITE_DECISION = "rewrite"
 ERROR_DECISION = "error"
 
 ALLOWED_PROMPT_DECISIONS = frozenset(
-    {ALLOW_DECISION, REFUSE_DECISION, REWRITE_DECISION}
+    {ALLOW_DECISION, REFUSE_DECISION, REWRITE_DECISION, ERROR_DECISION}
 )
 
 
@@ -122,7 +122,7 @@ def run_before_prompt_hooks(
                 refused_by=str(hook["slug"]),
                 errors=errors,
             )
-        decision = str(hook_output["decision"]).strip().lower()
+        decision = step.decision
         if decision == ALLOW_DECISION:
             continue
         if decision == REWRITE_DECISION:
@@ -213,15 +213,27 @@ def _run_prompt_hook(
     hook_slug = str(hook["slug"])
     hook_title = str(hook["title"])
     try:
+        serialized_payload = json.dumps(payload)
         completed = runner(
             split_command_line(_resolve_runtime_text(str(hook["command"]))),
-            input=json.dumps(payload),
+            input=serialized_payload,
             text=True,
             capture_output=True,
             timeout=int(hook["timeout_seconds"]),
             cwd=_hook_cwd(hook),
             env=_hook_env(hook),
             check=False,
+        )
+    except (TypeError, ValueError) as exc:
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} payload serialization failed: {exc}",
+                elapsed_seconds=time.monotonic() - started,
+            ),
+            {},
         )
     except subprocess.TimeoutExpired as exc:
         return (

--- a/apps/skills/prompt_hooks.py
+++ b/apps/skills/prompt_hooks.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from django.conf import settings
+
+from apps.sigils.sigil_resolver import resolve_sigils
+from apps.skills.hook_context import current_hook_platform, list_hooks
+from apps.skills.models import Hook
+
+ALLOW_DECISION = "allow"
+REFUSE_DECISION = "refuse"
+REWRITE_DECISION = "rewrite"
+ERROR_DECISION = "error"
+
+ALLOWED_PROMPT_DECISIONS = frozenset(
+    {ALLOW_DECISION, REFUSE_DECISION, REWRITE_DECISION}
+)
+
+
+@dataclass(frozen=True)
+class PromptHookStep:
+    slug: str
+    title: str
+    decision: str
+    reason: str = ""
+    return_code: int | None = None
+    elapsed_seconds: float = 0.0
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class PromptGuardOutcome:
+    status: str
+    prompt: str
+    original_prompt: str
+    source: str
+    hooks: list[PromptHookStep]
+    reason: str = ""
+    refused_by: str = ""
+    errors: list[str] | None = None
+
+    @property
+    def should_launch(self) -> bool:
+        return self.status in {ALLOW_DECISION, REWRITE_DECISION}
+
+    def as_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["should_launch"] = self.should_launch
+        return payload
+
+
+class PromptGuardBlocked(RuntimeError):
+    def __init__(self, outcome: PromptGuardOutcome):
+        self.outcome = outcome
+        super().__init__(outcome.reason or "Prompt guard blocked the Codex prompt.")
+
+
+def split_command_line(value: str) -> list[str]:
+    parts = shlex.split(value, posix=sys.platform != "win32")
+    if sys.platform == "win32":
+        return [part.strip('"') for part in parts]
+    return parts
+
+
+def run_before_prompt_hooks(
+    prompt: str,
+    *,
+    source: str = "cli",
+    metadata: Mapping[str, object] | None = None,
+    platform: str | None = None,
+    fail_open: bool = False,
+    hooks: Sequence[Mapping[str, object]] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> PromptGuardOutcome:
+    runner = runner or subprocess.run
+    selected_platform = platform or current_hook_platform()
+    hook_records = list(hooks) if hooks is not None else list_hooks(
+        event=Hook.Event.BEFORE_PROMPT,
+        platform=selected_platform,
+    )
+    current_prompt = prompt
+    steps: list[PromptHookStep] = []
+    errors: list[str] = []
+    rewritten = False
+    base_metadata = _base_prompt_metadata(selected_platform)
+    if metadata:
+        base_metadata.update({str(key): value for key, value in metadata.items()})
+
+    for hook in hook_records:
+        payload = {
+            "event": Hook.Event.BEFORE_PROMPT,
+            "prompt": current_prompt,
+            "source": source,
+            "metadata": base_metadata,
+            "hook": {
+                "slug": str(hook["slug"]),
+                "title": str(hook["title"]),
+            },
+        }
+        step, hook_output = _run_prompt_hook(hook, payload, runner=runner)
+        steps.append(step)
+        if step.decision == ERROR_DECISION:
+            errors.append(step.reason)
+            if fail_open:
+                continue
+            return PromptGuardOutcome(
+                status=ERROR_DECISION,
+                prompt=current_prompt,
+                original_prompt=prompt,
+                source=source,
+                hooks=steps,
+                reason=step.reason,
+                refused_by=str(hook["slug"]),
+                errors=errors,
+            )
+        decision = str(hook_output["decision"]).strip().lower()
+        if decision == ALLOW_DECISION:
+            continue
+        if decision == REWRITE_DECISION:
+            rewritten_prompt = hook_output.get("prompt")
+            if not isinstance(rewritten_prompt, str):
+                reason = f"before_prompt hook {hook['slug']} returned rewrite without a string prompt."
+                errors.append(reason)
+                error_step = PromptHookStep(
+                    slug=str(hook["slug"]),
+                    title=str(hook["title"]),
+                    decision=ERROR_DECISION,
+                    reason=reason,
+                )
+                steps[-1] = error_step
+                if fail_open:
+                    continue
+                return PromptGuardOutcome(
+                    status=ERROR_DECISION,
+                    prompt=current_prompt,
+                    original_prompt=prompt,
+                    source=source,
+                    hooks=steps,
+                    reason=reason,
+                    refused_by=str(hook["slug"]),
+                    errors=errors,
+                )
+            rewritten = rewritten or rewritten_prompt != current_prompt
+            current_prompt = rewritten_prompt
+            continue
+        if decision == REFUSE_DECISION:
+            reason = str(hook_output.get("reason") or "Prompt refused by before_prompt hook.")
+            return PromptGuardOutcome(
+                status=REFUSE_DECISION,
+                prompt=current_prompt,
+                original_prompt=prompt,
+                source=source,
+                hooks=steps,
+                reason=reason,
+                refused_by=str(hook["slug"]),
+                errors=errors,
+            )
+
+    return PromptGuardOutcome(
+        status=REWRITE_DECISION if rewritten else ALLOW_DECISION,
+        prompt=current_prompt,
+        original_prompt=prompt,
+        source=source,
+        hooks=steps,
+        errors=errors,
+    )
+
+
+def require_prompt_allowed(
+    prompt: str,
+    *,
+    source: str = "cli",
+    metadata: Mapping[str, object] | None = None,
+    platform: str | None = None,
+    fail_open: bool = False,
+) -> PromptGuardOutcome:
+    outcome = run_before_prompt_hooks(
+        prompt,
+        source=source,
+        metadata=metadata,
+        platform=platform,
+        fail_open=fail_open,
+    )
+    if not outcome.should_launch:
+        raise PromptGuardBlocked(outcome)
+    return outcome
+
+
+def _base_prompt_metadata(platform: str) -> dict[str, object]:
+    return {
+        "base_dir": str(settings.BASE_DIR),
+        "cwd": str(Path.cwd()),
+        "platform": platform,
+    }
+
+
+def _run_prompt_hook(
+    hook: Mapping[str, object],
+    payload: Mapping[str, object],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> tuple[PromptHookStep, dict[str, object]]:
+    started = time.monotonic()
+    hook_slug = str(hook["slug"])
+    hook_title = str(hook["title"])
+    try:
+        completed = runner(
+            split_command_line(_resolve_runtime_text(str(hook["command"]))),
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            timeout=int(hook["timeout_seconds"]),
+            cwd=_hook_cwd(hook),
+            env=_hook_env(hook),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} timed out after {hook['timeout_seconds']} seconds.",
+                elapsed_seconds=time.monotonic() - started,
+                stderr=str(exc.stderr or ""),
+            ),
+            {},
+        )
+    except (OSError, ValueError) as exc:
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} failed to start: {exc}",
+                elapsed_seconds=time.monotonic() - started,
+            ),
+            {},
+        )
+
+    elapsed = time.monotonic() - started
+    stderr = (completed.stderr or "").strip()
+    if completed.returncode != 0:
+        detail = stderr or f"exit status {completed.returncode}"
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} failed: {detail}",
+                return_code=completed.returncode,
+                elapsed_seconds=elapsed,
+                stderr=stderr,
+            ),
+            {},
+        )
+
+    try:
+        hook_output = json.loads(completed.stdout or "")
+    except json.JSONDecodeError as exc:
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} returned invalid JSON: {exc.msg}",
+                return_code=completed.returncode,
+                elapsed_seconds=elapsed,
+                stderr=stderr,
+            ),
+            {},
+        )
+    if not isinstance(hook_output, dict):
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} returned a non-object JSON payload.",
+                return_code=completed.returncode,
+                elapsed_seconds=elapsed,
+                stderr=stderr,
+            ),
+            {},
+        )
+    decision = str(hook_output.get("decision", "")).strip().lower()
+    if decision not in ALLOWED_PROMPT_DECISIONS:
+        return (
+            PromptHookStep(
+                slug=hook_slug,
+                title=hook_title,
+                decision=ERROR_DECISION,
+                reason=f"before_prompt hook {hook_slug} returned unsupported decision: {decision or '<blank>'}.",
+                return_code=completed.returncode,
+                elapsed_seconds=elapsed,
+                stderr=stderr,
+            ),
+            {},
+        )
+    return (
+        PromptHookStep(
+            slug=hook_slug,
+            title=hook_title,
+            decision=decision,
+            reason=str(hook_output.get("reason") or ""),
+            return_code=completed.returncode,
+            elapsed_seconds=elapsed,
+            stderr=stderr,
+        ),
+        hook_output,
+    )
+
+
+def _hook_cwd(hook: Mapping[str, object]) -> str:
+    working_directory = str(hook.get("working_directory") or "").strip()
+    if not working_directory:
+        return str(settings.BASE_DIR)
+    return _resolve_runtime_text(working_directory)
+
+
+def _hook_env(hook: Mapping[str, object]) -> dict[str, str]:
+    environment = hook.get("environment") or {}
+    resolved = dict(os.environ)
+    if not isinstance(environment, Mapping):
+        return resolved
+    for key, value in environment.items():
+        if value is None:
+            continue
+        resolved[str(key)] = _resolve_runtime_text(str(value))
+    return resolved
+
+
+def _resolve_runtime_text(value: str) -> str:
+    return resolve_sigils(value, current=None)

--- a/apps/skills/tests/test_prompt_hooks.py
+++ b/apps/skills/tests/test_prompt_hooks.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from apps.skills.codex_wrapper import run_codex_with_prompt_hooks
+from apps.skills.models import Hook
+from apps.skills.prompt_hooks import run_before_prompt_hooks
+
+pytestmark = [pytest.mark.django_db]
+
+
+class PromptHookRunner:
+    def __init__(self, responses: dict[str, dict[str, object] | str]):
+        self.responses = responses
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, command, **kwargs):
+        self.calls.append((list(command), kwargs))
+        response = self.responses[command[0]]
+        if isinstance(response, str):
+            stdout = response
+        else:
+            stdout = json.dumps(response)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+
+def test_before_prompt_hooks_rewrite_then_refuse():
+    Hook.objects.create(
+        slug="rewrite-prompt",
+        title="Rewrite prompt",
+        event=Hook.Event.BEFORE_PROMPT,
+        command="rewrite-hook",
+        priority=10,
+    )
+    Hook.objects.create(
+        slug="refuse-prompt",
+        title="Refuse prompt",
+        event=Hook.Event.BEFORE_PROMPT,
+        command="refuse-hook",
+        priority=20,
+    )
+    runner = PromptHookRunner(
+        {
+            "rewrite-hook": {"decision": "rewrite", "prompt": "rewritten prompt"},
+            "refuse-hook": {"decision": "refuse", "reason": "blocked keyword"},
+        }
+    )
+
+    outcome = run_before_prompt_hooks("raw prompt", runner=runner)
+
+    assert outcome.status == "refuse"
+    assert outcome.prompt == "rewritten prompt"
+    assert outcome.refused_by == "refuse-prompt"
+    assert outcome.reason == "blocked keyword"
+    assert json.loads(runner.calls[0][1]["input"])["prompt"] == "raw prompt"
+    assert json.loads(runner.calls[1][1]["input"])["prompt"] == "rewritten prompt"
+
+
+def test_before_prompt_hook_invalid_json_fails_closed():
+    Hook.objects.create(
+        slug="broken-prompt",
+        title="Broken prompt",
+        event=Hook.Event.BEFORE_PROMPT,
+        command="broken-hook",
+    )
+    runner = PromptHookRunner({"broken-hook": "not-json"})
+
+    outcome = run_before_prompt_hooks("raw prompt", runner=runner)
+
+    assert outcome.status == "error"
+    assert outcome.should_launch is False
+    assert "invalid JSON" in outcome.reason
+
+
+def test_codex_wrapper_launches_with_rewritten_prompt():
+    Hook.objects.create(
+        slug="rewrite-prompt",
+        title="Rewrite prompt",
+        event=Hook.Event.BEFORE_PROMPT,
+        command="rewrite-hook",
+    )
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((list(command), kwargs))
+        if "input" in kwargs:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {"decision": "rewrite", "prompt": "rewritten prompt"}
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0)
+
+    result = run_codex_with_prompt_hooks(
+        "raw prompt",
+        codex_command="codex --model test",
+        runner=runner,
+    )
+
+    assert result.guard.status == "rewrite"
+    assert result.command == ["codex", "--model", "test", "rewritten prompt"]
+    assert result.launched is True
+    assert calls[-1][0] == result.command
+
+
+def test_propose_dry_run_json_reports_allowed_prompt():
+    stdout = StringIO()
+
+    call_command(
+        "propose",
+        "--prompt",
+        "hello",
+        "--dry-run",
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["guard"]["status"] == "allow"
+    assert payload["guard"]["should_launch"] is True
+    assert payload["launched"] is False

--- a/docs/development/codex-skill-packages.md
+++ b/docs/development/codex-skill-packages.md
@@ -69,6 +69,41 @@ python manage.py codex_hooks list --event session_start
 python manage.py codex_hooks list --event before_command --platform windows
 ```
 
+`before_prompt` hooks can also be enforced through the suite-owned Codex wrapper:
+
+```bash
+python manage.py propose --prompt "List open PRs"
+python manage.py propose --prompt-file request.txt --dry-run --json
+```
+
+`propose` reads the raw prompt, runs enabled `before_prompt` hooks in priority
+order, and only launches Codex when the final hook decision allows it. Hook
+failures are fail-closed by default; `--fail-open` is available for local
+debugging only.
+
+Each `before_prompt` hook receives JSON on stdin:
+
+```json
+{
+  "event": "before_prompt",
+  "prompt": "raw or rewritten prompt",
+  "source": "cli",
+  "metadata": {
+    "base_dir": "/path/to/arthexis",
+    "cwd": "/current/working/directory",
+    "platform": "linux"
+  },
+  "hook": {
+    "slug": "prompt-guard",
+    "title": "Prompt Guard"
+  }
+}
+```
+
+The hook must print one JSON object with a `decision` of `allow`, `rewrite`, or
+`refuse`. A rewrite must include a string `prompt`; a refusal should include a
+human-readable `reason`.
+
 ## SIGILS In Portable Documents
 
 Use **SIGILS** when a suite-owned skill or document needs local customization on


### PR DESCRIPTION
## Summary
- add a reusable before_prompt guard service that runs enabled Hook records in priority order and fails closed on hook errors
- add manage.py propose to guard raw prompts and launch Codex only after allow/rewrite decisions
- route WhatsApp Secretary Codex launches through the same prompt guard path
- document the before_prompt hook stdin/stdout protocol

## Verification
- .venv\Scripts\python.exe manage.py test run -- apps\skills\tests\test_prompt_hooks.py apps\meta\tests\test_whatsapp.py
- .venv\Scripts\python.exe -m ruff check apps\skills\prompt_hooks.py apps\skills\codex_wrapper.py apps\skills\management\commands\propose.py apps\skills\tests\test_prompt_hooks.py apps\meta\services.py apps\meta\tests\test_whatsapp.py
- .venv\Scripts\python.exe manage.py check --fail-level ERROR
- .venv\Scripts\python.exe manage.py migrations check
- .venv\Scripts\python.exe scripts\check_import_resolution.py apps\skills apps\meta
- git diff --check
- .venv\Scripts\python.exe manage.py propose --prompt hello --dry-run --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Introduces a prompt guard framework that executes "before_prompt" hooks to validate, rewrite, or refuse prompts before passing them to Codex. Hooks run in priority order as external processes receiving and returning JSON, with fail-closed default behavior. Integrates this guard into the Codex wrapper and WhatsApp Secretary launcher, and provides a `propose` management command for testing and running guarded prompts.

## Core Changes

### Prompt Hook Framework (`apps/skills/prompt_hooks.py`)
- Defines hook orchestration with decision types: `allow`, `refuse`, `rewrite`, `error`
- `PromptGuardOutcome` dataclass captures overall guard status, final prompt, hooks executed, and whether the prompt should launch
- `run_before_prompt_hooks()` iterates through enabled hooks in priority order, invoking each as a subprocess with JSON stdin/stdout protocol
- Implements fail-closed behavior: on hook errors or invalid JSON, returns an error outcome that prevents launch (unless `fail_open=True`)
- `require_prompt_allowed()` convenience wrapper that raises `PromptGuardBlocked` if guard refuses the prompt
- Supports runtime sigil resolution for hook commands and configurable hook working directory/environment

### Codex Wrapper (`apps/skills/codex_wrapper.py`)
- `CodexWrapperResult` dataclass holds guard outcome, final command, launch status, and return code
- `prepare_codex_prompt()` runs the guard and returns the (possibly rewritten) prompt
- `build_codex_command()` constructs Codex CLI command with the guarded prompt
- `run_codex_with_prompt_hooks()` orchestrates the full flow: guards the prompt, optionally launches Codex subprocess, returns detailed execution result; never raises on non-zero subprocess exit

### Prompt Guard Command (`apps/skills/management/commands/propose.py`)
- `manage.py propose` command runs Codex through the prompt guard
- Accepts prompt via positional args, `--prompt`, `--prompt-file`, or `--stdin`
- Options for `--codex-command`, `--source`, `--dry-run`, `--fail-open`, and `--json` output
- Raises `CommandError` if prompt is refused or Codex exits non-zero (unless dry-run)

### WhatsApp Secretary Integration (`apps/meta/services.py`)
- Updated `launch_codex_secretary_terminal()` to construct Codex command via `prepare_codex_prompt()` and `build_codex_command()`
- Routes all Secretary Codex launches through the prompt guard

## Testing

- `apps/skills/tests/test_prompt_hooks.py` covers hook rewriting/refusal chains, invalid hook JSON (fails closed), wrapper behavior with rewritten prompts, and `propose --dry-run --json` output
- `apps/meta/tests/test_whatsapp.py` verifies Secretary launcher applies before_prompt rewrites and marks tests with `@pytest.mark.django_db`

## Documentation

Updated `docs/development/codex-skill-packages.md` with before_prompt hook behavior, `propose` command usage, and JSON input/output contract for hooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7753)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->