### PR TITLE
Suppress unchanged release readiness comments

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -616,7 +616,6 @@ jobs:
               }))
               .digest('hex');
             const fingerprintMarker = `<!-- release-readiness-fingerprint:${reportFingerprint} -->`;
-            const stableReportPassed = blockers.length === 0 && simulatedOk;
 
             const body = [
               marker,
@@ -648,8 +647,9 @@ jobs:
 
             const existing = openIssues.find((issue) => issue.title === title && issue.body?.includes(marker));
             if (existing) {
-              if (stableReportPassed && existing.body?.includes(fingerprintMarker)) {
-                core.info(`Release readiness report #${existing.number} already passed with unchanged content; skipping refresh comment.`);
+              const reportUnchanged = existing.body?.includes(fingerprintMarker);
+              if (reportUnchanged) {
+                core.info(`Release readiness report #${existing.number} already has unchanged content; skipping refresh comment.`);
                 return;
               }
               await github.rest.issues.update({

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -783,7 +783,7 @@ def test_release_simulator_pr_and_issue_blockers_have_required_permissions() -> 
     assert "issue.body?.includes(releaseReadinessReportMarker)" in script
 
 
-def test_release_simulator_suppresses_unchanged_passed_report_comments() -> None:
+def test_release_simulator_suppresses_unchanged_report_comments() -> None:
     workflow = _workflow_data("release-simulator.yml")
     report_job = workflow["jobs"]["report"]
     report_step = _workflow_step(report_job, "Create or update release readiness report issue")
@@ -792,8 +792,10 @@ def test_release_simulator_suppresses_unchanged_passed_report_comments() -> None
     assert "const crypto = require('crypto')" in script
     assert "const reportFingerprint = crypto" in script
     assert "<!-- release-readiness-fingerprint:" in script
-    assert "const stableReportPassed = blockers.length === 0 && simulatedOk" in script
-    assert "stableReportPassed && existing.body?.includes(fingerprintMarker)" in script
+    assert "const reportUnchanged = existing.body?.includes(fingerprintMarker)" in script
+    assert "if (reportUnchanged)" in script
+    assert "stableReportPassed" not in script
+    assert "already has unchanged content; skipping refresh comment" in script
     assert "skipping refresh comment" in script
 
 

--- a/apps/core/tests/reports/test_release_publish_regressions.py
+++ b/apps/core/tests/reports/test_release_publish_regressions.py
@@ -796,7 +796,6 @@ def test_release_simulator_suppresses_unchanged_report_comments() -> None:
     assert "if (reportUnchanged)" in script
     assert "stableReportPassed" not in script
     assert "already has unchanged content; skipping refresh comment" in script
-    assert "skipping refresh comment" in script
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Summary
- Treat an unchanged release readiness report fingerprint as a no-op for both passing and blocked reports.
- Stop posting hourly refresh comments when the same blocker state is already present on the open report issue.
- Update the regression test so the guard is no longer limited to passed reports.

### Testing
- `.venv\Scripts\python.exe manage.py test run -- apps\core\tests\reports\test_release_publish_regressions.py::test_release_simulator_suppresses_unchanged_report_comments`
- `.venv\Scripts\python.exe manage.py test run -- apps\core\tests\reports\test_release_publish_regressions.py`
- `git diff --check`