### PR TITLE
Follow-up fixes for Kindle postbox review feedback

### DIFF
--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -88,7 +88,7 @@ class KindlePostboxSyncResult:
 def kindle_postbox_available(*, node: object) -> bool:
     """Return whether this node can run Kindle postbox sync."""
 
-    return bool(node is not None and node_is_control(node) and usb_inventory.has_usb_inventory_tools())
+    return bool(node is not None and node_is_control(node))
 
 
 def default_output_dir() -> Path:
@@ -210,7 +210,11 @@ def build_suite_documentation_bundle(
     output_path = destination_dir / KINDLE_POSTBOX_BUNDLE_FILENAME
     manifest_path = destination_dir / KINDLE_POSTBOX_MANIFEST_FILENAME
     generated_at = datetime.now(timezone.utc).isoformat()
-    documents = iter_suite_documentation_files(base_dir=root, exclude_paths=(destination_dir,))
+    resolved_destination = destination_dir.resolve()
+    excluded_paths = ()
+    if resolved_destination not in {root / "docs", root / "apps" / "docs"}:
+        excluded_paths = (destination_dir,)
+    documents = iter_suite_documentation_files(base_dir=root, exclude_paths=excluded_paths)
     sources = tuple(path.relative_to(root).as_posix() for path in documents)
 
     _write_suite_documentation_payload(

--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -232,7 +232,10 @@ def build_suite_documentation_bundle(
     generated_at = datetime.now(timezone.utc).isoformat()
     resolved_destination = destination_dir.resolve()
     excluded_paths = ()
-    if resolved_destination not in {root / "docs", root / "apps" / "docs"}:
+    if resolved_destination != root and resolved_destination not in {
+        root / "docs",
+        root / "apps" / "docs",
+    }:
         excluded_paths = (destination_dir,)
     documents = iter_suite_documentation_files(base_dir=root, exclude_paths=excluded_paths)
     sources = tuple(path.relative_to(root).as_posix() for path in documents)

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -80,6 +80,20 @@ def test_build_suite_documentation_bundle_allows_docs_root_output_dir(tmp_path):
 
 
 @pytest.mark.django_db
+def test_build_suite_documentation_bundle_allows_project_root_output_dir(tmp_path):
+    _write(tmp_path / "README.md", "# Root\n")
+    _write(tmp_path / "docs" / "guide.md", "# Guide\n")
+
+    bundle = kindle_postbox.build_suite_documentation_bundle(
+        base_dir=tmp_path,
+        output_dir=tmp_path,
+    )
+
+    assert "README.md" in bundle.sources
+    assert "docs/guide.md" in bundle.sources
+
+
+@pytest.mark.django_db
 def test_iter_suite_documentation_files_skips_symlinks_outside_base_dir(tmp_path):
     root = tmp_path / "root"
     outside = tmp_path / "outside.md"

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -67,6 +67,19 @@ def test_build_suite_documentation_bundle_excludes_existing_postbox_outputs(tmp_
 
 
 @pytest.mark.django_db
+def test_build_suite_documentation_bundle_allows_docs_root_output_dir(tmp_path):
+    _write(tmp_path / "README.md", "# Root\n")
+    _write(tmp_path / "docs" / "guide.md", "# Guide\n")
+
+    bundle = kindle_postbox.build_suite_documentation_bundle(
+        base_dir=tmp_path,
+        output_dir=tmp_path / "docs",
+    )
+
+    assert "docs/guide.md" in bundle.sources
+
+
+@pytest.mark.django_db
 def test_iter_suite_documentation_files_skips_symlinks_outside_base_dir(tmp_path):
     root = tmp_path / "root"
     outside = tmp_path / "outside.md"
@@ -197,7 +210,6 @@ def test_sync_to_kindle_postboxes_dry_run_does_not_write_target(tmp_path):
 
 
 def test_kindle_postbox_node_feature_is_control_only(monkeypatch, tmp_path):
-    monkeypatch.setattr(kindle_postbox.usb_inventory, "has_usb_inventory_tools", lambda: True)
     control = SimpleNamespace(role=SimpleNamespace(name="Control"))
     terminal = SimpleNamespace(role=SimpleNamespace(name="Terminal"))
 
@@ -219,6 +231,13 @@ def test_kindle_postbox_node_feature_is_control_only(monkeypatch, tmp_path):
         )
         is False
     )
+
+
+def test_kindle_postbox_available_does_not_require_usb_tools(monkeypatch):
+    monkeypatch.setattr(kindle_postbox.usb_inventory, "has_usb_inventory_tools", lambda: False)
+    control = SimpleNamespace(role=SimpleNamespace(name="Control"))
+
+    assert kindle_postbox.kindle_postbox_available(node=control) is True
 
 
 def test_kindle_postbox_sync_command_rejects_non_control_node(monkeypatch, tmp_path):

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -156,6 +156,29 @@ def test_usb_inventory_reads_service_generated_claim_state(settings, tmp_path):
     assert usb_inventory.path_claims(kindle_mount / "documents") == ["kindle-postbox"]
 
 
+def test_usb_inventory_reads_dict_claims_and_mount_maps(settings, tmp_path):
+    kindle_mount = tmp_path / "kindle"
+    state_path = tmp_path / "devices.json"
+    settings.USB_INVENTORY_STATE_PATH = state_path
+    state_path.write_text(
+        json.dumps(
+            {
+                "devices": [
+                    {
+                        "path": "/dev/sdb",
+                        "claims": {"kindle-postbox": {"owner": "docs"}},
+                        "mounts": {"main": {"target": str(kindle_mount)}},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert usb_inventory.claimed_paths("kindle-postbox") == [str(kindle_mount)]
+    assert usb_inventory.path_claims(kindle_mount / "documents") == ["kindle-postbox"]
+
+
 def test_usb_inventory_ignores_string_claim_collections(settings, tmp_path):
     state_path = tmp_path / "devices.json"
     settings.USB_INVENTORY_STATE_PATH = state_path

--- a/apps/sensors/tests/test_usb_inventory.py
+++ b/apps/sensors/tests/test_usb_inventory.py
@@ -156,6 +156,29 @@ def test_usb_inventory_reads_service_generated_claim_state(settings, tmp_path):
     assert usb_inventory.path_claims(kindle_mount / "documents") == ["kindle-postbox"]
 
 
+def test_usb_inventory_ignores_string_claim_collections(settings, tmp_path):
+    state_path = tmp_path / "devices.json"
+    settings.USB_INVENTORY_STATE_PATH = state_path
+    state_path.write_text(
+        json.dumps(
+            {
+                "devices": [
+                    {
+                        "path": "/dev/sdz1",
+                        "claimed_roles": "kindle-postbox",
+                        "claims": "kindle-postbox",
+                        "mountpoints": "/media/kindle",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert usb_inventory.claimed_paths("kindle-postbox") == []
+    assert usb_inventory.path_claims("/media/kindle/documents") == []
+
+
 def test_atomic_write_json_cleans_temp_file_on_failure(tmp_path):
     target = tmp_path / "devices.json"
 

--- a/apps/sensors/usb_inventory.py
+++ b/apps/sensors/usb_inventory.py
@@ -224,12 +224,14 @@ def _state_text_values(value: Any) -> list[str]:
 
 
 def _claim_items(value: Any) -> list[Any]:
-    if not isinstance(value, dict):
-        return _as_state_items(value)
-    return [
-        {"role": role, **claim} if isinstance(claim, dict) else role
-        for role, claim in value.items()
-    ]
+    if isinstance(value, dict):
+        return [
+            {"role": role, **claim} if isinstance(claim, dict) else role
+            for role, claim in value.items()
+        ]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return []
 
 
 def _role_from_claim_item(claim: Any) -> str:
@@ -248,13 +250,8 @@ def _device_claim_roles(device: dict[str, Any]) -> set[str]:
                 roles.add(normalized_role)
 
     claims = device.get("claims")
-    if not isinstance(claims, (list, tuple)):
-        return roles
-    for claim in claims:
-        if isinstance(claim, dict):
-            role = _claim_role(claim)
-        else:
-            role = str(claim).strip()
+    for claim in _claim_items(claims):
+        role = _role_from_claim_item(claim)
         if role:
             roles.add(role)
     return roles
@@ -284,13 +281,10 @@ def _device_candidate_paths(device: dict[str, Any]) -> list[str]:
             if path:
                 paths.append(path)
     mounts = device.get("mounts")
-    if isinstance(mounts, (list, tuple)):
-        for mount in mounts:
-            if not isinstance(mount, dict):
-                continue
-            path = str(mount.get("target") or "").strip()
-            if path:
-                paths.append(path)
+    for mount in _mount_items(mounts):
+        path = _mount_path(mount)
+        if path:
+            paths.append(path)
     if not paths:
         paths.extend(_state_text_values(device.get("path")))
     return paths

--- a/apps/sensors/usb_inventory.py
+++ b/apps/sensors/usb_inventory.py
@@ -205,8 +205,18 @@ def _claim_role(claim: dict[str, Any]) -> str:
 
 
 def _device_claim_roles(device: dict[str, Any]) -> set[str]:
-    roles = {str(role).strip() for role in device.get("claimed_roles") or []}
-    for claim in device.get("claims") or []:
+    roles: set[str] = set()
+    claimed_roles = device.get("claimed_roles")
+    if isinstance(claimed_roles, (list, tuple, set)):
+        for role in claimed_roles:
+            normalized_role = str(role).strip()
+            if normalized_role:
+                roles.add(normalized_role)
+
+    claims = device.get("claims")
+    if not isinstance(claims, (list, tuple)):
+        return roles
+    for claim in claims:
         if isinstance(claim, dict):
             role = _claim_role(claim)
         else:
@@ -221,16 +231,20 @@ def _device_candidate_paths(device: dict[str, Any]) -> list[str]:
     mountpoint = str(device.get("mountpoint") or "").strip()
     if mountpoint:
         paths.append(mountpoint)
-    for mountpoint in device.get("mountpoints") or []:
-        path = str(mountpoint or "").strip()
-        if path:
-            paths.append(path)
-    for mount in device.get("mounts") or []:
-        if not isinstance(mount, dict):
-            continue
-        path = str(mount.get("target") or "").strip()
-        if path:
-            paths.append(path)
+    mountpoints = device.get("mountpoints")
+    if isinstance(mountpoints, (list, tuple, set)):
+        for mountpoint in mountpoints:
+            path = str(mountpoint or "").strip()
+            if path:
+                paths.append(path)
+    mounts = device.get("mounts")
+    if isinstance(mounts, (list, tuple)):
+        for mount in mounts:
+            if not isinstance(mount, dict):
+                continue
+            path = str(mount.get("target") or "").strip()
+            if path:
+                paths.append(path)
     if not paths:
         path = str(device.get("path") or "").strip()
         if path:


### PR DESCRIPTION
### Motivation
- Address reviewer findings to make the Kindle postbox feature robust and align feature detection with actual command behavior.
- Prevent recursive bundle inclusion and accidental exclusion of valid source docs when `--output-dir` is set to `docs/` or `apps/docs/`.
- Harden USB-inventory parsing to avoid malformed persisted-state inputs producing incorrect claims or paths.

### Description
- `kindle_postbox_available()` no longer requires USB discovery binaries and only gates on the node being a Control node so explicit `--target` sync remains usable without `lsblk`/`findmnt`.
- `build_suite_documentation_bundle()` now resolves the selected output directory and only excludes that subtree when it is not the `docs` or `apps/docs` roots, preventing the entire docs tree from being omitted when `--output-dir` points into docs.
- `apps/sensors/usb_inventory.py` hardens `_device_claim_roles()` and `_device_candidate_paths()` by validating collection types before iterating, avoiding character-wise iteration when persisted fields are strings.
- Added regression tests: `test_build_suite_documentation_bundle_allows_docs_root_output_dir`, `test_kindle_postbox_available_does_not_require_usb_tools`, and `test_usb_inventory_ignores_string_claim_collections`, and updated related tests to reflect behavior changes.

### Testing
- Ran `git diff --check` which reported no whitespace or check errors.
- Committed the changes and verified the working tree status updated for the four modified files.
- Attempted to run the project test entrypoint (`.venv/bin/python manage.py test run -- apps/docs/tests/test_kindle_postbox.py -q`) but the environment lacks the repo `.venv`, so tests could not be executed here.
- Attempted repository bootstrap (`./install.sh`) but it is blocked in this environment due to a missing system dependency (`redis-server`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0921d0eab88326a0af17ad08009dd8)