### PR TITLE
Add Control-node USB inventory and LCD summary services

### DIFF
--- a/apps/features/fixtures/features__usb_inventory.json
+++ b/apps/features/fixtures/features__usb_inventory.json
@@ -1,0 +1,39 @@
+[
+  {
+    "model": "features.feature",
+    "fields": {
+      "admin_requirements": "Sensor management command exposes local USB inventory refresh and claim lookup operations.",
+      "admin_views": [
+        "admin:features_feature_changelist"
+      ],
+      "code_locations": [
+        "apps/sensors/usb_inventory.py",
+        "apps/sensors/management/commands/sensors.py",
+        "apps/sensors/node_features.py"
+      ],
+      "created_at": "2024-03-01T00:00:00Z",
+      "display": "USB Inventory",
+      "is_deleted": false,
+      "is_enabled": true,
+      "is_seed_data": true,
+      "main_app": [
+        "sensors"
+      ],
+      "metadata": {},
+      "node_feature": [
+        "usb-inventory"
+      ],
+      "protocol_coverage": {},
+      "public_requirements": "No public interface; inventory is local to eligible Control nodes.",
+      "public_views": [],
+      "service_requirements": "Requires Linux block-device tooling and a Control node role before inventory state is refreshed.",
+      "service_views": [
+        "apps.sensors.usb_inventory.refresh_inventory"
+      ],
+      "slug": "usb-inventory",
+      "source": "mainstream",
+      "summary": "Controls local USB block-device inventory and role claim lookup for Control nodes.",
+      "updated_at": "2024-03-01T00:00:00Z"
+    }
+  }
+]

--- a/apps/nodes/feature_registry.py
+++ b/apps/nodes/feature_registry.py
@@ -16,6 +16,9 @@ from apps.playwright.node_features import (
 from apps.screens.node_features import (
     register_node_feature_detection as register_screens_features,
 )
+from apps.sensors.node_features import (
+    register_node_feature_detection as register_sensors_features,
+)
 from apps.summary.node_features import (
     register_node_feature_detection as register_summary_features,
 )
@@ -27,6 +30,7 @@ APPROVED_NODE_FEATURE_REGISTRARS: Sequence[DetectionRegistrar] = (
     register_cards_features,
     register_playwright_features,
     register_screens_features,
+    register_sensors_features,
     register_summary_features,
 )
 

--- a/apps/nodes/fixtures/node_features__nodefeature_usb_inventory.json
+++ b/apps/nodes/fixtures/node_features__nodefeature_usb_inventory.json
@@ -1,0 +1,16 @@
+[
+  {
+    "model": "nodes.nodefeature",
+    "fields": {
+      "is_seed_data": true,
+      "is_deleted": false,
+      "slug": "usb-inventory",
+      "display": "USB Inventory",
+      "roles": [
+        [
+          "Control"
+        ]
+      ]
+    }
+  }
+]

--- a/apps/nodes/models/features.py
+++ b/apps/nodes/models/features.py
@@ -20,7 +20,7 @@ from apps.clocks.utils import has_clock_device
 from apps.core.systemctl import _systemctl_command
 from apps.emails import mailer
 from apps.nodes.feature_detection import node_feature_detection_registry
-from apps.nodes.roles import node_feature_allowed_for_node
+from apps.nodes.roles import node_feature_allowed_for_node, node_is_control
 
 from .slug_entities import SlugDisplayNaturalKeyMixin, SlugEntityManager
 
@@ -403,12 +403,11 @@ class NodeFeatureMixin:
         llm_summary_suite_enabled = is_suite_feature_enabled(
             "llm-summary-suite", default=True
         )
-        role_name = getattr(getattr(self, "role", None), "name", None)
         celery_enabled = self.is_local and self.has_feature("celery-queue")
         llm_summary_enabled = (
             llm_summary_suite_enabled
             and celery_enabled
-            and role_name == "Control"
+            and node_is_control(self)
             and self.has_feature("llm-summary")
         )
         self._sync_screenshot_task(screenshot_enabled)

--- a/apps/nodes/models/features.py
+++ b/apps/nodes/models/features.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from dataclasses import dataclass
 import json
 import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.db import models, transaction
-from django.db.utils import DatabaseError
 from django.db.models.signals import post_delete
+from django.db.utils import DatabaseError
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
@@ -20,6 +20,8 @@ from apps.clocks.utils import has_clock_device
 from apps.core.systemctl import _systemctl_command
 from apps.emails import mailer
 from apps.nodes.feature_detection import node_feature_detection_registry
+from apps.nodes.roles import node_feature_allowed_for_node
+
 from .slug_entities import SlugDisplayNaturalKeyMixin, SlugEntityManager
 
 logger = logging.getLogger(__name__)
@@ -121,6 +123,8 @@ class NodeFeature(SlugDisplayNaturalKeyMixin, Entity):
         node = NodeModel.get_local()
         if not node:
             return False
+        if not node_feature_allowed_for_node(self.slug, node):
+            return False
         if node.features.filter(pk=self.pk).exists():
             return True
         base_path = node.get_base_path()
@@ -217,6 +221,7 @@ class NodeFeatureMixin:
         "playwright-browser-chromium",
         "playwright-browser-firefox",
         "playwright-browser-webkit",
+        "usb-inventory",
         "video-cam",
     }
     LAZY_AUTO_DETECTION_FEATURE_SLUGS = {"rfid-scanner"}
@@ -226,6 +231,8 @@ class NodeFeatureMixin:
 
     def has_feature(self, slug: str) -> bool:
         """Return whether the node has the requested feature slug."""
+        if not node_feature_allowed_for_node(slug, self):
+            return False
         return self.features.filter(slug=slug).exists()
 
     def _apply_role_manual_features(self) -> None:
@@ -314,8 +321,6 @@ class NodeFeatureMixin:
         except (DatabaseError, RuntimeError):
             return True
 
-
-
     def refresh_features(self):
         """Refresh auto-managed feature assignments and tasks."""
         if not self.pk:
@@ -323,7 +328,9 @@ class NodeFeatureMixin:
         if not self.is_local:
             self.sync_feature_tasks()
             return
-        managed_slugs = self.AUTO_MANAGED_FEATURES - self.LAZY_AUTO_DETECTION_FEATURE_SLUGS
+        managed_slugs = (
+            self.AUTO_MANAGED_FEATURES - self.LAZY_AUTO_DETECTION_FEATURE_SLUGS
+        )
         reconciliation_slugs = self.AUTO_MANAGED_FEATURES
         detected_slugs = set()
         base_path = self.get_base_path()
@@ -383,17 +390,25 @@ class NodeFeatureMixin:
         if screenshot_enabled:
             from apps.nodes.feature_checks import feature_checks
 
-            screenshot_feature = NodeFeature.objects.filter(slug="screenshot-poll").first()
+            screenshot_feature = NodeFeature.objects.filter(
+                slug="screenshot-poll"
+            ).first()
             if screenshot_feature is not None:
                 screenshot_result = feature_checks.run(screenshot_feature, node=self)
-                screenshot_enabled = bool(screenshot_result and screenshot_result.success)
+                screenshot_enabled = bool(
+                    screenshot_result and screenshot_result.success
+                )
             else:
                 screenshot_enabled = False
-        llm_summary_suite_enabled = is_suite_feature_enabled("llm-summary-suite", default=True)
+        llm_summary_suite_enabled = is_suite_feature_enabled(
+            "llm-summary-suite", default=True
+        )
+        role_name = getattr(getattr(self, "role", None), "name", None)
         celery_enabled = self.is_local and self.has_feature("celery-queue")
         llm_summary_enabled = (
             llm_summary_suite_enabled
             and celery_enabled
+            and role_name == "Control"
             and self.has_feature("llm-summary")
         )
         self._sync_screenshot_task(screenshot_enabled)
@@ -469,8 +484,8 @@ class NodeFeatureMixin:
 
     def _sync_ocpp_session_report_task(self, celery_enabled: bool):
         """Sync the periodic OCPP session report task."""
-        from django_celery_beat.models import CrontabSchedule, PeriodicTask
         from django.db.utils import OperationalError, ProgrammingError
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
         raw_task_name = "ocpp_send_daily_session_report"
         task_name = normalize_periodic_task_name(PeriodicTask.objects, raw_task_name)

--- a/apps/nodes/roles.py
+++ b/apps/nodes/roles.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+CONTROL_NODE_ROLE = "Control"
+CONTROL_ONLY_NODE_FEATURE_SLUGS = frozenset({"llm-summary", "usb-inventory"})
+
+
+def node_has_role(node: object, role_name: str) -> bool:
+    """Return whether a node-like object has the named role."""
+
+    role = getattr(node, "role", None)
+    return getattr(role, "name", None) == role_name
+
+
+def node_is_control(node: object) -> bool:
+    """Return whether a node-like object is assigned to the Control role."""
+
+    return node_has_role(node, CONTROL_NODE_ROLE)
+
+
+def node_feature_allowed_for_node(slug: str, node: object) -> bool:
+    """Return whether a node feature may be active for a node role."""
+
+    if slug not in CONTROL_ONLY_NODE_FEATURE_SLUGS:
+        return True
+    return node_is_control(node)
+
+
+__all__ = [
+    "CONTROL_NODE_ROLE",
+    "CONTROL_ONLY_NODE_FEATURE_SLUGS",
+    "node_feature_allowed_for_node",
+    "node_has_role",
+    "node_is_control",
+]

--- a/apps/nodes/tests/test_models_split.py
+++ b/apps/nodes/tests/test_models_split.py
@@ -8,7 +8,7 @@ from django.contrib.sites.models import Site
 from apps.features.models import Feature
 from apps.nodes import utils as nodes_utils
 from apps.nodes.feature_detection import node_feature_detection_registry
-from apps.nodes.models import Node, NodeFeature
+from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment, NodeRole
 from apps.nodes.models import utils as node_utils
 from apps.sites.models import SiteProfile
 
