### PR TITLE
Fix module fixture role filtering fail-open during env refresh

### DIFF
--- a/env-refresh.py
+++ b/env-refresh.py
@@ -1018,6 +1018,17 @@ def run_database_tasks(
             model_counts: dict[str, int] = defaultdict(int)
             site_fixture_defaults: dict[str, dict] = {}
             pending_user_m2m: dict[int, list[tuple[str, Any]]] = defaultdict(list)
+            pending_role_names: set[str] = set()
+            for name in fixtures:
+                source = Path(settings.BASE_DIR, name)
+                with source.open() as f:
+                    data = json.load(f)
+                for obj in data:
+                    if obj.get("model") != "nodes.noderole":
+                        continue
+                    role_name = obj.get("fields", {}).get("name")
+                    if isinstance(role_name, str) and role_name:
+                        pending_role_names.add(role_name)
             for name in fixtures:
                 priority, _ = _fixture_sort_key(name)
                 source = Path(settings.BASE_DIR, name)
@@ -1067,15 +1078,16 @@ def run_database_tasks(
                         roles_field = fields.get("roles")
                         if isinstance(roles_field, list):
                             NodeRole = apps.get_model("nodes", "NodeRole")
-                            available_role_names = set(
+                            referenced_role_names = [
+                                role[0]
+                                for role in roles_field
+                                if isinstance(role, (list, tuple))
+                                and role
+                                and isinstance(role[0], str)
+                            ]
+                            available_role_names = pending_role_names | set(
                                 NodeRole.objects.filter(
-                                    name__in=[
-                                        role[0]
-                                        for role in roles_field
-                                        if isinstance(role, (list, tuple))
-                                        and role
-                                        and isinstance(role[0], str)
-                                    ]
+                                    name__in=referenced_role_names
                                 ).values_list("name", flat=True)
                             )
                             filtered_roles = [


### PR DESCRIPTION
### Motivation

- During fixture preprocessing `env-refresh.py` filtered `modules.module` `roles` only against `NodeRole` rows already present in the database, but fixtures are pre-patched before any fixtures are loaded which can make a clean/reset run see no roles and reduce role-scoped modules to an empty list (which means "apply to all roles").
- This change prevents unintended widening of module visibility on fresh databases by accounting for role fixtures declared in the pending fixture payloads.

### Description

- Add a pre-scan over fixture files to collect `nodes.noderole` names into a `pending_role_names` set before patching fixture objects in `env-refresh.py`.
- When filtering `modules.module` `roles`, union `pending_role_names` with the names currently present in the `NodeRole` table so referenced roles declared in fixtures are recognized even before they are loaded.
- Preserve the existing filtering logic and only restrict module `roles` entries when referenced roles are absent from both pending fixtures and the database.

### Testing

- Attempted to run tests via the repository entrypoint `./venv/bin/python -m pytest` but `.venv` was not available in this environment, so the standard wrapper could not be used.
- Ran `python3 -m pytest tests/test_env_refresh_migration_mismatch.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ea7fb2888326860924c057efec48)