### PR TITLE
Harden RFID setup log-level assertion test

### DIFF
--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -109,7 +109,13 @@ def test_setup_hardware_logs_info_for_expected_missing_device(caplog, monkeypatc
             assert background_reader._setup_hardware() is False
 
     assert "RFID hardware disabled for this process after setup failure" in caplog.text
-    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+    reader_logs = [record for record in caplog.records if record.name == background_reader.__name__]
+    assert any(
+        record.levelno == logging.INFO
+        and "RFID hardware disabled for this process after setup failure" in record.getMessage()
+        for record in reader_logs
+    )
+    assert not any(record.levelno >= logging.WARNING for record in reader_logs)
 
 
 def test_start_skips_when_hardware_is_disabled(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent intermittent CI failures where unrelated WARNING logs in the shared `caplog` stream tripped a brittle global assertion; the test should only validate logs emitted by `apps.cards.background_reader`.

### Description
- Update `apps/cards/tests/test_background_reader.py::test_setup_hardware_logs_info_for_expected_missing_device` to filter `caplog.records` for the `apps.cards.background_reader` logger and assert there is an INFO record with the expected message and that no WARNING-or-higher records originate from that module.

### Testing
- Ran `python3 -m pytest apps/cards/tests/test_background_reader.py -k "setup_hardware_logs_info_for_expected_missing_device or setup_hardware_gpio_missing_disables_reader or record_setup_failure" -q` which passed (`5 passed, 6 deselected`).
- Note: the repository canonical test entrypoint using `.venv/bin/python manage.py test run -- ...` was not runnable in this environment because the `.venv` bootstrap is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064e5fd0408326816012a48aa553a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the `test_setup_hardware_logs_info_for_expected_missing_device` test to filter caplog records for the `apps.cards.background_reader` logger specifically, preventing intermittent CI failures caused by unrelated WARNING logs in the shared caplog stream.

## Changes

**File: `apps/cards/tests/test_background_reader.py`**

Modified assertions to operate only on log records from the `background_reader` module:
- Filters `caplog.records` to include only records where `record.name == background_reader.__name__`
- Verifies at least one INFO-level log from that module contains "RFID hardware disabled for this process after setup failure"
- Confirms no WARNING-or-higher logs originate from that specific logger

This replaces the previous assertion that checked for the absence of all warning-or-higher logs across the entire captured record set, which was brittle when other modules emitted warnings during test execution.

## Testing

Verified with: `python3 -m pytest apps/cards/tests/test_background_reader.py -k "setup_hardware_logs_info_for_expected_missing_device or setup_hardware_gpio_missing_disables_reader or record_setup_failure" -q` → 5 passed, 6 deselected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7774)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->