### PR TITLE
Fix Install CI badge workflow path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Constellation
 
 [![OCPP 1.6 Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/media/ocpp_coverage.svg)](https://github.com/arthexis/arthexis/blob/main/docs/development/ocpp-user-manual.md) [![OCPP 2.0.1 Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/media/ocpp201_coverage.svg)](https://github.com/arthexis/arthexis/blob/main/docs/development/ocpp-user-manual.md) [![OCPP 2.1 Coverage](https://raw.githubusercontent.com/arthexis/arthexis/main/media/ocpp21_coverage.svg)](https://github.com/arthexis/arthexis/blob/main/docs/development/ocpp-user-manual.md)
-[![Install CI](https://img.shields.io/github/actions/workflow/status/arthexis/arthexis/install-hourly.yml?branch=main&label=Install%20CI&cacheSeconds=300)](https://github.com/arthexis/arthexis/actions/workflows/install-hourly.yml) [![PyPI](https://img.shields.io/pypi/v/arthexis?label=PyPI)](https://pypi.org/project/arthexis/) [![License: Arthexis 1.0](https://img.shields.io/badge/License-Arthexis%201.0-blue.svg)](https://github.com/arthexis/arthexis/blob/main/LICENSE)
+[![Install CI](https://img.shields.io/github/actions/workflow/status/arthexis/arthexis/install-health.yml?branch=main&label=Install%20CI&cacheSeconds=300)](https://github.com/arthexis/arthexis/actions/workflows/install-health.yml) [![PyPI](https://img.shields.io/pypi/v/arthexis?label=PyPI)](https://pypi.org/project/arthexis/) [![License: Arthexis 1.0](https://img.shields.io/badge/License-Arthexis%201.0-blue.svg)](https://github.com/arthexis/arthexis/blob/main/LICENSE)
 
 
 ## Purpose


### PR DESCRIPTION
### Motivation
- The README's Install CI badge referenced `install-hourly.yml` which no longer exists, causing the badge to display "repo or workflow not found".

### Description
- Update the README badge image URL and click-through link to point at the existing workflow ` .github/workflows/install-health.yml` (replace `install-hourly.yml` with `install-health.yml`).

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c4244e688326a64034b3c9faed1b)