### PR TITLE
Enforce public host for Workgroup page and add configurable Workgroup hosts

### DIFF
--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -41,19 +41,24 @@ def test_current_workgroup_password_uses_configured_timezone():
 
 @pytest.mark.django_db
 @override_settings(
-    ALLOWED_HOSTS=["play.example.test"],
+    ALLOWED_HOSTS=["arthexis.com", "play.example.test"],
+    WORKGROUP_PUBLIC_HOST="arthexis.com",
+    WORKGROUP_SSH_HOST="arthexis.com",
     WORKGROUP_DAILY_PASSWORD_SEED="view-seed",
     WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
 )
 def test_workgroup_page_shows_daily_password_and_usage(client):
     expected = current_password().password
 
-    response = client.get(reverse("pages:workgroup"), HTTP_HOST="play.example.test")
+    blocked = client.get(reverse("pages:workgroup"), HTTP_HOST="play.example.test")
+    assert blocked.status_code == 404
+
+    response = client.get(reverse("pages:workgroup"), HTTP_HOST="arthexis.com")
 
     assert response.status_code == 200
     assert "The Workgroup" in response.content.decode()
     assert expected in response.content.decode()
-    assert "ssh -p 2222 play@play.example.test" in response.content.decode()
+    assert "ssh -p 2222 play@arthexis.com" in response.content.decode()
     assert "connect &lt;account&gt; &lt;account-password&gt;" in response.content.decode()
 
 

--- a/apps/sites/tests/test_workgroup_password.py
+++ b/apps/sites/tests/test_workgroup_password.py
@@ -43,7 +43,7 @@ def test_current_workgroup_password_uses_configured_timezone():
 @override_settings(
     ALLOWED_HOSTS=["arthexis.com", "play.example.test"],
     WORKGROUP_PUBLIC_HOST="arthexis.com",
-    WORKGROUP_SSH_HOST="arthexis.com",
+    WORKGROUP_SSH_HOST="ssh.arthexis.com",
     WORKGROUP_DAILY_PASSWORD_SEED="view-seed",
     WORKGROUP_DAILY_PASSWORD_TIMEZONE="America/Monterrey",
 )
@@ -58,7 +58,7 @@ def test_workgroup_page_shows_daily_password_and_usage(client):
     assert response.status_code == 200
     assert "The Workgroup" in response.content.decode()
     assert expected in response.content.decode()
-    assert "ssh -p 2222 play@arthexis.com" in response.content.decode()
+    assert "ssh -p 2222 play@ssh.arthexis.com" in response.content.decode()
     assert "connect &lt;account&gt; &lt;account-password&gt;" in response.content.decode()
 
 

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -131,16 +131,31 @@ def _format_workgroup_ssh_host(request) -> str:
     return parsed.hostname or raw_host
 
 
+def _workgroup_public_host() -> str:
+    return str(getattr(settings, "WORKGROUP_PUBLIC_HOST", "arthexis.com")).strip().lower()
+
+
+def _workgroup_ssh_host() -> str:
+    configured = str(getattr(settings, "WORKGROUP_SSH_HOST", "")).strip()
+    if configured:
+        return configured
+    return _workgroup_public_host() or "arthexis.com"
+
+
 @require_GET
 @never_cache
 def workgroup(request):
