### PR TITLE
Harden Kindle postbox sync against symlink target abuse

### DIFF
--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import tempfile
 from collections.abc import Iterable
@@ -263,14 +262,19 @@ def build_suite_documentation_bundle(
 def _resolve_documents_dir(root_path: Path) -> Path | None:
     if not root_path.is_dir():
         return None
-    root_real_path = root_path.resolve()
+    try:
+        root_real_path = root_path.resolve()
+    except OSError:
+        return None
     documents_dir = root_path / KINDLE_DOCUMENTS_DIR_NAME
     if documents_dir.exists():
         if documents_dir.is_symlink() or not documents_dir.is_dir():
             return None
         try:
-            documents_dir.resolve().relative_to(root_real_path)
-        except ValueError:
+            resolved_docs = documents_dir.resolve()
+        except OSError:
+            return None
+        if not _path_is_relative_to(resolved_docs, root_real_path):
             return None
         return documents_dir
     return root_path
@@ -301,24 +305,22 @@ def _copy_bundle_to_target(
             status="would-copy",
         )
 
-    temp_file = tempfile.NamedTemporaryFile(
-        mode="wb",
-        delete=False,
-        dir=documents_dir,
-        prefix=f".{output_path.name}.",
-        suffix=".tmp",
-    )
-    temp_path = Path(temp_file.name)
+    temp_path: Path | None = None
     try:
-        with bundle.output_path.open("rb") as source_file, temp_file:
-            shutil.copyfileobj(source_file, temp_file)
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=documents_dir,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            with open(bundle.output_path, "rb") as source_file:
+                shutil.copyfileobj(source_file, temp_file)
         shutil.copystat(bundle.output_path, temp_path, follow_symlinks=False)
         temp_path.replace(output_path)
+        temp_path = None
     except OSError as exc:
-        try:
-            os.unlink(temp_path)
-        except OSError:
-            pass
         return KindlePostboxTargetResult(
             root_path=root_path,
             documents_path=documents_dir,
@@ -326,6 +328,12 @@ def _copy_bundle_to_target(
             status="failed",
             error=str(exc),
         )
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
 
     return KindlePostboxTargetResult(
         root_path=root_path,

--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -261,8 +263,15 @@ def build_suite_documentation_bundle(
 def _resolve_documents_dir(root_path: Path) -> Path | None:
     if not root_path.is_dir():
         return None
+    root_real_path = root_path.resolve()
     documents_dir = root_path / KINDLE_DOCUMENTS_DIR_NAME
-    if documents_dir.is_dir():
+    if documents_dir.exists():
+        if documents_dir.is_symlink() or not documents_dir.is_dir():
+            return None
+        try:
+            documents_dir.resolve().relative_to(root_real_path)
+        except ValueError:
+            return None
         return documents_dir
     return root_path
 
@@ -292,13 +301,22 @@ def _copy_bundle_to_target(
             status="would-copy",
         )
 
-    temp_path = output_path.with_name(f".{output_path.name}.tmp")
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="wb",
+        delete=False,
+        dir=documents_dir,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
     try:
-        shutil.copy2(bundle.output_path, temp_path)
+        with bundle.output_path.open("rb") as source_file, temp_file:
+            shutil.copyfileobj(source_file, temp_file)
+        shutil.copystat(bundle.output_path, temp_path, follow_symlinks=False)
         temp_path.replace(output_path)
     except OSError as exc:
         try:
-            temp_path.unlink()
+            os.unlink(temp_path)
         except OSError:
             pass
         return KindlePostboxTargetResult(

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -135,21 +134,38 @@ def test_sync_to_explicit_kindle_target_copies_bundle_to_documents_dir(tmp_path)
 
 
 @pytest.mark.django_db
-def test_sync_to_explicit_kindle_target_uses_metadata_preserving_copy(
-    monkeypatch,
-    tmp_path,
-):
+def test_sync_to_explicit_kindle_target_rejects_symlinked_documents_dir(tmp_path):
     _write(tmp_path / "README.md", "# Root\n")
     target = tmp_path / "kindle"
-    (target / "documents").mkdir(parents=True)
-    real_copy2 = shutil.copy2
-    calls: list[tuple[Path, Path]] = []
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir(parents=True)
+    try:
+        (target / "documents").symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable on this platform: {exc}")
 
-    def _copy2(source: Path, destination: Path) -> Path:
-        calls.append((Path(source), Path(destination)))
-        return Path(real_copy2(source, destination))
+    result = kindle_postbox.sync_to_kindle_postboxes(
+        base_dir=tmp_path,
+        output_dir=tmp_path / "out",
+        targets=[target],
+    )
 
-    monkeypatch.setattr(kindle_postbox.shutil, "copy2", _copy2)
+    assert result.targets[0].status == "missing"
+
+
+@pytest.mark.django_db
+def test_sync_to_explicit_kindle_target_rejects_existing_temp_symlink(tmp_path):
+    _write(tmp_path / "README.md", "# Root\n")
+    target = tmp_path / "kindle"
+    documents_dir = target / "documents"
+    documents_dir.mkdir(parents=True)
+    victim_path = tmp_path / "victim.txt"
+    victim_path.write_text("original", encoding="utf-8")
+    temp_path = documents_dir / f".{kindle_postbox.KINDLE_POSTBOX_BUNDLE_FILENAME}.evil.tmp"
+    try:
+        temp_path.symlink_to(victim_path)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable on this platform: {exc}")
 
     result = kindle_postbox.sync_to_kindle_postboxes(
         base_dir=tmp_path,
@@ -158,14 +174,7 @@ def test_sync_to_explicit_kindle_target_uses_metadata_preserving_copy(
     )
 
     assert result.targets[0].status == "copied"
-    assert calls == [
-        (
-            result.bundle.output_path,
-            target
-            / "documents"
-            / f".{kindle_postbox.KINDLE_POSTBOX_BUNDLE_FILENAME}.tmp",
-        )
-    ]
+    assert victim_path.read_text(encoding="utf-8") == "original"
 
 
 @pytest.mark.django_db

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -139,6 +139,7 @@ def test_sync_to_explicit_kindle_target_rejects_symlinked_documents_dir(tmp_path
     target = tmp_path / "kindle"
     outside_dir = tmp_path / "outside"
     outside_dir.mkdir(parents=True)
+    target.mkdir(parents=True)
     try:
         (target / "documents").symlink_to(outside_dir, target_is_directory=True)
     except OSError as exc:


### PR DESCRIPTION
### Motivation

- Address a filesystem integrity vulnerability where the Kindle postbox sync could be coerced into overwriting arbitrary files by following attacker-controlled symlinks in the target `documents` tree or in a predictable temp filename.
- Prevent a malicious USB/mounted target from redirecting writes outside the intended mount when the sync runs with operator/system privileges.

### Description

- Tighten target directory resolution in `_resolve_documents_dir` to reject `documents` when it is a symlink, not a directory, or resolves outside the claimed root path, returning `None` for unsafe targets.
- Replace the predictable fixed temp-path + `shutil.copy2` flow with a securely-created per-run temp file inside the target directory using `tempfile.NamedTemporaryFile`, copy contents with `shutil.copyfileobj`, preserve metadata with `shutil.copystat(..., follow_symlinks=False)`, and atomically replace the final bundle via `Path.replace`.
- Use `os.unlink` for cleanup of the created temp file on error to avoid following destination symlinks during cleanup.
- Add regression tests in `apps/docs/tests/test_kindle_postbox.py` that assert rejection of symlinked `documents` directories and that a pre-existing malicious temp symlink does not cause an overwrite of an external victim file.

### Testing

- Added unit tests: `test_sync_to_explicit_kindle_target_rejects_symlinked_documents_dir` and `test_sync_to_explicit_kindle_target_rejects_existing_temp_symlink` in `apps/docs/tests/test_kindle_postbox.py` (these validate the symlink defenses).
- Attempted to run the test suite with `.venv` (via `.venv/bin/python manage.py test run -- apps.docs.tests.test_kindle_postbox` and `./py manage.py test run -- apps.docs.tests.test_kindle_postbox`), but the environment bootstrap failed in this container because `./install.sh` could not complete due to a missing `redis-server`, so tests were not executed here.
- All changes are constrained to `apps/docs/kindle_postbox.py` and the test module referenced above and are designed to preserve existing behavior for normal (non-malicious) targets while eliminating symlink-follow overwrite vectors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092c57398883268ba78ada8afc61cc)