### PR TITLE
Fix secret redaction for symbol-containing and malformed quoted values

### DIFF
--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -26,7 +26,7 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r")"
     r"(?:\"(?P<double_quoted_value>(?:[^\"\\\r\n]|\\.)*)\""
     r"|\'(?P<single_quoted_value>(?:[^'\\\r\n]|\\.)*)\'"
-    r"|(?P<unquoted_value>[^\s;,]+))",
+    r"|(?P<unquoted_value>[^\s;,\]\)\}]+))",
     re.IGNORECASE,
 )
 SECRET_EXPOSURE_PATTERN = re.compile(

--- a/apps/users/error_report_analysis.py
+++ b/apps/users/error_report_analysis.py
@@ -26,7 +26,7 @@ SECRET_ASSIGNMENT_PATTERN = re.compile(
     r")"
     r"(?:\"(?P<double_quoted_value>(?:[^\"\\\r\n]|\\.)*)\""
     r"|\'(?P<single_quoted_value>(?:[^'\\\r\n]|\\.)*)\'"
-    r"|(?P<unquoted_value>[A-Za-z0-9._~+/=:@%!\-\\\"]+|[\"'][^\s;,]*))",
+    r"|(?P<unquoted_value>[^\s;,]+))",
     re.IGNORECASE,
 )
 SECRET_EXPOSURE_PATTERN = re.compile(

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -335,6 +335,22 @@ def test_redact_sensitive_text_handles_pem_variants_and_quoted_values():
     assert "db_password=[redacted]" in redacted
     assert "api_key=[redacted]" in redacted
 
+
+def test_redact_sensitive_text_redacts_unquoted_values_with_symbol_suffixes():
+    text = "password=abc$def&ghi?jkl"
+
+    redacted = redact_sensitive_text(text)
+
+    assert redacted == "password=[redacted]"
+
+
+def test_redact_sensitive_text_redacts_malformed_double_quoted_symbol_values():
+    text = 'password="$ecret'
+
+    redacted = redact_sensitive_text(text)
+
+    assert redacted == "password=[redacted]"
+
 def test_redact_sensitive_text_handles_unterminated_quoted_backslash_sequence():
     text = 'password="' + ('\\' * 64)
 

--- a/apps/users/tests/test_error_report_analysis.py
+++ b/apps/users/tests/test_error_report_analysis.py
@@ -351,12 +351,22 @@ def test_redact_sensitive_text_redacts_malformed_double_quoted_symbol_values():
 
     assert redacted == "password=[redacted]"
 
+
+def test_redact_sensitive_text_preserves_structural_delimiters_after_unquoted_value():
+    text = '{"password":hunter2}'
+
+    redacted = redact_sensitive_text(text)
+
+    assert redacted == '{"password":[redacted]}'
+
+
 def test_redact_sensitive_text_handles_unterminated_quoted_backslash_sequence():
     text = 'password="' + ('\\' * 64)
 
     redacted = redact_sensitive_text(text)
 
     assert redacted == 'password=[redacted]'
+
 
 def test_redact_analysis_payload_preserves_tuple_type():
     redacted = redact_analysis_payload(("password=hunter2", "ok"))


### PR DESCRIPTION
### Motivation
- A recent change narrowed the unquoted secret-value matcher and introduced a redaction bypass where symbols like `$`, `&`, or `?` (or malformed quoted values) could remain visible in diagnostic output. 
- This PR restores robust redaction so secret values are fully consumed up to existing delimiters and not partially leaked.

### Description
- Broaden the unquoted branch of `SECRET_ASSIGNMENT_PATTERN` in `apps/users/error_report_analysis.py` to `(?P<unquoted_value>[^\s;,]+)` so values are consumed until whitespace or common delimiters instead of a restricted punctuation allowlist. 
- Preserve existing handling for double- and single-quoted values and the replacement behavior that emits `prefix + [redacted]` with matching quotes. 
- Add two focused regression tests in `apps/users/tests/test_error_report_analysis.py` named `test_redact_sensitive_text_redacts_unquoted_values_with_symbol_suffixes` and `test_redact_sensitive_text_redacts_malformed_double_quoted_symbol_values` to ensure symbol-containing unquoted values and malformed quoted inputs are fully redacted.

### Testing
- Attempted to run the package tests with `.venv/bin/python manage.py test run -- apps/users/tests/test_error_report_analysis.py`, but the environment lacks `.venv`, so automated tests could not be executed here. 
- Attempted to run `./install.sh` to provision the environment, but it fails locally because `redis-server` is not installed in this environment. 
- The new tests were added to the test suite and should be validated by CI or a developer environment with the repository `.venv` and system dependencies installed; they are expected to pass and prevent the previously observed redaction regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06093490f08326a1f8a2d247304958)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix secret redaction for symbol-containing and malformed quoted values

### Motivation
A previous change narrowed the unquoted secret-value matcher regex, creating a redaction bypass where symbols such as `$`, `&`, `?` or malformed quoted values (e.g., unclosed quotes) could remain visible in diagnostic output. This fix restores comprehensive redaction by ensuring secret values are fully consumed to existing delimiters without partial leakage.

### Changes

**apps/users/error_report_analysis.py**
- Updated the `SECRET_ASSIGNMENT_PATTERN` regex (line 29): the unquoted value group now uses `(?P<unquoted_value>[^\s;,\]\)\}]+)` to match and consume all non-whitespace, non-delimiter characters, including symbols. This ensures that values like `abc$def&ghi?jkl` are fully matched and redacted rather than allowing symbol-based escapes.
- Preserved existing double- and single-quoted value patterns and the replacement behavior that emits `prefix + [redacted] + matching_quotes`.

**apps/users/tests/test_error_report_analysis.py**
- Added `test_redact_sensitive_text_redacts_unquoted_values_with_symbol_suffixes`: validates that `password=abc$def&ghi?jkl` is fully redacted to `password=[redacted]`
- Added `test_redact_sensitive_text_redacts_malformed_double_quoted_symbol_values`: validates that malformed double-quoted values like `password="$ecret` (unclosed quote) are fully redacted to `password=[redacted]`
- Existing test `test_redact_sensitive_text_preserves_structural_delimiters_after_unquoted_value` confirms that structural JSON delimiters (closing braces) are correctly preserved
- Existing test `test_redact_sensitive_text_handles_unterminated_quoted_backslash_sequence` confirms unterminated quoted sequences are fully redacted

### Testing notes
The contributor reported inability to run the test suite locally due to missing `.venv` and system dependency (`redis-server`). The new tests are expected to pass and prevent regression of the prior vulnerability when executed in an environment with proper dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7766)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->