### PR TITLE
Require staff access for workgroup page to avoid public SSH credential disclosure

### DIFF
--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 from django.apps import apps as django_apps
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.db import connection
 from django.template.loader import render_to_string
@@ -46,9 +47,20 @@ def test_current_workgroup_password_uses_configured_timezone():
     WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
 )
 def test_workgroup_page_shows_daily_password_and_usage(client):
+    user_model = get_user_model()
+    staff_user = user_model.objects.create_user(
+        username="workgroup-staff",
+        email="workgroup-staff@example.com",
+        password="secret",
+        is_staff=True,
+    )
     expected = current_password().password
+    url = reverse("pages:workgroup")
 
-    response = client.get(reverse("pages:workgroup"), HTTP_HOST="play.example.test")
+    assert client.get(url, HTTP_HOST="play.example.test").status_code == 302
+
+    client.force_login(staff_user)
+    response = client.get(url, HTTP_HOST="play.example.test")
 
     assert response.status_code == 200
     assert "The Workgroup" in response.content.decode()

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -133,6 +133,7 @@ def _format_workgroup_ssh_host(request) -> str:
 
 @require_GET
 @never_cache
+@staff_required
 def workgroup(request):
     password = current_password()
     return TemplateResponse(


### PR DESCRIPTION
### Motivation
- The public `/workgroup/` page exposed the daily `play` Unix account password and SSH instructions, creating a credential-disclosure vulnerability; this change limits exposure by requiring staff access.

### Description
- Add `@staff_required` to the `workgroup` view in `apps/sites/views/landing.py` and update the test in `apps/sites/tests/test_workgroup_password.py` so anonymous clients are redirected and staff users can still view the page and its SSH instructions.

### Testing
- The unit test `test_workgroup_page_shows_daily_password_and_usage` was updated to create a staff user, assert anonymous access returns a redirect, then log in as staff and assert the page renders with the expected password and SSH command; attempts to run the test in this environment failed because `.venv/bin/python` is not present and `./install.sh` cannot complete due to missing `redis-server`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a9e6329083268bbec64cc19b928a)