### PR TITLE
[codex] Add Kindle operators manual bundle

### DIFF
--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -623,7 +623,16 @@ def _resolve_documents_dir(root_path: Path) -> Path | None:
 
 def _same_file_content(source: Path, destination: Path) -> bool:
     try:
-        return destination.is_file() and source.read_bytes() == destination.read_bytes()
+        if (
+            not destination.is_file()
+            or source.stat().st_size != destination.stat().st_size
+        ):
+            return False
+        with source.open("rb") as source_file, destination.open("rb") as destination_file:
+            for source_chunk in iter(lambda: source_file.read(64 * 1024), b""):
+                if source_chunk != destination_file.read(len(source_chunk)):
+                    return False
+            return destination_file.read(1) == b""
     except OSError:
         return False
 

--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from django.conf import settings
+from django.db import DatabaseError
 
 from apps.docs import rendering
 from apps.nodes.roles import node_is_control
@@ -17,13 +18,24 @@ from apps.sensors import usb_inventory
 
 KINDLE_POSTBOX_NODE_FEATURE_SLUG = "kindle-postbox"
 KINDLE_POSTBOX_USB_CLAIM = "kindle-postbox"
+KINDLE_POSTBOX_SUITE_BUNDLE = "suite"
+KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE = "operators"
+KINDLE_POSTBOX_BUNDLE_CHOICES = (
+    KINDLE_POSTBOX_SUITE_BUNDLE,
+    KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE,
+)
 KINDLE_POSTBOX_BUNDLE_FILENAME = "arthexis-suite-documentation.txt"
 KINDLE_POSTBOX_MANIFEST_FILENAME = "arthexis-suite-documentation.json"
+KINDLE_OPERATORS_MANUAL_FILENAME = "arthexis-operators-manual.txt"
+KINDLE_OPERATORS_MANUAL_MANIFEST_FILENAME = "arthexis-operators-manual.json"
+KINDLE_OPERATORS_MANUAL_SOURCE_MANIFEST = Path("docs/operators-manual.json")
 KINDLE_DOCUMENTS_DIR_NAME = "documents"
 GENERATED_DOCUMENTATION_FILENAMES = frozenset(
     {
         KINDLE_POSTBOX_BUNDLE_FILENAME,
         KINDLE_POSTBOX_MANIFEST_FILENAME,
+        KINDLE_OPERATORS_MANUAL_FILENAME,
+        KINDLE_OPERATORS_MANUAL_MANIFEST_FILENAME,
     }
 )
 DOCUMENT_EXTENSIONS = (
@@ -34,6 +46,16 @@ DOCUMENT_EXTENSIONS = (
 )
 
 
+class DocumentationBundleError(Exception):
+    """Raised when a Kindle documentation bundle cannot be generated."""
+
+
+@dataclass(frozen=True)
+class OperatorManualSection:
+    title: str
+    sources: tuple[Path, ...]
+
+
 @dataclass(frozen=True)
 class DocumentationBundle:
     output_path: Path
@@ -42,6 +64,8 @@ class DocumentationBundle:
     document_count: int
     byte_count: int
     sources: tuple[str, ...]
+    title: str = "Arthexis Suite Documentation"
+    bundle: str = KINDLE_POSTBOX_SUITE_BUNDLE
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -51,6 +75,24 @@ class DocumentationBundle:
             "document_count": self.document_count,
             "byte_count": self.byte_count,
             "sources": list(self.sources),
+            "title": self.title,
+            "bundle": self.bundle,
+        }
+
+
+@dataclass(frozen=True)
+class KindlePostboxPublishResult:
+    public_library: Path
+    output_path: Path
+    status: str
+    error: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "public_library": str(self.public_library),
+            "output_path": str(self.output_path),
+            "status": self.status,
+            "error": self.error,
         }
 
 
@@ -100,6 +142,33 @@ def default_output_dir() -> Path:
             Path(settings.BASE_DIR) / "work" / "docs" / "kindle-postbox",
         )
     )
+
+
+def _normalize_bundle(bundle: str) -> str:
+    normalized = str(bundle or KINDLE_POSTBOX_SUITE_BUNDLE).strip().casefold()
+    if normalized not in KINDLE_POSTBOX_BUNDLE_CHOICES:
+        raise DocumentationBundleError(
+            f"Unsupported Kindle documentation bundle: {bundle}"
+        )
+    return normalized
+
+
+def _bundle_title(bundle: str) -> str:
+    if bundle == KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE:
+        return "Arthexis Operators Manual"
+    return "Arthexis Suite Documentation"
+
+
+def _bundle_filename(bundle: str) -> str:
+    if bundle == KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE:
+        return KINDLE_OPERATORS_MANUAL_FILENAME
+    return KINDLE_POSTBOX_BUNDLE_FILENAME
+
+
+def _bundle_manifest_filename(bundle: str) -> str:
+    if bundle == KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE:
+        return KINDLE_OPERATORS_MANUAL_MANIFEST_FILENAME
+    return KINDLE_POSTBOX_MANIFEST_FILENAME
 
 
 def _path_is_relative_to(path: Path, parent: Path) -> bool:
@@ -190,9 +259,10 @@ def _write_suite_documentation_payload(
     generated_at: str,
     documents: list[Path],
     sources: tuple[str, ...],
+    title: str = "Arthexis Suite Documentation",
 ) -> None:
     with output_path.open("w", encoding="utf-8", newline="\n") as handle:
-        handle.write("Arthexis Suite Documentation\n")
+        handle.write(f"{title}\n")
         handle.write(f"Generated: {generated_at}\n")
         handle.write(f"Source root: {root}\n")
         handle.write(f"Documents: {len(documents)}\n")
