### PR TITLE
Follow-up: keep Redis-backed Celery config for Debian default Terminal installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,7 @@ CLEAN=false
 ENABLE_CONTROL=false
 NODE_ROLE="Terminal"
 REQUIRES_REDIS=false
+WRITE_REDIS_ENV=false
 START_SERVICES=false
 REPAIR=false
 
@@ -409,7 +410,7 @@ done
 if [ ${#ORIGINAL_ARGS[@]} -eq 0 ] && is_debian_host; then
     SERVICE="arthexis"
     ENABLE_CELERY=true
-    NODE_ROLE="Terminal"
+    WRITE_REDIS_ENV=true
 fi
 
 if [ "$ENABLE_CAMERA_SERVICE" = true ]; then
@@ -541,6 +542,8 @@ fi
 # Record role-specific prerequisites and capture supporting state for service management.
 if [ "$REQUIRES_REDIS" = true ]; then
     require_redis "$NODE_ROLE"
+elif [ "$WRITE_REDIS_ENV" = true ] && [ "$ENABLE_CELERY" = true ]; then
+    write_redis_env "$NODE_ROLE"
 fi
 
 if [ "$ENABLE_CELERY" = true ]; then


### PR DESCRIPTION
### Motivation

- Ensure Debian hosts that run the default no-argument installer still get a Redis-backed Celery configuration so background tasks do not silently stop working. 
- Respond to reviewer feedback that removing `REQUIRES_REDIS` also prevented `redis.env` from being generated, which breaks Celery broker/result settings. 
- Preserve the intended behavior of avoiding a hard Redis health-gate for Debian defaults while still providing sensible runtime configuration for Celery.

### Description

- Modified `install.sh` to introduce a new boolean flag `WRITE_REDIS_ENV` and initialize it to `false`. 
- When the installer is invoked with no arguments on a Debian host, the script now sets `WRITE_REDIS_ENV=true` alongside `ENABLE_CELERY=true` so `redis.env` will be produced without enforcing runtime Redis checks. 
- Updated the prerequisite handling so that when `REQUIRES_REDIS=true` the script still runs `require_redis`, and otherwise when `WRITE_REDIS_ENV=true` and `ENABLE_CELERY=true` it calls `write_redis_env` to generate the `CELERY_BROKER_URL`/`CELERY_RESULT_BACKEND` entries.

### Testing

- Ran a syntax check with `bash -n install.sh`, which completed successfully. 
- Attempted to run `shellcheck install.sh` but `shellcheck` is not available in this execution environment, so static linting could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d4c5fbc483268cf406a0e5fcbd73)