### PR TITLE
Handle missing NodeRole entries when loading modules.module fixtures

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -1063,6 +1063,31 @@ def run_database_tasks(
                             modified = True
                             continue
                     fields = obj.setdefault("fields", {})
+                    if model_label == "modules.module":
+                        roles_field = fields.get("roles")
+                        if isinstance(roles_field, list):
+                            NodeRole = apps.get_model("nodes", "NodeRole")
+                            available_role_names = set(
+                                NodeRole.objects.filter(
+                                    name__in=[
+                                        role[0]
+                                        for role in roles_field
+                                        if isinstance(role, (list, tuple))
+                                        and role
+                                        and isinstance(role[0], str)
+                                    ]
+                                ).values_list("name", flat=True)
+                            )
+                            filtered_roles = [
+                                role
+                                for role in roles_field
+                                if isinstance(role, (list, tuple))
+                                and role
+                                and role[0] in available_role_names
+                            ]
+                            if filtered_roles != roles_field:
+                                fields["roles"] = filtered_roles
+                                modified = True
                     if "user" in fields and isinstance(fields["user"], int):
                         original_user = fields["user"]
                         mapped_user = user_pk_map.get(original_user, original_user)


### PR DESCRIPTION
### Motivation

- Module fixtures include `roles` natural-key lists that can reference `NodeRole` names not present on every node, which caused fixture deserialization failures or skips during refresh. 
- The fixture loader should be resilient to local node role sets so bootstrapping a node with a narrower role set does not fail.

### Description

- Added preprocessing in `env-refresh.py` to detect `modules.module` objects and inspect their `roles` field before deserialization. 
- The code queries `apps.get_model("nodes", "NodeRole")` to compute available role names and filters the fixture `roles` list to only include names present on this node, then writes the patched fixture when a change is required. 
- The loader sets `modified = True` when filtering occurs so the patched fixture is used in deferred loading and avoids `DeserializationError` caused by missing `NodeRole` references.

### Testing

- Attempted to run the targeted test `apps/gallery/tests/test_gallery.py::test_gallery_module_fixture_exposes_ap_guest_landing` via `.venv/bin/python manage.py test run --`, but the environment lacked `.venv` so the test could not be executed here. 
- Attempted to bootstrap the environment with `./install.sh`, but it failed because `redis-server` is not installed in this container, so no automated tests were completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b49c9a3883268748cc659a6075ed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixture Role Filtering for Module Objects

Added preprocessing logic in `env-refresh.py` to handle `modules.module` fixtures that contain references to `NodeRole` entries not present on the current node. 

### Changes

The script now inspects the `roles` field of `modules.module` fixture objects before deserialization. When a `roles` field is detected as a list, the code:

1. Queries the available `NodeRole` names from the database
2. Filters the fixture's `roles` list to retain only entries whose first element (the role name) matches an available `NodeRole`
3. Updates the fixture data and marks it as modified when filtering occurs

This prevents `DeserializationError` exceptions during environment refresh when module fixtures reference role names that don't exist on a given node, allowing bootstrapping to proceed successfully with each node's narrower role set.

### Implementation Details

- Operates within the existing fixture preprocessing loop
- Only processes `modules.module` model fixtures
- Validates that the `roles` field is a list and each role entry is a tuple/list with a string name
- Preserves all other fixture data unchanged
- Sets the `modified` flag to ensure patched fixtures are used in subsequent deferred loading

### Testing Context

Automated test execution was not completed in the environment due to missing dependencies (`.venv`, `redis-server`). The implementation follows the existing fixture preprocessing patterns and integrates with the deferred loading mechanism already used for user fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->