@@ -212,10 +282,188 @@ def _write_suite_documentation_payload(
             handle.write("\n")
             handle.write("=" * 78)
             handle.write("\n\n")
-            handle.write(rendering.read_document_text(path).strip())
+            handle.write(_read_document_text_for_bundle(path).strip())
             handle.write("\n")
             if index != last_index:
                 handle.write("\n")
+
+
+def _manifest_error(message: str, manifest_path: Path) -> DocumentationBundleError:
+    return DocumentationBundleError(f"{manifest_path}: {message}")
+
+
+def _load_json_manifest(manifest_path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise _manifest_error(str(exc), manifest_path) from exc
+    except json.JSONDecodeError as exc:
+        raise _manifest_error(f"invalid JSON: {exc}", manifest_path) from exc
+    if not isinstance(payload, dict):
+        raise _manifest_error("manifest must be a JSON object", manifest_path)
+    return payload
+
+
+def _relative_manifest_path(source: object, manifest_path: Path) -> Path:
+    text = str(source or "").strip()
+    if not text:
+        raise _manifest_error("source path cannot be empty", manifest_path)
+    path = Path(text)
+    if path.is_absolute() or ".." in path.parts:
+        raise _manifest_error(
+            f"source path must stay inside the repo: {text}",
+            manifest_path,
+        )
+    return path
+
+
+def _resolve_operator_manual_source(
+    source: object,
+    *,
+    root: Path,
+    manifest_path: Path,
+    excluded_roots: tuple[Path, ...],
+    seen: set[Path],
+) -> Path | None:
+    relative = _relative_manifest_path(source, manifest_path)
+    candidate = (root / relative).resolve()
+    if not candidate.is_file():
+        raise _manifest_error(
+            f"source file is missing: {relative.as_posix()}",
+            manifest_path,
+        )
+    resolved = _resolve_document_candidate(
+        candidate,
+        root=root,
+        excluded_roots=excluded_roots,
+        seen=seen,
+    )
+    if resolved is None:
+        return None
+    seen.add(resolved)
+    return resolved
+
+
+def iter_operator_manual_sections(
+    *,
+    base_dir: Path | None = None,
+    manifest_path: Path | None = None,
+    exclude_paths: Iterable[Path] | None = None,
+) -> list[OperatorManualSection]:
+    """Return the curated operator-manual sections from the source manifest."""
+
+    root = Path(base_dir or settings.BASE_DIR).resolve()
+    source_manifest = (
+        Path(manifest_path)
+        if manifest_path is not None
+        else root / KINDLE_OPERATORS_MANUAL_SOURCE_MANIFEST
+    )
+    if not source_manifest.is_absolute():
+        source_manifest = root / source_manifest
+    source_manifest = source_manifest.resolve()
+    payload = _load_json_manifest(source_manifest)
+    raw_sections = payload.get("sections")
+    if not isinstance(raw_sections, list) or not raw_sections:
+        raise _manifest_error(
+            "manifest requires at least one section",
+            source_manifest,
+        )
+
+    excluded_roots = tuple(Path(path).resolve() for path in exclude_paths or ())
+    seen: set[Path] = set()
+    sections: list[OperatorManualSection] = []
+    for index, raw_section in enumerate(raw_sections, start=1):
+        if not isinstance(raw_section, dict):
+            raise _manifest_error(
+                f"section {index} must be an object",
+                source_manifest,
+            )
+        title = str(raw_section.get("title") or "").strip()
+        if not title:
+            raise _manifest_error(f"section {index} requires a title", source_manifest)
+        raw_sources = raw_section.get("sources")
+        if not isinstance(raw_sources, list) or not raw_sources:
+            raise _manifest_error(f"section {index} requires sources", source_manifest)
+        sources = tuple(
+            source
+            for source in (
+                _resolve_operator_manual_source(
+                    raw_source,
+                    root=root,
+                    manifest_path=source_manifest,
+                    excluded_roots=excluded_roots,
+                    seen=seen,
+                )
+                for raw_source in raw_sources
+            )
+            if source is not None
+        )
+        if sources:
+            sections.append(OperatorManualSection(title=title, sources=sources))
+    if not sections:
+        raise _manifest_error(
+            "manifest did not resolve any documentation sources",
+            source_manifest,
+        )
+    return sections
+
+
+def _write_operator_manual_payload(
+    *,
+    output_path: Path,
+    root: Path,
+    generated_at: str,
+    sections: list[OperatorManualSection],
+    sources: tuple[str, ...],
+) -> None:
+    with output_path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write("Arthexis Operators Manual\n")
+        handle.write(f"Generated: {generated_at}\n")
+        handle.write(f"Source root: {root}\n")
+        handle.write(f"Documents: {len(sources)}\n")
+        handle.write("\n")
+        handle.write("Contents\n")
+        handle.write("========\n")
+        source_index = 1
+        for section_index, section in enumerate(sections, start=1):
+            handle.write(f"{section_index}. {section.title}\n")
+            for source in section.sources:
+                relative = source.relative_to(root).as_posix()
+                handle.write(f"   {source_index}. {relative}\n")
+                source_index += 1
+        handle.write("\n")
+
+        for section_index, section in enumerate(sections, start=1):
+            if section_index > 1:
+                handle.write("\n")
+            handle.write("=" * 78)
+            handle.write("\n")
+            handle.write(section.title)
+            handle.write("\n")
+            handle.write("=" * 78)
+            handle.write("\n\n")
+            last_index = len(section.sources) - 1
+            for index, path in enumerate(section.sources):
+                source = path.relative_to(root).as_posix()
+                handle.write(source)
+                handle.write("\n")
+                handle.write("-" * len(source))
+                handle.write("\n\n")
+                handle.write(_read_document_text_for_bundle(path).strip())
+                handle.write("\n")
+                if index != last_index:
+                    handle.write("\n")
+
+
+def _read_document_text_for_bundle(path: Path) -> str:
+    try:
+        return rendering.read_document_text(path)
+    except DatabaseError:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except RuntimeError as exc:
+        if "Database access not allowed" not in str(exc):
+            raise
+        return path.read_text(encoding="utf-8", errors="replace")
 
 
 def build_suite_documentation_bundle(
@@ -228,8 +476,10 @@ def build_suite_documentation_bundle(
     root = Path(base_dir or settings.BASE_DIR).resolve()
     destination_dir = Path(output_dir or default_output_dir())
     destination_dir.mkdir(parents=True, exist_ok=True)
-    output_path = destination_dir / KINDLE_POSTBOX_BUNDLE_FILENAME
-    manifest_path = destination_dir / KINDLE_POSTBOX_MANIFEST_FILENAME
+    output_path = destination_dir / _bundle_filename(KINDLE_POSTBOX_SUITE_BUNDLE)
+    manifest_path = destination_dir / _bundle_manifest_filename(
+        KINDLE_POSTBOX_SUITE_BUNDLE
+    )
     generated_at = datetime.now(timezone.utc).isoformat()
     documents = iter_suite_documentation_files(base_dir=root)
     sources = tuple(path.relative_to(root).as_posix() for path in documents)
@@ -242,13 +492,18 @@ def build_suite_documentation_bundle(
         sources=sources,
     )
     manifest = {
+        "bundle": KINDLE_POSTBOX_SUITE_BUNDLE,
+        "title": _bundle_title(KINDLE_POSTBOX_SUITE_BUNDLE),
         "generated_at": generated_at,
         "document_count": len(documents),
         "byte_count": output_path.stat().st_size,
         "sources": list(sources),
         "output_path": str(output_path),
     }
-    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     return DocumentationBundle(
         output_path=output_path,
         manifest_path=manifest_path,
@@ -256,7 +511,93 @@ def build_suite_documentation_bundle(
         document_count=len(documents),
         byte_count=output_path.stat().st_size,
         sources=sources,
+        title=_bundle_title(KINDLE_POSTBOX_SUITE_BUNDLE),
+        bundle=KINDLE_POSTBOX_SUITE_BUNDLE,
     )
+
+
+def build_operators_manual_bundle(
+    *,
+    output_dir: Path | None = None,
+    base_dir: Path | None = None,
+    manifest_path: Path | None = None,
+) -> DocumentationBundle:
+    """Generate the curated plain-text operators manual for Kindle readers."""
+
+    root = Path(base_dir or settings.BASE_DIR).resolve()
+    destination_dir = Path(output_dir or default_output_dir())
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    output_path = destination_dir / _bundle_filename(
+        KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE
+    )
+    manifest_output_path = destination_dir / _bundle_manifest_filename(
+        KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE
+    )
+    generated_at = datetime.now(timezone.utc).isoformat()
+    sections = iter_operator_manual_sections(
+        base_dir=root,
+        manifest_path=manifest_path,
+    )
+    sources = tuple(
+        source.relative_to(root).as_posix()
+        for section in sections
+        for source in section.sources
+    )
+
+    _write_operator_manual_payload(
+        output_path=output_path,
+        root=root,
+        generated_at=generated_at,
+        sections=sections,
+        sources=sources,
+    )
+    manifest = {
+        "bundle": KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE,
+        "title": _bundle_title(KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE),
+        "generated_at": generated_at,
+        "document_count": len(sources),
+        "byte_count": output_path.stat().st_size,
+        "sections": [
+            {
+                "title": section.title,
+                "sources": [
+                    source.relative_to(root).as_posix()
+                    for source in section.sources
+                ],
+            }
+            for section in sections
+        ],
+        "sources": list(sources),
+        "output_path": str(output_path),
+    }
+    manifest_output_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return DocumentationBundle(
+        output_path=output_path,
+        manifest_path=manifest_output_path,
+        generated_at=generated_at,
+        document_count=len(sources),
+        byte_count=output_path.stat().st_size,
+        sources=sources,
+        title=_bundle_title(KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE),
+        bundle=KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE,
+    )
+
+
+def build_documentation_bundle(
+    *,
+    bundle: str = KINDLE_POSTBOX_SUITE_BUNDLE,
+    output_dir: Path | None = None,
+    base_dir: Path | None = None,
+) -> DocumentationBundle:
+    """Generate a Kindle documentation bundle by bundle type."""
+
+    normalized = _normalize_bundle(bundle)
+    if normalized == KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE:
+        return build_operators_manual_bundle(output_dir=output_dir, base_dir=base_dir)
+    return build_suite_documentation_bundle(output_dir=output_dir, base_dir=base_dir)
 
 
 def _resolve_documents_dir(root_path: Path) -> Path | None:
@@ -280,6 +621,56 @@ def _resolve_documents_dir(root_path: Path) -> Path | None:
     return root_path
 
 
+def _same_file_content(source: Path, destination: Path) -> bool:
+    try:
+        return destination.is_file() and source.read_bytes() == destination.read_bytes()
+    except OSError:
+        return False
+
+
+def _copy_bundle_file(
+    source: Path,
+    destination: Path,
+    *,
+    dry_run: bool,
+    copied_status: str,
+    dry_run_status: str,
+) -> tuple[str, str]:
+    if _same_file_content(source, destination):
+        return "current", ""
+    if dry_run:
+        return dry_run_status, ""
+
+    temp_path: Path | None = None
+    error = ""
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            with source.open("rb") as source_file:
+                shutil.copyfileobj(source_file, temp_file)
+        shutil.copystat(source, temp_path, follow_symlinks=False)
+        temp_path.replace(destination)
+        temp_path = None
+    except OSError as exc:
+        error = str(exc)
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+    if error:
+        return "failed", error
+    return copied_status, ""
+
+
 def _copy_bundle_to_target(
     bundle: DocumentationBundle,
     root_path: Path,
@@ -296,55 +687,58 @@ def _copy_bundle_to_target(
             error="Target path is not a directory.",
         )
 
-    output_path = documents_dir / KINDLE_POSTBOX_BUNDLE_FILENAME
-    if dry_run:
+    output_path = documents_dir / bundle.output_path.name
+    status, error = _copy_bundle_file(
+        bundle.output_path,
+        output_path,
+        dry_run=dry_run,
+        copied_status="copied",
+        dry_run_status="would-copy",
+    )
+    if error:
         return KindlePostboxTargetResult(
             root_path=root_path,
             documents_path=documents_dir,
             output_path=output_path,
-            status="would-copy",
+            status=status,
+            error=error,
         )
-
-    temp_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            delete=False,
-            dir=documents_dir,
-            prefix=f".{output_path.name}.",
-            suffix=".tmp",
-        ) as temp_file:
-            temp_path = Path(temp_file.name)
-            with open(bundle.output_path, "rb") as source_file:
-                shutil.copyfileobj(source_file, temp_file)
-        shutil.copystat(bundle.output_path, temp_path, follow_symlinks=False)
-        temp_path.replace(output_path)
-        temp_path = None
-    except OSError as exc:
-        return KindlePostboxTargetResult(
-            root_path=root_path,
-            documents_path=documents_dir,
-            output_path=output_path,
-            status="failed",
-            error=str(exc),
-        )
-    finally:
-        if temp_path is not None:
-            try:
-                temp_path.unlink()
-            except OSError:
-                pass
-
     return KindlePostboxTargetResult(
         root_path=root_path,
         documents_path=documents_dir,
         output_path=output_path,
-        status="copied",
+        status=status,
+    )
+
+
+def publish_bundle_to_public_library(
+    bundle: DocumentationBundle,
+    public_library: Path,
+    *,
+    dry_run: bool = False,
+) -> KindlePostboxPublishResult:
+    """Copy a generated bundle into a local public library watched by postbox tools."""
+
+    public_library = Path(public_library)
+    output_path = public_library / bundle.output_path.name
+    status, error = _copy_bundle_file(
+        bundle.output_path,
+        output_path,
+        dry_run=dry_run,
+        copied_status="published",
+        dry_run_status="would-publish",
+    )
+    return KindlePostboxPublishResult(
+        public_library=public_library,
+        output_path=output_path,
+        status=status,
+        error=error,
     )
 
 
 def sync_to_kindle_postboxes(
     *,
+    bundle: str = KINDLE_POSTBOX_SUITE_BUNDLE,
     output_dir: Path | None = None,
     base_dir: Path | None = None,
     refresh_usb: bool = False,
@@ -353,7 +747,11 @@ def sync_to_kindle_postboxes(
 ) -> KindlePostboxSyncResult:
     """Build suite documentation and copy it to Kindle postbox targets."""
 
-    bundle = build_suite_documentation_bundle(output_dir=output_dir, base_dir=base_dir)
+    built_bundle = build_documentation_bundle(
+        bundle=bundle,
+        output_dir=output_dir,
+        base_dir=base_dir,
+    )
     raw_targets = (
         list(targets)
         if targets is not None
@@ -363,11 +761,11 @@ def sync_to_kindle_postboxes(
         )
     )
     target_results = tuple(
-        _copy_bundle_to_target(bundle, Path(path), dry_run=dry_run)
+        _copy_bundle_to_target(built_bundle, Path(path), dry_run=dry_run)
         for path in sorted({str(path) for path in raw_targets if str(path).strip()})
     )
     return KindlePostboxSyncResult(
-        bundle=bundle,
+        bundle=built_bundle,
         targets=target_results,
         dry_run=dry_run,
     )
@@ -377,16 +775,29 @@ __all__ = [
     "DOCUMENT_EXTENSIONS",
     "GENERATED_DOCUMENTATION_FILENAMES",
     "KINDLE_DOCUMENTS_DIR_NAME",
+    "KINDLE_OPERATORS_MANUAL_FILENAME",
+    "KINDLE_OPERATORS_MANUAL_MANIFEST_FILENAME",
+    "KINDLE_OPERATORS_MANUAL_SOURCE_MANIFEST",
+    "KINDLE_POSTBOX_BUNDLE_CHOICES",
     "KINDLE_POSTBOX_BUNDLE_FILENAME",
     "KINDLE_POSTBOX_MANIFEST_FILENAME",
     "KINDLE_POSTBOX_NODE_FEATURE_SLUG",
+    "KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE",
+    "KINDLE_POSTBOX_SUITE_BUNDLE",
     "KINDLE_POSTBOX_USB_CLAIM",
+    "DocumentationBundleError",
     "DocumentationBundle",
+    "KindlePostboxPublishResult",
     "KindlePostboxSyncResult",
     "KindlePostboxTargetResult",
+    "OperatorManualSection",
+    "build_documentation_bundle",
+    "build_operators_manual_bundle",
     "build_suite_documentation_bundle",
     "default_output_dir",
+    "iter_operator_manual_sections",
     "iter_suite_documentation_files",
     "kindle_postbox_available",
+    "publish_bundle_to_public_library",
     "sync_to_kindle_postboxes",
 ]

--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -633,11 +633,15 @@ def _resolve_documents_dir(root_path: Path) -> Path | None:
 def _same_file_content(source: Path, destination: Path) -> bool:
     try:
         if (
-            not destination.is_file()
+            destination.is_symlink()
+            or not destination.is_file()
             or source.stat().st_size != destination.stat().st_size
         ):
             return False
-        with source.open("rb") as source_file, destination.open("rb") as destination_file:
+        with (
+            source.open("rb") as source_file,
+            destination.open("rb") as destination_file,
+        ):
             for source_chunk in iter(lambda: source_file.read(64 * 1024), b""):
                 if source_chunk != destination_file.read(len(source_chunk)):
                     return False

--- a/apps/docs/kindle_postbox.py
+++ b/apps/docs/kindle_postbox.py
@@ -324,22 +324,35 @@ def _resolve_operator_manual_source(
     manifest_path: Path,
     excluded_roots: tuple[Path, ...],
     seen: set[Path],
-) -> Path | None:
+) -> Path:
     relative = _relative_manifest_path(source, manifest_path)
-    candidate = (root / relative).resolve()
+    candidate = root / relative
     if not candidate.is_file():
         raise _manifest_error(
             f"source file is missing: {relative.as_posix()}",
             manifest_path,
         )
-    resolved = _resolve_document_candidate(
-        candidate,
-        root=root,
-        excluded_roots=excluded_roots,
-        seen=seen,
-    )
-    if resolved is None:
-        return None
+    if candidate.suffix.lower() not in DOCUMENT_EXTENSIONS:
+        raise _manifest_error(
+            f"source file is not a supported documentation file: {relative.as_posix()}",
+            manifest_path,
+        )
+    resolved = candidate.resolve()
+    if not _path_is_relative_to(resolved, root):
+        raise _manifest_error(
+            f"source file must stay inside the repo: {relative.as_posix()}",
+            manifest_path,
+        )
+    if _path_is_excluded(resolved, excluded_roots):
+        raise _manifest_error(
+            f"source file is excluded from the bundle: {relative.as_posix()}",
+            manifest_path,
+        )
+    if resolved in seen:
+        raise _manifest_error(
+            f"source file is listed more than once: {relative.as_posix()}",
+            manifest_path,
+        )
     seen.add(resolved)
     return resolved
 
@@ -385,18 +398,14 @@ def iter_operator_manual_sections(
         if not isinstance(raw_sources, list) or not raw_sources:
             raise _manifest_error(f"section {index} requires sources", source_manifest)
         sources = tuple(
-            source
-            for source in (
-                _resolve_operator_manual_source(
-                    raw_source,
-                    root=root,
-                    manifest_path=source_manifest,
-                    excluded_roots=excluded_roots,
-                    seen=seen,
-                )
-                for raw_source in raw_sources
+            _resolve_operator_manual_source(
+                raw_source,
+                root=root,
+                manifest_path=source_manifest,
+                excluded_roots=excluded_roots,
+                seen=seen,
             )
-            if source is not None
+            for raw_source in raw_sources
         )
         if sources:
             sections.append(OperatorManualSection(title=title, sources=sources))

--- a/apps/docs/management/commands/docs.py
+++ b/apps/docs/management/commands/docs.py
@@ -35,6 +35,24 @@ class Command(BaseCommand):
             help="Directory where generated documentation artifacts should be written.",
         )
         build_parser.add_argument(
+            "--bundle",
+            choices=kindle_postbox.KINDLE_POSTBOX_BUNDLE_CHOICES,
+            default=kindle_postbox.KINDLE_POSTBOX_SUITE_BUNDLE,
+            help="Kindle documentation bundle to generate.",
+        )
+        build_parser.add_argument(
+            "--public-library",
+            help=(
+                "Optional public library directory that should receive a copy "
+                "for local postbox daemons to distribute."
+            ),
+        )
+        build_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report public-library copy status without writing the public copy.",
+        )
+        build_parser.add_argument(
             "--json",
             action="store_true",
             help="Emit machine-readable JSON output.",
@@ -46,7 +64,16 @@ class Command(BaseCommand):
         )
         sync_parser.add_argument(
             "--output-dir",
-            help="Directory where generated documentation artifacts should be written before copying.",
+            help=(
+                "Directory where generated documentation artifacts should be "
+                "written before copying."
+            ),
+        )
+        sync_parser.add_argument(
+            "--bundle",
+            choices=kindle_postbox.KINDLE_POSTBOX_BUNDLE_CHOICES,
+            default=kindle_postbox.KINDLE_POSTBOX_SUITE_BUNDLE,
+            help="Kindle documentation bundle to sync.",
         )
         sync_parser.add_argument(
             "--target",
@@ -83,12 +110,20 @@ class Command(BaseCommand):
         if postbox_action == "build":
             return self._handle_kindle_postbox_build(
                 output_dir=output_dir,
+                bundle=options["bundle"],
+                public_library=(
+                    Path(options["public_library"])
+                    if options.get("public_library")
+                    else None
+                ),
+                dry_run=options["dry_run"],
                 json_output=options["json"],
             )
 
         if postbox_action == "sync":
             return self._handle_kindle_postbox_sync(
                 output_dir=output_dir,
+                bundle=options["bundle"],
                 json_output=options["json"],
                 refresh_usb=options["refresh_usb"],
                 dry_run=options["dry_run"],
@@ -101,24 +136,48 @@ class Command(BaseCommand):
         self,
         *,
         output_dir: Path | None,
+        bundle: str,
+        public_library: Path | None,
+        dry_run: bool,
         json_output: bool,
     ) -> None:
-        bundle = kindle_postbox.build_suite_documentation_bundle(
-            output_dir=output_dir,
-        )
+        try:
+            built_bundle = kindle_postbox.build_documentation_bundle(
+                bundle=bundle,
+                output_dir=output_dir,
+            )
+        except kindle_postbox.DocumentationBundleError as exc:
+            raise CommandError(f"Kindle postbox build failed: {exc}") from exc
+        publish_result = None
+        if public_library is not None:
+            publish_result = kindle_postbox.publish_bundle_to_public_library(
+                built_bundle,
+                public_library,
+                dry_run=dry_run,
+            )
         if json_output:
-            self.stdout.write(json.dumps(bundle.as_dict(), sort_keys=True))
+            payload = built_bundle.as_dict()
+            if publish_result is not None:
+                payload["public_library"] = publish_result.as_dict()
+            self.stdout.write(json.dumps(payload, sort_keys=True))
+            self._raise_failed_public_library_publish(publish_result)
             return
         self.stdout.write(
-            "Kindle postbox documentation built: "
-            f"documents={bundle.document_count} bytes={bundle.byte_count} "
-            f"file={bundle.output_path}"
+            f"Kindle postbox {built_bundle.title} built: "
+            f"documents={built_bundle.document_count} bytes={built_bundle.byte_count} "
+            f"file={built_bundle.output_path}"
         )
+        if publish_result is not None:
+            self.stdout.write(f"{publish_result.status}: {publish_result.output_path}")
+            if publish_result.error:
+                self.stderr.write(publish_result.error)
+        self._raise_failed_public_library_publish(publish_result)
 
     def _handle_kindle_postbox_sync(
         self,
         *,
         output_dir: Path | None,
+        bundle: str,
         json_output: bool,
         refresh_usb: bool,
         dry_run: bool,
@@ -132,11 +191,14 @@ class Command(BaseCommand):
             )
         try:
             result = kindle_postbox.sync_to_kindle_postboxes(
+                bundle=bundle,
                 output_dir=output_dir,
                 refresh_usb=refresh_usb,
                 dry_run=dry_run,
                 targets=targets,
             )
+        except kindle_postbox.DocumentationBundleError as exc:
+            raise CommandError(f"Kindle postbox build failed: {exc}") from exc
         except kindle_postbox.usb_inventory.UsbInventoryError as exc:
             raise CommandError(f"Kindle postbox USB discovery failed: {exc}") from exc
         failed_targets = self._failed_kindle_targets(result)
@@ -167,12 +229,19 @@ class Command(BaseCommand):
                 f"{len(failed_targets)} target(s)."
             )
 
+    @staticmethod
+    def _raise_failed_public_library_publish(
+        publish_result: kindle_postbox.KindlePostboxPublishResult | None,
+    ) -> None:
+        if publish_result is not None and publish_result.status == "failed":
+            raise CommandError("Kindle postbox public-library publish failed.")
+
     def _write_kindle_sync_text(
         self,
         result: kindle_postbox.KindlePostboxSyncResult,
     ) -> None:
         self.stdout.write(
-            "Kindle postbox documentation built: "
+            f"Kindle postbox {result.bundle.title} built: "
             f"documents={result.bundle.document_count} bytes={result.bundle.byte_count} "
             f"file={result.bundle.output_path}"
         )

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -66,6 +66,55 @@ def test_build_suite_documentation_bundle_excludes_existing_postbox_outputs(tmp_
 
 
 @pytest.mark.django_db
+def test_build_operators_manual_bundle_uses_manifest_sections(tmp_path):
+    _write(tmp_path / "README.md", "# Root\n")
+    _write(tmp_path / "docs" / "operations" / "runbook.md", "# Runbook\n")
+    _write(tmp_path / "docs" / "services" / "suite-service.md", "# Suite\n")
+    _write(
+        tmp_path / "docs" / "operators-manual.json",
+        json.dumps(
+            {
+                "sections": [
+                    {
+                        "title": "Start Here",
+                        "sources": ["README.md"],
+                    },
+                    {
+                        "title": "Operate The Node",
+                        "sources": [
+                            "docs/operations/runbook.md",
+                            "docs/services/suite-service.md",
+                        ],
+                    },
+                ]
+            }
+        ),
+    )
+
+    bundle = kindle_postbox.build_operators_manual_bundle(
+        base_dir=tmp_path,
+        output_dir=tmp_path / "out",
+    )
+
+    output = bundle.output_path.read_text(encoding="utf-8")
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+
+    assert bundle.bundle == kindle_postbox.KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE
+    assert bundle.title == "Arthexis Operators Manual"
+    assert bundle.sources == (
+        "README.md",
+        "docs/operations/runbook.md",
+        "docs/services/suite-service.md",
+    )
+    assert "Start Here" in output
+    assert "Operate The Node" in output
+    assert manifest["sections"][1]["sources"] == [
+        "docs/operations/runbook.md",
+        "docs/services/suite-service.md",
+    ]
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("output_relative", "source_relative"),
     (
@@ -176,6 +225,54 @@ def test_sync_to_explicit_kindle_target_rejects_existing_temp_symlink(tmp_path):
 
     assert result.targets[0].status == "copied"
     assert victim_path.read_text(encoding="utf-8") == "original"
+
+
+@pytest.mark.django_db
+def test_sync_to_explicit_kindle_target_skips_identical_bundle(tmp_path):
+    _write(tmp_path / "bundle.txt", "same content\n")
+    target = tmp_path / "kindle"
+    (target / "documents").mkdir(parents=True)
+    _write(target / "documents" / "bundle.txt", "same content\n")
+    bundle = kindle_postbox.DocumentationBundle(
+        output_path=tmp_path / "bundle.txt",
+        manifest_path=tmp_path / "bundle.json",
+        generated_at="2026-05-17T00:00:00+00:00",
+        document_count=1,
+        byte_count=13,
+        sources=("README.md",),
+    )
+
+    result = kindle_postbox._copy_bundle_to_target(
+        bundle,
+        target,
+        dry_run=False,
+    )
+
+    assert result.status == "current"
+    assert result.output_path == target / "documents" / "bundle.txt"
+
+
+@pytest.mark.django_db
+def test_publish_bundle_to_public_library_is_content_aware(tmp_path):
+    _write(tmp_path / "bundle.txt", "same content\n")
+    public_library = tmp_path / "Bookshelf"
+    _write(public_library / "bundle.txt", "same content\n")
+    bundle = kindle_postbox.DocumentationBundle(
+        output_path=tmp_path / "bundle.txt",
+        manifest_path=tmp_path / "bundle.json",
+        generated_at="2026-05-17T00:00:00+00:00",
+        document_count=1,
+        byte_count=13,
+        sources=("README.md",),
+    )
+
+    result = kindle_postbox.publish_bundle_to_public_library(
+        bundle,
+        public_library,
+    )
+
+    assert result.status == "current"
+    assert result.output_path == public_library / "bundle.txt"
 
 
 @pytest.mark.django_db
@@ -434,3 +531,60 @@ def test_kindle_postbox_build_command_emits_json(tmp_path):
     payload = json.loads(stdout.getvalue())
     assert payload["document_count"] >= 1
     assert payload["output_path"].endswith(kindle_postbox.KINDLE_POSTBOX_BUNDLE_FILENAME)
+
+
+@pytest.mark.django_db
+def test_kindle_postbox_build_command_publishes_operators_manual(tmp_path):
+    stdout = StringIO()
+
+    call_command(
+        "docs",
+        "kindle-postbox",
+        "build",
+        "--bundle",
+        "operators",
+        "--output-dir",
+        str(tmp_path / "out"),
+        "--public-library",
+        str(tmp_path / "Bookshelf"),
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    public_copy = tmp_path / "Bookshelf" / kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME
+    assert payload["bundle"] == kindle_postbox.KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE
+    assert payload["output_path"].endswith(kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME)
+    assert payload["public_library"]["status"] == "published"
+    assert public_copy.exists()
+
+
+def test_kindle_postbox_sync_command_supports_operators_bundle(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        Node,
+        "get_local",
+        classmethod(lambda cls: SimpleNamespace(role=SimpleNamespace(name="Control"))),
+    )
+    target = tmp_path / "kindle"
+    (target / "documents").mkdir(parents=True)
+    stdout = StringIO()
+
+    call_command(
+        "docs",
+        "kindle-postbox",
+        "sync",
+        "--bundle",
+        "operators",
+        "--output-dir",
+        str(tmp_path / "out"),
+        "--target",
+        str(target),
+        "--json",
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    copied = target / "documents" / kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME
+    assert payload["bundle"]["bundle"] == kindle_postbox.KINDLE_POSTBOX_OPERATORS_MANUAL_BUNDLE
+    assert payload["targets"][0]["status"] == "copied"
+    assert copied.exists()

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -115,6 +115,62 @@ def test_build_operators_manual_bundle_uses_manifest_sections(tmp_path):
 
 
 @pytest.mark.django_db
+def test_iter_operator_manual_sections_rejects_excluded_manifest_source(tmp_path):
+    _write(
+        tmp_path / "docs" / kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME,
+        "generated manual\n",
+    )
+    _write(
+        tmp_path / "docs" / "operators-manual.json",
+        json.dumps(
+            {
+                "sections": [
+                    {
+                        "title": "Generated",
+                        "sources": [
+                            f"docs/{kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME}"
+                        ],
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(
+        kindle_postbox.DocumentationBundleError,
+        match=(
+            "source file is excluded from the bundle: "
+            f"docs/{kindle_postbox.KINDLE_OPERATORS_MANUAL_FILENAME}"
+        ),
+    ):
+        kindle_postbox.iter_operator_manual_sections(base_dir=tmp_path)
+
+
+@pytest.mark.django_db
+def test_iter_operator_manual_sections_rejects_duplicate_manifest_source(tmp_path):
+    _write(tmp_path / "README.md", "# Root\n")
+    _write(
+        tmp_path / "docs" / "operators-manual.json",
+        json.dumps(
+            {
+                "sections": [
+                    {
+                        "title": "Start Here",
+                        "sources": ["README.md", "README.md"],
+                    }
+                ]
+            }
+        ),
+    )
+
+    with pytest.raises(
+        kindle_postbox.DocumentationBundleError,
+        match="source file is listed more than once: README.md",
+    ):
+        kindle_postbox.iter_operator_manual_sections(base_dir=tmp_path)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("output_relative", "source_relative"),
     (

--- a/apps/docs/tests/test_kindle_postbox.py
+++ b/apps/docs/tests/test_kindle_postbox.py
@@ -309,6 +309,41 @@ def test_sync_to_explicit_kindle_target_skips_identical_bundle(tmp_path):
 
 
 @pytest.mark.django_db
+def test_sync_to_explicit_kindle_target_replaces_matching_bundle_symlink(tmp_path):
+    _write(tmp_path / "bundle.txt", "same content\n")
+    target = tmp_path / "kindle"
+    documents_dir = target / "documents"
+    documents_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    _write(outside, "same content\n")
+    destination = documents_dir / "bundle.txt"
+    try:
+        destination.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable on this platform: {exc}")
+    bundle = kindle_postbox.DocumentationBundle(
+        output_path=tmp_path / "bundle.txt",
+        manifest_path=tmp_path / "bundle.json",
+        generated_at="2026-05-17T00:00:00+00:00",
+        document_count=1,
+        byte_count=13,
+        sources=("README.md",),
+    )
+
+    result = kindle_postbox._copy_bundle_to_target(
+        bundle,
+        target,
+        dry_run=False,
+    )
+
+    assert result.status == "copied"
+    assert result.output_path == destination
+    assert not destination.is_symlink()
+    assert destination.read_text(encoding="utf-8") == "same content\n"
+    assert outside.read_text(encoding="utf-8") == "same content\n"
+
+
+@pytest.mark.django_db
 def test_publish_bundle_to_public_library_is_content_aware(tmp_path):
     _write(tmp_path / "bundle.txt", "same content\n")
     public_library = tmp_path / "Bookshelf"

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ In Arthexis terminology, the **suite** is the collection of applications, while 
 - [Good Command](operations/good-command.md)
 - [Install & Lifecycle Scripts Manual](development/install-lifecycle-scripts-manual.md)
 - [Kindle Postbox](services/kindle-postbox.md)
+- [Operators Manual](operators-manual.md)
 - [Agent Card v1 RFID Layout](development/agent-card-v1.md)
 - [AP Portal Recovery](operations/ap-portal.md)
 - [Sigil Script Command](development/sigil-script-command.md)

--- a/docs/operators-manual.json
+++ b/docs/operators-manual.json
@@ -1,0 +1,71 @@
+{
+  "title": "Arthexis Operators Manual",
+  "sections": [
+    {
+      "title": "Orientation",
+      "sources": [
+        "docs/operators-manual.md",
+        "README.md",
+        "docs/index.md"
+      ]
+    },
+    {
+      "title": "Install, Start, Stop, And Upgrade",
+      "sources": [
+        "docs/development/install-lifecycle-scripts-manual.md",
+        "docs/auto-upgrade.md",
+        "docs/startup-sequence.md",
+        "apps/docs/cookbooks/install-start-stop-upgrade-uninstall.md",
+        "docs/upgrade-error-handling.md"
+      ]
+    },
+    {
+      "title": "Service Operations",
+      "sources": [
+        "docs/suite-services-report.md",
+        "docs/services/suite-service.md",
+        "docs/services/celery-worker.md",
+        "docs/services/celery-beat.md",
+        "docs/operations/operational-commands.md",
+        "docs/operations/good-command.md",
+        "docs/operations/error-report.md"
+      ]
+    },
+    {
+      "title": "Control Node Hardware",
+      "sources": [
+        "docs/services/lcd-screen.md",
+        "docs/lcd-screen-hardware.md",
+        "docs/services/llm-lcd-summary.md",
+        "docs/services/rfid-scanner-service.md",
+        "docs/development/rfid-card-layout.md",
+        "docs/services/usb-inventory.md",
+        "docs/services/kindle-postbox.md",
+        "docs/usb-camera-power-off.md"
+      ]
+    },
+    {
+      "title": "Network And Access",
+      "sources": [
+        "docs/routing.md",
+        "docs/security-model.md",
+        "docs/operations/ap-portal.md",
+        "docs/operations/logging-loki-promtail.md",
+        "docs/logging-domain.md",
+        "docs/operations/workgroup-play-password.md"
+      ]
+    },
+    {
+      "title": "Recovery And Field Data",
+      "sources": [
+        "docs/operations/imager-sd-card-recovery.md",
+        "docs/operations/reinstall-data-import-runbook.md",
+        "apps/docs/cookbooks/managing-local-node-data.md",
+        "apps/docs/cookbooks/node-features.md",
+        "apps/docs/cookbooks/lcd-screen-flicker-troubleshooting.md",
+        "apps/docs/cookbooks/sigils.md",
+        "apps/docs/cookbooks/user-data.md"
+      ]
+    }
+  ]
+}

--- a/docs/operators-manual.md
+++ b/docs/operators-manual.md
@@ -1,0 +1,62 @@
+# Operators Manual
+
+The Arthexis operators manual is a curated, Kindle-readable field handbook built
+from canonical suite documentation. It is generated as one plain-text file so a
+Control node can place the same current manual on every connected Kindle.
+
+## Build The Manual
+
+Generate the operators manual in the local work directory:
+
+```bash
+python manage.py docs kindle-postbox build --bundle operators
+```
+
+Generate it and publish a copy to a local public library watched by a Kindle
+postbox daemon:
+
+```bash
+python manage.py docs kindle-postbox build --bundle operators --public-library /home/arthe/Bookshelf
+```
+
+Copy it directly to every connected USB target claimed as `kindle-postbox`:
+
+```bash
+python manage.py docs kindle-postbox sync --bundle operators --refresh-usb
+```
+
+Preview direct Kindle writes without changing removable storage:
+
+```bash
+python manage.py docs kindle-postbox sync --bundle operators --refresh-usb --dry-run
+```
+
+## Source Manifest
+
+The manual order is controlled by `docs/operators-manual.json`. Each section in
+that manifest lists existing documentation files in the order they should appear
+in the single generated handbook.
+
+Keep operational facts in their canonical source documents and update the
+manifest only when the manual should gain, remove, or reorder a source. The
+manual builder fails when a listed source is missing, which keeps stale field
+handbooks from being generated silently.
+
+## Kindle Handoff
+
+The generated file is:
+
+```text
+work/docs/kindle-postbox/arthexis-operators-manual.txt
+```
+
+The generated manifest beside it is:
+
+```text
+work/docs/kindle-postbox/arthexis-operators-manual.json
+```
+
+When `--public-library` is used, Arthexis copies the generated file only when
+the public-library copy differs. Local postbox services can then distribute that
+public-library file to connected Kindles without requiring the suite process to
+own the long-running USB scan loop.

--- a/docs/services/kindle-postbox.md
+++ b/docs/services/kindle-postbox.md
@@ -16,10 +16,30 @@ Build the current documentation bundle:
 python manage.py docs kindle-postbox build
 ```
 
+Build the curated operators manual bundle:
+
+```bash
+python manage.py docs kindle-postbox build --bundle operators
+```
+
+Publish the curated operators manual into a public library watched by a local
+postbox daemon:
+
+```bash
+python manage.py docs kindle-postbox build --bundle operators --public-library /home/arthe/Bookshelf
+```
+
 Copy the bundle to every connected USB target claimed as `kindle-postbox`:
 
 ```bash
 python manage.py docs kindle-postbox sync
+```
+
+Copy the operators manual to every connected USB target claimed as
+`kindle-postbox`:
+
+```bash
+python manage.py docs kindle-postbox sync --bundle operators
 ```
 
 Refresh USB inventory before resolving connected Kindles:
@@ -48,11 +68,23 @@ The generated bundle is:
 work/docs/kindle-postbox/arthexis-suite-documentation.txt
 ```
 
+The generated operators manual is:
+
+```text
+work/docs/kindle-postbox/arthexis-operators-manual.txt
+```
+
 The local manifest beside it records generation time, byte count, and the source
 documents included in the bundle:
 
 ```text
 work/docs/kindle-postbox/arthexis-suite-documentation.json
+```
+
+The operators manual manifest is:
+
+```text
+work/docs/kindle-postbox/arthexis-operators-manual.json
 ```
 
 The sync command writes the text bundle to the target `documents/` directory
@@ -77,3 +109,7 @@ The bundle is regenerated from the current checkout each time. It includes:
 Supported formats are Markdown, plain text, CSV, and reStructuredText. The bundle
 is intentionally plain text so it remains readable on Kindle devices without
 requiring an ebook conversion toolchain.
+
+The operators manual is also regenerated from the current checkout, but it uses
+the curated source order in `docs/operators-manual.json`. Use that manifest for
+field-handbook ordering and keep detailed facts in the owning canonical docs.


### PR DESCRIPTION
## Summary

- Add an `operators` Kindle bundle that builds `arthexis-operators-manual.txt` from a curated `docs/operators-manual.json` source manifest.
- Add public-library publishing for local Kindle postbox daemons and content-aware copy status so unchanged generated manuals are reported as current instead of recopied.
- Preserve the current symlink-safe Kindle target copy behavior while adding the new operators-manual sync path.
- Document the operators manual flow and expand Kindle postbox tests for manifest ordering, public-library publish, direct sync, current-file handling, and existing USB inventory behavior.

## Validation

- `python -m py_compile apps/docs/kindle_postbox.py apps/docs/management/commands/docs.py`
- `pytest apps/docs/tests/test_kindle_postbox.py apps/sensors/tests/test_usb_inventory.py` -> 35 passed, 1 warning
- `python manage.py docs kindle-postbox build --bundle operators --output-dir /tmp/arthexis-operators-manual-pr --json`
- `python manage.py check`
- `git diff --check`

## Notes

`ruff` is not installed in this checkout, so lint could not be run locally. The operators-manual build falls back to raw document text when the sigil database is unavailable, which keeps documentation export usable in checkouts that have not been migrated yet.