### PR TITLE
Fix non-ASCII RFID login_poll token comparison

### DIFF
--- a/apps/cards/login_poll.py
+++ b/apps/cards/login_poll.py
@@ -30,4 +30,6 @@ def request_has_rfid_login_poll_token(request) -> bool:
         or request.headers.get(RFID_LOGIN_POLL_HEADER)
         or ""
     )
-    return secrets.compare_digest(expected, str(supplied))
+    expected_bytes = expected.encode("utf-8")
+    supplied_bytes = str(supplied).encode("utf-8")
+    return secrets.compare_digest(expected_bytes, supplied_bytes)

--- a/apps/cards/tests/test_scan_next_access.py
+++ b/apps/cards/tests/test_scan_next_access.py
@@ -150,6 +150,26 @@ def test_scan_next_blocks_login_poll_with_mismatched_session_token(monkeypatch):
     assert json.loads(get_response.content) == {"error": "Authentication required"}
 
 
+def test_scan_next_blocks_login_poll_with_non_ascii_token(monkeypatch):
+    node = _make_node("Control")
+    monkeypatch.setattr(views.Node, "get_local", lambda: node)
+
+    factory = RequestFactory()
+    get_request = factory.get(
+        reverse("rfid-scan-next"),
+        {RFID_LOGIN_POLL_QUERY_PARAM: "é"},
+        HTTP_ACCEPT="application/json",
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    get_request.user = AnonymousUser()
+    get_request.session = {RFID_LOGIN_POLL_SESSION_KEY: "session-token"}
+
+    get_response = views.scan_next(get_request)
+
+    assert get_response.status_code == 401
+    assert json.loads(get_response.content) == {"error": "Authentication required"}
+
+
 def test_scan_next_blocks_anonymous_post_for_control_role(monkeypatch):
     node = _make_node("Control")
     monkeypatch.setattr(views.Node, "get_local", lambda: node)


### PR DESCRIPTION
### Motivation
- Prevent a remotely reachable `TypeError` and 500 response when an attacker supplies a non-ASCII `login_poll` token that was previously passed to `secrets.compare_digest()` as a `str`.

### Description
- Encode both the session `expected` token and the user-supplied `login_poll` value to UTF-8 bytes before calling `secrets.compare_digest()` in `apps/cards/login_poll.py`, and add a regression test in `apps/cards/tests/test_scan_next_access.py` that asserts a non-ASCII token is rejected with `401` instead of crashing.

### Testing
- Attempted to run the unit test with `.venv/bin/python manage.py test run -- apps/cards/tests/test_scan_next_access.py`, but test execution could not be completed in this environment because `.venv` is not present and `./install.sh` fails due to a missing `redis-server`; the regression test was added and should run in CI or a properly provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cb62685c8326aeba4df561c8b706)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix non-ASCII RFID login_poll token comparison

### Issue
The RFID login_poll token comparison was vulnerable to a remotely reachable `TypeError` when an attacker supplied a non-ASCII token. The issue arose because `secrets.compare_digest()` requires bytes, but the token values were being passed as strings containing non-ASCII characters, causing a 500 error instead of a proper 401 authentication failure.

### Solution
Modified `request_has_rfid_login_poll_token()` in `apps/cards/login_poll.py` to encode both the session `expected` token and the user-supplied `login_poll` value to UTF-8 bytes before passing them to `secrets.compare_digest()`. This maintains the constant-time comparison behavior while properly handling non-ASCII characters.

### Testing
Added a regression test `test_scan_next_blocks_login_poll_with_non_ascii_token` in `apps/cards/tests/test_scan_next_access.py` that verifies a non-ASCII token (containing the character `"é"`) is properly rejected with a 401 response and error payload `{"error": "Authentication required"}` instead of causing a crash.

### Changes
- `apps/cards/login_poll.py`: +3/-1 lines (encode tokens to UTF-8 bytes before comparison)
- `apps/cards/tests/test_scan_next_access.py`: +20/-0 lines (added regression test case)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7757)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->