### PR TITLE
Fix invalid upload-artifact action version in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
 
       - name: Upload pytest log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-gate-pytest-log
           path: pytest.log
@@ -397,7 +397,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade-gate-failure-summary
           path: ci-failure-summary.md

--- a/.github/workflows/dashboard-screenshot.yml
+++ b/.github/workflows/dashboard-screenshot.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: Upload dashboard screenshot
         id: upload-admin-dashboard
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: admin-dashboard
           path: artifacts/admin-desktop.png
@@ -336,7 +336,7 @@ jobs:
       - name: Upload OCPP dashboard screenshot for pull requests
         if: ${{ github.event_name == 'pull_request' }}
         id: upload-ocpp-dashboard
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ocpp-dashboard
           path: artifacts/ocpp-cpms-dashboard-desktop.png
@@ -344,7 +344,7 @@ jobs:
       - name: Upload developer library screenshot for pull requests
         if: ${{ github.event_name == 'pull_request' }}
         id: upload-developer-library
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: developer-library
           path: artifacts/docs-library-desktop.png
@@ -352,7 +352,7 @@ jobs:
       - name: Upload gallery screenshot for pull requests
         if: ${{ github.event_name == 'pull_request' }}
         id: upload-gallery
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: image-gallery
           path: artifacts/gallery-desktop.png
@@ -360,7 +360,7 @@ jobs:
       - name: Upload OCPP charger detail screenshot for pull requests
         if: ${{ github.event_name == 'pull_request' }}
         id: upload-ocpp-charger-detail
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ocpp-charger-detail
           path: artifacts/ocpp-c-SIM-CP-1-desktop.png
@@ -424,7 +424,7 @@ jobs:
       - name: Upload screenshot metadata
         if: ${{ always() && github.event_name == 'pull_request' }}
         id: upload-pr-screenshot-metadata
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: screenshot-metadata
           path: |
@@ -616,28 +616,28 @@ jobs:
 
       - name: Upload public screenshot
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: public-site
           path: artifacts/root-desktop.png
 
       - name: Upload OCPP dashboard screenshot
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ocpp-dashboard
           path: artifacts/ocpp-cpms-dashboard-desktop.png
 
       - name: Upload developer library screenshot
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: developer-library
           path: artifacts/docs-library-desktop.png
 
       - name: Upload EVCS public screenshot
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: evcs-public
           path: artifacts/ocpp-c-sim-cp-1-desktop.png

--- a/.github/workflows/install-health.yml
+++ b/.github/workflows/install-health.yml
@@ -213,7 +213,7 @@ jobs:
           python -m pytest "${xdist_args[@]}" --maxfail=1 --disable-warnings -q --timeout=300 --junitxml=pytest-junit.xml | tee pytest.log
       - name: Upload pytest log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: install-health-pytest-results-${{ matrix.os_flavor }}-${{ matrix.db_backend }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
           python -m pytest --maxfail=1 --disable-warnings -q --timeout=180 | tee pytest.log
       - name: Upload pytest log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: release-pytest-log
           path: pytest.log
@@ -309,14 +309,14 @@ jobs:
 
       - name: Upload validation logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: arthexis-validation-logs
           path: validation-logs/
           if-no-files-found: warn
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: arthexis-dists
           path: dist/

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Gitleaks reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: gitleaks-reports
           path: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload PR ZAP reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: zap-baseline-pr-report
           path: |
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload ZAP reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: zap-baseline-report
           path: |


### PR DESCRIPTION
### Motivation
- The Install Health Check and other CI workflows were failing early because they pinned `actions/upload-artifact@v7`, which is not a valid major tag and prevents GitHub from resolving the action. 
- Fixing the action pin ensures workflow steps that upload artifacts run and prevents failures before tests start.

### Description
- Replaced all `actions/upload-artifact@v7` references with `actions/upload-artifact@v4` across workflow files. 
- Updated the following workflow files: `.github/workflows/install-health.yml`, `.github/workflows/ci.yml`, `.github/workflows/publish.yml`, `.github/workflows/secret-scan.yml`, `.github/workflows/security-scan.yml`, and `.github/workflows/dashboard-screenshot.yml`.
- Kept existing artifact names and paths unchanged to preserve downstream consumers of those artifacts.

### Testing
- Verified no remaining `@v7` references with `rg -n "actions/upload-artifact@v7|actions/upload-artifact@v4"` against the updated workflows and confirmed `@v4` is present, which succeeded. 
- Confirmed the change was staged and committed locally using the repository git tooling, which succeeded. 
- Inspected modified workflow sections to ensure artifact upload steps still reference the same artifact names and `if-no-files-found` behavior, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c87703c48326a634f3a78a19e07c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes CI workflow failures by correcting the invalid `actions/upload-artifact` action version across six workflow files.

## Changes

Updated `actions/upload-artifact` from the invalid `@v7` tag to `@v4` in the following files:

- `.github/workflows/ci.yml` – Updated artifact uploads for `pytest.log` and conditional `ci-failure-summary.md` 
- `.github/workflows/dashboard-screenshot.yml` – Updated screenshot artifact uploads for PR and non-PR workflows
- `.github/workflows/install-health.yml` – Updated pytest log artifact upload
- `.github/workflows/publish.yml` – Updated artifact uploads in `test` and `build` jobs
- `.github/workflows/secret-scan.yml` – Updated Gitleaks scan report upload
- `.github/workflows/security-scan.yml` – Updated OWASP ZAP scan artifact uploads

All artifact names, paths, and conditional logic remain unchanged. Only the action version is updated.

## Lines Changed
+19 / -19

## Motivation

The `@v7` tag for `actions/upload-artifact` is invalid and prevents GitHub from resolving the action, causing early workflow failures. This fix restores workflow functionality by using the valid `@v4` tag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->