@@ -273,14 +273,16 @@ def test_ensure_feature_enabled_handles_lazy_detection_exception(monkeypatch, tm
 
 
 @pytest.fixture
-def llm_summary_node(tmp_path):
+def llm_summary_node(tmp_path, db):
     """Provide a node for llm-summary detection."""
 
+    role = NodeRole.objects.create(name="Control")
     return (
         Node(
             hostname="summary-node",
             base_path=str(tmp_path),
             public_endpoint="summary-node",
+            role=role,
         ),
         tmp_path,
     )
@@ -322,6 +324,52 @@ def test_detect_auto_feature_skips_llm_summary_when_config_inactive(
     )
 
     assert result is False
+
+
+@pytest.mark.django_db
+def test_detect_auto_feature_skips_llm_summary_on_non_control_node(
+    tmp_path,
+):
+    """llm-summary is local Control-node behavior even when config is active."""
+
+    from apps.summary.models import LLMSummaryConfig
+
+    role = NodeRole.objects.create(name="Terminal")
+    node = Node(
+        hostname="summary-node",
+        base_path=str(tmp_path),
+        public_endpoint="summary-node",
+        role=role,
+    )
+    LLMSummaryConfig.objects.create(is_active=True)
+
+    result = node._detect_auto_feature(
+        "llm-summary", base_dir=tmp_path, base_path=tmp_path
+    )
+
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_control_only_feature_assignment_is_inactive_on_non_control_node(tmp_path):
+    """Stale manual assignments should not bypass Control-only feature boundaries."""
+
+    Node._local_cache.clear()
+    role = NodeRole.objects.create(name="Terminal")
+    node = Node.objects.create(
+        hostname="terminal-summary-node",
+        base_path=str(tmp_path),
+        public_endpoint="terminal-summary-node",
+        current_relation=Node.Relation.SELF,
+        role=role,
+    )
+    feature = NodeFeature.objects.create(slug="llm-summary", display="LLM Summary")
+    NodeFeatureAssignment.objects.bulk_create(
+        [NodeFeatureAssignment(node=node, feature=feature)]
+    )
+
+    assert node.has_feature("llm-summary") is False
+    assert feature.is_enabled is False
 
 
 @pytest.mark.django_db

--- a/apps/nodes/tests/test_node_feature_sync_tasks.py
+++ b/apps/nodes/tests/test_node_feature_sync_tasks.py
@@ -1,12 +1,14 @@
 import pytest
 from django.contrib import messages
 
-from apps.nodes.models import Node
+from apps.nodes.models import Node, NodeRole
 from apps.summary.constants import LLM_SUMMARY_CELERY_TASK_NAME
 
 
 @pytest.mark.django_db
-def test_sync_feature_tasks_disables_screenshots_when_feature_record_missing(monkeypatch):
+def test_sync_feature_tasks_disables_screenshots_when_feature_record_missing(
+    monkeypatch,
+):
     node = Node.objects.create(hostname="sync-local", public_endpoint="sync-local")
 
     monkeypatch.setattr(Node, "is_local", property(lambda self: True))
@@ -22,11 +24,17 @@ def test_sync_feature_tasks_disables_screenshots_when_feature_record_missing(mon
         lambda self, enabled: screenshot_enabled.append(enabled),
     )
     monkeypatch.setattr(Node, "_sync_landing_lead_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_ocpp_session_report_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_ocpp_session_report_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_upstream_poll_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_net_message_purge_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_net_message_purge_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_node_update_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_connectivity_monitor_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_connectivity_monitor_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_llm_summary_task", lambda self, enabled: None)
 
     node.sync_feature_tasks()
@@ -61,11 +69,17 @@ def test_sync_feature_tasks_scopes_screenshot_task_to_local_node(monkeypatch):
         lambda self, enabled: screenshot_enabled.append(enabled),
     )
     monkeypatch.setattr(Node, "_sync_landing_lead_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_ocpp_session_report_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_ocpp_session_report_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_upstream_poll_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_net_message_purge_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_net_message_purge_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_node_update_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_connectivity_monitor_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_connectivity_monitor_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_llm_summary_task", lambda self, enabled: None)
 
     node.sync_feature_tasks()
@@ -75,7 +89,9 @@ def test_sync_feature_tasks_scopes_screenshot_task_to_local_node(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_sync_feature_tasks_disables_llm_summary_when_suite_gate_is_disabled(monkeypatch):
+def test_sync_feature_tasks_disables_llm_summary_when_suite_gate_is_disabled(
+    monkeypatch,
+):
     """LLM summary periodic task should disable when suite gate is off."""
 
     node = Node.objects.create(hostname="sync-llm", public_endpoint="sync-llm")
@@ -85,17 +101,74 @@ def test_sync_feature_tasks_disables_llm_summary_when_suite_gate_is_disabled(mon
         "apps.features.utils.is_suite_feature_enabled",
         lambda slug, default=True: False if slug == "llm-summary-suite" else True,
     )
-    monkeypatch.setattr(Node, "has_feature", lambda self, slug: slug in {"celery-queue", "llm-summary"})
+    monkeypatch.setattr(
+        Node, "has_feature", lambda self, slug: slug in {"celery-queue", "llm-summary"}
+    )
 
     llm_enabled: list[bool] = []
     monkeypatch.setattr(Node, "_sync_screenshot_task", lambda self, enabled: None)
     monkeypatch.setattr(Node, "_sync_landing_lead_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_ocpp_session_report_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_ocpp_session_report_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_upstream_poll_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_net_message_purge_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_net_message_purge_task", lambda self, enabled: None
+    )
     monkeypatch.setattr(Node, "_sync_node_update_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_connectivity_monitor_task", lambda self, enabled: None)
-    monkeypatch.setattr(Node, "_sync_llm_summary_task", lambda self, enabled: llm_enabled.append(enabled))
+    monkeypatch.setattr(
+        Node, "_sync_connectivity_monitor_task", lambda self, enabled: None
+    )
+    monkeypatch.setattr(
+        Node,
+        "_sync_llm_summary_task",
+        lambda self, enabled: llm_enabled.append(enabled),
+    )
+
+    node.sync_feature_tasks()
+
+    assert llm_enabled == [False]
+
+
+@pytest.mark.django_db
+def test_sync_feature_tasks_disables_llm_summary_on_non_control_node(monkeypatch):
+    """LLM summary scheduling is isolated to Control nodes."""
+
+    role = NodeRole.objects.create(name="Terminal")
+    node = Node.objects.create(
+        hostname="sync-llm-terminal",
+        public_endpoint="sync-llm-terminal",
+        role=role,
+    )
+
+    monkeypatch.setattr(Node, "is_local", property(lambda self: True))
+    monkeypatch.setattr(
+        "apps.features.utils.is_suite_feature_enabled",
+        lambda slug, default=True: True,
+    )
+    monkeypatch.setattr(
+        Node, "has_feature", lambda self, slug: slug in {"celery-queue", "llm-summary"}
+    )
+
+    llm_enabled: list[bool] = []
+    monkeypatch.setattr(Node, "_sync_screenshot_task", lambda self, enabled: None)
+    monkeypatch.setattr(Node, "_sync_landing_lead_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_ocpp_session_report_task", lambda self, enabled: None
+    )
+    monkeypatch.setattr(Node, "_sync_upstream_poll_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_net_message_purge_task", lambda self, enabled: None
+    )
+    monkeypatch.setattr(Node, "_sync_node_update_task", lambda self, enabled: None)
+    monkeypatch.setattr(
+        Node, "_sync_connectivity_monitor_task", lambda self, enabled: None
+    )
+    monkeypatch.setattr(
+        Node,
+        "_sync_llm_summary_task",
+        lambda self, enabled: llm_enabled.append(enabled),
+    )
 
     node.sync_feature_tasks()
 

--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -276,7 +276,13 @@ class Command(BaseCommand):
             devices = payload.get("devices", [])
             self.stdout.write(f"USB inventory devices: {len(devices)}")
             for device in devices:
-                claims = ",".join(device.get("claims") or []) or "-"
+                if not isinstance(device, dict):
+                    self.stderr.write("Skipping malformed USB inventory entry.")
+                    continue
+                claims = (
+                    ",".join(str(claim) for claim in (device.get("claims") or []))
+                    or "-"
+                )
                 path = device.get("mountpoint") or device.get("path") or "-"
                 label = (
                     device.get("label")

--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -7,6 +7,8 @@ import json
 from django.core.management.base import BaseCommand, CommandError
 
 from apps.nodes.models import Node
+from apps.nodes.roles import node_is_control
+from apps.sensors import usb_inventory
 from apps.sensors.models import UsbPortMapping
 from apps.sensors.tasks import scan_usb_trackers
 from apps.sensors.usb_lcd import normalize_usb_lcd_label, write_usb_lcd_status
@@ -88,6 +90,66 @@ class Command(BaseCommand):
             action="store_true",
             help="Emit machine-readable JSON output.",
         )
+        inventory_parser = subparsers.add_parser(
+            "usb-inventory",
+            help="Refresh and query local USB block-device inventory.",
+        )
+        inventory_subparsers = inventory_parser.add_subparsers(dest="usb_action")
+        inventory_subparsers.required = True
+
+        inventory_refresh = inventory_subparsers.add_parser(
+            "refresh",
+            help="Refresh the local USB inventory state file.",
+        )
+        inventory_refresh.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit machine-readable JSON output.",
+        )
+        inventory_list = inventory_subparsers.add_parser(
+            "list",
+            help="List USB inventory state, refreshing if no state file exists.",
+        )
+        inventory_list.add_argument(
+            "--refresh",
+            action="store_true",
+            help="Refresh before listing devices.",
+        )
+        inventory_list.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit machine-readable JSON output.",
+        )
+        claimed_path = inventory_subparsers.add_parser(
+            "claimed-path",
+            help="Print mount or device paths claimed for a local USB role.",
+        )
+        claimed_path.add_argument("--role", required=True)
+        claimed_path.add_argument(
+            "--refresh",
+            action="store_true",
+            help="Refresh before resolving claims.",
+        )
+        claimed_path.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit machine-readable JSON output.",
+        )
+        path_claims = inventory_subparsers.add_parser(
+            "path-claims",
+            help="Print USB roles claimed by the supplied path.",
+        )
+        path_claims.add_argument("path")
+        path_claims.add_argument(
+            "--refresh",
+            action="store_true",
+            help="Refresh before resolving claims.",
+        )
+        path_claims.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit machine-readable JSON output.",
+        )
 
     def handle(self, *args, **options):
         action = options["action"]
@@ -99,6 +161,8 @@ class Command(BaseCommand):
             return self._handle_clear_usb_lcd_port(**options)
         if action == "write-usb-lcd-status":
             return self._handle_write_usb_lcd_status(**options)
+        if action == "usb-inventory":
+            return self._handle_usb_inventory(**options)
         raise CommandError(f"Unsupported action: {action}")
 
     def _handle_scan_usb_trackers(self, **options):
@@ -188,8 +252,82 @@ class Command(BaseCommand):
             return
         self.stdout.write("USB LCD status cleared: no active mappings configured")
 
