### PR TITLE
Sanitize USB inventory human-readable command output

### DIFF
--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -332,6 +332,14 @@ class Command(BaseCommand):
 
     @staticmethod
     def _safe_terminal_text(value):
+        """Return terminal-safe text for console output by JSON-escaping control characters.
+
+        Converts ``value`` to ``str`` and applies ``json.dumps(..., ensure_ascii=False)[1:-1]``
+        so control characters, quotes, and backslashes are escaped while Unicode remains
+        readable. Example: ``"line\n\x1b[31mred"`` becomes ``"line\\n\\u001b[31mred"``.
+
+        This is for terminal/console rendering only and is not HTML, SQL, or shell escaping.
+        """
         return json.dumps(str(value), ensure_ascii=False)[1:-1]
 
     def _local_node_or_error(self):

--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -336,11 +336,19 @@ class Command(BaseCommand):
 
         Converts ``value`` to ``str`` and applies ``json.dumps(..., ensure_ascii=False)[1:-1]``
         so control characters, quotes, and backslashes are escaped while Unicode remains
-        readable. Example: ``"line\n\x1b[31mred"`` becomes ``"line\\n\\u001b[31mred"``.
+        readable. C1 control characters are escaped after JSON rendering because
+        ``ensure_ascii=False`` leaves them raw. Example: ``"line\n\x1b[31mred"``
+        becomes ``"line\\n\\u001b[31mred"``.
 
         This is for terminal/console rendering only and is not HTML, SQL, or shell escaping.
         """
-        return json.dumps(str(value), ensure_ascii=False)[1:-1]
+        rendered = json.dumps(str(value), ensure_ascii=False)[1:-1]
+        return "".join(
+            f"\\u{ord(character):04x}"
+            if "\x80" <= character <= "\x9f"
+            else character
+            for character in rendered
+        )
 
     def _local_node_or_error(self):
         node = Node.get_local()

--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -336,7 +336,7 @@ class Command(BaseCommand):
 
         Converts ``value`` to ``str`` and applies ``json.dumps(..., ensure_ascii=False)[1:-1]``
         so control characters, quotes, and backslashes are escaped while Unicode remains
-        readable. C1 control characters are escaped after JSON rendering because
+        readable. DEL and C1 controls are escaped after JSON rendering because
         ``ensure_ascii=False`` leaves them raw. Example: ``"line\n\x1b[31mred"``
         becomes ``"line\\n\\u001b[31mred"``.
 
@@ -345,7 +345,7 @@ class Command(BaseCommand):
         rendered = json.dumps(str(value), ensure_ascii=False)[1:-1]
         return "".join(
             f"\\u{ord(character):04x}"
-            if "\x80" <= character <= "\x9f"
+            if character == "\x7f" or "\x80" <= character <= "\x9f"
             else character
             for character in rendered
         )

--- a/apps/sensors/management/commands/sensors.py
+++ b/apps/sensors/management/commands/sensors.py
@@ -280,16 +280,22 @@ class Command(BaseCommand):
                     self.stderr.write("Skipping malformed USB inventory entry.")
                     continue
                 claims = (
-                    ",".join(str(claim) for claim in (device.get("claims") or []))
+                    ",".join(
+                        self._safe_terminal_text(claim)
+                        for claim in (device.get("claims") or [])
+                    )
                     or "-"
                 )
-                path = device.get("mountpoint") or device.get("path") or "-"
+                path = self._safe_terminal_text(
+                    device.get("mountpoint") or device.get("path") or "-"
+                )
                 label = (
                     device.get("label")
                     or device.get("model")
                     or device.get("name")
                     or "-"
                 )
+                label = self._safe_terminal_text(label)
                 self.stdout.write(f"{label} {path} claims={claims}")
             return
         if usb_action == "claimed-path":
@@ -305,7 +311,7 @@ class Command(BaseCommand):
                 )
                 return
             for path in paths:
-                self.stdout.write(path)
+                self.stdout.write(self._safe_terminal_text(path))
             return
         if usb_action == "path-claims":
             claims = usb_inventory.path_claims(
@@ -320,9 +326,13 @@ class Command(BaseCommand):
                 )
                 return
             for claim in claims:
-                self.stdout.write(claim)
+                self.stdout.write(self._safe_terminal_text(claim))
             return
         raise CommandError(f"Unsupported usb-inventory action: {usb_action}")
+
+    @staticmethod
+    def _safe_terminal_text(value):
+        return json.dumps(str(value), ensure_ascii=False)[1:-1]
 
     def _local_node_or_error(self):
         node = Node.get_local()

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -192,9 +192,12 @@ def test_usb_inventory_text_output_escapes_control_characters(
         lambda *, refresh=False: {
             "devices": [
                 {
-                    "label": "EVIL\x1b]2;OWNED\x07\nspoofed",
-                    "mountpoint": "/mnt/usb\x1b[31m\nFAKEPATH",
-                    "claims": ["camera", "claim\x1b]2;CLAIM\x07\nFAKE-CLAIM"],
+                    "label": "EVIL\x1b]2;OWNED\x07\n\x9b31mspoofed",
+                    "mountpoint": "/mnt/usb\x1b[31m\n\x9b32mFAKEPATH",
+                    "claims": [
+                        "camera",
+                        "claim\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM",
+                    ],
                 }
             ]
         },
@@ -202,20 +205,22 @@ def test_usb_inventory_text_output_escapes_control_characters(
     monkeypatch.setattr(
         usb_inventory,
         "claimed_paths",
-        lambda *args, **kwargs: ["/mnt/usb\x1b[31m\nFAKEPATH"],
+        lambda *args, **kwargs: ["/mnt/usb\x1b[31m\n\x9b32mFAKEPATH"],
     )
     monkeypatch.setattr(
         usb_inventory,
         "path_claims",
-        lambda *args, **kwargs: ["claim\x1b]2;CLAIM\x07\nFAKE-CLAIM"],
+        lambda *args, **kwargs: ["claim\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM"],
     )
 
     list_stdout = StringIO()
     call_command("sensors", "usb-inventory", "list", stdout=list_stdout)
     list_output = list_stdout.getvalue()
     assert "\\u001b" in list_output
+    assert "\\u009b" in list_output
     assert "\\n" in list_output
     assert "\x1b" not in list_output
+    assert "\x9b" not in list_output
 
     claimed_stdout = StringIO()
     call_command(
@@ -228,8 +233,10 @@ def test_usb_inventory_text_output_escapes_control_characters(
     )
     claimed_output = claimed_stdout.getvalue()
     assert "\\u001b" in claimed_output
+    assert "\\u009b" in claimed_output
     assert "\\n" in claimed_output
     assert "\x1b" not in claimed_output
+    assert "\x9b" not in claimed_output
 
     claims_stdout = StringIO()
     call_command(
@@ -241,5 +248,7 @@ def test_usb_inventory_text_output_escapes_control_characters(
     )
     claims_output = claims_stdout.getvalue()
     assert "\\u001b" in claims_output
+    assert "\\u009b" in claims_output
     assert "\\n" in claims_output
     assert "\x1b" not in claims_output
+    assert "\x9b" not in claims_output

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -212,8 +212,10 @@ def test_usb_inventory_text_output_escapes_control_characters(
 
     list_stdout = StringIO()
     call_command("sensors", "usb-inventory", "list", stdout=list_stdout)
-    assert "\\u001b" in list_stdout.getvalue()
-    assert "\\n" in list_stdout.getvalue()
+    list_output = list_stdout.getvalue()
+    assert "\\u001b" in list_output
+    assert "\\n" in list_output
+    assert "\x1b" not in list_output
 
     claimed_stdout = StringIO()
     call_command(
@@ -224,17 +226,20 @@ def test_usb_inventory_text_output_escapes_control_characters(
         "camera",
         stdout=claimed_stdout,
     )
-    assert "\\u001b" in claimed_stdout.getvalue()
-    assert "\\n" in claimed_stdout.getvalue()
+    claimed_output = claimed_stdout.getvalue()
+    assert "\\u001b" in claimed_output
+    assert "\\n" in claimed_output
+    assert "\x1b" not in claimed_output
 
     claims_stdout = StringIO()
     call_command(
         "sensors",
         "usb-inventory",
         "path-claims",
-        "--path",
         "/dev/sda1",
         stdout=claims_stdout,
     )
-    assert "\\u001b" in claims_stdout.getvalue()
-    assert "\\n" in claims_stdout.getvalue()
+    claims_output = claims_stdout.getvalue()
+    assert "\\u001b" in claims_output
+    assert "\\n" in claims_output
+    assert "\x1b" not in claims_output

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -174,3 +174,67 @@ def test_usb_inventory_list_skips_malformed_state_entries(
 
     assert "sda1 /media/kindle claims=123" in stdout.getvalue()
     assert "Skipping malformed USB inventory entry." in stderr.getvalue()
+
+
+@pytest.mark.django_db
+def test_usb_inventory_text_output_escapes_control_characters(
+    settings, monkeypatch, tmp_path
+):
+    settings.BASE_DIR = tmp_path
+    Node._local_cache.clear()
+    role = NodeRole.objects.create(name="Control")
+    node = Node.objects.create(hostname="gway", public_endpoint="gway", role=role)
+    Node.objects.filter(pk=node.pk).update(current_relation=Node.Relation.SELF)
+    monkeypatch.setattr(usb_inventory, "has_usb_inventory_tools", lambda: True)
+    monkeypatch.setattr(
+        usb_inventory,
+        "state_or_refresh",
+        lambda *, refresh=False: {
+            "devices": [
+                {
+                    "label": "EVIL\x1b]2;OWNED\x07\nspoofed",
+                    "mountpoint": "/mnt/usb\x1b[31m\nFAKEPATH",
+                    "claims": ["camera", "claim\x1b]2;CLAIM\x07\nFAKE-CLAIM"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        usb_inventory,
+        "claimed_paths",
+        lambda *args, **kwargs: ["/mnt/usb\x1b[31m\nFAKEPATH"],
+    )
+    monkeypatch.setattr(
+        usb_inventory,
+        "path_claims",
+        lambda *args, **kwargs: ["claim\x1b]2;CLAIM\x07\nFAKE-CLAIM"],
+    )
+
+    list_stdout = StringIO()
+    call_command("sensors", "usb-inventory", "list", stdout=list_stdout)
+    assert "\\u001b" in list_stdout.getvalue()
+    assert "\\n" in list_stdout.getvalue()
+
+    claimed_stdout = StringIO()
+    call_command(
+        "sensors",
+        "usb-inventory",
+        "claimed-path",
+        "--role",
+        "camera",
+        stdout=claimed_stdout,
+    )
+    assert "\\u001b" in claimed_stdout.getvalue()
+    assert "\\n" in claimed_stdout.getvalue()
+
+    claims_stdout = StringIO()
+    call_command(
+        "sensors",
+        "usb-inventory",
+        "path-claims",
+        "--path",
+        "/dev/sda1",
+        stdout=claims_stdout,
+    )
+    assert "\\u001b" in claims_stdout.getvalue()
+    assert "\\n" in claims_stdout.getvalue()

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -192,11 +192,11 @@ def test_usb_inventory_text_output_escapes_control_characters(
         lambda *, refresh=False: {
             "devices": [
                 {
-                    "label": "EVIL\x1b]2;OWNED\x07\n\x9b31mspoofed",
-                    "mountpoint": "/mnt/usb\x1b[31m\n\x9b32mFAKEPATH",
+                    "label": "EVIL\x7f\x1b]2;OWNED\x07\n\x9b31mspoofed",
+                    "mountpoint": "/mnt/usb\x7f\x1b[31m\n\x9b32mFAKEPATH",
                     "claims": [
                         "camera",
-                        "claim\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM",
+                        "claim\x7f\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM",
                     ],
                 }
             ]
@@ -205,21 +205,23 @@ def test_usb_inventory_text_output_escapes_control_characters(
     monkeypatch.setattr(
         usb_inventory,
         "claimed_paths",
-        lambda *args, **kwargs: ["/mnt/usb\x1b[31m\n\x9b32mFAKEPATH"],
+        lambda *args, **kwargs: ["/mnt/usb\x7f\x1b[31m\n\x9b32mFAKEPATH"],
     )
     monkeypatch.setattr(
         usb_inventory,
         "path_claims",
-        lambda *args, **kwargs: ["claim\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM"],
+        lambda *args, **kwargs: ["claim\x7f\x1b]2;CLAIM\x07\n\x9b33mFAKE-CLAIM"],
     )
 
     list_stdout = StringIO()
     call_command("sensors", "usb-inventory", "list", stdout=list_stdout)
     list_output = list_stdout.getvalue()
     assert "\\u001b" in list_output
+    assert "\\u007f" in list_output
     assert "\\u009b" in list_output
     assert "\\n" in list_output
     assert "\x1b" not in list_output
+    assert "\x7f" not in list_output
     assert "\x9b" not in list_output
 
     claimed_stdout = StringIO()
@@ -233,9 +235,11 @@ def test_usb_inventory_text_output_escapes_control_characters(
     )
     claimed_output = claimed_stdout.getvalue()
     assert "\\u001b" in claimed_output
+    assert "\\u007f" in claimed_output
     assert "\\u009b" in claimed_output
     assert "\\n" in claimed_output
     assert "\x1b" not in claimed_output
+    assert "\x7f" not in claimed_output
     assert "\x9b" not in claimed_output
 
     claims_stdout = StringIO()
@@ -248,7 +252,9 @@ def test_usb_inventory_text_output_escapes_control_characters(
     )
     claims_output = claims_stdout.getvalue()
     assert "\\u001b" in claims_output
+    assert "\\u007f" in claims_output
     assert "\\u009b" in claims_output
     assert "\\n" in claims_output
     assert "\x1b" not in claims_output
+    assert "\x7f" not in claims_output
     assert "\x9b" not in claims_output


### PR DESCRIPTION
### Motivation
- The `sensors usb-inventory` management command printed USB-derived fields (labels, mountpoints, claims, etc.) directly to stdout in human-readable mode, allowing attacker-controlled ANSI/OSC escape sequences and newlines to affect terminal output. 
- The JSON mode already escaped control characters via `json.dumps()`, but the default text rendering did not, creating a local-output injection/terminal-escape vulnerability. 
- The change aims to neutralize terminal-sensitive control characters in text output while preserving existing features and JSON behavior. 

### Description
- Escape all human-readable text fields before writing to stdout by adding a helper `_safe_terminal_text` that uses `json.dumps(str(value), ensure_ascii=False)[1:-1]` to emit escaped control characters. 
- Apply the sanitizer to the `list` flow (device `label`, `mountpoint`/`path`, and `claims`) and to the `claimed-path` and `path-claims` flows in `apps/sensors/management/commands/sensors.py`. 
- Add a regression test `test_usb_inventory_text_output_escapes_control_characters` in `apps/sensors/tests/test_usb_inventory.py` that injects ANSI/OSC/newline payloads into mocked inventory data and asserts escaped sequences (for example `\u001b` and `\n`) appear in text-mode output. 
- Leave JSON output untouched so callers requesting `--json` continue to receive regular JSON-escaped data. 

### Testing
- Added unit test coverage in `apps/sensors/tests/test_usb_inventory.py` to verify text-mode escaping for `list`, `claimed-path`, and `path-claims`. 
- Attempted to run the app test runner with the canonical command ` .venv/bin/python manage.py test run -- apps.sensors.tests.test_usb_inventory`, but the environment lacks the repository virtualenv entrypoint so the command could not be executed here. 
- Attempted `python3 -m pytest apps/sensors/tests/test_usb_inventory.py -q`, but the environment lacks `pytest-django` and CI test dependencies, so tests could not be executed in this session; CI or a local dev environment with the repo test dependencies should be used to run the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0926090ec48326a4f81258fd6ade06)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Sanitize USB inventory human-readable command output

### Problem
The `sensors usb-inventory` management command printed USB-derived fields (device labels, mountpoints/paths, and claims) directly to stdout in human-readable text mode without escaping control characters. This allowed attacker-controlled ANSI/OSC escape sequences and newlines to affect terminal output (local-output injection / terminal-escape vulnerability). JSON mode was already safe via `json.dumps()`.

### Solution
- Added Command._safe_terminal_text(value) as a `@staticmethod` in apps/sensors/management/commands/sensors.py. It converts the value to a string, JSON-escapes it with Unicode preserved, strips surrounding quotes, and additionally ensures C1/control characters are escaped (e.g., yielding \u001b).
- Applied the sanitizer to all human-readable text routes of the USB inventory flows:
  - `list` subcommand: device `label`, selected `mountpoint`/`path`, and joined `claims`.
  - `claimed-path` and `path-claims` subcommands: printed `path` and `claim` values go through the sanitizer.
- Left JSON output unchanged so `--json` returns normal JSON-escaped data.

### Testing
- Added regression test apps/sensors/tests/test_usb_inventory.py::test_usb_inventory_text_output_escapes_control_characters.
  - Mocks inventory, claimed_paths, and path_claims to include ANSI/OSC/C1 control bytes and newlines.
  - Runs text-mode flows (`list`, `claimed-path --role camera`, `path-claims /dev/sda1`) and asserts that escaped sequences (e.g., \\u001b, \\u009b, \\n) appear in text output while raw control bytes do not.
- Author could not run tests locally in this environment; CI or a local dev environment with test dependencies is required to execute them.

### Changes
- apps/sensors/management/commands/sensors.py: +30/-4
  - Added _safe_terminal_text() and applied it to the USB-inventory text output paths.
- apps/sensors/tests/test_usb_inventory.py: +78/-0
  - New regression test covering text-mode escaping for `list`, `claimed-path`, and `path-claims`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->