### PR TITLE
Add Workgroup daily play password

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,11 +4,13 @@ title = "Arthexis Gitleaks Configuration"
 useDefault = true
 
 [allowlist]
-  description = "Ignore known placeholder credentials and enum values in tests/admin code"
+  description = "Ignore known placeholder credentials, enum values, and non-secret test timezone literals"
   regexTarget = "line"
   regexes = [
     '''password=\"password\"''',
-    '''DNSProviderCredential\.Provider\.GODADDY,\s+is_enabled=True'''
+    '''DNSProviderCredential\.Provider\.GODADDY,\s+is_enabled=True''',
+    '''WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey"''',
+    '''password\.timezone_name == "America/Monterrey"'''
   ]
 
 [[rules]]

--- a/apps/core/templates/core/footer.html
+++ b/apps/core/templates/core/footer.html
@@ -5,7 +5,11 @@
       <div class="row row-cols-2 row-cols-md-6">
         {% for ref in footer_refs %}
           <div class="col mb-2">
-            <a href="{{ ref.value }}" target="_blank" rel="noopener noreferrer">{{ ref.alt_text|default:ref.value }}</a>
+            {% if ref.value|slice:":1" == "/" %}
+              <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
+            {% else %}
+              <a href="{{ ref.value }}" target="_blank" rel="noopener noreferrer">{{ ref.alt_text|default:ref.value }}</a>
+            {% endif %}
           </div>
         {% endfor %}
       </div>

--- a/apps/core/templates/core/footer.html
+++ b/apps/core/templates/core/footer.html
@@ -5,7 +5,7 @@
       <div class="row row-cols-2 row-cols-md-6">
         {% for ref in footer_refs %}
           <div class="col mb-2">
-            {% if ref.value|slice:":1" == "/" %}
+            {% if ref.value|slice:":1" == "/" and ref.value|slice:":2" != "//" %}
               <a href="{{ ref.value }}">{{ ref.alt_text|default:ref.value }}</a>
             {% else %}
               <a href="{{ ref.value }}" target="_blank" rel="noopener noreferrer">{{ ref.alt_text|default:ref.value }}</a>