+    request_host = _format_workgroup_ssh_host(request).strip().lower()
+    public_host = _workgroup_public_host()
+    if public_host and request_host != public_host:
+        raise Http404
     password = current_password()
     return TemplateResponse(
         request,
         "pages/workgroup.html",
         {
             "password": password,
-            "play_ssh_host": _format_workgroup_ssh_host(request),
+            "play_ssh_host": _workgroup_ssh_host(),
             "title": "The Workgroup",
             "force_footer": True,
         },

--- a/apps/sites/views/landing.py
+++ b/apps/sites/views/landing.py
@@ -132,14 +132,14 @@ def _format_workgroup_ssh_host(request) -> str:
 
 
 def _workgroup_public_host() -> str:
-    return str(getattr(settings, "WORKGROUP_PUBLIC_HOST", "arthexis.com")).strip().lower()
+    return str(getattr(settings, "WORKGROUP_PUBLIC_HOST", "")).strip().lower()
 
 
 def _workgroup_ssh_host() -> str:
     configured = str(getattr(settings, "WORKGROUP_SSH_HOST", "")).strip()
     if configured:
         return configured
-    return _workgroup_public_host() or "arthexis.com"
+    return _workgroup_public_host() or ""
 
 
 @require_GET
@@ -150,12 +150,13 @@ def workgroup(request):
     if public_host and request_host != public_host:
         raise Http404
     password = current_password()
+    play_ssh_host = _workgroup_ssh_host() or request_host
     return TemplateResponse(
         request,
         "pages/workgroup.html",
         {
             "password": password,
-            "play_ssh_host": _workgroup_ssh_host(),
+            "play_ssh_host": play_ssh_host,
             "title": "The Workgroup",
             "force_footer": True,
         },

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -38,6 +38,8 @@ WORKGROUP_DAILY_PASSWORD_SEED = os.environ.get("ARTHEXIS_WORKGROUP_PASSWORD_SEED
 WORKGROUP_DAILY_PASSWORD_TIMEZONE = os.environ.get(
     "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE", ""
 )
+WORKGROUP_PUBLIC_HOST = os.environ.get("ARTHEXIS_WORKGROUP_PUBLIC_HOST", "arthexis.com")
+WORKGROUP_SSH_HOST = os.environ.get("ARTHEXIS_WORKGROUP_SSH_HOST", "arthexis.com")
 
 # Determine the current node role for role-specific settings while leaving
 # DEBUG control to the environment.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -38,8 +38,8 @@ WORKGROUP_DAILY_PASSWORD_SEED = os.environ.get("ARTHEXIS_WORKGROUP_PASSWORD_SEED
 WORKGROUP_DAILY_PASSWORD_TIMEZONE = os.environ.get(
     "ARTHEXIS_WORKGROUP_PASSWORD_TIMEZONE", ""
 )
-WORKGROUP_PUBLIC_HOST = os.environ.get("ARTHEXIS_WORKGROUP_PUBLIC_HOST", "arthexis.com")
-WORKGROUP_SSH_HOST = os.environ.get("ARTHEXIS_WORKGROUP_SSH_HOST", "arthexis.com")
+WORKGROUP_PUBLIC_HOST = os.environ.get("ARTHEXIS_WORKGROUP_PUBLIC_HOST", "")
+WORKGROUP_SSH_HOST = os.environ.get("ARTHEXIS_WORKGROUP_SSH_HOST", "")
 
 # Determine the current node role for role-specific settings while leaving
 # DEBUG control to the environment.


### PR DESCRIPTION
### Motivation
- Ensure the public Workgroup page is only served on the configured public host and not on arbitrary Host headers. 
- Allow the SSH host shown on the Workgroup page to be overridden independently from the incoming request host. 
- Provide environment-configurable defaults for the Workgroup public and SSH hostnames.

### Description
- Add `WORKGROUP_PUBLIC_HOST` and `WORKGROUP_SSH_HOST` settings with defaults in `config/settings/base.py`.
- Add `_workgroup_public_host()` and `_workgroup_ssh_host()` helpers in `apps/sites/views/landing.py` and normalize request host via `_format_workgroup_ssh_host()`.
- Make `workgroup` view return `Http404` when the request host does not match `WORKGROUP_PUBLIC_HOST`, and use `_workgroup_ssh_host()` for the template `play_ssh_host` value.
- Update `apps/sites/tests/test_workgroup_password.py` to assert blocking on non-public hosts and to expect the configured SSH host in the rendered page.

### Testing
- Ran unit tests for the sites app including `apps/sites/tests/test_workgroup_password.py` using the Django test client, and they passed.
- Verified the updated test asserts that a request to a non-public host returns `404` and that the Workgroup page renders the configured SSH host correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bf966dc08326bc08261d9742b2c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR enforces the public host for the Workgroup page and introduces environment-configurable workgroup hostnames.

### Configuration (`config/settings/base.py`)
Added two new settings:
- `WORKGROUP_PUBLIC_HOST`: Configured public host for the Workgroup page (environment variable `ARTHEXIS_WORKGROUP_PUBLIC_HOST`, defaults to `arthexis.com`)
- `WORKGROUP_SSH_HOST`: SSH host displayed on the Workgroup page (environment variable `ARTHEXIS_WORKGROUP_SSH_HOST`, defaults to `arthexis.com`)

### View Logic (`apps/sites/views/landing.py`)
Updated the `workgroup` view to:
- Introduce `_workgroup_public_host()` helper that returns the configured public host
- Introduce `_workgroup_ssh_host()` helper that returns the configured SSH host (with fallback to public host)
- Validate incoming request host against `WORKGROUP_PUBLIC_HOST` and return `Http404` if they don't match
- Use `_workgroup_ssh_host()` to set the `play_ssh_host` template context variable instead of deriving it from the request host

### Tests (`apps/sites/tests/test_workgroup_password.py`)
Updated `test_workgroup_page_shows_daily_password_and_usage` to:
- Configure `ALLOWED_HOSTS` to include both `arthexis.com` and `play.example.test`
- Assert that requests to non-public hosts (`play.example.test`) return `404`
- Assert that requests to the public host (`arthexis.com`) return `200`
- Verify the rendered SSH command uses the configured host (`play@arthexis.com`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->