### PR TITLE
[codex] Interleave LCD summary rotation

### DIFF
--- a/apps/screens/lcd_screen/runner.py
+++ b/apps/screens/lcd_screen/runner.py
@@ -413,12 +413,16 @@ class LCDRunner:
                 return True
             return False
 
-        def _append_summary(normal_order: tuple[str, ...]) -> tuple[str, ...]:
+        def _interleave_summary(normal_order: tuple[str, ...]) -> tuple[str, ...]:
             if not normal_order:
                 return ("summary",)
-            return (*normal_order, "summary")
+            interleaved: list[str] = []
+            for label in normal_order:
+                interleaved.extend((label, "summary"))
+            return tuple(interleaved)
 
         previous_order = self.rotation.order
+        previous_index = self.rotation.index
         if configured_order:
             self.rotation.order = tuple(
                 label for label in configured_order if _channel_available(label)
@@ -444,13 +448,29 @@ class LCDRunner:
                     ("low", *utility_order) if low_available else utility_order
                 )
             self.rotation.order = (
-                _append_summary(normal_order) if summary_available else normal_order
+                _interleave_summary(normal_order)
+                if summary_available
+                else normal_order
             )
 
-        if previous_order and 0 <= self.rotation.index < len(previous_order):
-            current_label = previous_order[self.rotation.index]
+        if (
+            previous_order == self.rotation.order
+            and 0 <= previous_index < len(self.rotation.order)
+        ):
+            self.rotation.index = previous_index
+            return
+        if previous_order and 0 <= previous_index < len(previous_order):
+            current_label = previous_order[previous_index]
             if current_label in self.rotation.order:
-                self.rotation.index = self.rotation.order.index(current_label)
+                matching_indexes = [
+                    index
+                    for index, label in enumerate(self.rotation.order)
+                    if label == current_label
+                ]
+                self.rotation.index = min(
+                    matching_indexes,
+                    key=lambda index: (abs(index - previous_index), index),
+                )
             else:
                 self.rotation.index = 0
         else:

--- a/apps/screens/tests/test_lcd_runner.py
+++ b/apps/screens/tests/test_lcd_runner.py
@@ -484,7 +484,7 @@ def test_low_slot_does_not_mirror_high_when_rotation_order_excludes_high(monkeyp
     assert coordinator.high_repeat_count == 0
 
 
-def test_rotation_order_appends_summary_channel_once_when_active(monkeypatch):
+def test_rotation_order_interleaves_summary_channel_when_active(monkeypatch):
     coordinator = runner.LCDRunner()
 
     monkeypatch.setattr(runner.locks, "_load_channel_order", lambda lock_dir: None)
@@ -513,11 +513,60 @@ def test_rotation_order_appends_summary_channel_once_when_active(monkeypatch):
 
     assert coordinator.rotation.order == (
         "high",
+        "summary",
         "low",
+        "summary",
         "stats",
+        "summary",
         "clock",
         "summary",
     )
+    assert all(
+        label == "summary"
+        for index, label in enumerate(coordinator.rotation.order)
+        if index % 2 == 1
+    )
+
+
+def test_interleaved_summary_order_preserves_duplicate_summary_index(monkeypatch):
+    coordinator = runner.LCDRunner()
+    coordinator.rotation.order = (
+        "high",
+        "summary",
+        "low",
+        "summary",
+        "stats",
+        "summary",
+        "clock",
+        "summary",
+    )
+    coordinator.rotation.index = 3
+
+    monkeypatch.setattr(runner.locks, "_load_channel_order", lambda lock_dir: None)
+
+    payload_cycle = runner.ChannelCycle(
+        payloads=[runner.locks.LockPayload("x", "", 0)],
+        signature=((0, 0.0),),
+        index=0,
+    )
+    channel_info = {
+        "high": payload_cycle,
+        "low": payload_cycle,
+        "summary": payload_cycle,
+        "clock": payload_cycle,
+        "stats": payload_cycle,
+    }
+    channel_text = {
+        "high": True,
+        "low": True,
+        "summary": True,
+        "clock": False,
+        "stats": False,
+    }
+
+    coordinator.configure_rotation_order(channel_info, channel_text)
+
+    assert coordinator.rotation.index == 3
 
 
 def test_low_channel_keeps_generated_base_with_lock_payloads(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Interleave the LCD `summary` channel after every regular rotation slot when the summary channel is available.
- Preserve explicit `lcd-channels.lck` ordering as an operator override.
- Keep rotation index preservation stable when the order contains repeated `summary` entries.

## Validation

- `pytest apps/screens/tests/test_lcd_runner.py`
- `git diff --check`