--- a/apps/links/fixtures/references__reference_21.json
+++ b/apps/links/fixtures/references__reference_21.json
@@ -2,8 +2,8 @@
   {
     "model": "links.reference",
     "fields": {
-      "value": "https://company.wizards.com/",
-      "alt_text": "The Wizards",
+      "value": "/workgroup/",
+      "alt_text": "The Workgroup",
       "method": "link",
       "include_in_footer": true,
       "footer_visibility": "public",

--- a/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
+++ b/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
@@ -12,14 +12,16 @@ NEW_VALUE = "/workgroup/"
 
 
 def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
+    """Canonicalize wizard/workgroup footer references into one public workgroup link."""
     Reference = apps.get_model("links", "Reference")
     manager = getattr(Reference, "all_objects", Reference._base_manager)
+    db_manager = manager.using(schema_editor.connection.alias)
 
     filters = Q(alt_text=NEW_ALT_TEXT, value=NEW_VALUE)
     for alt_text, value in OLD_FOOTER_VARIANTS:
         filters |= Q(alt_text=alt_text, value=value)
 
-    candidates = list(manager.filter(filters).order_by("pk"))
+    candidates = list(db_manager.filter(filters).order_by("pk"))
     if not candidates:
         return
 
@@ -34,9 +36,7 @@ def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
 
     duplicate_pks = [row.pk for row in candidates if row.pk != keep.pk]
     if duplicate_pks:
-        manager.using(schema_editor.connection.alias).filter(
-            pk__in=duplicate_pks
-        ).delete()
+        db_manager.filter(pk__in=duplicate_pks).delete()
 
     changed_fields = []
     for field_name, value in (
@@ -58,6 +58,7 @@ def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
 
 
 def noop_reverse(apps, schema_editor) -> None:
+    """Leave reverse as a no-op because deleted duplicates cannot be reconstructed."""
     return None
 
 

--- a/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
+++ b/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from django.db import migrations
+from django.db.models import Q
+
+OLD_FOOTER_VARIANTS = [
+    ("Wizards of the Coast", "https://company.wizards.com/"),
+    ("The Wizards", "https://company.wizards.com/"),
+]
+NEW_ALT_TEXT = "The Workgroup"
+NEW_VALUE = "/workgroup/"
+
+
+def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
+    Reference = apps.get_model("links", "Reference")
+    manager = getattr(Reference, "all_objects", Reference._base_manager)
+
+    filters = Q(alt_text=NEW_ALT_TEXT, value=NEW_VALUE)
+    for alt_text, value in OLD_FOOTER_VARIANTS:
+        filters |= Q(alt_text=alt_text, value=value)
+
+    candidates = list(manager.filter(filters).order_by("pk"))
+    if not candidates:
+        return
+
+    keep = next(
+        (
+            row
+            for row in candidates
+            if row.alt_text == NEW_ALT_TEXT and row.value == NEW_VALUE
+        ),
+        candidates[0],
+    )
+
+    duplicate_pks = [row.pk for row in candidates if row.pk != keep.pk]
+    if duplicate_pks:
+        manager.using(schema_editor.connection.alias).filter(
+            pk__in=duplicate_pks
+        ).delete()
+
+    changed_fields = []
+    for field_name, value in (
+        ("alt_text", NEW_ALT_TEXT),
+        ("value", NEW_VALUE),
+        ("method", "link"),
+        ("include_in_footer", True),
+        ("footer_visibility", "public"),
+        ("is_seed_data", True),
+    ):
+        if getattr(keep, field_name) != value:
+            setattr(keep, field_name, value)
+            changed_fields.append(field_name)
+    if changed_fields:
+        keep.save(
+            update_fields=changed_fields,
+            using=schema_editor.connection.alias,
+        )
+
+
+def noop_reverse(apps, schema_editor) -> None:
+    return None
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("links", "0007_fix_github_footer_reference"),
+    ]
+
+    operations = [
+        migrations.RunPython(replace_wizards_with_workgroup_footer, noop_reverse),
+    ]

--- a/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
+++ b/apps/links/migrations/0008_replace_wizards_with_workgroup_footer.py
@@ -25,18 +25,21 @@ def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
     if not candidates:
         return
 
+    active_candidates = [row for row in candidates if not row.is_deleted]
     keep = next(
         (
             row
-            for row in candidates
+            for row in active_candidates
             if row.alt_text == NEW_ALT_TEXT and row.value == NEW_VALUE
         ),
-        candidates[0],
+        active_candidates[0] if active_candidates else candidates[0],
     )
 
     duplicate_pks = [row.pk for row in candidates if row.pk != keep.pk]
     if duplicate_pks:
-        db_manager.filter(pk__in=duplicate_pks).delete()
+        db_manager.filter(pk__in=duplicate_pks)._raw_delete(
+            schema_editor.connection.alias
+        )
 
     changed_fields = []
     for field_name, value in (
@@ -46,6 +49,7 @@ def replace_wizards_with_workgroup_footer(apps, schema_editor) -> None:
         ("include_in_footer", True),
         ("footer_visibility", "public"),
         ("is_seed_data", True),
+        ("is_deleted", False),
     ):
         if getattr(keep, field_name) != value:
             setattr(keep, field_name, value)

--- a/apps/sites/management/commands/workgroup_password.py
+++ b/apps/sites/management/commands/workgroup_password.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.sites.workgroup_passwords import current_password, password_record_for_date
+
+_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]*[$]?$")
+
+
+class Command(BaseCommand):
+    help = (
+        "Show the current Workgroup play SSH password or apply it to a local "
+        "Unix account."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--date",
+            help="Generate the password for a specific local date, YYYY-MM-DD.",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Print password metadata as JSON.",
+        )
+        parser.add_argument(
+            "--apply-user",
+            metavar="USER",
+            help="Set USER's local Unix password to the generated password.",
+        )
+
+    def _password_record(self, date_value: str | None):
+        if not date_value:
+            return current_password()
+        try:
+            day = dt.date.fromisoformat(date_value)
+        except ValueError as exc:
+            raise CommandError("--date must be in YYYY-MM-DD format.") from exc
+        return password_record_for_date(day)
+
+    def _apply_user_password(self, username: str, password: str) -> None:
+        if not _USER_RE.match(username):
+            raise CommandError(
+                "Invalid Unix username. Use letters, digits, underscore, dash, "
+                "and an optional trailing dollar."
+            )
+        command = (
+            ["chpasswd"]
+            if hasattr(os, "geteuid") and os.geteuid() == 0
+            else ["sudo", "chpasswd"]
+        )
+        try:
+            subprocess.run(
+                command,
+                input=f"{username}:{password}\n",
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+        except FileNotFoundError as exc:
+            raise CommandError(
+                f"Password update command not found: {command[0]}"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "").strip()
+            message = f"Failed to update password for {username}."
+            if detail:
+                message = f"{message} {detail}"
+            raise CommandError(message) from exc
+
+    def handle(self, *args, **options):
+        record = self._password_record(options.get("date"))
+        apply_user = options.get("apply_user")
+        if apply_user:
+            self._apply_user_password(apply_user, record.password)
+            self.stdout.write(
+                f"Updated password for {apply_user} for {record.date.isoformat()}."
+            )
+            return
+
+        if options.get("json"):
+            self.stdout.write(
+                json.dumps(
+                    {
+                        "password": record.password,
+                        "date": record.date.isoformat(),
+                        "timezone": record.timezone_name,
+                        "valid_from": record.valid_from.isoformat(),
+                        "valid_until": record.valid_until.isoformat(),
+                    },
+                    sort_keys=True,
+                )
+            )
+            return
+
+        self.stdout.write(record.password)

--- a/apps/sites/templates/pages/workgroup.html
+++ b/apps/sites/templates/pages/workgroup.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
-{% load i18n %}
+{% load i18n tz %}
 
 {% block title %}{% trans "The Workgroup" %} - {{ badge_site_name|default:"Arthexis" }}{% endblock %}
 {% block extra_head %}<meta name="robots" content="noindex,nofollow">{% endblock %}
@@ -17,7 +17,7 @@
       <div class="display-6 font-monospace my-2">{{ password.password }}</div>
       <div class="text-muted">
         {% trans "Valid for" %} {{ password.date|date:"Y-m-d" }}
-        {% trans "until" %} {{ password.valid_until|date:"Y-m-d H:i" }}
+        {% trans "until" %} {{ password.valid_until|timezone:password.timezone_name|date:"Y-m-d H:i" }}
         {{ password.timezone_name }}.
       </div>
     </section>

--- a/apps/sites/templates/pages/workgroup.html
+++ b/apps/sites/templates/pages/workgroup.html
@@ -27,7 +27,7 @@
       <p>
         {% trans "From a terminal, connect to the play account and enter the password above when SSH asks for it." %}
       </p>
-      <pre class="bg-dark text-light border rounded-2 p-3"><code>ssh -p 2222 play@arthexis.com</code></pre>
+      <pre class="bg-dark text-light border rounded-2 p-3"><code>ssh -p 2222 play@{{ play_ssh_host }}</code></pre>
       <p>
         {% trans "After the game prompt appears, sign in with your Evennia account:" %}
       </p>

--- a/apps/sites/templates/pages/workgroup.html
+++ b/apps/sites/templates/pages/workgroup.html
@@ -1,0 +1,38 @@
+{% extends "pages/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "The Workgroup" %} - {{ badge_site_name|default:"Arthexis" }}{% endblock %}
+{% block extra_head %}<meta name="robots" content="noindex,nofollow">{% endblock %}
+
+{% block content %}
+<main class="row justify-content-center py-4">
+  <div class="col-12 col-lg-8">
+    <h1 class="h2 mb-3">{% trans "The Workgroup" %}</h1>
+    <p class="lead">
+      {% trans "Use today's workgroup password to enter the Arthexis Evennia play shell." %}
+    </p>
+
+    <section class="border rounded-2 p-4 my-4">
+      <div class="text-muted small text-uppercase">{% trans "Today's password" %}</div>
+      <div class="display-6 font-monospace my-2">{{ password.password }}</div>
+      <div class="text-muted">
+        {% trans "Valid for" %} {{ password.date|date:"Y-m-d" }}
+        {% trans "until" %} {{ password.valid_until|date:"Y-m-d H:i" }}
+        {{ password.timezone_name }}.
+      </div>
+    </section>
+
+    <section class="mt-4">
+      <h2 class="h4">{% trans "Use It" %}</h2>
+      <p>
+        {% trans "From a terminal, connect to the play account and enter the password above when SSH asks for it." %}
+      </p>
+      <pre class="bg-dark text-light border rounded-2 p-3"><code>ssh -p 2222 play@arthexis.com</code></pre>
+      <p>
+        {% trans "After the game prompt appears, sign in with your Evennia account:" %}
+      </p>
+      <pre class="bg-dark text-light border rounded-2 p-3"><code>connect &lt;account&gt; &lt;account-password&gt;</code></pre>
+    </section>
+  </div>
+</main>
+{% endblock %}

--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -1,0 +1,132 @@
+import datetime as dt
+import io
+from types import SimpleNamespace
+
+import pytest
+from django.core.management import call_command
+from django.template.loader import render_to_string
+from django.test import override_settings
+from django.urls import reverse
+
+from apps.sites.workgroup_passwords import current_password, password_for_date
+
+
+def test_workgroup_password_is_stable_for_day_and_changes_next_day():
+    day = dt.date(2026, 5, 16)
+
+    password = password_for_date(day, seed="test-seed")
+
+    assert password == password_for_date(day, seed="test-seed")
+    assert password != password_for_date(day + dt.timedelta(days=1), seed="test-seed")
+    assert password.count("-") == 1
+    assert all(part.isalpha() for part in password.split("-"))
+
+
+@override_settings(
+    WORKGROUP_DAILY_PASSWORD_SEED="view-seed",
+    WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
+)
+def test_current_workgroup_password_uses_configured_timezone():
+    password = current_password(dt.datetime(2026, 5, 16, 5, 30, tzinfo=dt.UTC))
+
+    assert password.date == dt.date(2026, 5, 15)
+    assert password.timezone_name == "America/Monterrey"
+    assert password.password == password_for_date(dt.date(2026, 5, 15), seed="view-seed")
+
+
+@pytest.mark.django_db
+@override_settings(
+    WORKGROUP_DAILY_PASSWORD_SEED="view-seed",
+    WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
+)
+def test_workgroup_page_shows_daily_password_and_usage(client):
+    expected = current_password().password
+
+    response = client.get(reverse("pages:workgroup"))
+
+    assert response.status_code == 200
+    assert "The Workgroup" in response.content.decode()
+    assert expected in response.content.decode()
+    assert "ssh -p 2222 play@arthexis.com" in response.content.decode()
+    assert "connect &lt;account&gt; &lt;account-password&gt;" in response.content.decode()
+
+
+def test_footer_renders_workgroup_as_same_window_internal_link():
+    html = render_to_string(
+        "core/footer.html",
+        {
+            "footer_refs": [
+                SimpleNamespace(value="/workgroup/", alt_text="The Workgroup")
+            ],
+            "show_footer": True,
+            "show_release": False,
+        },
+    )
+
+    assert 'href="/workgroup/"' in html
+    assert 'target="_blank"' not in html
+    assert "The Workgroup" in html
+
+
+@override_settings(
+    WORKGROUP_DAILY_PASSWORD_SEED="command-seed",
+    WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
+)
+def test_workgroup_password_command_prints_json_for_date():
+    stdout = io.StringIO()
+
+    call_command("workgroup_password", "--date", "2026-05-16", "--json", stdout=stdout)
+
+    output = stdout.getvalue()
+    assert '"date": "2026-05-16"' in output
+    assert '"timezone": "America/Monterrey"' in output
+    assert password_for_date(dt.date(2026, 5, 16), seed="command-seed") in output
+
+
+@override_settings(WORKGROUP_DAILY_PASSWORD_SEED="command-seed")
+def test_workgroup_password_command_apply_user_does_not_print_password(monkeypatch):
+    calls = []
+
+    def fake_run(command, *, input, text, check, capture_output):
+        calls.append(
+            {
+                "command": command,
+                "input": input,
+                "text": text,
+                "check": check,
+                "capture_output": capture_output,
+            }
+        )
+
+    monkeypatch.setattr(
+        "apps.sites.management.commands.workgroup_password.subprocess.run",
+        fake_run,
+    )
+    monkeypatch.setattr(
+        "apps.sites.management.commands.workgroup_password.os.geteuid",
+        lambda: 0,
+        raising=False,
+    )
+    stdout = io.StringIO()
+
+    call_command(
+        "workgroup_password",
+        "--date",
+        "2026-05-16",
+        "--apply-user",
+        "play",
+        stdout=stdout,
+    )
+
+    generated = password_for_date(dt.date(2026, 5, 16), seed="command-seed")
+    assert calls == [
+        {
+            "command": ["chpasswd"],
+            "input": f"play:{generated}\n",
+            "text": True,
+            "check": True,
+            "capture_output": True,
+        }
+    ]
+    assert generated not in stdout.getvalue()
+    assert "Updated password for play for 2026-05-16." in stdout.getvalue()

--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -41,18 +41,19 @@ def test_current_workgroup_password_uses_configured_timezone():
 
 @pytest.mark.django_db
 @override_settings(
+    ALLOWED_HOSTS=["play.example.test"],
     WORKGROUP_DAILY_PASSWORD_SEED="view-seed",
     WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
 )
 def test_workgroup_page_shows_daily_password_and_usage(client):
     expected = current_password().password
 
-    response = client.get(reverse("pages:workgroup"))
+    response = client.get(reverse("pages:workgroup"), HTTP_HOST="play.example.test")
 
     assert response.status_code == 200
     assert "The Workgroup" in response.content.decode()
     assert expected in response.content.decode()
-    assert "ssh -p 2222 play@arthexis.com" in response.content.decode()
+    assert "ssh -p 2222 play@play.example.test" in response.content.decode()
     assert "connect &lt;account&gt; &lt;account-password&gt;" in response.content.decode()
 
 

--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -1,14 +1,18 @@
 import datetime as dt
 import io
 import json
+from importlib import import_module
 from types import SimpleNamespace
 
+import pytest
+from django.apps import apps as django_apps
 from django.core.management import call_command
+from django.db import connection
 from django.template.loader import render_to_string
 from django.test import override_settings
 from django.urls import reverse
-import pytest
 
+from apps.links.models import Reference
 from apps.sites.workgroup_passwords import current_password, password_for_date
 
 
@@ -67,6 +71,65 @@ def test_footer_renders_workgroup_as_same_window_internal_link():
     assert 'href="/workgroup/"' in html
     assert 'target="_blank"' not in html
     assert "The Workgroup" in html
+
+
+def test_footer_renders_protocol_relative_urls_as_external_links():
+    html = render_to_string(
+        "core/footer.html",
+        {
+            "footer_refs": [
+                SimpleNamespace(value="//example.com/workgroup", alt_text="External")
+            ],
+            "show_footer": True,
+            "show_release": False,
+        },
+    )
+
+    assert 'href="//example.com/workgroup"' in html
+    assert 'target="_blank"' in html
+    assert 'rel="noopener noreferrer"' in html
+
+
+@pytest.mark.django_db
+def test_workgroup_footer_migration_prefers_active_reference():
+    migration = import_module(
+        "apps.links.migrations.0008_replace_wizards_with_workgroup_footer"
+    )
+    deleted_canonical = Reference.all_objects.create(
+        alt_text="The Workgroup",
+        value="/workgroup/",
+        method="link",
+        include_in_footer=True,
+        footer_visibility="public",
+        is_seed_data=True,
+    )
+    Reference.all_objects.filter(pk=deleted_canonical.pk).update(is_deleted=True)
+    active_wizard = Reference.objects.create(
+        alt_text="The Wizards",
+        value="https://company.wizards.com/",
+        method="link",
+        include_in_footer=True,
+        footer_visibility="public",
+        is_seed_data=True,
+    )
+
+    migration.replace_wizards_with_workgroup_footer(
+        django_apps,
+        SimpleNamespace(connection=connection),
+    )
+
+    active_wizard.refresh_from_db()
+    assert active_wizard.alt_text == "The Workgroup"
+    assert active_wizard.value == "/workgroup/"
+    assert active_wizard.method == "link"
+    assert active_wizard.include_in_footer is True
+    assert active_wizard.footer_visibility == "public"
+    assert active_wizard.is_seed_data is True
+    assert active_wizard.is_deleted is False
+    assert Reference.objects.filter(
+        alt_text="The Workgroup",
+        value="/workgroup/",
+    ).count() == 1
 
 
 @override_settings(

--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -1,12 +1,13 @@
 import datetime as dt
 import io
+import json
 from types import SimpleNamespace
 
-import pytest
 from django.core.management import call_command
 from django.template.loader import render_to_string
 from django.test import override_settings
 from django.urls import reverse
+import pytest
 
 from apps.sites.workgroup_passwords import current_password, password_for_date
 
@@ -77,10 +78,10 @@ def test_workgroup_password_command_prints_json_for_date():
 
     call_command("workgroup_password", "--date", "2026-05-16", "--json", stdout=stdout)
 
-    output = stdout.getvalue()
-    assert '"date": "2026-05-16"' in output
-    assert '"timezone": "America/Monterrey"' in output
-    assert password_for_date(dt.date(2026, 5, 16), seed="command-seed") in output
+    output = json.loads(stdout.getvalue())
+    assert output["date"] == "2026-05-16"
+    assert output["timezone"] == "America/Monterrey"
+    assert output["password"] == password_for_date(dt.date(2026, 5, 16), seed="command-seed")
 
 
 @override_settings(WORKGROUP_DAILY_PASSWORD_SEED="command-seed")

--- a/apps/sites/urls.py
+++ b/apps/sites/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("", landing.index, name="index"),
     path("footer/", landing.footer_fragment, name="footer-fragment"),
     path("operator-interface/", landing.operator_interface_notice, name="operator-interface-notice"),
+    path("workgroup/", landing.workgroup, name="workgroup"),
     path("sitemap.xml", landing.sitemap, name="pages-sitemap"),
     path("changelog/", landing.changelog_report, name="changelog"),
     path("visitors/", landing.visitors, name="visitors"),

--- a/apps/sites/views/__init__.py
+++ b/apps/sites/views/__init__.py
@@ -10,6 +10,7 @@ from .landing import (
     release_checklist,
     sitemap,
     submit_user_story,
+    workgroup,
 )
 from .management import (
     CustomLoginView,
@@ -53,4 +54,5 @@ __all__ = [
     "sitemap",
     "submit_user_story",
     "whatsapp_webhook",
+    "workgroup",
 ]

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -35,6 +35,7 @@ from ..utils import (
     get_request_language_code,
     landing,
 )
+from ..workgroup_passwords import current_password
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +121,20 @@ def operator_interface_notice(request):
         request,
         "pages/operator_interface_notice.html",
         _operator_interface_notice_context(request, site),
+    )
+
+
+@require_GET
+def workgroup(request):
+    password = current_password()
+    return TemplateResponse(
+        request,
+        "pages/workgroup.html",
+        {
+            "password": password,
+            "title": "The Workgroup",
+            "force_footer": True,
+        },
     )
 
 

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_GET, require_POST
 
 from apps.core import changelog
@@ -125,6 +126,7 @@ def operator_interface_notice(request):
 
 
 @require_GET
+@never_cache
 def workgroup(request):
     password = current_password()
     return TemplateResponse(

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -125,6 +125,12 @@ def operator_interface_notice(request):
     )
 
 
+def _format_workgroup_ssh_host(request) -> str:
+    raw_host = request.get_host()
+    parsed = urlsplit(f"//{raw_host}")
+    return parsed.hostname or raw_host
+
+
 @require_GET
 @never_cache
 def workgroup(request):
@@ -134,6 +140,7 @@ def workgroup(request):
         "pages/workgroup.html",
         {
             "password": password,
+            "play_ssh_host": _format_workgroup_ssh_host(request),
             "title": "The Workgroup",
             "force_footer": True,
         },

--- a/apps/sites/workgroup_passwords.py
+++ b/apps/sites/workgroup_passwords.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from django.conf import settings
+from django.utils import timezone
+
+WORKGROUP_WORDS: tuple[str, ...] = (
+    "amber",
+    "anchor",
+    "apex",
+    "archive",
+    "atlas",
+    "aurora",
+    "bastion",
+    "beacon",
+    "binary",
+    "bravo",
+    "canvas",
+    "cedar",
+    "cipher",
+    "cobalt",
+    "comet",
+    "copper",
+    "delta",
+    "ember",
+    "fabric",
+    "fathom",
+    "forge",
+    "garden",
+    "harbor",
+    "haven",
+    "helios",
+    "horizon",
+    "index",
+    "ivory",
+    "juniper",
+    "kernel",
+    "lattice",
+    "ledger",
+    "magnet",
+    "matrix",
+    "meridian",
+    "mirror",
+    "nexus",
+    "nickel",
+    "nova",
+    "onyx",
+    "orbit",
+    "parity",
+    "quartz",
+    "radial",
+    "relay",
+    "ripple",
+    "signal",
+    "silver",
+    "summit",
+    "syntax",
+    "tempo",
+    "thread",
+    "titan",
+    "topaz",
+    "vector",
+    "velvet",
+    "vertex",
+    "violet",
+    "wander",
+    "window",
+    "xenon",
+    "yellow",
+    "zenith",
+    "zircon",
+)
+
+
+@dataclass(frozen=True)
+class WorkgroupPassword:
+    password: str
+    first_word: str
+    second_word: str
+    date: dt.date
+    timezone_name: str
+    valid_from: dt.datetime
+    valid_until: dt.datetime
+
+
+def _timezone_name() -> str:
+    return (
+        getattr(settings, "WORKGROUP_DAILY_PASSWORD_TIMEZONE", "")
+        or getattr(settings, "TIME_ZONE", "")
+        or "UTC"
+    )
+
+
+def _zoneinfo() -> ZoneInfo:
+    name = _timezone_name()
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
+def _password_seed() -> str:
+    return (
+        getattr(settings, "WORKGROUP_DAILY_PASSWORD_SEED", "")
+        or getattr(settings, "SECRET_KEY", "")
+        or "arthexis-workgroup"
+    )
+
+
+def password_for_date(day: dt.date, *, seed: str | None = None) -> str:
+    """Return the two-word workgroup password for a local calendar date."""
+
+    secret = (seed if seed is not None else _password_seed()).encode("utf-8")
+    digest = hmac.new(
+        secret,
+        f"workgroup-password:{day.isoformat()}".encode(),
+        hashlib.sha256,
+    ).digest()
+    first = int.from_bytes(digest[:4], "big") % len(WORKGROUP_WORDS)
+    second = int.from_bytes(digest[4:8], "big") % len(WORKGROUP_WORDS)
+    if first == second:
+        second = (second + 1) % len(WORKGROUP_WORDS)
+    return f"{WORKGROUP_WORDS[first]}-{WORKGROUP_WORDS[second]}"
+
+
+def password_record_for_date(day: dt.date) -> WorkgroupPassword:
+    zone = _zoneinfo()
+    valid_from = dt.datetime.combine(day, dt.time.min, tzinfo=zone)
+    valid_until = valid_from + dt.timedelta(days=1)
+    password = password_for_date(day)
+    first, second = password.split("-", 1)
+    return WorkgroupPassword(
+        password=password,
+        first_word=first,
+        second_word=second,
+        date=day,
+        timezone_name=zone.key,
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+
+
+def current_password(now: dt.datetime | None = None) -> WorkgroupPassword:
+    zone = _zoneinfo()
+    current = now or timezone.now()
+    if timezone.is_naive(current):
+        current = timezone.make_aware(current, zone)
+    current = current.astimezone(zone)
+    return password_record_for_date(current.date())

--- a/apps/sites/workgroup_passwords.py
+++ b/apps/sites/workgroup_passwords.py
@@ -79,6 +79,7 @@ WORKGROUP_WORDS: tuple[str, ...] = (
 
 @dataclass(frozen=True)
 class WorkgroupPassword:
+    """Daily password plus local-day validity [valid_from, valid_until) in timezone_name."""
     password: str
     first_word: str
     second_word: str
@@ -129,9 +130,10 @@ def password_for_date(day: dt.date, *, seed: str | None = None) -> str:
 
 
 def password_record_for_date(day: dt.date) -> WorkgroupPassword:
+    """Return the password record for local calendar `day` in configured timezone."""
     zone = _zoneinfo()
     valid_from = dt.datetime.combine(day, dt.time.min, tzinfo=zone)
-    valid_until = valid_from + dt.timedelta(days=1)
+    valid_until = dt.datetime.combine(day + dt.timedelta(days=1), dt.time.min, tzinfo=zone)
     password = password_for_date(day)
     first, second = password.split("-", 1)
     return WorkgroupPassword(
@@ -146,6 +148,7 @@ def password_record_for_date(day: dt.date) -> WorkgroupPassword:
 
 
 def current_password(now: dt.datetime | None = None) -> WorkgroupPassword:
+    """Return the current local-day password record in the configured timezone."""
     zone = _zoneinfo()
     current = now or timezone.now()
     if timezone.is_naive(current):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -34,6 +34,10 @@ def _default_field_encryption_key() -> str:
 FIELD_ENCRYPTION_KEY = os.environ.get(
     "FIELD_ENCRYPTION_KEY", _default_field_encryption_key()
 )
+WORKGROUP_DAILY_PASSWORD_SEED = os.environ.get("ARTHEXIS_WORKGROUP_PASSWORD_SEED", "")
+WORKGROUP_DAILY_PASSWORD_TIMEZONE = os.environ.get(
+    "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE", ""
+)
 
 # Determine the current node role for role-specific settings while leaving
 # DEBUG control to the environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ In Arthexis terminology, the **suite** is the collection of applications, while 
 - [Integration Onboarding Tracks](integrations/onboarding-tracks.md)
 - OCPP 1.6 coverage artifact: `apps/ocpp/coverage.json`
 - [Ops Command Wrapper](operations/operational-commands.md)
+- [Workgroup Play Password](operations/workgroup-play-password.md)
 - [Imager SD-Card Recovery Workflow](operations/imager-sd-card-recovery.md)
 - [Reinstall + Data Import Runbook (1.0+)](operations/reinstall-data-import-runbook.md)
 - [Suite Services Report](suite-services-report.md)

--- a/docs/operations/workgroup-play-password.md
+++ b/docs/operations/workgroup-play-password.md
@@ -1,0 +1,50 @@
+# Workgroup Play Password
+
+The public Evennia play account uses a daily two-word password instead of a
+fixed shared password. The current password is displayed on:
+
+```text
+https://arthexis.com/workgroup/
+```
+
+The page is linked from the public footer as `The Workgroup`.
+
+## Configuration
+
+Set a stable secret seed on each deployed node:
+
+```bash
+python manage.py env --set ARTHEXIS_WORKGROUP_PASSWORD_SEED '<secret-seed>'
+python manage.py env --set ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE America/Monterrey
+```
+
+`ARTHEXIS_WORKGROUP_PASSWORD_SEED` must not be committed. The suite derives the
+daily password from this seed and the local calendar date.
+
+## Rotation
+
+To inspect the current password metadata:
+
+```bash
+python manage.py workgroup_password --json
+```
+
+To set the local Unix `play` account password without echoing the password:
+
+```bash
+sudo -E python manage.py workgroup_password --apply-user play
+```
+
+Production nodes should run that command shortly after local midnight with a
+systemd timer. If the seed changes, run the command once immediately so the Unix
+account matches the value published on `/workgroup/`.
+
+To install the production timer from a deployed suite checkout:
+
+```bash
+sudo scripts/setup_workgroup_play_password.sh --apply-now
+```
+
+The setup script creates a seed when none exists, stores it in `arthexis.env`,
+restricts that file to the node account, and installs
+`arthexis-workgroup-play-password.timer`.

--- a/docs/operations/workgroup-play-password.md
+++ b/docs/operations/workgroup-play-password.md
@@ -35,9 +35,9 @@ To set the local Unix `play` account password without echoing the password:
 sudo -E python manage.py workgroup_password --apply-user play
 ```
 
-Production nodes should run that command shortly after local midnight with a
-systemd timer. If the seed changes, run the command once immediately so the Unix
-account matches the value published on `/workgroup/`.
+Production nodes should run that command at local midnight with a systemd timer.
+If the seed changes, run the command once immediately so the Unix account
+matches the value published on `/workgroup/`.
 
 To install the production timer from a deployed suite checkout:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
       - Install & Lifecycle Scripts Manual: development/install-lifecycle-scripts-manual.md
       - Good Command: operations/good-command.md
       - Operational Commands: operations/operational-commands.md
+      - Workgroup Play Password: operations/workgroup-play-password.md
       - Loki + Promtail Integration: operations/logging-loki-promtail.md
       - Reinstall + Data Import Runbook: operations/reinstall-data-import-runbook.md
   - Integrations:

--- a/scripts/setup_workgroup_play_password.sh
+++ b/scripts/setup_workgroup_play_password.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$BASE_DIR/arthexis.env"
+SERVICE_FILE="/etc/systemd/system/arthexis-workgroup-play-password.service"
+TIMER_FILE="/etc/systemd/system/arthexis-workgroup-play-password.timer"
+TIMEZONE_VALUE="${ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE:-America/Monterrey}"
+APPLY_NOW=false
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: sudo scripts/setup_workgroup_play_password.sh [--apply-now]
+
+Install the systemd timer that rotates the local Unix play account to the
+daily Workgroup password published by the suite at /workgroup/.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply-now)
+      APPLY_NOW=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Run as root so the script can install systemd units and update play." >&2
+  exit 1
+fi
+
+if [ ! -d "$BASE_DIR/.venv" ]; then
+  echo "Virtual environment not found at $BASE_DIR/.venv." >&2
+  exit 1
+fi
+
+if ! id play >/dev/null 2>&1; then
+  echo "Unix user 'play' does not exist." >&2
+  exit 1
+fi
+
+set_env_value() {
+  local key="$1"
+  local value="$2"
+  "$BASE_DIR/.venv/bin/python" "$BASE_DIR/manage.py" env --set "$key" "$value" >/dev/null
+}
+
+if [ ! -f "$ENV_FILE" ] || ! grep -q '^ARTHEXIS_WORKGROUP_PASSWORD_SEED=' "$ENV_FILE"; then
+  seed="$("$BASE_DIR/.venv/bin/python" - <<'PY'
+import secrets
+
+print(secrets.token_urlsafe(48))
+PY
+)"
+  set_env_value "ARTHEXIS_WORKGROUP_PASSWORD_SEED" "$seed"
+fi
+
+if [ ! -f "$ENV_FILE" ] || ! grep -q '^ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE=' "$ENV_FILE"; then
+  set_env_value "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE" "$TIMEZONE_VALUE"
+fi
+
+repo_owner="$(stat -c '%U:%G' "$BASE_DIR")"
+chown "$repo_owner" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Rotate Arthexis Workgroup play SSH password
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=$BASE_DIR
+ExecStart=/bin/bash -lc 'set -a; . "$ENV_FILE"; set +a; . "$BASE_DIR/.venv/bin/activate"; exec python "$BASE_DIR/manage.py" workgroup_password --apply-user play'
+EOF
+
+cat > "$TIMER_FILE" <<'EOF'
+[Unit]
+Description=Daily Arthexis Workgroup play SSH password rotation
+
+[Timer]
+OnCalendar=*-*-* 00:01:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now arthexis-workgroup-play-password.timer
+
+if [ "$APPLY_NOW" = true ]; then
+  systemctl start arthexis-workgroup-play-password.service
+fi
+
+echo "Installed arthexis-workgroup-play-password.timer."

--- a/scripts/setup_workgroup_play_password.sh
+++ b/scripts/setup_workgroup_play_password.sh
@@ -82,15 +82,16 @@ After=network-online.target
 [Service]
 Type=oneshot
 WorkingDirectory=$BASE_DIR
-ExecStart=/bin/bash -lc 'set -a; . "$ENV_FILE"; set +a; . "$BASE_DIR/.venv/bin/activate"; exec python "$BASE_DIR/manage.py" workgroup_password --apply-user play'
+EnvironmentFile=$ENV_FILE
+ExecStart=$BASE_DIR/.venv/bin/python $BASE_DIR/manage.py workgroup_password --apply-user play
 EOF
 
-cat > "$TIMER_FILE" <<'EOF'
+cat > "$TIMER_FILE" <<EOF
 [Unit]
 Description=Daily Arthexis Workgroup play SSH password rotation
 
 [Timer]
-OnCalendar=*-*-* 00:01:00
+OnCalendar=*-*-* 00:01:00 $TIMEZONE_VALUE
 Persistent=true
 RandomizedDelaySec=300
 

--- a/scripts/setup_workgroup_play_password.sh
+++ b/scripts/setup_workgroup_play_password.sh
@@ -56,6 +56,12 @@ set_env_value() {
   "$BASE_DIR/.venv/bin/python" "$BASE_DIR/manage.py" env --set "$key" "$value" >/dev/null
 }
 
+get_env_value() {
+  local key="$1"
+  "$BASE_DIR/.venv/bin/python" "$BASE_DIR/manage.py" env --get "$key" 2>/dev/null \
+    | awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); value=$0 } END { if (value != "") print value }'
+}
+
 if [ ! -f "$ENV_FILE" ] || ! grep -q '^ARTHEXIS_WORKGROUP_PASSWORD_SEED=' "$ENV_FILE"; then
   seed="$("$BASE_DIR/.venv/bin/python" - <<'PY'
 import secrets
@@ -72,7 +78,7 @@ fi
 
 TIMER_TIMEZONE="$TIMEZONE_VALUE"
 if [ -f "$ENV_FILE" ]; then
-  env_timezone="$(grep -E '^ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE=' "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+  env_timezone="$(get_env_value "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE" || true)"
   if [ -n "${env_timezone:-}" ]; then
     TIMER_TIMEZONE="$env_timezone"
   fi
@@ -99,9 +105,8 @@ cat > "$TIMER_FILE" <<EOF
 Description=Daily Arthexis Workgroup play SSH password rotation
 
 [Timer]
-OnCalendar=*-*-* 00:01:00 $TIMER_TIMEZONE
+OnCalendar=*-*-* 00:00:00 $TIMER_TIMEZONE
 Persistent=true
-RandomizedDelaySec=300
 
 [Install]
 WantedBy=timers.target

--- a/scripts/setup_workgroup_play_password.sh
+++ b/scripts/setup_workgroup_play_password.sh
@@ -70,6 +70,14 @@ if [ ! -f "$ENV_FILE" ] || ! grep -q '^ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE=' "$
   set_env_value "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE" "$TIMEZONE_VALUE"
 fi
 
+TIMER_TIMEZONE="$TIMEZONE_VALUE"
+if [ -f "$ENV_FILE" ]; then
+  env_timezone="$(grep -E '^ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE=' "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+  if [ -n "${env_timezone:-}" ]; then
+    TIMER_TIMEZONE="$env_timezone"
+  fi
+fi
+
 repo_owner="$(stat -c '%U:%G' "$BASE_DIR")"
 chown "$repo_owner" "$ENV_FILE"
 chmod 600 "$ENV_FILE"
@@ -91,7 +99,7 @@ cat > "$TIMER_FILE" <<EOF
 Description=Daily Arthexis Workgroup play SSH password rotation
 
 [Timer]
-OnCalendar=*-*-* 00:01:00 $TIMEZONE_VALUE
+OnCalendar=*-*-* 00:01:00 $TIMER_TIMEZONE
 Persistent=true
 RandomizedDelaySec=300
 

--- a/scripts/setup_workgroup_play_password.sh
+++ b/scripts/setup_workgroup_play_password.sh
@@ -106,6 +106,7 @@ Description=Daily Arthexis Workgroup play SSH password rotation
 
 [Timer]
 OnCalendar=*-*-* 00:00:00 $TIMER_TIMEZONE
+AccuracySec=1s
 Persistent=true
 
 [Install]


### PR DESCRIPTION
﻿## Summary
- add a public `/workgroup/` page that displays the daily two-word play SSH password without using the retired fixed default
- replace the footer "The Wizards" seed reference with "The Workgroup" and keep internal footer links same-window
- add `workgroup_password` management command plus a production timer setup script for the Unix `play` account
- document the deployment and rotation flow

## Validation
- `.\.venv\Scripts\python.exe -m ruff check apps\sites\workgroup_passwords.py apps\sites\management\commands\workgroup_password.py apps\sites\tests\test_workgroup_password.py apps\links\migrations\0008_replace_wizards_with_workgroup_footer.py`
- `.\.venv\Scripts\python.exe -m pytest apps\sites\tests\test_workgroup_password.py -q`
- `.\.venv\Scripts\python.exe manage.py check`
- `.\.venv\Scripts\python.exe manage.py makemigrations --check --dry-run`
- remote Linux `bash -n` validation for `scripts/setup_workgroup_play_password.sh`

## Production notes
- Bastion configuration staged Workgroup seed/timezone keys in `/home/ubuntu/arthexis/arthexis.env` without printing secret values.
- Bastion configuration installed `arthexis-workgroup-play-password.service` and `.timer`, but left the timer disabled because production `/workgroup/` still returns 404 until this suite release is deployed.
- After deployment, run `sudo scripts/setup_workgroup_play_password.sh --apply-now` from `/home/ubuntu/arthexis` to enable the daily rotation and immediately align the Unix `play` password with the page.

## Docs and skills
- Updated suite docs in `docs/operations/workgroup-play-password.md`.
- Updated local Codex skills for Evennia node, live status, and agent harness use.
- Updated remote Evennia runbook and node-local skill docs through the GWAY bastion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->