### PR TITLE
Reinstate bounded OCPP forward-reply dispatch behavior

### DIFF
--- a/apps/ocpp/consumers/base/dispatch.py
+++ b/apps/ocpp/consumers/base/dispatch.py
@@ -63,30 +63,20 @@ class DispatchMixin:
             if done_task.done():
                 background_tasks.discard(done_task)
 
-        track_task = len(background_tasks) < MAX_BACKGROUND_FORWARD_REPLY_TASKS
-        if not track_task:
+        if len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS:
             logger.warning(
                 "Background forwarding task limit reached for message %s (%d active); "
-                "dispatching reply with overflow tracking.",
+                "skipping reply dispatch.",
                 message_id,
                 len(background_tasks),
             )
+            return
 
         task = create_task(forward_reply(message_id, raw))
-        if track_task:
-            background_tasks.add(task)
-        else:
-            overflow_tasks = getattr(self, "_overflow_forward_reply_tasks", None)
-            if overflow_tasks is None:
-                overflow_tasks = set()
-                self._overflow_forward_reply_tasks = overflow_tasks
-            overflow_tasks.add(task)
+        background_tasks.add(task)
 
         def _drop_completed(done_task):
             background_tasks.discard(done_task)
-            overflow_tasks = getattr(self, "_overflow_forward_reply_tasks", None)
-            if overflow_tasks is not None:
-                overflow_tasks.discard(done_task)
             try:
                 done_task.result()
             except CancelledError:

--- a/apps/ocpp/tests/test_ocpp_handlers.py
+++ b/apps/ocpp/tests/test_ocpp_handlers.py
@@ -2983,14 +2983,11 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
     started = asyncio.Event()
     release = asyncio.Event()
     calls = 0
-    all_started = asyncio.Event()
 
     async def _slow_forward_reply(*_args):
         nonlocal calls
         calls += 1
         started.set()
-        if calls >= 2:
-            all_started.set()
         await release.wait()
 
     consumer._dispatch_forward_reply(_slow_forward_reply, "msg-one", "[3]")
@@ -2999,13 +2996,13 @@ async def test_forward_reply_dispatch_limits_background_task_fanout(monkeypatch,
     with caplog.at_level("WARNING", logger=dispatch_module.logger.name):
         consumer._dispatch_forward_reply(_slow_forward_reply, "msg-two", "[3]")
 
-    await asyncio.wait_for(all_started.wait(), timeout=0.5)
-    assert calls == 2
+    await asyncio.sleep(0)
+    assert calls == 1
     assert len(consumer._background_forward_reply_tasks) == 1
-    assert len(consumer._overflow_forward_reply_tasks) == 1
-    assert "dispatching reply with overflow tracking" in caplog.text
+    assert not hasattr(consumer, "_overflow_forward_reply_tasks")
+    assert "skipping reply dispatch" in caplog.text
 
-    tasks = list(consumer._background_forward_reply_tasks | consumer._overflow_forward_reply_tasks)
+    tasks = list(consumer._background_forward_reply_tasks)
     release.set()
     await asyncio.gather(*tasks)
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded asyncio task creation in `_dispatch_forward_reply` that allowed an attacker to exhaust memory and event-loop/worker capacity by producing many slow forwarded replies. 
- Restore the previous hard-cap behavior so forwarding remains non-blocking but bounded by `MAX_BACKGROUND_FORWARD_REPLY_TASKS`.

### Description
- Reintroduced an early `return` when `len(background_tasks) >= MAX_BACKGROUND_FORWARD_REPLY_TASKS` inside `DispatchMixin._dispatch_forward_reply` so replies are skipped once the cap is hit. 
- Removed the unbounded `_overflow_forward_reply_tasks` bookkeeping and its removal from the done-callback since overflow tracking is no longer used. 
- Updated the test `test_forward_reply_dispatch_limits_background_task_fanout` to assert the second dispatch is skipped, that no `_overflow_forward_reply_tasks` attribute is created, and that the warning text reflects the skip behavior.

### Testing
- Ran the targeted test `./.venv/bin/python manage.py test run -- apps/ocpp/tests/test_ocpp_handlers.py::test_forward_reply_dispatch_limits_background_task_fanout` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0532d75b208326bd5ec101cbc29c34)