### PR TITLE
Harden Dependabot classification in PR oversee helper

### DIFF
--- a/apps/skills/packages/operator-framework-core/skills/arthexis-pr-oversee/scripts/pr_oversee.py
+++ b/apps/skills/packages/operator-framework-core/skills/arthexis-pr-oversee/scripts/pr_oversee.py
@@ -67,9 +67,7 @@ def author_login(pr: dict[str, Any]) -> str:
 
 
 def is_dependabot(pr: dict[str, Any]) -> bool:
-    login = author_login(pr).lower()
-    title = str(pr.get("title") or "").lower()
-    return "dependabot" in login or title.startswith("build(deps")
+    return author_login(pr).lower() == "dependabot[bot]"
 
 
 def check_rollup_state(pr: dict[str, Any]) -> tuple[list[str], list[str]]:


### PR DESCRIPTION
### Motivation
- Close a supply-chain integrity gap where attacker-controlled PR titles like `build(deps:...)` could be used to spoof Dependabot and bypass non-Dependabot merge guards.

### Description
- Remove title-based detection from `is_dependabot` and classify Dependabot PRs only when `author_login(pr).lower() == "dependabot[bot]"`, preventing title spoofing from granting auto-merge privileges.

### Testing
- Successfully compiled the updated script with `python3 -m py_compile apps/skills/packages/operator-framework-core/skills/arthexis-pr-oversee/scripts/pr_oversee.py`; attempting to run `--help` via `.venv/bin/python` failed due to a missing virtualenv in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06526d85bc83269bc8bd58c4b255b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Hardening: Dependabot Detection

The `is_dependabot()` function has been hardened to prevent supply-chain attacks where malicious PR titles or usernames could spoof Dependabot and bypass security controls.

**Change:**
The function now classifies PRs as Dependabot only when the PR author login exactly matches `dependabot[bot]` (case-insensitive), removing:
- Title-based detection that matched PR titles like `build(deps...)`
- Partial username matching that checked if "dependabot" appeared anywhere in the login

**Impact:**
This eliminates the ability for attackers to:
1. Create PRs with Dependabot-style titles to trigger auto-merge
2. Create accounts containing "dependabot" to spoof the bot

The classification is now solely author-based, ensuring only the genuine Dependabot bot can be auto-merged without manual approval (controlled by the `--allow-non-dependabot` flag in the merge workflow).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->