+    def _handle_usb_inventory(self, **options):
+        self._local_control_node_or_error()
+        if not usb_inventory.has_usb_inventory_tools():
+            raise CommandError("USB inventory requires lsblk and findmnt on this host")
+
+        usb_action = options["usb_action"]
+        if usb_action == "refresh":
+            payload = usb_inventory.refresh_inventory()
+            if options["json"]:
+                self.stdout.write(json.dumps(payload, sort_keys=True))
+                return
+            self.stdout.write(
+                "USB inventory refreshed: "
+                f"devices={len(payload.get('devices', []))} state={usb_inventory.state_path()}"
+            )
+            return
+        if usb_action == "list":
+            payload = usb_inventory.state_or_refresh(refresh=options["refresh"])
+            if options["json"]:
+                self.stdout.write(json.dumps(payload, sort_keys=True))
+                return
+            devices = payload.get("devices", [])
+            self.stdout.write(f"USB inventory devices: {len(devices)}")
+            for device in devices:
+                claims = ",".join(device.get("claims") or []) or "-"
+                path = device.get("mountpoint") or device.get("path") or "-"
+                label = (
+                    device.get("label")
+                    or device.get("model")
+                    or device.get("name")
+                    or "-"
+                )
+                self.stdout.write(f"{label} {path} claims={claims}")
+            return
+        if usb_action == "claimed-path":
+            paths = usb_inventory.claimed_paths(
+                options["role"],
+                refresh=options["refresh"],
+            )
+            if options["json"]:
+                self.stdout.write(
+                    json.dumps(
+                        {"role": options["role"], "paths": paths}, sort_keys=True
+                    )
+                )
+                return
+            for path in paths:
+                self.stdout.write(path)
+            return
+        if usb_action == "path-claims":
+            claims = usb_inventory.path_claims(
+                options["path"],
+                refresh=options["refresh"],
+            )
+            if options["json"]:
+                self.stdout.write(
+                    json.dumps(
+                        {"path": options["path"], "claims": claims}, sort_keys=True
+                    )
+                )
+                return
+            for claim in claims:
+                self.stdout.write(claim)
+            return
+        raise CommandError(f"Unsupported usb-inventory action: {usb_action}")
+
     def _local_node_or_error(self):
         node = Node.get_local()
         if node is None:
             raise CommandError("No local node is registered for USB LCD mappings")
+        return node
+
+    def _local_control_node_or_error(self):
+        node = Node.get_local()
+        if node is None:
+            raise CommandError("No local node is registered for USB inventory")
+        if not node_is_control(node):
+            raise CommandError("USB inventory is only available on Control nodes")
         return node

