### PR TITLE
Fix RFID setup log test isolation

### DIFF
--- a/apps/cards/tests/test_background_reader.py
+++ b/apps/cards/tests/test_background_reader.py
@@ -5,8 +5,7 @@ import queue
 import sys
 from types import SimpleNamespace
 
-from apps.cards import background_reader
-from apps.cards import reader
+from apps.cards import background_reader, reader
 
 
 def test_setup_hardware_gpio_missing_disables_reader(caplog, monkeypatch):
@@ -97,6 +96,7 @@ def test_setup_hardware_logs_info_for_expected_missing_device(caplog, monkeypatc
     monkeypatch.setattr(background_reader, "GPIO", DummyGPIO)
     monkeypatch.setattr(background_reader, "resolve_spi_bus_device", lambda: (0, 0))
     monkeypatch.setattr(background_reader, "_reader", None)
+    monkeypatch.setattr(background_reader, "_hardware_disabled_reason", None)
 
     with caplog.at_level(logging.INFO):
         with monkeypatch.context() as patch_ctx:


### PR DESCRIPTION
## Summary
- reset the background reader disabled-hardware sentinel in the expected missing SPI-device log test
- keep the production one-log hardware disable behavior while preventing prior pytest worker state from emptying `caplog`
- apply Ruff's import normalization for the touched test file

## Validation
- `.\.venv\Scripts\python.exe -m pytest apps/cards/tests/test_background_reader.py -q --maxfail=1`
- `.\.venv\Scripts\python.exe -m pytest -n auto --dist loadfile apps/cards/tests/test_background_reader.py -q --maxfail=1`
- `.\.venv\Scripts\python.exe -m pytest -n auto --dist loadfile apps/cards/tests/test_background_reader.py apps/cards/tests/test_scan_next_access.py apps/sites/tests/test_rfid_login_page.py -q --maxfail=1`
- `.\.venv\Scripts\ruff.exe check apps/cards/tests/test_background_reader.py`

Fixes #7762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix RFID Setup Log Test Isolation

This PR fixes test isolation issues that cause intermittent failures in the install health check workflow when running tests in parallel.

## Changes
- **Test isolation fix**: Added explicit reset of the `background_reader._hardware_disabled_reason` sentinel in `test_setup_hardware_logs_info_for_expected_missing_device` (line 99). This ensures the test starts with a clean state, preventing leftover hardware-disabled markers from prior parallel test execution from interfering with caplog assertions.
- **Import normalization**: Consolidated imports into a single statement: `from apps.cards import background_reader, reader` (line 8).

## Problem Addressed
When running tests in parallel with pytest-xdist, the module-level `_hardware_disabled_reason` global variable from one test could persist into subsequent tests. Since the background reader's `_disable_hardware()` function uses this sentinel to prevent duplicate logging and decide log levels, a stale value would cause `test_setup_hardware_logs_info_for_expected_missing_device` to log differently than expected, breaking caplog assertions that verify exactly one log message is generated.

## Testing
The fix can be validated with:
- Single-file run: `pytest apps/cards/tests/test_background_reader.py`
- Parallel execution: `pytest -n auto apps/cards/tests/test_background_reader.py`
- Import formatting: `ruff check apps/cards/tests/test_background_reader.py`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7776)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->