### PR TITLE
Stabilize hardware setup log assertion

### DIFF
--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -109,7 +109,7 @@ def test_setup_hardware_logs_info_for_expected_missing_device(caplog, monkeypatc
             assert background_reader._setup_hardware() is False
 
     assert "RFID hardware disabled for this process after setup failure" in caplog.text
-    assert all(record.levelno < logging.WARNING for record in caplog.records)
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
 
 def test_start_skips_when_hardware_is_disabled(monkeypatch):

--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -101,13 +101,15 @@ def test_setup_hardware_logs_info_for_expected_missing_device(caplog, monkeypatc
     with caplog.at_level(logging.INFO):
         with monkeypatch.context() as patch_ctx:
             patch_ctx.setitem(sys.modules, "mfrc522", SimpleNamespace())
+
             def _mfrc_ctor(**_kwargs):
                 raise FileNotFoundError("[Errno 2] No such file or directory: '/dev/spidev0.0'")
+
             sys.modules["mfrc522"].MFRC522 = _mfrc_ctor
             assert background_reader._setup_hardware() is False
 
     assert "RFID hardware disabled for this process after setup failure" in caplog.text
-    assert "WARNING" not in caplog.text
+    assert all(record.levelno < logging.WARNING for record in caplog.records)
 
 
 def test_start_skips_when_hardware_is_disabled(monkeypatch):


### PR DESCRIPTION
### Motivation
- Fix a flaky test in the install health-check matrix by removing a brittle text-based log assertion that caused unrelated formatting to trigger failures.

### Description
- Replace the string containment check (`"WARNING" not in caplog.text`) with a semantic severity check using `caplog.records` in `apps/cards/tests/test_background_reader.py` so the test asserts no `WARNING`-level records were emitted.

### Testing
- Ran the targeted test selection with `python3 -m pytest apps/cards/tests/test_background_reader.py -k "setup_hardware_logs_info_for_expected_missing_device or setup_hardware_gpio_missing_disables_reader or record_setup_failure" -q` and it passed. 
- Running the whole test file with `python3 -m pytest apps/cards/tests/test_background_reader.py -q` exercised the change but produced environment-related fixture errors for unrelated tests (`settings` fixture missing) in this runner, not caused by the assertion change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06158ee0888326b47b9a831e1ae08b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7769)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->