--- a/apps/sensors/node_features.py
+++ b/apps/sensors/node_features.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from apps.nodes.feature_detection import NodeFeatureDetectionRegistry
+from apps.sensors.usb_inventory import (
+    USB_INVENTORY_NODE_FEATURE_SLUG,
+    usb_inventory_available,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from apps.nodes.models import Node
+
+
+def check_node_feature(
+    slug: str,
+    *,
+    node: Node,
+    base_dir: Path,
+    base_path: Path,
+) -> bool | None:
+    """Return whether sensors can auto-enable a node feature."""
+
+    del base_dir, base_path
+    if slug != USB_INVENTORY_NODE_FEATURE_SLUG:
+        return None
+    return usb_inventory_available(node=node)
+
+
+def setup_node_feature(
+    slug: str,
+    *,
+    node: Node,
+    base_dir: Path,
+    base_path: Path,
+) -> bool | None:
+    """Allow the sensors app to own USB inventory auto-detection."""
+
+    return check_node_feature(
+        slug,
+        node=node,
+        base_dir=base_dir,
+        base_path=base_path,
+    )
+
+
+def register_node_feature_detection(registry: NodeFeatureDetectionRegistry) -> None:
+    """Register sensors feature auto-detection callbacks."""
+
+    registry.register(
+        USB_INVENTORY_NODE_FEATURE_SLUG,
+        check=check_node_feature,
+        setup=setup_node_feature,
+    )
+
+
+__all__ = [
+    "check_node_feature",
+    "register_node_feature_detection",
+    "setup_node_feature",
+]

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.nodes.models import Node, NodeRole
+from apps.sensors import node_features, usb_inventory
+
+
+def test_usb_inventory_matches_kindle_claim(settings, monkeypatch, tmp_path):
+    mount = tmp_path / "kindle"
+    (mount / "documents").mkdir(parents=True)
+    (mount / "system").mkdir()
+    settings.USB_INVENTORY_CLAIMS_PATH = tmp_path / "claims.json"
+    settings.USB_INVENTORY_STATE_PATH = tmp_path / "devices.json"
+    settings.USB_INVENTORY_CLAIMS_PATH.write_text(
+        json.dumps({"kindle-postbox": {"match": {"kindle": True, "label": "Kindle"}}}),
+        encoding="utf-8",
+    )
+
+    def fake_run_json(command):
+        if command[0] == "lsblk":
+            return {
+                "blockdevices": [
+                    {
+                        "name": "sda",
+                        "path": "/dev/sda",
+                        "type": "disk",
+                        "tran": "usb",
+                        "children": [
+                            {
+                                "name": "sda1",
+                                "path": "/dev/sda1",
+                                "type": "part",
+                                "label": "Kindle",
+                            }
+                        ],
+                    }
+                ]
+            }
+        return {
+            "filesystems": [
+                {
+                    "source": "/dev/sda1",
+                    "target": str(mount),
+                    "fstype": "vfat",
+                    "options": "rw",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(usb_inventory, "run_json", fake_run_json)
+
+    payload = usb_inventory.refresh_inventory()
+
+    assert payload["devices"][1]["claims"] == ["kindle-postbox"]
+    assert payload["devices"][1]["kindle_shape"] is True
+    assert usb_inventory.claimed_paths("kindle-postbox") == [str(mount)]
+
+
+@pytest.mark.django_db
+def test_usb_inventory_feature_detection_requires_control_role(monkeypatch, tmp_path):
+    control = NodeRole.objects.create(name="Control")
+    terminal = NodeRole.objects.create(name="Terminal")
+    node = Node(hostname="control", public_endpoint="control", role=control)
+    monkeypatch.setattr(usb_inventory, "has_usb_inventory_tools", lambda: True)
+
+    assert (
+        node_features.check_node_feature(
+            "usb-inventory",
+            node=node,
+            base_dir=tmp_path,
+            base_path=tmp_path,
+        )
+        is True
+    )
+
+    node.role = terminal
+
+    assert (
+        node_features.check_node_feature(
+            "usb-inventory",
+            node=node,
+            base_dir=tmp_path,
+            base_path=tmp_path,
+        )
+        is False
+    )
+
+
+@pytest.mark.django_db
+def test_usb_inventory_command_requires_control_role(settings, tmp_path):
+    settings.BASE_DIR = tmp_path
+    Node._local_cache.clear()
+    node = Node.objects.create(hostname="terminal", public_endpoint="terminal")
+    Node.objects.filter(pk=node.pk).update(current_relation=Node.Relation.SELF)
+
+    with pytest.raises(CommandError, match="only available on Control nodes"):
+        call_command("sensors", "usb-inventory", "list")
+
+
+@pytest.mark.django_db
+def test_usb_inventory_command_refreshes_for_control_role(
+    settings, monkeypatch, tmp_path
+):
+    settings.BASE_DIR = tmp_path
+    settings.USB_INVENTORY_STATE_PATH = tmp_path / "devices.json"
+    Node._local_cache.clear()
+    role = NodeRole.objects.create(name="Control")
+    node = Node.objects.create(hostname="gway", public_endpoint="gway", role=role)
+    Node.objects.filter(pk=node.pk).update(current_relation=Node.Relation.SELF)
+    monkeypatch.setattr(usb_inventory, "has_usb_inventory_tools", lambda: True)
+    monkeypatch.setattr(
+        usb_inventory,
+        "refresh_inventory",
+        lambda: {"generated_at": "now", "devices": [{"name": "sda"}]},
+    )
+
+    output = StringIO()
+    call_command("sensors", "usb-inventory", "refresh", stdout=output)
+
+    assert "USB inventory refreshed: devices=1" in output.getvalue()

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from io import StringIO
 
 import pytest
@@ -60,6 +61,26 @@ def test_usb_inventory_matches_kindle_claim(settings, monkeypatch, tmp_path):
     assert payload["devices"][1]["claims"] == ["kindle-postbox"]
     assert payload["devices"][1]["kindle_shape"] is True
     assert usb_inventory.claimed_paths("kindle-postbox") == [str(mount)]
+
+
+def test_atomic_write_json_cleans_temp_file_on_failure(tmp_path):
+    target = tmp_path / "devices.json"
+
+    with pytest.raises(TypeError):
+        usb_inventory.atomic_write_json(target, {"bad": object()})
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_run_json_raises_inventory_error_on_timeout(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(usb_inventory.subprocess, "run", fake_run)
+
+    with pytest.raises(usb_inventory.UsbInventoryError, match="timed out"):
+        usb_inventory.run_json(["lsblk"])
 
 
 @pytest.mark.django_db
@@ -124,3 +145,32 @@ def test_usb_inventory_command_refreshes_for_control_role(
     call_command("sensors", "usb-inventory", "refresh", stdout=output)
 
     assert "USB inventory refreshed: devices=1" in output.getvalue()
+
+
+@pytest.mark.django_db
+def test_usb_inventory_list_skips_malformed_state_entries(
+    settings, monkeypatch, tmp_path
+):
+    settings.BASE_DIR = tmp_path
+    Node._local_cache.clear()
+    role = NodeRole.objects.create(name="Control")
+    node = Node.objects.create(hostname="gway", public_endpoint="gway", role=role)
+    Node.objects.filter(pk=node.pk).update(current_relation=Node.Relation.SELF)
+    monkeypatch.setattr(usb_inventory, "has_usb_inventory_tools", lambda: True)
+    monkeypatch.setattr(
+        usb_inventory,
+        "state_or_refresh",
+        lambda *, refresh=False: {
+            "devices": [
+                "bad-entry",
+                {"name": "sda1", "mountpoint": "/media/kindle", "claims": [123]},
+            ]
+        },
+    )
+
+    stdout = StringIO()
+    stderr = StringIO()
+    call_command("sensors", "usb-inventory", "list", stdout=stdout, stderr=stderr)
+
+    assert "sda1 /media/kindle claims=123" in stdout.getvalue()
+    assert "Skipping malformed USB inventory entry." in stderr.getvalue()

--- a/apps/sensors/usb_inventory.py
+++ b/apps/sensors/usb_inventory.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+from django.conf import settings
+
+from apps.nodes.roles import node_is_control
+
+USB_INVENTORY_NODE_FEATURE_SLUG = "usb-inventory"
+DEFAULT_CLAIMS_PATH = Path("/etc/arthexis-usb/claims.json")
+DEFAULT_STATE_PATH = Path("/run/arthexis-usb/devices.json")
+DEFAULT_KINDLE_MARKERS = ("documents", "system")
+
+
+def claims_path() -> Path:
+    return Path(getattr(settings, "USB_INVENTORY_CLAIMS_PATH", DEFAULT_CLAIMS_PATH))
+
+
+def state_path() -> Path:
+    return Path(getattr(settings, "USB_INVENTORY_STATE_PATH", DEFAULT_STATE_PATH))
+
+
+def kindle_markers() -> tuple[str, ...]:
+    markers = getattr(settings, "USB_INVENTORY_KINDLE_MARKERS", DEFAULT_KINDLE_MARKERS)
+    return tuple(str(marker).strip("/") for marker in markers if str(marker).strip("/"))
+
+
+def has_usb_inventory_tools() -> bool:
+    """Return whether the Linux block-device inventory tools are available."""
+
+    return bool(shutil.which("lsblk") and shutil.which("findmnt"))
+
+
+def usb_inventory_available(*, node=None) -> bool:
+    """Return whether the current node may own USB inventory state."""
+
+    return bool(
+        node is not None and node_is_control(node) and has_usb_inventory_tools()
+    )
+
+
+def load_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def atomic_write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def run_json(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or result.stdout or "command failed").strip())
+    try:
+        return json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{command[0]} returned invalid JSON") from exc
+
+
+def _flatten_lsblk(
+    devices: Iterable[dict[str, Any]], *, parent_usb: bool = False
+) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for device in devices:
+        item = dict(device)
+        children = item.pop("children", []) or []
+        current_usb = parent_usb or _is_usb_device(item)
+        item["_parent_usb"] = parent_usb
+        flattened.append(item)
+        flattened.extend(_flatten_lsblk(children, parent_usb=current_usb))
+    return flattened
+
+
+def _mount_index(findmnt_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    filesystems = findmnt_data.get("filesystems", [])
+    if not isinstance(filesystems, list):
+        return index
+    for filesystem in filesystems:
+        if not isinstance(filesystem, dict):
+            continue
+        source = str(filesystem.get("source") or "")
+        target = str(filesystem.get("target") or "")
+        if not source or not target:
+            continue
+        entry = {
+            "source": source,
+            "target": target,
+            "fstype": filesystem.get("fstype") or "",
+            "options": filesystem.get("options") or "",
+        }
+        index[source] = entry
+        index[Path(source).name] = entry
+    return index
+
+
+def _device_mount(
+    device: dict[str, Any], mounts: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    mountpoint = device.get("mountpoint")
+    if mountpoint:
+        return {"target": str(mountpoint)}
+    for candidate in (device.get("path"), device.get("name"), device.get("kname")):
+        if not candidate:
+            continue
+        match = mounts.get(str(candidate)) or mounts.get(Path(str(candidate)).name)
+        if match:
+            return match
+    return {}
+
+
+def _is_usb_device(device: dict[str, Any]) -> bool:
+    if device.get("_parent_usb"):
+        return True
+    signals = {
+        str(device.get("tran") or "").lower(),
+        str(device.get("subsystems") or "").lower(),
+    }
+    if "usb" in signals or any("usb" in signal for signal in signals):
+        return True
+    if str(device.get("hotplug") or "").lower() in {"1", "true"}:
+        return True
+    if str(device.get("rm") or "").lower() in {"1", "true"}:
+        return True
+    return False
+
+
+def has_kindle_shape(mountpoint: str | None) -> bool:
+    if not mountpoint:
+        return False
+    root = Path(mountpoint)
+    if not root.is_dir():
+        return False
+    markers = kindle_markers()
+    return bool(markers) and all((root / marker).exists() for marker in markers)
+
+
+def _normalize_claims(raw: Any) -> list[dict[str, Any]]:
+    if isinstance(raw, dict):
+        claims = raw.get("claims")
+        if isinstance(claims, list):
+            return [claim for claim in claims if isinstance(claim, dict)]
+        normalized: list[dict[str, Any]] = []
+        for role, claim in raw.items():
+            if role in {"claims", "version"}:
+                continue
+            if isinstance(claim, dict):
+                normalized.append({"role": role, **claim})
+        return normalized
+    if isinstance(raw, list):
+        return [claim for claim in raw if isinstance(claim, dict)]
+    return []
+
+
+def _claim_role(claim: dict[str, Any]) -> str:
+    return str(claim.get("role") or claim.get("name") or "").strip()
+
+
+def _match_text(expected: object, actual: object) -> bool:
+    if expected in (None, ""):
+        return True
+    actual_text = str(actual or "")
+    expected_text = str(expected)
+    if any(char in expected_text for char in "*?["):
+        return fnmatch(actual_text.lower(), expected_text.lower())
+    return actual_text.lower() == expected_text.lower()
+
+
+def _claim_match_fields(claim: dict[str, Any]) -> dict[str, Any]:
+    match = claim.get("match")
+    if isinstance(match, dict):
+        return match
+    return claim
+
+
+def match_claim(device: dict[str, Any], claim: dict[str, Any]) -> bool:
+    """Return whether a device satisfies one local claim rule."""
+
+    fields = _claim_match_fields(claim)
+    for key in (
+        "name",
+        "kname",
+        "path",
+        "model",
+        "serial",
+        "uuid",
+        "partuuid",
+        "label",
+        "partlabel",
+        "fstype",
+        "vendor",
+    ):
+        if key in fields and not _match_text(fields[key], device.get(key)):
+            return False
+
+    if fields.get("kindle") is True and not device.get("kindle_shape"):
+        return False
+
+    required_paths = fields.get("mount_contains", [])
+    if isinstance(required_paths, str):
+        required_paths = [required_paths]
+    mountpoint = device.get("mountpoint")
+    for relative in required_paths or []:
+        if not mountpoint:
+            return False
+        candidate = (Path(str(mountpoint)) / str(relative).strip("/")).resolve()
+        try:
+            if not candidate.is_relative_to(Path(str(mountpoint)).resolve()):
+                return False
+        except OSError:
+            return False
+        if not candidate.exists():
+            return False
+    return True
+
+
+def _normalize_device(
+    device: dict[str, Any], mounts: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    mount = _device_mount(device, mounts)
+    mountpoint = str(mount.get("target") or "")
+    normalized = {
+        "name": device.get("name") or "",
+        "kname": device.get("kname") or "",
+        "path": device.get("path") or "",
+        "type": device.get("type") or "",
+        "tran": device.get("tran") or "",
+        "model": device.get("model") or "",
+        "serial": device.get("serial") or "",
+        "vendor": device.get("vendor") or "",
+        "uuid": device.get("uuid") or "",
+        "partuuid": device.get("partuuid") or "",
+        "label": device.get("label") or "",
+        "partlabel": device.get("partlabel") or "",
+        "fstype": device.get("fstype") or mount.get("fstype") or "",
+        "mountpoint": mountpoint,
+        "source": mount.get("source") or "",
+        "kindle_shape": has_kindle_shape(mountpoint),
+    }
+    normalized["id"] = (
+        normalized["uuid"]
+        or normalized["partuuid"]
+        or normalized["serial"]
+        or normalized["path"]
+        or normalized["name"]
+    )
+    return normalized
+
+
+def inventory_devices() -> list[dict[str, Any]]:
+    lsblk_data = run_json(
+        [
+            "lsblk",
+            "--json",
+            "--output",
+            "NAME,KNAME,PATH,TYPE,TRAN,MODEL,SERIAL,VENDOR,UUID,PARTUUID,LABEL,PARTLABEL,FSTYPE,MOUNTPOINT,HOTPLUG,RM,SUBSYSTEMS",
+        ]
+    )
+    findmnt_data = run_json(
+        ["findmnt", "--json", "--output", "SOURCE,TARGET,FSTYPE,OPTIONS"]
+    )
+    mounts = _mount_index(findmnt_data)
+    devices = []
+    for device in _flatten_lsblk(lsblk_data.get("blockdevices", [])):
+        if not isinstance(device, dict) or not _is_usb_device(device):
+            continue
+        normalized = _normalize_device(device, mounts)
+        if normalized["type"] in {"disk", "part"}:
+            devices.append(normalized)
+    return devices
+
+
+def refresh_inventory() -> dict[str, Any]:
+    """Refresh and persist the local USB inventory snapshot."""
+
+    claims = _normalize_claims(load_json(claims_path(), {}))
+    devices = inventory_devices()
+    for device in devices:
+        device_claims = []
+        for claim in claims:
+            role = _claim_role(claim)
+            if role and match_claim(device, claim):
+                device_claims.append(role)
+        device["claims"] = sorted(set(device_claims))
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "claims_path": str(claims_path()),
+        "devices": devices,
+    }
+    atomic_write_json(state_path(), payload)
+    return payload
+
+
+def state_or_refresh(*, refresh: bool = False) -> dict[str, Any]:
+    if refresh:
+        return refresh_inventory()
+    state = load_json(state_path(), {})
+    if isinstance(state, dict) and isinstance(state.get("devices"), list):
+        return state
+    return refresh_inventory()
+
+
+def claimed_paths(role: str, *, refresh: bool = False) -> list[str]:
+    wanted = role.strip()
+    if not wanted:
+        return []
+    state = state_or_refresh(refresh=refresh)
+    paths = []
+    for device in state.get("devices", []):
+        if not isinstance(device, dict):
+            continue
+        if wanted not in set(device.get("claims") or []):
+            continue
+        path = str(device.get("mountpoint") or device.get("path") or "")
+        if path:
+            paths.append(path)
+    return sorted(set(paths))
+
+
+def path_claims(path: str | Path, *, refresh: bool = False) -> list[str]:
+    target = Path(path)
+    try:
+        resolved_target = target.resolve()
+    except OSError:
+        resolved_target = target
+    state = state_or_refresh(refresh=refresh)
+    claims: set[str] = set()
+    for device in state.get("devices", []):
+        if not isinstance(device, dict):
+            continue
+        roots = [device.get("mountpoint"), device.get("path")]
+        for root in roots:
+            if not root:
+                continue
+            root_path = Path(str(root))
+            try:
+                if resolved_target.is_relative_to(root_path.resolve()):
+                    claims.update(str(claim) for claim in device.get("claims") or [])
+            except OSError:
+                continue
+    return sorted(claims)
+
+
+__all__ = [
+    "USB_INVENTORY_NODE_FEATURE_SLUG",
+    "claimed_paths",
+    "has_usb_inventory_tools",
+    "inventory_devices",
+    "match_claim",
+    "path_claims",
+    "refresh_inventory",
+    "state_or_refresh",
+    "usb_inventory_available",
+]

--- a/apps/sensors/usb_inventory.py
+++ b/apps/sensors/usb_inventory.py
@@ -15,9 +15,14 @@ from django.conf import settings
 from apps.nodes.roles import node_is_control
 
 USB_INVENTORY_NODE_FEATURE_SLUG = "usb-inventory"
+USB_INVENTORY_COMMAND_TIMEOUT_SECONDS = 15
 DEFAULT_CLAIMS_PATH = Path("/etc/arthexis-usb/claims.json")
 DEFAULT_STATE_PATH = Path("/run/arthexis-usb/devices.json")
 DEFAULT_KINDLE_MARKERS = ("documents", "system")
+
+
+class UsbInventoryError(Exception):
+    """Raised when USB inventory command execution or parsing fails."""
 
 
 def claims_path() -> Path:
@@ -56,31 +61,48 @@ def load_json(path: Path, default: Any) -> Any:
 
 def atomic_write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        "w",
-        encoding="utf-8",
-        dir=str(path.parent),
-        delete=False,
-    ) as handle:
-        json.dump(payload, handle, indent=2, sort_keys=True)
-        handle.write("\n")
-        temp_path = Path(handle.name)
-    temp_path.replace(path)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        temp_path.replace(path)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
 
 
 def run_json(command: list[str]) -> dict[str, Any]:
-    result = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=USB_INVENTORY_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UsbInventoryError(
+            f"{command[0]} timed out after {USB_INVENTORY_COMMAND_TIMEOUT_SECONDS}s"
+        ) from exc
     if result.returncode != 0:
-        raise RuntimeError((result.stderr or result.stdout or "command failed").strip())
+        raise UsbInventoryError(
+            (result.stderr or result.stdout or "command failed").strip()
+        )
     try:
         return json.loads(result.stdout or "{}")
     except json.JSONDecodeError as exc:
-        raise RuntimeError(f"{command[0]} returned invalid JSON") from exc
+        raise UsbInventoryError(f"{command[0]} returned invalid JSON") from exc
 
 
 def _flatten_lsblk(
@@ -370,6 +392,7 @@ def path_claims(path: str | Path, *, refresh: bool = False) -> list[str]:
 
 __all__ = [
     "USB_INVENTORY_NODE_FEATURE_SLUG",
+    "UsbInventoryError",
     "claimed_paths",
     "has_usb_inventory_tools",
     "inventory_devices",

--- a/apps/services/admin.py
+++ b/apps/services/admin.py
@@ -17,12 +17,13 @@ class LifecycleServiceAdmin(admin.ModelAdmin):
         "display",
         "slug",
         "unit_template",
+        "unit_kind",
         "activation",
         "suite_feature_binding",
         "feature_slug",
         "sort_order",
     )
-    list_filter = ("activation",)
+    list_filter = ("activation", "unit_kind")
     search_fields = ("display", "slug", "unit_template", "feature_slug")
     ordering = ("sort_order", "display")
     actions = ("check_selected_statuses",)
@@ -68,7 +69,9 @@ class LifecycleServiceAdmin(admin.ModelAdmin):
                 continue
 
         services = list(
-            LifecycleService.objects.filter(pk__in=selected_ids).order_by("sort_order", "display")
+            LifecycleService.objects.filter(pk__in=selected_ids).order_by(
+                "sort_order", "display"
+            )
         )
         locks = lock_dir()
         service_name = read_service_name(locks / "service.lck")
@@ -76,8 +79,10 @@ class LifecycleServiceAdmin(admin.ModelAdmin):
 
         report_rows: list[dict[str, object]] = []
         for service in services:
-            unit_name = service.unit_template.format(service=service_name_placeholder)
-            configured = service.is_configured(service_name=service_name, lock_dir=locks)
+            unit_name = service.resolved_unit_name(service_name_placeholder)
+            configured = service.is_configured(
+                service_name=service_name, lock_dir=locks
+            )
             suite_parameter = ""
             if service.slug == "celery-worker":
                 suite_parameter = self.suite_feature_binding(service)
@@ -85,6 +90,7 @@ class LifecycleServiceAdmin(admin.ModelAdmin):
                 {
                     "service": service,
                     "unit_name": unit_name,
+                    "unit_kind": service.get_unit_kind_display(),
                     "configured": configured,
                     "service_name": service_name,
                     "suite_parameter": suite_parameter,

--- a/apps/services/lifecycle.py
+++ b/apps/services/lifecycle.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
 import json
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 
 from django.conf import settings
 from django.db.utils import OperationalError, ProgrammingError
@@ -11,7 +11,6 @@ from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 
 from .models import LifecycleService
-
 
 logger = logging.getLogger(__name__)
 
@@ -53,15 +52,26 @@ def _service_docs_url(doc: str) -> str:
         return ""
 
 
-def _normalize_unit(unit_name: str) -> tuple[str, str]:
+def _normalize_unit(
+    unit_name: str,
+    *,
+    unit_kind: str = LifecycleService.UnitKind.SERVICE,
+) -> tuple[str, str]:
     """Normalize a unit name for systemd display and lookups."""
     normalized = unit_name.strip()
     unit_display = normalized
     unit = normalized
-    if normalized.endswith(".service"):
-        unit = normalized.removesuffix(".service")
+    suffixes = (".service", ".timer")
+    if normalized.endswith(suffixes):
+        for suffix in suffixes:
+            if normalized.endswith(suffix):
+                unit = normalized.removesuffix(suffix)
+                break
     else:
-        unit_display = f"{normalized}.service"
+        suffix = (
+            ".timer" if unit_kind == LifecycleService.UnitKind.TIMER else ".service"
+        )
+        unit_display = f"{normalized}{suffix}"
     return unit, unit_display
 
 
@@ -74,19 +84,23 @@ def _add_unit(
     configured: bool = True,
     docs_url: str = "",
     pid_file: str = "",
+    unit_kind: str = LifecycleService.UnitKind.SERVICE,
 ) -> None:
     """Add or update a unit entry in the service list."""
     normalized = unit_name.strip()
     if not normalized or normalized.startswith("-"):
         return
+    if normalized.endswith(".timer"):
+        unit_kind = LifecycleService.UnitKind.TIMER
 
-    unit, unit_display = _normalize_unit(normalized)
+    unit, unit_display = _normalize_unit(normalized, unit_kind=unit_kind)
     for existing_unit in service_units:
         if existing_unit["unit_display"] == unit_display:
             if key and not existing_unit.get("key"):
                 existing_unit["key"] = key
             existing_unit["label"] = label or existing_unit["label"]
             existing_unit["configured"] = configured
+            existing_unit["unit_kind"] = unit_kind
             if docs_url:
                 existing_unit["docs_url"] = docs_url
             if pid_file and not existing_unit.get("pid_file"):
@@ -98,6 +112,7 @@ def _add_unit(
             "label": label or normalized,
             "unit": unit,
             "unit_display": unit_display,
+            "unit_kind": unit_kind,
             "configured": configured,
             "docs_url": docs_url,
             "pid_file": pid_file or "",
@@ -108,7 +123,9 @@ def _add_unit(
 def _read_extra_systemd_units(lock_path: Path) -> list[str]:
     """Return systemd units listed in the lock file."""
     try:
-        return [line for line in lock_path.read_text(encoding="utf-8").splitlines() if line]
+        return [
+            line for line in lock_path.read_text(encoding="utf-8").splitlines() if line
+        ]
     except OSError:
         return []
 
@@ -142,19 +159,21 @@ def reconcile_feature_service_locks(base_dir: Path | None = None) -> None:
             _set_lock_file_state(locks / lock_name, enabled=enabled)
 
 
-
-
 def _iter_lifecycle_services() -> list[LifecycleService]:
     """Return lifecycle services, tolerating unapplied database migrations."""
 
     try:
         return list(LifecycleService.objects.all())
     except (OperationalError, ProgrammingError):
-        logger.warning("Lifecycle services table unavailable during reconciliation", exc_info=True)
+        logger.warning(
+            "Lifecycle services table unavailable during reconciliation", exc_info=True
+        )
         return []
 
 
-def build_lifecycle_service_units(base_dir: Path | None = None) -> list[dict[str, object]]:
+def build_lifecycle_service_units(
+    base_dir: Path | None = None,
+) -> list[dict[str, object]]:
     """Build a list of configured lifecycle service units."""
     resolved_base = Path(base_dir or settings.BASE_DIR)
     locks = lock_dir(resolved_base)
@@ -164,7 +183,7 @@ def build_lifecycle_service_units(base_dir: Path | None = None) -> list[dict[str
     service_units: list[dict[str, object]] = []
 
     for service in _iter_lifecycle_services():
-        unit_name = service.unit_template.format(service=service_name_placeholder)
+        unit_name = service.resolved_unit_name(service_name_placeholder)
         configured = service.is_configured(service_name=service_name, lock_dir=locks)
         _add_unit(
             service_units,
@@ -174,6 +193,7 @@ def build_lifecycle_service_units(base_dir: Path | None = None) -> list[dict[str
             configured=configured,
             docs_url=_service_docs_url(service.docs_path),
             pid_file=service.pid_file,
+            unit_kind=service.unit_kind,
         )
 
     for unit_name in _read_extra_systemd_units(locks / SYSTEMD_UNITS_LOCK):
@@ -240,7 +260,9 @@ def write_lifecycle_config(base_dir: Path | None = None) -> LifecycleConfig:
     return config
 
 
-def reconcile_node_features_and_services(base_dir: Path | None = None) -> LifecycleConfig:
+def reconcile_node_features_and_services(
+    base_dir: Path | None = None,
+) -> LifecycleConfig:
     """Refresh local auto-detected node features and lifecycle service artifacts."""
 
     resolved_base = Path(base_dir or settings.BASE_DIR)
@@ -248,7 +270,9 @@ def reconcile_node_features_and_services(base_dir: Path | None = None) -> Lifecy
     try:
         from apps.nodes.models import Node
     except ImportError:
-        logger.warning("Unable to import Node for lifecycle reconciliation", exc_info=True)
+        logger.warning(
+            "Unable to import Node for lifecycle reconciliation", exc_info=True
+        )
     else:
         node = Node.get_local()
         if node is not None:

--- a/apps/services/lifecycle.py
+++ b/apps/services/lifecycle.py
@@ -60,18 +60,13 @@ def _normalize_unit(
     """Normalize a unit name for systemd display and lookups."""
     normalized = unit_name.strip()
     unit_display = normalized
-    unit = normalized
     suffixes = (".service", ".timer")
-    if normalized.endswith(suffixes):
-        for suffix in suffixes:
-            if normalized.endswith(suffix):
-                unit = normalized.removesuffix(suffix)
-                break
-    else:
+    if not normalized.endswith(suffixes):
         suffix = (
             ".timer" if unit_kind == LifecycleService.UnitKind.TIMER else ".service"
         )
         unit_display = f"{normalized}{suffix}"
+    unit = unit_display
     return unit, unit_display
 
 

--- a/apps/services/migrations/0002_lifecycleservice_unit_kind.py
+++ b/apps/services/migrations/0002_lifecycleservice_unit_kind.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("services", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lifecycleservice",
+            name="unit_kind",
+            field=models.CharField(
+                choices=[("service", "Service"), ("timer", "Timer")],
+                default="service",
+                max_length=16,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="lifecycleservice",
+            name="unit_template",
+            field=models.CharField(
+                help_text='Systemd unit template, for example "celery-{service}" or "arthexis-usb-inventory.timer".',
+                max_length=120,
+            ),
+        ),
+    ]

--- a/apps/services/migrations/0003_seed_control_local_services.py
+++ b/apps/services/migrations/0003_seed_control_local_services.py
@@ -1,0 +1,75 @@
+from django.db import migrations
+
+
+CONTROL_LOCAL_SERVICES = (
+    {
+        "slug": "llm-lcd-summary",
+        "display": "LLM LCD Summary",
+        "unit_template": "arthexis-llm-lcd-summary.service",
+        "unit_kind": "service",
+        "docs_path": "services/llm-lcd-summary",
+        "activation": "feature",
+        "feature_slug": "llm-summary",
+        "lock_names": [],
+        "sort_order": 50,
+    },
+    {
+        "slug": "llm-lcd-summary-timer",
+        "display": "LLM LCD Summary Timer",
+        "unit_template": "arthexis-llm-lcd-summary.timer",
+        "unit_kind": "timer",
+        "docs_path": "services/llm-lcd-summary",
+        "activation": "feature",
+        "feature_slug": "llm-summary",
+        "lock_names": [],
+        "sort_order": 51,
+    },
+    {
+        "slug": "usb-inventory",
+        "display": "USB Inventory",
+        "unit_template": "arthexis-usb-inventory.service",
+        "unit_kind": "service",
+        "docs_path": "services/usb-inventory",
+        "activation": "feature",
+        "feature_slug": "usb-inventory",
+        "lock_names": [],
+        "sort_order": 60,
+    },
+    {
+        "slug": "usb-inventory-timer",
+        "display": "USB Inventory Timer",
+        "unit_template": "arthexis-usb-inventory.timer",
+        "unit_kind": "timer",
+        "docs_path": "services/usb-inventory",
+        "activation": "feature",
+        "feature_slug": "usb-inventory",
+        "lock_names": [],
+        "sort_order": 61,
+    },
+)
+
+
+def seed_control_local_services(apps, schema_editor):
+    LifecycleService = apps.get_model("services", "LifecycleService")
+    for service in CONTROL_LOCAL_SERVICES:
+        slug = service["slug"]
+        defaults = {key: value for key, value in service.items() if key != "slug"}
+        LifecycleService.objects.update_or_create(slug=slug, defaults=defaults)
+
+
+def remove_control_local_services(apps, schema_editor):
+    LifecycleService = apps.get_model("services", "LifecycleService")
+    LifecycleService.objects.filter(
+        slug__in=[service["slug"] for service in CONTROL_LOCAL_SERVICES]
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("services", "0002_lifecycleservice_unit_kind"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_control_local_services, remove_control_local_services),
+    ]

--- a/apps/services/models.py
+++ b/apps/services/models.py
@@ -62,7 +62,7 @@ class LifecycleService(models.Model):
 
     def resolved_unit_name(self, service_name: str) -> str:
         """Return the unit template with the service placeholder expanded."""
-        return self.unit_template.format(service=service_name)
+        return self.unit_template.replace("{service}", service_name)
 
     def _safe_lock_names(self) -> list[str]:
         """Return lock file names that are safe to resolve within the lock directory."""

--- a/apps/services/models.py
+++ b/apps/services/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import logging
+from pathlib import Path
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -19,11 +19,23 @@ class LifecycleService(models.Model):
         LOCKFILE = "lockfile", _("Lock file")
         MANUAL = "manual", _("Manual")
 
+    class UnitKind(models.TextChoices):
+        SERVICE = "service", _("Service")
+        TIMER = "timer", _("Timer")
+
     slug = models.SlugField(max_length=64, unique=True)
     display = models.CharField(max_length=80)
     unit_template = models.CharField(
         max_length=120,
-        help_text=_('Systemd unit template, for example "celery-{service}.service".'),
+        help_text=_(
+            'Systemd unit template, for example "celery-{service}" or '
+            '"arthexis-usb-inventory.timer".'
+        ),
+    )
+    unit_kind = models.CharField(
+        max_length=16,
+        choices=UnitKind.choices,
+        default=UnitKind.SERVICE,
     )
     pid_file = models.CharField(max_length=120, blank=True)
     docs_path = models.CharField(max_length=160, blank=True)
@@ -47,6 +59,10 @@ class LifecycleService(models.Model):
     def uses_service_name(self) -> bool:
         """Return True when the unit template uses a service placeholder."""
         return "{service}" in self.unit_template
+
+    def resolved_unit_name(self, service_name: str) -> str:
+        """Return the unit template with the service placeholder expanded."""
+        return self.unit_template.format(service=service_name)
 
     def _safe_lock_names(self) -> list[str]:
         """Return lock file names that are safe to resolve within the lock directory."""

--- a/apps/services/templates/admin/services/lifecycleservice/status_report.html
+++ b/apps/services/templates/admin/services/lifecycleservice/status_report.html
@@ -18,6 +18,7 @@
       <thead>
         <tr>
           <th>{% trans "Service" %}</th>
+          <th>{% trans "Kind" %}</th>
           <th>{% trans "Unit" %}</th>
           <th>{% trans "Activation" %}</th>
           <th>{% trans "Suite parameter" %}</th>
@@ -28,6 +29,7 @@
         {% for row in rows %}
           <tr>
             <td>{{ row.service.display }}</td>
+            <td>{{ row.unit_kind }}</td>
             <td><code>{{ row.unit_name }}</code></td>
             <td>{{ row.service.get_activation_display }}</td>
             <td>{{ row.suite_parameter|default:"—" }}</td>
@@ -41,7 +43,7 @@
           </tr>
         {% empty %}
           <tr>
-            <td colspan="5">{% trans "No services were selected." %}</td>
+            <td colspan="6">{% trans "No services were selected." %}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/apps/services/tests/test_lifecycle_reconcile.py
+++ b/apps/services/tests/test_lifecycle_reconcile.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from apps.nodes.feature_detection import node_feature_detection_registry
-from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
+from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment, NodeRole
 from apps.services.lifecycle import write_lifecycle_config
 from apps.services.models import LifecycleService
 from gate_markers import gate
@@ -115,21 +115,24 @@ def test_reconcile_node_features_services_command_uses_auto_detection(
 
 @pytest.mark.django_db
 @override_settings(BASE_DIR="/tmp")
-def test_lifecycle_config_preserves_timer_unit_kind(tmp_path, settings):
+def test_lifecycle_config_preserves_timer_unit_kind(monkeypatch, tmp_path, settings):
     """Timer lifecycle rows should render as timers, not service defaults."""
 
     settings.BASE_DIR = tmp_path
     lock_dir = tmp_path / ".locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
+    role = NodeRole.objects.create(name="Control")
     node = Node.objects.create(
         hostname="control-node",
         mac_address=Node.get_current_mac(),
         current_relation=Node.Relation.SELF,
         public_endpoint="control-node",
         base_path=str(tmp_path),
+        role=role,
     )
     feature = NodeFeature.objects.create(slug="usb-inventory", display="USB Inventory")
     NodeFeatureAssignment.objects.create(node=node, feature=feature)
+    monkeypatch.setattr(Node, "get_local", staticmethod(lambda: node))
     LifecycleService.objects.update_or_create(
         slug="usb-inventory-timer",
         defaults={
@@ -150,4 +153,13 @@ def test_lifecycle_config_preserves_timer_unit_kind(tmp_path, settings):
         if service["key"] == "usb-inventory-timer"
     )
     assert timer["unit_kind"] == LifecycleService.UnitKind.TIMER
+    assert timer["unit"] == "arthexis-usb-inventory.timer"
     assert timer["unit_display"] == "arthexis-usb-inventory.timer"
+
+
+def test_lifecycle_service_name_resolution_only_replaces_service_placeholder():
+    """Unexpected brace tokens should not break lifecycle reconciliation."""
+
+    service = LifecycleService(unit_template="demo-{service}-{unknown}.service")
+
+    assert service.resolved_unit_name("suite") == "demo-suite-{unknown}.service"

--- a/apps/services/tests/test_lifecycle_reconcile.py
+++ b/apps/services/tests/test_lifecycle_reconcile.py
@@ -111,3 +111,43 @@ def test_reconcile_node_features_services_command_uses_auto_detection(
         (lock_dir / "lifecycle_services.json").read_text(encoding="utf-8")
     )
     assert "camera-suite.service" in payload["systemd_units"]
+
+
+@pytest.mark.django_db
+@override_settings(BASE_DIR="/tmp")
+def test_lifecycle_config_preserves_timer_unit_kind(tmp_path, settings):
+    """Timer lifecycle rows should render as timers, not service defaults."""
+
+    settings.BASE_DIR = tmp_path
+    lock_dir = tmp_path / ".locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    node = Node.objects.create(
+        hostname="control-node",
+        mac_address=Node.get_current_mac(),
+        current_relation=Node.Relation.SELF,
+        public_endpoint="control-node",
+        base_path=str(tmp_path),
+    )
+    feature = NodeFeature.objects.create(slug="usb-inventory", display="USB Inventory")
+    NodeFeatureAssignment.objects.create(node=node, feature=feature)
+    LifecycleService.objects.update_or_create(
+        slug="usb-inventory-timer",
+        defaults={
+            "display": "USB Inventory Timer",
+            "unit_template": "arthexis-usb-inventory",
+            "unit_kind": LifecycleService.UnitKind.TIMER,
+            "activation": LifecycleService.Activation.FEATURE,
+            "feature_slug": "usb-inventory",
+        },
+    )
+
+    payload = write_lifecycle_config(tmp_path)
+
+    assert "arthexis-usb-inventory.timer" in payload.systemd_units
+    timer = next(
+        service
+        for service in payload.services
+        if service["key"] == "usb-inventory-timer"
+    )
+    assert timer["unit_kind"] == LifecycleService.UnitKind.TIMER
+    assert timer["unit_display"] == "arthexis-usb-inventory.timer"

--- a/apps/summary/dense_lcd.py
+++ b/apps/summary/dense_lcd.py
@@ -108,6 +108,9 @@ def execute_dense_lcd_summary(*, ignore_suite_feature_gate: bool = False) -> str
     run_status = execute_log_summary_generation(
         ignore_suite_feature_gate=ignore_suite_feature_gate,
     )
+    if not run_status.startswith("wrote:"):
+        return run_status
+
     config = get_summary_config()
     frames = dense_frames_from_prompt(config.last_prompt)
     if not frames:

--- a/apps/summary/dense_lcd.py
+++ b/apps/summary/dense_lcd.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+from django.conf import settings
+from django.utils import timezone
+
+from apps.features.utils import is_suite_feature_enabled
+from apps.nodes.roles import node_is_control
+
+from .constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from .services import (
+    LCD_SUMMARY_EXPIRES_AFTER,
+    compact_log_line,
+    execute_log_summary_generation,
+    get_summary_config,
+)
+
+DENSE_LCD_LOCK_NAME = "lcd-low"
+DENSE_LCD_FRAME_COUNT = 6
+PROMPT_LOGS_MARKER = "LOGS:"
+SOURCE_RE = re.compile(r"^\[(?P<source>[^\]]+)\]$")
+ERROR_RE = re.compile(
+    r"\b(?:ERR|ERROR|CRITICAL|fail(?:ed|ure)?|exception|panic)\b", re.I
+)
+WARNING_RE = re.compile(r"\b(?:WRN|WARN|WARNING|blocked|retry|timeout)\b", re.I)
+
+
+def _prompt_log_lines(prompt: str) -> list[str]:
+    _head, separator, tail = str(prompt or "").partition(PROMPT_LOGS_MARKER)
+    if not separator:
+        return []
+    return [line.strip() for line in tail.splitlines() if line.strip()]
+
+
+def _severity(line: str) -> str:
+    if ERROR_RE.search(line):
+        return "ERROR"
+    if WARNING_RE.search(line):
+        return "WARNING"
+    return "NORMAL"
+
+
+def _source_label(source: str) -> str:
+    if not source:
+        return "logs"
+    stem = Path(source).stem or source
+    return stem[:10]
+
+
+def dense_frames_from_prompt(prompt: str) -> list[tuple[str, str]]:
+    """Return compact LCD frames derived from the prompt logs."""
+
+    frames: list[tuple[str, str]] = []
+    counts: Counter[str] = Counter()
+    source = ""
+    for raw_line in _prompt_log_lines(prompt):
+        source_match = SOURCE_RE.match(raw_line)
+        if source_match:
+            source = source_match.group("source")
+            continue
+        line = compact_log_line(raw_line)
+        if not line:
+            continue
+        severity = _severity(line)
+        counts[severity] += 1
+        if len(frames) >= DENSE_LCD_FRAME_COUNT:
+            continue
+        prefix = (
+            "ERR" if severity == "ERROR" else "WRN" if severity == "WARNING" else "OK"
+        )
+        frames.append((f"{prefix} {_source_label(source)}", line[:16]))
+
+    if not counts:
+        return []
+
+    summary = f"{sum(counts.values())} ln"
+    state = (
+        f"ERR {counts['ERROR']}"
+        if counts["ERROR"]
+        else f"WRN {counts['WARNING']}"
+        if counts["WARNING"]
+        else "NORMAL"
+    )
+    return [(summary, state), *frames[: DENSE_LCD_FRAME_COUNT - 1]]
+
+
+def execute_dense_lcd_summary(*, ignore_suite_feature_gate: bool = False) -> str:
+    """Generate log summaries and write dense frames to the low LCD channel."""
+
+    from apps.nodes.models import Node
+    from apps.tasks.tasks import _write_lcd_frames
+
+    node = Node.get_local()
+    if not node:
+        return "skipped:no-node"
+    if not node_is_control(node):
+        return "skipped:non-control-node"
+    if not ignore_suite_feature_gate and not is_suite_feature_enabled(
+        LLM_SUMMARY_SUITE_FEATURE_SLUG, default=True
+    ):
+        return "skipped:suite-feature-disabled"
+    if not node.has_feature("llm-summary"):
+        return "skipped:feature-disabled"
+
+    run_status = execute_log_summary_generation(
+        ignore_suite_feature_gate=ignore_suite_feature_gate,
+    )
+    config = get_summary_config()
+    frames = dense_frames_from_prompt(config.last_prompt)
+    if not frames:
+        return run_status
+
+    lock_file = Path(settings.BASE_DIR) / ".locks" / DENSE_LCD_LOCK_NAME
+    if node.has_feature("lcd-screen"):
+        _write_lcd_frames(
+            frames,
+            lock_file=lock_file,
+            expires_at=timezone.now() + LCD_SUMMARY_EXPIRES_AFTER,
+        )
+    elif lock_file.parent.exists():
+        _write_lcd_frames([], lock_file=lock_file)
+    return f"{run_status};dense:{len(frames)}"
+
+
+__all__ = [
+    "DENSE_LCD_LOCK_NAME",
+    "dense_frames_from_prompt",
+    "execute_dense_lcd_summary",
+]

--- a/apps/summary/management/commands/summary.py
+++ b/apps/summary/management/commands/summary.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from apps.features.utils import is_suite_feature_enabled
 from apps.nodes.models import Node, NodeFeature, NodeFeatureAssignment
+from apps.nodes.roles import node_is_control
 from apps.screens.lcd_screen import locks as lcd_locks
 from apps.screens.startup_notifications import (
     LCD_CHANNELS_LOCK_FILE,
@@ -16,6 +17,7 @@ from apps.screens.startup_notifications import (
     read_lcd_lock_file,
 )
 from apps.summary.constants import LLM_SUMMARY_SUITE_FEATURE_SLUG
+from apps.summary.dense_lcd import execute_dense_lcd_summary
 from apps.summary.models import LLMSummaryConfig
 from apps.summary.node_features import get_llm_summary_prereq_state
 from apps.summary.services import (
@@ -55,6 +57,11 @@ class Command(BaseCommand):
                 "feature is disabled."
             ),
         )
+        parser.add_argument(
+            "--dense-lcd",
+            action="store_true",
+            help="Generate dense low-channel LCD frames and exit.",
+        )
 
     def handle(self, *args, **options) -> None:
         """Render status output and apply optional auto-enable actions."""
@@ -69,6 +76,13 @@ class Command(BaseCommand):
 
         if options["enabled"]:
             self._enable_prerequisites(node=node, config=config, base_dir=base_dir)
+
+        if options["dense_lcd"]:
+            status = execute_dense_lcd_summary(
+                ignore_suite_feature_gate=options["allow_disabled_feature"],
+            )
+            self.stdout.write(f"Dense LCD: {status}")
+            return
 
         if options["run_now"]:
             if not is_suite_feature_enabled(
@@ -162,6 +176,9 @@ class Command(BaseCommand):
         self, *, node: Node, config: LLMSummaryConfig, base_dir: Path
     ) -> None:
         """Enable lock files, feature assignments, and model artifacts for summaries."""
+
+        if not node_is_control(node):
+            raise CommandError("LLM summary can only be enabled on Control nodes.")
 
         lock_dir = base_dir / ".locks"
         lock_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/summary/node_features.py
+++ b/apps/summary/node_features.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from django.db.utils import OperationalError, ProgrammingError
 
 from apps.nodes.feature_detection import NodeFeatureDetectionRegistry
+from apps.nodes.roles import node_is_control
 from apps.screens.startup_notifications import lcd_feature_enabled_for_paths
 from apps.summary.models import LLMSummaryConfig
 
@@ -51,6 +52,8 @@ def check_node_feature(
 
     if slug != LLM_SUMMARY_SLUG:
         return None
+    if not node_is_control(node):
+        return False
     return _is_llm_summary_active(base_dir=base_dir, base_path=base_path)
 
 

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 
 from apps.features.parameters import get_feature_parameter
 from apps.features.utils import is_suite_feature_enabled
+from apps.nodes.roles import node_is_control
 from apps.screens.startup_notifications import render_lcd_lock_file
 
 from .constants import (
@@ -360,6 +361,8 @@ def execute_log_summary_generation(*, ignore_suite_feature_gate: bool = False) -
     node = Node.get_local()
     if not node:
         return "skipped:no-node"
+    if not node_is_control(node):
+        return "skipped:non-control-node"
 
     if not ignore_suite_feature_gate and not is_suite_feature_enabled(
         LLM_SUMMARY_SUITE_FEATURE_SLUG, default=True

--- a/apps/summary/tests/test_command.py
+++ b/apps/summary/tests/test_command.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.nodes.models import Node, NodeRole
+
+
+@pytest.mark.django_db
+def test_summary_enabled_requires_control_node(settings, tmp_path):
+    settings.BASE_DIR = tmp_path
+    Node._local_cache.clear()
+    role = NodeRole.objects.create(name="Terminal")
+    node = Node.objects.create(
+        hostname="terminal",
+        public_endpoint="terminal",
+        role=role,
+    )
+    Node.objects.filter(pk=node.pk).update(current_relation=Node.Relation.SELF)
+
+    with pytest.raises(CommandError, match="only be enabled on Control nodes"):
+        call_command("summary", "--enabled")

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
-from apps.summary import services
+from apps.summary import dense_lcd, services
 from apps.tasks import tasks as task_services
 from apps.tasks.tasks import _write_lcd_frames
 
@@ -146,6 +147,8 @@ def test_no_log_generation_preserves_low_channel_messages(
     (lock_dir / "lcd-low-1").write_text("old\nsummary\n", encoding="utf-8")
 
     class FakeNode:
+        role = SimpleNamespace(name="Control")
+
         def has_feature(self, slug: str) -> bool:
             return slug == "llm-summary"
 
@@ -185,7 +188,11 @@ def test_suite_gate_skip_preserves_low_channel_messages(
     (lock_dir / "lcd-low-1").write_text("old\nsummary\n", encoding="utf-8")
 
     settings.BASE_DIR = tmp_path
-    monkeypatch.setattr(Node, "get_local", staticmethod(lambda: object()))
+    monkeypatch.setattr(
+        Node,
+        "get_local",
+        staticmethod(lambda: SimpleNamespace(role=SimpleNamespace(name="Control"))),
+    )
     monkeypatch.setattr(
         services,
         "is_suite_feature_enabled",
@@ -211,6 +218,8 @@ def test_generation_without_lcd_feature_does_not_write_summary_lock(
     (lock_dir / "lcd-summary-2").write_text("stale\nsummary\n", encoding="utf-8")
 
     class FakeNode:
+        role = SimpleNamespace(name="Control")
+
         def has_feature(self, slug: str) -> bool:
             return slug in {"llm-summary"}
 
@@ -256,3 +265,33 @@ def test_generation_without_lcd_feature_does_not_write_summary_lock(
     assert not (lock_dir / "lcd-summary").exists()
     assert not (lock_dir / "lcd-summary-1").exists()
     assert not (lock_dir / "lcd-summary-2").exists()
+
+
+def test_dense_frames_from_prompt_builds_summary_frame() -> None:
+    prompt = "\n".join(
+        [
+            "Instructions",
+            "LOGS:",
+            "[journal.log]",
+            "ERROR worker failed to refresh inventory",
+            "WARNING retry scheduled",
+        ]
+    )
+
+    frames = dense_lcd.dense_frames_from_prompt(prompt)
+
+    assert frames[0] == ("2 ln", "ERR 1")
+    assert frames[1] == ("ERR journal", "ERR worker faile")
+
+
+def test_log_summary_generation_skips_non_control_node(monkeypatch, settings, tmp_path):
+    from apps.nodes.models import Node
+
+    settings.BASE_DIR = tmp_path
+    monkeypatch.setattr(
+        Node,
+        "get_local",
+        staticmethod(lambda: SimpleNamespace(role=SimpleNamespace(name="Terminal"))),
+    )
+
+    assert services.execute_log_summary_generation() == "skipped:non-control-node"

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+
 from apps.summary import dense_lcd, services
 from apps.tasks import tasks as task_services
 from apps.tasks.tasks import _write_lcd_frames
@@ -295,3 +297,36 @@ def test_log_summary_generation_skips_non_control_node(monkeypatch, settings, tm
     )
 
     assert services.execute_log_summary_generation() == "skipped:non-control-node"
+
+
+def test_dense_lcd_summary_does_not_replay_stale_prompt(
+    monkeypatch, settings, tmp_path
+):
+    from apps.nodes.models import Node
+
+    settings.BASE_DIR = tmp_path
+
+    class FakeNode:
+        role = SimpleNamespace(name="Control")
+
+        def has_feature(self, slug: str) -> bool:
+            return slug in {"llm-summary", "lcd-screen"}
+
+    monkeypatch.setattr(Node, "get_local", staticmethod(lambda: FakeNode()))
+    monkeypatch.setattr(
+        dense_lcd,
+        "is_suite_feature_enabled",
+        lambda slug, default=True: True,
+    )
+    monkeypatch.setattr(
+        dense_lcd,
+        "execute_log_summary_generation",
+        lambda *, ignore_suite_feature_gate=False: "skipped:no-logs",
+    )
+    monkeypatch.setattr(
+        dense_lcd,
+        "get_summary_config",
+        lambda: pytest.fail("stale prompt should not be read"),
+    )
+
+    assert dense_lcd.execute_dense_lcd_summary() == "skipped:no-logs"

--- a/docs/services/llm-lcd-summary.md
+++ b/docs/services/llm-lcd-summary.md
@@ -1,0 +1,25 @@
+# LLM LCD Summary
+
+The LLM LCD summary service writes dense log-summary frames for the low-priority
+LCD channel on Control nodes. It builds on the suite summary pipeline and keeps
+the generated frames in `.locks/lcd-low`, `.locks/lcd-low-1`, and later rotation
+files.
+
+## Control-node boundary
+
+The `llm-summary` node feature is assigned to the `Control` role fixture and
+runtime auto-detection now checks the local node role before enabling it.
+Summary generation and dense LCD frame generation both return
+`skipped:non-control-node` on other node roles.
+
+## Command
+
+Generate dense frames immediately:
+
+```bash
+python manage.py summary --dense-lcd
+```
+
+Use `--allow-disabled-feature` only for an explicit one-off operator run when
+the `llm-summary-suite` feature gate is disabled. The command still requires a
+local Control node with the `llm-summary` feature.

--- a/docs/services/usb-inventory.md
+++ b/docs/services/usb-inventory.md
@@ -35,6 +35,12 @@ Resolve a claimed role to mounted paths:
 python manage.py sensors usb-inventory claimed-path --role kindle-postbox
 ```
 
+Resolve a mounted path to matching claims:
+
+```bash
+python manage.py sensors usb-inventory path-claims /media/kindle
+```
+
 The default local paths are `/etc/arthexis-usb/claims.json` for claims and
 `/run/arthexis-usb/devices.json` for generated state. Override them with
 `USB_INVENTORY_CLAIMS_PATH` and `USB_INVENTORY_STATE_PATH` in Django settings.

--- a/docs/services/usb-inventory.md
+++ b/docs/services/usb-inventory.md
@@ -1,0 +1,40 @@
+# USB Inventory
+
+USB inventory is a Control-node local service that records attached USB block
+devices and maps them to local claim roles such as removable media workflows.
+Claims live in a host-local JSON file, not in suite fixtures, so device serials
+and operator-specific role bindings stay off the shared source tree.
+
+## Control-node boundary
+
+The `usb-inventory` node feature is assigned to the `Control` role fixture and
+auto-detection also checks the local node role at runtime. Non-Control nodes do
+not auto-enable the feature and the `sensors usb-inventory` command refuses to
+run on them.
+
+The feature also requires Linux `lsblk` and `findmnt` commands. Hosts without
+those tools do not auto-detect the feature.
+
+## Commands
+
+Refresh inventory:
+
+```bash
+python manage.py sensors usb-inventory refresh
+```
+
+List current inventory:
+
+```bash
+python manage.py sensors usb-inventory list
+```
+
+Resolve a claimed role to mounted paths:
+
+```bash
+python manage.py sensors usb-inventory claimed-path --role kindle-postbox
+```
+
+The default local paths are `/etc/arthexis-usb/claims.json` for claims and
+`/run/arthexis-usb/devices.json` for generated state. Override them with
+`USB_INVENTORY_CLAIMS_PATH` and `USB_INVENTORY_STATE_PATH` in Django settings.

--- a/docs/suite-services-report.md
+++ b/docs/suite-services-report.md
@@ -11,8 +11,8 @@ The Suite Services Report (Admin → System → Suite Services Report) summarize
 | [Celery beat](services/celery-beat.md) | `celery-beat-{service-name}.service` | Scheduler that triggers periodic Celery tasks. | [Celery beat](services/celery-beat.md) |
 | [LCD screen](services/lcd-screen.md) | `lcd-{service-name}.service` | 16x2 LCD updater service for Control nodes. | [LCD screen](services/lcd-screen.md) |
 | [RFID scanner service](services/rfid-scanner-service.md) | `rfid-{service-name}.service` | UDP-backed RFID scanner service for local reads. | [RFID scanner service](services/rfid-scanner-service.md) |
-| [LLM LCD summary](services/llm-lcd-summary.md) | `arthexis-llm-lcd-summary.service` / `.timer` | Dense low-channel LCD log summaries for Control nodes. | [LLM LCD summary](services/llm-lcd-summary.md) |
-| [USB inventory](services/usb-inventory.md) | `arthexis-usb-inventory.service` / `.timer` | Local USB block-device inventory and claim lookup for Control nodes. | [USB inventory](services/usb-inventory.md) |
+| [LLM LCD summary](services/llm-lcd-summary.md) | `arthexis-llm-lcd-summary.service` / `arthexis-llm-lcd-summary.timer` | Dense low-channel LCD log summaries for Control nodes. | [LLM LCD summary](services/llm-lcd-summary.md) |
+| [USB inventory](services/usb-inventory.md) | `arthexis-usb-inventory.service` / `arthexis-usb-inventory.timer` | Local USB block-device inventory and claim lookup for Control nodes. | [USB inventory](services/usb-inventory.md) |
 
 ## Reading the report
 

--- a/docs/suite-services-report.md
+++ b/docs/suite-services-report.md
@@ -11,6 +11,8 @@ The Suite Services Report (Admin → System → Suite Services Report) summarize
 | [Celery beat](services/celery-beat.md) | `celery-beat-{service-name}.service` | Scheduler that triggers periodic Celery tasks. | [Celery beat](services/celery-beat.md) |
 | [LCD screen](services/lcd-screen.md) | `lcd-{service-name}.service` | 16x2 LCD updater service for Control nodes. | [LCD screen](services/lcd-screen.md) |
 | [RFID scanner service](services/rfid-scanner-service.md) | `rfid-{service-name}.service` | UDP-backed RFID scanner service for local reads. | [RFID scanner service](services/rfid-scanner-service.md) |
+| [LLM LCD summary](services/llm-lcd-summary.md) | `arthexis-llm-lcd-summary.service` / `.timer` | Dense low-channel LCD log summaries for Control nodes. | [LLM LCD summary](services/llm-lcd-summary.md) |
+| [USB inventory](services/usb-inventory.md) | `arthexis-usb-inventory.service` / `.timer` | Local USB block-device inventory and claim lookup for Control nodes. | [USB inventory](services/usb-inventory.md) |
 
 ## Reading the report
 


### PR DESCRIPTION
## Summary
- add timer-aware lifecycle service metadata and seed Control-node LCD summary/USB inventory service rows
- promote USB inventory into `apps.sensors` with Control-only feature detection, fixtures, CLI refresh/list/claim lookup, and docs
- harden `llm-summary` so detection, scheduling, enablement, and execution stay isolated to Control nodes

## Tests
- `python -m ruff check ...` on touched Python files
- `python -m pytest apps/nodes/tests/test_models_split.py apps/nodes/tests/test_node_feature_sync_tasks.py apps/summary/tests/test_command.py apps/summary/tests/test_services.py apps/sensors/tests/test_usb_inventory.py apps/services/tests/test_lifecycle_reconcile.py`
- `python -m pytest apps/services/tests/test_lifecycle_reconcile.py apps/sensors/tests/test_command.py apps/sensors/tests/test_usb_inventory.py apps/summary/tests/test_services.py apps/nodes/tests/test_models_split.py apps/nodes/tests/test_node_feature_sync_tasks.py`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python scripts/lint_seed_fixtures.py apps/nodes/fixtures/node_features__nodefeature_usb_inventory.json apps/features/fixtures/features__usb_inventory.json`
- `python manage.py loaddata apps/nodes/fixtures/node_features__nodefeature_usb_inventory.json apps/features/fixtures/features__usb_inventory.json --database default`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->