### PR TITLE
Sanitize RFID scan state before LCD summary collection

### DIFF
--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -580,13 +580,13 @@ def _sanitize_rfid_scan_state(content: str) -> str:
     try:
         payload = json.loads(content)
     except (TypeError, ValueError):
-        return content
+        return "{}"
     if not isinstance(payload, dict):
-        return content
+        return "{}"
     payload.pop("deep_read", None)
     payload.pop("dump", None)
     payload.pop("keys", None)
-    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
 
 
 def _run_summary_command(command: list[str]) -> str:

--- a/apps/summary/services.py
+++ b/apps/summary/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -563,6 +564,8 @@ def _collect_state_file_source(
             continue
         seen.add(path)
         content = _read_tail_text(path, remaining_bytes)
+        if path.name == "rfid-scan.json":
+            content = _sanitize_rfid_scan_state(content)
         remaining_bytes -= len(content.encode("utf-8", errors="replace"))
         chunk = _virtual_chunk(
             _state_chunk_name(path, context.base_dir),
@@ -571,6 +574,19 @@ def _collect_state_file_source(
         if chunk:
             chunks.append(chunk)
     return chunks
+
+
+def _sanitize_rfid_scan_state(content: str) -> str:
+    try:
+        payload = json.loads(content)
+    except (TypeError, ValueError):
+        return content
+    if not isinstance(payload, dict):
+        return content
+    payload.pop("deep_read", None)
+    payload.pop("dump", None)
+    payload.pop("keys", None)
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
 
 
 def _run_summary_command(command: list[str]) -> str:

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -308,6 +308,39 @@ def test_collect_state_file_source_sanitizes_rfid_scan_state(
     assert "deep_read" not in chunks[0].content
 
 
+def test_collect_state_file_source_fail_closed_for_truncated_rfid_json(
+    monkeypatch, tmp_path
+) -> None:
+    rfid_state = tmp_path / ".locks" / "rfid-scan.json"
+    rfid_state.parent.mkdir()
+    rfid_state.write_text(
+        '{"uid":"1","keys":{"a":"A0A1A2A3A4A5"},"dump":{"b":"c"},"deep_read":true}\n',
+        encoding="utf-8",
+    )
+    context = services.SummarySourceContext(
+        config=SimpleNamespace(log_offsets={}),
+        since=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        base_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+    )
+    source = services.SummarySource(
+        name="state",
+        group="state",
+        priority=20,
+        max_bytes=32,
+        collector=services._collect_state_file_source,
+    )
+    monkeypatch.setattr(services, "_summary_state_paths", lambda base_dir: [rfid_state])
+
+    chunks = services._collect_state_file_source(context, source)
+
+    assert len(chunks) == 1
+    assert "{}" in chunks[0].content
+    assert "keys" not in chunks[0].content
+    assert "dump" not in chunks[0].content
+    assert "deep_read" not in chunks[0].content
+
+
 def test_systemctl_failed_source_skips_clean_output(monkeypatch, settings, tmp_path):
     settings.BASE_DIR = tmp_path
     monkeypatch.setattr(

--- a/apps/summary/tests/test_services.py
+++ b/apps/summary/tests/test_services.py
@@ -275,6 +275,39 @@ def test_collect_state_file_source_enforces_total_byte_budget(
     assert "b" * 5 not in "\n".join(chunk.content for chunk in chunks)
 
 
+def test_collect_state_file_source_sanitizes_rfid_scan_state(
+    monkeypatch, tmp_path
+) -> None:
+    rfid_state = tmp_path / ".locks" / "rfid-scan.json"
+    rfid_state.parent.mkdir()
+    rfid_state.write_text(
+        '{"uid":"1","keys":{"a":"A0A1A2A3A4A5"},"dump":{"b":"c"},"deep_read":true}\n',
+        encoding="utf-8",
+    )
+    context = services.SummarySourceContext(
+        config=SimpleNamespace(log_offsets={}),
+        since=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        base_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+    )
+    source = services.SummarySource(
+        name="state",
+        group="state",
+        priority=20,
+        max_bytes=1024,
+        collector=services._collect_state_file_source,
+    )
+    monkeypatch.setattr(services, "_summary_state_paths", lambda base_dir: [rfid_state])
+
+    chunks = services._collect_state_file_source(context, source)
+
+    assert len(chunks) == 1
+    assert '"uid": "1"' in chunks[0].content
+    assert "keys" not in chunks[0].content
+    assert "dump" not in chunks[0].content
+    assert "deep_read" not in chunks[0].content
+
+
 def test_systemctl_failed_source_skips_clean_output(monkeypatch, settings, tmp_path):
     settings.BASE_DIR = tmp_path
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation

- The state summary source was reading `.locks/rfid-scan.json` verbatim and could copy sensitive RFID deep-read fields (`keys`, `dump`, `deep_read`) into generated prompts and `LLMSummaryConfig.last_prompt`, exposing secrets via the admin/database/LCD surface.

### Description

- Add a JSON sanitizer `_sanitize_rfid_scan_state` that strips `keys`, `dump`, and `deep_read` from parsed `rfid-scan.json` payloads and pretty-prints the sanitized JSON as the collected content. 
- Integrate the sanitizer into the state collector so `_collect_state_file_source` applies it only when `path.name == "rfid-scan.json"`, preserving behavior for other state files and non-JSON content. 
- Add a regression test `test_collect_state_file_source_sanitizes_rfid_scan_state` that writes a synthetic `rfid-scan.json` containing sensitive fields and verifies those fields are absent from collected chunks while non-sensitive fields remain. 
- Files changed: `apps/summary/services.py` and `apps/summary/tests/test_services.py`.

### Testing

- Attempted to run the targeted tests with `python3 manage.py test run -- apps.summary.tests.test_services`, which initially failed due to a missing virtualenv; dependency/bootstrap remediation was required. 
- Ran `./install.sh --terminal` which installed the project virtualenv and dependencies and applied migrations successfully in this environment. 
- Ran `./env-refresh.sh --deps-only` to refresh CI/test dependencies (completed in this session). 
- The new unit test `test_collect_state_file_source_sanitizes_rfid_scan_state` was added to `apps.summary.tests.test_services`; a full automated run of the specific target was attempted but a final, clean test run was not completed within this session due to environment bootstrap timing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ace08d24832693cbb63480e4c875)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Fix: Sanitize RFID Scan State Before LCD Summary Collection

**Problem**: The state summary collector was reading `.locks/rfid-scan.json` verbatim and embedding it into LCD summary content, potentially exposing sensitive RFID fields (`keys`, `dump`, `deep_read`) via admin interfaces, database records, and LCD displays.

**Solution**:
- Added `import json` to support JSON parsing and sanitization
- Implemented `_sanitize_rfid_scan_state(content: str) -> str` function that:
  - Parses JSON content and returns `"{}"` on parse errors or non-dict payloads (fail-closed)
  - Removes sensitive fields: `deep_read`, `dump`, `keys`
  - Re-serializes remaining fields deterministically with sorted keys and UTF-8 preservation
- Integrated sanitization into `_collect_state_file_source` by checking if `path.name == "rfid-scan.json"` and applying the sanitizer before chunk collection
- Other state files and non-JSON content are unaffected

**Tests Added**:
- `test_collect_state_file_source_sanitizes_rfid_scan_state`: Verifies that sensitive fields are stripped while non-sensitive fields like `uid` are retained
- `test_collect_state_file_source_fail_closed_for_truncated_rfid_json`: Tests fail-closed behavior when RFID JSON is truncated by enforcing a small `max_bytes` threshold, confirming truncated content is safely reduced to `"{}"` without exposing sensitive fields

**Code Changes**: +16 lines in `services.py` (sanitizer function), +66 lines in `tests/test_services.py` (two test cases)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arthexis/arthexis/pull/7814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->