### PR TITLE
Add "Changes since last release" section to release readiness report

### DIFF
--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -578,6 +578,7 @@ jobs:
           CAN_SIMULATE: ${{ needs.evaluate.outputs.can_simulate }}
           SIMULATED_OK: ${{ needs.simulate_release.outputs.simulated_ok }}
           SIM_SUMMARY: ${{ needs.simulate_release.outputs.summary_markdown }}
+          DEFAULT_BRANCH: ${{ needs.evaluate.outputs.default_branch }}
         with:
           script: |
             const title = 'Release Readiness Report';
@@ -592,6 +593,7 @@ jobs:
               '',
               '- ❌ Release simulation failed before producing a summary. Check the workflow run logs.'
             ].join('\n');
+            const defaultBranch = process.env.DEFAULT_BRANCH || context.payload.repository?.default_branch;
 
             async function collectChangeLines() {
               const maxEntries = 25;
@@ -612,28 +614,29 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   base: tagName,
-                  head: context.sha,
+                  head: defaultBranch,
                 });
                 const commits = comparison.data?.commits || [];
+                const totalCommits = comparison.data?.total_commits ?? commits.length;
                 if (!commits.length) {
                   return {
-                    heading: `## Changes since last release (${tagName} → ${context.sha.slice(0, 7)})`,
+                    heading: `## Changes since last release (${tagName} → ${defaultBranch})`,
                     lines: ['- No unreleased commits detected.'],
                   };
                 }
 
-                const lines = commits.slice(0, maxEntries).map((commit) => {
+                const lines = commits.slice(-maxEntries).reverse().map((commit) => {
                   const shortSha = (commit.sha || '').slice(0, 7);
                   const message = String(commit.commit?.message || '').split('\n')[0].trim();
                   const author = commit.commit?.author?.name || commit.author?.login || 'unknown author';
                   const url = commit.html_url || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit.sha}`;
                   return `- [${shortSha}](${url}) ${message} — ${author}`;
                 });
-                if (commits.length > maxEntries) {
-                  lines.push(`- _And ${commits.length - maxEntries} more commit(s)._`);
+                if (totalCommits > lines.length) {
+                  lines.push(`- _And ${totalCommits - lines.length} more commit(s)._`);
                 }
                 return {
-                  heading: `## Changes since last release (${tagName} → ${context.sha.slice(0, 7)})`,
+                  heading: `## Changes since last release (${tagName} → ${defaultBranch})`,
                   lines,
                 };
               } catch (error) {

--- a/.github/workflows/release-simulator.yml
+++ b/.github/workflows/release-simulator.yml
@@ -593,6 +593,66 @@ jobs:
               '- ❌ Release simulation failed before producing a summary. Check the workflow run logs.'
             ].join('\n');
 
+            async function collectChangeLines() {
+              const maxEntries = 25;
+              try {
+                const latestRelease = await github.rest.repos.getLatestRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+                const tagName = latestRelease.data?.tag_name;
+                if (!tagName) {
+                  return {
+                    heading: '## Changes since last release',
+                    lines: ['- Unable to determine the latest release tag.'],
+                  };
+                }
+
+                const comparison = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: tagName,
+                  head: context.sha,
+                });
+                const commits = comparison.data?.commits || [];
+                if (!commits.length) {
+                  return {
+                    heading: `## Changes since last release (${tagName} → ${context.sha.slice(0, 7)})`,
+                    lines: ['- No unreleased commits detected.'],
+                  };
+                }
+
+                const lines = commits.slice(0, maxEntries).map((commit) => {
+                  const shortSha = (commit.sha || '').slice(0, 7);
+                  const message = String(commit.commit?.message || '').split('\n')[0].trim();
+                  const author = commit.commit?.author?.name || commit.author?.login || 'unknown author';
+                  const url = commit.html_url || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit.sha}`;
+                  return `- [${shortSha}](${url}) ${message} — ${author}`;
+                });
+                if (commits.length > maxEntries) {
+                  lines.push(`- _And ${commits.length - maxEntries} more commit(s)._`);
+                }
+                return {
+                  heading: `## Changes since last release (${tagName} → ${context.sha.slice(0, 7)})`,
+                  lines,
+                };
+              } catch (error) {
+                if (error?.status === 404) {
+                  return {
+                    heading: '## Changes since last release',
+                    lines: ['- No published release found yet.'],
+                  };
+                }
+                core.warning(`Unable to collect changes since last release: ${error?.message || error}`);
+                return {
+                  heading: '## Changes since last release',
+                  lines: ['- Unable to collect change list for this run. Check workflow logs.'],
+                };
+              }
+            }
+
+            const changesSinceRelease = await collectChangeLines();
+
             const blockerSection = blockers.length
               ? blockers.map((blocker) => `- ${blocker}`).join('\n')
               : '- None detected.';
@@ -613,6 +673,7 @@ jobs:
                 ref: context.ref,
                 simulatedOk,
                 simulationSummary,
+                changesSinceRelease,
               }))
               .digest('hex');
             const fingerprintMarker = `<!-- release-readiness-fingerprint:${reportFingerprint} -->`;
@@ -633,6 +694,9 @@ jobs:
               '',
               canSimulate ? '## Release simulation' : '## Release simulation',
               canSimulate ? simulationSummary : '- Skipped because release readiness blockers are currently open.',
+              '',
+              changesSinceRelease.heading,
+              ...changesSinceRelease.lines,
               '',
               '## Recommendation',
               recommendation,


### PR DESCRIPTION
### Motivation

- Provide immediate visibility into unreleased commits so maintainers can see what changed since the last published release. 
- Make the readiness report sensitive to commit-level changes so the report fingerprint changes when new commits are present. 

### Description

- Added an async helper `collectChangeLines` that calls `repos.getLatestRelease` and `repos.compareCommits` to assemble a short list of recent commits since the latest release. 
- Limits the displayed commit entries using `maxEntries` (25) and appends a note when more commits exist. 
- Handles missing releases and GitHub API errors (including `404`) and returns appropriate headings and fallback lines. 
- Injects the resulting `changesSinceRelease` heading and lines into the issue body and includes `changesSinceRelease` in the report fingerprint to ensure updates refresh the issue. 

### Testing

- No automated tests were added or modified for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0877d4a26c8326a13ef5f783daedfe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

The release simulator workflow's "report" job now includes a "Changes since last release" section in the generated release readiness report. 

### Implementation details

A new async helper function `collectChangeLines()` was added that:

- Fetches the latest GitHub release tag using `github.rest.repos.getLatestRelease()`
- Compares commits between that tag and the current commit SHA using `github.rest.repos.compareCommits()`
- Formats commit entries with short SHA (7 characters), commit message, and author name
- Limits displayed commits to 25 entries, with a note appended if additional commits exist
- Returns appropriate fallback messages for edge cases: missing releases (404 errors), unable to determine latest tag, or no unreleased commits detected

### Integration into report generation

The `changesSinceRelease` object (containing heading and formatted lines) is:
- Included in the report fingerprint calculation, ensuring the issue updates when commits change
- Inserted into the issue body immediately after the release simulation section

### Error handling

The helper includes error handling for GitHub API failures:
- 404 errors return a message indicating no published release found
- Other errors log a warning and return a fallback message directing users to check workflow logs

The workflow continues functioning normally regardless of helper success or failure, preventing blockers to the main report generation flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->